### PR TITLE
Do not reset online information when saving beatmap

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneLocallyModifyingOnlineBeatmaps.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneLocallyModifyingOnlineBeatmaps.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Tests.Resources;
 
@@ -25,13 +26,16 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestLocallyModifyingOnlineBeatmap()
         {
+            string initialHash = string.Empty;
             AddAssert("editor beatmap has online ID", () => EditorBeatmap.BeatmapInfo.OnlineID, () => Is.GreaterThan(0));
+            AddStep("store hash for later", () => initialHash = EditorBeatmap.BeatmapInfo.MD5Hash);
 
             AddStep("delete first hitobject", () => EditorBeatmap.RemoveAt(0));
             SaveEditor();
 
             ReloadEditorToSameBeatmap();
-            AddAssert("editor beatmap online ID reset", () => EditorBeatmap.BeatmapInfo.OnlineID, () => Is.EqualTo(-1));
+            AddAssert("beatmap marked as locally modified", () => EditorBeatmap.BeatmapInfo.Status, () => Is.EqualTo(BeatmapOnlineStatus.LocallyModified));
+            AddAssert("beatmap hash changed", () => EditorBeatmap.BeatmapInfo.MD5Hash, () => Is.Not.EqualTo(initialHash));
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -475,11 +475,8 @@ namespace osu.Game.Beatmaps
             beatmapContent.BeatmapInfo = beatmapInfo;
 
             // Since now this is a locally-modified beatmap, we also set all relevant flags to indicate this.
-            // Importantly, the `ResetOnlineInfo()` call must happen before encoding, as online ID is encoded into the `.osu` file,
-            // which influences the beatmap checksums.
             beatmapInfo.LastLocalUpdate = DateTimeOffset.Now;
             beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
-            beatmapInfo.ResetOnlineInfo();
 
             Realm.Write(r =>
             {

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Play
                                 Logger.Log($"Please ensure that you are using the latest version of the official game releases.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;
 
-                            case @"invalid beatmap_hash":
+                            case @"invalid or missing beatmap_hash":
                                 Logger.Log($"This beatmap does not match the online version. Please update or redownload it.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23524 (or at least the majority case, excluding all of the "practice difficulty" discourse).

This is more or less a direct revert of https://github.com/ppy/osu/pull/23362. That was supposed to be a quick fixup of an exploitable situation, that sort of outlived its usefulness.

The reason why I'm coming back to it now out of all times is that... I need this gone for BSS. For beatmaps that are actively being worked on, stripping out the online IDs every time the beatmap set is saved means that a submitted beatmap just... cannot be updated by the creator anymore.

Since that initial PR mentioned above, we've tightened down checks extensively via means of changes such as:

- https://github.com/ppy/osu/pull/27143 (which was later partially relaxed in https://github.com/ppy/osu/pull/30453, but end-of-day MD5 is still checked on import when performing online metadata lookups)
- https://github.com/ppy/osu/pull/18978 + https://github.com/ppy/osu/pull/27113
- https://github.com/ppy/osu/pull/27239

After making this change I've red-teamed a few ways I could think of wherein I could modify a beatmap and checking whether things still behave as expected, and I was not able to produce a scenario ***affecting an `.osu` file*** that would result in a bogus score submission.

However, note that all of these checks pertain to ***the MD5 of the `.osu` file only*** and do nothing for things like swapping backgrounds or audio. Whether they should, is up for debate; https://github.com/ppy/osu/discussions/31745 is relevant here in that extent.

This also incidentally fixes https://github.com/ppy/osu/pull/27783 which regressed at some point because the string changed osu-web side. Probably wasn't noticed by anyone because this was probably not hittable by anyone without some major shenanigans before this change.