### PR TITLE
Fix beatmap export failure not aborting submission process

### DIFF
--- a/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
+++ b/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
@@ -249,6 +249,7 @@ namespace osu.Game.Screens.Edit.Submission
                 exportProgressNotification = null;
                 Logger.Log($"Beatmap set submission failed on export: {ex}");
                 allowExit();
+                return;
             }
 
             exportStep.SetCompleted();


### PR DESCRIPTION
As spotted in testing with production by @peppy. Would cause submission to proceed even if the export did, with an empty archive.