### PR TITLE
Hide Discord RPC error messages away from user attention

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -82,7 +82,7 @@ namespace osu.Desktop
             };
 
             client.OnReady += onReady;
-            client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Message} ({e.Code})", LoggingTarget.Network, LogLevel.Error);
+            client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Message} ({e.Code})", LoggingTarget.Network);
 
             try
             {


### PR DESCRIPTION
Fixes the awful experience led by the RPC API suddenly blowing up and spamming every single user with error notifications in https://github.com/ppy/osu/issues/31639. We shouldn't raise error notifications for things which we can't really control.