### PR TITLE
Fix nudge operations incurring FP error from coordinate space conversions

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -27,7 +27,6 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -110,71 +109,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             var blueprint = (HitObjectSelectionBlueprint)GetBlueprintFor(hitObject);
             blueprint.DrawableObject = drawableObject;
-        }
-
-        private bool nudgeMovementActive;
-
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            // Until the keys below are global actions, this will prevent conflicts with "seek between sample points"
-            // which has a default of ctrl+shift+arrows.
-            if (e.ShiftPressed)
-                return false;
-
-            if (e.ControlPressed)
-            {
-                switch (e.Key)
-                {
-                    case Key.Left:
-                        return nudgeSelection(new Vector2(-1, 0));
-
-                    case Key.Right:
-                        return nudgeSelection(new Vector2(1, 0));
-
-                    case Key.Up:
-                        return nudgeSelection(new Vector2(0, -1));
-
-                    case Key.Down:
-                        return nudgeSelection(new Vector2(0, 1));
-                }
-            }
-
-            return false;
-        }
-
-        protected override void OnKeyUp(KeyUpEvent e)
-        {
-            base.OnKeyUp(e);
-
-            if (nudgeMovementActive && !e.ControlPressed)
-            {
-                Beatmap.EndChange();
-                nudgeMovementActive = false;
-            }
-        }
-
-        /// <summary>
-        /// Move the current selection spatially by the specified delta, in gamefield coordinates (ie. the same coordinates as the blueprints).
-        /// </summary>
-        /// <param name="delta"></param>
-        private bool nudgeSelection(Vector2 delta)
-        {
-            if (!nudgeMovementActive)
-            {
-                nudgeMovementActive = true;
-                Beatmap.BeginChange();
-            }
-
-            var firstBlueprint = SelectionHandler.SelectedBlueprints.FirstOrDefault();
-
-            if (firstBlueprint == null)
-                return false;
-
-            // convert to game space coordinates
-            delta = firstBlueprint.ToScreenSpace(delta) - firstBlueprint.ToScreenSpace(Vector2.Zero);
-
-            SelectionHandler.HandleMovement(new MoveSelectionEvent<HitObject>(firstBlueprint, delta));
-            return true;
         }
 
         private void updatePlacementNewCombo()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31915.

Reproduction of aforementioned issue requires 1280x720 resolution, which should also be a good way to confirm that this does anything.

![1739802025](https://github.com/user-attachments/assets/7ded85f5-4526-45df-92fa-97074f2c3590)

To me this is also equal-parts-bugfix, equal-parts-code-quality PR, because tell me: what on earth was this code ever doing at `ComposeBlueprintContainer` level? Nudging by one playfield-space-unit doesn't even *make sense* in something like taiko or mania.