### PR TITLE
Change menus to fade out with a slight delay so settings changes are visible

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
@@ -12,8 +12,6 @@ namespace osu.Game.Graphics.UserInterface
 {
     public partial class OsuContextMenu : OsuMenu
     {
-        private const int fade_duration = 250;
-
         [Resolved]
         private OsuMenuSamples menuSamples { get; set; } = null!;
 
@@ -48,7 +46,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override void AnimateOpen()
         {
             wasOpened = true;
-            this.FadeIn(fade_duration, Easing.OutQuint);
+            this.FadeIn(FADE_DURATION, Easing.OutQuint);
 
             if (!playClickSample)
                 return;
@@ -59,7 +57,8 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void AnimateClose()
         {
-            this.FadeOut(fade_duration, Easing.OutQuint);
+            this.Delay(DELAY_BEFORE_FADE_OUT)
+                .FadeOut(FADE_DURATION, Easing.OutQuint);
 
             if (wasOpened)
                 menuSamples.PlayCloseSample();

--- a/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
@@ -15,12 +15,8 @@ namespace osu.Game.Graphics.UserInterface
         [Resolved]
         private OsuMenuSamples menuSamples { get; set; } = null!;
 
-        // todo: this shouldn't be required after https://github.com/ppy/osu-framework/issues/4519 is fixed.
-        private bool wasOpened;
-        private readonly bool playClickSample;
-
-        public OsuContextMenu(bool playClickSample = false)
-            : base(Direction.Vertical)
+        public OsuContextMenu(bool playSamples)
+            : base(Direction.Vertical, topLevelMenu: false, playSamples)
         {
             MaskingContainer.CornerRadius = 5;
             MaskingContainer.EdgeEffect = new EdgeEffectParameters
@@ -33,8 +29,6 @@ namespace osu.Game.Graphics.UserInterface
             ItemsContainer.Padding = new MarginPadding { Vertical = DrawableOsuMenuItem.MARGIN_VERTICAL };
 
             MaxHeight = 250;
-
-            this.playClickSample = playClickSample;
         }
 
         [BackgroundDependencyLoader]
@@ -45,27 +39,12 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void AnimateOpen()
         {
-            wasOpened = true;
-            this.FadeIn(FADE_DURATION, Easing.OutQuint);
+            if (PlaySamples && !WasOpened)
+                menuSamples.PlayClickSample();
 
-            if (!playClickSample)
-                return;
-
-            menuSamples.PlayClickSample();
-            menuSamples.PlayOpenSample();
+            base.AnimateOpen();
         }
 
-        protected override void AnimateClose()
-        {
-            this.Delay(DELAY_BEFORE_FADE_OUT)
-                .FadeOut(FADE_DURATION, Easing.OutQuint);
-
-            if (wasOpened)
-                menuSamples.PlayCloseSample();
-
-            wasOpened = false;
-        }
-
-        protected override Menu CreateSubMenu() => new OsuContextMenu();
+        protected override Menu CreateSubMenu() => new OsuContextMenu(false); // sub menu samples are handled by OsuMenu.OnSubmenuOpen.
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -22,20 +22,28 @@ namespace osu.Game.Graphics.UserInterface
         protected const double FADE_DURATION = 280;
 
         // todo: this shouldn't be required after https://github.com/ppy/osu-framework/issues/4519 is fixed.
-        private bool wasOpened;
+        protected bool WasOpened { get; private set; }
+
+        public bool PlaySamples { get; }
 
         [Resolved]
         private OsuMenuSamples menuSamples { get; set; } = null!;
 
         public OsuMenu(Direction direction, bool topLevelMenu = false)
+            : this(direction, topLevelMenu, playSamples: !topLevelMenu)
+        {
+        }
+
+        protected OsuMenu(Direction direction, bool topLevelMenu, bool playSamples)
             : base(direction, topLevelMenu)
         {
+            PlaySamples = playSamples;
             BackgroundColour = Color4.Black.Opacity(0.5f);
 
             MaskingContainer.CornerRadius = 4;
             ItemsContainer.Padding = new MarginPadding(5);
 
-            OnSubmenuOpen += _ => { menuSamples?.PlaySubOpenSample(); };
+            OnSubmenuOpen += _ => menuSamples?.PlaySubOpenSample();
         }
 
         protected override void Update()
@@ -59,22 +67,22 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void AnimateOpen()
         {
-            if (!TopLevelMenu && !wasOpened)
+            if (PlaySamples && !WasOpened)
                 menuSamples?.PlayOpenSample();
 
-            this.FadeIn(300, Easing.OutQuint);
-            wasOpened = true;
+            WasOpened = true;
+            this.FadeIn(FADE_DURATION, Easing.OutQuint);
         }
 
         protected override void AnimateClose()
         {
-            if (!TopLevelMenu && wasOpened)
+            if (PlaySamples && WasOpened)
                 menuSamples?.PlayCloseSample();
 
             this.Delay(DELAY_BEFORE_FADE_OUT)
                 .FadeOut(FADE_DURATION, Easing.OutQuint);
 
-            wasOpened = false;
+            WasOpened = false;
         }
 
         protected override void UpdateSize(Vector2 newSize)
@@ -87,7 +95,7 @@ namespace osu.Game.Graphics.UserInterface
                     this.ResizeHeightTo(newSize.Y, 300, Easing.OutQuint);
                 else
                     // Delay until the fade out finishes from AnimateClose.
-                    this.Delay(350).ResizeHeightTo(0);
+                    this.Delay(DELAY_BEFORE_FADE_OUT + FADE_DURATION).ResizeHeightTo(0);
             }
             else
             {
@@ -96,7 +104,7 @@ namespace osu.Game.Graphics.UserInterface
                     this.ResizeWidthTo(newSize.X, 300, Easing.OutQuint);
                 else
                     // Delay until the fade out finishes from AnimateClose.
-                    this.Delay(350).ResizeWidthTo(0);
+                    this.Delay(DELAY_BEFORE_FADE_OUT + FADE_DURATION).ResizeWidthTo(0);
             }
         }
 

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -18,6 +18,9 @@ namespace osu.Game.Graphics.UserInterface
 {
     public partial class OsuMenu : Menu
     {
+        protected const double DELAY_BEFORE_FADE_OUT = 50;
+        protected const double FADE_DURATION = 280;
+
         // todo: this shouldn't be required after https://github.com/ppy/osu-framework/issues/4519 is fixed.
         private bool wasOpened;
 
@@ -68,8 +71,8 @@ namespace osu.Game.Graphics.UserInterface
             if (!TopLevelMenu && wasOpened)
                 menuSamples?.PlayCloseSample();
 
-            this.Delay(50)
-                .FadeOut(300, Easing.OutQuint);
+            this.Delay(DELAY_BEFORE_FADE_OUT)
+                .FadeOut(FADE_DURATION, Easing.OutQuint);
 
             wasOpened = false;
         }

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -68,7 +68,9 @@ namespace osu.Game.Graphics.UserInterface
             if (!TopLevelMenu && wasOpened)
                 menuSamples?.PlayCloseSample();
 
-            this.FadeOut(300, Easing.OutQuint);
+            this.Delay(50)
+                .FadeOut(300, Easing.OutQuint);
+
             wasOpened = false;
         }
 
@@ -77,12 +79,21 @@ namespace osu.Game.Graphics.UserInterface
             if (Direction == Direction.Vertical)
             {
                 Width = newSize.X;
-                this.ResizeHeightTo(newSize.Y, 300, Easing.OutQuint);
+
+                if (newSize.Y > 0)
+                    this.ResizeHeightTo(newSize.Y, 300, Easing.OutQuint);
+                else
+                    // Delay until the fade out finishes from AnimateClose.
+                    this.Delay(350).ResizeHeightTo(0);
             }
             else
             {
                 Height = newSize.Y;
-                this.ResizeWidthTo(newSize.X, 300, Easing.OutQuint);
+                if (newSize.X > 0)
+                    this.ResizeWidthTo(newSize.X, 300, Easing.OutQuint);
+                else
+                    // Delay until the fade out finishes from AnimateClose.
+                    this.Delay(350).ResizeWidthTo(0);
             }
         }
 


### PR DESCRIPTION
Useful for cases like https://github.com/ppy/osu/pull/31778, where a change to one setting can affect another.

https://github.com/user-attachments/assets/562d4df3-a736-4f6a-9875-c7b56fd9a275