### PR TITLE
Fix potential crash when adjusting offset

### DIFF
--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -123,8 +123,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     if (realmWriteTask == null)
                     {
                         Current.Disabled = false;
-                        Current.Disabled = allowOffsetAdjust;
                         Current.Value = val;
+                        Current.Disabled = allowOffsetAdjust;
                     }
 
                     if (realmWriteTask?.IsCompleted == true)

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -121,7 +121,11 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     // At the point we reach here, it's not guaranteed that all realm writes have taken place (there may be some in-flight).
                     // We are only aware of writes that originated from our own flow, so if we do see one that's active we can avoid handling the feedback value arriving.
                     if (realmWriteTask == null)
+                    {
+                        Current.Disabled = false;
+                        Current.Disabled = allowOffsetAdjust;
                         Current.Value = val;
+                    }
 
                     if (realmWriteTask?.IsCompleted == true)
                     {

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -245,6 +245,9 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     Text = BeatmapOffsetControlStrings.CalibrateUsingLastPlay,
                     Action = () =>
                     {
+                        if (Current.Disabled)
+                            return;
+
                         Current.Value = lastPlayBeatmapOffset - lastPlayAverage;
                         lastAppliedScore.Value = ReferenceScore.Value;
                     },
@@ -277,6 +280,9 @@ namespace osu.Game.Screens.Play.PlayerSettings
         protected override void Update()
         {
             base.Update();
+
+            if (useAverageButton != null)
+                useAverageButton.Enabled.Value = allowOffsetAdjust;
             Current.Disabled = !allowOffsetAdjust;
         }
 


### PR DESCRIPTION
If offset is adjusted close to the cutoff point of being allowed, a realm callback might cause a crash when it really shouldn't.

Also guarded against one other potential failure scenario which probably can't happen (see commit message).

We could probably dump this in the hotfix release.

Closes #31642.