### PR TITLE
Fix wrong beatmap attributes in multiplayer spectate

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -154,12 +154,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private partial class PlayerIsolationContainer : Container
         {
             [Cached]
+            [Cached(typeof(IBindable<RulesetInfo>))]
             private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
 
             [Cached]
+            [Cached(typeof(IBindable<WorkingBeatmap>))]
             private readonly Bindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
 
             [Cached]
+            [Cached(typeof(IBindable<IReadOnlyList<Mod>>))]
             private readonly Bindable<IReadOnlyList<Mod>> mods = new Bindable<IReadOnlyList<Mod>>();
 
             public PlayerIsolationContainer(WorkingBeatmap beatmap, RulesetInfo ruleset, IReadOnlyList<Mod> mods)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/31957

Resolved as `IBindable`s, which are cached by `OsuGameBase` here:

https://github.com/ppy/osu/blob/1350256599447fa4b6c7a5ec53e5083bc00bdb4c/osu.Game/OsuGameBase.cs#L175-L192

Also noticed in the process that `OsuScreen` doesn't cache as `IBindable`s, but I'm going to look away from that for the time being of concern to not break something:

https://github.com/ppy/osu/blob/1350256599447fa4b6c7a5ec53e5083bc00bdb4c/osu.Game/Screens/OsuScreenDependencies.cs#L26-L51