### PR TITLE
Fix multi-segment-type sliders getting mangled on legacy export

### DIFF
--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Database
                     // however, the Bézier path as output by the converter has multiple segments.
                     // `LegacyBeatmapEncoder` will attempt to encode this by emitting per-control-point curve type specs which don't do anything for stable.
                     // instead, stable expects control points that start a segment to be present in the path twice in succession.
-                    if (convertedPoint.Type == PathType.BEZIER)
+                    if (convertedPoint.Type == PathType.BEZIER && i > 0)
                         hasPath.Path.ControlPoints.Add(new PathControlPoint(position));
                 }
             }

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -120,18 +120,30 @@ namespace osu.Game.Database
                 if (BezierConverter.CountSegments(hasPath.Path.ControlPoints) <= 1
                     && hasPath.Path.ControlPoints[0].Type!.Value.Degree == null) continue;
 
-                var newControlPoints = BezierConverter.ConvertToModernBezier(hasPath.Path.ControlPoints);
-
-                // Truncate control points to integer positions
-                foreach (var pathControlPoint in newControlPoints)
-                {
-                    pathControlPoint.Position = new Vector2(
-                        (float)Math.Floor(pathControlPoint.Position.X),
-                        (float)Math.Floor(pathControlPoint.Position.Y));
-                }
+                var convertedToBezier = BezierConverter.ConvertToModernBezier(hasPath.Path.ControlPoints);
 
                 hasPath.Path.ControlPoints.Clear();
-                hasPath.Path.ControlPoints.AddRange(newControlPoints);
+
+                for (int i = 0; i < convertedToBezier.Count; i++)
+                {
+                    var convertedPoint = convertedToBezier[i];
+
+                    // Truncate control points to integer positions
+                    var position = new Vector2(
+                        (float)Math.Floor(convertedPoint.Position.X),
+                        (float)Math.Floor(convertedPoint.Position.Y));
+
+                    // stable only supports a single curve type specification per slider.
+                    // we exploit the fact that the converted-to-Bézier path only has Bézier segments,
+                    // and thus we specify the Bézier curve type once ever at the start of the slider.
+                    hasPath.Path.ControlPoints.Add(new PathControlPoint(position, i == 0 ? PathType.BEZIER : null));
+
+                    // however, the Bézier path as output by the converter has multiple segments.
+                    // `LegacyBeatmapEncoder` will attempt to encode this by emitting per-control-point curve type specs which don't do anything for stable.
+                    // instead, stable expects control points that start a segment to be present in the path twice in succession.
+                    if (convertedPoint.Type == PathType.BEZIER)
+                        hasPath.Path.ControlPoints.Add(new PathControlPoint(position));
+                }
             }
 
             // Encode to legacy format

--- a/osu.Game/Rulesets/Objects/BezierConverter.cs
+++ b/osu.Game/Rulesets/Objects/BezierConverter.cs
@@ -136,6 +136,7 @@ namespace osu.Game.Rulesets.Objects
                         {
                             for (int j = 0; j < segment.Length - 1; j++)
                             {
+                                if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(segment[j]));
                                 result.Add(new PathControlPoint(segment[j], j == 0 ? PathType.BEZIER : null));
                             }
                         }
@@ -147,6 +148,7 @@ namespace osu.Game.Rulesets.Objects
                         {
                             for (int j = 0; j < segment.Length - 1; j++)
                             {
+                                if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(segment[j]));
                                 result.Add(new PathControlPoint(segment[j], j == 0 ? PathType.BEZIER : null));
                             }
                         }
@@ -158,6 +160,7 @@ namespace osu.Game.Rulesets.Objects
 
                         for (int j = 0; j < circleResult.Length - 1; j++)
                         {
+                            if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(circleResult[j]));
                             result.Add(new PathControlPoint(circleResult[j], j == 0 ? PathType.BEZIER : null));
                         }
 
@@ -170,6 +173,7 @@ namespace osu.Game.Rulesets.Objects
 
                         for (int j = 0; j < bSplineResult.Length - 1; j++)
                         {
+                            if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(bSplineResult[j]));
                             result.Add(new PathControlPoint(bSplineResult[j], j == 0 ? PathType.BEZIER : null));
                         }
 

--- a/osu.Game/Rulesets/Objects/BezierConverter.cs
+++ b/osu.Game/Rulesets/Objects/BezierConverter.cs
@@ -136,7 +136,6 @@ namespace osu.Game.Rulesets.Objects
                         {
                             for (int j = 0; j < segment.Length - 1; j++)
                             {
-                                if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(segment[j]));
                                 result.Add(new PathControlPoint(segment[j], j == 0 ? PathType.BEZIER : null));
                             }
                         }
@@ -148,7 +147,6 @@ namespace osu.Game.Rulesets.Objects
                         {
                             for (int j = 0; j < segment.Length - 1; j++)
                             {
-                                if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(segment[j]));
                                 result.Add(new PathControlPoint(segment[j], j == 0 ? PathType.BEZIER : null));
                             }
                         }
@@ -160,7 +158,6 @@ namespace osu.Game.Rulesets.Objects
 
                         for (int j = 0; j < circleResult.Length - 1; j++)
                         {
-                            if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(circleResult[j]));
                             result.Add(new PathControlPoint(circleResult[j], j == 0 ? PathType.BEZIER : null));
                         }
 
@@ -173,7 +170,6 @@ namespace osu.Game.Rulesets.Objects
 
                         for (int j = 0; j < bSplineResult.Length - 1; j++)
                         {
-                            if (result.Count > 0 && j == 0) result.Add(new PathControlPoint(bSplineResult[j]));
                             result.Add(new PathControlPoint(bSplineResult[j], j == 0 ? PathType.BEZIER : null));
                         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/31713
- Closes https://github.com/ppy/osu/issues/31714

[Previously](https://github.com/ppy/osu/pull/12303), [previously](https://github.com/ppy/osu/pull/12309), [previously](https://github.com/ppy/osu/pull/12310).

While I don't see immediate breakage in light testing, I accept that this may turn out to be entirely incorrect from the start line, so please treat with as much skepticism as you see warranted.

The logic in `LegacyBeatmapEncoder` that was supposed to handle the lazer-exclusive feature of supporting multiple slider segment types in a single slider was interfering rather badly with the Bezier converter. Generally it was a bit difficult to follow, too.

The nice thing about `BezierConverter` is that it is *guaranteed* to only output Bezier control points. In light of this, the same double-up-the-control-point logic that was supposed to make multiple slider segment types backwards-compatible with stable can be placed in the Bezier conversion logic, and be *much* more understandable, too. So I did that instead of attempting to jam more exceptions into the existing encoder code.

@OliBomby tagging in, as you may be interested in checking out this proposal, and maybe you can spot if I'm missing something in all this as well.

---

This change fixes some sliders which use mutliple curve types not getting correctly exported to the stable `.osz` beatmap package format.