### PR TITLE
Send "notify on discussion replies" setting value in beatmap creation request

### DIFF
--- a/osu.Game/Online/API/Requests/PutBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/PutBeatmapSetRequest.cs
@@ -11,6 +11,7 @@ using osu.Framework.IO.Network;
 using osu.Framework.Localisation;
 using osu.Game.Localisation;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Screens.Edit.Submission;
 
 namespace osu.Game.Online.API.Requests
 {
@@ -42,22 +43,27 @@ namespace osu.Game.Online.API.Requests
         [JsonProperty("target")]
         public BeatmapSubmissionTarget SubmissionTarget { get; init; }
 
+        [JsonProperty("notify_on_discussion_replies")]
+        public bool NotifyOnDiscussionReplies { get; init; }
+
         private PutBeatmapSetRequest()
         {
         }
 
-        public static PutBeatmapSetRequest CreateNew(uint beatmapCount, BeatmapSubmissionTarget target) => new PutBeatmapSetRequest
+        public static PutBeatmapSetRequest CreateNew(uint beatmapCount, BeatmapSubmissionSettings settings) => new PutBeatmapSetRequest
         {
             BeatmapsToCreate = beatmapCount,
-            SubmissionTarget = target,
+            SubmissionTarget = settings.Target.Value,
+            NotifyOnDiscussionReplies = settings.NotifyOnDiscussionReplies.Value,
         };
 
-        public static PutBeatmapSetRequest UpdateExisting(uint beatmapSetId, IEnumerable<uint> beatmapsToKeep, uint beatmapsToCreate, BeatmapSubmissionTarget target) => new PutBeatmapSetRequest
+        public static PutBeatmapSetRequest UpdateExisting(uint beatmapSetId, IEnumerable<uint> beatmapsToKeep, uint beatmapsToCreate, BeatmapSubmissionSettings settings) => new PutBeatmapSetRequest
         {
             BeatmapSetID = beatmapSetId,
             BeatmapsToKeep = beatmapsToKeep.ToArray(),
             BeatmapsToCreate = beatmapsToCreate,
-            SubmissionTarget = target,
+            SubmissionTarget = settings.Target.Value,
+            NotifyOnDiscussionReplies = settings.NotifyOnDiscussionReplies.Value,
         };
 
         protected override WebRequest CreateWebRequest()

--- a/osu.Game/Online/ProductionEndpointConfiguration.cs
+++ b/osu.Game/Online/ProductionEndpointConfiguration.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Online
             SpectatorUrl = "https://spectator.ppy.sh/spectator";
             MultiplayerUrl = "https://spectator.ppy.sh/multiplayer";
             MetadataUrl = "https://spectator.ppy.sh/metadata";
+            BeatmapSubmissionServiceUrl = "https://bss.ppy.sh";
         }
     }
 }

--- a/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
+++ b/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
@@ -192,8 +192,8 @@ namespace osu.Game.Screens.Edit.Submission
                     (uint)Beatmap.Value.BeatmapSetInfo.OnlineID,
                     Beatmap.Value.BeatmapSetInfo.Beatmaps.Where(b => b.OnlineID > 0).Select(b => (uint)b.OnlineID).ToArray(),
                     (uint)Beatmap.Value.BeatmapSetInfo.Beatmaps.Count(b => b.OnlineID <= 0),
-                    settings.Target.Value)
-                : PutBeatmapSetRequest.CreateNew((uint)Beatmap.Value.BeatmapSetInfo.Beatmaps.Count, settings.Target.Value);
+                    settings)
+                : PutBeatmapSetRequest.CreateNew((uint)Beatmap.Value.BeatmapSetInfo.Beatmaps.Count, settings);
 
             createRequest.Success += async response =>
             {

--- a/osu.Game/Screens/Edit/Submission/BeatmapSubmissionSettings.cs
+++ b/osu.Game/Screens/Edit/Submission/BeatmapSubmissionSettings.cs
@@ -9,5 +9,7 @@ namespace osu.Game.Screens.Edit.Submission
     public class BeatmapSubmissionSettings
     {
         public Bindable<BeatmapSubmissionTarget> Target { get; } = new Bindable<BeatmapSubmissionTarget>();
+
+        public Bindable<bool> NotifyOnDiscussionReplies { get; } = new Bindable<bool>();
     }
 }

--- a/osu.Game/Screens/Edit/Submission/ScreenSubmissionSettings.cs
+++ b/osu.Game/Screens/Edit/Submission/ScreenSubmissionSettings.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Edit.Submission
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager configManager, OsuColour colours, BeatmapSubmissionSettings settings)
         {
-            configManager.BindWith(OsuSetting.EditorSubmissionNotifyOnDiscussionReplies, notifyOnDiscussionReplies);
+            configManager.BindWith(OsuSetting.EditorSubmissionNotifyOnDiscussionReplies, settings.NotifyOnDiscussionReplies);
             configManager.BindWith(OsuSetting.EditorSubmissionLoadInBrowserAfterSubmission, loadInBrowserAfterSubmission);
 
             Content.Add(new FillFlowContainer
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Edit.Submission
                     new FormCheckBox
                     {
                         Caption = BeatmapSubmissionStrings.NotifyOnDiscussionReplies,
-                        Current = notifyOnDiscussionReplies,
+                        Current = settings.NotifyOnDiscussionReplies,
                     },
                     new FormCheckBox
                     {


### PR DESCRIPTION
Noticed in testing this was not actually hooked up to anything :skull: 

Pull also includes the address of the production deployment of this. I've done a little bit of testing today and it doesn't appear to be obviously broken, and cohabit pretty amicably with stable.

(Before any bystanders reading get stupid ideas: first of all, I'm asking nicely, ***PLEASE DON'T*** - you can do that on staging if you so desire and disclose responsibly, and secondly, this service is currently allowlisted to specific users, so unless I screwed something up, you're not doing anything with that anyway... *yet*)