### PR TITLE
Stop "hold for HUD" key binding from blocking other key presses

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -414,7 +414,7 @@ namespace osu.Game.Screens.Play
 
                 case GlobalAction.HoldForHUD:
                     holdingForHUD.Value = true;
-                    return true;
+                    return false;
 
                 case GlobalAction.ToggleInGameInterface:
                     switch (configVisibilityMode.Value)


### PR DESCRIPTION
I don't think there's a good reason for this to be blocking.

Closes https://github.com/ppy/osu/issues/31274.
Closes https://github.com/ppy/osu/issues/30039.