### PR TITLE
Fix beat snap grid being lines not being corectly centered to time

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BeatSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatSnapGrid.cs
@@ -185,9 +185,28 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
             {
-                Origin = Anchor = direction.NewValue == ScrollingDirection.Up
-                    ? Anchor.TopLeft
-                    : Anchor.BottomLeft;
+                switch (direction.NewValue)
+                {
+                    case ScrollingDirection.Up:
+                        Anchor = Anchor.TopLeft;
+                        Origin = Anchor.CentreLeft;
+                        break;
+
+                    case ScrollingDirection.Down:
+                        Anchor = Anchor.BottomLeft;
+                        Origin = Anchor.CentreLeft;
+                        break;
+
+                    case ScrollingDirection.Left:
+                        Anchor = Anchor.TopLeft;
+                        Origin = Anchor.TopCentre;
+                        break;
+
+                    case ScrollingDirection.Right:
+                        Anchor = Anchor.TopRight;
+                        Origin = Anchor.TopCentre;
+                        break;
+                }
 
                 bool isHorizontal = direction.NewValue == ScrollingDirection.Left || direction.NewValue == ScrollingDirection.Right;
 


### PR DESCRIPTION
This was pointed out as an issue in the osu!taiko editor, but actually affects all rulesets. Has now been fixed everywhere.

---

Closes https://github.com/ppy/osu/issues/31548.

osu!mania could arguable be consdiered "more correct" with the old display, but I don't think it's a huge deal either way (subjective at best).