### PR TITLE
Changed the Currently Playing Text when no track is selected

### DIFF
--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -30,8 +30,8 @@ namespace osu.Game.Beatmaps
             {
                 Metadata = new BeatmapMetadata
                 {
-                    Artist = "please load a beatmap!",
-                    Title = "no beatmaps available!"
+                    Artist = "please select or load a beatmap!",
+                    Title = "no beatmap selected!"
                 },
                 BeatmapSet = new BeatmapSetInfo(),
                 Difficulty = new BeatmapDifficulty


### PR DESCRIPTION
Changed the currently playing text for when the track isn't selected/loaded acording to suggestion so it fixes #17666 

It was a really small change and was open long ago so I just did the suggested text

New Text 
![image](https://github.com/user-attachments/assets/c19cdb23-3243-4891-96a6-f54df19d663e)

