### PR TITLE
Do not bundle explicit beatmaps

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
@@ -345,7 +345,6 @@ namespace osu.Game.Beatmaps.Drawables
             "1971951 James Landino - Shiba Paradise.osz",
             "1972518 Toromaru - Sleight of Hand.osz",
             "1982302 KINEMA106 - INVITE.osz",
-            "1983475 KNOWER - The Government Knows.osz",
             "2010165 Junk - Yellow Smile (bms edit).osz",
             "2022737 Andora - Euphoria (feat. WaMi).osz",
             "2025023 tephe - Genjitsu Escape.osz",

--- a/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
@@ -292,7 +292,7 @@ namespace osu.Game.Beatmaps.Drawables
             "1407228 II-L - VANGUARD-1.osz",
             "1422686 II-L - VANGUARD-2.osz",
             "1429217 Street - Phi.osz",
-            "1442235 2ToneDisco x Cosmicosmo - Shoelaces (feat. Puniden).osz",
+            "1442235 2ToneDisco x Cosmicosmo - Shoelaces (feat. Puniden).osz", // set is not marked as FA, but track is listed in https://osu.ppy.sh/beatmaps/artists/157
             "1447478 Cres. - End Time.osz",
             "1449942 m108 - Crescent Sakura.osz",
             "1463778 MuryokuP - A tree without a branch.osz",
@@ -336,8 +336,8 @@ namespace osu.Game.Beatmaps.Drawables
             "1854710 Blaster & Extra Terra - Spacecraft (Cut Ver.).osz",
             "1859322 Hino Isuka - Delightness Brightness.osz",
             "1884102 Maduk - Go (feat. Lachi) (Cut Ver.).osz",
-            "1884578 Neko Hacker - People People feat. Nanahira.osz",
-            "1897902 uma vs. Morimori Atsushi - Re: End of a Dream.osz",
+            "1884578 Neko Hacker - People People feat. Nanahira.osz", // set is not marked as FA, but track is listed in https://osu.ppy.sh/beatmaps/artists/266
+            "1897902 uma vs. Morimori Atsushi - Re: End of a Dream.osz", // set is not marked as FA, but track is listed in https://osu.ppy.sh/beatmaps/artists/108
             "1905582 KINEMA106 - Fly Away (Cut Ver.).osz",
             "1934686 ARForest - Rainbow Magic!!.osz",
             "1963076 METAROOM - S.N.U.F.F.Y.osz",


### PR DESCRIPTION
Or single explicit beamap, really. Closes https://github.com/ppy/osu/issues/31654.

During screening I noticed a few beatmap sets in there that were not marked FA, but should be. For now I added inline comments to denote that fact, but in light of mobile release it may make sense to expedite marking these specific sets as FA correctly.