### PR TITLE
Fix replays not correctly pre-importing beatmap when arriving from a cold start

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Online.API
             if (HasLogin)
             {
                 // Early call to ensure the local user / "logged in" state is correct immediately.
-                prepareForConnect();
+                setPlaceholderLocalUser();
 
                 // This is required so that Queue() requests during startup sequence don't fail due to "not logged in".
                 state.Value = APIState.Connecting;
@@ -258,7 +258,7 @@ namespace osu.Game.Online.API
         /// <returns>Whether the connection attempt was successful.</returns>
         private void attemptConnect()
         {
-            Scheduler.Add(prepareForConnect, false);
+            Scheduler.Add(setPlaceholderLocalUser, false);
 
             // save the username at this point, if the user requested for it to be.
             config.SetValue(OsuSetting.Username, config.Get<bool>(OsuSetting.SaveUsername) ? ProvidedUsername : string.Empty);
@@ -374,7 +374,7 @@ namespace osu.Game.Online.API
         /// This is useful for storing local scores and showing a placeholder username after starting the game,
         /// until a valid connection has been established.
         /// </summary>
-        private void prepareForConnect()
+        private void setPlaceholderLocalUser()
         {
             if (!localUser.IsDefault)
                 return;

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -111,8 +111,14 @@ namespace osu.Game.Online.API
 
             config.BindWith(OsuSetting.UserOnlineStatus, configStatus);
 
-            // Early call to ensure the local user / "logged in" state is correct immediately.
-            setPlaceholderLocalUser();
+            if (HasLogin)
+            {
+                // Early call to ensure the local user / "logged in" state is correct immediately.
+                prepareForConnect();
+
+                // This is required so that Queue() requests during startup sequence don't fail due to "not logged in".
+                state.Value = APIState.Connecting;
+            }
 
             localUser.BindValueChanged(u =>
             {
@@ -251,7 +257,7 @@ namespace osu.Game.Online.API
         /// <returns>Whether the connection attempt was successful.</returns>
         private void attemptConnect()
         {
-            Scheduler.Add(setPlaceholderLocalUser, false);
+            Scheduler.Add(prepareForConnect, false);
 
             // save the username at this point, if the user requested for it to be.
             config.SetValue(OsuSetting.Username, config.Get<bool>(OsuSetting.SaveUsername) ? ProvidedUsername : string.Empty);
@@ -367,7 +373,7 @@ namespace osu.Game.Online.API
         /// This is useful for storing local scores and showing a placeholder username after starting the game,
         /// until a valid connection has been established.
         /// </summary>
-        private void setPlaceholderLocalUser()
+        private void prepareForConnect()
         {
             if (!localUser.IsDefault)
                 return;


### PR DESCRIPTION
Until now, if you double-clicked a replay while lazer wasn't open, if the beatmap isn't already locally available it would just show a fail message rather than attempting to download the beatmap for you.

---


- [x] Depends on https://github.com/ppy/osu/pull/31507 for mergeability

Currently, there's a period where the API is `Offline` even though it is about to connect (as soon as the `run` thread starts up).

This can cause any `Queue`d requests to fail if they arrive too early. To avoid this, let's ensure the `Connecting` state is set as early as possible.

Closes https://github.com/ppy/osu/issues/31489.

I'm sure we want test coverage of this, but it's a pretty high bar since async and no existing tests of `APIAccess`.