### PR TITLE
Penalise the reading difficulty of high velocity notes using "note density"

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 current = previousHitObject;
             }
 
-            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.235;
+            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.40;
 
             return ratioPenalty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -1,3 +1,5 @@
+
+
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
@@ -36,17 +38,63 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             return 2 * (1 - DifficultyCalculationUtils.Logistic(exponent: Math.E * repeatingHitPattern.RepetitionInterval - 2 * Math.E));
         }
 
+        /// <summary>
+        /// Calculates a consistency penalty based on the number of consecutive consistent intervals,
+        /// considering the delta time between each colour sequence.
+        /// </summary>
+        /// <param name="hitObject">The current hitObject to consider.</param>
+        /// <param name="threshold"> The allowable margin of error for determining whether ratios are consistent.</param>
+        private static double consistentRatioPenalty(TaikoDifficultyHitObject hitObject, double threshold = 0.01)
+        {
+            int consistentRatioCount = 0;
+            double totalRatioCount = 0.0;
+
+            TaikoDifficultyHitObject current = hitObject;
+
+            while (current.Previous(1) is TaikoDifficultyHitObject previousHitObject)
+            {
+                double currentRatio = current.Rhythm.Ratio;
+                double previousRatio = previousHitObject.Rhythm.Ratio;
+
+                // If there's no valid hit object before the previous one, break the loop.
+                if (previousHitObject.Previous(1) is not TaikoDifficultyHitObject)
+                    break;
+
+                // A consistent interval is defined as the percentage difference between the two rhythmic ratios with the margin of error.
+                if (Math.Abs(1 - currentRatio / previousRatio) <= threshold)
+                {
+                    consistentRatioCount++;
+                    totalRatioCount += currentRatio;
+                }
+
+                current = previousHitObject;
+            }
+
+            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.30;
+
+            return ratioPenalty;
+        }
+
+        /// <summary>
+        /// Evaluate the difficulty of the first hitobject within a colour streak.
+        /// </summary>
         public static double EvaluateDifficultyOf(DifficultyHitObject hitObject)
         {
-            TaikoDifficultyHitObjectColour colour = ((TaikoDifficultyHitObject)hitObject).Colour;
+            var taikoObject = (TaikoDifficultyHitObject)hitObject;
+            TaikoDifficultyHitObjectColour colour = taikoObject.Colour;
             double difficulty = 0.0d;
 
             if (colour.MonoStreak?.FirstHitObject == hitObject) // Difficulty for MonoStreak
                 difficulty += EvaluateDifficultyOf(colour.MonoStreak);
+
             if (colour.AlternatingMonoPattern?.FirstHitObject == hitObject) // Difficulty for AlternatingMonoPattern
                 difficulty += EvaluateDifficultyOf(colour.AlternatingMonoPattern);
+
             if (colour.RepeatingHitPattern?.FirstHitObject == hitObject) // Difficulty for RepeatingHitPattern
                 difficulty += EvaluateDifficultyOf(colour.RepeatingHitPattern);
+
+            double consistencyPenalty = consistentRatioPenalty(taikoObject);
+            difficulty *= consistencyPenalty;
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 current = previousHitObject;
             }
 
-            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.25;
+            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.235;
 
             return ratioPenalty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 current = previousHitObject;
             }
 
-            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.30;
+            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.25;
 
             return ratioPenalty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// https://www.desmos.com/calculator/sgab5r9nh1
+			// https://www.desmos.com/calculator/biltwjojyo
 			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 1, 15);
 			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 
@@ -41,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// High velocity notes are penalised if they are close to other notes
 			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
-			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
+			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
 			
 			// https://www.desmos.com/calculator/r1ffltv1i6
 			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.95, 15);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -44,8 +44,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
 			
-			// https://www.desmos.com/calculator/r1ffltv1i6
-			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.95, 15);
+			// https://www.desmos.com/calculator/u63f3ntdsi
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
 			
 			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
 			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -34,18 +34,21 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double effectiveBPM = noteObject.EffectiveBPM;
 
 			var midVelocity = new VelocityRange(360, 480);
