### PR TITLE
Roll back windows build image to 2019 on android build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
   build-only-android:
     name: Build only (Android)
-    runs-on: windows-latest
+    runs-on: windows-2019
     timeout-minutes: 60
     steps:
       - name: Checkout


### PR DESCRIPTION
Per workaround suggested in https://github.com/actions/runner-images/issues/11402#issuecomment-2596473501.

Applying this now as my hopes for a swift resolution without changes on our side are slim to none (read thread linked above in full to learn why).