### PR TITLE
Don't run tests when doing a CI pass for a PR into `pp-dev` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{matrix.os.fullname}}
+    if: github.event.pull_request.base.ref != 'pp-dev'
     env:
       OSU_EXECUTION_MODE: ${{matrix.threadingMode}}
     strategy:
@@ -97,6 +98,7 @@ jobs:
   build-only-android:
     name: Build only (Android)
     runs-on: windows-latest
+    if: github.event.pull_request.base.ref != 'pp-dev'
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -125,6 +127,7 @@ jobs:
   build-only-ios:
     name: Build only (iOS)
     runs-on: macos-latest
+    if: github.event.pull_request.base.ref != 'pp-dev'
     timeout-minutes: 60
     steps:
       - name: Checkout


### PR DESCRIPTION
The idea is that changes to diffcalc shouldn't ever affect tests (except the diffcalc ones which are useless mid-development anyway), and any changes to `pp-dev` are going to be merged to master and go through CI before that anyway.

Right now CI passes waste a lot of time (like 30 minutes per commit) and are also annoying because **every** diffcalc change requires test adjustments. 