-            var highVelocity = new VelocityRange(480, 660);
+            var highVelocity = new VelocityRange(480, 640);
+			
+			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-			// High velocity notes are penalised if their note density is high
-			// Density is worked out by taking the time between this note and the previous
+			// High velocity notes are penalised if they are close to other notes
+			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// https://www.desmos.com/calculator/biltwjojyo
-			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 1, 15);
+			// https://www.desmos.com/calculator/r1ffltv1i6
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.95, 15);
 			
-			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
-			double highVelDifficulty = (1.0 - 0.6 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, (highVelocity.Center + 30 * densityPenalty), 0.1 * (highVelocity.Range + 0.8 * densityPenalty));
+			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
+			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);
+			double highVelDifficulty = (1.0 - 0.33 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, midpointOffset, multiplier);
 			
             return midVelDifficulty + highVelDifficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -42,10 +42,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// High velocity notes are penalised if they are close to other notes
 			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
-			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
-			
-			// https://www.desmos.com/calculator/u63f3ntdsi
-			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
+			double densityPenalty = 0.0;
+			if (effectiveBPM > 0 && noteObject.DeltaTime > 0)
+			{
+				double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
+				// https://www.desmos.com/calculator/u63f3ntdsi
+				densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
+			}
 			
 			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
 			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -41,8 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// Explain properly soon
-			// https://www.desmos.com/calculator/ftvspcqgqd
+			// https://www.desmos.com/calculator/mx4dyydxji
 			double densityPenalty = 0.5 * DifficultyCalculationUtils.Logistic(density, 1, 15);
 
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -33,19 +33,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         {
             double effectiveBPM = noteObject.EffectiveBPM;
 
-            var highVelocity = new VelocityRange(480, 640);
-            var midVelocity = new VelocityRange(360, 480);
+			var midVelocity = new VelocityRange(360, 480);
+            var highVelocity = new VelocityRange(480, 660);
 
-			// High velocity notes are penalised if their note density is highVelDifficulty
+			// High velocity notes are penalised if their note density is high
 			// Density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// https://www.desmos.com/calculator/mx4dyydxji
-			double densityPenalty = 0.5 * DifficultyCalculationUtils.Logistic(density, 1, 15);
-
+			// https://www.desmos.com/calculator/sgab5r9nh1
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 1, 15);
+			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
-			double highVelDifficulty = (1.0 - densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10));
+			double highVelDifficulty = (1.0 - 0.6 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, (highVelocity.Center + 30 * densityPenalty), 0.1 * (highVelocity.Range + 0.8 * densityPenalty));
 			
             return midVelDifficulty + highVelDifficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -36,8 +36,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             var highVelocity = new VelocityRange(480, 640);
             var midVelocity = new VelocityRange(360, 480);
 
-            return 1.0 * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10))
-                   + 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+			// High velocity notes are penalised if their note density is highVelDifficulty
+			// Density is worked out by taking the time between this note and the previous
+			// and comparing it to the expected time at this note's effective BPM
+			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
+			
+			// Explain properly soon
+			// https://www.desmos.com/calculator/ftvspcqgqd
+			double densityPenalty = 0.5 * DifficultyCalculationUtils.Logistic(density, 1, 15);
+
+			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+			double highVelDifficulty = (1.0 - densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10));
+			
+            return midVelDifficulty + highVelDifficulty;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <returns>The reading difficulty value for the given hit object.</returns>
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
-            double effectiveBPM = noteObject.EffectiveBPM;
+            double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
 
 			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
@@ -42,13 +42,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// High velocity notes are penalised if they are close to other notes
 			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
-			double densityPenalty = 0.0;
-			if (effectiveBPM > 0 && noteObject.DeltaTime > 0)
-			{
-				double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
-				// https://www.desmos.com/calculator/u63f3ntdsi
-				densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
-			}
+			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
+			
+			// https://www.desmos.com/calculator/u63f3ntdsi
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
 			
 			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
 			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -33,16 +33,17 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
             double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
