### PR TITLE
Add ruleset icon to expanded score panel

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -62,12 +62,6 @@ namespace osu.Game.Tests.Visual.Ranking
                 if (beatmapInfo != null)
                     Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo);
             });
-
-            AddToggleStep("toggle legacy classic skin", v =>
-            {
-                if (skins != null)
-                    skins.CurrentSkinInfo.Value = v ? skins.DefaultClassicSkin.SkinInfo : skins.CurrentSkinInfo.Default;
-            });
         }
 
         [SetUp]
@@ -82,6 +76,16 @@ namespace osu.Game.Tests.Visual.Ranking
                 Content.Scale = new Vector2(v);
                 Content.Size = new Vector2(1f / v);
             }));
+        }
+
+        [Test]
+        public void TestLegacySkin()
+        {
+            AddToggleStep("toggle legacy classic skin", v =>
+            {
+                if (skins != null)
+                    skins.CurrentSkinInfo.Value = v ? skins.DefaultClassicSkin.SkinInfo : skins.CurrentSkinInfo.Default;
+            });
         }
 
         private int onlineScoreID = 1;

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -11,13 +11,15 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
 using osu.Game.Users.Drawables;
 using osu.Game.Utils;
@@ -134,14 +136,33 @@ namespace osu.Game.Screens.Ranking.Contracted
                                                 createStatistic(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, $"{score.Accuracy.FormatAccuracy()}"),
                                             }
                                         },
-                                        new ModFlowDisplay
+                                        new FillFlowContainer
                                         {
                                             Anchor = Anchor.TopCentre,
                                             Origin = Anchor.TopCentre,
-                                            AutoSizeAxes = Axes.Y,
                                             RelativeSizeAxes = Axes.X,
-                                            Current = { Value = score.Mods },
-                                            IconScale = 0.5f,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Full,
+                                            Spacing = new Vector2(3),
+                                            ChildrenEnumerable =
+                                            [
+                                                new DifficultyIcon(score.BeatmapInfo!, score.Ruleset)
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Size = new Vector2(20),
+                                                    TooltipType = DifficultyIconTooltipType.Extended,
+                                                    Margin = new MarginPadding { Right = 2 }
+                                                },
+                                                ..
+                                                score.Mods.AsOrdered().Select(m => new ModIcon(m)
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Scale = new Vector2(0.3f),
+                                                    Margin = new MarginPadding { Top = -6 }
+                                                })
+                                            ]
                                         }
                                     }
                                 }

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Ranking.Contracted
                                 Colour = Color4.Black.Opacity(0.25f),
                                 Type = EdgeEffectType.Shadow,
                                 Radius = 1,
-                                Offset = new Vector2(0, 4)
+                                Offset = new Vector2(0, 2)
                             },
                             Children = new Drawable[]
                             {
@@ -100,10 +100,10 @@ namespace osu.Game.Screens.Ranking.Contracted
                                             CornerRadius = 20,
                                             EdgeEffect = new EdgeEffectParameters
                                             {
-                                                Colour = Color4.Black.Opacity(0.25f),
+                                                Colour = Color4.Black.Opacity(0.15f),
                                                 Type = EdgeEffectType.Shadow,
                                                 Radius = 8,
-                                                Offset = new Vector2(0, 4),
+                                                Offset = new Vector2(0, 1),
                                             }
                                         },
                                         new OsuSpriteText

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -41,7 +41,6 @@ namespace osu.Game.Screens.Ranking.Expanded
 
         private readonly List<StatisticDisplay> statisticDisplays = new List<StatisticDisplay>();
 
-        private FillFlowContainer starAndModDisplay;
         private RollingCounter<long> scoreCounter;
 
         [Resolved]
@@ -139,12 +138,35 @@ namespace osu.Game.Screens.Ranking.Expanded
                                 Alpha = 0,
                                 AlwaysPresent = true
                             },
