### PR TITLE
Fix multiplayer spectator not working with freestyle

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -372,7 +372,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             sendFrames(getPlayerIds(4), 300);
 
-            AddUntilStep("wait for correct track speed", () => Beatmap.Value.Track.Rate, () => Is.EqualTo(1.5));
+            AddUntilStep("wait for correct track speed",
+                () => this.ChildrenOfType<MultiSpectatorPlayer>().All(player => player.ClockAdjustmentsFromMods.AggregateTempo.Value == 1.5));
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -60,6 +61,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private readonly Container gameplayContent;
         private readonly LoadingLayer loadingLayer;
         private OsuScreenStack? stack;
+        private Track? loadedTrack;
 
         public PlayerArea(int userId, SpectatorPlayerClock clock)
         {
@@ -90,7 +92,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             Score = score;
 
             var workingBeatmap = beatmapManager.GetWorkingBeatmap(Score.ScoreInfo.BeatmapInfo);
-            workingBeatmap.LoadTrack();
+            if (!workingBeatmap.TrackLoaded)
+                loadedTrack = workingBeatmap.LoadTrack();
             gameplayContent.Child = new PlayerIsolationContainer(workingBeatmap, Score.ScoreInfo.Ruleset, Score.ScoreInfo.Mods)
             {
                 RelativeSizeAxes = Axes.Both,
@@ -128,6 +131,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         // Player interferes with global input, so disable input for now.
         public override bool PropagatePositionalInputSubTree => false;
         public override bool PropagateNonPositionalInputSubTree => false;
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            loadedTrack?.Dispose();
+        }
 
         /// <summary>
         /// Isolates each player instance from the game-wide ruleset/beatmap/mods (to allow for different players having different settings).

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         public Score? Score { get; private set; }
 
         [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+        private BeatmapManager beatmapManager { get; set; } = null!;
 
         private readonly AudioAdjustments clockAdjustmentsFromMods = new AudioAdjustments();
         private readonly BindableDouble volumeAdjustment = new BindableDouble();
@@ -89,7 +89,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             Score = score;
 
-            gameplayContent.Child = new PlayerIsolationContainer(beatmap.Value, Score.ScoreInfo.Ruleset, Score.ScoreInfo.Mods)
+            var workingBeatmap = beatmapManager.GetWorkingBeatmap(Score.ScoreInfo.BeatmapInfo);
+            workingBeatmap.LoadTrack();
+            gameplayContent.Child = new PlayerIsolationContainer(workingBeatmap, Score.ScoreInfo.Ruleset, Score.ScoreInfo.Mods)
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = stack = new OsuScreenStack

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -91,9 +91,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             Score = score;
 
+            // Required for freestyle, where each player may be playing a different beatmap.
             var workingBeatmap = beatmapManager.GetWorkingBeatmap(Score.ScoreInfo.BeatmapInfo);
+
+            // Required to avoid crashes, but we really don't want to be doing this if we can avoid it.
+            // If we get to fixing this, we will want to investigate every access to `Track` in gameplay.
             if (!workingBeatmap.TrackLoaded)
                 loadedTrack = workingBeatmap.LoadTrack();
+
             gameplayContent.Child = new PlayerIsolationContainer(workingBeatmap, Score.ScoreInfo.Ruleset, Score.ScoreInfo.Mods)
             {
                 RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
It's no longer possible to just assume that using the ambient `WorkingBeatmap` is gonna work.

Bit dodgy but seems to work and also I'd hope that `WorkingBeatmapCache` makes this not overly taxing. If there are concerns this can probably be an async load or something.