### PR TITLE
Always select the closest control point group regardless of whether it has a timing point on entering timing screen

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Screens.Edit.Timing
 {
     public partial class ControlPointList : CompositeDrawable
     {
+        public Action? SelectClosestTimingPoint { get; init; }
+
         private ControlPointTable table = null!;
         private Container controls = null!;
         private OsuButton deleteButton = null!;
@@ -75,7 +77,7 @@ namespace osu.Game.Screens.Edit.Timing
                                 new RoundedButton
                                 {
                                     Text = "Select closest to current time",
-                                    Action = goToCurrentGroup,
+                                    Action = SelectClosestTimingPoint,
                                     Size = new Vector2(220, 30),
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
@@ -144,17 +146,6 @@ namespace osu.Game.Screens.Edit.Timing
 
             addButton.Enabled.Value = clock.CurrentTimeAccurate != selectedGroup.Value?.Time;
             table.Padding = new MarginPadding { Bottom = controls.DrawHeight };
-        }
-
-        private void goToCurrentGroup()
-        {
-            double accurateTime = clock.CurrentTimeAccurate;
-
-            var activeTimingPoint = Beatmap.ControlPointInfo.TimingPointAt(accurateTime);
-            var activeEffectPoint = Beatmap.ControlPointInfo.EffectPointAt(accurateTime);
-
-            double latestActiveTime = Math.Max(activeTimingPoint.Time, activeEffectPoint.Time);
-            selectedGroup.Value = Beatmap.ControlPointInfo.GroupAt(latestActiveTime);
         }
 
         private void delete()

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -79,8 +79,13 @@ namespace osu.Game.Screens.Edit.Timing
             var activeTimingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(accurateTime);
             var activeEffectPoint = EditorBeatmap.ControlPointInfo.EffectPointAt(accurateTime);
 
-            double latestActiveTime = Math.Max(activeTimingPoint.Time, activeEffectPoint.Time);
-            SelectedGroup.Value = EditorBeatmap.ControlPointInfo.GroupAt(latestActiveTime);
+            if (activeEffectPoint.Equals(EffectControlPoint.DEFAULT))
+                SelectedGroup.Value = EditorBeatmap.ControlPointInfo.GroupAt(activeTimingPoint.Time);
+            else
+            {
+                double latestActiveTime = Math.Max(activeTimingPoint.Time, activeEffectPoint.Time);
+                SelectedGroup.Value = EditorBeatmap.ControlPointInfo.GroupAt(latestActiveTime);
+            }
         }
 
         protected override void ConfigureTimeline(TimelineArea timelineArea)

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -37,7 +38,10 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 new Drawable[]
                 {
-                    new ControlPointList(),
+                    new ControlPointList
+                    {
+                        SelectClosestTimingPoint = selectClosestTimingPoint,
+                    },
                     new ControlPointSettings(),
                 },
             }
@@ -70,8 +74,13 @@ namespace osu.Game.Screens.Edit.Timing
             if (editorClock == null)
                 return;
 
-            var nearestTimingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(editorClock.CurrentTime);
-            SelectedGroup.Value = EditorBeatmap.ControlPointInfo.GroupAt(nearestTimingPoint.Time);
+            double accurateTime = editorClock.CurrentTimeAccurate;
+
+            var activeTimingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(accurateTime);
+            var activeEffectPoint = EditorBeatmap.ControlPointInfo.EffectPointAt(accurateTime);
+
+            double latestActiveTime = Math.Max(activeTimingPoint.Time, activeEffectPoint.Time);
+            SelectedGroup.Value = EditorBeatmap.ControlPointInfo.GroupAt(latestActiveTime);
         }
 
         protected override void ConfigureTimeline(TimelineArea timelineArea)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31648.