### PR TITLE
Fix juice stream placement blueprint being initially visually offset

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamPlacementBlueprint.cs
@@ -88,10 +88,9 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             switch (PlacementActive)
             {
                 case PlacementState.Waiting:
-                    if (!(result.Time is double snappedTime)) return;
-
                     HitObject.OriginalX = ToLocalSpace(result.ScreenSpacePosition).X;
-                    HitObject.StartTime = snappedTime;
+                    if (result.Time is double snappedTime)
+                        HitObject.StartTime = snappedTime;
                     break;
 
                 case PlacementState.Active:
@@ -107,21 +106,13 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             Vector2 startPosition = CatchHitObjectUtils.GetStartPosition(HitObjectContainer, HitObject);
             editablePath.Position = nestedOutlineContainer.Position = scrollingPath.Position = startPosition;
 
-            updateHitObjectFromPath();
-        }
+            if (lastEditablePathId != editablePath.PathId)
+                editablePath.UpdateHitObjectFromPath(HitObject);
+            lastEditablePathId = editablePath.PathId;
 
-        private void updateHitObjectFromPath()
-        {
-            if (lastEditablePathId == editablePath.PathId)
-                return;
-
-            editablePath.UpdateHitObjectFromPath(HitObject);
             ApplyDefaultsToHitObject();
-
             scrollingPath.UpdatePathFrom(HitObjectContainer, HitObject);
             nestedOutlineContainer.UpdateNestedObjectsFrom(HitObjectContainer, HitObject);
-
-            lastEditablePathId = editablePath.PathId;
         }
 
         private double positionToTime(float relativeYPosition)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/31423.
- Regressed in https://github.com/ppy/osu/pull/30411.

Admittedly, I don't completely understand all of the pieces here, because code quality of this placement blueprint code is ALL-CAPS ATROCIOUS, but I believe the failure mode to be something along the lines of:

- User activates juice stream tool, blueprint gets created in initial state. It reads in a mouse position far outside of the playfield, and sets internal positioning appropriately.
- When the user moves the mouse into the bounds of the playfield, some positions update (the ones inside `UpdateTimeAndPosition()`, but the fruit markers are for *nested* objects, and `updateHitObjectFromPath()` is responsible for updating those... however, it only fires if the `editablePath.PathId` changes, which it won't here, because there is only one path vertex until the user commits the starting point of the juice stream and it's always at (0,0).
- Therefore the position of the starting fruit marker remains bogus until left click, at which point the path changes and everything returns to *relative* sanity.

The part in https://github.com/ppy/osu/pull/30411 that regresses the above scenario is the "blueprint is always created even if not visible / cursor is outside playfield" part.

This PR essentially relies on inlining the broken method and only guarding the relevant part of processing behind the path version check (which is actually updating the path). Everything else that can touch positions of nesteds (like default application, and the drawable piece updates) is allowed to happen unconditionally.