### PR TITLE
Add API request & response structures for beatmap submission

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -173,7 +173,7 @@ namespace osu.Desktop
                         new Button
                         {
                             Label = "View beatmap",
-                            Url = $@"{api.WebsiteRootUrl}/beatmaps/{beatmapId}?mode={ruleset.Value.ShortName}"
+                            Url = $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmaps/{beatmapId}?mode={ruleset.Value.ShortName}"
                         }
                     };
                 }

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -173,7 +173,7 @@ namespace osu.Desktop
                         new Button
                         {
                             Label = "View beatmap",
-                            Url = $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmaps/{beatmapId}?mode={ruleset.Value.ShortName}"
+                            Url = $@"{api.Endpoints.WebsiteUrl}/beatmaps/{beatmapId}?mode={ruleset.Value.ShortName}"
                         }
                     };
                 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Visual.Menus
                     new APIMenuImage
                     {
                         Image = @"https://assets.ppy.sh/main-menu/project-loved-2@2x.png",
-                        Url = $@"{API.EndpointConfiguration.WebsiteRootUrl}/home/news/2023-12-21-project-loved-december-2023",
+                        Url = $@"{API.Endpoints.WebsiteUrl}/home/news/2023-12-21-project-loved-december-2023",
                     }
                 }
             });

--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Visual.Menus
                     new APIMenuImage
                     {
                         Image = @"https://assets.ppy.sh/main-menu/project-loved-2@2x.png",
-                        Url = $@"{API.WebsiteRootUrl}/home/news/2023-12-21-project-loved-december-2023",
+                        Url = $@"{API.EndpointConfiguration.WebsiteRootUrl}/home/news/2023-12-21-project-loved-december-2023",
                     }
                 }
             });

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
@@ -67,19 +67,19 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestLink()
         {
-            AddStep("set current path", () => markdownContainer.CurrentPath = $"{API.WebsiteRootUrl}/wiki/Article_styling_criteria/");
+            AddStep("set current path", () => markdownContainer.CurrentPath = $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Article_styling_criteria/");
 
             AddStep("set '/wiki/Main_page''", () => markdownContainer.Text = "[wiki main page](/wiki/Main_page)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.WebsiteRootUrl}/wiki/Main_page");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Main_page");
 
             AddStep("set '../FAQ''", () => markdownContainer.Text = "[FAQ](../FAQ)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.WebsiteRootUrl}/wiki/FAQ");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/FAQ");
 
             AddStep("set './Writing''", () => markdownContainer.Text = "[wiki writing guidline](./Writing)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.WebsiteRootUrl}/wiki/Article_styling_criteria/Writing");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Article_styling_criteria/Writing");
 
             AddStep("set 'Formatting''", () => markdownContainer.Text = "[wiki formatting guidline](Formatting)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.WebsiteRootUrl}/wiki/Article_styling_criteria/Formatting");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Article_styling_criteria/Formatting");
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
@@ -67,19 +67,19 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestLink()
         {
-            AddStep("set current path", () => markdownContainer.CurrentPath = $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Article_styling_criteria/");
+            AddStep("set current path", () => markdownContainer.CurrentPath = $"{API.Endpoints.WebsiteUrl}/wiki/Article_styling_criteria/");
 
             AddStep("set '/wiki/Main_page''", () => markdownContainer.Text = "[wiki main page](/wiki/Main_page)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Main_page");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.Endpoints.WebsiteUrl}/wiki/Main_page");
 
             AddStep("set '../FAQ''", () => markdownContainer.Text = "[FAQ](../FAQ)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/FAQ");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.Endpoints.WebsiteUrl}/wiki/FAQ");
 
             AddStep("set './Writing''", () => markdownContainer.Text = "[wiki writing guidline](./Writing)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Article_styling_criteria/Writing");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.Endpoints.WebsiteUrl}/wiki/Article_styling_criteria/Writing");
 
             AddStep("set 'Formatting''", () => markdownContainer.Text = "[wiki formatting guidline](Formatting)");
-            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.EndpointConfiguration.WebsiteRootUrl}/wiki/Article_styling_criteria/Formatting");
+            AddAssert("check url", () => markdownContainer.Link.Url == $"{API.Endpoints.WebsiteUrl}/wiki/Article_styling_criteria/Formatting");
         }
 
         [Test]

--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Beatmaps
             if (beatmapInfo.OnlineID <= 0 || beatmapInfo.BeatmapSet == null)
                 return null;
 
-            return $@"{api.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{ruleset?.ShortName ?? beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}";
+            return $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{ruleset?.ShortName ?? beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}";
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Beatmaps
             if (beatmapInfo.OnlineID <= 0 || beatmapInfo.BeatmapSet == null)
                 return null;
 
-            return $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{ruleset?.ShortName ?? beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}";
+            return $@"{api.Endpoints.WebsiteUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{ruleset?.ShortName ?? beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}";
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapSetInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfoExtensions.cs
@@ -41,9 +41,9 @@ namespace osu.Game.Beatmaps
                 return null;
 
             if (ruleset != null)
-                return $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}#{ruleset.ShortName}";
+                return $@"{api.Endpoints.WebsiteUrl}/beatmapsets/{beatmapSetInfo.OnlineID}#{ruleset.ShortName}";
 
-            return $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}";
+            return $@"{api.Endpoints.WebsiteUrl}/beatmapsets/{beatmapSetInfo.OnlineID}";
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapSetInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfoExtensions.cs
@@ -41,9 +41,9 @@ namespace osu.Game.Beatmaps
                 return null;
 
             if (ruleset != null)
-                return $@"{api.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}#{ruleset.ShortName}";
+                return $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}#{ruleset.ShortName}";
 
-            return $@"{api.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}";
+            return $@"{api.EndpointConfiguration.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}";
         }
     }
 }

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -40,9 +40,7 @@ namespace osu.Game.Online.API
 
         private readonly Queue<APIRequest> queue = new Queue<APIRequest>();
 
-        public string APIEndpointUrl { get; }
-
-        public string WebsiteRootUrl { get; }
+        public EndpointConfiguration EndpointConfiguration { get; }
 
         /// <summary>
         /// The API response version.
@@ -89,14 +87,13 @@ namespace osu.Game.Online.API
                 APIVersion = now.Year * 10000 + now.Month * 100 + now.Day;
             }
 
