### PR TITLE
Fix crash from new combo colour selector when there are no combo colours present

### DIFF
--- a/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             {
                 Enabled.Value = SelectedHitObject.Value != null;
 
-                if (SelectedHitObject.Value == null || SelectedHitObject.Value.ComboOffset == 0)
+                if (SelectedHitObject.Value == null || SelectedHitObject.Value.ComboOffset == 0 || ComboColours.Count <= 1)
                 {
                     BackgroundColour = colourProvider.Background3;
                     icon.Colour = BackgroundColour.Darken(0.5f);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31615.

The conditional catches a bit more than just the crash case, it also catches the "only 1 combo colour" case (in which case colorhax just can't work, so might as well not show a colour anyway).