### PR TITLE
Fix osu!mania judgement position not shifted on flipped scroll direction

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonJudgementPiece.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -12,6 +13,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Graphics;
 
@@ -26,18 +28,22 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
+        private IBindable<ScrollingDirection> direction = null!;
+
         public ArgonJudgementPiece(HitResult result)
             : base(result)
         {
             AutoSizeAxes = Axes.Both;
 
             Origin = Anchor.Centre;
-            Y = judgement_y_position;
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(IScrollingInfo scrollingInfo)
         {
+            direction = scrollingInfo.Direction.GetBoundCopy();
+            direction.BindValueChanged(_ => onDirectionChanged(), true);
+
             if (Result.IsHit())
             {
                 AddInternal(ringExplosion = new RingExplosion(Result)
@@ -46,6 +52,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 });
             }
         }
+
+        private void onDirectionChanged() => Y = direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position;
 
         protected override SpriteText CreateJudgementText() =>
             new OsuSpriteText
@@ -78,7 +86,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                     this.ScaleTo(1.6f);
                     this.ScaleTo(1, 100, Easing.In);
 
-                    this.MoveToY(judgement_y_position);
+                    this.MoveToY(direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position);
                     this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
 
                     this.RotateTo(0);

--- a/osu.Game.Rulesets.Mania/UI/DefaultManiaJudgementPiece.cs
+++ b/osu.Game.Rulesets.Mania/UI/DefaultManiaJudgementPiece.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
+
+namespace osu.Game.Rulesets.Mania.UI
+{
+    public partial class DefaultManiaJudgementPiece : DefaultJudgementPiece
+    {
+        private const float judgement_y_position = -180f;
+
+        private IBindable<ScrollingDirection> direction = null!;
+
+        public DefaultManiaJudgementPiece(HitResult result)
+            : base(result)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IScrollingInfo scrollingInfo)
+        {
+            direction = scrollingInfo.Direction.GetBoundCopy();
+            direction.BindValueChanged(_ => onDirectionChanged(), true);
+        }
+
+        private void onDirectionChanged() => Y = direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            JudgementText.Font = JudgementText.Font.With(size: 25);
+        }
+
+        public override void PlayAnimation()
+        {
+            switch (Result)
+            {
+                case HitResult.None:
+                    this.FadeOutFromOne(800);
+                    break;
+
+                case HitResult.Miss:
+                    this.ScaleTo(1.6f);
+                    this.ScaleTo(1, 100, Easing.In);
+
+                    this.MoveToY(direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position);
+                    this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+
+                    this.RotateTo(0);
+                    this.RotateTo(40, 800, Easing.InQuint);
+
+                    this.FadeOutFromOne(800);
+                    break;
+
+                default:
+                    this.ScaleTo(0.8f);
+                    this.ScaleTo(1, 250, Easing.OutElastic);
+
+                    this.Delay(50)
+                        .ScaleTo(0.75f, 250)
+                        .FadeOut(200);
+
+                    // osu!mania uses a custom fade length, so the base call is intentionally omitted.
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -3,65 +3,32 @@
 
 #nullable disable
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osuTK;
+using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
     public partial class DrawableManiaJudgement : DrawableJudgement
     {
-        protected override Drawable CreateDefaultJudgement(HitResult result) => new DefaultManiaJudgementPiece(result);
+        private IBindable<ScrollingDirection> direction;
 
-        private partial class DefaultManiaJudgementPiece : DefaultJudgementPiece
+        [BackgroundDependencyLoader]
+        private void load(IScrollingInfo scrollingInfo)
         {
-            private const float judgement_y_position = -180f;
-
-            public DefaultManiaJudgementPiece(HitResult result)
-                : base(result)
-            {
-                Y = judgement_y_position;
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                JudgementText.Font = JudgementText.Font.With(size: 25);
-            }
-
-            public override void PlayAnimation()
-            {
-                switch (Result)
-                {
-                    case HitResult.None:
-                        this.FadeOutFromOne(800);
-                        break;
-
-                    case HitResult.Miss:
-                        this.ScaleTo(1.6f);
-                        this.ScaleTo(1, 100, Easing.In);
-
-                        this.MoveToY(judgement_y_position);
-                        this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
-
-                        this.RotateTo(0);
-                        this.RotateTo(40, 800, Easing.InQuint);
-
-                        this.FadeOutFromOne(800);
-                        break;
-
-                    default:
-                        this.ScaleTo(0.8f);
-                        this.ScaleTo(1, 250, Easing.OutElastic);
-
-                        this.Delay(50)
-                            .ScaleTo(0.75f, 250)
-                            .FadeOut(200);
-                        break;
-                }
-            }
+            direction = scrollingInfo.Direction.GetBoundCopy();
+            direction.BindValueChanged(_ => onDirectionChanged(), true);
         }
+
+        private void onDirectionChanged()
+        {
+            Anchor = direction.Value == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
+            Origin = Anchor.Centre;
+        }
+
+        protected override Drawable CreateDefaultJudgement(HitResult result) => new DefaultManiaJudgementPiece(result);
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -216,13 +216,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 return;
 
             judgements.Clear(false);
-            judgements.Add(judgementPooler.Get(result.Type, j =>
-            {
-                j.Apply(result, judgedObject);
-
-                j.Anchor = Anchor.BottomCentre;
-                j.Origin = Anchor.Centre;
-            })!);
+            judgements.Add(judgementPooler.Get(result.Type, j => j.Apply(result, judgedObject))!);
         }
 
         protected override void Update()


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/31368 because of https://github.com/ppy/osu/commit/1e08b3dbdac1ed07fd56c0d55d83ce200053c336

This became more of an issue with the judgement positioning changes in #31368. That can be best demonstrated with visual snippets of gameplay on master / #31368. 

Now the position of judgements are flipped upside down when flipping the scroll direction, relative to the position of the hit target. This matches stable, and should be a good change overall given that judgement indication should be closer to the player instead of being far away from them.

master:

https://github.com/user-attachments/assets/0aec1d78-b3e0-4d11-81b9-b48bdc607363

#31368 :

https://github.com/user-attachments/assets/e9ab91a9-4f58-439b-bb88-618a2f39e631

this PR:

https://github.com/user-attachments/assets/591a0029-1958-4480-952e-54df4f7357a1


