### PR TITLE
Improve convert considerations in osu!taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -14,13 +14,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
-        [TestCase(3.3167800835687551d, 200, "diffcalc-test")]
-        [TestCase(3.3167800835687551d, 200, "diffcalc-test-strong")]
+        [TestCase(3.3056113401782845d, 200, "diffcalc-test")]
+        [TestCase(3.3056113401782845d, 200, "diffcalc-test-strong")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(4.4631326105105122d, 200, "diffcalc-test")]
-        [TestCase(4.4631326105105122d, 200, "diffcalc-test-strong")]
+        [TestCase(4.4473902679506896d, 200, "diffcalc-test")]
+        [TestCase(4.4473902679506896d, 200, "diffcalc-test-strong")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new TaikoModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/StaminaEvaluator.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 return 2;
             }
 
-            return 4;
+            return 8;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         private double strainDecayBase => 0.4;
 
         private readonly bool singleColourStamina;
+        private readonly bool isConvert;
 
         private double currentStrain;
 
@@ -28,10 +29,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         /// </summary>
         /// <param name="mods">Mods for use in skill calculations.</param>
         /// <param name="singleColourStamina">Reads when Stamina is from a single coloured pattern.</param>
-        public Stamina(Mod[] mods, bool singleColourStamina)
+        /// <param name="isConvert">Determines if the currently evaluated beatmap is converted.</param>
+        public Stamina(Mod[] mods, bool singleColourStamina, bool isConvert)
             : base(mods)
         {
             this.singleColourStamina = singleColourStamina;
+            this.isConvert = isConvert;
         }
 
         private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
@@ -45,7 +48,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             var currentObject = current as TaikoDifficultyHitObject;
             int index = currentObject?.Colour.MonoStreak?.HitObjects.IndexOf(currentObject) ?? 0;
 
-            double monolengthBonus = 1 + Math.Min(Math.Max((index - 5) / 50.0, 0), 0.30);
+            double monolengthBonus = isConvert ? 1 : 1 + Math.Min(Math.Max((index - 5) / 50.0, 0), 0.30);
 
             if (singleColourStamina)
                 return DifficultyCalculationUtils.Logistic(-(index - 10) / 2.0, currentStrain);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -124,6 +124,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             double colourDifficultStrains = colour.CountTopWeightedStrains();
             double rhythmDifficultStrains = rhythm.CountTopWeightedStrains();
+            // Due to constraints of strain in cases where difficult strain values don't shift with range changes, we manually apply clockrate.
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
             // As we don't have pattern integration in osu!taiko, we apply the other two skills relative to rhythm.

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             // Scale accuracy more harshly on nearly-completely mono (single coloured) speed maps.
             double accScalingExponent = 2 + attributes.MonoStaminaFactor;
-            double accScalingShift = 500 - 100 * attributes.MonoStaminaFactor;
+            double accScalingShift = 500 - 100 * (attributes.MonoStaminaFactor * 3);
 
             return difficultyValue * Math.Pow(SpecialFunctions.Erf(accScalingShift / (Math.Sqrt(2) * estimatedUnstableRate.Value)), accScalingExponent);
         }


### PR DESCRIPTION
From the moment I had to implement it, blanket nerfing star rating of converts was something I severely disliked.

This change aims to 

- Remove conditional convert nerf to starrating, and focus on what becomes abuseable - stamina.
- Harshen `MonoStaminaFactor`'s accuracy curve, keeping the same performance points for the theoretical limits of stamina (an SS on a map like StrangeProgram)
- Nerf stamina based on the concept that with most high-end converts, finger count gets increased by 150%, thus our considerations for stamina must be nerfed by 150%, as we assume a finger count of 4. 
- Disable the `mono` (single coloured) note buff that's found in stamina, to ensure that `MonoStaminaFactor` behaves correctly.
- Clean up the instances of where stamina and relax share nerfs, and implement them in line.

This will 100% need a sheet, and some absolute scrutinisation of values @ppy/taiko-pp-commitee, I'm not repeating last deploy, and I hope to catch it much sooner if there's issues to be faced.