### PR TITLE
Extract leaderboard fetch logic from song select beatmap leaderboard drawable

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModNoRelease.cs
@@ -631,7 +631,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -578,7 +578,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneMaximumScore.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneMaximumScore.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneOutOfOrderHits.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneOutOfOrderHits.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModTouchDevice.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModTouchDevice.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleSoloPlayer()
-                : base(new PlayerConfiguration
+                : base(null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
@@ -860,7 +860,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderEarlyHitJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderEarlyHitJudgement.cs
@@ -217,7 +217,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -570,7 +570,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderLateHitJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderLateHitJudgement.cs
@@ -516,7 +516,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
@@ -338,7 +338,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
@@ -494,7 +494,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/JudgementTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/JudgementTest.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             protected override bool PauseOnFocusLost => false;
 
             public ScoreAccessibleReplayPlayer(Score score)
-                : base(score, new PlayerConfiguration
+                : base(score, null, new PlayerConfiguration
                 {
                     AllowPause = false,
                     ShowResults = false,

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -60,6 +60,7 @@ using osu.Game.Resources;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Skinning;
 using osu.Game.Utils;
 using RuntimeInfo = osu.Framework.RuntimeInfo;
@@ -338,6 +339,10 @@ namespace osu.Game
 
             dependencies.Cache(beatmapCache = new BeatmapLookupCache());
             base.Content.Add(beatmapCache);
+
+            var leaderboardProvider = new LeaderboardProvider();
+            dependencies.Cache(leaderboardProvider);
+            base.Content.Add(leaderboardProvider);
 
             dependencies.CacheAs<IRulesetConfigCache>(rulesetConfigCache = new RulesetConfigCache(realm, RulesetStore));
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -343,7 +343,7 @@ namespace osu.Game.Overlays.SkinEditor
             public override bool? AllowGlobalTrackControl => false;
 
             public EndlessPlayer(Func<IBeatmap, IReadOnlyList<Mod>, Score> createScore)
-                : base(createScore, new PlayerConfiguration
+                : base(createScore, null, new PlayerConfiguration
                 {
                     ShowResults = false,
                     AutomaticallySkipIntro = true,

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -3,21 +3,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
-using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
-using Realms;
 
 namespace osu.Game.Screens.Select.Leaderboards
 {
@@ -48,24 +44,10 @@ namespace osu.Game.Screens.Select.Leaderboards
             }
         }
 
-        private bool filterMods;
-
         /// <summary>
         /// Whether to apply the game's currently selected mods as a filter when retrieving scores.
         /// </summary>
-        public bool FilterMods
-        {
-            get => filterMods;
-            set
-            {
-                if (value == filterMods)
-                    return;
-
-                filterMods = value;
-
-                RefetchScores();
-            }
-        }
+        public Bindable<bool> FilterMods { get; set; } = new Bindable<bool>();
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
@@ -77,32 +59,16 @@ namespace osu.Game.Screens.Select.Leaderboards
         private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private RulesetStore rulesets { get; set; } = null!;
+        private LeaderboardProvider leaderboardProvider { get; set; } = null!;
 
-        [Resolved]
-        private RealmAccess realm { get; set; } = null!;
-
-        private IDisposable? scoreSubscription;
-
-        private GetScoresRequest? scoreRetrievalRequest;
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            ruleset.ValueChanged += _ => RefetchScores();
-            mods.ValueChanged += _ =>
-            {
-                if (filterMods)
-                    RefetchScores();
-            };
-        }
+        public StateTrackingLeaderboardProvider? LeaderboardProvider { get; private set; }
 
         protected override bool IsOnlineScope => Scope != BeatmapLeaderboardScope.Local;
 
         protected override APIRequest? FetchScores(CancellationToken cancellationToken)
         {
-            scoreRetrievalRequest?.Cancel();
-            scoreRetrievalRequest = null;
+            LeaderboardProvider?.RemoveAndDisposeImmediately();
+            LeaderboardProvider = null;
 
             var fetchBeatmapInfo = BeatmapInfo;
 
@@ -113,12 +79,6 @@ namespace osu.Game.Screens.Select.Leaderboards
             }
 
             var fetchRuleset = ruleset.Value ?? fetchBeatmapInfo.Ruleset;
-
-            if (Scope == BeatmapLeaderboardScope.Local)
-            {
-                subscribeToLocalScores(fetchBeatmapInfo, cancellationToken);
-                return null;
-            }
 
             if (!api.IsLoggedIn)
             {
@@ -132,41 +92,34 @@ namespace osu.Game.Screens.Select.Leaderboards
                 return null;
             }
 
-            if (fetchBeatmapInfo.OnlineID <= 0 || fetchBeatmapInfo.Status <= BeatmapOnlineStatus.Pending)
+            if ((fetchBeatmapInfo.OnlineID <= 0 || fetchBeatmapInfo.Status <= BeatmapOnlineStatus.Pending) && IsOnlineScope)
             {
                 SetErrorState(LeaderboardState.BeatmapUnavailable);
                 return null;
             }
 
-            if (!api.LocalUser.Value.IsSupporter && (Scope != BeatmapLeaderboardScope.Global || filterMods))
+            if (!api.LocalUser.Value.IsSupporter && (Scope >= BeatmapLeaderboardScope.Country || FilterMods.Value))
             {
                 SetErrorState(LeaderboardState.NotSupporter);
                 return null;
             }
 
-            IReadOnlyList<Mod>? requestMods = null;
-
-            if (filterMods && !mods.Value.Any())
-                // add nomod for the request
-                requestMods = new Mod[] { new ModNoMod() };
-            else if (filterMods)
-                requestMods = mods.Value;
-
-            var newRequest = new GetScoresRequest(fetchBeatmapInfo, fetchRuleset, Scope, requestMods);
-            newRequest.Success += response => Schedule(() =>
+            LeaderboardProvider = new StateTrackingLeaderboardProvider(leaderboardProvider)
             {
-                // Request may have changed since fetch request.
-                // Can't rely on request cancellation due to Schedule inside SetScores so let's play it safe.
-                if (!newRequest.Equals(scoreRetrievalRequest))
-                    return;
-
-                SetScores(
-                    response.Scores.Select(s => s.ToScoreInfo(rulesets, fetchBeatmapInfo)).OrderByTotalScore(),
-                    response.UserScore?.CreateScoreInfo(rulesets, fetchBeatmapInfo)
-                );
-            });
-
-            return scoreRetrievalRequest = newRequest;
+                Beatmap = { Value = BeatmapInfo! },
+                Ruleset = { BindTarget = ruleset },
+                ModFilterActive = { BindTarget = FilterMods },
+                Mods = { BindTarget = mods },
+                Scope = { Value = Scope },
+            };
+            LeaderboardProvider.Scores.BindValueChanged(val =>
+            {
+                if (val.NewValue != null)
+                    SetScores(val.NewValue.Value.best, val.NewValue.Value.userScore);
+            }, true);
+            LeaderboardProvider.RetrievalFailed += _ => Schedule(() => SetErrorState(LeaderboardState.NetworkFailure));
+            AddInternal(LeaderboardProvider);
+            return null;
         }
 
         protected override LeaderboardScore CreateDrawableScore(ScoreInfo model, int index) => new LeaderboardScore(model, index, IsOnlineScope, Scope != BeatmapLeaderboardScope.Friend)
@@ -178,59 +131,5 @@ namespace osu.Game.Screens.Select.Leaderboards
         {
             Action = () => ScoreSelected?.Invoke(model)
         };
-
-        private void subscribeToLocalScores(BeatmapInfo beatmapInfo, CancellationToken cancellationToken)
-        {
-            Debug.Assert(beatmapInfo != null);
-
-            scoreSubscription?.Dispose();
-            scoreSubscription = null;
-
-            scoreSubscription = realm.RegisterForNotifications(r =>
-                r.All<ScoreInfo>().Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $0"
-                                          + $" AND {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.Hash)} == {nameof(ScoreInfo.BeatmapHash)}"
-                                          + $" AND {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $1"
-                                          + $" AND {nameof(ScoreInfo.DeletePending)} == false"
-                    , beatmapInfo.ID, ruleset.Value.ShortName), localScoresChanged);
-
-            void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet? changes)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                    return;
-
-                // This subscription may fire from changes to linked beatmaps, which we don't care about.
-                // It's currently not possible for a score to be modified after insertion, so we can safely ignore callbacks with only modifications.
-                if (changes?.HasCollectionChanges() == false)
-                    return;
-
-                var scores = sender.AsEnumerable();
-
-                if (filterMods && !mods.Value.Any())
-                {
-                    // we need to filter out all scores that have any mods to get all local nomod scores
-                    scores = scores.Where(s => !s.Mods.Any());
-                }
-                else if (filterMods)
-                {
-                    // otherwise find all the scores that have all of the currently selected mods (similar to how web applies mod filters)
-                    // we're creating and using a string HashSet representation of selected mods so that it can be translated into the DB query itself
-                    var selectedMods = mods.Value.Select(m => m.Acronym).ToHashSet();
-
-                    scores = scores.Where(s => selectedMods.SetEquals(s.Mods.Select(m => m.Acronym)));
-                }
-
-                scores = scores.Detach().OrderByTotalScore();
-
-                SetScores(scores);
-            }
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            scoreSubscription?.Dispose();
-            scoreRetrievalRequest?.Cancel();
-        }
     }
 }

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardProvider.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using Realms;
+
+namespace osu.Game.Screens.Select.Leaderboards
+{
+    public partial class LeaderboardProvider : Component
+    {
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        private IQueryable<ScoreInfo> getLocalScoresFor(Realm r, BeatmapInfo beatmap, RulesetInfo ruleset)
+        {
+            return r.All<ScoreInfo>().Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $0"
+                                             + $" AND {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.Hash)} == {nameof(ScoreInfo.BeatmapHash)}"
+                                             + $" AND {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $1"
+                                             + $" AND {nameof(ScoreInfo.DeletePending)} == false", beatmap.ID, ruleset.ShortName);
+        }
+
+        public IEnumerable<ScoreInfo> GetLocalScoresFor(BeatmapInfo beatmap, RulesetInfo ruleset) => realm.Run(r => getLocalScoresFor(r, beatmap, ruleset)).AsEnumerable();
+
+        public IDisposable SubscribeToLocalScores(BeatmapInfo beatmap, RulesetInfo ruleset, NotificationCallbackDelegate<ScoreInfo> onChange)
+            => realm.RegisterForNotifications(r => getLocalScoresFor(r, beatmap, ruleset), onChange);
+
+        public Task<(IEnumerable<ScoreInfo> best, ScoreInfo? userScore)> GetOnlineScoresAsync(BeatmapInfo beatmap, RulesetInfo ruleset, IReadOnlyList<Mod>? mods, BeatmapLeaderboardScope scope,
+                                                                                              CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<Mod>? requestMods = mods;
+
+            if (mods != null && !mods.Any())
+                // add nomod for the request
+                requestMods = new Mod[] { new ModNoMod() };
+
+            var tcs = new TaskCompletionSource<(IEnumerable<ScoreInfo>, ScoreInfo?)>();
+            var newRequest = new GetScoresRequest(beatmap, ruleset, scope, requestMods);
+            newRequest.Success += response =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    tcs.SetCanceled(cancellationToken);
+                    return;
+                }
+
+                // Request may have changed since fetch request.
+                IEnumerable<ScoreInfo> newScores = response.Scores.Select(s => s.ToScoreInfo(rulesets, beatmap)).OrderByTotalScore().ToArray();
+                var userScore = response.UserScore?.CreateScoreInfo(rulesets, beatmap);
+
+                tcs.SetResult((newScores, userScore));
+            };
+            newRequest.Failure += ex =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    tcs.SetCanceled(cancellationToken);
+                    return;
+                }
+
+                tcs.SetException(ex);
+            };
+            api.Queue(newRequest);
+            return tcs.Task;
+        }
+    }
+}

