### PR TITLE
Fix results screen sounds persisting after exit

### DIFF
--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
@@ -2,8 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -91,6 +91,9 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
 
         private readonly ScoreInfo score;
 
+        [Resolved]
+        private ResultsScreen? resultsScreen { get; set; }
+
         private CircularProgress accuracyCircle = null!;
         private GradedCircles gradedCircles = null!;
         private Container<RankBadge> badges = null!;
@@ -101,7 +104,6 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
         private PoolableSkinnableSample? badgeMaxSound;
         private PoolableSkinnableSample? swooshUpSound;
         private PoolableSkinnableSample? rankImpactSound;
-        private PoolableSkinnableSample? rankApplauseSound;
 
         private readonly Bindable<double> tickPlaybackRate = new Bindable<double>();
 
@@ -197,15 +199,9 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
 
             if (withFlair)
             {
-                var applauseSamples = new List<string> { applauseSampleName };
-                if (score.Rank >= ScoreRank.B)
-                    // when rank is B or higher, play legacy applause sample on legacy skins.
-                    applauseSamples.Insert(0, @"applause");
-
                 AddRangeInternal(new Drawable[]
                 {
                     rankImpactSound = new PoolableSkinnableSample(new SampleInfo(impactSampleName)),
-                    rankApplauseSound = new PoolableSkinnableSample(new SampleInfo(applauseSamples.ToArray())),
                     scoreTickSound = new PoolableSkinnableSample(new SampleInfo(@"Results/score-tick")),
                     badgeTickSound = new PoolableSkinnableSample(new SampleInfo(@"Results/badge-dink")),
                     badgeMaxSound = new PoolableSkinnableSample(new SampleInfo(@"Results/badge-dink-max")),
@@ -333,16 +329,9 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                         });
 
                         const double applause_pre_delay = 545f;
-                        const double applause_volume = 0.8f;
 
                         using (BeginDelayedSequence(applause_pre_delay))
-                        {
-                            Schedule(() =>
-                            {
-                                rankApplauseSound!.VolumeTo(applause_volume);
-                                rankApplauseSound!.Play();
-                            });
-                        }
+                            Schedule(() => resultsScreen?.PlayApplause(score.Rank));
                     }
                 }
 
@@ -381,34 +370,6 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
             {
                 scoreTickSound?.Play();
                 lastTickPlaybackTime = Clock.CurrentTime;
-            }
-        }
-
-        private string applauseSampleName
-        {
-            get
-            {
-                switch (score.Rank)
-                {
-                    default:
-                    case ScoreRank.D:
-                        return @"Results/applause-d";
-
-                    case ScoreRank.C:
-                        return @"Results/applause-c";
-
-                    case ScoreRank.B:
-                        return @"Results/applause-b";
-
-                    case ScoreRank.A:
-                        return @"Results/applause-a";
-
-                    case ScoreRank.S:
-                    case ScoreRank.SH:
-                    case ScoreRank.X:
-                    case ScoreRank.XH:
-                        return @"Results/applause-s";
-                }
             }
         }
 

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Screens.Ranking
 
         private Drawable bottomPanel = null!;
         private Container<ScorePanel> detachedPanelContainer = null!;
+        private AudioContainer audioContainer = null!;
 
         private bool lastFetchCompleted;
 
@@ -100,76 +101,80 @@ namespace osu.Game.Screens.Ranking
 
             popInSample = audio.Samples.Get(@"UI/overlay-pop-in");
 
-            InternalChild = new PopoverContainer
+            InternalChild = audioContainer = new AudioContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = new GridContainer
+                Child = new PopoverContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Content = new[]
+                    Child = new GridContainer
                     {
-                        new Drawable[]
+                        RelativeSizeAxes = Axes.Both,
+                        Content = new[]
                         {
-                            VerticalScrollContent = new VerticalScrollContainer
+                            new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                ScrollbarVisible = false,
-                                Child = new Container
+                                VerticalScrollContent = new VerticalScrollContainer
                                 {
                                     RelativeSizeAxes = Axes.Both,
+                                    ScrollbarVisible = false,
+                                    Child = new Container
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Children = new Drawable[]
+                                        {
+                                            StatisticsPanel = createStatisticsPanel().With(panel =>
+                                            {
+                                                panel.RelativeSizeAxes = Axes.Both;
+                                                panel.Score.BindTarget = SelectedScore;
+                                            }),
+                                            ScorePanelList = new ScorePanelList
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                SelectedScore = { BindTarget = SelectedScore },
+                                                PostExpandAction = () => StatisticsPanel.ToggleVisibility()
+                                            },
+                                            detachedPanelContainer = new Container<ScorePanel>
+                                            {
+                                                RelativeSizeAxes = Axes.Both
+                                            },
+                                        }
+                                    }
+                                },
+                            },
+                            new[]
+                            {
+                                bottomPanel = new Container
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = TwoLayerButton.SIZE_EXTENDED.Y,
+                                    Alpha = 0,
                                     Children = new Drawable[]
                                     {
-                                        StatisticsPanel = createStatisticsPanel().With(panel =>
-                                        {
-                                            panel.RelativeSizeAxes = Axes.Both;
-                                            panel.Score.BindTarget = SelectedScore;
-                                        }),
-                                        ScorePanelList = new ScorePanelList
+                                        new Box
                                         {
                                             RelativeSizeAxes = Axes.Both,
-                                            SelectedScore = { BindTarget = SelectedScore },
-                                            PostExpandAction = () => StatisticsPanel.ToggleVisibility()
+                                            Colour = Color4Extensions.FromHex("#333")
                                         },
-                                        detachedPanelContainer = new Container<ScorePanel>
+                                        buttons = new FillFlowContainer
                                         {
-                                            RelativeSizeAxes = Axes.Both
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            AutoSizeAxes = Axes.Both,
+                                            Spacing = new Vector2(5),
+                                            Direction = FillDirection.Horizontal
                                         },
                                     }
                                 }
