### PR TITLE
Fix stutter on intensive storyboards when entering break time with 100% background dim

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Linq;
 using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -15,6 +16,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -31,6 +33,7 @@ using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
+using osu.Game.Storyboards.Drawables;
 using osu.Game.Tests.Resources;
 using osuTK;
 using osuTK.Graphics;
@@ -45,6 +48,7 @@ namespace osu.Game.Tests.Visual.Background
         private LoadBlockingTestPlayer player;
         private BeatmapManager manager;
         private RulesetStore rulesets;
+        private UpdateCounter storyboardUpdateCounter;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -195,6 +199,28 @@ namespace osu.Game.Tests.Visual.Background
         }
 
         [Test]
+        public void TestStoryboardUpdatesWhenDimmed()
+        {
+            performFullSetup();
+            createFakeStoryboard();
+
+            AddStep("Enable fully dimmed storyboard", () =>
+            {
+                player.StoryboardReplacesBackground.Value = true;
+                player.StoryboardEnabled.Value = true;
+                player.DimmableStoryboard.IgnoreUserSettings.Value = false;
+                songSelect.DimLevel.Value = 1f;
+            });
+
+            AddUntilStep("Storyboard is invisible", () => !player.IsStoryboardVisible);
+
+            AddWaitStep("wait some", 20);
+
+            AddUntilStep("Storyboard is always present", () => player.ChildrenOfType<DrawableStoryboard>().Single().AlwaysPresent, () => Is.True);
+            AddUntilStep("Dimmable storyboard content is being updated", () => storyboardUpdateCounter.StoryboardContentLastUpdated, () => Is.EqualTo(Time.Current).Within(100));
+        }
+
+        [Test]
         public void TestStoryboardIgnoreUserSettings()
         {
             performFullSetup();
@@ -269,15 +295,19 @@ namespace osu.Game.Tests.Visual.Background
         {
             player.StoryboardEnabled.Value = false;
             player.StoryboardReplacesBackground.Value = false;
-            player.DimmableStoryboard.Add(new OsuSpriteText
+            player.DimmableStoryboard.AddRange(new Drawable[]
             {
-                Size = new Vector2(500, 50),
-                Alpha = 1,
-                Colour = Color4.White,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Text = "THIS IS A STORYBOARD",
-                Font = new FontUsage(size: 50)
+                storyboardUpdateCounter = new UpdateCounter(),
+                new OsuSpriteText
+                {
+                    Size = new Vector2(500, 50),
+                    Alpha = 1,
+                    Colour = Color4.White,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "THIS IS A STORYBOARD",
+                    Font = new FontUsage(size: 50)
+                }
             });
         });
 
@@ -353,7 +383,7 @@ namespace osu.Game.Tests.Visual.Background
             /// <summary>
             /// Make sure every time a screen gets pushed, the background doesn't get replaced
             /// </summary>
-            /// <returns>Whether or not the original background (The one created in DummySongSelect) is still the current background</returns>
+            /// <returns>Whether the original background (The one created in DummySongSelect) is still the current background</returns>
             public bool IsBackgroundCurrent() => background?.IsCurrentScreen() == true;
         }
 
@@ -384,7 +414,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public new DimmableStoryboard DimmableStoryboard => base.DimmableStoryboard;
 
-            // Whether or not the player should be allowed to load.
+            // Whether the player should be allowed to load.
             public bool BlockLoad;
 
             public Bindable<bool> StoryboardEnabled;
@@ -448,6 +478,17 @@ namespace osu.Game.Tests.Visual.Background
             public FadeAccessibleBackground(WorkingBeatmap beatmap)
                 : base(beatmap)
             {
+            }
+        }
+
+        private class UpdateCounter : Drawable
+        {
+            public double StoryboardContentLastUpdated;
+
+            protected override void Update()
+            {
+                base.Update();
+                StoryboardContentLastUpdated = Time.Current;
             }
         }
 

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -481,7 +481,7 @@ namespace osu.Game.Tests.Visual.Background
             }
         }
 
-        private class UpdateCounter : Drawable
+        private partial class UpdateCounter : Drawable
         {
             public double StoryboardContentLastUpdated;
 

--- a/osu.Game/Screens/Play/DimmableStoryboard.cs
+++ b/osu.Game/Screens/Play/DimmableStoryboard.cs
@@ -69,7 +69,22 @@ namespace osu.Game.Screens.Play
 
         protected override void LoadComplete()
         {
-            ShowStoryboard.BindValueChanged(_ => initializeStoryboard(true), true);
+            ShowStoryboard.BindValueChanged(show =>
+            {
+                initializeStoryboard(true);
+
+                if (drawableStoryboard != null)
+                {
+                    // Regardless of user dim setting, for the time being we need to ensure storyboards are still updated in the background (even if not displayed).
+                    // If we don't do this, an intensive storyboard will have a lot of catch-up work to do at the start of a break, causing a huge stutter.
+                    //
+                    // This can be reconsidered when https://github.com/ppy/osu-framework/issues/6491 is resolved.
+                    bool alwaysPresent = show.NewValue;
+
+                    Content.AlwaysPresent = alwaysPresent;
+                    drawableStoryboard.AlwaysPresent = alwaysPresent;
+                }
+            }, true);
             base.LoadComplete();
         }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Storyboards.Drawables
 
         protected override Container<DrawableStoryboardLayer> Content { get; }
 
-        protected override Vector2 DrawScale => new Vector2(Parent!.DrawHeight / 480);
+        protected override Vector2 DrawScale => new Vector2((Parent?.DrawHeight ?? 0) / 480);
 
         public override bool RemoveCompletedTransforms => false;
 


### PR DESCRIPTION
This avoids piled-up overhead when entering break time. It's not great, but it is what we need for now to avoid weirdness.

Addresses https://github.com/ppy/osu/discussions/31465.