### PR TITLE
Fix team flag layout on user profile

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -346,6 +346,13 @@ namespace osu.Game.Tests.Visual.Online
             Twitter = "test_user",
             Discord = "test_user",
             Website = "https://google.com",
+            Team = new APITeam
+            {
+                Id = 1,
+                Name = "Collective Wangs",
+                ShortName = "WANG",
+                FlagUrl = "https://assets.ppy.sh/teams/logo/1/wanglogo.jpg",
+            }
         };
     }
 }

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -42,9 +42,10 @@ namespace osu.Game.Overlays.Profile.Header
         private ExternalLinkButton openUserExternally = null!;
         private OsuSpriteText titleText = null!;
         private UpdateableFlag userFlag = null!;
-        private UpdateableTeamFlag teamFlag = null!;
         private OsuHoverContainer userCountryContainer = null!;
         private OsuSpriteText userCountryText = null!;
+        private UpdateableTeamFlag teamFlag = null!;
+        private OsuSpriteText teamText = null!;
         private GroupBadgeFlow groupBadgeFlow = null!;
         private ToggleCoverButton coverToggle = null!;
         private PreviousUsernamesDisplay previousUsernamesDisplay = null!;
@@ -161,27 +162,51 @@ namespace osu.Game.Overlays.Profile.Header
                                                 {
                                                     AutoSizeAxes = Axes.Both,
                                                     Direction = FillDirection.Horizontal,
+                                                    Spacing = new Vector2(10, 0),
                                                     Children = new Drawable[]
                                                     {
-                                                        userFlag = new UpdateableFlag
-                                                        {
-                                                            Size = new Vector2(28, 20),
-                                                        },
-                                                        teamFlag = new UpdateableTeamFlag
-                                                        {
-                                                            Size = new Vector2(40, 20),
-                                                        },
-                                                        userCountryContainer = new OsuHoverContainer
+                                                        new FillFlowContainer
                                                         {
                                                             AutoSizeAxes = Axes.Both,
-                                                            Anchor = Anchor.CentreLeft,
-                                                            Origin = Anchor.CentreLeft,
-                                                            Margin = new MarginPadding { Left = 5 },
-                                                            Child = userCountryText = new OsuSpriteText
+                                                            Direction = FillDirection.Horizontal,
+                                                            Spacing = new Vector2(4, 0),
+                                                            Children = new Drawable[]
                                                             {
-                                                                Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
-                                                            },
+                                                                userFlag = new UpdateableFlag
+                                                                {
+                                                                    Size = new Vector2(28, 20),
+                                                                },
+                                                                userCountryContainer = new OsuHoverContainer
+                                                                {
+                                                                    AutoSizeAxes = Axes.Both,
+                                                                    Anchor = Anchor.CentreLeft,
+                                                                    Origin = Anchor.CentreLeft,
+                                                                    Child = userCountryText = new OsuSpriteText
+                                                                    {
+                                                                        Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
+                                                                    },
+                                                                },
+                                                            }
                                                         },
+                                                        new FillFlowContainer
+                                                        {
+                                                            AutoSizeAxes = Axes.Both,
+                                                            Direction = FillDirection.Horizontal,
+                                                            Spacing = new Vector2(4, 0),
+                                                            Children = new Drawable[]
+                                                            {
+                                                                teamFlag = new UpdateableTeamFlag
+                                                                {
+                                                                    Size = new Vector2(40, 20),
+                                                                },
+                                                                teamText = new OsuSpriteText
+                                                                {
+                                                                    Anchor = Anchor.CentreLeft,
+                                                                    Origin = Anchor.CentreLeft,
+                                                                    Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
+                                                                },
+                                                            }
+                                                        }
                                                     }
                                                 },
                                             }
@@ -220,9 +245,10 @@ namespace osu.Game.Overlays.Profile.Header
             usernameText.Text = user?.Username ?? string.Empty;
             openUserExternally.Link = $@"{api.Endpoints.WebsiteUrl}/users/{user?.Id ?? 0}";
             userFlag.CountryCode = user?.CountryCode ?? default;
-            teamFlag.Team = user?.Team;
             userCountryText.Text = (user?.CountryCode ?? default).GetDescription();
             userCountryContainer.Action = () => rankingsOverlay?.ShowCountry(user?.CountryCode ?? default);
+            teamFlag.Team = user?.Team;
+            teamText.Text = user?.Team?.Name ?? string.Empty;
             supporterTag.SupportLevel = user?.SupportLevel ?? 0;
             titleText.Text = user?.Title ?? string.Empty;
             titleText.Colour = Color4Extensions.FromHex(user?.Colour ?? "fff");

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -156,10 +156,11 @@ namespace osu.Game.Overlays.Profile.Header
                                                 titleText = new OsuSpriteText
                                                 {
                                                     Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular),
-                                                    Margin = new MarginPadding { Bottom = 5 }
+                                                    Margin = new MarginPadding { Bottom = 3 },
                                                 },
                                                 new FillFlowContainer
                                                 {
+                                                    Margin = new MarginPadding { Top = 3 },
                                                     AutoSizeAxes = Axes.Both,
                                                     Direction = FillDirection.Horizontal,
                                                     Spacing = new Vector2(10, 0),


### PR DESCRIPTION
Recommend reading with no whitespace changes. Spacing matches gap on web.

| Before | After | Web |
| --- | --- | --- |
| <img width="141" alt="Screenshot 2025-02-16 at 1 48 19 PM" src="https://github.com/user-attachments/assets/2132f526-fd4e-4e32-8bb0-97e23c3f9b39" /> | <img width="237" alt="Screenshot 2025-02-16 at 1 47 11 PM" src="https://github.com/user-attachments/assets/0cf4aa7d-a878-4bcb-bbb3-913df55bf4c6" /> | <img width="322" alt="Screenshot 2025-02-16 at 1 48 27 PM" src="https://github.com/user-attachments/assets/5f82aa25-5093-4d3b-b9dd-e731d32d73cf" /> |