### PR TITLE
Fix some more visual issues with osu! distance snap grid

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 const float thickness = 4;
                 float diameter = (offset + (i + 1) * DistanceBetweenTicks + thickness / 2) * 2;
 
-                AddInternal(new Ring(StartTime, GetColourForIndexFromPlacement(i))
+                AddInternal(new Ring(StartTime, GetColourForIndexFromPlacement(i), SliderVelocitySource)
                 {
                     Position = StartPosition,
                     Origin = Anchor.Centre,
@@ -128,12 +128,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
             private EditorClock? editorClock { get; set; }
 
             private readonly double startTime;
+            private readonly IHasSliderVelocity? sliderVelocitySource;
 
             private readonly Color4 baseColour;
 
-            public Ring(double startTime, Color4 baseColour)
+            public Ring(double startTime, Color4 baseColour, IHasSliderVelocity? sliderVelocitySource)
             {
                 this.startTime = startTime;
+                this.sliderVelocitySource = sliderVelocitySource;
 
                 Colour = this.baseColour = baseColour;
 
@@ -150,7 +152,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 float distanceSpacingMultiplier = (float)snapProvider.DistanceSpacingMultiplier.Value;
                 double timeFromReferencePoint = editorClock.CurrentTime - startTime;
 
-                float distanceForCurrentTime = snapProvider.DurationToDistance(timeFromReferencePoint, startTime)
+                float distanceForCurrentTime = snapProvider.DurationToDistance(timeFromReferencePoint, startTime, sliderVelocitySource)
                                                * distanceSpacingMultiplier;
 
                 float timeBasedAlpha = 1 - Math.Clamp(Math.Abs(distanceForCurrentTime - Size.X / 2) / 30, 0, 1);

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -11,6 +11,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects.Types;
@@ -148,7 +149,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             var timingPoint = Beatmap.ControlPointInfo.TimingPointAt(StartTime);
             double beatLength = timingPoint.BeatLength / beatDivisor.Value;
-            int beatIndex = (int)Math.Floor((StartTime - timingPoint.Time) / beatLength);
+            double fractionalBeatIndex = (StartTime - timingPoint.Time) / beatLength;
+            int beatIndex = (int)Math.Round(fractionalBeatIndex);
+            // `fractionalBeatIndex` could differ from `beatIndex` for two reasons:
+            // - rounding errors (which can be exacerbated by timing point start times being truncated by/for stable),
+            // - `StartTime` is not snapped to the beat.
+            // in case 1, we want rounding to occur to prevent an off-by-one,
+            // as `StartTime` *is* quantised to the beat. but it just doesn't look like it because floats do float things.
+            // in case 2, we want *flooring* to occur, to prevent a possible off-by-one
+            // because of the rounding snapping forward by a chunk of time significantly too high to be considered a rounding error.
+            // the tolerance margin chosen here is arbitrary and can be adjusted if more cases of this are found.
+            if (Precision.DefinitelyBigger(beatIndex, fractionalBeatIndex, 0.005))
+                beatIndex = (int)Math.Floor(fractionalBeatIndex);
 
             var colour = BindableBeatDivisor.GetColourFor(BindableBeatDivisor.GetDivisorForBeatIndex(beatIndex + placementIndex + 1, beatDivisor.Value), Colours);
 


### PR DESCRIPTION
## [Fix distance snap grid colours being off-by-one in certain cases](https://github.com/ppy/osu/commit/8423d9de9b6447a42110ca69136c236175431439)

Closes https://github.com/ppy/osu/issues/31909.

[Previously.](https://github.com/ppy/osu/pull/30062)

Happening because of rounding errors - in this case the beat index pre-flooring was something like a 0.003 off of a full beat, which would get floored down rather than rounded up which created the discrepancy. But also we don't want to round *too* far, which is why this frankenstein solution has to exist I think. This is probably all exacerbated by stable not handling decimal control point start times.

Would add tests if not for the fact that this is like extremely annoying to test. Will do on request.

## [Fix distance snap grid line opacity being incorrect on non-1.0x velocities](https://github.com/ppy/osu/commit/2b4b21beb6c50b12e0daf4031b1dcb4fab75b3d3)

Noticed in passing.