### PR TITLE
Remove unnecessary strain sorting in difficult slider count

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -53,13 +53,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (sliderStrains.Count == 0)
                 return 0;
 
-            double[] sortedStrains = sliderStrains.OrderDescending().ToArray();
-
-            double maxSliderStrain = sortedStrains.Max();
+            double maxSliderStrain = sliderStrains.Max();
             if (maxSliderStrain == 0)
                 return 0;
 
-            return sortedStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxSliderStrain * 12.0 - 6.0))));
+            return sliderStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxSliderStrain * 12.0 - 6.0))));
         }
     }
 }


### PR DESCRIPTION
Removes the sorting that is done in `Aim.GetDifficultSliders` since it will not affect the result of `.Max` and `.Sum`.

Supposedly, this counts as an optimization PR, but I am not able to provide benchmark results, so I would hope the optimization part is clear enough.