### PR TITLE
Refactor absolute scrolling at song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         private OsuTextFlowContainer stats = null!;
         private BeatmapCarousel carousel = null!;
 
-        private OsuScrollContainer scroll => carousel.ChildrenOfType<OsuScrollContainer>().Single();
+        private OsuScrollContainer<Drawable> scroll => carousel.ChildrenOfType<OsuScrollContainer<Drawable>>().Single();
 
         private int beatmapCount;
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -170,8 +170,6 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ScreenshotFormat, ScreenshotFormat.Jpg);
             SetDefault(OsuSetting.ScreenshotCaptureMenuCursor, false);
 
-            SetDefault(OsuSetting.SongSelectRightMouseScroll, false);
-
             SetDefault(OsuSetting.Scaling, ScalingMode.Off);
             SetDefault(OsuSetting.SafeAreaConsiderations, true);
             SetDefault(OsuSetting.ScalingBackgroundDim, 0.9f, 0.5f, 1f, 0.01f);
@@ -401,7 +399,6 @@ namespace osu.Game.Configuration
         Skin,
         ScreenshotFormat,
         ScreenshotCaptureMenuCursor,
-        SongSelectRightMouseScroll,
         BeatmapSkins,
         BeatmapColours,
         BeatmapHitsounds,

--- a/osu.Game/Graphics/Containers/OsuScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuScrollContainer.cs
@@ -26,25 +26,11 @@ namespace osu.Game.Graphics.Containers
         }
     }
 
-    public partial class OsuScrollContainer<T> : ScrollContainer<T> where T : Drawable
+    public partial class OsuScrollContainer<T> : ScrollContainer<T>
+        where T : Drawable
     {
         public const float SCROLL_BAR_WIDTH = 10;
         public const float SCROLL_BAR_PADDING = 3;
-
-        /// <summary>
-        /// Allows controlling the scroll bar from any position in the container using the right mouse button.
-        /// Uses the value of <see cref="DistanceDecayOnRightMouseScrollbar"/> to smoothly scroll to the dragged location.
-        /// </summary>
-        public bool RightMouseScrollbar;
-
-        /// <summary>
-        /// Controls the rate with which the target position is approached when performing a relative drag. Default is 0.02.
-        /// </summary>
-        public double DistanceDecayOnRightMouseScrollbar = 0.02;
-
-        private bool rightMouseDragging;
-
-        protected override bool IsDragging => base.IsDragging || rightMouseDragging;
 
         public OsuScrollContainer(Direction scrollDirection = Direction.Vertical)
             : base(scrollDirection)
@@ -71,50 +57,6 @@ namespace osu.Game.Graphics.Containers
                 ScrollTo(maxPos - DisplayableContent + extraScroll, animated);
         }
 
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            if (shouldPerformRightMouseScroll(e))
-            {
-                ScrollFromMouseEvent(e);
-                return true;
-            }
-
-            return base.OnMouseDown(e);
-        }
-
-        protected override void OnDrag(DragEvent e)
-        {
-            if (rightMouseDragging)
-            {
-                ScrollFromMouseEvent(e);
-                return;
-            }
-
-            base.OnDrag(e);
-        }
-
-        protected override bool OnDragStart(DragStartEvent e)
-        {
-            if (shouldPerformRightMouseScroll(e))
-            {
-                rightMouseDragging = true;
-                return true;
-            }
-
-            return base.OnDragStart(e);
-        }
-
-        protected override void OnDragEnd(DragEndEvent e)
-        {
-            if (rightMouseDragging)
-            {
-                rightMouseDragging = false;
-                return;
-            }
-
-            base.OnDragEnd(e);
-        }
-
         protected override bool OnScroll(ScrollEvent e)
         {
             // allow for controlling volume when alt is held.
@@ -124,15 +66,22 @@ namespace osu.Game.Graphics.Containers
             return base.OnScroll(e);
         }
 
-        protected virtual void ScrollFromMouseEvent(MouseEvent e)
+        #region Absolute scrolling
+
+        /// <summary>
+        /// Controls the rate with which the target position is approached when performing a relative drag. Default is 0.02.
+        /// </summary>
+        public double DistanceDecayOnAbsoluteScroll = 0.02;
+
+        protected virtual void ScrollToAbsolutePosition(Vector2 screenSpacePosition)
         {
-            float fromScrollbarPosition = FromScrollbarPosition(ToLocalSpace(e.ScreenSpaceMousePosition)[ScrollDim]);
+            float fromScrollbarPosition = FromScrollbarPosition(ToLocalSpace(screenSpacePosition)[ScrollDim]);
             float scrollbarCentreOffset = FromScrollbarPosition(Scrollbar.DrawHeight) * 0.5f;
 
-            ScrollTo(Clamp(fromScrollbarPosition - scrollbarCentreOffset), true, DistanceDecayOnRightMouseScrollbar);
+            ScrollTo(Clamp(fromScrollbarPosition - scrollbarCentreOffset), true, DistanceDecayOnAbsoluteScroll);
         }
 
