### PR TITLE
Add invalidation on draw size change in beatmap carousel v2

### DIFF
--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Layout;
 using osu.Framework.Logging;
 using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
@@ -676,6 +677,15 @@ namespace osu.Game.Screens.SelectV2
             carouselPanel.Selected.Value = false;
             carouselPanel.KeyboardSelected.Value = false;
             carouselPanel.Expanded.Value = false;
+        }
+
+        protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
+        {
+            // handles the vertical size of the carousel changing (ie. on window resize when aspect ratio has changed).
+            if (invalidation.HasFlag(Invalidation.DrawSize))
+                selectionValid.Invalidate();
+
+            return base.OnInvalidate(invalidation, source);
         }
 
         #endregion


### PR DESCRIPTION
Matching old implementation. Required because `DrawHeight` (and therefore `visibleHalfHeight`) changes on aspect ratio change.

Before:

https://github.com/user-attachments/assets/a2bd1bb4-6102-40d1-af50-cdb5fada8eec


After:

https://github.com/user-attachments/assets/d7ddc0b0-1df2-4e46-8f9a-a6b09f73f550