--- a/osu.Game/Screens/Select/Leaderboards/StateTrackingLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/StateTrackingLeaderboardProvider.cs
@@ -1,0 +1,137 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using Realms;
+
+namespace osu.Game.Screens.Select.Leaderboards
+{
+    public partial class StateTrackingLeaderboardProvider : Component
+    {
+        /// <summary>
+        /// List of all fetched scores.
+        /// <see langword="null"/> if fetch is in progress.
+        /// Updates to this bindable may not be delivered on the update thread. Consumers are expected to schedule locally as required.
+        /// </summary>
+        public Bindable<(IEnumerable<ScoreInfo> best, ScoreInfo? userScore)?> Scores => scores;
+
+        private Bindable<(IEnumerable<ScoreInfo>, ScoreInfo?)?> scores { get; } = new Bindable<(IEnumerable<ScoreInfo>, ScoreInfo?)?>();
+
+        /// <summary>
+        /// Raised when fetching scores fails.
+        /// This event may not be invoked on the update thread. Consumers are expected to schedule locally as required.
+        /// </summary>
+        public event Action<Exception>? RetrievalFailed;
+
+        public Bindable<BeatmapLeaderboardScope> Scope { get; } = new Bindable<BeatmapLeaderboardScope>();
+        public Bindable<BeatmapInfo> Beatmap { get; } = new Bindable<BeatmapInfo>();
+        public Bindable<RulesetInfo> Ruleset { get; } = new Bindable<RulesetInfo>();
+        public Bindable<bool> ModFilterActive { get; } = new BindableBool();
+        public Bindable<IReadOnlyList<Mod>> Mods { get; } = new Bindable<IReadOnlyList<Mod>>([]);
+
+        private readonly LeaderboardProvider leaderboardProvider;
+
+        private IDisposable? localScoreSubscription;
+        private CancellationTokenSource? onlineLookupCancellationTokenSource;
+
+        public StateTrackingLeaderboardProvider(LeaderboardProvider leaderboardProvider)
+        {
+            this.leaderboardProvider = leaderboardProvider;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Scope.BindValueChanged(_ => Scheduler.AddOnce(refetch));
+            Beatmap.BindValueChanged(_ => Scheduler.AddOnce(refetch));
+            Ruleset.BindValueChanged(_ => Scheduler.AddOnce(refetch));
+            ModFilterActive.BindValueChanged(_ => Scheduler.AddOnce(refetch));
+            Mods.BindValueChanged(_ => Scheduler.AddOnce(refetch));
+            refetch();
+        }
+
+        private void refetch()
+        {
+            localScoreSubscription?.Dispose();
+            localScoreSubscription = null;
+
+            onlineLookupCancellationTokenSource?.Cancel();
+            onlineLookupCancellationTokenSource = null;
+
+            if (Scope.Value == BeatmapLeaderboardScope.Local)
+            {
+                localScoreSubscription = leaderboardProvider.SubscribeToLocalScores(Beatmap.Value, Ruleset.Value, localScoresChanged);
+            }
+            else
+            {
+                onlineLookupCancellationTokenSource = new CancellationTokenSource();
+                scores.Value = null;
+                leaderboardProvider.GetOnlineScoresAsync(Beatmap.Value, Ruleset.Value, ModFilterActive.Value ? Mods.Value : null, Scope.Value, onlineLookupCancellationTokenSource.Token)
+                                   .ContinueWith(t =>
+                                   {
+                                       switch (t.Status)
+                                       {
+                                           case TaskStatus.RanToCompletion:
+                                               scores.Value = t.GetResultSafely();
+                                               break;
+
+                                           case TaskStatus.Faulted:
+                                               RetrievalFailed?.Invoke(t.Exception!);
+                                               break;
+                                       }
+                                   });
+            }
+        }
+
+        private void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet? changes)
+        {
+            // This subscription may fire from changes to linked beatmaps, which we don't care about.
+            // It's currently not possible for a score to be modified after insertion, so we can safely ignore callbacks with only modifications.
+            if (changes?.HasCollectionChanges() == false)
+                return;
+
+            var newScores = sender.AsEnumerable();
+
+            if (ModFilterActive.Value && !Mods.Value.Any())
+            {
+                // we need to filter out all scores that have any mods to get all local nomod scores
+                newScores = newScores.Where(s => !s.Mods.Any());
+            }
+            else if (ModFilterActive.Value)
+            {
+                // otherwise find all the scores that have all of the currently selected mods (similar to how web applies mod filters)
+                // we're creating and using a string HashSet representation of selected mods so that it can be translated into the DB query itself
+                var selectedMods = Mods.Value.Select(m => m.Acronym).ToHashSet();
+
+                newScores = newScores.Where(s => selectedMods.SetEquals(s.Mods.Select(m => m.Acronym)));
+            }
+
+            newScores = newScores.Detach().OrderByTotalScore();
+            scores.Value = (newScores, null);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            localScoreSubscription?.Dispose();
+            localScoreSubscription = null;
+
+            onlineLookupCancellationTokenSource?.Cancel();
+            onlineLookupCancellationTokenSource = null;
+        }
+    }
+}

