### PR TITLE
add warning text on team acronym conflict

### DIFF
--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -71,6 +71,8 @@ namespace osu.Game.Tournament.Screens.Editors
             [Resolved]
             private LadderInfo ladderInfo { get; set; } = null!;
 
+            private readonly SettingsTextBox acronymTextBox;
+
             public TeamRow(TournamentTeam team, TournamentScreen parent)
             {
                 Model = team;
@@ -112,7 +114,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 Width = 0.2f,
                                 Current = Model.FullName
                             },
-                            new SettingsTextBox
+                            acronymTextBox = new SettingsTextBox
                             {
                                 LabelText = "Acronym",
                                 Width = 0.2f,
@@ -175,6 +177,28 @@ namespace osu.Game.Tournament.Screens.Editors
                         }
                     },
                 };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Model.Acronym.BindValueChanged(acronym =>
+                {
+                    var matchingTeams = ladderInfo.Teams
+                                                  .Where(t => t.Acronym.Value == acronym.NewValue && t != Model)
+                                                  .ToList();
+
+                    if (matchingTeams.Count > 0)
+                    {
+                        acronymTextBox.SetNoticeText(
+                            $"Acronym '{acronym.NewValue}' is already in use by team{(matchingTeams.Count > 1 ? "s" : "")}:\n"
+                            + $"{string.Join(",\n", matchingTeams)}", true);
+                        return;
+                    }
+
+                    acronymTextBox.ClearNoticeText();
+                }, true);
             }
 
             private partial class LastYearPlacementSlider : RoundedSliderBar<int>

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -185,19 +185,18 @@ namespace osu.Game.Tournament.Screens.Editors
 
                 Model.Acronym.BindValueChanged(acronym =>
                 {
-                    var matchingTeams = ladderInfo.Teams
-                                                  .Where(t => t.Acronym.Value == acronym.NewValue && t != Model)
-                                                  .ToList();
+                    var teamsWithSameAcronym = ladderInfo.Teams
+                                                         .Where(t => t.Acronym.Value == acronym.NewValue && t != Model)
+                                                         .ToList();
 
-                    if (matchingTeams.Count > 0)
+                    if (teamsWithSameAcronym.Count > 0)
                     {
                         acronymTextBox.SetNoticeText(
-                            $"Acronym '{acronym.NewValue}' is already in use by team{(matchingTeams.Count > 1 ? "s" : "")}:\n"
-                            + $"{string.Join(",\n", matchingTeams)}", true);
-                        return;
+                            $"Acronym '{acronym.NewValue}' is already in use by team{(teamsWithSameAcronym.Count > 1 ? "s" : "")}:\n"
+                            + $"{string.Join(",\n", teamsWithSameAcronym)}", true);
                     }
-
-                    acronymTextBox.ClearNoticeText();
+                    else
+                        acronymTextBox.ClearNoticeText();
                 }, true);
             }
 


### PR DESCRIPTION
Team acronyms are used to identify teams in matches in the bracket. When multiple teams share the same acronym, closing and re-opening the lazer tournament client can result in incorrect teams being displayed in the matchups.

This adds some warning text under the team acronym field warning if more than one team share the same acronym.

https://github.com/user-attachments/assets/dea48390-5856-48ef-aebe-58d7bc4a0d51

The alternative would be to not use team acronym as team identifier in matches, but that seemed like more effort.

