### PR TITLE
Change friend online notifications' icon and colours

### DIFF
--- a/osu.Game/Online/FriendPresenceNotifier.cs
+++ b/osu.Game/Online/FriendPresenceNotifier.cs
@@ -171,9 +171,9 @@ namespace osu.Game.Online
             {
                 Transient = true,
                 IsImportant = false,
-                Icon = FontAwesome.Solid.UserPlus,
+                Icon = FontAwesome.Solid.User,
                 Text = $"Online: {string.Join(@", ", onlineAlertQueue.Select(u => u.Username))}",
-                IconColour = colours.Green,
+                IconColour = colours.GrayD,
                 Activated = () =>
                 {
                     if (singleUser != null)
@@ -208,9 +208,9 @@ namespace osu.Game.Online
             {
                 Transient = true,
                 IsImportant = false,
-                Icon = FontAwesome.Solid.UserMinus,
+                Icon = FontAwesome.Solid.UserSlash,
                 Text = $"Offline: {string.Join(@", ", offlineAlertQueue.Select(u => u.Username))}",
-                IconColour = colours.Red
+                IconColour = colours.Gray3
             });
 
             offlineAlertQueue.Clear();


### PR DESCRIPTION
The previous choices made it seem like potentially destructive actions were being performed. I've gone with neutral colours and more suiting icons to attempt to avoid this.

![osu Game Tests 2025-01-28 at 12 29 13](https://github.com/user-attachments/assets/b4fbad68-1a2a-466a-a79f-bfe84ade957e)


---

Addresses concerns in
https://github.com/ppy/osu/discussions/31621#discussioncomment-11948377.

I chose this design even though it wasn't the #1 most popular because I personally feel that using green/red doesn't work great for these.