-            APIEndpointUrl = endpointConfiguration.APIEndpointUrl;
-            WebsiteRootUrl = endpointConfiguration.WebsiteRootUrl;
+            EndpointConfiguration = endpointConfiguration;
             NotificationsClient = setUpNotificationsClient();
 
-            authentication = new OAuth(endpointConfiguration.APIClientID, endpointConfiguration.APIClientSecret, APIEndpointUrl);
+            authentication = new OAuth(endpointConfiguration.APIClientID, endpointConfiguration.APIClientSecret, EndpointConfiguration.APIEndpointUrl);
 
             log = Logger.GetLogger(LoggingTarget.Network);
-            log.Add($@"API endpoint root: {APIEndpointUrl}");
+            log.Add($@"API endpoint root: {EndpointConfiguration.APIEndpointUrl}");
             log.Add($@"API request version: {APIVersion}");
 
             ProvidedUsername = config.Get<string>(OsuSetting.Username);
@@ -408,7 +405,7 @@ namespace osu.Game.Online.API
 
             var req = new RegistrationRequest
             {
-                Url = $@"{APIEndpointUrl}/users",
+                Url = $@"{EndpointConfiguration.APIEndpointUrl}/users",
                 Method = HttpMethod.Post,
                 Username = username,
                 Email = email,

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Online.API
 
         private readonly Queue<APIRequest> queue = new Queue<APIRequest>();
 
-        public EndpointConfiguration EndpointConfiguration { get; }
+        public EndpointConfiguration Endpoints { get; }
 
         /// <summary>
         /// The API response version.
@@ -73,7 +73,7 @@ namespace osu.Game.Online.API
         private readonly CancellationTokenSource cancellationToken = new CancellationTokenSource();
         private readonly Logger log;
 
-        public APIAccess(OsuGameBase game, OsuConfigManager config, EndpointConfiguration endpointConfiguration, string versionHash)
+        public APIAccess(OsuGameBase game, OsuConfigManager config, EndpointConfiguration endpoints, string versionHash)
         {
             this.game = game;
             this.config = config;
@@ -87,13 +87,13 @@ namespace osu.Game.Online.API
                 APIVersion = now.Year * 10000 + now.Month * 100 + now.Day;
             }
 
-            EndpointConfiguration = endpointConfiguration;
+            Endpoints = endpoints;
             NotificationsClient = setUpNotificationsClient();
 
-            authentication = new OAuth(endpointConfiguration.APIClientID, endpointConfiguration.APIClientSecret, EndpointConfiguration.APIEndpointUrl);
+            authentication = new OAuth(endpoints.APIClientID, endpoints.APIClientSecret, Endpoints.APIUrl);
 
             log = Logger.GetLogger(LoggingTarget.Network);
-            log.Add($@"API endpoint root: {EndpointConfiguration.APIEndpointUrl}");
+            log.Add($@"API endpoint root: {Endpoints.APIUrl}");
             log.Add($@"API request version: {APIVersion}");
 
             ProvidedUsername = config.Get<string>(OsuSetting.Username);
@@ -405,7 +405,7 @@ namespace osu.Game.Online.API
 
             var req = new RegistrationRequest
             {
-                Url = $@"{EndpointConfiguration.APIEndpointUrl}/users",
+                Url = $@"{Endpoints.APIUrl}/users",
                 Method = HttpMethod.Post,
                 Username = username,
                 Email = email,

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Online.API
 
         protected virtual WebRequest CreateWebRequest() => new OsuWebRequest(Uri);
 
-        protected virtual string Uri => $@"{API!.EndpointConfiguration.APIEndpointUrl}/api/v2/{Target}";
+        protected virtual string Uri => $@"{API!.Endpoints.APIUrl}/api/v2/{Target}";
 
         protected IAPIProvider? API;
 

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Online.API
 
         protected virtual WebRequest CreateWebRequest() => new OsuWebRequest(Uri);
 
-        protected virtual string Uri => $@"{API!.APIEndpointUrl}/api/v2/{Target}";
+        protected virtual string Uri => $@"{API!.EndpointConfiguration.APIEndpointUrl}/api/v2/{Target}";
 
         protected IAPIProvider? API;
 

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -41,9 +41,11 @@ namespace osu.Game.Online.API
 
         public string ProvidedUsername => LocalUser.Value.Username;
 
-        public string APIEndpointUrl => "http://localhost";
-
-        public string WebsiteRootUrl => "http://localhost";
+        public EndpointConfiguration EndpointConfiguration { get; } = new EndpointConfiguration
+        {
+            APIEndpointUrl = "http://localhost",
+            WebsiteRootUrl = "http://localhost",
+        };
 
         public int APIVersion => int.Parse(DateTime.Now.ToString("yyyyMMdd"));
 

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -41,10 +41,10 @@ namespace osu.Game.Online.API
 
         public string ProvidedUsername => LocalUser.Value.Username;
 
-        public EndpointConfiguration EndpointConfiguration { get; } = new EndpointConfiguration
+        public EndpointConfiguration Endpoints { get; } = new EndpointConfiguration
         {
-            APIEndpointUrl = "http://localhost",
-            WebsiteRootUrl = "http://localhost",
+            APIUrl = "http://localhost",
+            WebsiteUrl = "http://localhost",
         };
 
         public int APIVersion => int.Parse(DateTime.Now.ToString("yyyyMMdd"));

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -51,14 +51,9 @@ namespace osu.Game.Online.API
         string ProvidedUsername { get; }
 
         /// <summary>
-        /// The URL endpoint for this API. Does not include a trailing slash.
+        /// Holds configuration for online endpoints.
         /// </summary>
-        string APIEndpointUrl { get; }
-
-        /// <summary>
-        /// The root URL of the website, excluding the trailing slash.
-        /// </summary>
-        string WebsiteRootUrl { get; }
+        EndpointConfiguration EndpointConfiguration { get; }
 
         /// <summary>
         /// The version of the API.

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Online.API
         /// <summary>
         /// Holds configuration for online endpoints.
         /// </summary>
-        EndpointConfiguration EndpointConfiguration { get; }
+        EndpointConfiguration Endpoints { get; }
 
         /// <summary>
         /// The version of the API.

--- a/osu.Game/Online/API/Requests/APIUploadRequest.cs
+++ b/osu.Game/Online/API/Requests/APIUploadRequest.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using osu.Framework.IO.Network;
+
+namespace osu.Game.Online.API.Requests
+{
+    public abstract class APIUploadRequest : APIRequest
+    {
+        protected override WebRequest CreateWebRequest()
+        {
+            var request = base.CreateWebRequest();
+            request.UploadProgress += onUploadProgress;
+            return request;
+        }
+
+        private void onUploadProgress(long current, long total)
+        {
+            Debug.Assert(API != null);
+            API.Schedule(() => Progressed?.Invoke(current, total));
+        }
+
+        public event APIProgressHandler? Progressed;
+    }
+}

--- a/osu.Game/Online/API/Requests/PatchBeatmapPackageRequest.cs
+++ b/osu.Game/Online/API/Requests/PatchBeatmapPackageRequest.cs
@@ -25,7 +25,11 @@ namespace osu.Game.Online.API.Requests
         protected override string Target => throw new NotSupportedException();
 
         public uint BeatmapSetID { get; }
+
+        // ReSharper disable once CollectionNeverUpdated.Global
         public Dictionary<string, byte[]> FilesChanged { get; } = new Dictionary<string, byte[]>();
+
+        // ReSharper disable once CollectionNeverUpdated.Global
         public HashSet<string> FilesDeleted { get; } = new HashSet<string>();
 
         public PatchBeatmapPackageRequest(uint beatmapSetId)

--- a/osu.Game/Online/API/Requests/PatchBeatmapPackageRequest.cs
+++ b/osu.Game/Online/API/Requests/PatchBeatmapPackageRequest.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using osu.Framework.IO.Network;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class PatchBeatmapPackageRequest : APIUploadRequest
+    {
+        protected override string Uri
+        {
+            get
+            {
+                // can be removed once the service has been successfully deployed to production
+                if (API!.EndpointConfiguration.BeatmapSubmissionServiceUrl == null)
+                    throw new NotSupportedException("Beatmap submission not supported in this configuration!");
+
+                return $@"{API!.EndpointConfiguration.BeatmapSubmissionServiceUrl!}/beatmapsets/{BeatmapSetID}";
+            }
+        }
+
+        protected override string Target => throw new NotSupportedException();
+
+        public uint BeatmapSetID { get; }
+        public Dictionary<string, byte[]> FilesChanged { get; } = new Dictionary<string, byte[]>();
+        public HashSet<string> FilesDeleted { get; } = new HashSet<string>();
+
+        public PatchBeatmapPackageRequest(uint beatmapSetId)
+        {
+            BeatmapSetID = beatmapSetId;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var request = base.CreateWebRequest();
+            request.Method = HttpMethod.Patch;
+
+            foreach ((string filename, byte[] content) in FilesChanged)
+                request.AddFile(@"filesChanged", content, filename);
+
+            foreach (string filename in FilesDeleted)
+                request.AddParameter(@"filesDeleted", filename, RequestParameterType.Form);
+
+            request.Timeout = 60_000;
+            return request;
+        }
+    }
+}

--- a/osu.Game/Online/API/Requests/PatchBeatmapPackageRequest.cs
+++ b/osu.Game/Online/API/Requests/PatchBeatmapPackageRequest.cs
@@ -15,10 +15,10 @@ namespace osu.Game.Online.API.Requests
             get
             {
                 // can be removed once the service has been successfully deployed to production
-                if (API!.EndpointConfiguration.BeatmapSubmissionServiceUrl == null)
+                if (API!.Endpoints.BeatmapSubmissionServiceUrl == null)
                     throw new NotSupportedException("Beatmap submission not supported in this configuration!");
 
-                return $@"{API!.EndpointConfiguration.BeatmapSubmissionServiceUrl!}/beatmapsets/{BeatmapSetID}";
+                return $@"{API!.Endpoints.BeatmapSubmissionServiceUrl!}/beatmapsets/{BeatmapSetID}";
             }
         }
 

