### PR TITLE
Fix nullref when opening files or URIs on startup on Android

### DIFF
--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -13,7 +13,6 @@ using Android.Graphics;
 using Android.OS;
 using Android.Views;
 using osu.Framework.Android;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Database;
 using Debug = System.Diagnostics.Debug;
 using Uri = Android.Net.Uri;
@@ -95,25 +94,38 @@ namespace osu.Android
 
         private void handleIntent(Intent? intent)
         {
-            switch (intent?.Action)
+            if (intent == null)
+                return;
+
+            switch (intent.Action)
             {
                 case Intent.ActionDefault:
                     if (intent.Scheme == ContentResolver.SchemeContent)
-                        handleImportFromUris(intent.Data.AsNonNull());
+                    {
+                        if (intent.Data != null)
+                            handleImportFromUris(intent.Data);
+                    }
                     else if (osu_url_schemes.Contains(intent.Scheme))
-                        game.HandleLink(intent.DataString);
+                    {
+                        if (intent.DataString != null)
+                            game.HandleLink(intent.DataString);
+                    }
+
                     break;
 
                 case Intent.ActionSend:
                 case Intent.ActionSendMultiple:
                 {
+                    if (intent.ClipData == null)
+                        break;
+
                     var uris = new List<Uri>();
 
-                    for (int i = 0; i < intent.ClipData?.ItemCount; i++)
+                    for (int i = 0; i < intent.ClipData.ItemCount; i++)
                     {
-                        var content = intent.ClipData?.GetItemAt(i);
-                        if (content != null)
-                            uris.Add(content.Uri.AsNonNull());
+                        var item = intent.ClipData.GetItemAt(i);
+                        if (item?.Uri != null)
+                            uris.Add(item.Uri);
                     }
 
                     handleImportFromUris(uris.ToArray());

--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -49,9 +49,23 @@ namespace osu.Android
         /// <remarks>Adjusted on startup to match expected UX for the current device type (phone/tablet).</remarks>
         public ScreenOrientation DefaultOrientation = ScreenOrientation.Unspecified;
 
-        private OsuGameAndroid game = null!;
+        private readonly OsuGameAndroid game;
 
-        protected override Framework.Game CreateGame() => game = new OsuGameAndroid(this);
+        private bool gameCreated;
+
+        protected override Framework.Game CreateGame()
+        {
+            if (gameCreated)
+                throw new InvalidOperationException("Framework tried to create a game twice.");
+
+            gameCreated = true;
+            return game;
+        }
+
+        public OsuGameActivity()
+        {
+            game = new OsuGameAndroid(this);
+        }
 
         protected override void OnCreate(Bundle? savedInstanceState)
         {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28790
- Resolves https://github.com/ppy/osu/discussions/14540#discussioncomment-10384080

I think this regressed with SDL3, as `CreateGame()` is called later in the startup process compared to osutk. This will cause the `private OsuGameAndroid game = null!;` to be null. But we promised it won't be, so it's a nullref when the intent handling code tries to call `game.Import()`.

To fix this, `OsuGameAndroid` is constructed immediately. And `CreateGame()` will just return that existing game. I also added a guard against calling `CreateGame()` twice. Calling it twice will likely crash somewhere deep in framework code, this just makes the failure point obvious.

Also fixes some nullrefs in intent handling, unrelated to the above issues.