### PR TITLE
Fix several issues with API login flow which manifest on second factor authentication

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -244,7 +244,7 @@ namespace osu.Game.Online.API
             // save the username at this point, if the user requested for it to be.
             config.SetValue(OsuSetting.Username, config.Get<bool>(OsuSetting.SaveUsername) ? ProvidedUsername : string.Empty);
 
-            if (!authentication.HasValidAccessToken)
+            if (!authentication.HasValidAccessToken && HasLogin)
             {
                 state.Value = APIState.Connecting;
                 LastLoginError = null;

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -253,6 +253,10 @@ namespace osu.Game.Online.API
                 {
                     authentication.AuthenticateWithLogin(ProvidedUsername, password);
                 }
+                catch (WebRequestFlushedException)
+                {
+                    return;
+                }
                 catch (Exception e)
                 {
                     //todo: this fails even on network-related issues. we should probably handle those differently.
@@ -313,7 +317,7 @@ namespace osu.Game.Online.API
                             log.Add(@"Login no longer valid");
                             Logout();
                         }
-                        else
+                        else if (ex is not WebRequestFlushedException)
                         {
                             state.Value = APIState.Failing;
                         }
@@ -494,6 +498,11 @@ namespace osu.Game.Online.API
                 handleWebException(we);
                 return false;
             }
+            catch (WebRequestFlushedException wrf)
+            {
+                log.Add(wrf.Message);
+                return false;
+            }
             catch (Exception ex)
             {
                 Logger.Error(ex, "Error occurred while handling an API request.");
@@ -575,7 +584,7 @@ namespace osu.Game.Online.API
                 if (failOldRequests)
                 {
                     foreach (var req in oldQueueRequests)
-                        req.Fail(new WebException($@"Request failed from flush operation (state {state.Value})"));
+                        req.Fail(new WebRequestFlushedException(state.Value));
                 }
             }
         }
@@ -606,7 +615,11 @@ namespace osu.Game.Online.API
                 return;
 
             var friendsReq = new GetFriendsRequest();
-            friendsReq.Failure += _ => state.Value = APIState.Failing;
+            friendsReq.Failure += ex =>
+            {
+                if (ex is not WebRequestFlushedException)
+                    state.Value = APIState.Failing;
+            };
             friendsReq.Success += res =>
             {
                 var existingFriends = friends.Select(f => f.TargetID).ToHashSet();
@@ -630,6 +643,14 @@ namespace osu.Game.Online.API
 
             flushQueue();
             cancellationToken.Cancel();
+        }
+
+        private class WebRequestFlushedException : Exception
+        {
+            public WebRequestFlushedException(APIState state)
+                : base($@"Request failed from flush operation (state {state})")
+            {
+            }
         }
     }
 

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -238,7 +238,8 @@ namespace osu.Game.Online.API
         /// <returns>Whether the connection attempt was successful.</returns>
         private void attemptConnect()
         {
-            Scheduler.Add(setPlaceholderLocalUser, false);
+            if (localUser.IsDefault)
+                Scheduler.Add(setPlaceholderLocalUser, false);
 
             // save the username at this point, if the user requested for it to be.
             config.SetValue(OsuSetting.Username, config.Get<bool>(OsuSetting.SaveUsername) ? ProvidedUsername : string.Empty);


### PR DESCRIPTION
This is an assorted collection of fixes around `APIAccess` that arise from me noticing that the behaviour of the second factor auth form can only be described as "utterly broken" in several respects.

I didn't say anything at the time to not make a fuss but this is one of the reasons why I wasn't very happy with disabling 2FA on staging, because this 2FA a flow that is inherently not very testable, and allows such silent breakage to appear under our noses while we're not aware of it unless users tell us of it.

## [Add local guard before scheduled placeholder user set](https://github.com/ppy/osu/commit/8299dfc6f2341f82ac1baeeb40967a5391296de8)

When API is in `RequiresSecondFactorAuth` state, `attemptConnect()` is called over and over in a loop, with no sleeping, which means that the scheduler accumulates hundreds of thousands of these delegates. Sure you could add a sleep in there maybe, but it seems pretty wasteful to have the `localUser.IsDefault` guard *inside* the schedule anyway, so this is what I opted for.

## [Do not attempt to automatically reconnect if there is no login to use](https://github.com/ppy/osu/commit/d6552f00bed2359296df91050062a3786c59493e)

Because it'll fail anyway - there is either no username or no password. The reason why this is important is that the block was also setting API state to `Connecting`.

This is important because `Logout()` clears credentials, and so not doing this can dump you at the login screen with "Missing password" shown which makes no sense if it happens just after logging out.

## [Do not allow flushed requests to transition API into `Failing` state](https://github.com/ppy/osu/commit/930e02300f200388e5398fee1e34f14108f09d78)

This fixes the "logout" link on the 2FA verification form not working properly (on master the login overlay ends up in the "failing" state).

Flushes are assumed to have already come from a definitive state change (read: disconnection). Allowing the exceptions that come from failing the flushed requests to trigger the `Failing` code paths makes completely incorrect behaviour possible.