--- a/osu.Game/Online/API/Requests/PutBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/PutBeatmapSetRequest.cs
@@ -21,10 +21,10 @@ namespace osu.Game.Online.API.Requests
             get
             {
                 // can be removed once the service has been successfully deployed to production
-                if (API!.EndpointConfiguration.BeatmapSubmissionServiceUrl == null)
+                if (API!.Endpoints.BeatmapSubmissionServiceUrl == null)
                     throw new NotSupportedException("Beatmap submission not supported in this configuration!");
 
-                return $@"{API!.EndpointConfiguration.BeatmapSubmissionServiceUrl}/beatmapsets";
+                return $@"{API!.Endpoints.BeatmapSubmissionServiceUrl}/beatmapsets";
             }
         }
 

--- a/osu.Game/Online/API/Requests/PutBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/PutBeatmapSetRequest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using osu.Framework.IO.Network;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class PutBeatmapSetRequest : APIRequest<PutBeatmapSetResponse>
+    {
+        protected override string Uri
+        {
+            get
+            {
+                // can be removed once the service has been successfully deployed to production
+                if (API!.EndpointConfiguration.BeatmapSubmissionServiceUrl == null)
+                    throw new NotSupportedException("Beatmap submission not supported in this configuration!");
+
+                return $@"{API!.EndpointConfiguration.BeatmapSubmissionServiceUrl}/beatmapsets";
+            }
+        }
+
+        protected override string Target => throw new NotSupportedException();
+
+        [JsonProperty("beatmapset_id")]
+        public uint? BeatmapSetID { get; init; }
+
+        [JsonProperty("beatmaps_to_create")]
+        public uint BeatmapsToCreate { get; init; }
+
+        [JsonProperty("beatmaps_to_keep")]
+        public uint[] BeatmapsToKeep { get; init; } = [];
+
+        [JsonProperty("target")]
+        public BeatmapSubmissionTarget SubmissionTarget { get; init; }
+
+        private PutBeatmapSetRequest()
+        {
+        }
+
+        public static PutBeatmapSetRequest CreateNew(uint beatmapCount, BeatmapSubmissionTarget target) => new PutBeatmapSetRequest
+        {
+            BeatmapsToCreate = beatmapCount,
+            SubmissionTarget = target,
+        };
+
+        public static PutBeatmapSetRequest UpdateExisting(uint beatmapSetId, IEnumerable<uint> beatmapsToKeep, uint beatmapsToCreate, BeatmapSubmissionTarget target) => new PutBeatmapSetRequest
+        {
+            BeatmapSetID = beatmapSetId,
+            BeatmapsToKeep = beatmapsToKeep.ToArray(),
+            BeatmapsToCreate = beatmapsToCreate,
+            SubmissionTarget = target,
+        };
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+            req.Method = HttpMethod.Put;
+            req.ContentType = @"application/json";
+            req.AddRaw(JsonConvert.SerializeObject(this));
+            return req;
+        }
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum BeatmapSubmissionTarget
+    {
+        [LocalisableDescription(typeof(BeatmapSubmissionStrings), nameof(BeatmapSubmissionStrings.BeatmapSubmissionTargetWIP))]
+        WIP,
+
+        [LocalisableDescription(typeof(BeatmapSubmissionStrings), nameof(BeatmapSubmissionStrings.BeatmapSubmissionTargetPending))]
+        Pending,
+    }
+}

