### PR TITLE
Add view in browser context menu functionality to multiplayer/playlist rooms

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -12,15 +12,19 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Online.Chat;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -31,10 +35,16 @@ using Container = osu.Framework.Graphics.Containers.Container;
 
 namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 {
-    public abstract partial class DrawableRoom : CompositeDrawable
+    public abstract partial class DrawableRoom : CompositeDrawable, IHasContextMenu
     {
         protected const float CORNER_RADIUS = 10;
         private const float height = 100;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private OsuGame? game { get; set; } = null!;
 
         public readonly Room Room;
 
@@ -329,6 +339,29 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     drawableRoomParticipantsList.NumberOfCircles = value;
             }
         }
+
+        public MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                var items = new List<MenuItem>();
+
+                if (Room.RoomID.HasValue)
+                {
+                    items.AddRange([new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
+                    {
+                        game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
+                    }), new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
+                    {
+                        game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
+                    })]);
+                }
+
+                return items.ToArray();
+            }
+        }
+
+        private string formatRoomUrl(long id) => $@"{api.WebsiteRootUrl}/multiplayer/rooms/{id}";
 
         protected virtual UpdateableBeatmapBackgroundSprite CreateBackground() => new UpdateableBeatmapBackgroundSprite();
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private OsuGame? game { get; set; } = null!;
+        private OsuGame? game { get; set; }
 
         public readonly Room Room;
 
@@ -348,13 +348,16 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
                 if (Room.RoomID.HasValue)
                 {
-                    items.AddRange([new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
-                    {
-                        game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
-                    }), new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
-                    {
-                        game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
-                    })]);
+                    items.AddRange([
+                        new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
+                        {
+                            game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
+                        }),
+                        new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
+                        {
+                            game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
+                        })
+                    ]);
                 }
 
                 return items.ToArray();

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -349,22 +349,16 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 if (Room.RoomID.HasValue)
                 {
                     items.AddRange([
-                        new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
-                        {
-                            game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
-                        }),
-                        new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
-                        {
-                            game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
-                        })
+                        new OsuMenuItem("View in browser", MenuItemType.Standard, () => game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value))),
+                        new OsuMenuItem("Copy link", MenuItemType.Standard, () => game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value)))
                     ]);
                 }
 
                 return items.ToArray();
+
+                string formatRoomUrl(long id) => $@"{api.WebsiteRootUrl}/multiplayer/rooms/{id}";
             }
         }
-
-        private string formatRoomUrl(long id) => $@"{api.WebsiteRootUrl}/multiplayer/rooms/{id}";
 
         protected virtual UpdateableBeatmapBackgroundSprite CreateBackground() => new UpdateableBeatmapBackgroundSprite();
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -340,7 +340,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
             }
         }
 