-			// Effective BPM normalised such that base SV 1/4 is 1.0, 1/8 is 2.0 etc.
-			double normalisedBPM = 21000.0 / effectiveBPM;
+			// Expected deltatime is the deltatime this note would need
+			// to be spaced equally to a base SV 1/4 note
+			double expectedDeltaTime = 21000.0 / effectiveBPM;
 
 			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
 			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-			// Density refers to an object's normalised BPM relative to its deltatime
-			double density = normalisedBPM / Math.Max(1.0, noteObject.DeltaTime);
+			// Density refers to an object's deltatime relative to its expected deltatime
+			double density = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
 			
 			// Dense notes are penalised at high velocities
 			// https://www.desmos.com/calculator/u63f3ntdsi

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -33,17 +33,18 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
             double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
+			// Effective BPM normalised such that base SV 1/4 is 1.0, 1/8 is 2.0 etc.
+			double normalisedBPM = 21000.0 / effectiveBPM;
 
 			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
 			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-			// High velocity notes are penalised if they are close to other notes
-			// Note density is worked out by taking the time between this note and the previous
-			// and comparing it to the expected time at this note's effective BPM
-			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
+			// Density refers to an object's normalised BPM relative to its deltatime
+			double density = normalisedBPM / Math.Max(1.0, noteObject.DeltaTime);
 			
+			// Dense notes are penalised at high velocities
 			// https://www.desmos.com/calculator/u63f3ntdsi
 			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
 			

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                     {
                         double ratio = intervals[i]!.Value / intervals[j]!.Value;
                         if (Math.Abs(1 - ratio) <= threshold) // If any two intervals are similar, apply a penalty.
-                            return 0.5;
+                            return 0.99;
                     }
                 }
 
@@ -139,11 +139,16 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             TaikoDifficultyHitObjectRhythm rhythm = ((TaikoDifficultyHitObject)hitObject).Rhythm;
             double difficulty = 0.0d;
 