--- a/osu.Game/Online/API/Requests/ReplaceBeatmapPackageRequest.cs
+++ b/osu.Game/Online/API/Requests/ReplaceBeatmapPackageRequest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Net.Http;
+using osu.Framework.IO.Network;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class ReplaceBeatmapPackageRequest : APIUploadRequest
+    {
+        protected override string Uri
+        {
+            get
+            {
+                // can be removed once the service has been successfully deployed to production
+                if (API!.EndpointConfiguration.BeatmapSubmissionServiceUrl == null)
+                    throw new NotSupportedException("Beatmap submission not supported in this configuration!");
+
+                return $@"{API!.EndpointConfiguration.BeatmapSubmissionServiceUrl}/beatmapsets/{BeatmapSetID}";
+            }
+        }
+
+        protected override string Target => throw new NotSupportedException();
+
+        public uint BeatmapSetID { get; }
+
+        private readonly byte[] oszPackage;
+
+        public ReplaceBeatmapPackageRequest(uint beatmapSetID, byte[] oszPackage)
+        {
+            this.oszPackage = oszPackage;
+            BeatmapSetID = beatmapSetID;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var request = base.CreateWebRequest();
+            request.AddFile(@"beatmapArchive", oszPackage);
+            request.Method = HttpMethod.Put;
+            request.Timeout = 60_000;
+            return request;
+        }
+    }
+}

--- a/osu.Game/Online/API/Requests/ReplaceBeatmapPackageRequest.cs
+++ b/osu.Game/Online/API/Requests/ReplaceBeatmapPackageRequest.cs
@@ -14,10 +14,10 @@ namespace osu.Game.Online.API.Requests
             get
             {
                 // can be removed once the service has been successfully deployed to production
-                if (API!.EndpointConfiguration.BeatmapSubmissionServiceUrl == null)
+                if (API!.Endpoints.BeatmapSubmissionServiceUrl == null)
                     throw new NotSupportedException("Beatmap submission not supported in this configuration!");
 
-                return $@"{API!.EndpointConfiguration.BeatmapSubmissionServiceUrl}/beatmapsets/{BeatmapSetID}";
+                return $@"{API!.Endpoints.BeatmapSubmissionServiceUrl}/beatmapsets/{BeatmapSetID}";
             }
         }
 

--- a/osu.Game/Online/API/Requests/Responses/PutBeatmapSetResponse.cs
+++ b/osu.Game/Online/API/Requests/Responses/PutBeatmapSetResponse.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class PutBeatmapSetResponse
+    {
+        [JsonProperty("beatmapset_id")]
+        public uint BeatmapSetId { get; set; }
+
+        [JsonProperty("beatmap_ids")]
+        public ICollection<uint> BeatmapIds { get; set; } = Array.Empty<uint>();
+
+        [JsonProperty("files")]
+        public ICollection<BeatmapSetFile> Files { get; set; } = Array.Empty<BeatmapSetFile>();
+    }
+
+    public struct BeatmapSetFile
+    {
+        [JsonProperty("filename")]
+        public string Filename { get; set; }
+
+        [JsonProperty("sha2_hash")]
+        public string SHA2Hash { get; set; }
+    }
+}

--- a/osu.Game/Online/Chat/ExternalLinkOpener.cs
+++ b/osu.Game/Online/Chat/ExternalLinkOpener.cs
@@ -49,12 +49,12 @@ namespace osu.Game.Online.Chat
 
             if (url.StartsWith('/'))
             {
-                url = $"{api.WebsiteRootUrl}{url}";
+                url = $"{api.EndpointConfiguration.WebsiteRootUrl}{url}";
                 isTrustedDomain = true;
             }
             else
             {
-                isTrustedDomain = url.StartsWith(api.WebsiteRootUrl, StringComparison.Ordinal);
+                isTrustedDomain = url.StartsWith(api.EndpointConfiguration.WebsiteRootUrl, StringComparison.Ordinal);
             }
 
             if (!url.CheckIsValidUrl())

--- a/osu.Game/Online/Chat/ExternalLinkOpener.cs
+++ b/osu.Game/Online/Chat/ExternalLinkOpener.cs
@@ -49,12 +49,12 @@ namespace osu.Game.Online.Chat
 
             if (url.StartsWith('/'))
             {
-                url = $"{api.EndpointConfiguration.WebsiteRootUrl}{url}";
+                url = $"{api.Endpoints.WebsiteUrl}{url}";
                 isTrustedDomain = true;
             }
             else
             {
-                isTrustedDomain = url.StartsWith(api.EndpointConfiguration.WebsiteRootUrl, StringComparison.Ordinal);
+                isTrustedDomain = url.StartsWith(api.Endpoints.WebsiteUrl, StringComparison.Ordinal);
             }
 
             if (!url.CheckIsValidUrl())

--- a/osu.Game/Online/Chat/NowPlayingCommand.cs
+++ b/osu.Game/Online/Chat/NowPlayingCommand.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Online.Chat
 
             string getBeatmapPart()
             {
-                return beatmapOnlineID > 0 ? $"[{api.EndpointConfiguration.WebsiteRootUrl}/b/{beatmapOnlineID} {beatmapDisplayTitle}]" : beatmapDisplayTitle;
+                return beatmapOnlineID > 0 ? $"[{api.Endpoints.WebsiteUrl}/b/{beatmapOnlineID} {beatmapDisplayTitle}]" : beatmapDisplayTitle;
             }
 
             string getRulesetPart()

--- a/osu.Game/Online/Chat/NowPlayingCommand.cs
+++ b/osu.Game/Online/Chat/NowPlayingCommand.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Online.Chat
 
             string getBeatmapPart()
             {
-                return beatmapOnlineID > 0 ? $"[{api.WebsiteRootUrl}/b/{beatmapOnlineID} {beatmapDisplayTitle}]" : beatmapDisplayTitle;
+                return beatmapOnlineID > 0 ? $"[{api.EndpointConfiguration.WebsiteRootUrl}/b/{beatmapOnlineID} {beatmapDisplayTitle}]" : beatmapDisplayTitle;
             }
 
             string getRulesetPart()