--- a/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.Select
         {
             base.OnTabChanged(tab, selectedMods);
 
-            Leaderboard.FilterMods = selectedMods;
+            Leaderboard.FilterMods.Value = selectedMods;
 
             switch (tab)
             {

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -129,17 +129,11 @@ namespace osu.Game.Screens.Select
 
                 if (replayGeneratingMod != null)
                 {
-                    player = new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods))
-                    {
-                        LeaderboardScores = { BindTarget = playBeatmapDetailArea.Leaderboard.Scores }
-                    };
+                    player = new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods), playBeatmapDetailArea.Leaderboard.LeaderboardProvider);
                 }
                 else
                 {
-                    player = new SoloPlayer
-                    {
-                        LeaderboardScores = { BindTarget = playBeatmapDetailArea.Leaderboard.Scores }
-                    };
+                    player = new SoloPlayer(playBeatmapDetailArea.Leaderboard.LeaderboardProvider);
                 }
 
                 return player;

--- a/osu.Game/Screens/SelectV2/SongSelectV2.cs
+++ b/osu.Game/Screens/SelectV2/SongSelectV2.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.SelectV2
 
             logo.Action = () =>
             {
-                this.Push(new PlayerLoaderV2(() => new SoloPlayer()));
+                this.Push(new PlayerLoaderV2(() => new SoloPlayer(null)));
                 return false;
             };
         }

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Visual
         private SpectatorClient spectatorClient { get; set; }
 
         public TestPlayer(bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false)
