### PR TITLE
Add the Fade-In effect to `DrawableSwell`

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
@@ -167,8 +166,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             double start_time_delta = HitObject.StartTime - LifetimeStart;
             // scale Alpha value to adjust to stable's fade-in object opacity when LifetimeStart begins, being the first accessible time point in which changing Alpha is possible
             Alpha = (float)(1d - Math.Exp(-(start_time_delta - min_start_time_delta) / fade_in_curve_factor));
-
-            Logger.Log($"time delta: {HitObject.StartTime - LifetimeStart}, LifetimeStart alpha value: {Alpha}");
 
             using (BeginAbsoluteSequence(LifetimeStart))
             {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// <summary>
         /// Offset away from the start time of the swell at which the Fade-In effect starts.
         /// </summary>
-        private const double fade_in_offset = 1800;
+        private const double fade_in_offset = 1833;
         /// <summary>
         /// Duration of the Fade-In time of the swell.
         /// </summary>

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -35,6 +35,15 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// </summary>
         private const double ring_appear_offset = 100;
 
+        /// <summary>
+        /// Offset away from the start time of the swell at which the Fade-In effect starts.
+        /// </summary>
+        private const double fade_in_offset = 1800;
+        /// <summary>
+        /// Duration of the Fade-In time of the swell.
+        /// </summary>
+        private const double fade_in_duration = 666;
+
         private Vector2 baseSize;
 
         private readonly Container<DrawableSwellTick> ticks;
@@ -248,9 +257,19 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             }
         }
 
+        protected override void UpdateInitialTransforms()
+        {
+            // allow for the fade-in effect
+            Alpha = 0;
+        }
+
         protected override void UpdateStartTimeStateTransforms()
         {
             base.UpdateStartTimeStateTransforms();
+
+            // swell fade-in effect from stable
+            using (BeginDelayedSequence(-fade_in_offset))
+                this.FadeIn(fade_in_duration, Easing.In);
 
             using (BeginDelayedSequence(-ring_appear_offset))
                 targetRing.ScaleTo(target_ring_scale, 400, Easing.OutQuint);


### PR DESCRIPTION
partially fixes #21769

**Theory: Fade-in effect in stable**
The fade-in effect affects both swells and drumroll tails. Fade-in effect happens a set amount of ms before the object collides with the judgement cirlce. It will be called *visible time* in this PR.

**Time analysis: Swell and drumroll tail fade-in effect**
[Footage](https://youtu.be/3_uuCjYiMJc)
[Footage analysis notes](https://pastebin.com/Xz1cGSRD)

Visible time was roughly estimated to be 1800ms for swells and 1700ms for drumroll tails. 
The time between 0% and 100% opacity of an affected object was estimated to be 666ms for swells and 1700ms for drumroll tails. 
Footage analysis also confirmed that DT decreases the fade-in effect time by 33%, and that the time is independent of the control points BPM.

**Lazer: Implementation**
- Swells: Start increasing the opacity for the duration of 666ms, when the object is 1833ms (+33ms after comparison review) away from it's starting point.

- Drumroll tails: Not implemented. Not sure how to separate the drumroll head from the tail in the `DrawableDrumRoll`. Also, it would likely break the argon and triangles drumroll object, since both skins don't contain a drumroll head.

**Lazer: Comparison to stable**
This is how lazer compares to stable in the current PR.

https://github.com/user-attachments/assets/1ae440dd-9482-48dd-83ea-a737bf35f512

