### PR TITLE
Change mirror mod direction setting description & tooltip to hopefully be less confusing

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => "Flip objects on the chosen axes.";
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock) };
 
-        [SettingSource("Mirrored axes", "Choose which axes objects are mirrored over.")]
+        [SettingSource("Flipped axes")]
         public Bindable<MirrorType> Reflection { get; } = new Bindable<MirrorType>();
 
         public void ApplyToHitObject(HitObject hitObject)


### PR DESCRIPTION
See https://github.com/ppy/osu/issues/29720, https://discord.com/channels/188630481301012481/188630652340404224/1334294048541904906.

This removes the tooltip due to being zero or negative information, and also changes the description of the setting to not contain the word "mirror", which will hopefully quash the "this is where I would place a mirror to my screen to achieve what I want" interpretation which seems to be a minority interpretation.

The first time this was complained about I figured this was probably a one guy issue, but now it's happened twice, and I never want to see this conversation again.