### PR TITLE
Fix carousel tests failing due to dependency on depth ordering

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
@@ -175,7 +175,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddStep($"click panel at index {index}", () =>
             {
-                Carousel.ChildrenOfType<T>()
+                Carousel.ChildrenOfType<UserTrackingScrollContainer>().Single()
+                        .ChildrenOfType<T>()
                         .Where(p => ((ICarouselPanel)p).Item?.IsVisible == true)
                         .Reverse()
                         .ElementAt(index)

--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 Carousel.ChildrenOfType<UserTrackingScrollContainer>().Single()
                         .ChildrenOfType<T>()
                         .Where(p => ((ICarouselPanel)p).Item?.IsVisible == true)
-                        .Reverse()
+                        .OrderBy(p => p.Y)
                         .ElementAt(index)
                         .TriggerClick();
             });


### PR DESCRIPTION
Regressed with #31776 in combination with #31764