--- a/osu.Game/Online/DevelopmentEndpointConfiguration.cs
+++ b/osu.Game/Online/DevelopmentEndpointConfiguration.cs
@@ -7,12 +7,12 @@ namespace osu.Game.Online
     {
         public DevelopmentEndpointConfiguration()
         {
-            WebsiteRootUrl = APIEndpointUrl = @"https://dev.ppy.sh";
+            WebsiteUrl = APIUrl = @"https://dev.ppy.sh";
             APIClientSecret = @"3LP2mhUrV89xxzD1YKNndXHEhWWCRLPNKioZ9ymT";
             APIClientID = "5";
-            SpectatorEndpointUrl = $@"{APIEndpointUrl}/signalr/spectator";
-            MultiplayerEndpointUrl = $@"{APIEndpointUrl}/signalr/multiplayer";
-            MetadataEndpointUrl = $@"{APIEndpointUrl}/signalr/metadata";
+            SpectatorUrl = $@"{APIUrl}/signalr/spectator";
+            MultiplayerUrl = $@"{APIUrl}/signalr/multiplayer";
+            MetadataUrl = $@"{APIUrl}/signalr/metadata";
         }
     }
 }

--- a/osu.Game/Online/EndpointConfiguration.cs
+++ b/osu.Game/Online/EndpointConfiguration.cs
@@ -42,5 +42,10 @@ namespace osu.Game.Online
         /// The endpoint for the SignalR metadata server.
         /// </summary>
         public string MetadataEndpointUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The root URL for the service handling beatmap submission. Does not include a trailing slash.
+        /// </summary>
+        public string? BeatmapSubmissionServiceUrl { get; set; }
     }
 }

--- a/osu.Game/Online/EndpointConfiguration.cs
+++ b/osu.Game/Online/EndpointConfiguration.cs
@@ -9,16 +9,6 @@ namespace osu.Game.Online
     public class EndpointConfiguration
     {
         /// <summary>
-        /// The base URL for the website. Does not include a trailing slash.
-        /// </summary>
-        public string WebsiteRootUrl { get; set; } = string.Empty;
-
-        /// <summary>
-        /// The endpoint for the main (osu-web) API. Does not include a trailing slash.
-        /// </summary>
-        public string APIEndpointUrl { get; set; } = string.Empty;
-
-        /// <summary>
         /// The OAuth client secret.
         /// </summary>
         public string APIClientSecret { get; set; } = string.Empty;
@@ -29,23 +19,33 @@ namespace osu.Game.Online
         public string APIClientID { get; set; } = string.Empty;
 
         /// <summary>
-        /// The endpoint for the SignalR spectator server.
+        /// The base URL for the website. Does not include a trailing slash.
         /// </summary>
-        public string SpectatorEndpointUrl { get; set; } = string.Empty;
+        public string WebsiteUrl { get; set; } = string.Empty;
 
         /// <summary>
-        /// The endpoint for the SignalR multiplayer server.
+        /// The endpoint for the main (osu-web) API. Does not include a trailing slash.
         /// </summary>
-        public string MultiplayerEndpointUrl { get; set; } = string.Empty;
-
-        /// <summary>
-        /// The endpoint for the SignalR metadata server.
-        /// </summary>
-        public string MetadataEndpointUrl { get; set; } = string.Empty;
+        public string APIUrl { get; set; } = string.Empty;
 
         /// <summary>
         /// The root URL for the service handling beatmap submission. Does not include a trailing slash.
         /// </summary>
         public string? BeatmapSubmissionServiceUrl { get; set; }
+
+        /// <summary>
+        /// The endpoint for the SignalR spectator server.
+        /// </summary>
+        public string SpectatorUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The endpoint for the SignalR multiplayer server.
+        /// </summary>
+        public string MultiplayerUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The endpoint for the SignalR metadata server.
+        /// </summary>
+        public string MetadataUrl { get; set; } = string.Empty;
     }
 }

