### PR TITLE
Apply a bunch of balancing changes to aim

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -15,22 +15,22 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Osu.Tests";
 
-        [TestCase(6.7230435389286045d, 239, "diffcalc-test")]
-        [TestCase(1.4484916289194889d, 54, "zero-length-sliders")]
-        [TestCase(0.42912495021837549d, 4, "very-fast-slider")]
+        [TestCase(6.6860329680488437d, 239, "diffcalc-test")]
+        [TestCase(1.4485740324170036d, 54, "zero-length-sliders")]
+        [TestCase(0.43052813047866129d, 4, "very-fast-slider")]
         [TestCase(0.14143808967817237d, 2, "nan-slider")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(9.6468019709446171d, 239, "diffcalc-test")]
-        [TestCase(1.754888327422514d, 54, "zero-length-sliders")]
-        [TestCase(0.55601568006454294d, 4, "very-fast-slider")]
+        [TestCase(9.6300773538770041d, 239, "diffcalc-test")]
+        [TestCase(1.7550155729445993d, 54, "zero-length-sliders")]
+        [TestCase(0.55785578988249407d, 4, "very-fast-slider")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModDoubleTime());
 
-        [TestCase(6.7230435389286045d, 239, "diffcalc-test")]
-        [TestCase(1.4484916289194889d, 54, "zero-length-sliders")]
-        [TestCase(0.42912495021837549d, 4, "very-fast-slider")]
+        [TestCase(6.6860329680488437d, 239, "diffcalc-test")]
+        [TestCase(1.4485740324170036d, 54, "zero-length-sliders")]
+        [TestCase(0.43052813047866129d, 4, "very-fast-slider")]
         public void TestClassicMod(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModClassic());
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     public static class AimEvaluator
     {
         private const double wide_angle_multiplier = 1.5;
-        private const double acute_angle_multiplier = 2.7;
+        private const double acute_angle_multiplier = 2.6;
         private const double slider_multiplier = 1.35;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                     // Penalize angle repetition.
                     wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(calcWideAngleBonus(lastAngle), 3));
-                    acuteAngleBonus *= 0.03 + 0.97 * (1 - Math.Min(acuteAngleBonus, Math.Pow(calcAcuteAngleBonus(lastAngle), 3)));
+                    acuteAngleBonus *= 0.1 + 0.9 * (1 - Math.Min(acuteAngleBonus, Math.Pow(calcAcuteAngleBonus(lastAngle), 3)));
 
                     // Apply full wide angle bonus for distance more than one diameter
                     wideAngleBonus *= angleBonus * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, 0, diameter);
@@ -142,8 +142,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             return aimStrain;
         }
 
-        private static double calcWideAngleBonus(double angle) => DifficultyCalculationUtils.Smoothstep(angle, double.DegreesToRadians(30), double.DegreesToRadians(150));
+        private static double calcWideAngleBonus(double angle) => DifficultyCalculationUtils.Smoothstep(angle, double.DegreesToRadians(40), double.DegreesToRadians(140));
 
-        private static double calcAcuteAngleBonus(double angle) => DifficultyCalculationUtils.Smoothstep(angle, double.DegreesToRadians(150), double.DegreesToRadians(30));
+        private static double calcAcuteAngleBonus(double angle) => DifficultyCalculationUtils.Smoothstep(angle, double.DegreesToRadians(140), double.DegreesToRadians(40));
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public class Speed : OsuStrainSkill
     {
-        private double skillMultiplier => 1.45;
+        private double skillMultiplier => 1.46;
         private double strainDecayBase => 0.3;
 
         private double currentStrain;


### PR DESCRIPTION
This changes a few multipliers to adjust values to be closer to community's expectations.

Speed is being buffed slightly to keep values on non-acute maps closer to 0 because they get slightly nerfed by the wide angle bonus change

https://pp.huismetbenen.nl/rankings/players/aim-balancing