### PR TITLE
Add comment warning about enum entry order in `GlobalAction`

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -227,6 +227,10 @@ namespace osu.Game.Input.Bindings
         };
     }
 
+    /// <remarks>
+    /// IMPORTANT: New entries should always be added at the end of the enum, as key bindings are stored using the enum's numeric value and
+    /// changes in order would cause key bindings to get associated with the wrong action.
+    /// </remarks>
     public enum GlobalAction
     {
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleChat))]


### PR DESCRIPTION
As discussed on [discord](https://discord.com/channels/188630481301012481/188630652340404224/1338914577651470439).

Adds a comment explaining why new entries should always be added to the end of the `GlobalAction` enum.