### PR TITLE
Fix incremental unstable rate calculation not matching expectations

### DIFF
--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -36,6 +36,10 @@ namespace osu.Game.Tests.NonVisual.Ranking
                                    .Select(t => new HitEvent(t - 5, 1.0, HitResult.Great, new HitObject(), null, null))
                                    .ToList();
 
+            // Add some red herrings
+            events.Insert(4, new HitEvent(200, 1.0, HitResult.Meh, new HitObject { HitWindows = HitWindows.Empty }, null, null));
+            events.Insert(8, new HitEvent(-100, 1.0, HitResult.Miss, new HitObject(), null, null));
+
             HitEventExtensions.UnstableRateCalculationResult result = null;
 
             for (int i = 0; i < events.Count; i++)
@@ -56,6 +60,10 @@ namespace osu.Game.Tests.NonVisual.Ranking
             var events = Enumerable.Range(-5, 11)
                                    .Select(t => new HitEvent(t - 5, 1.0, HitResult.Great, new HitObject(), null, null))
                                    .ToList();
+
+            // Add some red herrings
+            events.Insert(4, new HitEvent(200, 1.0, HitResult.Meh, new HitObject { HitWindows = HitWindows.Empty }, null, null));
+            events.Insert(8, new HitEvent(-100, 1.0, HitResult.Miss, new HitObject(), null, null));
 
             HitEventExtensions.UnstableRateCalculationResult result = null;
 

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -28,11 +28,12 @@ namespace osu.Game.Rulesets.Scoring
             result ??= new UnstableRateCalculationResult();
 
             // Handle rewinding in the simplest way possible.
-            if (hitEvents.Count < result.EventCount + 1)
+            if (hitEvents.Count < result.LastProcessedIndex + 1)
                 result = new UnstableRateCalculationResult();
 
-            for (int i = result.EventCount; i < hitEvents.Count; i++)
+            for (int i = result.LastProcessedIndex + 1; i < hitEvents.Count; i++)
             {
+                result.LastProcessedIndex = i;
                 HitEvent e = hitEvents[i];
 
                 if (!AffectsUnstableRate(e))
@@ -84,6 +85,11 @@ namespace osu.Game.Rulesets.Scoring
         /// </remarks>
         public class UnstableRateCalculationResult
         {
+            /// <summary>
+            /// The last result index processed. For internal incremental calculation use.
+            /// </summary>
+            public int LastProcessedIndex = -1;
+
             /// <summary>
             /// Total events processed. For internal incremental calculation use.
             /// </summary>


### PR DESCRIPTION
The `EventCount` variable wasn't factoring in that some results do not affect unstable rate. It would therefore become more incorrect as the play continued.

Closes https://github.com/ppy/osu/issues/31712.