### PR TITLE
Enable mouse/pen aim + touch click play style

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [SetUpSteps]
         public void SetUpSteps()
         {
-            releaseAllTouches();
+            resetState();
 
             AddStep("Create tests", () =>
             {
@@ -737,14 +737,19 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert($"The right key was pressed {right} times", () => rightKeyCounter.CountPresses.Value, () => Is.EqualTo(right));
         }
 
-        private void releaseAllTouches()
+        private void resetState()
         {
-            AddStep("Release all touches", () =>
+            AddStep("Reset state", () =>
             {
                 config.SetValue(OsuSetting.MouseDisableButtons, false);
                 config.SetValue(OsuSetting.TouchDisableGameplayTaps, false);
                 foreach (TouchSource source in InputManager.CurrentState.Touch.ActiveSources)
                     InputManager.EndTouch(new Touch(source, osuInputManager.ScreenSpaceDrawQuad.Centre));
+
+                foreach (var button in InputManager.CurrentState.Mouse.Buttons)
+                    InputManager.ReleaseButton(button);
+
+                InputManager.MoveMouseTo(Vector2.Zero);
             });
         }
 

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private TrackedTouch? positionTrackingTouch;
 
+        private bool updatingMousePositionFromTouch;
+
         private readonly OsuInputManager osuInputManager;
 
         private Bindable<bool> tapsDisabled = null!;
@@ -48,6 +50,16 @@ namespace osu.Game.Rulesets.Osu.UI
 
         // Required to handle touches outside of the playfield when screen scaling is enabled.
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            if (!updatingMousePositionFromTouch)
+            {
+                positionTrackingTouch = null;
+            }
+
+            return base.OnMouseMove(e);
+        }
 
         protected override void OnTouchMove(TouchMoveEvent e)
         {
@@ -135,7 +147,9 @@ namespace osu.Game.Rulesets.Osu.UI
             if (!osuInputManager.AllowUserCursorMovement)
                 return;
 
+            updatingMousePositionFromTouch = true;
             new MousePositionAbsoluteInput { Position = touchEvent.ScreenSpaceTouch.Position }.Apply(osuInputManager.CurrentState, osuInputManager);
+            updatingMousePositionFromTouch = false;
         }
 
         protected override void OnTouchUp(TouchUpEvent e)

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -63,7 +63,10 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             // MouseMoveEvents that don't move the mouse are a fluke and not from a real mouse device. They are probably from PassTroughInputManager syncing state (seen in testing).
             // Ignore them since the user is not actually using a mouse or pen for aiming.
-            if (!updatingMousePositionFromTouch && e.ScreenSpaceMousePosition != e.ScreenSpaceLastMousePosition)
+            if (e.ScreenSpaceMousePosition == e.ScreenSpaceLastMousePosition)
+                return false;
+
+            if (!updatingMousePositionFromTouch)
             {
                 trackPositionOfIndirectTouches = false; // user is moving their mouse or pen, assume hovering play style -- position from mouse hover, clicking from touches.
                 positionTrackingTouch = null;

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -61,7 +61,9 @@ namespace osu.Game.Rulesets.Osu.UI
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            if (!updatingMousePositionFromTouch)
+            // MouseMoveEvents that don't move the mouse are a fluke and not from a real mouse device. They are probably from PassTroughInputManager syncing state (seen in testing).
+            // Ignore them since the user is not actually using a mouse or pen for aiming.
+            if (!updatingMousePositionFromTouch && e.ScreenSpaceMousePosition != e.ScreenSpaceLastMousePosition)
             {
                 trackPositionOfIndirectTouches = false; // user is moving their mouse or pen, assume hovering play style -- position from mouse hover, clicking from touches.
                 positionTrackingTouch = null;


### PR DESCRIPTION
- Alternative to / closes https://github.com/ppy/osu-framework/pull/6509
- Closes https://github.com/ppy/osu/pull/31680
- Fixes https://github.com/ppy/osu/issues/31570

This PR enables a playstyle where a hovering mouse or pen is used for position, and finger touches are used for clicking (as a keyboard). This is enabled by a new flag (`trackPositionOfIndirectTouches`), which will prevent touches from "stealing" the cursor position. The flag is dynamic: if a user directly touches a hitcircle with their finger, the game will assume the previous playstyle of aiming with a finger and using fingers for clicking. But if a user then hovers their pen or mouse, the game will instantly switch to the playstyle described in this PR.

The implementation is not perfect (see `TestFirstTouchBrokenWhenMousePressed`), but it's possible to work around some of the issues (see `TestFirstTouchWorksWhenMousePressedAndMouseButtonsDisabled`). It's recommended that users who wish to aim with the pen pressing down on the tablet surface, and don't want to use the pen for clicking, disable "mouse clicks during gameplay". (This is currently under the "Mouse" section, as there is no "Pen" section in input settings.)

The changes are scoped to `OsuTouchInputMapper`, so it only affect touch input (i.e. mouse/keyboard/tablet input will not regress).

## Testing

A [previous version of this branch](https://github.com/Susko3/osu/commit/708b09cf612f36947e28e00a58e8f49f1ab4e351) was tested by [frenzi](https://discord.com/channels/188630481301012481/188630652340404224/1333431022515130409) and [Walavouchey](https://github.com/ppy/osu-framework/pull/6511#issuecomment-2615927428).

As seen in the Walavouchey replay, a common user "error" is accidentally directly tapping on a circle. Here, a hitcircle happened to appear exactly under where the user is trying to tap for a click, stealing the position from the pen, resulting in a sliderbreak.

This is not a new issue, as the same thing can happen when using touch instead of a pen for aiming.

A user can fix this by not tapping on the playfield, maybe best accomplished by resizing or moving the playfield using `Screen scaling`.

The following logic could be updated (in a separate PR) to fix this (perhaps it should consider notelock):

https://github.com/ppy/osu/blob/ff0c0d54c9127df3006bcb4249fea225d5cc3f6f/osu.Game.Rulesets.Osu/OsuInputManager.cs#L45-L50

![osu_2025-01-27_15-36-41](https://github.com/user-attachments/assets/6410ba1b-439b-414e-b983-ee1a4e5a22a4)
