### PR TITLE
Penalise the reading difficulty of high velocity notes using "note density"

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// to be spaced equally to a base SV 1/4 note
 			double expectedDeltaTime = 21000.0 / effectiveBPM;
 
+			var highVelocity = new VelocityRange(480, 640);
 			var midVelocity = new VelocityRange(360, 480);
-            var highVelocity = new VelocityRange(480, 640);
 			
 			double midVelocityDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -32,25 +32,24 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <returns>The reading difficulty value for the given hit object.</returns>
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
+            var highVelocity = new VelocityRange(480, 640);
+            var midVelocity = new VelocityRange(360, 480);
+
+            // Apply a cap to prevent outlier values on maps that exceed the editor's parameters.
             double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
-			// Expected deltatime is the deltatime this note would need
-			// to be spaced equally to a base SV 1/4 note
-			double expectedDeltaTime = 21000.0 / effectiveBPM;
 
-			var highVelocity = new VelocityRange(480, 640);
-			var midVelocity = new VelocityRange(360, 480);
-			
-			double midVelocityDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+            double midVelocityDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-			// Density refers to an object's deltatime relative to its expected deltatime
-			double objectDensity = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
-			
-			// High density is penalised at high velocity as it is generally considered easier to read
-			// https://www.desmos.com/calculator/u63f3ntdsi
-			double densityPenalty = DifficultyCalculationUtils.Logistic(objectDensity, 0.925, 15);
-			
-			double highVelocityDifficulty = (1.0 - 0.33 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center + 8 * densityPenalty, (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10));
-			
+            // Expected DeltaTime is the DeltaTime this note would need to be spaced equally to a base slider velocity 1/4 note.
+            double expectedDeltaTime = 21000.0 / effectiveBPM;
+            double objectDensity = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
+
+            // High density is penalised at high velocity as it is generally considered easier to read. See https://www.desmos.com/calculator/u63f3ntdsi
+            double densityPenalty = DifficultyCalculationUtils.Logistic(objectDensity, 0.925, 15);
+
+            double highVelocityDifficulty = (1.0 - 0.33 * densityPenalty) * DifficultyCalculationUtils.Logistic
+                (effectiveBPM, highVelocity.Center + 8 * densityPenalty, (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10));
+
             return midVelocityDifficulty + highVelocityDifficulty;
         }
     }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -31,13 +31,28 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <returns>The reading difficulty value for the given hit object.</returns>
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
-            double effectiveBPM = noteObject.EffectiveBPM;
+            double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
+			// Expected deltatime is the deltatime this note would need
+			// to be spaced equally to a base SV 1/4 note
+			double expectedDeltaTime = 21000.0 / effectiveBPM;
 
+			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
-            var midVelocity = new VelocityRange(360, 480);
+			
+			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-            return 1.0 * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10))
-                   + 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+			// Density refers to an object's deltatime relative to its expected deltatime
+			double density = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
+			
+			// Dense notes are penalised at high velocities
+			// https://www.desmos.com/calculator/u63f3ntdsi
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
+			
+			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
+			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);
+			double highVelDifficulty = (1.0 - 0.33 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, midpointOffset, multiplier);
+			
+            return midVelDifficulty + highVelDifficulty;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// Density refers to an object's deltatime relative to its expected deltatime
 			double objectDensity = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
 			
-			// Dense notes are penalised at high velocities
+			// High density is penalised at high velocity as it is generally considered easier to read
 			// https://www.desmos.com/calculator/u63f3ntdsi
 			double densityPenalty = DifficultyCalculationUtils.Logistic(objectDensity, 0.925, 15);
 			

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -40,20 +40,18 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
 			
-			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+			double midVelocityDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
 			// Density refers to an object's deltatime relative to its expected deltatime
-			double density = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
+			double objectDensity = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
 			
 			// Dense notes are penalised at high velocities
 			// https://www.desmos.com/calculator/u63f3ntdsi
-			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
+			double densityPenalty = DifficultyCalculationUtils.Logistic(objectDensity, 0.925, 15);
 			
-			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
-			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);
-			double highVelDifficulty = (1.0 - 0.33 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, midpointOffset, multiplier);
+			double highVelocityDifficulty = (1.0 - 0.33 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center + 8 * densityPenalty, (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10));
 			
-            return midVelDifficulty + highVelDifficulty;
+            return midVelocityDifficulty + highVelocityDifficulty;
         }
     }
 }


### PR DESCRIPTION
Note density refers to how close a note object is to the previous note object, relative to the spacing of base SV 1/4 notes. Pictured below is notes at 1.0 density (top), 0.667 density (middle) and 0.9 with 1.35 mixed in (bottom).

![screenshot473](https://github.com/user-attachments/assets/1660d276-5873-435c-9193-226f568a2f98)

High velocity notes are generally agreed to be easier to read at higher density than lower, making the reading difficulty awarded by some maps with DT unreasonably high. These changes penalise the reading difficulty of high velocity notes at higher densities according to this curve: https://www.desmos.com/calculator/u63f3ntdsi

Some notable SR changes:
XHRONOXAPSULE [HEAVENLY] +DT: 10.36 -> 10.11
Kyouki Chinden [The End] +DT: 10.59 -> 10.37
This Little Girl (Nightcore Amen Edit) [Murder Oni] +DT: 9.87 -> 9.69
No change to SR +HR on any of these maps