### PR TITLE
Fix osu!taiko and osu!catch being oversized on mobile platforms

### DIFF
--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -21,7 +21,7 @@ namespace osu.Android
         [Cached]
         private readonly OsuGameActivity gameActivity;
 
-        protected override Vector2 ScalingContainerTargetDrawSize => new Vector2(1024, 1024 * DrawHeight / DrawWidth);
+        public override Vector2 ScalingContainerTargetDrawSize => new Vector2(1024, 1024 * DrawHeight / DrawWidth);
 
         public OsuGameAndroid(OsuGameActivity activity)
             : base(null)

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfieldAdjustmentContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.UI;
@@ -15,6 +16,8 @@ namespace osu.Game.Rulesets.Catch.UI
         protected override Container<Drawable> Content => content;
         private readonly Container content;
 
+        private readonly Container scaleContainer;
+
         public CatchPlayfieldAdjustmentContainer()
         {
             const float base_game_width = 1024f;
@@ -26,28 +29,47 @@ namespace osu.Game.Rulesets.Catch.UI
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            InternalChild = new Container
+            InternalChild = scaleContainer = new Container
             {
-                // This container limits vertical visibility of the playfield to ensure fairness between wide and tall resolutions (i.e. tall resolutions should not see more fruits).
-                // Note that the container still extends across the screen horizontally, so that hit explosions at the sides of the playfield do not get cut off.
-                Name = "Visible area",
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.X,
-                Height = base_game_height + extra_bottom_space,
-                Y = extra_bottom_space / 2,
-                Masking = true,
+                RelativeSizeAxes = Axes.Both,
                 Child = new Container
                 {
-                    Name = "Playable area",
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    // playfields in stable are positioned vertically at three fourths the difference between the playfield height and the window height in stable.
-                    Y = base_game_height * ((1 - playfield_size_adjust) / 4 * 3),
-                    Size = new Vector2(base_game_width, base_game_height) * playfield_size_adjust,
-                    Child = content = new ScalingContainer { RelativeSizeAxes = Axes.Both }
-                },
+                    // This container limits vertical visibility of the playfield to ensure fairness between wide and tall resolutions (i.e. tall resolutions should not see more fruits).
+                    // Note that the container still extends across the screen horizontally, so that hit explosions at the sides of the playfield do not get cut off.
+                    Name = "Visible area",
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.X,
+                    Height = base_game_height + extra_bottom_space,
+                    Y = extra_bottom_space / 2,
+                    Masking = true,
+                    Child = new Container
+                    {
+                        Name = "Playable area",
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        // playfields in stable are positioned vertically at three fourths the difference between the playfield height and the window height in stable.
+                        Y = base_game_height * ((1 - playfield_size_adjust) / 4 * 3),
+                        Size = new Vector2(base_game_width, base_game_height) * playfield_size_adjust,
+                        Child = content = new ScalingContainer { RelativeSizeAxes = Axes.Both }
+                    },
+                }
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGame? osuGame)
+        {
+            if (osuGame != null)
+            {
+                // on mobile platforms where the base aspect ratio is wider, the catch playfield
+                // needs to be scaled down to remain playable.
+                const float base_aspect_ratio = 1024f / 768f;
+                float aspectRatio = osuGame.ScalingContainerTargetDrawSize.X / osuGame.ScalingContainerTargetDrawSize.Y;
+                scaleContainer.Scale = new Vector2(base_aspect_ratio / aspectRatio);
+            }
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -59,11 +59,10 @@ namespace osu.Game.Rulesets.Taiko.UI
                 {
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.BottomCentre,
-                    RelativeSizeAxes = Axes.X,
-                    Height = 350,
+                    RelativeSizeAxes = Axes.Both,
+                    Height = 0.45f,
                     Y = 20,
                     Masking = true,
-                    FillMode = FillMode.Fit,
                     Children = new Drawable[]
                     {
                         mainContent = new Container

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Taiko.Beatmaps;
@@ -18,6 +20,9 @@ namespace osu.Game.Rulesets.Taiko.UI
         private const float stable_gamefield_height = 480f;
 
         public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
+
+        [Resolved]
+        private OsuGame? osuGame { get; set; }
 
         public TaikoPlayfieldAdjustmentContainer()
         {
@@ -56,6 +61,18 @@ namespace osu.Game.Rulesets.Taiko.UI
             relativeHeight = Math.Min(relativeHeight, 1f / 3f);
 
             Scale = new Vector2(Math.Max((Parent!.ChildSize.Y / 768f) * (relativeHeight / base_relative_height), 1f));
+
+            // on mobile platforms where the base aspect ratio is wider, the taiko playfield
+            // needs to be scaled down to remain playable.
+            if (RuntimeInfo.IsMobile && osuGame != null)
+            {
+                const float base_aspect_ratio = 1024f / 768f;
+                float gameAspectRatio = osuGame.ScalingContainerTargetDrawSize.X / osuGame.ScalingContainerTargetDrawSize.Y;
+                // this magic scale is unexplainable, but required so the playfield doesn't become too zoomed out as the aspect ratio increases.
+                const float magic_scale = 1.25f;
+                Scale *= magic_scale * new Vector2(base_aspect_ratio / gameAspectRatio);
+            }
+
             Width = 1 / Scale.X;
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -818,7 +818,7 @@ namespace osu.Game
         /// Adjust the globally applied <see cref="DrawSizePreservingFillContainer.TargetDrawSize"/> in every <see cref="ScalingContainer"/>.
         /// Useful for changing how the game handles different aspect ratios.
         /// </summary>
-        protected internal virtual Vector2 ScalingContainerTargetDrawSize { get; } = new Vector2(1024, 768);
+        public virtual Vector2 ScalingContainerTargetDrawSize { get; } = new Vector2(1024, 768);
 
         protected override Container CreateScalingContainer() => new ScalingContainer(ScalingMode.Everything);
 

--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -23,7 +23,7 @@ namespace osu.iOS
 
         public override bool HideUnlicensedContent => true;
 
-        protected override Vector2 ScalingContainerTargetDrawSize => new Vector2(1024, 1024 * DrawHeight / DrawWidth);
+        public override Vector2 ScalingContainerTargetDrawSize => new Vector2(1024, 1024 * DrawHeight / DrawWidth);
 
         public OsuGameIOS(AppDelegate appDelegate)
         {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/31954
- Closes https://github.com/ppy/osu/issues/31960
- Fixes taiko playfield scaled too much

Attached are screenshots taken on iPhone and iPad after applying the changes in this PR. The changes applied to taiko and catch playfield containers are mostly temporary and will be replaced with appropriate handling for mobile at a later point.

iPad:

![IMG_0474](https://github.com/user-attachments/assets/695f9976-b944-4246-a07f-7e1c2dea2557)
![IMG_0473](https://github.com/user-attachments/assets/55b8848a-ba69-4dc9-9590-ac9aea3e2c5c)
![IMG_0472](https://github.com/user-attachments/assets/a72be756-eb3a-4eaf-bf2b-7837e7872c90)
![IMG_0471](https://github.com/user-attachments/assets/d20f4fa7-39fc-4fc0-93fb-c0a58be4d9dc)

iPhone:

![IMG_2003](https://github.com/user-attachments/assets/b99b010f-d829-4b98-9d24-1b90fed1f5b0)
![IMG_2007](https://github.com/user-attachments/assets/6f893f72-41bb-424e-b30e-623aebdea22a)
![IMG_2006](https://github.com/user-attachments/assets/c650e246-1194-48b9-b3ef-03088bd7706c)
![IMG_2004](https://github.com/user-attachments/assets/532c03a4-2fd2-4a87-ae92-a2dbf2354b9b)
