### PR TITLE
Fix gameplay offset adjustment limits not being enforced

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -318,6 +318,82 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestOffsetAdjustDuringPause()
+        {
+            Player player = null;
+
+            Screens.Select.SongSelect songSelect = null;
+            PushAndConfirm(() => songSelect = new TestPlaySongSelect());
+            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("set mods", () => Game.SelectedMods.Value = new Mod[] { new OsuModNoFail() });
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("wait for player", () =>
+            {
+                DismissAnyNotifications();
+                player = Game.ScreenStack.CurrentScreen as Player;
+                return player?.IsLoaded == true;
+            });
+
+            AddUntilStep("wait for track playing", () => Game.Beatmap.Value.Track.IsRunning);
+            checkOffset(0);
+
+            AddStep("adjust offset via keyboard", () => InputManager.Key(Key.Minus));
+            checkOffset(-1);
+
+            AddStep("pause", () => player.ChildrenOfType<GameplayClockContainer>().First().Stop());
+            AddUntilStep("wait for pause", () => player.ChildrenOfType<GameplayClockContainer>().First().IsPaused.Value, () => Is.True);
+            AddStep("attempt adjust offset via keyboard", () => InputManager.Key(Key.Minus));
+            checkOffset(-1);
+
+            void checkOffset(double offset) => AddUntilStep($"offset is {offset}", () => Game.BeatmapManager.QueryBeatmap(b => b.ID == Game.Beatmap.Value.BeatmapInfo.ID)!.UserSettings.Offset,
+                () => Is.EqualTo(offset));
+        }
+
+        [Test]
+        public void TestOffsetAdjustDuringGameplay()
+        {
+            Player player = null;
+
+            Screens.Select.SongSelect songSelect = null;
+            PushAndConfirm(() => songSelect = new TestPlaySongSelect());
+            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadOszIntoOsu(Game).WaitSafely());
+
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("set mods", () => Game.SelectedMods.Value = new Mod[] { new OsuModNoFail() });
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("wait for player", () =>
+            {
+                DismissAnyNotifications();
+                player = Game.ScreenStack.CurrentScreen as Player;
+                return player?.IsLoaded == true;
+            });
+
+            AddUntilStep("wait for track playing", () => Game.Beatmap.Value.Track.IsRunning);
+            checkOffset(0);
+
+            AddStep("adjust offset via keyboard", () => InputManager.Key(Key.Minus));
+            checkOffset(-1);
+
+            AddStep("seek beyond 10 seconds", () => player.ChildrenOfType<GameplayClockContainer>().First().Seek(10500));
+            AddUntilStep("wait for seek", () => player.ChildrenOfType<GameplayClockContainer>().First().CurrentTime, () => Is.GreaterThan(10600));
+            AddStep("attempt adjust offset via keyboard", () => InputManager.Key(Key.Minus));
+            checkOffset(-1);
+
+            void checkOffset(double offset) => AddUntilStep($"offset is {offset}", () => Game.BeatmapManager.QueryBeatmap(b => b.ID == Game.Beatmap.Value.BeatmapInfo.ID)!.UserSettings.Offset,
+                () => Is.EqualTo(offset));
+        }
+
+        [Test]
         public void TestRetryCountIncrements()
         {
             Player player = null;

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -41,6 +41,7 @@ using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
@@ -351,8 +352,13 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("attempt adjust offset via keyboard", () => InputManager.Key(Key.Minus));
             checkOffset(-1);
 
-            void checkOffset(double offset) => AddUntilStep($"offset is {offset}", () => Game.BeatmapManager.QueryBeatmap(b => b.ID == Game.Beatmap.Value.BeatmapInfo.ID)!.UserSettings.Offset,
-                () => Is.EqualTo(offset));
+            void checkOffset(double offset)
+            {
+                AddUntilStep($"control offset is {offset}", () => this.ChildrenOfType<GameplayOffsetControl>().Single().ChildrenOfType<BeatmapOffsetControl>().Single().Current.Value,
+                    () => Is.EqualTo(offset));
+                AddUntilStep($"database offset is {offset}", () => Game.BeatmapManager.QueryBeatmap(b => b.ID == Game.Beatmap.Value.BeatmapInfo.ID)!.UserSettings.Offset,
+                    () => Is.EqualTo(offset));
+            }
         }
 
         [Test]
@@ -389,8 +395,13 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("attempt adjust offset via keyboard", () => InputManager.Key(Key.Minus));
             checkOffset(-1);
 
-            void checkOffset(double offset) => AddUntilStep($"offset is {offset}", () => Game.BeatmapManager.QueryBeatmap(b => b.ID == Game.Beatmap.Value.BeatmapInfo.ID)!.UserSettings.Offset,
-                () => Is.EqualTo(offset));
+            void checkOffset(double offset)
+            {
+                AddUntilStep($"control offset is {offset}", () => this.ChildrenOfType<GameplayOffsetControl>().Single().ChildrenOfType<BeatmapOffsetControl>().Single().Current.Value,
+                    () => Is.EqualTo(offset));
+                AddUntilStep($"database offset is {offset}", () => Game.BeatmapManager.QueryBeatmap(b => b.ID == Game.Beatmap.Value.BeatmapInfo.ID)!.UserSettings.Offset,
+                    () => Is.EqualTo(offset));
+            }
         }
 
         [Test]

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -322,6 +322,7 @@ namespace osu.Game.Screens.Play
             }
 
             dependencies.CacheAs(DrawableRuleset.FrameStableClock);
+            dependencies.CacheAs<IGameplayClock>(DrawableRuleset.FrameStableClock);
 
             // add the overlay components as a separate step as they proxy some elements from the above underlay/gameplay components.
             // also give the overlays the ruleset skin provider to allow rulesets to potentially override HUD elements (used to disable combo counters etc.)


### PR DESCRIPTION
An incorrect DI type lookup meant the limitations were never being applied. I've added test coverage for these and they should now be working.

I change the flow through which the limitations were applied to account for the control potentially being visible (where the user could adjust the slider bar). Now that the bindable is disabled, this would also not work during the disallowed scenarios.