-        public MenuItem[] ContextMenuItems
+        public virtual MenuItem[] ContextMenuItems
         {
             get
             {

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
         public Popover GetPopover() => new PasswordEntryPopover(Room);
 
-        public new MenuItem[] ContextMenuItems
+        public override MenuItem[] ContextMenuItems
         {
             get
             {
@@ -170,19 +170,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                     })
                 };
 
-                if (Room.RoomID.HasValue)
-                {
-                    items.AddRange([
-                        new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
-                        {
-                            game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
-                        }),
-                        new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
-                        {
-                            game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
-                        })
-                    ]);
-                }
+                items.AddRange(base.ContextMenuItems);
 
                 if (Room.Type == MatchType.Playlists && Room.Host?.Id == api.LocalUser.Value.Id && Room.StartDate?.AddMinutes(5) >= DateTimeOffset.Now && !Room.HasEnded)
                 {

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
     /// <summary>
     /// A <see cref="DrawableRoom"/> with lounge-specific interactions such as selection and hover sounds.
     /// </summary>
-    public partial class DrawableLoungeRoom : DrawableRoom, IFilterable, IHasContextMenu, IHasPopover, IKeyBindingHandler<GlobalAction>
+    public partial class DrawableLoungeRoom : DrawableRoom, IFilterable, IHasPopover, IKeyBindingHandler<GlobalAction>
     {
         private const float transition_duration = 60;
         private const float selection_border_width = 4;
@@ -58,9 +58,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
-
-        [Resolved]
-        private OsuGame? game { get; set; }
 
         private readonly BindableWithCurrent<Room?> selectedRoom = new BindableWithCurrent<Room?>();
         private Sample? sampleSelect;

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -159,15 +159,12 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         {
             get
             {
-                var items = new List<MenuItem>
-                {
-                    new OsuMenuItem("Create copy", MenuItemType.Standard, () =>
-                    {
-                        lounge?.OpenCopy(Room);
-                    })
-                };
+                var items = new List<MenuItem>();
 
                 items.AddRange(base.ContextMenuItems);
+
+                items.Add(new OsuMenuItemSpacer());
+                items.Add(new OsuMenuItem("Create copy", MenuItemType.Standard, () => lounge?.OpenCopy(Room)));
 
                 if (Room.Type == MatchType.Playlists && Room.Host?.Id == api.LocalUser.Value.Id && Room.StartDate?.AddMinutes(5) >= DateTimeOffset.Now && !Room.HasEnded)
                 {

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -59,6 +59,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
+        [Resolved]
+        private OsuGame? game { get; set; } = null!;
+
         private readonly BindableWithCurrent<Room?> selectedRoom = new BindableWithCurrent<Room?>();
         private Sample? sampleSelect;
         private Sample? sampleJoin;
@@ -167,6 +170,17 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                     })
                 };
 
+                if (Room.RoomID.HasValue)
+                {
+                    items.AddRange([new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
+                    {
+                        game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
+                    }), new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
+                    {
+                        game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
+                    })]);
+                }
+
                 if (Room.Type == MatchType.Playlists && Room.Host?.Id == api.LocalUser.Value.Id && Room.StartDate?.AddMinutes(5) >= DateTimeOffset.Now && !Room.HasEnded)
                 {
                     items.Add(new OsuMenuItem("Close playlist", MenuItemType.Destructive, () =>
@@ -233,6 +247,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             base.Dispose(isDisposing);
             Room.PropertyChanged -= onRoomPropertyChanged;
         }
+
+        private string formatRoomUrl(long id) => $@"{api.WebsiteRootUrl}/multiplayer/rooms/{id}";
 
         public partial class PasswordEntryPopover : OsuPopover
         {

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -236,8 +236,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             Room.PropertyChanged -= onRoomPropertyChanged;
         }
 
-        private string formatRoomUrl(long id) => $@"{api.WebsiteRootUrl}/multiplayer/rooms/{id}";
-
         public partial class PasswordEntryPopover : OsuPopover
         {
             private readonly Room room;

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private OsuGame? game { get; set; } = null!;
+        private OsuGame? game { get; set; }
 
         private readonly BindableWithCurrent<Room?> selectedRoom = new BindableWithCurrent<Room?>();
         private Sample? sampleSelect;
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
         public Popover GetPopover() => new PasswordEntryPopover(Room);
 
-        public MenuItem[] ContextMenuItems
+        public new MenuItem[] ContextMenuItems
         {
             get
             {
@@ -172,13 +172,16 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
                 if (Room.RoomID.HasValue)
                 {
-                    items.AddRange([new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
-                    {
-                        game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
-                    }), new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
-                    {
-                        game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
-                    })]);
+                    items.AddRange([
+                        new OsuMenuItem("View in browser", MenuItemType.Standard, () =>
+                        {
+                            game?.OpenUrlExternally(formatRoomUrl(Room.RoomID.Value));
+                        }),
+                        new OsuMenuItem("Copy link", MenuItemType.Standard, () =>
+                        {
+                            game?.CopyUrlToClipboard(formatRoomUrl(Room.RoomID.Value));
+                        })
+                    ]);
                 }
 
                 if (Room.Type == MatchType.Playlists && Room.Host?.Id == api.LocalUser.Value.Id && Room.StartDate?.AddMinutes(5) >= DateTimeOffset.Now && !Room.HasEnded)

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -18,6 +18,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -156,10 +157,15 @@ namespace osu.Game.Screens.OnlinePlay.Match
                                             {
                                                 new Drawable[]
                                                 {
-                                                    new DrawableMatchRoom(Room, allowEdit)
+                                                    new OsuContextMenuContainer
                                                     {
-                                                        OnEdit = () => settingsOverlay.Show(),
-                                                        SelectedItem = SelectedItem
+                                                        RelativeSizeAxes = Axes.X,
+                                                        AutoSizeAxes = Axes.Y,
+                                                        Child = new DrawableMatchRoom(Room, allowEdit)
+                                                        {
+                                                            OnEdit = () => settingsOverlay.Show(),
+                                                            SelectedItem = SelectedItem
+                                                        }
                                                     }
                                                 },
                                                 null,


### PR DESCRIPTION
Adds context menu items to lounge rooms and a new context menu to match rooms to open the room in the browser.

Match room | Lounge room
--- | ---
<img width="400" alt="image" src="https://github.com/user-attachments/assets/19c6848b-9a54-4608-9a54-58dfe532c10c" /> | <img width="388" alt="image" src="https://github.com/user-attachments/assets/6f66af96-fde4-4c89-8412-925539ccd641" />

Originally meant to be a context menu in lounge and a button in match room, but could not manage to fix truncating issue in the name without messing up layout (see: https://github.com/ppy/osu/pull/31006#issuecomment-2526580770).