### PR TITLE
Fix host change sounds playing when exiting multiplayer rooms

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -52,6 +52,11 @@ namespace osu.Game.Online.Multiplayer
         public event Action<MultiplayerRoomUser>? UserKicked;
 
         /// <summary>
+        /// Invoked when the room's host is changed.
+        /// </summary>
+        public event Action<MultiplayerRoomUser?>? HostChanged;
+
+        /// <summary>
         /// Invoked when a new item is added to the playlist.
         /// </summary>
         public event Action<MultiplayerPlaylistItem>? ItemAdded;
@@ -531,6 +536,7 @@ namespace osu.Game.Online.Multiplayer
                 Room.Host = user;
                 APIRoom.Host = user?.User;
 
+                HostChanged?.Invoke(user);
                 RoomUpdated?.Invoke();
             }, false);
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/30665

Catching up on a bit of backlog. This was supposed to be done shortly after the refactorings late last year removing bindables from multiplayer.

Kinda weird (imo) that this sound plays on _any_ host change, rather than just the local user becoming host, but I'm not looking to change that here unless specifically requested.