### PR TITLE
Use decibel scaling for volume control (version 2)

### DIFF
--- a/osu.Game/Audio/DecibelScaling.cs
+++ b/osu.Game/Audio/DecibelScaling.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Audio
+{
+    /// <summary>
+    /// Common functions and constants for implementing decibel scaling into sliders and meters.
+    /// </summary>
+    public static class DecibelScaling
+    {
+        /// <summary>
+        /// Arbitrary silence threshold. Required for sliders, since the decibel scale is bottomless.
+        /// </summary>
+        public const double DB_MIN = -60;
+
+        /// <summary>
+        /// Decibel equivalent of full volume.
+        /// </summary>
+        public const double DB_MAX = 0;
+
+        /// <summary>
+        /// Decibel precision level.
+        /// </summary>
+        public const double DB_PRECISION = 0.5;
+
+        /// <summary>
+        /// Linear equivalent of <see cref="DB_MIN"/>
+        /// </summary>
+        private static readonly double cutoff = Math.Pow(10, DB_MIN / 20);
+
+        /// <summary>
+        /// Returns the decibel equivalent of a linear value.
+        /// </summary>
+        public static double DecibelFromLinear(double linear) => linear <= cutoff ? DB_MIN : 20 * Math.Log10(linear);
+
+        /// <summary>
+        /// Returns the linear equivalent of a decibel value.
+        /// </summary>
+        public static double LinearFromDecibel(double decibel) => decibel <= DB_MIN ? 0 : Math.Pow(10, decibel / 20);
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.NotifyOnFriendPresenceChange, true);
 
             // Audio
-            SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1);
 
             SetDefault(OsuSetting.MenuVoice, true);
             SetDefault(OsuSetting.MenuMusic, true);

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -3,11 +3,13 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
+using static osu.Game.Audio.DecibelScaling;
 
 namespace osu.Game.Overlays.Settings.Sections.Audio
 {
@@ -23,42 +25,83 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 new VolumeAdjustSlider
                 {
                     LabelText = AudioSettingsStrings.MasterVolume,
-                    Current = audio.Volume,
-                    KeyboardStep = 0.01f,
-                    DisplayAsPercentage = true
+                    Volume = audio.Volume,
                 },
-                new SettingsSlider<double>
+                new VolumeAdjustSlider
                 {
                     LabelText = AudioSettingsStrings.MasterVolumeInactive,
-                    Current = config.GetBindable<double>(OsuSetting.VolumeInactive),
-                    KeyboardStep = 0.01f,
-                    DisplayAsPercentage = true
+                    Volume = config.GetBindable<double>(OsuSetting.VolumeInactive),
+                    PlaySamplesOnAdjust = true,
                 },
                 new VolumeAdjustSlider
                 {
                     LabelText = AudioSettingsStrings.EffectVolume,
-                    Current = audio.VolumeSample,
-                    KeyboardStep = 0.01f,
-                    DisplayAsPercentage = true
+                    Volume = audio.VolumeSample,
                 },
-
                 new VolumeAdjustSlider
                 {
                     LabelText = AudioSettingsStrings.MusicVolume,
-                    Current = audio.VolumeTrack,
-                    KeyboardStep = 0.01f,
-                    DisplayAsPercentage = true
+                    Volume = audio.VolumeTrack,
                 },
             };
         }
 
         private partial class VolumeAdjustSlider : SettingsSlider<double>
         {
-            protected override Drawable CreateControl()
+            protected override Drawable CreateControl() => new DecibelSliderBar();
+
+            public bool PlaySamplesOnAdjust { set => ((DecibelSliderBar)Control).PlaySamplesOnAdjust = value; }
+
+            public Bindable<double> Volume { set => ((DecibelSliderBar)Control).Volume = value; }
+
+            protected partial class DecibelSliderBar : RoundedSliderBar<double>
             {
-                var sliderBar = (RoundedSliderBar<double>)base.CreateControl();
-                sliderBar.PlaySamplesOnAdjust = false;
-                return sliderBar;
+                public override LocalisableString TooltipText => Current.Value <= DB_MIN ? "-∞ dB" : $"{Current.Value:+#0.0;-#0.0;+0.0} dB";
+
+                public DecibelSliderBar()
+                {
+                    RelativeSizeAxes = Axes.X;
+                    PlaySamplesOnAdjust = false;
+                    KeyboardStep = (float)DB_PRECISION;
+
+                    Current = new BindableNumber<double>(0)
+                    {
+                        Precision = DB_PRECISION,
+                        MinValue = DB_MIN,
+                        MaxValue = DB_MAX,
+                    };
+                }
+
+                public Bindable<double> Volume = new Bindable<double>(1);
+
+                private bool currentFirstInvoked;
+                private bool volumeFirstInvoked;
+
+                protected override void LoadComplete()
+                {
+                    base.LoadComplete();
+                    Current.Default = DecibelFromLinear(Volume.Default);
+
+                    Current.ValueChanged += v =>
+                    {
+                        if (!volumeFirstInvoked)
+                        {
+                            currentFirstInvoked = true;
+                            Volume.Value = LinearFromDecibel(v.NewValue);
+                            currentFirstInvoked = false;
+                        }
+                    };
+
+                    Volume.BindValueChanged(v =>
+                    {
+                        if (!currentFirstInvoked)
+                        {
+                            volumeFirstInvoked = true;
+                            Current.Value = DecibelFromLinear(v.NewValue);
+                            volumeFirstInvoked = false;
+                        }
+                    }, true);
+                }
             }
         }
     }

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -16,6 +16,7 @@ using osu.Framework.Threading;
 using osu.Game.Input.Bindings;
 using osuTK.Graphics;
 using osuTK.Input;
+using static osu.Game.Audio.DecibelScaling;
 
 namespace osu.Game.Overlays.Toolbar
 {
@@ -78,7 +79,7 @@ namespace osu.Game.Overlays.Toolbar
             base.LoadComplete();
 
             globalVolume = audio.Volume.GetBoundCopy();
-            globalVolume.BindValueChanged(v => volumeBar.ResizeHeightTo((float)v.NewValue, 200, Easing.OutQuint), true);
+            globalVolume.BindValueChanged(v => volumeBar.ResizeHeightTo((float)((DecibelFromLinear(v.NewValue) - DB_MIN) / (DB_MAX - DB_MIN)), 200, Easing.OutQuint), true);
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)


### PR DESCRIPTION
An alternative approach to https://github.com/ppy/osu/pull/31493

Meant to work alongside https://github.com/ppy/osu-framework/pull/6515

This approach works under the philosophy of implementing decibel scaling right at the slider/meter level. As a result, it makes far fewer changes to `osu-framework`, and decibel scaling is not forced on the developer the same way that it was with the first version.

Here is a video showing that our decibel scaling matches PulseAudio's decibel scaling:

https://github.com/user-attachments/assets/0f0cd014-0a0d-4889-9f23-b462fa2c4e65

During the workflow run, `MouseWheelVolumeAdjust` tests fail. This is due to the volume's precision level not being high enough. When the precision level is increased, these tests pass:

https://github.com/user-attachments/assets/ad0ecab6-6129-43be-b217-3348794b1d2f