### PR TITLE
Delete entire juice stream when only one vertex remains after deleting another vertex

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -194,6 +194,17 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
         }
 
         [Test]
+        public void TestDeletingSecondVertexDeletesEntireJuiceStream()
+        {
+            double[] times = { 100, 400 };
+            float[] positions = { 100, 150 };
+            addBlueprintStep(times, positions);
+
+            addDeleteVertexSteps(times[1], positions[1]);
+            AddAssert("juice stream deleted", () => EditorBeatmap.HitObjects, () => Is.Empty);
+        }
+
+        [Test]
         public void TestVertexResampling()
         {
             addBlueprintStep(100, 100, new SliderPath(PathType.PERFECT_CURVE, new[]

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -21,7 +19,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
 {
     public partial class TestSceneJuiceStreamSelectionBlueprint : CatchSelectionBlueprintTestScene
     {
-        private JuiceStream hitObject;
+        private JuiceStream hitObject = null!;
 
         private readonly ManualClock manualClock = new ManualClock();
 

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             }));
         }
 
-        public void UpdateHitObjectFromPath(JuiceStream hitObject)
+        public virtual void UpdateHitObjectFromPath(JuiceStream hitObject)
         {
             // The SV setting may need to be changed for the current path.
             var svBindable = hitObject.SliderVelocityMultiplierBindable;

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
@@ -138,5 +138,13 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
             EditorBeatmap?.EndChange();
         }
+
+        public override void UpdateHitObjectFromPath(JuiceStream hitObject)
+        {
+            base.UpdateHitObjectFromPath(hitObject);
+
+            if (hitObject.Path.ControlPoints.Count <= 1 || !hitObject.Path.HasValidLength)
+                EditorBeatmap?.Remove(hitObject);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31425.

Matches handling of sliders:

https://github.com/ppy/osu/blob/e7070bd8120460562330957d24a7b99b41c6092a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs#L478-L483