### PR TITLE
Add speed acceleration bonus

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 nextDistance *= DifficultyCalculationUtils.Smoothstep(osuCurrObj.StrainTime, osuPrevObj.StrainTime * 1.75, osuPrevObj.StrainTime * 1.5);
 
                 // Have a threshold so very small changes aren't buffed
-                if (distance > 0) nextDistance *= DifficultyCalculationUtils.Smoothstep(nextDistance, distance, distance * 1.1);
+                if (distance > 0) nextDistance *= DifficultyCalculationUtils.Smoothstep(nextDistance, distance, distance * 1.25);
             }
 
             distance = Math.Max(distance, nextDistance);


### PR DESCRIPTION
Instead of using current distance - it's using max between current and next, with few checks to avoid buffing unrelated patterns

This:
![image](https://github.com/user-attachments/assets/15e0b6af-3c42-4ba2-9e93-f7a1edbe0a5c)
Shouldn't ever have less distance bonus than this:
![image](https://github.com/user-attachments/assets/db28c7ec-af09-4077-b72c-1a7e674a16f6)

Actually first one should be worth way more, but there's no proper flow aim eval yet, so here at least we're making them the same