### PR TITLE
Fix depth ordering in new carousel not being relative to selected item

### DIFF
--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -544,8 +544,8 @@ namespace osu.Game.Screens.SelectV2
                 if (c.Item == null)
                     continue;
 
-                if (panel.Depth != c.DrawYPosition)
-                    scroll.Panels.ChangeChildDepth(panel, (float)c.DrawYPosition);
+                double selectedYPos = currentSelection?.CarouselItem?.CarouselYPosition ?? 0;
+                scroll.Panels.ChangeChildDepth(panel, (float)Math.Abs(c.DrawYPosition - selectedYPos));
 
                 if (c.DrawYPosition != c.Item.CarouselYPosition)
                     c.DrawYPosition = Interpolation.DampContinuously(c.DrawYPosition, c.Item.CarouselYPosition, 50, Time.Elapsed);


### PR DESCRIPTION
Noticed while working on https://github.com/ppy/osu/pull/31774. This makes it match lazer behaviour.

Another thing that should eventually be done is that the depth ordering should also consider the type of carousel item, so that difficulty panels are always displayed behind set panels, otherwise they may appear on top of set panels during motion (i.e. when expanding/collapsing a set).

Before (with https://github.com/ppy/osu/pull/31774 checked out):

![CleanShot 2025-02-03 at 02 39 05](https://github.com/user-attachments/assets/36e0908f-305d-4c92-b76e-c3b4a23ebc2a)

After (with https://github.com/ppy/osu/pull/31774 checked out):

![CleanShot 2025-02-03 at 02 38 17](https://github.com/user-attachments/assets/cdd50801-ce1f-4b92-8739-62adc30169e5)