--- a/osu.Game/Online/EndpointConfiguration.cs
+++ b/osu.Game/Online/EndpointConfiguration.cs
@@ -9,12 +9,12 @@ namespace osu.Game.Online
     public class EndpointConfiguration
     {
         /// <summary>
-        /// The base URL for the website.
+        /// The base URL for the website. Does not include a trailing slash.
         /// </summary>
         public string WebsiteRootUrl { get; set; } = string.Empty;
 
         /// <summary>
-        /// The endpoint for the main (osu-web) API.
+        /// The endpoint for the main (osu-web) API. Does not include a trailing slash.
         /// </summary>
         public string APIEndpointUrl { get; set; } = string.Empty;
 

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -436,7 +436,7 @@ namespace osu.Game.Online.Leaderboards
                     items.Add(new OsuMenuItem("Use these mods", MenuItemType.Highlighted, () => songSelect.Mods.Value = Score.Mods));
 
                 if (Score.OnlineID > 0)
-                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.EndpointConfiguration.WebsiteRootUrl}/scores/{Score.OnlineID}")));
+                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.Endpoints.WebsiteUrl}/scores/{Score.OnlineID}")));
 
                 if (Score.Files.Count > 0)
                 {

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -436,7 +436,7 @@ namespace osu.Game.Online.Leaderboards
                     items.Add(new OsuMenuItem("Use these mods", MenuItemType.Highlighted, () => songSelect.Mods.Value = Score.Mods));
 
                 if (Score.OnlineID > 0)
-                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.WebsiteRootUrl}/scores/{Score.OnlineID}")));
+                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.EndpointConfiguration.WebsiteRootUrl}/scores/{Score.OnlineID}")));
 
                 if (Score.Files.Count > 0)
                 {

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Online.Metadata
 
         public OnlineMetadataClient(EndpointConfiguration endpoints)
         {
-            endpoint = endpoints.MetadataEndpointUrl;
+            endpoint = endpoints.MetadataUrl;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Online.Multiplayer
 
         public OnlineMultiplayerClient(EndpointConfiguration endpoints)
         {
-            endpoint = endpoints.MultiplayerEndpointUrl;
+            endpoint = endpoints.MultiplayerUrl;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Online/ProductionEndpointConfiguration.cs
+++ b/osu.Game/Online/ProductionEndpointConfiguration.cs
@@ -7,12 +7,12 @@ namespace osu.Game.Online
     {
         public ProductionEndpointConfiguration()
         {
-            WebsiteRootUrl = APIEndpointUrl = @"https://osu.ppy.sh";
+            WebsiteUrl = APIUrl = @"https://osu.ppy.sh";
             APIClientSecret = @"FGc9GAtyHzeQDshWP5Ah7dega8hJACAJpQtw6OXk";
             APIClientID = "5";
-            SpectatorEndpointUrl = "https://spectator.ppy.sh/spectator";
-            MultiplayerEndpointUrl = "https://spectator.ppy.sh/multiplayer";
-            MetadataEndpointUrl = "https://spectator.ppy.sh/metadata";
+            SpectatorUrl = "https://spectator.ppy.sh/spectator";
+            MultiplayerUrl = "https://spectator.ppy.sh/multiplayer";
+            MetadataUrl = "https://spectator.ppy.sh/metadata";
         }
     }
 }

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Online.Spectator
 
         public OnlineSpectatorClient(EndpointConfiguration endpoints)
         {
-            endpoint = endpoints.SpectatorEndpointUrl;
+            endpoint = endpoints.SpectatorUrl;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -295,7 +295,7 @@ namespace osu.Game
 
             EndpointConfiguration endpoints = CreateEndpoints();
 
-            MessageFormatter.WebsiteRootUrl = endpoints.WebsiteRootUrl;
+            MessageFormatter.WebsiteRootUrl = endpoints.WebsiteUrl;
 
             frameworkLocale = frameworkConfig.GetBindable<string>(FrameworkSetting.Locale);
             frameworkLocale.BindValueChanged(_ => updateLanguage());

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -419,7 +419,7 @@ namespace osu.Game.Overlays.Comments
 
         private void copyUrl()
         {
-            clipboard.SetText($@"{api.APIEndpointUrl}/comments/{Comment.Id}");
+            clipboard.SetText($@"{api.EndpointConfiguration.APIEndpointUrl}/comments/{Comment.Id}");
             onScreenDisplay?.Display(new CopyUrlToast());
         }
 

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -419,7 +419,7 @@ namespace osu.Game.Overlays.Comments
 
         private void copyUrl()
         {
-            clipboard.SetText($@"{api.EndpointConfiguration.APIEndpointUrl}/comments/{Comment.Id}");
+            clipboard.SetText($@"{api.Endpoints.APIUrl}/comments/{Comment.Id}");
             onScreenDisplay?.Display(new CopyUrlToast());
         }
 

--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.Login
                 }
             };
 
-            forgottenPasswordLink.AddLink(LayoutStrings.PopupLoginLoginForgot, $"{api.WebsiteRootUrl}/home/password-reset");
+            forgottenPasswordLink.AddLink(LayoutStrings.PopupLoginLoginForgot, $"{api.EndpointConfiguration.WebsiteRootUrl}/home/password-reset");
 
             password.OnCommit += (_, _) => performLogin();
 

--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.Login
                 }
             };
 
-            forgottenPasswordLink.AddLink(LayoutStrings.PopupLoginLoginForgot, $"{api.EndpointConfiguration.WebsiteRootUrl}/home/password-reset");
+            forgottenPasswordLink.AddLink(LayoutStrings.PopupLoginLoginForgot, $"{api.Endpoints.WebsiteUrl}/home/password-reset");
 
             password.OnCommit += (_, _) => performLogin();
 

--- a/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
+++ b/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Overlays.Login
             explainText.AddParagraph(UserVerificationStrings.BoxInfoCheckSpam);
             // We can't support localisable strings with nested links yet. Not sure if we even can (probably need to allow markdown link formatting or something).
             explainText.AddParagraph("If you can't access your email or have forgotten what you used, please follow the ");
-            explainText.AddLink(UserVerificationStrings.BoxInfoRecoverLink, $"{api.WebsiteRootUrl}/home/password-reset");
+            explainText.AddLink(UserVerificationStrings.BoxInfoRecoverLink, $"{api.EndpointConfiguration.WebsiteRootUrl}/home/password-reset");
             explainText.AddText(". You can also ");
             explainText.AddLink(UserVerificationStrings.BoxInfoReissueLink, () =>
             {

--- a/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
+++ b/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Overlays.Login
             explainText.AddParagraph(UserVerificationStrings.BoxInfoCheckSpam);
             // We can't support localisable strings with nested links yet. Not sure if we even can (probably need to allow markdown link formatting or something).
             explainText.AddParagraph("If you can't access your email or have forgotten what you used, please follow the ");
-            explainText.AddLink(UserVerificationStrings.BoxInfoRecoverLink, $"{api.EndpointConfiguration.WebsiteRootUrl}/home/password-reset");
+            explainText.AddLink(UserVerificationStrings.BoxInfoRecoverLink, $"{api.Endpoints.WebsiteUrl}/home/password-reset");
             explainText.AddText(". You can also ");
             explainText.AddLink(UserVerificationStrings.BoxInfoReissueLink, () =>
             {

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -124,12 +124,12 @@ namespace osu.Game.Overlays.Profile.Header
             }
 
             topLinkContainer.AddText("Contributed ");
-            topLinkContainer.AddLink("forum post".ToQuantity(user.PostCount, "#,##0"), $"{api.WebsiteRootUrl}/users/{user.Id}/posts", creationParameters: embolden);
+            topLinkContainer.AddLink("forum post".ToQuantity(user.PostCount, "#,##0"), $"{api.EndpointConfiguration.WebsiteRootUrl}/users/{user.Id}/posts", creationParameters: embolden);
 
             addSpacer(topLinkContainer);
 
             topLinkContainer.AddText("Posted ");
-            topLinkContainer.AddLink("comment".ToQuantity(user.CommentsCount, "#,##0"), $"{api.WebsiteRootUrl}/comments?user_id={user.Id}", creationParameters: embolden);
+            topLinkContainer.AddLink("comment".ToQuantity(user.CommentsCount, "#,##0"), $"{api.EndpointConfiguration.WebsiteRootUrl}/comments?user_id={user.Id}", creationParameters: embolden);
 
             string websiteWithoutProtocol = user.Website;
 

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -124,12 +124,12 @@ namespace osu.Game.Overlays.Profile.Header
             }
 
             topLinkContainer.AddText("Contributed ");
-            topLinkContainer.AddLink("forum post".ToQuantity(user.PostCount, "#,##0"), $"{api.EndpointConfiguration.WebsiteRootUrl}/users/{user.Id}/posts", creationParameters: embolden);
+            topLinkContainer.AddLink("forum post".ToQuantity(user.PostCount, "#,##0"), $"{api.Endpoints.WebsiteUrl}/users/{user.Id}/posts", creationParameters: embolden);
 
             addSpacer(topLinkContainer);
 
             topLinkContainer.AddText("Posted ");
-            topLinkContainer.AddLink("comment".ToQuantity(user.CommentsCount, "#,##0"), $"{api.EndpointConfiguration.WebsiteRootUrl}/comments?user_id={user.Id}", creationParameters: embolden);
+            topLinkContainer.AddLink("comment".ToQuantity(user.CommentsCount, "#,##0"), $"{api.Endpoints.WebsiteUrl}/comments?user_id={user.Id}", creationParameters: embolden);
 
             string websiteWithoutProtocol = user.Website;
 

--- a/osu.Game/Overlays/Profile/Header/Components/DrawableTournamentBanner.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DrawableTournamentBanner.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 Texture = textures.Get(banner.Image),
             };
 
-            Action = () => game?.OpenUrlExternally($@"{api.WebsiteRootUrl}/community/tournaments/{banner.TournamentId}");
+            Action = () => game?.OpenUrlExternally($@"{api.EndpointConfiguration.WebsiteRootUrl}/community/tournaments/{banner.TournamentId}");
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Profile/Header/Components/DrawableTournamentBanner.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DrawableTournamentBanner.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 Texture = textures.Get(banner.Image),
             };
 
