### PR TITLE
Add configuration option to disable Taiko notes flying after hit

### DIFF
--- a/osu.Game.Rulesets.Taiko/Configuration/TaikoHitFlyingEnable.cs
+++ b/osu.Game.Rulesets.Taiko/Configuration/TaikoHitFlyingEnable.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
+
+namespace osu.Game.Rulesets.Taiko.Configuration
+{
+    public enum TaikoHitFlyingEnable
+    {
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.FlyingHitEnableNever))]
+        Never,
+
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.FlyingHitEnableHUD))]
+        HUD,
+
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.FlyingHitEnableAlways))]
+        Always,
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
@@ -18,11 +18,13 @@ namespace osu.Game.Rulesets.Taiko.Configuration
             base.InitialiseDefaults();
 
             SetDefault(TaikoRulesetSetting.TouchControlScheme, TaikoTouchControlScheme.KDDK);
+            SetDefault(TaikoRulesetSetting.HitFlyingEnable, TaikoHitFlyingEnable.Always);
         }
     }
 
     public enum TaikoRulesetSetting
     {
-        TouchControlScheme
+        TouchControlScheme,
+        HitFlyingEnable
     }
 }

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -30,6 +30,12 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     LabelText = RulesetSettingsStrings.TouchControlScheme,
                     Current = config.GetBindable<TaikoTouchControlScheme>(TaikoRulesetSetting.TouchControlScheme)
+                },
+                new SettingsEnumDropdown<TaikoHitFlyingEnable>
+                {
+                    ClassicDefault = TaikoHitFlyingEnable.HUD,
+                    LabelText = RulesetSettingsStrings.FlyingHitEnable,
+                    Current = config.GetBindable<TaikoHitFlyingEnable>(TaikoRulesetSetting.HitFlyingEnable)
                 }
             };
         }

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -89,6 +89,26 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString TouchControlScheme => new TranslatableString(getKey(@"touch_control_scheme"), @"Touch control scheme");
 
+        /// <summary>
+        /// "Circles fly off after successful hit"
+        /// </summary>
+        public static LocalisableString FlyingHitEnable => new TranslatableString(getKey(@"hit_flying_enable"), @"Circles fly off after successful hit");
+
+        /// <summary>
+        /// "Never"
+        /// </summary>
+        public static LocalisableString FlyingHitEnableNever => new TranslatableString(getKey(@"hit_flying_enable_never"), @"Never");
+
+        /// <summary>
+        /// "When HUD is visible"
+        /// </summary>
+        public static LocalisableString FlyingHitEnableHUD => new TranslatableString(getKey(@"hit_flying_enable_hud"), @"When HUD is visible");
+
+        /// <summary>
+        /// "Always"
+        /// </summary>
+        public static LocalisableString FlyingHitEnableAlways => new TranslatableString(getKey(@"hit_flying_enable_always"), @"Always");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }


### PR DESCRIPTION
In osu!stable, the "flying away" animation is shown only when the HUD is active. This adds a configuration option to restore this behaviour or to disable the animation altogether.

Discussed previously: https://github.com/ppy/osu/discussions/23656