### PR TITLE
Avoid accessing `WorkingBeatmap.Beatmap` every update call

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -203,6 +203,8 @@ namespace osu.Game.Beatmaps
             {
                 try
                 {
+                    // TODO: This is a touch expensive and can become an issue if being accessed every Update call.
+                    // Optimally we would not involve the async flow if things are already loaded.
                     return loadBeatmapAsync().GetResultSafely();
                 }
                 catch (AggregateException ae)

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Overlays;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Screens.Play
 {
@@ -72,10 +73,10 @@ namespace osu.Game.Screens.Play
             track = working.Track;
 
             GameplayStartTime = gameplayStartTime;
-            StartTime = findEarliestStartTime(gameplayStartTime, working);
+            StartTime = findEarliestStartTime(gameplayStartTime, beatmap, working.Storyboard);
         }
 
-        private static double findEarliestStartTime(double gameplayStartTime, WorkingBeatmap working)
+        private static double findEarliestStartTime(double gameplayStartTime, IBeatmap beatmap, Storyboard storyboard)
         {
             // here we are trying to find the time to start playback from the "zero" point.
             // generally this is either zero, or some point earlier than zero in the case of storyboards, lead-ins etc.
@@ -85,15 +86,15 @@ namespace osu.Game.Screens.Play
 
             // if a storyboard is present, it may dictate the appropriate start time by having events in negative time space.
             // this is commonly used to display an intro before the audio track start.
-            double? firstStoryboardEvent = working.Storyboard.EarliestEventTime;
+            double? firstStoryboardEvent = storyboard.EarliestEventTime;
             if (firstStoryboardEvent != null)
                 time = Math.Min(time, firstStoryboardEvent.Value);
 
             // some beatmaps specify a current lead-in time which should be used instead of the ruleset-provided value when available.
             // this is not available as an option in the live editor but can still be applied via .osu editing.
-            double firstHitObjectTime = working.Beatmap.HitObjects.First().StartTime;
-            if (working.Beatmap.AudioLeadIn > 0)
-                time = Math.Min(time, firstHitObjectTime - working.Beatmap.AudioLeadIn);
+            double firstHitObjectTime = beatmap.HitObjects.First().StartTime;
+            if (beatmap.AudioLeadIn > 0)
+                time = Math.Min(time, firstHitObjectTime - beatmap.AudioLeadIn);
 
             return time;
         }


### PR DESCRIPTION
Notice in passing.

Comes with overheads that can be easily avoided. Left a note for a future (slightly more involved) optimisation.

Wouldn't have bothered with this because marginal-gains but it also makes the code/variables a bit easier to follow in the clock class.

![JetBrains Rider-EAP 2025-02-03 at 07 35 31](https://github.com/user-attachments/assets/8a29b19d-c81d-4850-9a21-17e9a6acb685)
![JetBrains Rider-EAP 2025-02-03 at 07 36 52](https://github.com/user-attachments/assets/81bd8aac-5511-44d6-acb5-61bab66f728d)

