### PR TITLE
Force new combo on objects succeeding a break

### DIFF
--- a/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
+++ b/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
@@ -539,5 +539,78 @@ namespace osu.Game.Tests.Editing
                 Assert.That(beatmap.Breaks[0].EndTime, Is.EqualTo(5000 - OsuHitObject.PREEMPT_MAX));
             });
         }
+
+        [Test]
+        public void TestPuttingObjectBetweenBreakEndAndAnotherObjectForcesNewCombo()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new EditorBeatmap(new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
+                Difficulty =
+                {
+                    ApproachRate = 10,
+                },
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 1000, NewCombo = true },
+                    new HitCircle { StartTime = 4500 },
+                    new HitCircle { StartTime = 5000, NewCombo = true },
+                },
+                Breaks =
+                {
+                    new BreakPeriod(2000, 4000),
+                }
+            });
+
+            foreach (var ho in beatmap.HitObjects)
+                ho.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(((HitCircle)beatmap.HitObjects[1]).NewCombo, Is.True);
+                Assert.That(((HitCircle)beatmap.HitObjects[2]).NewCombo, Is.True);
+            });
+        }
+
+        [Test]
+        public void TestAutomaticallyInsertedBreakForcesNewCombo()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new EditorBeatmap(new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
+                Difficulty =
+                {
+                    ApproachRate = 10,
+                },
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 1000, NewCombo = true },
+                    new HitCircle { StartTime = 5000 },
+                },
+            });
+
+            foreach (var ho in beatmap.HitObjects)
+                ho.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(beatmap.Breaks, Has.Count.EqualTo(1));
+                Assert.That(((HitCircle)beatmap.HitObjects[1]).NewCombo, Is.True);
+            });
+        }
     }
 }

--- a/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
+++ b/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
@@ -576,6 +576,10 @@ namespace osu.Game.Tests.Editing
             {
                 Assert.That(((HitCircle)beatmap.HitObjects[1]).NewCombo, Is.True);
                 Assert.That(((HitCircle)beatmap.HitObjects[2]).NewCombo, Is.True);
+
+                Assert.That(((HitCircle)beatmap.HitObjects[0]).ComboIndex, Is.EqualTo(1));
+                Assert.That(((HitCircle)beatmap.HitObjects[1]).ComboIndex, Is.EqualTo(2));
+                Assert.That(((HitCircle)beatmap.HitObjects[2]).ComboIndex, Is.EqualTo(3));
             });
         }
 
@@ -610,6 +614,9 @@ namespace osu.Game.Tests.Editing
             {
                 Assert.That(beatmap.Breaks, Has.Count.EqualTo(1));
                 Assert.That(((HitCircle)beatmap.HitObjects[1]).NewCombo, Is.True);
+
+                Assert.That(((HitCircle)beatmap.HitObjects[0]).ComboIndex, Is.EqualTo(1));
+                Assert.That(((HitCircle)beatmap.HitObjects[1]).ComboIndex, Is.EqualTo(2));
             });
         }
     }

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -111,20 +111,29 @@ namespace osu.Game.Screens.Edit
 
             int currentBreak = 0;
 
-            for (int i = 0; i < Beatmap.HitObjects.Count; ++i)
-            {
-                var hitObject = Beatmap.HitObjects[i];
+            IHasComboInformation? lastObj = null;
+            bool comboInformationUpdateRequired = false;
 
+            foreach (var hitObject in Beatmap.HitObjects)
+            {
                 if (hitObject is not IHasComboInformation hasCombo)
                     continue;
 
                 if (currentBreak < breakEnds.Count && hitObject.StartTime >= breakEnds[currentBreak])
                 {
-                    hasCombo.NewCombo = true;
+                    if (!hasCombo.NewCombo)
+                    {
+                        hasCombo.NewCombo = true;
+                        comboInformationUpdateRequired = true;
+                    }
+
                     currentBreak += 1;
                 }
 
-                hasCombo.UpdateComboInformation(i > 0 ? Beatmap.HitObjects[i - 1] as IHasComboInformation : null);
+                if (comboInformationUpdateRequired)
+                    hasCombo.UpdateComboInformation(lastObj);
+
+                lastObj = hasCombo;
             }
         }
     }


### PR DESCRIPTION
No issue thread for this again. [Reported internally on discord](https://discord.com/channels/90072389919997952/1259818301517725707/1320420768814727229).

Placing this logic in the beatmap processor, as a post-processing step, means that the new combo force won't be visible until a placement has been committed. That can be seen as subpar, but I tried putting this logic in the placement and it sucked anyway:

- While the combo number was correct, the colour looked off, because it would use the same combo colour as the already-placed objects after said break, which would only cycle to the next, correct one on placement
- Not all scenarios can be handled in the placement. Refer to one of the test cases added in 973f606a9e48fb5d43cbbff03af514ca8a48766a, wherein two objects are placed far apart from each other, and an automated break is inserted between them - the placement has no practical way of knowing whether it's going to have a break inserted automatically before it or not.

If you wanna check out the original version I tried and see why I didn't end up PRing it, see diff below:

<details>

```diff
diff --git a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
index 0ffd1072cd..2d340a08a4 100644
--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -46,6 +46,9 @@ public partial class ComposeBlueprintContainer : EditorBlueprintContainer
         [Resolved(canBeNull: true)]
         private EditorScreenWithTimeline editorScreen { get; set; }
 
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
+
         /// <remarks>
         /// Positional input must be received outside the container's bounds,
         /// in order to handle composer blueprints which are partially offscreen.
@@ -173,8 +176,14 @@ private void nudgeSelection(Vector2 delta)
 
         private void updatePlacementNewCombo()
         {
-            if (CurrentHitObjectPlacement?.HitObject is IHasComboInformation c)
-                c.NewCombo = NewCombo.Value == TernaryState.True;
+            var hitObject = CurrentHitObjectPlacement?.HitObject;
+            if (hitObject is not IHasComboInformation c)
+                return;
+
+            var closestBreak = editorBeatmap.Breaks.LastOrDefault(b => b.StartTime <= hitObject.StartTime);
+            bool isFirstAfterBreak = closestBreak != null && !editorBeatmap.HitObjects.Any(ho => ho.StartTime >= closestBreak.EndTime && ho.StartTime <= hitObject.StartTime);
+
+            c.NewCombo = NewCombo.Value == TernaryState.True || isFirstAfterBreak;
         }
 
         private void updatePlacementSamples()
@@ -364,6 +373,7 @@ protected override void Update()
 
                 // updates the placement with the latest editor clock time.
                 updatePlacementTimeAndPosition();
+                updatePlacementNewCombo();
             }
         }
 

```


</details>