### PR TITLE
Clean up windows association manager code

### DIFF
--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -190,7 +190,7 @@ namespace osu.Desktop.Windows
                 // register a program id for the given extension
                 using (var programKey = classes.CreateSubKey(programId))
                 {
-                    programKey.SetValue(null, description);
+                    programKey.SetValue(null, description.ToString());
 
                     using (var defaultIconKey = programKey.CreateSubKey(default_icon))
                         defaultIconKey.SetValue(null, iconPath);


### PR DESCRIPTION
I'm supposed to be working on this logic to add support to stable, but I couldn't work with this class so I spent 10 minutes fixing it up.

- No `records` for anything that isn't a barebones model
- Removing weird `null` calls to setup defaults. The localisation flow is now completely isolated and not required to be called until we want to support it.