### PR TITLE
Make offset adjust more lenient

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneClicksPerSecondCalculator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneClicksPerSecondCalculator.cs
@@ -120,6 +120,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             public double FramesPerSecond => throw new NotImplementedException();
             public FrameTimeInfo TimeInfo => throw new NotImplementedException();
             public double StartTime => throw new NotImplementedException();
+            public double GameplayStartTime => throw new NotImplementedException();
 
             public IAdjustableAudioComponent AdjustmentsFromMods => adjustableAudioComponent;
 

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.UI
 
         private readonly Bindable<bool> waitingOnFrames = new Bindable<bool>();
 
-        private readonly double gameplayStartTime;
+        public double GameplayStartTime { get; }
 
         private IGameplayClock? parentGameplayClock;
 
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.UI
 
             framedClock = new FramedClock(manualClock = new ManualClock());
 
-            this.gameplayStartTime = gameplayStartTime;
+            GameplayStartTime = gameplayStartTime;
         }
 
         [BackgroundDependencyLoader(true)]
@@ -257,8 +257,8 @@ namespace osu.Game.Rulesets.UI
                 return;
             }
 
-            if (manualClock.CurrentTime < gameplayStartTime)
-                manualClock.CurrentTime = proposedTime = Math.Min(gameplayStartTime, proposedTime);
+            if (manualClock.CurrentTime < GameplayStartTime)
+                manualClock.CurrentTime = proposedTime = Math.Min(GameplayStartTime, proposedTime);
             else if (Math.Abs(manualClock.CurrentTime - proposedTime) > sixty_frame_time * 1.2f)
             {
                 proposedTime = proposedTime > manualClock.CurrentTime

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Screens.Play
         /// </remarks>
         public double StartTime { get; protected set; }
 
+        public double GameplayStartTime { get; protected set; }
+
         public IAdjustableAudioComponent AdjustmentsFromMods { get; } = new AudioAdjustments();
 
         private readonly BindableBool isPaused = new BindableBool(true);

--- a/osu.Game/Screens/Play/IGameplayClock.cs
+++ b/osu.Game/Screens/Play/IGameplayClock.cs
@@ -19,6 +19,11 @@ namespace osu.Game.Screens.Play
         double StartTime { get; }
 
         /// <summary>
+        /// The time from which actual gameplay should start. When intro time is skipped, this will be the seeked location.
+        /// </summary>
+        double GameplayStartTime { get; }
+
+        /// <summary>
         /// All adjustments applied to this clock which come from mods.
         /// </summary>
         IAdjustableAudioComponent AdjustmentsFromMods { get; }

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -57,8 +57,6 @@ namespace osu.Game.Screens.Play
 
         private Track track;
 
-        private readonly double skipTargetTime;
-
         [Resolved]
         private MusicController musicController { get; set; } = null!;
 
@@ -66,16 +64,16 @@ namespace osu.Game.Screens.Play
         /// Create a new master gameplay clock container.
         /// </summary>
         /// <param name="beatmap">The beatmap to be used for time and metadata references.</param>
-        /// <param name="skipTargetTime">The latest time which should be used when introducing gameplay. Will be used when skipping forward.</param>
-        public MasterGameplayClockContainer(WorkingBeatmap beatmap, double skipTargetTime)
+        /// <param name="gameplayStartTime">The latest time which should be used when introducing gameplay. Will be used when skipping forward.</param>
+        public MasterGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStartTime)
             : base(beatmap.Track, applyOffsets: true, requireDecoupling: true)
         {
             this.beatmap = beatmap;
-            this.skipTargetTime = skipTargetTime;
 
             track = beatmap.Track;
 
             StartTime = findEarliestStartTime();
+            GameplayStartTime = gameplayStartTime;
         }
 
         private double findEarliestStartTime()
@@ -84,7 +82,7 @@ namespace osu.Game.Screens.Play
             // generally this is either zero, or some point earlier than zero in the case of storyboards, lead-ins etc.
 
             // start with the originally provided latest time (if before zero).
-            double time = Math.Min(0, skipTargetTime);
+            double time = Math.Min(0, GameplayStartTime);
 
             // if a storyboard is present, it may dictate the appropriate start time by having events in negative time space.
             // this is commonly used to display an intro before the audio track start.
@@ -119,10 +117,10 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public void Skip()
         {
-            if (GameplayClock.CurrentTime > skipTargetTime - MINIMUM_SKIP_TIME)
+            if (GameplayClock.CurrentTime > GameplayStartTime - MINIMUM_SKIP_TIME)
                 return;
 
-            double skipTarget = skipTargetTime - MINIMUM_SKIP_TIME;
+            double skipTarget = GameplayStartTime - MINIMUM_SKIP_TIME;
 
             if (StartTime < -10000 && GameplayClock.CurrentTime < 0 && skipTarget > 6000)
                 // double skip exception for storyboards with very long intros
@@ -187,7 +185,8 @@ namespace osu.Game.Screens.Play
                     }
                     else
                     {
-                        Logger.Log($"Playback discrepancy detected ({playbackDiscrepancyCount} of allowed {allowed_playback_discrepancies}): {elapsedGameplayClockTime:N1} vs {elapsedValidationTime:N1}");
+                        Logger.Log(
+                            $"Playback discrepancy detected ({playbackDiscrepancyCount} of allowed {allowed_playback_discrepancies}): {elapsedGameplayClockTime:N1} vs {elapsedValidationTime:N1}");
                     }
 
                     elapsedValidationTime = null;

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -72,17 +72,17 @@ namespace osu.Game.Screens.Play
 
             track = beatmap.Track;
 
-            StartTime = findEarliestStartTime();
             GameplayStartTime = gameplayStartTime;
+            StartTime = findEarliestStartTime(gameplayStartTime, beatmap);
         }
 
-        private double findEarliestStartTime()
+        private static double findEarliestStartTime(double gameplayStartTime, WorkingBeatmap beatmap)
         {
             // here we are trying to find the time to start playback from the "zero" point.
             // generally this is either zero, or some point earlier than zero in the case of storyboards, lead-ins etc.
 
             // start with the originally provided latest time (if before zero).
-            double time = Math.Min(0, GameplayStartTime);
+            double time = Math.Min(0, gameplayStartTime);
 
             // if a storyboard is present, it may dictate the appropriate start time by having events in negative time space.
             // this is commonly used to display an intro before the audio track start.

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     Debug.Assert(gameplayClock != null);
 
                     // TODO: the blocking conditions should probably display a message.
-                    if (!player.IsBreakTime.Value && gameplayClock.CurrentTime - gameplayClock.StartTime > 10000)
+                    if (!player.IsBreakTime.Value && gameplayClock.CurrentTime - gameplayClock.GameplayStartTime > 10000)
                         return false;
 
                     if (gameplayClock.IsPaused.Value)


### PR DESCRIPTION
Noticed in passing that we are a bit too harsh, basing the restrictions on `time=0` instead of gameplay start time (see [stable reference](https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/GameModes/Play/Player.cs#L2085-L2086)).

Of note, it's still a bit more strict due to the 2 second offset to `GameplayStartTime` in lazer. Not sure this is too important, but if we want to match 1:1 we can either change the allowance to 12 seconds or source the `GameplayStartTime` directly from the beatmap, I guess.