### PR TITLE
Add group support to beatmap carousel v2

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
         }
 
-        protected void SortBy(FilterCriteria criteria) => AddStep($"sort by {criteria.Sort}", () => Carousel.Filter(criteria));
+        protected void SortBy(FilterCriteria criteria) => AddStep($"sort {criteria.Sort} group {criteria.Group}", () => Carousel.Filter(criteria));
 
         protected void WaitForDrawablePanels() => AddUntilStep("drawable panels loaded", () => Carousel.ChildrenOfType<ICarouselPanel>().Count(), () => Is.GreaterThan(0));
         protected void WaitForSorting() => AddUntilStep("sorting finished", () => Carousel.IsFiltering, () => Is.False);

--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
@@ -21,6 +21,7 @@ using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Resources;
 using osuTK.Graphics;
+using osuTK.Input;
 using BeatmapCarousel = osu.Game.Screens.SelectV2.BeatmapCarousel;
 
 namespace osu.Game.Tests.Visual.SongSelect
@@ -53,7 +54,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [SetUpSteps]
-        public void SetUpSteps()
+        public virtual void SetUpSteps()
         {
             RemoveAllBeatmaps();
 
@@ -134,6 +135,53 @@ namespace osu.Game.Tests.Visual.SongSelect
         protected void WaitForDrawablePanels() => AddUntilStep("drawable panels loaded", () => Carousel.ChildrenOfType<ICarouselPanel>().Count(), () => Is.GreaterThan(0));
         protected void WaitForSorting() => AddUntilStep("sorting finished", () => Carousel.IsFiltering, () => Is.False);
         protected void WaitForScrolling() => AddUntilStep("scroll finished", () => Scroll.Current, () => Is.EqualTo(Scroll.Target));
+
+        protected void SelectNextPanel() => AddStep("select next panel", () => InputManager.Key(Key.Down));
+        protected void SelectPrevPanel() => AddStep("select prev panel", () => InputManager.Key(Key.Up));
+        protected void SelectNextGroup() => AddStep("select next group", () => InputManager.Key(Key.Right));
+        protected void SelectPrevGroup() => AddStep("select prev group", () => InputManager.Key(Key.Left));
+
+        protected void Select() => AddStep("select", () => InputManager.Key(Key.Enter));
+
+        protected void CheckNoSelection() => AddAssert("has no selection", () => Carousel.CurrentSelection, () => Is.Null);
+        protected void CheckHasSelection() => AddAssert("has selection", () => Carousel.CurrentSelection, () => Is.Not.Null);
+
+        protected void WaitForGroupSelection(int group, int panel)
+        {
+            AddUntilStep($"selected is group{group} panel{panel}", () =>
+            {
+                var groupingFilter = Carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single();
+
+                GroupDefinition g = groupingFilter.GroupItems.Keys.ElementAt(group);
+                CarouselItem item = groupingFilter.GroupItems[g].ElementAt(panel);
+
+                return ReferenceEquals(Carousel.CurrentSelection, item.Model);
+            });
+        }
+
+        protected void WaitForSelection(int set, int? diff = null)
+        {
+            AddUntilStep($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
+            {
+                if (diff != null)
+                    return ReferenceEquals(Carousel.CurrentSelection, BeatmapSets[set].Beatmaps[diff.Value]);
+
+                return BeatmapSets[set].Beatmaps.Contains(Carousel.CurrentSelection);
+            });
+        }
+
+        protected void ClickVisiblePanel<T>(int index)
+            where T : Drawable
+        {
+            AddStep($"click panel at index {index}", () =>
+            {
+                Carousel.ChildrenOfType<T>()
+                        .Where(p => ((ICarouselPanel)p).Item?.IsVisible == true)
+                        .Reverse()
+                        .ElementAt(index)
+                        .TriggerClick();
+            });
+        }
 
         /// <summary>
         /// Add requested beatmap sets count to list.

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Basics.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Basics.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestSorting()
         {
             AddBeatmaps(10);
-            SortBy(new FilterCriteria { Sort = SortMode.Difficulty });
+            SortBy(new FilterCriteria { Group = GroupMode.Difficulty, Sort = SortMode.Difficulty });
             SortBy(new FilterCriteria { Sort = SortMode.Artist });
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Basics.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Basics.cs
@@ -33,6 +33,13 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestOffScreenLoading()
+        {
+            AddStep("disable masking", () => Scroll.Masking = false);
+            AddStep("enable masking", () => Scroll.Masking = true);
+        }
+
+        [Test]
         public void TestAddRemoveOneByOne()
         {
             AddRepeatStep("add beatmaps", () => BeatmapSets.Add(TestResources.CreateTestBeatmapSetInfo(RNG.Next(1, 4))), 20);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2GroupSelection.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2GroupSelection.cs
@@ -82,6 +82,20 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestGroupSelectionOnHeader()
+        {
+            AddBeatmaps(10, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            WaitForGroupSelection(0, 0);
+
+            SelectPrevPanel();
+            SelectPrevGroup();
+            WaitForGroupSelection(2, 9);
+        }
+
+        [Test]
         public void TestKeyboardSelection()
         {
             AddBeatmaps(10, 3);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2GroupSelection.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2GroupSelection.cs
@@ -1,0 +1,121 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
+
+namespace osu.Game.Tests.Visual.SongSelect
+{
+    [TestFixture]
+    public partial class TestSceneBeatmapCarouselV2GroupSelection : BeatmapCarouselV2TestScene
+    {
+        public override void SetUpSteps()
+        {
+            RemoveAllBeatmaps();
+
+            CreateCarousel();
+
+            SortBy(new FilterCriteria { Sort = SortMode.Difficulty });
+        }
+
+        [Test]
+        public void TestOpenCloseGroupWithNoSelection()
+        {
+            AddBeatmaps(10, 5);
+            WaitForDrawablePanels();
+
+            AddAssert("no beatmaps visible", () => Carousel.ChildrenOfType<BeatmapPanel>().Count(p => p.Alpha > 0), () => Is.Zero);
+            CheckNoSelection();
+
+            ClickVisiblePanel<GroupPanel>(0);
+            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<BeatmapPanel>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
+            CheckNoSelection();
+
+            ClickVisiblePanel<GroupPanel>(0);
+            AddUntilStep("no beatmaps visible", () => Carousel.ChildrenOfType<BeatmapPanel>().Count(p => p.Alpha > 0), () => Is.Zero);
+            CheckNoSelection();
+        }
+
+        [Test]
+        public void TestCarouselRemembersSelection()
+        {
+            AddBeatmaps(10);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+
+            object? selection = null;
+
+            AddStep("store drawable selection", () => selection = getSelectedPanel()?.Item?.Model);
+
+            CheckHasSelection();
+            AddAssert("drawable selection non-null", () => selection, () => Is.Not.Null);
+            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+
+            RemoveAllBeatmaps();
+            AddUntilStep("no drawable selection", getSelectedPanel, () => Is.Null);
+
+            AddBeatmaps(10);
+            WaitForDrawablePanels();
+
+            CheckHasSelection();
+            AddAssert("no drawable selection", getSelectedPanel, () => Is.Null);
+
+            AddStep("add previous selection", () => BeatmapSets.Add(((BeatmapInfo)selection!).BeatmapSet!));
+
+            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddUntilStep("drawable selection restored", () => getSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));
+            AddAssert("carousel item is visible", () => getSelectedPanel()?.Item?.IsVisible, () => Is.True);
+
+            ClickVisiblePanel<GroupPanel>(0);
+            AddUntilStep("carousel item not visible", getSelectedPanel, () => Is.Null);
+
+            ClickVisiblePanel<GroupPanel>(0);
+            AddUntilStep("carousel item is visible", () => getSelectedPanel()?.Item?.IsVisible, () => Is.True);
+
+            BeatmapPanel? getSelectedPanel() => Carousel.ChildrenOfType<BeatmapPanel>().SingleOrDefault(p => p.Selected.Value);
+        }
+
+        [Test]
+        public void TestKeyboardSelection()
+        {
+            AddBeatmaps(10, 3);
+            WaitForDrawablePanels();
+
+            SelectNextPanel();
+            SelectNextPanel();
+            SelectNextPanel();
+            SelectNextPanel();
+            CheckNoSelection();
+
+            // open first group
+            Select();
+            CheckNoSelection();
+            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<BeatmapPanel>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
+
+            SelectNextPanel();
+            Select();
+            WaitForGroupSelection(0, 0);
+
+            SelectNextGroup();
+            WaitForGroupSelection(0, 1);
+
+            SelectNextGroup();
+            WaitForGroupSelection(0, 2);
+
+            SelectPrevGroup();
+            WaitForGroupSelection(0, 1);
+
+            SelectPrevGroup();
+            WaitForGroupSelection(0, 0);
+
+            SelectPrevGroup();
+            WaitForGroupSelection(2, 9);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2GroupSelection.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2GroupSelection.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             CreateCarousel();
 
-            SortBy(new FilterCriteria { Sort = SortMode.Difficulty });
+            SortBy(new FilterCriteria { Group = GroupMode.Difficulty, Sort = SortMode.Difficulty });
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Selection.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Selection.cs
@@ -130,6 +130,21 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestGroupSelectionOnHeader()
+        {
+            AddBeatmaps(10, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            SelectNextGroup();
+            WaitForSelection(1, 0);
+
+            SelectPrevPanel();
+            SelectPrevGroup();
+            WaitForSelection(0, 0);
+        }
+
+        [Test]
         public void TestKeyboardSelection()
         {
             AddBeatmaps(10, 3);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Selection.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2Selection.cs
@@ -22,10 +22,10 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddBeatmaps(10);
             WaitForDrawablePanels();
-            checkNoSelection();
+            CheckNoSelection();
 
-            select();
-            checkNoSelection();
+            Select();
+            CheckNoSelection();
 
             AddStep("press down arrow", () => InputManager.PressKey(Key.Down));
             checkSelectionIterating(false);
@@ -39,8 +39,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("release up arrow", () => InputManager.ReleaseKey(Key.Up));
             checkSelectionIterating(false);
 
-            select();
-            checkHasSelection();
+            Select();
+            CheckHasSelection();
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddBeatmaps(10);
             WaitForDrawablePanels();
-            checkNoSelection();
+            CheckNoSelection();
 
             AddStep("press right arrow", () => InputManager.PressKey(Key.Right));
             checkSelectionIterating(true);
@@ -73,13 +73,13 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddBeatmaps(10);
             WaitForDrawablePanels();
 
-            selectNextGroup();
+            SelectNextGroup();
 
             object? selection = null;
 
             AddStep("store drawable selection", () => selection = getSelectedPanel()?.Item?.Model);
 
-            checkHasSelection();
+            CheckHasSelection();
             AddAssert("drawable selection non-null", () => selection, () => Is.Not.Null);
             AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
 
@@ -89,13 +89,14 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddBeatmaps(10);
             WaitForDrawablePanels();
 
-            checkHasSelection();
+            CheckHasSelection();
             AddAssert("no drawable selection", getSelectedPanel, () => Is.Null);
 
             AddStep("add previous selection", () => BeatmapSets.Add(((BeatmapInfo)selection!).BeatmapSet!));
 
+            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
             AddUntilStep("drawable selection restored", () => getSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));
-            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddAssert("carousel item is visible", () => getSelectedPanel()?.Item?.IsVisible, () => Is.True);
 
             BeatmapPanel? getSelectedPanel() => Carousel.ChildrenOfType<BeatmapPanel>().SingleOrDefault(p => p.Selected.Value);
         }
@@ -108,10 +109,10 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddBeatmaps(total_set_count);
             WaitForDrawablePanels();
 
-            selectNextGroup();
-            waitForSelection(0, 0);
-            selectPrevGroup();
-            waitForSelection(total_set_count - 1, 0);
+            SelectNextGroup();
+            WaitForSelection(0, 0);
+            SelectPrevGroup();
+            WaitForSelection(total_set_count - 1, 0);
         }
 
         [Test]
@@ -122,10 +123,10 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddBeatmaps(total_set_count);
             WaitForDrawablePanels();
 
-            selectPrevGroup();
-            waitForSelection(total_set_count - 1, 0);
-            selectNextGroup();
-            waitForSelection(0, 0);
+            SelectPrevGroup();
+            WaitForSelection(total_set_count - 1, 0);
+            SelectNextGroup();
+            WaitForSelection(0, 0);
         }
 
         [Test]
@@ -134,70 +135,49 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddBeatmaps(10, 3);
             WaitForDrawablePanels();
 
-            selectNextPanel();
-            selectNextPanel();
-            selectNextPanel();
-            selectNextPanel();
-            checkNoSelection();
+            SelectNextPanel();
+            SelectNextPanel();
+            SelectNextPanel();
+            SelectNextPanel();
+            CheckNoSelection();
 
-            select();
-            waitForSelection(3, 0);
+            Select();
+            WaitForSelection(3, 0);
 
-            selectNextPanel();
-            waitForSelection(3, 0);
+            SelectNextPanel();
+            WaitForSelection(3, 0);
 
-            select();
-            waitForSelection(3, 1);
+            Select();
+            WaitForSelection(3, 1);
 
-            selectNextPanel();
-            waitForSelection(3, 1);
+            SelectNextPanel();
+            WaitForSelection(3, 1);
 
-            select();
-            waitForSelection(3, 2);
+            Select();
+            WaitForSelection(3, 2);
 
-            selectNextPanel();
-            waitForSelection(3, 2);
+            SelectNextPanel();
+            WaitForSelection(3, 2);
 
-            select();
-            waitForSelection(4, 0);
+            Select();
+            WaitForSelection(4, 0);
         }
 
         [Test]
         public void TestEmptyTraversal()
         {
-            selectNextPanel();
-            checkNoSelection();
+            SelectNextPanel();
+            CheckNoSelection();
 
-            selectNextGroup();
-            checkNoSelection();
+            SelectNextGroup();
+            CheckNoSelection();
 
-            selectPrevPanel();
-            checkNoSelection();
+            SelectPrevPanel();
+            CheckNoSelection();
 
-            selectPrevGroup();
-            checkNoSelection();
+            SelectPrevGroup();
+            CheckNoSelection();
         }
-
-        private void waitForSelection(int set, int? diff = null)
-        {
-            AddUntilStep($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
-            {
-                if (diff != null)
-                    return ReferenceEquals(Carousel.CurrentSelection, BeatmapSets[set].Beatmaps[diff.Value]);
-
-                return BeatmapSets[set].Beatmaps.Contains(Carousel.CurrentSelection);
-            });
-        }
-
-        private void selectNextPanel() => AddStep("select next panel", () => InputManager.Key(Key.Down));
-        private void selectPrevPanel() => AddStep("select prev panel", () => InputManager.Key(Key.Up));
-        private void selectNextGroup() => AddStep("select next group", () => InputManager.Key(Key.Right));
-        private void selectPrevGroup() => AddStep("select prev group", () => InputManager.Key(Key.Left));
-
-        private void select() => AddStep("select", () => InputManager.Key(Key.Enter));
-
-        private void checkNoSelection() => AddAssert("has no selection", () => Carousel.CurrentSelection, () => Is.Null);
-        private void checkHasSelection() => AddAssert("has selection", () => Carousel.CurrentSelection, () => Is.Not.Null);
 
         private void checkSelectionIterating(bool isIterating)
         {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -124,9 +124,10 @@ namespace osu.Game.Screens.SelectV2
                     if (Criteria.SplitOutDifficulties)
                     {
                         // Find the containing group. There should never be too many groups so iterating is efficient enough.
-                        GroupDefinition group = grouping.GroupItems.Single(kvp => kvp.Value.Any(i => ReferenceEquals(i.Model, beatmapInfo))).Key;
+                        GroupDefinition? group = grouping.GroupItems.SingleOrDefault(kvp => kvp.Value.Any(i => ReferenceEquals(i.Model, beatmapInfo))).Key;
 
-                        setVisibleGroup(group);
+                        if (group != null)
+                            setVisibleGroup(group);
                     }
                     else
                     {

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -87,22 +87,19 @@ namespace osu.Game.Screens.SelectV2
 
                     if (item.Model is BeatmapInfo beatmap)
                     {
-                        if (groupSetsTogether)
+                        bool newBeatmapSet = lastItem == null || (lastItem.Model is BeatmapInfo lastBeatmap && lastBeatmap.BeatmapSet!.ID != beatmap.BeatmapSet!.ID);
+
+                        if (newBeatmapSet)
                         {
-                            bool newBeatmapSet = lastItem == null || (lastItem.Model is BeatmapInfo lastBeatmap && lastBeatmap.BeatmapSet!.ID != beatmap.BeatmapSet!.ID);
-
-                            if (newBeatmapSet)
-                            {
-                                newItems.Insert(i, new CarouselItem(beatmap.BeatmapSet!) { DrawHeight = BeatmapSetPanel.HEIGHT });
-                                i++;
-                            }
-
-                            if (!setItems.TryGetValue(beatmap.BeatmapSet!, out var related))
-                                setItems[beatmap.BeatmapSet!] = related = new HashSet<CarouselItem>();
-
-                            related.Add(item);
-                            item.IsVisible = false;
+                            newItems.Insert(i, new CarouselItem(beatmap.BeatmapSet!) { DrawHeight = BeatmapSetPanel.HEIGHT });
+                            i++;
                         }
+
+                        if (!setItems.TryGetValue(beatmap.BeatmapSet!, out var related))
+                            setItems[beatmap.BeatmapSet!] = related = new HashSet<CarouselItem>();
+
+                        related.Add(item);
+                        item.IsVisible = false;
                     }
 
                     lastItem = item;

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -35,6 +35,9 @@ namespace osu.Game.Screens.SelectV2
 
         public async Task<IEnumerable<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken) => await Task.Run(() =>
         {
+            setItems.Clear();
+            groupItems.Clear();
+
             var criteria = getCriteria();
 
             int starGroup = int.MinValue;

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -56,11 +56,7 @@ namespace osu.Game.Screens.SelectV2
                     {
                         starGroup = (int)Math.Floor(b.StarRating);
                         group = new GroupDefinition($"{starGroup} - {++starGroup} *");
-                        diffItems.Add(new CarouselItem(group)
-                        {
-                            DrawHeight = GroupPanel.HEIGHT,
-                            IsGroupSelectionTarget = true
-                        });
+                        diffItems.Add(new CarouselItem(group) { DrawHeight = GroupPanel.HEIGHT });
                     }
 
                     if (!groupItems.TryGetValue(group!, out var related))
@@ -70,7 +66,6 @@ namespace osu.Game.Screens.SelectV2
                     diffItems.Add(item);
 
                     item.IsVisible = false;
-                    item.IsGroupSelectionTarget = true;
                 }
 
                 return diffItems;
@@ -92,7 +87,6 @@ namespace osu.Game.Screens.SelectV2
                         newItems.Add(new CarouselItem(b.BeatmapSet!)
                         {
                             DrawHeight = BeatmapSetPanel.HEIGHT,
-                            IsGroupSelectionTarget = true
                         });
                     }
 
@@ -104,7 +98,6 @@ namespace osu.Game.Screens.SelectV2
                 newItems.Add(item);
                 lastItem = item;
 
-                item.IsGroupSelectionTarget = false;
                 item.IsVisible = false;
             }
 

--- a/osu.Game/Screens/SelectV2/BeatmapSetPanel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapSetPanel.cs
@@ -67,7 +67,6 @@ namespace osu.Game.Screens.SelectV2
             base.PrepareForUse();
 
             Debug.Assert(Item != null);
-            Debug.Assert(Item.IsGroupSelectionTarget);
 
             var beatmapSetInfo = (BeatmapSetInfo)Item.Model;
 

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -205,7 +205,6 @@ namespace osu.Game.Screens.SelectV2
             InternalChild = scroll = new CarouselScrollContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                Masking = false,
             };
 
             Items.BindCollectionChanged((_, _) => FilterAsync());

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Screens.SelectV2
         ///
         /// A filter may add, mutate or remove items.
         /// </remarks>
-        protected IEnumerable<ICarouselFilter> Filters { get; init; } = Enumerable.Empty<ICarouselFilter>();
+        public IEnumerable<ICarouselFilter> Filters { get; init; } = Enumerable.Empty<ICarouselFilter>();
 
         /// <summary>
         /// All items which are to be considered for display in this carousel.

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -377,26 +377,31 @@ namespace osu.Game.Screens.SelectV2
             if (currentSelection.CarouselItem != currentKeyboardSelection.CarouselItem)
             {
                 TryActivateSelection();
-                return;
+
+                // There's a chance this couldn't resolve, at which point continue with standard traversal.
+                if (currentSelection.CarouselItem == currentKeyboardSelection.CarouselItem)
+                    return;
             }
 
             int originalIndex;
+            int newIndex;
 
-            if (currentKeyboardSelection.Index != null)
-                originalIndex = currentKeyboardSelection.Index.Value;
-            else if (direction > 0)
-                originalIndex = carouselItems.Count - 1;
-            else
-                originalIndex = 0;
-
-            int newIndex = originalIndex;
-
-            // As a second special case, if we're group selecting backwards and the current selection isn't a group,
-            // make sure to go back to the group header this item belongs to, so that the block below doesn't find it and stop too early.
-            if (direction < 0)
+            if (currentSelection.Index == null)
             {
-                while (!CheckValidForGroupSelection(carouselItems[newIndex]))
-                    newIndex--;
+                // If there's no current selection, start from either end of the full list.
+                newIndex = originalIndex = direction > 0 ? carouselItems.Count - 1 : 0;
+            }
+            else
+            {
+                newIndex = originalIndex = currentSelection.Index.Value;
+
+                // As a second special case, if we're group selecting backwards and the current selection isn't a group,
+                // make sure to go back to the group header this item belongs to, so that the block below doesn't find it and stop too early.
+                if (direction < 0)
+                {
+                    while (!CheckValidForGroupSelection(carouselItems[newIndex]))
+                        newIndex--;
+                }
             }
 
             // Iterate over every item back to the current selection, finding the first valid item.

--- a/osu.Game/Screens/SelectV2/CarouselItem.cs
+++ b/osu.Game/Screens/SelectV2/CarouselItem.cs
@@ -30,11 +30,6 @@ namespace osu.Game.Screens.SelectV2
         public float DrawHeight { get; set; } = DEFAULT_HEIGHT;
 
         /// <summary>
-        /// Whether this item should be a valid target for user group selection hotkeys.
-        /// </summary>
-        public bool IsGroupSelectionTarget { get; set; }
-
-        /// <summary>
         /// Whether this item is visible or collapsed (hidden).
         /// </summary>
         public bool IsVisible { get; set; } = true;

--- a/osu.Game/Screens/SelectV2/GroupPanel.cs
+++ b/osu.Game/Screens/SelectV2/GroupPanel.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class GroupPanel : PoolableDrawable, ICarouselPanel
+    {
+        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 2;
+
+        [Resolved]
+        private BeatmapCarousel carousel { get; set; } = null!;
+
+        private Box activationFlash = null!;
+        private OsuSpriteText text = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Size = new Vector2(500, HEIGHT);
+            Masking = true;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = Color4.DarkBlue.Darken(5),
+                    Alpha = 0.8f,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                activationFlash = new Box
+                {
+                    Colour = Color4.White,
+                    Blending = BlendingParameters.Additive,
+                    Alpha = 0,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                text = new OsuSpriteText
+                {
+                    Padding = new MarginPadding(5),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                }
+            };
+
+            Selected.BindValueChanged(value =>
+            {
+                activationFlash.FadeTo(value.NewValue ? 0.2f : 0, 500, Easing.OutQuint);
+            });
+
+            KeyboardSelected.BindValueChanged(value =>
+            {
+                if (value.NewValue)
+                {
+                    BorderThickness = 5;
+                    BorderColour = Color4.Pink;
+                }
+                else
+                {
+                    BorderThickness = 0;
+                }
+            });
+        }
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+
+            Debug.Assert(Item != null);
+            Debug.Assert(Item.IsGroupSelectionTarget);
+
+            GroupDefinition group = (GroupDefinition)Item.Model;
+
+            text.Text = group.Title;
+
+            this.FadeInFromZero(500, Easing.OutQuint);
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            carousel.CurrentSelection = Item!.Model;
+            return true;
+        }
+
+        #region ICarouselPanel
+
+        public CarouselItem? Item { get; set; }
+        public BindableBool Selected { get; } = new BindableBool();
+        public BindableBool KeyboardSelected { get; } = new BindableBool();
+
+        public double DrawYPosition { get; set; }
+
+        public void Activated()
+        {
+            // sets should never be activated.
+            throw new InvalidOperationException();
+        }
+
+        #endregion
+    }
+}

