### PR TITLE
Bump NVika tool to 4.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "nvika": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "commands": [
         "nvika"
       ]


### PR DESCRIPTION
Code quality CI runs have suddenly started failing out of nowhere:

- Passing run: https://github.com/ppy/osu/actions/runs/12806242929/job/35704267944#step:10:1
- Failing run: https://github.com/ppy/osu/actions/runs/12807108792/job/35707131634#step:10:1

In classic github fashion, they began rolling out another runner change wherein `ubuntu-latest` has started meaning `ubuntu-24.04` rather than `ubuntu-22.04`. `ubuntu-24.04` no longer has .NET 6 bundled.

Therefore, upgrade NVika to 4.0.0 because that version is compatible with .NET 8.

See https://github.com/bdach/osu/actions/runs/12808006553/job/35709785355#step:10:1 for proof that this does anything.