-        private bool shouldPerformRightMouseScroll(MouseButtonEvent e) => RightMouseScrollbar && e.Button == MouseButton.Right;
+        #endregion
 
         protected override ScrollbarContainer CreateScrollbar(Direction direction) => new OsuScrollbar(direction);
 

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Input.Events;
+using osuTK;
 
 namespace osu.Game.Graphics.Containers
 {
@@ -47,10 +47,10 @@ namespace osu.Game.Graphics.Containers
             base.ScrollIntoView(target, animated);
         }
 
-        protected override void ScrollFromMouseEvent(MouseEvent e)
+        protected override void ScrollToAbsolutePosition(Vector2 screenSpacePosition)
         {
             UserScrolling = true;
-            base.ScrollFromMouseEvent(e);
+            base.ScrollToAbsolutePosition(screenSpacePosition);
         }
 
         public new void ScrollTo(double value, bool animated = true, double? distanceDecay = null)

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -204,6 +204,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.BackSpace, GlobalAction.DeselectAllMods),
             new KeyBinding(new[] { InputKey.Control, InputKey.Up }, GlobalAction.IncreaseModSpeed),
             new KeyBinding(new[] { InputKey.Control, InputKey.Down }, GlobalAction.DecreaseModSpeed),
+            new KeyBinding(new[] { InputKey.MouseRight }, GlobalAction.AbsoluteScrollSongList),
         };
 
         private static IEnumerable<KeyBinding> audioControlKeyBindings => new[]
@@ -490,6 +491,9 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorSeekToNextBookmark))]
         EditorSeekToNextBookmark,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.AbsoluteScrollSongList))]
+        AbsoluteScrollSongList
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -449,6 +449,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditorSeekToNextBookmark => new TranslatableString(getKey(@"editor_seek_to_next_bookmark"), @"Seek to next bookmark");
 
+        /// <summary>
+        /// "Absolute scroll song list"
+        /// </summary>
+        public static LocalisableString AbsoluteScrollSongList => new TranslatableString(getKey(@"absolute_scroll_song_list"), @"Absolute scroll song list");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -21,12 +21,6 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
             {
                 new SettingsCheckbox
                 {
-                    ClassicDefault = true,
-                    LabelText = UserInterfaceStrings.RightMouseScroll,
-                    Current = config.GetBindable<bool>(OsuSetting.SongSelectRightMouseScroll),
-                },
-                new SettingsCheckbox
-                {
                     LabelText = UserInterfaceStrings.ShowConvertedBeatmaps,
                     Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
                 },

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -184,8 +184,6 @@ namespace osu.Game.Screens.Select
         private readonly Cached itemsCache = new Cached();
         private PendingScrollOperation pendingScrollOperation = PendingScrollOperation.None;
 
-        public Bindable<bool> RightClickScrollingEnabled = new Bindable<bool>();
-
         public Bindable<RandomSelectAlgorithm> RandomAlgorithm = new Bindable<RandomSelectAlgorithm>();
         private readonly List<CarouselBeatmapSet> previouslyVisitedRandomSets = new List<CarouselBeatmapSet>();
         private readonly List<CarouselBeatmap> randomSelectedBeatmaps = new List<CarouselBeatmap>();
@@ -210,6 +208,7 @@ namespace osu.Game.Screens.Select
                     setPool,
                     Scroll = new CarouselScrollContainer
                     {
+                        RightMouseScrollbar = true,
                         RelativeSizeAxes = Axes.Both,
                     },
                     noResultsPlaceholder = new NoResultsPlaceholder()
@@ -226,9 +225,6 @@ namespace osu.Game.Screens.Select
             randomSelectSample = audio.Samples.Get(@"SongSelect/select-random");
 
             config.BindWith(OsuSetting.RandomSelectAlgorithm, RandomAlgorithm);
-            config.BindWith(OsuSetting.SongSelectRightMouseScroll, RightClickScrollingEnabled);
-
-            RightClickScrollingEnabled.BindValueChanged(enabled => Scroll.RightMouseScrollbar = enabled.NewValue, true);
 
             detachedBeatmapSets = beatmaps.GetBeatmapSets(cancellationToken);
             detachedBeatmapSets.BindCollectionChanged(beatmapSetsChanged);

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -121,6 +121,7 @@ namespace osu.Game.Screens.SelectV2
                 },
                 scroll = new CarouselScrollContainer
                 {
+                    RightMouseScrollbar = true,
                     RelativeSizeAxes = Axes.Both,
                     Masking = false,
                 }
@@ -390,7 +391,7 @@ namespace osu.Game.Screens.SelectV2
         /// Implementation of scroll container which handles very large vertical lists by internally using <c>double</c> precision
         /// for pre-display Y values.
         /// </summary>
-        private partial class CarouselScrollContainer : OsuScrollContainer
+        private partial class CarouselScrollContainer : UserTrackingScrollContainer
         {
             public readonly Container Panels;
 


### PR DESCRIPTION
This is a bit of a catch-all fix up while implementing this in the new carousel.

- Adds support for absolute scrolling to carousel v2
- User can now choose a custom binding instead of right mouse if you wish
- Removes most of the handling code from `OsuScrollContainer`
- Removes the setting. This can now be disabled by unbinding the key. Note that this changes the default to have it as right mouse button. **This is an intentional change** – I believe this functionality should be on by default as it's beneficial to most users.