-                            },
-                        },
-                        new[]
-                        {
-                            bottomPanel = new Container
-                            {
-                                Anchor = Anchor.BottomLeft,
-                                Origin = Anchor.BottomLeft,
-                                RelativeSizeAxes = Axes.X,
-                                Height = TwoLayerButton.SIZE_EXTENDED.Y,
-                                Alpha = 0,
-                                Children = new Drawable[]
-                                {
-                                    new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4Extensions.FromHex("#333")
-                                    },
-                                    buttons = new FillFlowContainer
-                                    {
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        AutoSizeAxes = Axes.Both,
-                                        Spacing = new Vector2(5),
-                                        Direction = FillDirection.Horizontal
-                                    },
-                                }
                             }
+                        },
+                        RowDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.AutoSize)
                         }
-                    },
-                    RowDimensions = new[]
-                    {
-                        new Dimension(),
-                        new Dimension(GridSizeMode.AutoSize)
                     }
                 }
             };
@@ -330,6 +335,8 @@ namespace osu.Game.Screens.Ranking
 
             if (!skipExitTransition)
                 this.FadeOut(100);
+
+            audioContainer.Volume.Value = 0;
             return false;
         }
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/31740

I probably uncovered about 4 issues down multiple implementations, and this is the best/simplest that I've come up with for now.

Testing:
```diff
diff --git a/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs b/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
index 319a87fdfc..2a4f499faf 100644
--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -122,7 +123,7 @@ public partial class AccuracyCircle : CompositeDrawable
         public AccuracyCircle(ScoreInfo score, bool withFlair = false)
         {
             this.score = score;
-            this.withFlair = withFlair;
+            this.withFlair = true;
 
             ScoreProcessor scoreProcessor = score.Ruleset.CreateInstance().CreateScoreProcessor();
             accuracyX = scoreProcessor.AccuracyCutoffFromRank(ScoreRank.X);
@@ -339,6 +340,7 @@ protected override void LoadComplete()
                         {
                             Schedule(() =>
                             {
+                                rankApplauseSound!.Looping = true;
                                 rankApplauseSound!.VolumeTo(applause_volume);
                                 rankApplauseSound!.Play();
                             });
@@ -464,5 +466,12 @@ private double inverseEasing(Easing easing, double targetValue)
 
             return test;
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            Thread.Sleep(10000);
+
+            base.Dispose(isDisposing);
+        }
     }
 }
diff --git a/osu.Game/Screens/Ranking/ResultsScreen.cs b/osu.Game/Screens/Ranking/ResultsScreen.cs
index 95dbfb2712..2ab186abcf 100644
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -333,8 +333,8 @@ public override bool OnExiting(ScreenExitEvent e)
             // HitObject references from HitEvent.
             Score?.HitEvents.Clear();
 
-            if (!skipExitTransition)
-                this.FadeOut(100);
+            // if (!skipExitTransition)
+            //     this.FadeOut(100);
 
             audioContainer.Volume.Value = 0;
             return false;

```

> Q: Why fade out immediately instead of over 100ms or so?

Primarily, I ran into https://github.com/ppy/osu-framework/issues/6518. In most cases it works fine but there's the odd case where the sample remains audible and feels very bad.

I judge the immediate fade out to be acceptable here as it's masked by the screen exiting sound. To my ears at least...

> Q: Why not use `ISamplePlaybackDisabler`?

Note that this will also result in immediate fade out as above.

For `AccuracyCircle` it'll work fine (with few changes), however there are other components involved in this screen that don't use or can't easily be made to use `PausableSkinnableSound` because they shouldn't be skinnable. Without this, some sounds pause but others continue for a little while which feels bad to me.  
We don't really have a `PausableDrawableSample` that responds to this interface right now for non-skinnable cases, and it's not immediately obvious what its semantics would be.

Using `AudioContainer` means that _all_ sounds are muted at the same time.

> Q: What about `DrawableAudioMixer`?

I think this will also work, but I don't want to deal with nested mixers right now.