### PR TITLE
Make friend notifications less prominent

### DIFF
--- a/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
+++ b/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
@@ -30,8 +30,6 @@ namespace osu.Desktop.Security
 
         private partial class ElevatedPrivilegesNotification : SimpleNotification
         {
-            public override bool IsImportant => true;
-
             public ElevatedPrivilegesNotification()
             {
                 Text = $"Running osu! as {(RuntimeInfo.IsUnix ? "root" : "administrator")} does not improve performance, may break integrations and poses a security risk. Please run the game as a normal user.";

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -668,12 +668,18 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private partial class BackgroundNotification : SimpleNotification
         {
-            public override bool IsImportant => false;
+            public BackgroundNotification()
+            {
+                IsImportant = false;
+            }
         }
 
         private partial class BackgroundProgressNotification : ProgressNotification
         {
-            public override bool IsImportant => false;
+            public BackgroundProgressNotification()
+            {
+                IsImportant = false;
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -84,6 +84,40 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestNormalDoesForwardToOverlay()
+        {
+            SimpleNotification notification = null!;
+
+            AddStep(@"simple #1", () => notificationOverlay.Post(notification = new SimpleNotification
+            {
+                Text = @"This shouldn't annoy you too much",
+                Transient = false,
+            }));
+
+            AddAssert("notification in toast tray", () => notification.IsInToastTray, () => Is.True);
+            AddUntilStep("wait for dismissed", () => notification.IsInToastTray, () => Is.False);
+
+            checkDisplayedCount(1);
+        }
+
+        [Test]
+        public void TestTransientDoesNotForwardToOverlay()
+        {
+            SimpleNotification notification = null!;
+
+            AddStep(@"simple #1", () => notificationOverlay.Post(notification = new SimpleNotification
+            {
+                Text = @"This shouldn't annoy you too much",
+                Transient = true,
+            }));
+
+            AddAssert("notification in toast tray", () => notification.IsInToastTray, () => Is.True);
+            AddUntilStep("wait for dismissed", () => notification.IsInToastTray, () => Is.False);
+
+            checkDisplayedCount(0);
+        }
+
+        [Test]
         public void TestForwardWithFlingRight()
         {
             bool activated = false;

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -131,8 +131,6 @@ namespace osu.Game.Database
 
         private partial class DownloadNotification : ProgressNotification
         {
-            public override bool IsImportant => false;
-
             protected override Notification CreateCompletionNotification() => new SilencedProgressCompletionNotification
             {
                 Activated = CompletionClickAction,
@@ -141,7 +139,10 @@ namespace osu.Game.Database
 
             private partial class SilencedProgressCompletionNotification : ProgressCompletionNotification
             {
-                public override bool IsImportant => false;
+                public SilencedProgressCompletionNotification()
+                {
+                    IsImportant = false;
+                }
             }
         }
     }

--- a/osu.Game/Online/FriendPresenceNotifier.cs
+++ b/osu.Game/Online/FriendPresenceNotifier.cs
@@ -170,6 +170,7 @@ namespace osu.Game.Online
             notifications.Post(new SimpleNotification
             {
                 Transient = true,
+                IsImportant = false,
                 Icon = FontAwesome.Solid.UserPlus,
                 Text = $"Online: {string.Join(@", ", onlineAlertQueue.Select(u => u.Username))}",
                 IconColour = colours.Green,
@@ -206,6 +207,7 @@ namespace osu.Game.Online
             notifications.Post(new SimpleNotification
             {
                 Transient = true,
+                IsImportant = false,
                 Icon = FontAwesome.Solid.UserMinus,
                 Text = $"Offline: {string.Join(@", ", offlineAlertQueue.Select(u => u.Username))}",
                 IconColour = colours.Red

--- a/osu.Game/Online/FriendPresenceNotifier.cs
+++ b/osu.Game/Online/FriendPresenceNotifier.cs
@@ -169,6 +169,7 @@ namespace osu.Game.Online
 
             notifications.Post(new SimpleNotification
             {
+                Transient = true,
                 Icon = FontAwesome.Solid.UserPlus,
                 Text = $"Online: {string.Join(@", ", onlineAlertQueue.Select(u => u.Username))}",
                 IconColour = colours.Green,
@@ -204,6 +205,7 @@ namespace osu.Game.Online
 
             notifications.Post(new SimpleNotification
             {
+                Transient = true,
                 Icon = FontAwesome.Solid.UserMinus,
                 Text = $"Offline: {string.Join(@", ", offlineAlertQueue.Select(u => u.Username))}",
                 IconColour = colours.Red

--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
-        public Action<Notification>? ForwardNotificationToPermanentStore { get; set; }
+        public required Action<Notification> ForwardNotificationToPermanentStore { get; init; }
 
         public int UnreadCount => Notifications.Count(n => !n.WasClosed && !n.Read);
 
@@ -142,8 +142,15 @@ namespace osu.Game.Overlays
             notification.MoveToOffset(new Vector2(400, 0), NotificationOverlay.TRANSITION_LENGTH, Easing.OutQuint);
             notification.FadeOut(NotificationOverlay.TRANSITION_LENGTH, Easing.OutQuint).OnComplete(_ =>
             {
+                if (notification.Transient)
+                {
+                    notification.IsInToastTray = false;
+                    notification.Close(false);
+                    return;
+                }
+
                 RemoveInternal(notification, false);
-                ForwardNotificationToPermanentStore?.Invoke(notification);
+                ForwardNotificationToPermanentStore(notification);
 
                 notification.FadeIn(300, Easing.OutQuint);
             });

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -34,9 +34,15 @@ namespace osu.Game.Overlays.Notifications
         public abstract LocalisableString Text { get; set; }
 
         /// <summary>
-        /// Whether this notification should forcefully display itself.
+        /// Important notifications display for longer, and announce themselves at an OS level (ie flashing the taskbar).
+        /// This defaults to <c>true</c>.
         /// </summary>
         public virtual bool IsImportant => true;
+
+        /// <summary>
+        /// Transient notifications only show as a toast, and do not linger in notification history.
+        /// </summary>
+        public bool Transient { get; init; }
 
         /// <summary>
         /// Run on user activating the notification. Return true to close.

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Notifications
         /// Important notifications display for longer, and announce themselves at an OS level (ie flashing the taskbar).
         /// This defaults to <c>true</c>.
         /// </summary>
-        public virtual bool IsImportant => true;
+        public bool IsImportant { get; init; } = true;
 
         /// <summary>
         /// Transient notifications only show as a toast, and do not linger in notification history.

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -191,8 +191,6 @@ namespace osu.Game.Overlays.Notifications
 
         public override bool DisplayOnTop => false;
 
-        public override bool IsImportant => false;
-
         private readonly ProgressBar progressBar;
         private Color4 colourQueued;
         private Color4 colourActive;
@@ -206,6 +204,8 @@ namespace osu.Game.Overlays.Notifications
 
         public ProgressNotification()
         {
+            IsImportant = false;
+
             Content.Add(textDrawable = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 14, weight: FontWeight.Medium))
             {
                 AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -663,8 +663,6 @@ namespace osu.Game.Screens.Play
 
         private partial class MutedNotification : SimpleNotification
         {
-            public override bool IsImportant => true;
-
             public MutedNotification()
             {
                 Text = NotificationsStrings.GameVolumeTooLow;
@@ -716,8 +714,6 @@ namespace osu.Game.Screens.Play
 
         private partial class BatteryWarningNotification : SimpleNotification
         {
-            public override bool IsImportant => true;
-
             public BatteryWarningNotification()
             {
                 Text = NotificationsStrings.BatteryLow;


### PR DESCRIPTION
They will no longer stick in notification history, nor will they flash the taskbar.

---

Addresses https://github.com/ppy/osu/discussions/31611 and many other requests for this to be changed over the last few days.

Took the opportunity to clean up the `IsImportant` flag too, since it was a bit weird. It's still weird that it defaults to `true`, but is what it is for now.