### PR TITLE
Fix toolbox settings hiding when dragging a slider

### DIFF
--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Layout;
 using osu.Game.Graphics;
@@ -53,6 +54,8 @@ namespace osu.Game.Overlays
         private Box background = null!;
 
         private IconButton expandButton = null!;
+
+        private InputManager inputManager = null!;
 
         /// <summary>
         /// Create a new instance.
@@ -125,6 +128,8 @@ namespace osu.Game.Overlays
         {
             base.LoadComplete();
 
+            inputManager = GetContainingInputManager()!;
+
             Expanded.BindValueChanged(_ => updateExpandedState(true));
             updateExpandedState(false);
 
@@ -172,7 +177,9 @@ namespace osu.Game.Overlays
             // potentially continuing to get processed while content has changed to autosize.
             content.ClearTransforms();
 
-            if (Expanded.Value || IsHovered)
+            bool sliderDraggedInHimself = inputManager.DraggedDrawable.IsRootedAt(this);
+
+            if (Expanded.Value || IsHovered || sliderDraggedInHimself)
             {
                 content.AutoSizeAxes = Axes.Y;
                 content.AutoSizeDuration = animate ? transition_duration : 0;


### PR DESCRIPTION
## Need https://github.com/ppy/osu-framework/pull/6500

### Fix in the beatmap loading screen and in a replay

## Before : 

#### In replay
https://github.com/user-attachments/assets/e76265e5-2e5e-4f6b-9198-f8b1da496b3a

#### In beatmap loading

https://github.com/user-attachments/assets/c9c47fd2-c6aa-4a56-a8f0-b590c0f6d192


## After: 

#### In replay
https://github.com/user-attachments/assets/3b608152-1111-4641-b7c1-3a30dff5d25e

#### In beatmap loading

https://github.com/user-attachments/assets/b569b37d-6fa9-4caf-9e9b-00b8d454b154






