### PR TITLE
Use correct `HitWindows` class for osu!taiko hit windows in difficulty calculator

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                     intervalDifficulty *= DifficultyCalculationUtils.Logistic(
                         durationDifference / hitWindow,
                         midpointOffset: 0.7,
-                        multiplier: 1.5,
+                        multiplier: 1.0,
                         maxValue: 1);
                 }
             }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -64,9 +64,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)
         {
-            var hitWindows = new HitWindows();
-            hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
-
             var difficultyHitObjects = new List<DifficultyHitObject>();
             var centreObjects = new List<TaikoDifficultyHitObject>();
             var rimObjects = new List<TaikoDifficultyHitObject>();

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
         {
-            HitWindows hitWindows = new HitWindows();
+            HitWindows hitWindows = new TaikoHitWindows();
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
 
             return new Skill[]


### PR DESCRIPTION
Caught whilst porting over changes to osu!stable. This causes a noticable difference in the hit windows passed to the `Rhythm` skill as Taiko hit windows are not the same as the default provided in the `HitWindows` class.

Leaving it up to @ppy/taiko-pp-commitee to figure out what this means for their changes, but this is a non-negotiable fix.