### PR TITLE
Fix spinners not increasing cumulative strain time in flashlight diffcalc

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -52,11 +52,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 var currentObj = (OsuDifficultyHitObject)current.Previous(i);
                 var currentHitObject = (OsuHitObject)(currentObj.BaseObject);
 
+                cumulativeStrainTime += lastObj.StrainTime;
+
                 if (!(currentObj.BaseObject is Spinner))
                 {
                     double jumpDistance = (osuHitObject.StackedPosition - currentHitObject.StackedEndPosition).Length;
-
-                    cumulativeStrainTime += lastObj.StrainTime;
 
                     // We want to nerf objects that can be easily seen within the Flashlight circle radius.
                     if (i == 0)


### PR DESCRIPTION
This fix is also included as part of #28278, however due to review contraints, this is made so that this simple fix can definitely be included in the next deploy.