-            Action = () => game?.OpenUrlExternally($@"{api.EndpointConfiguration.WebsiteRootUrl}/community/tournaments/{banner.TournamentId}");
+            Action = () => game?.OpenUrlExternally($@"{api.Endpoints.WebsiteUrl}/community/tournaments/{banner.TournamentId}");
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -213,7 +213,7 @@ namespace osu.Game.Overlays.Profile.Header
             cover.User = user;
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
-            openUserExternally.Link = $@"{api.WebsiteRootUrl}/users/{user?.Id ?? 0}";
+            openUserExternally.Link = $@"{api.EndpointConfiguration.WebsiteRootUrl}/users/{user?.Id ?? 0}";
             userFlag.CountryCode = user?.CountryCode ?? default;
             userCountryText.Text = (user?.CountryCode ?? default).GetDescription();
             userCountryContainer.Action = () => rankingsOverlay?.ShowCountry(user?.CountryCode ?? default);

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -213,7 +213,7 @@ namespace osu.Game.Overlays.Profile.Header
             cover.User = user;
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
-            openUserExternally.Link = $@"{api.EndpointConfiguration.WebsiteRootUrl}/users/{user?.Id ?? 0}";
+            openUserExternally.Link = $@"{api.Endpoints.WebsiteUrl}/users/{user?.Id ?? 0}";
             userFlag.CountryCode = user?.CountryCode ?? default;
             userCountryText.Text = (user?.CountryCode ?? default).GetDescription();
             userCountryContainer.Action = () => rankingsOverlay?.ShowCountry(user?.CountryCode ?? default);

--- a/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
         private void addBeatmapsetLink()
             => content.AddLink(activity.Beatmapset.AsNonNull().Title, LinkAction.OpenBeatmapSet, getLinkArgument(activity.Beatmapset.AsNonNull().Url), creationParameters: t => t.Font = getLinkFont());
 
-        private object getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.EndpointConfiguration.WebsiteRootUrl}{url}").Argument.AsNonNull();
+        private object getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.Endpoints.WebsiteUrl}{url}").Argument.AsNonNull();
 
         private FontUsage getLinkFont(FontWeight fontWeight = FontWeight.Regular)
             => OsuFont.GetFont(size: font_size, weight: fontWeight, italics: true);

--- a/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
         private void addBeatmapsetLink()
             => content.AddLink(activity.Beatmapset.AsNonNull().Title, LinkAction.OpenBeatmapSet, getLinkArgument(activity.Beatmapset.AsNonNull().Url), creationParameters: t => t.Font = getLinkFont());
 
-        private object getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.WebsiteRootUrl}{url}").Argument.AsNonNull();
+        private object getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.EndpointConfiguration.WebsiteRootUrl}{url}").Argument.AsNonNull();
 
         private FontUsage getLinkFont(FontWeight fontWeight = FontWeight.Regular)
             => OsuFont.GetFont(size: font_size, weight: fontWeight, italics: true);

--- a/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
+++ b/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Wiki
                     Padding = new MarginPadding(padding),
                     Child = new WikiPanelMarkdownContainer(isFullWidth)
                     {
-                        CurrentPath = $@"{api.WebsiteRootUrl}/wiki/",
+                        CurrentPath = $@"{api.EndpointConfiguration.WebsiteRootUrl}/wiki/",
                         Text = text,
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y

--- a/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
+++ b/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Wiki
                     Padding = new MarginPadding(padding),
                     Child = new WikiPanelMarkdownContainer(isFullWidth)
                     {
-                        CurrentPath = $@"{api.EndpointConfiguration.WebsiteRootUrl}/wiki/",
+                        CurrentPath = $@"{api.Endpoints.WebsiteUrl}/wiki/",
                         Text = text,
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y

--- a/osu.Game/Overlays/WikiOverlay.cs
+++ b/osu.Game/Overlays/WikiOverlay.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Overlays
             }
             else
             {
-                LoadDisplay(articlePage = new WikiArticlePage($@"{api.EndpointConfiguration.WebsiteRootUrl}/wiki/{path.Value}/", response.Markdown));
+                LoadDisplay(articlePage = new WikiArticlePage($@"{api.Endpoints.WebsiteUrl}/wiki/{path.Value}/", response.Markdown));
             }
         }
 
@@ -176,7 +176,7 @@ namespace osu.Game.Overlays
             wikiData.Value = null;
             path.Value = "error";
 
-            LoadDisplay(articlePage = new WikiArticlePage($@"{api.EndpointConfiguration.WebsiteRootUrl}/wiki/",
+            LoadDisplay(articlePage = new WikiArticlePage($@"{api.Endpoints.WebsiteUrl}/wiki/",
                 $"Something went wrong when trying to fetch page \"{originalPath}\".\n\n[Return to the main page]({INDEX_PATH})."));
         }
 

--- a/osu.Game/Overlays/WikiOverlay.cs
+++ b/osu.Game/Overlays/WikiOverlay.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Overlays
             }
             else
             {
-                LoadDisplay(articlePage = new WikiArticlePage($@"{api.WebsiteRootUrl}/wiki/{path.Value}/", response.Markdown));
+                LoadDisplay(articlePage = new WikiArticlePage($@"{api.EndpointConfiguration.WebsiteRootUrl}/wiki/{path.Value}/", response.Markdown));
             }
         }
 