+            double sameRhythm = 0;
+            double samePattern = 0;
+
             if (rhythm.SameRhythmHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmHitObjects
-                difficulty += 5.0 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
+                sameRhythm = 4.0 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
 
             if (rhythm.SamePatterns?.FirstHitObject == hitObject) // Difficulty for SamePatterns
-                difficulty += 5.0 * evaluateDifficultyOf(rhythm.SamePatterns);
+                samePattern += 3.0 * evaluateDifficultyOf(rhythm.SamePatterns);
+
+            difficulty += Math.Max(sameRhythm, samePattern);
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <summary>
         /// Calculates the difficulty of a given ratio using a combination of periodic penalties and bonuses.
         /// </summary>
-        private static double ratioDifficulty(double ratio, int terms = 8)
+        private static double ratioDifficulty(double ratio, int total = 1, int terms = 8)
         {
             double difficulty = 0;
 
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 difficulty += termPenalty(ratio, i, 2, 1);
             }
 
-            difficulty += terms / (1 + ratio);
+            difficulty += Math.Pow(terms / (1 + ratio), 1 / total);
 
             // Give bonus to near-1 ratios
             difficulty += DifficultyCalculationUtils.BellCurve(ratio, 1, 0.7);
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 
         private static double evaluateDifficultyOf(SamePatterns samePatterns)
         {
-            return ratioDifficulty(samePatterns.IntervalRatio);
+            return ratioDifficulty(samePatterns.IntervalRatio, samePatterns.Total);
         }
 
         /// <summary>
@@ -143,14 +143,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double samePattern = 0;
 
             if (rhythm.SameRhythmHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmHitObjects
-                sameRhythm = 5.5 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
+                sameRhythm = 9 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
 
             if (rhythm.SamePatterns?.FirstHitObject == hitObject) // Difficulty for SamePatterns
                 samePattern += 2.5 * evaluateDifficultyOf(rhythm.SamePatterns);
 
             difficulty += Math.Max(sameRhythm, samePattern);
 
-            return difficulty;
+            return difficulty * 0.5;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                     {
                         double ratio = intervals[i]!.Value / intervals[j]!.Value;
                         if (Math.Abs(1 - ratio) <= threshold) // If any two intervals are similar, apply a penalty.
-                            return 0.99;
+                            return 0.80;
                     }
                 }
 
@@ -143,10 +143,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double samePattern = 0;
 
             if (rhythm.SameRhythmHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmHitObjects
-                sameRhythm = 4.0 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
+                sameRhythm = 5.5 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
 
             if (rhythm.SamePatterns?.FirstHitObject == hitObject) // Difficulty for SamePatterns
-                samePattern += 3.0 * evaluateDifficultyOf(rhythm.SamePatterns);
+                samePattern += 2.5 * evaluateDifficultyOf(rhythm.SamePatterns);
 
             difficulty += Math.Max(sameRhythm, samePattern);
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -140,10 +140,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double difficulty = 0.0d;
 
             if (rhythm.SameRhythmHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmHitObjects
-                difficulty += 1.75 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
+                difficulty += 5.0 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
 
             if (rhythm.SamePatterns?.FirstHitObject == hitObject) // Difficulty for SamePatterns
-                difficulty += 1.25 * evaluateDifficultyOf(rhythm.SamePatterns);
+                difficulty += 5.0 * evaluateDifficultyOf(rhythm.SamePatterns);
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 difficulty += termPenalty(ratio, i, 2, 1);
             }
 
-            difficulty += Math.Pow(terms / (1 + ratio), 1 / total);
+            difficulty += Math.Pow(terms / (1.0 + ratio), 1.0 / total);
 
             // Give bonus to near-1 ratios
             difficulty += DifficultyCalculationUtils.BellCurve(ratio, 1, 0.7);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                     {
                         double ratio = intervals[i]!.Value / intervals[j]!.Value;
                         if (Math.Abs(1 - ratio) <= threshold) // If any two intervals are similar, apply a penalty.
-                            return 0.95;
+                            return 0.5;
                     }
                 }
 
@@ -140,10 +140,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double difficulty = 0.0d;
 
             if (rhythm.SameRhythmHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmHitObjects
-                difficulty += evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
+                difficulty += 1.75 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
 
             if (rhythm.SamePatterns?.FirstHitObject == hitObject) // Difficulty for SamePatterns
-                difficulty += 1.5 * evaluateDifficultyOf(rhythm.SamePatterns);
+                difficulty += 1.25 * evaluateDifficultyOf(rhythm.SamePatterns);
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             // Interval is capped at a very small value to prevent infinite values.
             interval = Math.Max(interval, 1);
 
-            return 30 / interval;
+            return 20 / interval;
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             // Consecutive notes exceeding 100 are buffed slowly, capped at 800 objects.
             if (consecutiveCount >= 100)
             {
-                objectStrain += 0.00025 * Math.Min(consecutiveCount, 800);
+                objectStrain += 0.00025 * Math.Min(consecutiveCount, 600);
             }
 
             return objectStrain;

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
@@ -57,36 +57,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             }
 
             TaikoDifficultyHitObject taikoCurrent = (TaikoDifficultyHitObject)current;
-            TaikoDifficultyHitObject? previousObject = taikoCurrent.Previous(1) as TaikoDifficultyHitObject;
             TaikoDifficultyHitObject? previousMono = taikoCurrent.PreviousMono(availableFingersFor(taikoCurrent) - 1);
 
-            // There is no previous hit object hit by the current finger
-            if (previousMono == null)
-                return 0.0;
-
-            int consecutiveCount = 1;
-
-            while (previousObject != null)
-            {
-                if (Math.Abs(previousObject.DeltaTime - taikoCurrent.DeltaTime) < 5.0) // Tolerance of 5ms for unsnaps
-                {
-                    consecutiveCount++;
-                    previousObject = previousObject.Previous(1) as TaikoDifficultyHitObject;
-                }
-                else
-                {
-                    break;
-                }
-            }
-
             double objectStrain = 0.5; // Add a base strain to all objects
-            objectStrain += speedBonus(taikoCurrent.StartTime - previousMono.StartTime);
-
-            // Consecutive notes exceeding 100 are buffed slowly, capped at 800 objects.
-            if (consecutiveCount >= 200)
-            {
-                objectStrain += 0.00025 * Math.Min(consecutiveCount, 600);
-            }
+            if (previousMono != null) objectStrain += speedBonus(taikoCurrent.StartTime - previousMono.StartTime);
 
             return objectStrain;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
@@ -57,10 +57,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             }
 
             TaikoDifficultyHitObject taikoCurrent = (TaikoDifficultyHitObject)current;
