### PR TITLE
Fix distance snap time part ceasing to work when grid snap is also active

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -273,7 +273,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             pos = Vector2.Clamp(pos, Vector2.Zero, OsuPlayfield.BASE_SIZE);
 
             var playfield = PlayfieldAtScreenSpacePosition(screenSpacePosition);
-            return new SnapResult(positionSnapGrid.ToScreenSpace(pos), null, playfield);
+            return new SnapResult(positionSnapGrid.ToScreenSpace(pos), fallbackTime, playfield);
         }
 
         private bool snapToVisibleBlueprints(Vector2 screenSpacePosition, out SnapResult snapResult)


### PR DESCRIPTION
As pointed out in https://github.com/ppy/osu/pull/31655#discussion_r1935536934.

Before:

https://github.com/user-attachments/assets/e254c14c-0e21-4603-b8c3-9b73a6735ce9

After:

https://github.com/user-attachments/assets/8d3fbd32-2b6f-429c-bdad-8567bbe82968

Things to pay attention to on videos above: indicator whether <kbd>Ctrl</kbd>/<kbd>Shift</kbd> is pressed down below, and what happens to the start time of the object on the timeline up above.

Will attempt test coverage on request. It's a bit annoying to add coverage of snapping in an actual composer scenario (need to set up some credible pre-calculated scenario with snapping involved and hardcode expected coordinates).