-            : base(new PlayerConfiguration
+            : base(null, new PlayerConfiguration
             {
                 AllowPause = allowPause,
                 ShowResults = showResults

--- a/osu.Game/Tests/Visual/TestReplayPlayer.cs
+++ b/osu.Game/Tests/Visual/TestReplayPlayer.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Tests.Visual
         /// Instantiate a replay player that renders an autoplay mod.
         /// </summary>
         public TestReplayPlayer(bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false)
-            : base((beatmap, mods) => mods.OfType<ModAutoplay>().First().CreateScoreFromReplayData(beatmap, mods), new PlayerConfiguration
+            : base((beatmap, mods) => mods.OfType<ModAutoplay>().First().CreateScoreFromReplayData(beatmap, mods), null, new PlayerConfiguration
             {
                 AllowPause = allowPause,
                 ShowResults = showResults
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual
         /// Instantiate a replay player that renders the provided replay.
         /// </summary>
         public TestReplayPlayer(Score score, bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false)
-            : base(score, new PlayerConfiguration
+            : base(score, null, new PlayerConfiguration
             {
                 AllowPause = allowPause,
                 ShowResults = showResults


### PR DESCRIPTION
This is an RFC. It appears to be fully functional and pass tests, but I'm not super sure on the direction here, so opening as draft.

- Would supersede / close https://github.com/ppy/osu/pull/31355
- Would close https://github.com/ppy/osu/issues/29861

The key points:

- The core logic of online and local leaderboard fetches has been moved out to `LeaderboardProvider` - a component at `OsuGameBase` level. The reason for pulling it up there is to avoid many stupid issues related to presence, schedules not running, etc., that would result from putting that component in one piece in `SongSelect`.
- `SongSelect` has a second component - `StateTrackingLeaderboardProvider` - that is responsible for tracking the user filter preferences and calling appropriate `LeaderboardProvider` methods. This component is passed around to `Player` implementations which fixes https://github.com/ppy/osu/issues/29861, and that is later intended to daisy-chain further into `ResultsScreen` implementations, which is prospective towards fixing https://github.com/ppy/osu/issues/26331. https://github.com/ppy/osu/issues/27609 is another related issue.

  In https://github.com/ppy/osu/pull/31355 I knocked the idea of doing state tracking, but I concede that having a thing that does it is easier than not, because you can pass this stuff forward without needing to pass forward the entirety of song select's leaderboard scope state.

  However, contrary to that pull, there are no weird generics here and no overfitted structures. Everything is written straight, for the specific use case of leaderboards in song select which I consider disparate and not 100% compatible with leaderboards in gameplay (more on that later down the chain of PRs, if this one passes review scrutiny).
- I admit out of the gate that the hookup of `StateTrackingLeaderboardProvider` to `BeatmapLeaderboard` is shoddy at best - the `StateTrackingLeaderboardProvider` is reconstructed more than it needs to. That is because `BeatmapLeaderboard` and its base `Leaderboard` abomination are bad and should be nuked from orbit. I am hoping this can happen with the song select leaderboard, which is why I'm tagging @frenzibyte in here to examine the structure. The hope is that the new implementation can focus on display logic and rely on the provider to provide scores, rather than having all of that `Refetch()` stuff.
- `StateTrackingLeaderboardProvider` keeps it head out of all of the special error logic (showing the messages about the beatmap not having online leaderboards, not having supporter, etc.) I was in two minds about this, and in the end I think this is better, but it's not a strong opinion and I am open to reconsideration.