--- a/osu.Game/Screens/SelectV2/GroupPanel.cs
+++ b/osu.Game/Screens/SelectV2/GroupPanel.cs
@@ -79,7 +79,6 @@ namespace osu.Game.Screens.SelectV2
             base.PrepareForUse();
 
             Debug.Assert(Item != null);
-            Debug.Assert(Item.IsGroupSelectionTarget);
 
             GroupDefinition group = (GroupDefinition)Item.Model;
 


### PR DESCRIPTION
This adds the basics of grouping – which is to say difficulty grouping.

Important changes:

- 645c26ca19a16e9c5b33fb66125011c806ca2d78 I split out keyboard and group traversal into two methods because this reduces the complexity (less conditional pathing)
- d74939e6e983267a5bc8be37d94108d46581b02f Removed `IsGroupSelectionTarget` from `CarouselItem`. This is no longer required and is instead handled using `CheckValidForGroupSelection`. Less memory overhead and less complexity (basically allows behaviour to be implemented for traversal of groups without even more `bool` flags).

https://github.com/user-attachments/assets/8530e902-87f9-45b5-bbec-a2ddb2a11693

What's next?

- Expanded state for groups and sets (required for display purposes, mainly). Probably `IsVisible` becomes a ternary `enum { Hidden, Contracted, Expanded }`.
- Grouping with nested sets (ie. artist / title / collection grouping). Should in theory work with no changes.