### PR TITLE
Abstract out `WizardOverlay` for multi-step wizard type screens

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
@@ -21,7 +21,7 @@ using Realms;
 namespace osu.Game.Overlays.FirstRunSetup
 {
     [LocalisableDescription(typeof(FirstRunSetupBeatmapScreenStrings), nameof(FirstRunSetupBeatmapScreenStrings.Header))]
-    public partial class ScreenBeatmaps : FirstRunSetupScreen
+    public partial class ScreenBeatmaps : WizardScreen
     {
         private ProgressRoundedButton downloadBundledButton = null!;
         private ProgressRoundedButton downloadTutorialButton = null!;

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
@@ -20,7 +20,7 @@ using osu.Game.Overlays.Settings.Sections;
 namespace osu.Game.Overlays.FirstRunSetup
 {
     [LocalisableDescription(typeof(FirstRunSetupOverlayStrings), nameof(FirstRunSetupOverlayStrings.Behaviour))]
-    public partial class ScreenBehaviour : FirstRunSetupScreen
+    public partial class ScreenBehaviour : WizardScreen
     {
         private SearchContainer<SettingsSection> searchContainer;
 

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -31,7 +31,7 @@ using osuTK;
 namespace osu.Game.Overlays.FirstRunSetup
 {
     [LocalisableDescription(typeof(FirstRunOverlayImportFromStableScreenStrings), nameof(FirstRunOverlayImportFromStableScreenStrings.Header))]
-    public partial class ScreenImportFromStable : FirstRunSetupScreen
+    public partial class ScreenImportFromStable : WizardScreen
     {
         private static readonly Vector2 button_size = new Vector2(400, 50);
 

--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -32,7 +32,7 @@ using osuTK;
 namespace osu.Game.Overlays.FirstRunSetup
 {
     [LocalisableDescription(typeof(GraphicsSettingsStrings), nameof(GraphicsSettingsStrings.UIScaling))]
-    public partial class ScreenUIScale : FirstRunSetupScreen
+    public partial class ScreenUIScale : WizardScreen
     {
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
@@ -23,7 +23,7 @@ using osuTK;
 namespace osu.Game.Overlays.FirstRunSetup
 {
     [LocalisableDescription(typeof(FirstRunSetupOverlayStrings), nameof(FirstRunSetupOverlayStrings.WelcomeTitle))]
-    public partial class ScreenWelcome : FirstRunSetupScreen
+    public partial class ScreenWelcome : WizardScreen
     {
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager frameworkConfig)

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -1,38 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Input.Events;
-using osu.Framework.Localisation;
-using osu.Framework.Screens;
-using osu.Framework.Threading;
 using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays.FirstRunSetup;
-using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Screens;
-using osu.Game.Screens.Footer;
 using osu.Game.Screens.Menu;
 
 namespace osu.Game.Overlays
 {
     [Cached]
-    public partial class FirstRunSetupOverlay : ShearedOverlayContainer
+    public partial class FirstRunSetupOverlay : WizardOverlay
     {
         [Resolved]
         private IPerformFromScreenRunner performer { get; set; } = null!;
@@ -43,27 +27,7 @@ namespace osu.Game.Overlays
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
 
-        private ScreenStack? stack;
-
-        public ShearedButton? NextButton => DisplayedFooterContent?.NextButton;
-
         private readonly Bindable<bool> showFirstRunSetup = new Bindable<bool>();
-
-        private int? currentStepIndex;
-
-        /// <summary>
-        /// The currently displayed screen, if any.
-        /// </summary>
-        public FirstRunSetupScreen? CurrentScreen => (FirstRunSetupScreen?)stack?.CurrentScreen;
-
-        private readonly List<Type> steps = new List<Type>();
-
-        private Container screenContent = null!;
-
-        private Container content = null!;
-
-        private LoadingSpinner loading = null!;
-        private ScheduledDelegate? loadingShowDelegate;
 
         public FirstRunSetupOverlay()
             : base(OverlayColourScheme.Purple)
@@ -73,67 +37,15 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(OsuColour colours, LegacyImportManager? legacyImportManager)
         {
-            steps.Add(typeof(ScreenWelcome));
-            steps.Add(typeof(ScreenUIScale));
-            steps.Add(typeof(ScreenBeatmaps));
+            AddStep<ScreenWelcome>();
+            AddStep<ScreenUIScale>();
+            AddStep<ScreenBeatmaps>();
             if (legacyImportManager?.SupportsImportFromStable == true)
-                steps.Add(typeof(ScreenImportFromStable));
-            steps.Add(typeof(ScreenBehaviour));
+                AddStep<ScreenImportFromStable>();
+            AddStep<ScreenBehaviour>();
 
             Header.Title = FirstRunSetupOverlayStrings.FirstRunSetupTitle;
             Header.Description = FirstRunSetupOverlayStrings.FirstRunSetupDescription;
-
-            MainAreaContent.AddRange(new Drawable[]
-            {
-                content = new PopoverContainer
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Bottom = 20 },
-                    Child = new GridContainer
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativeSizeAxes = Axes.Both,
-                        ColumnDimensions = new[]
-                        {
-                            new Dimension(),
-                            new Dimension(minSize: 640, maxSize: 800),
-                            new Dimension(),
-                        },
-                        Content = new[]
-                        {
-                            new[]
-                            {
-                                Empty(),
-                                new InputBlockingContainer
-                                {
-                                    Masking = true,
-                                    CornerRadius = 14,
-                                    RelativeSizeAxes = Axes.Both,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = ColourProvider.Background6,
-                                        },
-                                        loading = new LoadingSpinner(),
-                                        new Container
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Padding = new MarginPadding { Vertical = 20 },
-                                            Child = screenContent = new Container { RelativeSizeAxes = Axes.Both, },
-                                        },
-                                    },
-                                },
-                                Empty(),
-                            },
-                        }
-                    }
-                },
-            });
         }
 
         protected override void LoadComplete()
@@ -143,55 +55,6 @@ namespace osu.Game.Overlays
             config.BindWith(OsuSetting.ShowFirstRunSetup, showFirstRunSetup);
 
             if (showFirstRunSetup.Value) Show();
-        }
-
-        [Resolved]
-        private ScreenFooter footer { get; set; } = null!;
-
-        public new FirstRunSetupFooterContent? DisplayedFooterContent => base.DisplayedFooterContent as FirstRunSetupFooterContent;
-
-        public override VisibilityContainer CreateFooterContent()
-        {
-            var footerContent = new FirstRunSetupFooterContent
-            {
-                ShowNextStep = showNextStep,
-            };
-
-            footerContent.OnLoadComplete += _ => updateButtons();
-            return footerContent;
-        }
-
-        public override bool OnBackButton()
-        {
-            if (currentStepIndex == 0)
-                return false;
-
-            Debug.Assert(stack != null);
-
-            stack.CurrentScreen.Exit();
-            currentStepIndex--;
-
-            updateButtons();
-            return true;
-        }
-
-        public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
-        {
-            if (!e.Repeat)
-            {
-                switch (e.Action)
-                {
-                    case GlobalAction.Select:
-                        DisplayedFooterContent?.NextButton.TriggerClick();
-                        return true;
-
-                    case GlobalAction.Back:
-                        footer.BackButton.TriggerClick();
-                        return false;
-                }
-            }
-
-            return base.OnPressed(e);
         }
 
         public override void Show()
@@ -207,24 +70,11 @@ namespace osu.Game.Overlays
             }, new[] { typeof(MainMenu) });
         }
 
-        protected override void PopIn()
-        {
-            base.PopIn();
-
-            content.ScaleTo(0.99f)
-                   .ScaleTo(1, 400, Easing.OutQuint);
-
-            if (currentStepIndex == null)
-                showFirstStep();
-        }
-
         protected override void PopOut()
         {
             base.PopOut();
 
-            content.ScaleTo(0.99f, 400, Easing.OutQuint);
-
-            if (currentStepIndex != null)
+            if (CurrentStepIndex != null)
             {
                 notificationOverlay.Post(new SimpleNotification
                 {
@@ -237,112 +87,14 @@ namespace osu.Game.Overlays
                     },
                 });
             }
-            else
-            {
-                stack?.FadeOut(100)
-                     .Expire();
-            }
         }
 
