### PR TITLE
Fix kiai fountains sometimes not displaying when they should

### DIFF
--- a/osu.Game/Screens/Menu/KiaiMenuFountains.cs
+++ b/osu.Game/Screens/Menu/KiaiMenuFountains.cs
@@ -3,10 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Screens.Menu
@@ -40,27 +38,22 @@ namespace osu.Game.Screens.Menu
 
         private bool isTriggered;
 
-        private double? lastTrigger;
-
-        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+        protected override void Update()
         {
-            base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
+            base.Update();
 
-            if (effectPoint.KiaiMode && !isTriggered)
+            if (EffectPoint.KiaiMode && !isTriggered)
             {
-                bool isNearEffectPoint = Math.Abs(BeatSyncSource.Clock.CurrentTime - effectPoint.Time) < 500;
+                bool isNearEffectPoint = Math.Abs(BeatSyncSource.Clock.CurrentTime - EffectPoint.Time) < 500;
                 if (isNearEffectPoint)
                     Shoot();
             }
 
-            isTriggered = effectPoint.KiaiMode;
+            isTriggered = EffectPoint.KiaiMode;
         }
 
         public void Shoot()
         {
-            if (lastTrigger != null && Clock.CurrentTime - lastTrigger < 500)
-                return;
-
             int direction = RNG.Next(-1, 2);
 
             switch (direction)
@@ -80,8 +73,6 @@ namespace osu.Game.Screens.Menu
                     rightFountain.Shoot(1);
                     break;
             }
-
-            lastTrigger = Clock.CurrentTime;
         }
     }
 }

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -1,15 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Menu;
 
@@ -48,33 +46,28 @@ namespace osu.Game.Screens.Play
 
         private bool isTriggered;
 
-        private double? lastTrigger;
-
-        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+        protected override void Update()
         {
-            base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
+            base.Update();
 
             if (!kiaiStarFountains.Value)
                 return;
 
-            if (effectPoint.KiaiMode && !isTriggered)
+            if (EffectPoint.KiaiMode && !isTriggered)
             {
-                bool isNearEffectPoint = Math.Abs(BeatSyncSource.Clock.CurrentTime - effectPoint.Time) < 500;
+                Logger.Log("shooting");
+                bool isNearEffectPoint = Math.Abs(BeatSyncSource.Clock.CurrentTime - EffectPoint.Time) < 500;
                 if (isNearEffectPoint)
                     Shoot();
             }
 
-            isTriggered = effectPoint.KiaiMode;
+            isTriggered = EffectPoint.KiaiMode;
         }
 
         public void Shoot()
         {
-            if (lastTrigger != null && Clock.CurrentTime - lastTrigger < 500)
-                return;
-
             leftFountain.Shoot(1);
             rightFountain.Shoot(-1);
-            lastTrigger = Clock.CurrentTime;
         }
 
         public partial class GameplayStarFountain : StarFountain


### PR DESCRIPTION
The previous logic was very wrong, as the check would only occur on each beat. But that's not how kiai sections work – they can be placed at any timestamp, even if that doesn't align with a beat.

In addition, the rate limiting has been removed because it didn't exist on stable and causes some fountains to be missed. Overlap scenarios are already handled internally by the `StarFountain` class.

Tested using beatmap in linked issue.

Closes https://github.com/ppy/osu/issues/31855.