### PR TITLE
Fix `Carousel.FilterAsync` not working when called from a non-update thread

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
         }
 
-        protected void SortBy(FilterCriteria criteria) => AddStep($"sort {criteria.Sort} group {criteria.Group}", () => Carousel.Filter(criteria));
+        protected void SortBy(FilterCriteria criteria) => AddStep($"sort:{criteria.Sort} group:{criteria.Group}", () => Carousel.Filter(criteria));
 
         protected void WaitForDrawablePanels() => AddUntilStep("drawable panels loaded", () => Carousel.ChildrenOfType<ICarouselPanel>().Count(), () => Is.GreaterThan(0));
         protected void WaitForSorting() => AddUntilStep("sorting finished", () => Carousel.IsFiltering, () => Is.False);

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -228,8 +228,6 @@ namespace osu.Game.Screens.SelectV2
 
         private async Task performFilter()
         {
-            Debug.Assert(SynchronizationContext.Current != null);
-
             Stopwatch stopwatch = Stopwatch.StartNew();
             var cts = new CancellationTokenSource();
 
@@ -266,19 +264,22 @@ namespace osu.Game.Screens.SelectV2
                 {
                     log("Cancelled due to newer request arriving");
                 }
-            }, cts.Token).ConfigureAwait(true);
+            }, cts.Token).ConfigureAwait(false);
 
             if (cts.Token.IsCancellationRequested)
                 return;
 
-            log("Items ready for display");
-            carouselItems = items.ToList();
-            displayedRange = null;
+            Schedule(() =>
+            {
+                log("Items ready for display");
+                carouselItems = items.ToList();
+                displayedRange = null;
 
-            // Need to call this to ensure correct post-selection logic is handled on the new items list.
-            HandleItemSelected(currentSelection.Model);
+                // Need to call this to ensure correct post-selection logic is handled on the new items list.
+                HandleItemSelected(currentSelection.Model);
 
-            refreshAfterSelection();
+                refreshAfterSelection();
+            });
 
             void log(string text) => Logger.Log($"Carousel[op {cts.GetHashCode().ToString()}] {stopwatch.ElapsedMilliseconds} ms: {text}");
         }

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Screens.SelectV2
             if (DebounceDelay > 0)
             {
                 log($"Filter operation queued, waiting for {DebounceDelay} ms debounce");
-                await Task.Delay(DebounceDelay, cts.Token).ConfigureAwait(true);
+                await Task.Delay(DebounceDelay, cts.Token).ConfigureAwait(false);
             }
 
             // Copy must be performed on update thread for now (see ConfigureAwait above).

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -226,18 +226,13 @@ namespace osu.Game.Screens.SelectV2
         private Task filterTask = Task.CompletedTask;
         private CancellationTokenSource cancellationSource = new CancellationTokenSource();
 
-        private readonly object cancellationLock = new object();
-
         private async Task performFilter()
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
             var cts = new CancellationTokenSource();
 
-            lock (cancellationLock)
-            {
-                cancellationSource.Cancel();
-                cancellationSource = cts;
-            }
+            var previousCancellationSource = Interlocked.Exchange(ref cancellationSource, cts);
+            await previousCancellationSource.CancelAsync().ConfigureAwait(false);
 
             if (DebounceDelay > 0)
             {

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -226,12 +226,14 @@ namespace osu.Game.Screens.SelectV2
         private Task filterTask = Task.CompletedTask;
         private CancellationTokenSource cancellationSource = new CancellationTokenSource();
 
+        private readonly object cancellationLock = new object();
+
         private async Task performFilter()
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
             var cts = new CancellationTokenSource();
 
-            lock (this)
+            lock (cancellationLock)
             {
                 cancellationSource.Cancel();
                 cancellationSource = cts;


### PR DESCRIPTION
Spotted by @frenzibyte during implementation in the bigger picture.

I was trying to be smart about things and make use of our `SynchronisationContext` setup, but it turns out to not work in all cases due to the context being missing depending on where you are calling the method from.

For now let's prefer the "works everywhere" method of scheduling the final work back to update.