-        private void showFirstStep()
+        protected override void ShowNextStep()
         {
-            Debug.Assert(currentStepIndex == null);
+            base.ShowNextStep();
 
-            screenContent.Child = stack = new ScreenStack
-            {
-                RelativeSizeAxes = Axes.Both,
-            };
-
-            currentStepIndex = -1;
-            showNextStep();
-        }
-
-        private void showNextStep()
-        {
-            Debug.Assert(currentStepIndex != null);
-            Debug.Assert(stack != null);
-
-            currentStepIndex++;
-
-            if (currentStepIndex < steps.Count)
-            {
-                var nextScreen = (Screen)Activator.CreateInstance(steps[currentStepIndex.Value])!;
-
-                loadingShowDelegate = Scheduler.AddDelayed(() => loading.Show(), 200);
-                nextScreen.OnLoadComplete += _ =>
-                {
-                    loadingShowDelegate?.Cancel();
-                    loading.Hide();
-                };
-
-                stack.Push(nextScreen);
-            }
-            else
-            {
+            if (CurrentStepIndex == null)
                 showFirstRunSetup.Value = false;
-                currentStepIndex = null;
-                Hide();
-            }
-
-            updateButtons();
-        }
-
-        private void updateButtons() => DisplayedFooterContent?.UpdateButtons(currentStepIndex, steps);
-
-        public partial class FirstRunSetupFooterContent : VisibilityContainer
-        {
-            public ShearedButton NextButton { get; private set; } = null!;
-
-            public Action? ShowNextStep;
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                RelativeSizeAxes = Axes.Both;
-
-                InternalChild = NextButton = new ShearedButton(0)
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    Margin = new MarginPadding { Right = 12f },
-                    RelativeSizeAxes = Axes.X,
-                    Width = 1,
-                    Text = FirstRunSetupOverlayStrings.GetStarted,
-                    DarkerColour = colourProvider.Colour2,
-                    LighterColour = colourProvider.Colour1,
-                    Action = () => ShowNextStep?.Invoke(),
-                };
-            }
-
-            public void UpdateButtons(int? currentStep, IReadOnlyList<Type> steps)
-            {
-                NextButton.Enabled.Value = currentStep != null;
-
-                if (currentStep == null)
-                    return;
-
-                bool isFirstStep = currentStep == 0;
-                bool isLastStep = currentStep == steps.Count - 1;
-
-                if (isFirstStep)
-                    NextButton.Text = FirstRunSetupOverlayStrings.GetStarted;
-                else
-                {
-                    NextButton.Text = isLastStep
-                        ? CommonStrings.Finish
-                        : LocalisableString.Interpolate($@"{CommonStrings.Next} ({steps[currentStep.Value + 1].GetLocalisableDescription()})");
-                }
-            }
-
-            protected override void PopIn()
-            {
-                this.FadeIn();
-            }
-
-            protected override void PopOut()
-            {
-                this.Delay(400).FadeOut();
-            }
         }
     }
 }

