### PR TITLE
Fix stacked objects selection order on editor timeline

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
@@ -51,6 +52,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// in order to handle composer blueprints which are partially offscreen.
         /// </remarks>
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => editorScreen?.MainContent.ReceivePositionalInputAt(screenSpacePos) ?? base.ReceivePositionalInputAt(screenSpacePos);
+
+        protected override IEnumerable<SelectionBlueprint<HitObject>> ApplySelectionOrder(IEnumerable<SelectionBlueprint<HitObject>> blueprints) =>
+            base.ApplySelectionOrder(blueprints)
+                .OrderBy(b => Math.Min(Math.Abs(EditorClock.CurrentTime - b.Item.GetEndTime()), Math.Abs(EditorClock.CurrentTime - b.Item.StartTime)));
 
         protected ComposeBlueprintContainer(HitObjectComposer composer)
             : base(composer)

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -125,10 +124,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             EditorClock?.SeekSmoothlyTo(ClickedBlueprint.Item.StartTime);
             return true;
         }
-
-        protected override IEnumerable<SelectionBlueprint<HitObject>> ApplySelectionOrder(IEnumerable<SelectionBlueprint<HitObject>> blueprints) =>
-            base.ApplySelectionOrder(blueprints)
-                .OrderBy(b => Math.Min(Math.Abs(EditorClock.CurrentTime - b.Item.GetEndTime()), Math.Abs(EditorClock.CurrentTime - b.Item.StartTime)));
 
         protected override SelectionBlueprintContainer CreateSelectionBlueprintContainer() => new HitObjectOrderedSelectionContainer { RelativeSizeAxes = Axes.Both };
 


### PR DESCRIPTION
Closes #30406

Moved time based selection prioritization created in #24289 to only occur in playfield.

## Before:

https://github.com/user-attachments/assets/552d661a-5878-4897-8e04-0fbfee4abc67

## After:

https://github.com/user-attachments/assets/34850398-64dd-4eff-b0d5-139f368bfb03

