### PR TITLE
Fix incorrect thread access in recent iOS orientation changes

### DIFF
--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -41,7 +41,7 @@ namespace osu.iOS
                 updateOrientation();
         }
 
-        private void updateOrientation()
+        private void updateOrientation() => UIApplication.SharedApplication.InvokeOnMainThread(() =>
         {
             bool iPad = UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad;
             var orientation = MobileUtils.GetOrientation(this, (IOsuScreen)ScreenStack.CurrentScreen, iPad);
@@ -60,7 +60,7 @@ namespace osu.iOS
                     appDelegate.Orientations = null;
                     break;
             }
-        }
+        });
 
         protected override UpdateManager CreateUpdateManager() => new MobileUpdateNotifier();
 


### PR DESCRIPTION
Got bit by another one from https://github.com/ppy/osu/pull/31368, similar to https://github.com/ppy/osu-framework/pull/6517, and I wouldn't have noticed it if I didn't leave execution mode on multi-threaded. I don't have anything to say besides I'll try to focus more next time.