--- a/osu.Game/Overlays/WizardOverlay.cs
+++ b/osu.Game/Overlays/WizardOverlay.cs
@@ -1,0 +1,288 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Framework.Screens;
+using osu.Framework.Threading;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Mods;
+using osu.Game.Screens.Footer;
+
+namespace osu.Game.Overlays
+{
+    public partial class WizardOverlay : ShearedOverlayContainer
+    {
+        private ScreenStack? stack;
+
+        public ShearedButton? NextButton => DisplayedFooterContent?.NextButton;
+
+        protected int? CurrentStepIndex { get; private set; }
+
+        /// <summary>
+        /// The currently displayed screen, if any.
+        /// </summary>
+        public WizardScreen? CurrentScreen => (WizardScreen?)stack?.CurrentScreen;
+
+        private readonly List<Type> steps = new List<Type>();
+
+        private Container screenContent = null!;
+
+        private Container content = null!;
+
+        private LoadingSpinner loading = null!;
+        private ScheduledDelegate? loadingShowDelegate;
+
+        protected WizardOverlay(OverlayColourScheme scheme)
+            : base(scheme)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            MainAreaContent.AddRange(new Drawable[]
+            {
+                content = new PopoverContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Bottom = 20 },
+                    Child = new GridContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(minSize: 640, maxSize: 800),
+                            new Dimension(),
+                        },
+                        Content = new[]
+                        {
+                            new[]
+                            {
+                                Empty(),
+                                new InputBlockingContainer
+                                {
+                                    Masking = true,
+                                    CornerRadius = 14,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = ColourProvider.Background6,
+                                        },
+                                        loading = new LoadingSpinner(),
+                                        new Container
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Padding = new MarginPadding { Vertical = 20 },
+                                            Child = screenContent = new Container { RelativeSizeAxes = Axes.Both, },
+                                        },
+                                    },
+                                },
+                                Empty(),
+                            },
+                        }
+                    }
+                },
+            });
+        }
+
+        [Resolved]
+        private ScreenFooter footer { get; set; } = null!;
+
+        public new WizardFooterContent? DisplayedFooterContent => base.DisplayedFooterContent as WizardFooterContent;
+
+        public override VisibilityContainer CreateFooterContent()
+        {
+            var footerContent = new WizardFooterContent
+            {
+                ShowNextStep = ShowNextStep,
+            };
+
+            footerContent.OnLoadComplete += _ => updateButtons();
+            return footerContent;
+        }
+
+        public override bool OnBackButton()
+        {
+            if (CurrentStepIndex == 0)
+                return false;
+
+            Debug.Assert(stack != null);
+
+            stack.CurrentScreen.Exit();
+            CurrentStepIndex--;
+
+            updateButtons();
+            return true;
+        }
+
+        public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (!e.Repeat)
+            {
+                switch (e.Action)
+                {
+                    case GlobalAction.Select:
+                        DisplayedFooterContent?.NextButton.TriggerClick();
+                        return true;
+
+                    case GlobalAction.Back:
+                        footer.BackButton.TriggerClick();
+                        return false;
+                }
+            }
+
+            return base.OnPressed(e);
+        }
+
+        protected override void PopIn()
+        {
+            base.PopIn();
+
+            content.ScaleTo(0.99f)
+                   .ScaleTo(1, 400, Easing.OutQuint);
+
+            if (CurrentStepIndex == null)
+                showFirstStep();
+        }
+
+        protected override void PopOut()
+        {
+            base.PopOut();
+
+            content.ScaleTo(0.99f, 400, Easing.OutQuint);
+
+            if (CurrentStepIndex == null)
+            {
+                stack?.FadeOut(100)
+                     .Expire();
+            }
+        }
+
+        protected void AddStep<T>()
+            where T : WizardScreen
+        {
+            steps.Add(typeof(T));
+        }
+
+        private void showFirstStep()
+        {
+            Debug.Assert(CurrentStepIndex == null);
+
+            screenContent.Child = stack = new ScreenStack
+            {
+                RelativeSizeAxes = Axes.Both,
+            };
+
+            CurrentStepIndex = -1;
+            ShowNextStep();
+        }
+
+        protected virtual void ShowNextStep()
+        {
+            Debug.Assert(CurrentStepIndex != null);
+            Debug.Assert(stack != null);
+
+            CurrentStepIndex++;
+
+            if (CurrentStepIndex < steps.Count)
+            {
+                var nextScreen = (Screen)Activator.CreateInstance(steps[CurrentStepIndex.Value])!;
+
+                loadingShowDelegate = Scheduler.AddDelayed(() => loading.Show(), 200);
+                nextScreen.OnLoadComplete += _ =>
+                {
+                    loadingShowDelegate?.Cancel();
+                    loading.Hide();
+                };
+
+                stack.Push(nextScreen);
+            }
+            else
+            {
+                CurrentStepIndex = null;
+                Hide();
+            }
+
+            updateButtons();
+        }
+
+        private void updateButtons() => DisplayedFooterContent?.UpdateButtons(CurrentStepIndex, steps);
+
+        public partial class WizardFooterContent : VisibilityContainer
+        {
+            public ShearedButton NextButton { get; private set; } = null!;
+
+            public Action? ShowNextStep;
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                RelativeSizeAxes = Axes.Both;
+
+                InternalChild = NextButton = new ShearedButton(0)
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Margin = new MarginPadding { Right = 12f },
+                    RelativeSizeAxes = Axes.X,
+                    Width = 1,
+                    Text = FirstRunSetupOverlayStrings.GetStarted,
+                    DarkerColour = colourProvider.Colour2,
+                    LighterColour = colourProvider.Colour1,
+                    Action = () => ShowNextStep?.Invoke(),
+                };
+            }
+
+            public void UpdateButtons(int? currentStep, IReadOnlyList<Type> steps)
+            {
+                NextButton.Enabled.Value = currentStep != null;
+
+                if (currentStep == null)
+                    return;
+
+                bool isFirstStep = currentStep == 0;
+                bool isLastStep = currentStep == steps.Count - 1;
+
+                if (isFirstStep)
+                    NextButton.Text = FirstRunSetupOverlayStrings.GetStarted;
+                else
+                {
+                    NextButton.Text = isLastStep
+                        ? CommonStrings.Finish
+                        : LocalisableString.Interpolate($@"{CommonStrings.Next} ({steps[currentStep.Value + 1].GetLocalisableDescription()})");
+                }
+            }
+
+            protected override void PopIn()
+            {
+                this.FadeIn();
+            }
+
+            protected override void PopOut()
+            {
+                this.Delay(400).FadeOut();
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/WizardScreen.cs
+++ b/osu.Game/Overlays/WizardScreen.cs
@@ -13,9 +13,9 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 
-namespace osu.Game.Overlays.FirstRunSetup
+namespace osu.Game.Overlays
 {
-    public abstract partial class FirstRunSetupScreen : Screen
+    public abstract partial class WizardScreen : Screen
     {
         private const float offset = 100;
 


### PR DESCRIPTION
To be used in the editor, for the beatmap submission wizard.

I've recently been on record for hating "abstract" as a rationale to do anything, but seeing this commit ~3 months after I originally made it, it still feels okay to do for me in this particular case. I think the abstraction is loose enough, makes sense from a code reuse and UX consistency standpoint, and doesn't seem to leak any particular implementation details. That said, it is both a huge diffstat (even though not much *actually* happens here), and also potentially controversial, which is why I'm PRing first separately.