### PR TITLE
Display up to 2 decimal places for bpm in timing screen metronome

### DIFF
--- a/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
@@ -262,10 +262,9 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void updateBpmText()
         {
-            double bpm = Math.Round(interpolatedBpm.Value);
-
-            if (Precision.AlmostEquals(bpm, effectiveBpm, 1.0))
-                bpm = effectiveBpm;
+            double bpm = Precision.AlmostEquals(interpolatedBpm.Value, effectiveBpm, 1.0)
+                ? effectiveBpm
+                : Math.Round(interpolatedBpm.Value);
 
             bpmText.Text = bpm.ToLocalisableString("0.##");
         }

--- a/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
@@ -262,6 +262,8 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void updateBpmText()
         {
+            // While interpolating between two integer values, showing the decimal places would look a bit odd
+            // so rounding is applied until we're close to the final value.
             double bpm = Precision.AlmostEquals(interpolatedBpm.Value, effectiveBpm, 1.0)
                 ? effectiveBpm
                 : Math.Round(interpolatedBpm.Value);


### PR DESCRIPTION
Addresses part of #31263 

Displays the bpm value in the metronome with up to 2 decimal places.
While interpolating, the value will be displayed as an integer, since going between 2 integer bpm values looks kinda jank otherwise. Once the value is within 1 bpm of the target value it will display the final value with up to 2 decimal places.

https://github.com/user-attachments/assets/389024fb-4b76-435c-825d-bdf78978b8a0

For comparison, here's the jankiness that would result from not applying the rounding.

https://github.com/user-attachments/assets/4854d857-cab4-41c6-94da-ecb187d0e578