+            TaikoDifficultyHitObject? taikoPrevious = current.Previous(1) as TaikoDifficultyHitObject;
             TaikoDifficultyHitObject? previousMono = taikoCurrent.PreviousMono(availableFingersFor(taikoCurrent) - 1);
 
             double objectStrain = 0.5; // Add a base strain to all objects
-            if (previousMono != null) objectStrain += speedBonus(taikoCurrent.StartTime - previousMono.StartTime);
+            if (taikoPrevious == null) return objectStrain;
+
+            if (previousMono != null)
+                objectStrain += speedBonus(taikoCurrent.StartTime - previousMono.StartTime) + 0.5 * speedBonus(taikoCurrent.StartTime - taikoPrevious.StartTime);
 
             return objectStrain;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             objectStrain += speedBonus(taikoCurrent.StartTime - previousMono.StartTime);
 
             // Consecutive notes exceeding 100 are buffed slowly, capped at 800 objects.
-            if (consecutiveCount >= 100)
+            if (consecutiveCount >= 200)
             {
                 objectStrain += 0.00025 * Math.Min(consecutiveCount, 600);
             }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Rhythm/Data/SamePatterns.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Rhythm/Data/SamePatterns.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm.Data
 
         public TaikoDifficultyHitObject FirstHitObject => Children[0].FirstHitObject;
 
+        public int Total => Children.Sum(x => x.Children.Count);
+
         public IEnumerable<TaikoDifficultyHitObject> AllHitObjects => Children.SelectMany(child => child.Children);
 
         private SamePatterns(SamePatterns? previous, List<SameRhythmHitObjects> data, ref int i)

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -3,6 +3,7 @@
 
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Difficulty.Evaluators;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
@@ -34,6 +35,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             }
 
             var taikoObject = (TaikoDifficultyHitObject)current;
+            int index = taikoObject.Colour.MonoStreak?.HitObjects.IndexOf(taikoObject) ?? 0;
+
+            currentStrain *= DifficultyCalculationUtils.Logistic(index, 4, -1 / 25.0, 0.5) + 0.5;
 
             currentStrain *= StrainDecayBase;
             currentStrain += ReadingEvaluator.EvaluateDifficultyOf(taikoObject) * SkillMultiplier;

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -44,10 +44,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             var currentObject = current as TaikoDifficultyHitObject;
             int index = currentObject?.Colour.MonoStreak?.HitObjects.IndexOf(currentObject) ?? 0;
 
-            if (singleColourStamina)
-                return currentStrain / (1 + Math.Exp(-(index - 10) / 2.0));
+            double monolengthBonus = 1 + Math.Min(Math.Max((index - 5) / 20.0, 0), 0.30);
 
-            return currentStrain;
+            if (singleColourStamina)
+                return (currentStrain) / (1 + Math.Exp(-(index - 10) / 2.0));
+
+            return currentStrain * monolengthBonus;
         }
 
         protected override double CalculateInitialStrain(double time, DifficultyHitObject current) => singleColourStamina ? 0 : currentStrain * strainDecay(time - current.Previous(0).StartTime);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             var currentObject = current as TaikoDifficultyHitObject;
             int index = currentObject?.Colour.MonoStreak?.HitObjects.IndexOf(currentObject) ?? 0;
 
-            double monolengthBonus = 1 + Math.Min(Math.Max((index - 5) / 20.0, 0), 0.30);
+            double monolengthBonus = 1 + Math.Min(Math.Max((index - 5) / 50.0, 0), 0.30);
 
             if (singleColourStamina)
                 return (currentStrain) / (1 + Math.Exp(-(index - 10) / 2.0));

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -40,8 +40,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("mono_stamina_factor")]
         public double MonoStaminaFactor { get; set; }
 
-        [JsonProperty("reading_difficult_strains")]
-        public double ReadingTopStrains { get; set; }
+        [JsonProperty("rhythm_difficult_strains")]
+        public double RhythmTopStrains { get; set; }
 
         [JsonProperty("colour_difficult_strains")]
         public double ColourTopStrains { get; set; }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -118,12 +118,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);
 
             double colourDifficultStrains = colour.CountTopWeightedStrains();
