### PR TITLE
Disallow focus on difficulty range slider

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Graphics.UserInterface
     public abstract partial class OsuSliderBar<T> : SliderBar<T>, IHasTooltip
         where T : struct, INumber<T>, IMinMaxValue<T>
     {
+        public override bool AcceptsFocus => !Current.Disabled;
+
         public bool PlaySamplesOnAdjust { get; set; } = true;
 
         /// <summary>

--- a/osu.Game/Graphics/UserInterface/RangeSlider.cs
+++ b/osu.Game/Graphics/UserInterface/RangeSlider.cs
@@ -162,6 +162,8 @@ namespace osu.Game.Graphics.UserInterface
 
         protected partial class BoundSlider : RoundedSliderBar<double>
         {
+            public override bool AcceptsFocus => false;
+
             public new Nub Nub => base.Nub;
 
             public string? DefaultString;


### PR DESCRIPTION
Alternative to / closes https://github.com/ppy/osu/pull/31749 which keeps things simple.
Closes https://github.com/ppy/osu/issues/31559.

Also disables sliderbar focus when disabled