@@ -176,7 +176,7 @@ namespace osu.Game.Overlays
             wikiData.Value = null;
             path.Value = "error";
 
-            LoadDisplay(articlePage = new WikiArticlePage($@"{api.WebsiteRootUrl}/wiki/",
+            LoadDisplay(articlePage = new WikiArticlePage($@"{api.EndpointConfiguration.WebsiteRootUrl}/wiki/",
                 $"Something went wrong when trying to fetch page \"{originalPath}\".\n\n[Return to the main page]({INDEX_PATH})."));
         }
 

--- a/osu.Game/Screens/Edit/Submission/ScreenFrequentlyAskedQuestions.cs
+++ b/osu.Game/Screens/Edit/Submission/ScreenFrequentlyAskedQuestions.cs
@@ -46,14 +46,14 @@ namespace osu.Game.Screens.Edit.Submission
                         RelativeSizeAxes = Axes.X,
                         Caption = BeatmapSubmissionStrings.MappingHelpForumDescription,
                         ButtonText = BeatmapSubmissionStrings.MappingHelpForum,
-                        Action = () => game?.OpenUrlExternally($@"{api.WebsiteRootUrl}/community/forums/56"),
+                        Action = () => game?.OpenUrlExternally($@"{api.EndpointConfiguration.WebsiteRootUrl}/community/forums/56"),
                     },
                     new FormButton
                     {
                         RelativeSizeAxes = Axes.X,
                         Caption = BeatmapSubmissionStrings.ModdingQueuesForumDescription,
                         ButtonText = BeatmapSubmissionStrings.ModdingQueuesForum,
-                        Action = () => game?.OpenUrlExternally($@"{api.WebsiteRootUrl}/community/forums/60"),
+                        Action = () => game?.OpenUrlExternally($@"{api.EndpointConfiguration.WebsiteRootUrl}/community/forums/60"),
                     },
                 },
             });

--- a/osu.Game/Screens/Edit/Submission/ScreenFrequentlyAskedQuestions.cs
+++ b/osu.Game/Screens/Edit/Submission/ScreenFrequentlyAskedQuestions.cs
@@ -46,14 +46,14 @@ namespace osu.Game.Screens.Edit.Submission
                         RelativeSizeAxes = Axes.X,
                         Caption = BeatmapSubmissionStrings.MappingHelpForumDescription,
                         ButtonText = BeatmapSubmissionStrings.MappingHelpForum,
-                        Action = () => game?.OpenUrlExternally($@"{api.EndpointConfiguration.WebsiteRootUrl}/community/forums/56"),
+                        Action = () => game?.OpenUrlExternally($@"{api.Endpoints.WebsiteUrl}/community/forums/56"),
                     },
                     new FormButton
                     {
                         RelativeSizeAxes = Axes.X,
                         Caption = BeatmapSubmissionStrings.ModdingQueuesForumDescription,
                         ButtonText = BeatmapSubmissionStrings.ModdingQueuesForum,
-                        Action = () => game?.OpenUrlExternally($@"{api.EndpointConfiguration.WebsiteRootUrl}/community/forums/60"),
+                        Action = () => game?.OpenUrlExternally($@"{api.Endpoints.WebsiteUrl}/community/forums/60"),
                     },
                 },
             });

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -361,7 +361,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
                 return items.ToArray();
 
-                string formatRoomUrl(long id) => $@"{api.WebsiteRootUrl}/multiplayer/rooms/{id}";
+                string formatRoomUrl(long id) => $@"{api.EndpointConfiguration.WebsiteRootUrl}/multiplayer/rooms/{id}";
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -361,7 +361,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
                 return items.ToArray();
 
-                string formatRoomUrl(long id) => $@"{api.EndpointConfiguration.WebsiteRootUrl}/multiplayer/rooms/{id}";
+                string formatRoomUrl(long id) => $@"{api.Endpoints.WebsiteUrl}/multiplayer/rooms/{id}";
             }
         }
 

--- a/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
+++ b/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
@@ -778,7 +778,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                     items.Add(new OsuMenuItem("Use these mods", MenuItemType.Highlighted, () => SelectedMods.Value = score.Mods.Where(m => IsValidMod.Invoke(m)).ToArray()));
 
                 if (score.OnlineID > 0)
-                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.WebsiteRootUrl}/scores/{score.OnlineID}")));
+                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.EndpointConfiguration.WebsiteRootUrl}/scores/{score.OnlineID}")));
 
                 if (score.Files.Count <= 0) return items.ToArray();
 

--- a/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
+++ b/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
@@ -778,7 +778,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                     items.Add(new OsuMenuItem("Use these mods", MenuItemType.Highlighted, () => SelectedMods.Value = score.Mods.Where(m => IsValidMod.Invoke(m)).ToArray()));
 
                 if (score.OnlineID > 0)
-                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.EndpointConfiguration.WebsiteRootUrl}/scores/{score.OnlineID}")));
+                    items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => clipboard?.SetText($@"{api.Endpoints.WebsiteUrl}/scores/{score.OnlineID}")));
 
                 if (score.Files.Count <= 0) return items.ToArray();
 

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Utils
         {
             this.game = game;
 
-            if (!game.IsDeployedBuild || !game.CreateEndpoints().WebsiteRootUrl.EndsWith(@".ppy.sh", StringComparison.Ordinal))
+            if (!game.IsDeployedBuild || !game.CreateEndpoints().WebsiteUrl.EndsWith(@".ppy.sh", StringComparison.Ordinal))
                 return;
 
             sentrySession = SentrySdk.Init(options =>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/31803

This is split out of the main pull due to a significant change to `IAPIProvider`, in which rather than add a third string property next to `APIEndpointUrl` and `WebsiteRootUrl` specifically for submission, I decided to have `IAPIProvider` expose the full `EndpointConfiguration` and rerouted the usage sites of the removed two properties to go through it, which added extra size and warranted a detour.

Note that the development endpoint configuration does not yet specify an URL for a staging copy of the service. One exists, but is not currently ready to use (needs a few tweaks to make work).