-            double rhythmDifficultStrains = rhythm.CountTopWeightedStrains();
+            double rhythmDifficultStrains = rhythm.CountTopWeightedStrains() * Math.Max((rhythmRating - 4.0) / 0.5 * 2, 1);
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
             strainLengthBonus = 1
                 + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15) + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05)
-                + Math.Min(Math.Max((rhythmDifficultStrains - 150) / 50, 0), 0.15) - Math.Min(Math.Max((55 - rhythmDifficultStrains) / 45, 0), 0.10);
+                + Math.Min(Math.Max((rhythmRating - 4.25) / 0.75, 0), 0.15) - Math.Min(Math.Max((55 - rhythmDifficultStrains) / 45, 0), 0.10);
 
             double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax);
             double starRating = rescale(combinedRating * 1.4);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
     public class TaikoDifficultyCalculator : DifficultyCalculator
     {
         private const double difficulty_multiplier = 0.084375;
-        private double rhythm_skill_multiplier = 0.65 * difficulty_multiplier;
+        private const double rhythm_skill_multiplier = 0.65 * difficulty_multiplier;
         private const double reading_skill_multiplier = 0.100 * difficulty_multiplier;
         private const double colour_skill_multiplier = 0.375 * difficulty_multiplier;
         private const double stamina_skill_multiplier = 0.445 * difficulty_multiplier;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);
 
             double colourDifficultStrains = colour.CountTopWeightedStrains();
-            double rhythmDifficultStrains = rhythm.CountTopWeightedStrains() * Math.Max((rhythmRating - 4.0) / 0.5 * 2, 1);
+            double rhythmDifficultStrains = rhythm.CountTopWeightedStrains();
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
             strainLengthBonus = 1
@@ -218,11 +218,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         {
             if (sr < 0) return sr;
 
-            double midrange = 10.43 * Math.Log(sr / 8 + 1);
-            double toprange = 11.6 + Math.Log(Math.Max(midrange - 11, 1));
-            double range = Math.Min(midrange, toprange);
-
-            return range;
+            return 10.43 * Math.Log(sr / 8 + 1);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -122,8 +122,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
             strainLengthBonus = 1
-                + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15) + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05)
-                + Math.Min(Math.Max((rhythmRating - 4.25) / 0.75, 0), 0.15) - Math.Min(Math.Max((65 - rhythmDifficultStrains) / 25, 0), 0.10);
+                                + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15) + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05)
+                                + Math.Min(Math.Max((rhythmRating - 4.25) / 0.75, 0), 0.15);
 
             double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax);
             double starRating = rescale(combinedRating * 1.4);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             strainLengthBonus = 1
                 + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15) + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05)
-                + Math.Min(Math.Max((rhythmRating - 4.25) / 0.75, 0), 0.15) - Math.Min(Math.Max((55 - rhythmDifficultStrains) / 45, 0), 0.10);
+                + Math.Min(Math.Max((rhythmRating - 4.25) / 0.75, 0), 0.15) - Math.Min(Math.Max((65 - rhythmDifficultStrains) / 25, 0), 0.10);
 
             double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax);
             double starRating = rescale(combinedRating * 1.4);
@@ -218,14 +218,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         {
             if (sr < 0) return sr;
 
-            // Base rescaling formula
-            double scaled = 10.43 * Math.Log(sr / 8 + 1);
+            double midrange = 10.43 * Math.Log(sr / 8 + 1);
+            double toprange = 11.6 + Math.Log(Math.Max(midrange - 11, 1));
+            double range = Math.Min(midrange, toprange);
 
-            // Apply tightened spread for star ratings 15+
-            double adjusted = 11.6 + Math.Log(Math.Max(scaled - 11, 1));
-            scaled = Math.Min(scaled, adjusted);
-
-            return scaled;
+            return range;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private const double stamina_skill_multiplier = 0.445 * difficulty_multiplier;
 
         private double strainLengthBonus;
+        
+        private double rhythmScale;
 
         public override int Version => 20241007;
 
@@ -121,6 +123,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double rhythmDifficultStrains = rhythm.CountTopWeightedStrains();
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
+            rhythmScale = Math.Pow(staminaRating * colourRating, 0.28);
+
             strainLengthBonus = 1
                                 + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15)
                                 + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05);
