### PR TITLE
Fix weird follow circle display when rewinding through sliders in editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
@@ -13,8 +13,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 {
     public abstract partial class FollowCircle : CompositeDrawable
     {
-        [Resolved]
-        protected DrawableHitObject? ParentObject { get; private set; }
+        protected DrawableSlider? DrawableObject { get; private set; }
 
         protected FollowCircle()
         {
@@ -22,16 +21,18 @@ namespace osu.Game.Rulesets.Osu.Skinning
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(DrawableHitObject? hitObject)
         {
-            ((DrawableSlider?)ParentObject)?.Tracking.BindValueChanged(tracking =>
-            {
-                Debug.Assert(ParentObject != null);
+            DrawableObject = hitObject as DrawableSlider;
 
-                if (ParentObject.Judged)
+            DrawableObject?.Tracking.BindValueChanged(tracking =>
+            {
+                Debug.Assert(DrawableObject != null);
+
+                if (DrawableObject.Judged)
                     return;
 
-                using (BeginAbsoluteSequence(Math.Max(Time.Current, ParentObject.HitObject?.StartTime ?? 0)))
+                using (BeginAbsoluteSequence(Math.Max(Time.Current, DrawableObject.HitObject?.StartTime ?? 0)))
                 {
                     if (tracking.NewValue)
                         OnSliderPress();
@@ -45,13 +46,13 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             base.LoadComplete();
 
-            if (ParentObject != null)
+            if (DrawableObject != null)
             {
-                ParentObject.HitObjectApplied += onHitObjectApplied;
-                onHitObjectApplied(ParentObject);
+                DrawableObject.HitObjectApplied += onHitObjectApplied;
+                onHitObjectApplied(DrawableObject);
 
-                ParentObject.ApplyCustomUpdateState += updateStateTransforms;
-                updateStateTransforms(ParentObject, ParentObject.State.Value);
+                DrawableObject.ApplyCustomUpdateState += updateStateTransforms;
+                updateStateTransforms(DrawableObject, DrawableObject.State.Value);
             }
         }
 
@@ -61,26 +62,26 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 .FadeOut();
         }
 
-        private void updateStateTransforms(DrawableHitObject drawableObject, ArmedState state)
+        private void updateStateTransforms(DrawableHitObject d, ArmedState state)
         {
-            Debug.Assert(ParentObject != null);
+            Debug.Assert(DrawableObject != null);
 
             switch (state)
             {
                 case ArmedState.Hit:
-                    switch (drawableObject)
+                    switch (d)
                     {
                         case DrawableSliderTail:
-                            // Use ParentObject instead of drawableObject because slider tail's
+                            // Use DrawableObject instead of local object because slider tail's
                             // HitStateUpdateTime is ~36ms before the actual slider end (aka slider
                             // tail leniency)
-                            using (BeginAbsoluteSequence(ParentObject.HitStateUpdateTime))
+                            using (BeginAbsoluteSequence(DrawableObject.HitStateUpdateTime))
                                 OnSliderEnd();
                             break;
 
                         case DrawableSliderTick:
                         case DrawableSliderRepeat:
-                            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
+                            using (BeginAbsoluteSequence(d.HitStateUpdateTime))
                                 OnSliderTick();
                             break;
                     }
@@ -88,15 +89,15 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     break;
 
                 case ArmedState.Miss:
-                    switch (drawableObject)
+                    switch (d)
                     {
                         case DrawableSliderTail:
                         case DrawableSliderTick:
                         case DrawableSliderRepeat:
-                            // Despite above comment, ok to use drawableObject.HitStateUpdateTime
+                            // Despite above comment, ok to use d.HitStateUpdateTime
                             // here, since on stable, the break anim plays right when the tail is
                             // missed, not when the slider ends
-                            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
+                            using (BeginAbsoluteSequence(d.HitStateUpdateTime))
                                 OnSliderBreak();
                             break;
                     }
@@ -109,10 +110,10 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             base.Dispose(isDisposing);
 
-            if (ParentObject != null)
+            if (DrawableObject != null)
             {
-                ParentObject.HitObjectApplied -= onHitObjectApplied;
-                ParentObject.ApplyCustomUpdateState -= updateStateTransforms;
+                DrawableObject.HitObjectApplied -= onHitObjectApplied;
+                DrawableObject.ApplyCustomUpdateState -= updateStateTransforms;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -15,6 +16,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
     {
         protected DrawableSlider? DrawableObject { get; private set; }
 
+        private readonly IBindable<bool> tracking = new Bindable<bool>();
+
         protected FollowCircle()
         {
             RelativeSizeAxes = Axes.Both;
@@ -25,21 +28,23 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             DrawableObject = hitObject as DrawableSlider;
 
-            DrawableObject?.Tracking.BindValueChanged(tracking =>
+            if (DrawableObject != null)
             {
-                Debug.Assert(DrawableObject != null);
-
-                if (DrawableObject.Judged)
-                    return;
-
-                using (BeginAbsoluteSequence(Math.Max(Time.Current, DrawableObject.HitObject?.StartTime ?? 0)))
+                tracking.BindTo(DrawableObject.Tracking);
+                tracking.BindValueChanged(tracking =>
                 {
-                    if (tracking.NewValue)
-                        OnSliderPress();
-                    else
-                        OnSliderRelease();
-                }
-            }, true);
+                    if (DrawableObject.Judged)
+                        return;
+
+                    using (BeginAbsoluteSequence(Math.Max(Time.Current, DrawableObject.HitObject?.StartTime ?? 0)))
+                    {
+                        if (tracking.NewValue)
+                            OnSliderPress();
+                        else
+                            OnSliderRelease();
+                    }
+                }, true);
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
@@ -63,8 +63,12 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private void onHitObjectApplied(DrawableHitObject drawableObject)
         {
+            // Sane defaults when a new hitobject is applied to the drawable slider.
             this.ScaleTo(1f)
                 .FadeOut();
+
+            // Immediately play out any pending transforms from press/release
+            FinishTransforms(true);
         }
 
         private void updateStateTransforms(DrawableHitObject d, ArmedState state)

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
@@ -22,9 +22,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         protected override void OnSliderPress()
         {
-            Debug.Assert(ParentObject != null);
+            Debug.Assert(DrawableObject != null);
 
-            double remainingTime = Math.Max(0, ParentObject.HitStateUpdateTime - Time.Current);
+            double remainingTime = Math.Max(0, DrawableObject.HitStateUpdateTime - Time.Current);
 
             // Note that the scale adjust here is 2 instead of DrawableSliderBall.FOLLOW_AREA to match legacy behaviour.
             // This means the actual tracking area for gameplay purposes is larger than the sprite (but skins may be accounting for this).


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31812.

This goes much deeper (so many gameplay things look wrong in rewind). I still believe the correct path forward is to not use transforms here. I did consider doing that for this series of classes, but it's more than a 30 minute change and I don't want to go down that rabbit hole just yet.