### PR TITLE
🔧 Specify we're not using non-exempt encryption

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -153,6 +153,8 @@
 			<string>Editor</string>
 		</dict>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music-games</string>
 	<key>LSSupportsOpeningDocumentsInPlace</key>


### PR DESCRIPTION
Complying with https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations, avoids an extra step on every app submission