### PR TITLE
Add playlist to new collection button present on playlist room

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestSceneAddPlaylistToCollectionButton.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestSceneAddPlaylistToCollectionButton.cs
@@ -77,9 +77,9 @@ namespace osu.Game.Tests.Visual.Playlists
 
             AddStep("click button", () => InputManager.Click(MouseButton.Left));
 
-            AddAssert("notification shown", () => notificationOverlay.AllNotifications.FirstOrDefault(n => n.Text.ToString().StartsWith("Created", StringComparison.Ordinal)) != null);
+            AddUntilStep("notification shown", () => notificationOverlay.AllNotifications.Any(n => n.Text.ToString().StartsWith("Created new collection", StringComparison.Ordinal)));
 
-            AddAssert("realm is updated", () => Realm.Realm.All<BeatmapCollection>().FirstOrDefault(c => c.Name == room.Name) != null);
+            AddUntilStep("realm is updated", () => Realm.Realm.All<BeatmapCollection>().FirstOrDefault(c => c.Name == room.Name) != null);
         }
 
         private void importBeatmap() => AddStep("import beatmap", () =>

--- a/osu.Game.Tests/Visual/Playlists/TestSceneAddPlaylistToCollectionButton.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestSceneAddPlaylistToCollectionButton.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.OnlinePlay.Playlists;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Playlists
+{
+    public partial class TestSceneAddPlaylistToCollectionButton : OsuTestScene
+    {
+        private BeatmapManager manager = null!;
+        private BeatmapSetInfo importedBeatmap = null!;
+        private Room room = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host, AudioManager audio)
+        {
+            Dependencies.Cache(new RealmRulesetStore(Realm));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
+        }
+
+        [Cached(typeof(INotificationOverlay))]
+        private NotificationOverlay notificationOverlay = new NotificationOverlay
+        {
+            Anchor = Anchor.TopRight,
+            Origin = Anchor.TopRight,
+        };
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            importBeatmap();
+
+            setupRoom();
+
+            AddStep("create button", () =>
+            {
+                AddRange(new Drawable[]
+                {
+                    notificationOverlay,
+                    new AddPlaylistToCollectionButton(room)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(300, 40),
+                    }
+                });
+            });
+        }
+
+        private void importBeatmap() => AddStep("import beatmap", () =>
+        {
+            var beatmap = CreateBeatmap(new OsuRuleset().RulesetInfo);
+
+            Debug.Assert(beatmap.BeatmapInfo.BeatmapSet != null);
+
+            importedBeatmap = manager.Import(beatmap.BeatmapInfo.BeatmapSet)!.Value.Detach();
+        });
+
+        private void setupRoom() => AddStep("setup room", () =>
+        {
+            room = new Room
+            {
+                Name = "my awesome room",
+                MaxAttempts = 5,
+                Host = API.LocalUser.Value
+            };
+            room.RecentParticipants = [room.Host];
+            room.EndDate = DateTimeOffset.Now.AddMinutes(5);
+            room.Playlist =
+            [
+                new PlaylistItem(importedBeatmap.Beatmaps.First())
+                {
+                    RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                }
+            ];
+        });
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Game.Collections;
+using osu.Game.Database;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Screens.OnlinePlay.Playlists
+{
+    public partial class AddPlaylistToCollectionButton : RoundedButton
+    {
+        private readonly Room room;
+
+        [Resolved]
+        private RealmAccess realmAccess { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        private INotificationOverlay? notifications { get; set; }
+
+        public AddPlaylistToCollectionButton(Room room)
+        {
+            this.room = room;
+            Text = "Add Maps to Collection";
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            BackgroundColour = colours.Gray5;
+
+            Action = () =>
+            {
+                int[] ids = room.Playlist.Select(item => item.Beatmap.OnlineID).Where(onlineId => onlineId > 0).ToArray();
+
+                if (ids.Length == 0)
+                {
+                    notifications?.Post(new SimpleErrorNotification { Text = "Cannot add local beatmaps" });
+                    return;
+                }
+
+                beatmapLookupCache.GetBeatmapsAsync(ids).ContinueWith(task => Schedule(() =>
+                {
+                    var beatmaps = task.GetResultSafely().Where(item => item?.BeatmapSet != null).ToList();
+
+                    var collection = realmAccess.Realm.All<BeatmapCollection>().FirstOrDefault(c => c.Name == room.Name);
+
+                    if (collection == null)
+                    {
+                        collection = new BeatmapCollection(room.Name, beatmaps.Select(i => i!.MD5Hash).Distinct().ToList());
+                        realmAccess.Realm.Write(() => realmAccess.Realm.Add(collection));
+                        notifications?.Post(new SimpleNotification { Text = $"Created new playlist: {room.Name}" });
+                    }
+                    else
+                    {
+                        collection.ToLive(realmAccess).PerformWrite(c =>
+                        {
+                            beatmaps = beatmaps.Where(i => !c.BeatmapMD5Hashes.Contains(i!.MD5Hash)).ToList();
+                            foreach (var item in beatmaps)
+                                c.BeatmapMD5Hashes.Add(item!.MD5Hash);
+                            notifications?.Post(new SimpleNotification { Text = $"Updated playlist: {room.Name}" });
+                        });
+                    }
+                }), TaskContinuationOptions.OnlyOnRanToCompletion);
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
@@ -75,7 +75,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         {
             base.LoadComplete();
 
-            beatmapSubscription = realmAccess.RegisterForNotifications(r => r.All<BeatmapInfo>().Filter(formatFilterQuery(room.Playlist)), (sender, _) => downloadedBeatmapsCount.Value = sender.Count);
+            if (room.Playlist.Count > 0)
+                beatmapSubscription = realmAccess.RegisterForNotifications(r => r.All<BeatmapInfo>().Filter(formatFilterQuery(room.Playlist)), (sender, _) => downloadedBeatmapsCount.Value = sender.Count);
 
             collectionSubscription = realmAccess.RegisterForNotifications(r => r.All<BeatmapCollection>().Where(c => c.Name == room.Name), (sender, _) => collectionExists.Value = sender.Count > 0);
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     {
                         collection = new BeatmapCollection(room.Name, beatmaps.Select(i => i!.MD5Hash).Distinct().ToList());
                         realmAccess.Realm.Write(() => realmAccess.Realm.Add(collection));
-                        notifications?.Post(new SimpleNotification { Text = $"Created new playlist: {room.Name}" });
+                        notifications?.Post(new SimpleNotification { Text = $"Created new collection: {room.Name}" });
                     }
                     else
                     {
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                             beatmaps = beatmaps.Where(i => !c.BeatmapMD5Hashes.Contains(i!.MD5Hash)).ToList();
                             foreach (var item in beatmaps)
                                 c.BeatmapMD5Hashes.Add(item!.MD5Hash);
-                            notifications?.Post(new SimpleNotification { Text = $"Updated playlist: {room.Name}" });
+                            notifications?.Post(new SimpleNotification { Text = $"Updated collection: {room.Name}" });
                         });
                     }
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/AddPlaylistToCollectionButton.cs
@@ -35,15 +35,13 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         {
             Action = () =>
             {
-                int[] ids = room.Playlist.Select(item => item.Beatmap.OnlineID).Where(onlineId => onlineId > 0).ToArray();
-
-                if (ids.Length == 0)
+                if (room.Playlist.Count == 0)
                 {
                     notifications?.Post(new SimpleErrorNotification { Text = "Cannot add local beatmaps" });
                     return;
                 }
 
-                string filter = string.Join(" OR ", ids.Select(id => $"(OnlineID == {id})"));
+                string filter = string.Join(" OR ", room.Playlist.Select(item => $"(OnlineID == {item.Beatmap.OnlineID})").Distinct());
                 var beatmaps = realmAccess.Realm.All<BeatmapInfo>().Filter(filter).ToList();
 
                 var collection = realmAccess.Realm.All<BeatmapCollection>().FirstOrDefault(c => c.Name == room.Name);

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -153,11 +153,21 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                             }
                                         }
                                     },
+                                    new Drawable[]
+                                    {
+                                        new AddPlaylistToCollectionButton(Room)
+                                        {
+                                            Margin = new MarginPadding { Top = 5 },
+                                            RelativeSizeAxes = Axes.X,
+                                            Size = new Vector2(1, 40)
+                                        }
+                                    }
                                 },
                                 RowDimensions = new[]
                                 {
                                     new Dimension(GridSizeMode.AutoSize),
                                     new Dimension(),
+                                    new Dimension(GridSizeMode.AutoSize),
                                 }
                             },
                             // Spacer


### PR DESCRIPTION
https://github.com/ppy/osu/discussions/31541

Add a button to playlist room that creates a new collection with all the beatmaps present in the playlist.

Current function:
- if collection does not exist: create new playlist with the name of the room
- if a collection with the same name as the room does exist: append unique entries to collection
- will add beatmaps that are not downloaded to the collection. If the user downloads them later on, they will automatically be added to the collection (this means that it is not possible to remove an undownloaded beatmap from the collection until they download it)

Basic run through features

https://github.com/user-attachments/assets/6bbd1ce7-469e-4471-9e33-59036b96d54d

Adding beatmaps to existing collection

https://github.com/user-attachments/assets/e666f84d-8097-41fb-a13f-90511a88eac1