@@ -179,7 +183,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             for (int i = 0; i < colourPeaks.Count; i++)
             {
-                double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier * strainLengthBonus;
+                double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier * strainLengthBonus * rhythmScale;
                 double readingPeak = readingPeaks[i] * reading_skill_multiplier;
                 double colourPeak = colourPeaks[i] * colour_skill_multiplier;
                 double staminaPeak = staminaPeaks[i] * stamina_skill_multiplier * strainLengthBonus;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
     public class TaikoDifficultyCalculator : DifficultyCalculator
     {
         private const double difficulty_multiplier = 0.084375;
-        private double rhythm_skill_multiplier = 1.70 * difficulty_multiplier;
+        private double rhythm_skill_multiplier = 0.5 * difficulty_multiplier;
         private const double reading_skill_multiplier = 0.100 * difficulty_multiplier;
         private const double colour_skill_multiplier = 0.375 * difficulty_multiplier;
         private const double stamina_skill_multiplier = 0.445 * difficulty_multiplier;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
     public class TaikoDifficultyCalculator : DifficultyCalculator
     {
         private const double difficulty_multiplier = 0.084375;
-        private const double rhythm_skill_multiplier = 1.40 * difficulty_multiplier;
+        private double rhythm_skill_multiplier = 1.63 * difficulty_multiplier;
         private const double reading_skill_multiplier = 0.100 * difficulty_multiplier;
         private const double colour_skill_multiplier = 0.375 * difficulty_multiplier;
         private const double stamina_skill_multiplier = 0.425 * difficulty_multiplier;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
     public class TaikoDifficultyCalculator : DifficultyCalculator
     {
         private const double difficulty_multiplier = 0.084375;
-        private double rhythm_skill_multiplier = 0.5 * difficulty_multiplier;
+        private double rhythm_skill_multiplier = 0.65 * difficulty_multiplier;
         private const double reading_skill_multiplier = 0.100 * difficulty_multiplier;
         private const double colour_skill_multiplier = 0.375 * difficulty_multiplier;
         private const double stamina_skill_multiplier = 0.445 * difficulty_multiplier;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -24,10 +24,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
     public class TaikoDifficultyCalculator : DifficultyCalculator
     {
         private const double difficulty_multiplier = 0.084375;
-        private double rhythm_skill_multiplier = 1.63 * difficulty_multiplier;
+        private double rhythm_skill_multiplier = 1.70 * difficulty_multiplier;
         private const double reading_skill_multiplier = 0.100 * difficulty_multiplier;
         private const double colour_skill_multiplier = 0.375 * difficulty_multiplier;
-        private const double stamina_skill_multiplier = 0.425 * difficulty_multiplier;
+        private const double stamina_skill_multiplier = 0.445 * difficulty_multiplier;
 
         private double strainLengthBonus;
 
@@ -122,8 +122,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
             strainLengthBonus = 1
-                + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 7500, 0), 0.07) + Math.Min(Math.Max((staminaRating - 8.0) / 1.0, 0), 0.05)
-                + Math.Min(Math.Max((rhythmDifficultStrains - 140) / 30, 0), 0.075) - Math.Min(Math.Max((55 - rhythmDifficultStrains) / 45, 0), 0.10);
+                + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15) + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05)
+                + Math.Min(Math.Max((rhythmDifficultStrains - 150) / 50, 0), 0.15) - Math.Min(Math.Max((55 - rhythmDifficultStrains) / 45, 0), 0.10);
 
             double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax);
             double starRating = rescale(combinedRating * 1.4);
@@ -211,14 +211,21 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         }
 
         /// <summary>
