### PR TITLE
Prioritise mouse over touch position in osu! gameplay

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -600,11 +600,12 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestMousePositionPriority()
         {
-            moveMouseTo(TouchSource.Touch1);
-            checkPosition(TouchSource.Touch1);
+            AddStep("move mouse and touch shortly after", () =>
+            {
+                InputManager.MoveMouseTo(getSanePositionForSource(TouchSource.Touch1));
+                InputManager.BeginTouch(new Touch(TouchSource.Touch2, getSanePositionForSource(TouchSource.Touch2)));
+            });
 
-            // touch at a different position
-            beginTouch(TouchSource.Touch2);
             endTouch(TouchSource.Touch2);
 
             checkPosition(TouchSource.Touch1);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -597,6 +597,33 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPosition(TouchSource.Touch2);
         }
 
+        [Test]
+        public void TestMousePositionPriority()
+        {
+            moveMouseTo(TouchSource.Touch1);
+            checkPosition(TouchSource.Touch1);
+
+            // touch at a different position
+            beginTouch(TouchSource.Touch2);
+            endTouch(TouchSource.Touch2);
+
+            checkPosition(TouchSource.Touch1);
+        }
+
+        [Test]
+        public void TestTouchInputPriorityAfterTimeout()
+        {
+            moveMouseTo(TouchSource.Touch1);
+            checkPosition(TouchSource.Touch1);
+
+            AddWaitStep("wait for mouse priority timeout to expire", 10);
+
+            beginTouch(TouchSource.Touch2);
+            endTouch(TouchSource.Touch2);
+
+            checkPosition(TouchSource.Touch2);
+        }
+
         private void addHitCircleAt(TouchSource source)
         {
             AddStep($"Add circle at {source}", () =>
@@ -619,6 +646,9 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void endTouch(TouchSource source, Vector2? screenSpacePosition = null) =>
             AddStep($"Release touch for {source}", () => InputManager.EndTouch(new Touch(source, screenSpacePosition ??= getSanePositionForSource(source))));
+
+        private void moveMouseTo(TouchSource source) =>
+            AddStep($"Mouse mouse to {source} position", () => InputManager.MoveMouseTo(getSanePositionForSource(source)));
 
         private Vector2 getSanePositionForSource(TouchSource source)
         {

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Input.StateChanges;
 using osu.Framework.Lists;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -65,6 +66,15 @@ namespace osu.Game.Rulesets.Osu
             if ((e is MouseMoveEvent || e is TouchMoveEvent) && !AllowUserCursorMovement) return false;
 
             return base.Handle(e);
+        }
+
+        /// <summary>
+        /// Sets the cursor position from touch if it's allowed by the current state.
+        /// </summary>
+        /// <param name="position">The current position of a touch.</param>
+        internal void TrySetCursorPositionFromTouch(Vector2 position)
+        {
+            new MousePositionAbsoluteInput { Position = position }.Apply(CurrentState, this);
         }
 
         private partial class OsuKeyBindingContainer : RulesetKeyBindingContainer

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Framework.Input.StateChanges;
 using osu.Game.Configuration;
 using osuTK;
 
@@ -135,7 +134,7 @@ namespace osu.Game.Rulesets.Osu.UI
             if (!osuInputManager.AllowUserCursorMovement)
                 return;
 
-            new MousePositionAbsoluteInput { Position = touchEvent.ScreenSpaceTouch.Position }.Apply(osuInputManager.CurrentState, osuInputManager);
+            osuInputManager.TrySetCursorPositionFromTouch(touchEvent.ScreenSpaceTouch.Position);
         }
 
         protected override void OnTouchUp(TouchUpEvent e)


### PR DESCRIPTION
- Alternative to https://github.com/ppy/osu/pull/31704

Prioritises mouse (or pen hover) input over touch input for cursor position in osu! gameplay.

This will allow hovering pen + click with touch gameplay, with and without https://github.com/ppy/osu-framework/pull/6523. Clicking with the pen still doesn't play nice with touch.

I had a problem with trying to implement `isRealMouseMoveEvent()` as it was difficult to filter out fake events generated for `IRequireHighFrequencyMousePosition`. I settled on checking whether the new event reports a position different that the state of the nested input manager (i.e. a change in position).
One would expect filtering fake events would be as easy as checking `e.Delta == 0` (as high frequency events shouldn't report any), but the o!f [caching](https://github.com/ppy/osu-framework/blob/0ee307ed781391e26d90199c6be6ad8b15a4fd9c/osu.Framework/Input/InputManager.cs#L457) of events is broken, resulting in incorrect deltas.

## Testing

Tested on windows with a touchscreen monitor and [vTablet](https://github.com/Teages/vTablet) (simulating windows ink). Works fine. But for this virtual tablet specifically, `mouse_move_debounce_time` needs to be increased as it has a low report rate.

Mixing tablet and touch input causes visual issues because the game is rapidly switching `Static.TouchInputActive`. A jarring example is `HoldForMenuButton` (could be fixed by adding easing).