### PR TITLE
Allow ordering certain carousel panels behind others

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -66,7 +66,12 @@ namespace osu.Game.Screens.SelectV2
                         {
                             starGroup = (int)Math.Floor(b.StarRating);
                             var groupDefinition = new GroupDefinition($"{starGroup} - {++starGroup} *");
-                            var groupItem = new CarouselItem(groupDefinition) { DrawHeight = GroupPanel.HEIGHT };
+
+                            var groupItem = new CarouselItem(groupDefinition)
+                            {
+                                DrawHeight = GroupPanel.HEIGHT,
+                                DepthLayer = -2
+                            };
 
                             newItems.Add(groupItem);
                             groupItems[groupDefinition] = new HashSet<CarouselItem> { groupItem };
@@ -95,7 +100,12 @@ namespace osu.Game.Screens.SelectV2
 
                         if (newBeatmapSet)
                         {
-                            var setItem = new CarouselItem(beatmap.BeatmapSet!) { DrawHeight = BeatmapSetPanel.HEIGHT };
+                            var setItem = new CarouselItem(beatmap.BeatmapSet!)
+                            {
+                                DrawHeight = BeatmapSetPanel.HEIGHT,
+                                DepthLayer = -1
+                            };
+
                             setItems[beatmap.BeatmapSet!] = new HashSet<CarouselItem> { setItem };
                             newItems.Insert(i, setItem);
                             i++;

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -550,8 +550,7 @@ namespace osu.Game.Screens.SelectV2
                 updateDisplayedRange(range);
             }
 
-            double selectedYPos = currentSelection?.CarouselItem?.CarouselYPosition ?? 0;
-            double maximumDistanceFromSelection = scroll.Panels.Select(p => Math.Abs(((ICarouselPanel)p).DrawYPosition - selectedYPos)).DefaultIfEmpty().Max();
+            double selectedYPos = currentSelection.CarouselItem?.CarouselYPosition ?? 0;
 
             foreach (var panel in scroll.Panels)
             {
@@ -561,8 +560,8 @@ namespace osu.Game.Screens.SelectV2
                 if (c.Item == null)
                     continue;
 
-                float normalisedDepth = (float)(Math.Abs(selectedYPos - c.DrawYPosition) / maximumDistanceFromSelection);
-                scroll.Panels.ChangeChildDepth(panel, normalisedDepth + c.Item.DepthLayer);
+                float normalisedDepth = (float)(Math.Abs(selectedYPos - c.DrawYPosition) / DrawHeight);
+                scroll.Panels.ChangeChildDepth(panel, c.Item.DepthLayer + normalisedDepth);
 
                 if (c.DrawYPosition != c.Item.CarouselYPosition)
                     c.DrawYPosition = Interpolation.DampContinuously(c.DrawYPosition, c.Item.CarouselYPosition, 50, Time.Elapsed);

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -550,6 +550,9 @@ namespace osu.Game.Screens.SelectV2
                 updateDisplayedRange(range);
             }
 
+            double selectedYPos = currentSelection?.CarouselItem?.CarouselYPosition ?? 0;
+            double maximumDistanceFromSelection = scroll.Panels.Select(p => Math.Abs(((ICarouselPanel)p).DrawYPosition - selectedYPos)).DefaultIfEmpty().Max();
+
             foreach (var panel in scroll.Panels)
             {
                 var c = (ICarouselPanel)panel;
@@ -558,8 +561,8 @@ namespace osu.Game.Screens.SelectV2
                 if (c.Item == null)
                     continue;
 
-                double selectedYPos = currentSelection?.CarouselItem?.CarouselYPosition ?? 0;
-                scroll.Panels.ChangeChildDepth(panel, (float)Math.Abs(c.DrawYPosition - selectedYPos));
+                float normalisedDepth = (float)(Math.Abs(selectedYPos - c.DrawYPosition) / maximumDistanceFromSelection);
+                scroll.Panels.ChangeChildDepth(panel, normalisedDepth + c.Item.DepthLayer);
 
                 if (c.DrawYPosition != c.Item.CarouselYPosition)
                     c.DrawYPosition = Interpolation.DampContinuously(c.DrawYPosition, c.Item.CarouselYPosition, 50, Time.Elapsed);

--- a/osu.Game/Screens/SelectV2/CarouselItem.cs
+++ b/osu.Game/Screens/SelectV2/CarouselItem.cs
@@ -30,10 +30,9 @@ namespace osu.Game.Screens.SelectV2
         public float DrawHeight { get; set; } = DEFAULT_HEIGHT;
 
         /// <summary>
-        /// A number that defines the layer which this <see cref="CarouselItem"/> should be placed on depth-wise.
-        /// The higher the number, the farther the panel associated with this item is taken to the background.
+        /// Defines the display depth relative to other <see cref="CarouselItem"/>s.
         /// </summary>
-        public int DepthLayer { get; set; } = 0;
+        public int DepthLayer { get; set; }
 
         /// <summary>
         /// Whether this item is visible or hidden.

--- a/osu.Game/Screens/SelectV2/CarouselItem.cs
+++ b/osu.Game/Screens/SelectV2/CarouselItem.cs
@@ -30,6 +30,12 @@ namespace osu.Game.Screens.SelectV2
         public float DrawHeight { get; set; } = DEFAULT_HEIGHT;
 
         /// <summary>
+        /// A number that defines the layer which this <see cref="CarouselItem"/> should be placed on depth-wise.
+        /// The higher the number, the farther the panel associated with this item is taken to the background.
+        /// </summary>
+        public int DepthLayer { get; set; } = 0;
+
+        /// <summary>
         /// Whether this item is visible or hidden.
         /// </summary>
         public bool IsVisible { get; set; } = true;


### PR DESCRIPTION
There is no appropriate example to show where this helps currently, but this becomes more apparent during beatmap carousel transitions where beatmap difficulty panels may temporarily overlap with a beatmap set panel during transition, and at that point the difficulty panel should logically always be behind it. This is what this change aims to achieve.

I was considering to approach this with a virtual method computing the final depth value of each item, but I realised 99% of the logic is strongly attached to the internals of `Carousel`, and I was between making the virtual method accept many parameters to not deal with those internals or expose them to `BeatmapCarousel`, both of which sound bad quality-wise.