-                            starAndModDisplay = new FillFlowContainer
+                            new FillFlowContainer
                             {
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
                                 AutoSizeAxes = Axes.Both,
                                 Spacing = new Vector2(5, 0),
+                                Children = new Drawable[]
+                                {
+                                    new StarRatingDisplay(beatmapDifficultyCache.GetDifficultyAsync(beatmap, score.Ruleset, score.Mods).GetResultSafely() ?? default)
+                                    {
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft
+                                    },
+                                    new DifficultyIcon(beatmap, score.Ruleset)
+                                    {
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Size = new Vector2(20),
+                                        TooltipType = DifficultyIconTooltipType.Extended,
+                                    },
+                                    new ModDisplay
+                                    {
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        ExpansionMode = ExpansionMode.AlwaysExpanded,
+                                        Scale = new Vector2(0.5f),
+                                        Current = { Value = score.Mods }
+                                    }
+                                }
                             },
                             new FillFlowContainer
                             {
@@ -225,29 +247,6 @@ namespace osu.Game.Screens.Ranking.Expanded
 
             if (score.Date != default)
                 AddInternal(new PlayedOnText(score.Date));
-
-            var starDifficulty = beatmapDifficultyCache.GetDifficultyAsync(beatmap, score.Ruleset, score.Mods).GetResultSafely();
-
-            if (starDifficulty != null)
-            {
-                starAndModDisplay.Add(new StarRatingDisplay(starDifficulty.Value)
-                {
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft
-                });
-            }
-
-            if (score.Mods.Any())
-            {
-                starAndModDisplay.Add(new ModDisplay
-                {
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
-                    ExpansionMode = ExpansionMode.AlwaysExpanded,
-                    Scale = new Vector2(0.5f),
-                    Current = { Value = score.Mods }
-                });
-            }
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Not entirely sure we need this, but now that scores in multiplayer can be played on arbitrary rulesets I think it makes sense to display this somewhere. It sits between the star rating and mod displays:

<img width="440" alt="image" src="https://github.com/user-attachments/assets/d38127f0-f383-4f0e-b150-3b6aea9c9697" />

### What about the contracted panel?

I haven't added it to the contracted panel because I don't know where to fit it in. Also the beatmap isn't displayed there (which is also per-user in freestyle rooms), and I just think the design is in general inadequate for displaying so much info? Here's one of my attempts:
```diff
diff --git a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
index cfb6465e62..b2709670a0 100644
--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -11,13 +11,15 @@
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
 using osu.Game.Users.Drawables;
 using osu.Game.Utils;
@@ -134,14 +136,33 @@ private void load()
                                                 createStatistic(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, $"{score.Accuracy.FormatAccuracy()}"),
                                             }
                                         },
-                                        new ModFlowDisplay
+                                        new FillFlowContainer
                                         {
                                             Anchor = Anchor.TopCentre,
                                             Origin = Anchor.TopCentre,
-                                            AutoSizeAxes = Axes.Y,
                                             RelativeSizeAxes = Axes.X,
-                                            Current = { Value = score.Mods },
-                                            IconScale = 0.5f,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Full,
+                                            Spacing = new Vector2(3),
+                                            ChildrenEnumerable =
+                                            [
+                                                new DifficultyIcon(score.BeatmapInfo!, score.Ruleset)
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Size = new Vector2(20),
+                                                    TooltipType = DifficultyIconTooltipType.Extended,
+                                                    Margin = new MarginPadding { Right = 2 }
+                                                },
+                                                ..
+                                                score.Mods.AsOrdered().Select(m => new ModIcon(m)
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Scale = new Vector2(0.3f),
+                                                    Margin = new MarginPadding { Top = -6 }
+                                                })
+                                            ]
                                         }
                                     }
                                 }

```
<img width="179" alt="image" src="https://github.com/user-attachments/assets/ae2efa5a-ead8-4308-a265-c73b27edcb99" />

Also tried a little bit of a more wanky direction (check the top of the panel), but I'm not pleased with how it looks:

<img width="167" alt="image" src="https://github.com/user-attachments/assets/ee22818a-00fd-4a34-8bc2-393107097241" />

Would probably need some direction from @ppy/team-design.