### PR TITLE
Always transfer keyboard selection on activation

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselV2TestScene.cs
@@ -136,8 +136,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         protected void CheckNoSelection() => AddAssert("has no selection", () => Carousel.CurrentSelection, () => Is.Null);
         protected void CheckHasSelection() => AddAssert("has selection", () => Carousel.CurrentSelection, () => Is.Not.Null);
 
-        protected BeatmapPanel? GetSelectedPanel() => Carousel.ChildrenOfType<BeatmapPanel>().SingleOrDefault(p => p.Selected.Value);
-        protected GroupPanel? GetKeyboardSelectedPanel() => Carousel.ChildrenOfType<GroupPanel>().SingleOrDefault(p => p.KeyboardSelected.Value);
+        protected ICarouselPanel? GetSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.Selected.Value);
+        protected ICarouselPanel? GetKeyboardSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.KeyboardSelected.Value);
 
         protected void WaitForGroupSelection(int group, int panel)
         {

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2DifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2DifficultyGrouping.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             RemoveAllBeatmaps();
             AddUntilStep("no drawable selection", GetSelectedPanel, () => Is.Null);
 
-            AddBeatmaps(10);
+            AddBeatmaps(5);
             WaitForDrawablePanels();
 
             CheckHasSelection();

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2DifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarouselV2DifficultyGrouping.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
-        public void TestGroupSelectionOnHeader()
+        public void TestGroupSelectionOnHeaderKeyboard()
         {
             SelectNextGroup();
             WaitForGroupSelection(0, 0);
@@ -111,6 +111,26 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             WaitForGroupSelection(0, 0);
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
+        }
+
+        [Test]
+        public void TestGroupSelectionOnHeaderMouse()
+        {
+            SelectNextGroup();
+            WaitForGroupSelection(0, 0);
+
+            AddAssert("keyboard selected panel is beatmap", GetKeyboardSelectedPanel, Is.TypeOf<BeatmapPanel>);
+            AddAssert("selected panel is beatmap", GetSelectedPanel, Is.TypeOf<BeatmapPanel>);
+
+            ClickVisiblePanel<GroupPanel>(0);
+            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, Is.TypeOf<GroupPanel>);
+            AddAssert("keyboard selected panel is contracted", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.False);
+
+            ClickVisiblePanel<GroupPanel>(0);
+            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, Is.TypeOf<GroupPanel>);
+            AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
+
+            AddAssert("selected panel is still beatmap", GetSelectedPanel, Is.TypeOf<BeatmapPanel>);
         }
 
         [Test]

--- a/osu.Game/Screens/SelectV2/Carousel.cs
+++ b/osu.Game/Screens/SelectV2/Carousel.cs
@@ -124,6 +124,11 @@ namespace osu.Game.Screens.SelectV2
         /// <param name="item"></param>
         public void Activate(CarouselItem item)
         {
+            // Regardless of how the item handles activation, update keyboard selection to the activated panel.
+            // In other words, when a panel is clicked, keyboard selection should default to matching the clicked
+            // item.
+            setKeyboardSelection(item.Model);
+
             (GetMaterialisedDrawableForItem(item) as ICarouselPanel)?.Activated();
             HandleItemActivated(item);
 


### PR DESCRIPTION
Addresses issue pointed out [here](https://github.com/ppy/osu/pull/31801#issuecomment-2636896097).

Should make things make a whole heap more sense.

Before:

https://github.com/user-attachments/assets/84dae186-cb4e-4c64-a908-89df80be49fe

After:

https://github.com/user-attachments/assets/a02d77d6-2234-46c5-9645-a5ea4077c544

