### PR TITLE
Seek in replay scaled by replay speed

### DIFF
--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Screens.Play
 
         private readonly bool replayIsFailedScore;
 
+        private PlaybackSettings playbackSettings;
+
         protected override UserActivity InitialActivity => new UserActivity.WatchingReplay(Score.ScoreInfo);
 
         private bool isAutoplayPlayback => GameplayState.Mods.OfType<ModAutoplay>().Any();
@@ -73,7 +75,7 @@ namespace osu.Game.Screens.Play
             if (!LoadedBeatmapSuccessfully)
                 return;
 
-            var playbackSettings = new PlaybackSettings
+            playbackSettings = new PlaybackSettings
             {
                 Depth = float.MaxValue,
                 Expanded = { BindTarget = config.GetBindable<bool>(OsuSetting.ReplayPlaybackControlsExpanded) }
@@ -124,11 +126,11 @@ namespace osu.Game.Screens.Play
                     return true;
 
                 case GlobalAction.SeekReplayBackward:
-                    SeekInDirection(-5);
+                    SeekInDirection(-5 * (float)playbackSettings.UserPlaybackRate.Value);
                     return true;
 
                 case GlobalAction.SeekReplayForward:
-                    SeekInDirection(5);
+                    SeekInDirection(5 * (float)playbackSettings.UserPlaybackRate.Value);
                     return true;
 
                 case GlobalAction.TogglePauseReplay:


### PR DESCRIPTION
### Idea and explication: #31538
> When replay speed is 1.0x, pressing left or right button on keyboard will seek to prev/next 5 seconds.
The idea is to multiply the 5 second by the speed.
For example, when the replay speed is 0.5x, pressing left button will seek to previous 2.5 second.

### Video

https://github.com/user-attachments/assets/e94d416e-c3ab-4b3c-99a3-545bafed6408