-        /// Applies a final re-scaling of the star rating.
+        /// Applies a final re-scaling of the star rating with tightened spread for star ratings 15 and above.
         /// </summary>
         /// <param name="sr">The raw star rating value before re-scaling.</param>
         private double rescale(double sr)
         {
             if (sr < 0) return sr;
 
-            return 10.43 * Math.Log(sr / 8 + 1);
+            // Base rescaling formula
+            double scaled = 10.43 * Math.Log(sr / 8 + 1);
+
+            // Apply tightened spread for star ratings 15+
+            double adjusted = 11.6 + Math.Log(Math.Max(scaled - 11, 1));
+            scaled = Math.Min(scaled, adjusted);
+
+            return scaled;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -122,8 +122,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
             strainLengthBonus = 1
-                                + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15) + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05)
-                                + Math.Min(Math.Max((rhythmRating - 4.25) / 0.75, 0), 0.15);
+                                + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15)
+                                + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05);
 
             double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax);
             double starRating = rescale(combinedRating * 1.4);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double baseDifficulty = 5 * Math.Max(1.0, attributes.StarRating / 0.110) - 4.0;
             double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1250.0);
 
-            difficultyValue *= 1 + 0.20 * Math.Max(0, attributes.StarRating - 10);
+            difficultyValue *= 1 + 0.10 * Math.Max(0, attributes.StarRating - 10);
 
             double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
             difficultyValue *= lengthBonus;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -74,7 +74,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
         {
             double baseDifficulty = 5 * Math.Max(1.0, attributes.StarRating / 0.115) - 4.0;
-            double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1150.0);
+            double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1200.0);
+
+            difficultyValue *= 1 + 0.20 * Math.Max(0, attributes.StarRating - 10);
 
             double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
             difficultyValue *= lengthBonus;
@@ -95,7 +97,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             // Scale accuracy more harshly on nearly-completely mono (single coloured) speed maps.
             double accScalingExponent = 2 + attributes.MonoStaminaFactor;
-            double accScalingShift = 400 - 100 * attributes.MonoStaminaFactor;
+            double accScalingShift = 500 - 100 * attributes.MonoStaminaFactor;
 
             return difficultyValue * Math.Pow(SpecialFunctions.Erf(accScalingShift / (Math.Sqrt(2) * estimatedUnstableRate.Value)), accScalingExponent);
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
         {
             double baseDifficulty = 5 * Math.Max(1.0, attributes.StarRating / 0.110) - 4.0;
-            double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1200.0);
+            double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1450.0);
 
             difficultyValue *= 1 + 0.20 * Math.Max(0, attributes.StarRating - 10);
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
         {
             double baseDifficulty = 5 * Math.Max(1.0, attributes.StarRating / 0.110) - 4.0;
-            double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1450.0);
+            double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1250.0);
 
             difficultyValue *= 1 + 0.20 * Math.Max(0, attributes.StarRating - 10);
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
         {
-            double baseDifficulty = 5 * Math.Max(1.0, attributes.StarRating / 0.115) - 4.0;
+            double baseDifficulty = 5 * Math.Max(1.0, attributes.StarRating / 0.110) - 4.0;
             double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1200.0);
 
             difficultyValue *= 1 + 0.20 * Math.Max(0, attributes.StarRating - 10);


### PR DESCRIPTION
Note density refers to how close a note object is to the previous note object, relative to the spacing of base SV 1/4 notes. Pictured below is notes at 1.0 density (top), 0.667 density (middle) and 0.9 with 1.35 mixed in (bottom).

![screenshot473](https://github.com/user-attachments/assets/1660d276-5873-435c-9193-226f568a2f98)

High velocity notes are generally agreed to be easier to read at higher density than lower, making the reading difficulty awarded by some maps with DT unreasonably high. These changes penalise the reading difficulty of high velocity notes at higher densities according to this curve: https://www.desmos.com/calculator/u63f3ntdsi

Some notable SR changes:
XHRONOXAPSULE [HEAVENLY] +DT: 11.42 -> 11.28
Kyouki Chinden [The End] +DT: 11.54 -> 11.42
This Little Girl (Nightcore Amen Edit) [Murder Oni] +DT: 10.81 -> 10.70
No change to SR +HR on any of these maps

The only file changed is Difficulty/Evaluators/ReadingEvaluator.cs