### PR TITLE
Don't highlight friends' scores under beatmap's friend score leaderboard

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -54,6 +54,7 @@ namespace osu.Game.Online.Leaderboards
 
         private readonly int? rank;
         private readonly bool isOnlineScope;
+        private readonly bool highlightFriend;
 
         private Box background;
         private Container content;
@@ -86,12 +87,13 @@ namespace osu.Game.Online.Leaderboards
         [Resolved]
         private ScoreManager scoreManager { get; set; } = null!;
 
-        public LeaderboardScore(ScoreInfo score, int? rank, bool isOnlineScope = true)
+        public LeaderboardScore(ScoreInfo score, int? rank, bool isOnlineScope = true, bool highlightFriend = true)
         {
             Score = score;
 
             this.rank = rank;
             this.isOnlineScope = isOnlineScope;
+            this.highlightFriend = highlightFriend;
 
             RelativeSizeAxes = Axes.X;
             Height = HEIGHT;
@@ -130,7 +132,7 @@ namespace osu.Game.Online.Leaderboards
                                 background = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = isUserFriend ? colour.Yellow : (user.OnlineID == api.LocalUser.Value.Id && isOnlineScope ? colour.Green : Color4.Black),
+                                    Colour = (highlightFriend && isUserFriend) ? colour.Yellow : (user.OnlineID == api.LocalUser.Value.Id && isOnlineScope ? colour.Green : Color4.Black),
                                     Alpha = background_alpha,
                                 },
                             },

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -169,12 +169,12 @@ namespace osu.Game.Screens.Select.Leaderboards
             return scoreRetrievalRequest = newRequest;
         }
 
-        protected override LeaderboardScore CreateDrawableScore(ScoreInfo model, int index) => new LeaderboardScore(model, index, IsOnlineScope)
+        protected override LeaderboardScore CreateDrawableScore(ScoreInfo model, int index) => new LeaderboardScore(model, index, IsOnlineScope, Scope != BeatmapLeaderboardScope.Friend)
         {
             Action = () => ScoreSelected?.Invoke(model)
         };
 
-        protected override LeaderboardScore CreateDrawableTopScore(ScoreInfo model) => new LeaderboardScore(model, model.Position, false)
+        protected override LeaderboardScore CreateDrawableTopScore(ScoreInfo model) => new LeaderboardScore(model, model.Position, false, Scope != BeatmapLeaderboardScope.Friend)
         {
             Action = () => ScoreSelected?.Invoke(model)
         };


### PR DESCRIPTION
Although the idea to highlight friends' score entries in the leaderboard is good, it means less under the `Friends` leaderboard tab of a beatmap. And too much yellow would make the leaderboard seemingly dirty.

So in this PR I added a specific argument for this condition. When the current filter is set to show friends only, the score's background will remain black.

I think we won't encounter this situation in match leaderboards, since it doesn't have a filter tab (yet?).

| Current Version | In this PR |
| :-: | :-: |
| ![Friend leaderboard in current version](https://github.com/user-attachments/assets/f7654948-ea7c-44b2-993a-5c2bc10ef3e2) | ![This PR's friend leaderboard](https://github.com/user-attachments/assets/bb5b07ea-0ae5-4cfb-a7a9-d7c87865f450) |
