### PR TITLE
Snap to beat divisor when pasting hitobjects in editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddAssert("is one object", () => EditorBeatmap.HitObjects.Count == 1);
 
-            AddAssert("new object selected", () => EditorBeatmap.SelectedHitObjects.Single().StartTime == newTime);
+            AddAssert("new object selected", () => EditorBeatmap.SelectedHitObjects.Single().StartTime == EditorBeatmap.SnapTime(newTime, null));
         }
 
         [Test]
@@ -122,6 +122,8 @@ namespace osu.Game.Tests.Visual.Editing
         [TestCase(true)]
         public void TestCopyPaste(bool deselectAfterCopy)
         {
+            const int paste_time = 2000;
+
             var addedObject = new HitCircle { StartTime = 1000 };
 
             AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
@@ -130,7 +132,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("copy hitobject", () => Editor.Copy());
 
-            AddStep("move forward in time", () => EditorClock.Seek(2000));
+            AddStep("move forward in time", () => EditorClock.Seek(paste_time));
 
             if (deselectAfterCopy)
             {
@@ -144,7 +146,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddAssert("are two objects", () => EditorBeatmap.HitObjects.Count == 2);
 
-            AddAssert("new object selected", () => EditorBeatmap.SelectedHitObjects.Single().StartTime == 2000);
+            AddAssert("new object selected", () => EditorBeatmap.SelectedHitObjects.Single().StartTime == EditorBeatmap.SnapTime(paste_time, null));
 
             AddUntilStep("timeline selection box is visible", () => Editor.ChildrenOfType<Timeline>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha > 0);
             AddUntilStep("composer selection box is visible", () => Editor.ChildrenOfType<HitObjectComposer>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha > 0);

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboardSnapping.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboardSnapping.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public partial class TestSceneEditorClipboardSnapping : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        private const double beat_length = 60_000 / 180.0; // 180 bpm
+        private const double timing_point_time = 1500;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
+        {
+            var controlPointInfo = new ControlPointInfo();
+            controlPointInfo.Add(timing_point_time, new TimingControlPoint { BeatLength = beat_length });
+            return new TestBeatmap(ruleset, false)
+            {
+                ControlPointInfo = controlPointInfo
+            };
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        [TestCase(6)]
+        [TestCase(8)]
+        [TestCase(12)]
+        [TestCase(16)]
+        public void TestPasteSnapping(int divisor)
+        {
+            const double paste_time = timing_point_time + 1271; // arbitrary timestamp that doesn't snap to the timing point at any divisor
+
+            var addedObjects = new HitObject[]
+            {
+                new HitCircle { StartTime = 1000 },
+                new HitCircle { StartTime = 1200 },
+            };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));
+            AddStep("select added objects", () => EditorBeatmap.SelectedHitObjects.AddRange(addedObjects));
+            AddStep("copy hitobjects", () => Editor.Copy());
+
+            AddStep($"set beat divisor to 1/{divisor}", () =>
+            {
+                var beatDivisor = (BindableBeatDivisor)Editor.Dependencies.Get(typeof(BindableBeatDivisor));
+                beatDivisor.SetArbitraryDivisor(divisor);
+            });
+
+            AddStep("move forward in time", () => EditorClock.Seek(paste_time));
+            AddAssert("not at snapped time", () => EditorClock.CurrentTime != EditorBeatmap.SnapTime(EditorClock.CurrentTime, null));
+
+            AddStep("paste hitobjects", () => Editor.Paste());
+
+            AddAssert("first object is snapped", () => Precision.AlmostEquals(
+                EditorBeatmap.SelectedHitObjects.MinBy(h => h.StartTime).StartTime,
+                EditorBeatmap.ControlPointInfo.GetClosestSnappedTime(paste_time, divisor)
+            ));
+
+            AddAssert("duration between pasted objects is same", () =>
+            {
+                var firstObject = EditorBeatmap.SelectedHitObjects.MinBy(h => h.StartTime);
+                var secondObject = EditorBeatmap.SelectedHitObjects.MaxBy(h => h.StartTime);
+
+                return Precision.AlmostEquals(secondObject.StartTime - firstObject.StartTime, addedObjects[1].StartTime - addedObjects[0].StartTime);
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboardSnapping.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboardSnapping.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Utils;
@@ -68,14 +66,14 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("paste hitobjects", () => Editor.Paste());
 
             AddAssert("first object is snapped", () => Precision.AlmostEquals(
-                EditorBeatmap.SelectedHitObjects.MinBy(h => h.StartTime).StartTime,
+                EditorBeatmap.SelectedHitObjects.MinBy(h => h.StartTime)!.StartTime,
                 EditorBeatmap.ControlPointInfo.GetClosestSnappedTime(paste_time, divisor)
             ));
 
             AddAssert("duration between pasted objects is same", () =>
             {
-                var firstObject = EditorBeatmap.SelectedHitObjects.MinBy(h => h.StartTime);
-                var secondObject = EditorBeatmap.SelectedHitObjects.MaxBy(h => h.StartTime);
+                var firstObject = EditorBeatmap.SelectedHitObjects.MinBy(h => h.StartTime)!;
+                var secondObject = EditorBeatmap.SelectedHitObjects.MaxBy(h => h.StartTime)!;
 
                 return Precision.AlmostEquals(secondObject.StartTime - firstObject.StartTime, addedObjects[1].StartTime - addedObjects[0].StartTime);
             });

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -31,6 +31,9 @@ namespace osu.Game.Screens.Edit.Compose
         [Resolved]
         private IGameplaySettings globalGameplaySettings { get; set; }
 
+        [Resolved]
+        private IBeatSnapProvider beatSnapProvider { get; set; }
+
         private Bindable<string> clipboard { get; set; }
 
         private HitObjectComposer composer;
@@ -150,7 +153,7 @@ namespace osu.Game.Screens.Edit.Compose
 
             Debug.Assert(objects.Any());
 
-            double timeOffset = clock.CurrentTime - objects.Min(o => o.StartTime);
+            double timeOffset = beatSnapProvider.SnapTime(clock.CurrentTime) - objects.Min(o => o.StartTime);
 
             foreach (var h in objects)
                 h.StartTime += timeOffset;


### PR DESCRIPTION
Addresses part of #31263 

Will snap the first hitobject's time to the current beat divisor when pasting hitobjects.