### PR TITLE
osu!taiko new rhythm penalty for long intervals using stamina difficulty

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -14,13 +14,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
-        [TestCase(3.3056113401782845d, 200, "diffcalc-test")]
-        [TestCase(3.3056113401782845d, 200, "diffcalc-test-strong")]
+        [TestCase(3.305554470092722d, 200, "diffcalc-test")]
+        [TestCase(3.305554470092722d, 200, "diffcalc-test-strong")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(4.4473902679506896d, 200, "diffcalc-test")]
-        [TestCase(4.4473902679506896d, 200, "diffcalc-test-strong")]
+        [TestCase(4.4472572672057815d, 200, "diffcalc-test")]
+        [TestCase(4.4472572672057815d, 200, "diffcalc-test-strong")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new TaikoModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Rhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Rhythm.cs
@@ -29,8 +29,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         {
             double difficulty = RhythmEvaluator.EvaluateDifficultyOf(current, greatHitWindow);
 
-            // To prevent abuse of exceedingly long intervals between awkward rhythms, we penalise its difficulty.
-            difficulty *= DifficultyCalculationUtils.Logistic(current.DeltaTime, 350, -1 / 25.0, 0.5) + 0.5;
+			// To prevent abuse of exceedingly long intervals between awkward rhythms, we penalise its difficulty.
+			double staminaDifficulty = StaminaEvaluator.EvaluateDifficultyOf(current) - 0.5; // Remove base strain
+			difficulty *= DifficultyCalculationUtils.Logistic(staminaDifficulty, 1 / 15.0, 50.0);
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Rhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Rhythm.cs
@@ -29,9 +29,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         {
             double difficulty = RhythmEvaluator.EvaluateDifficultyOf(current, greatHitWindow);
 
-			// To prevent abuse of exceedingly long intervals between awkward rhythms, we penalise its difficulty.
-			double staminaDifficulty = StaminaEvaluator.EvaluateDifficultyOf(current) - 0.5; // Remove base strain
-			difficulty *= DifficultyCalculationUtils.Logistic(staminaDifficulty, 1 / 15.0, 50.0);
+            // To prevent abuse of exceedingly long intervals between awkward rhythms, we penalise its difficulty.
+            double staminaDifficulty = StaminaEvaluator.EvaluateDifficultyOf(current) - 0.5; // Remove base strain
+            difficulty *= DifficultyCalculationUtils.Logistic(staminaDifficulty, 1 / 15.0, 50.0);
 
             return difficulty;
         }


### PR DESCRIPTION
With the current rhythm penalty for long intervals (using DeltaTime), faster Futsuu and Muzukashii difficulties are avoiding the penalised DeltaTime range and awarding massive rhythm difficulty. These changes replace the penalty with a new one using stamina difficulty rather than DeltaTime, penalising fast easier difficulties more than slow rhythmically difficult maps.

Some notable SR changes:
3471041: 4.12 -> 2.97
3772247: 4.06 -> 3.11
3402527: 3.97 -> 2.54
4591315: 4.14 -> 2.99
4591317 4.74 -> 4.06

Harder maps for comparison:
3671908: 6.84 -> 6.66
2956690: 7.47 -> 7.35
4541868: 7.94 -> 7.85