### PR TITLE
Adjust rounding tolerance in distance snap grid ring colour logic

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // in case 2, we want *flooring* to occur, to prevent a possible off-by-one
             // because of the rounding snapping forward by a chunk of time significantly too high to be considered a rounding error.
             // the tolerance margin chosen here is arbitrary and can be adjusted if more cases of this are found.
-            if (Precision.DefinitelyBigger(beatIndex, fractionalBeatIndex, 0.005))
+            if (Precision.DefinitelyBigger(beatIndex, fractionalBeatIndex, 0.01))
                 beatIndex = (int)Math.Floor(fractionalBeatIndex);
 
             var colour = BindableBeatDivisor.GetColourFor(BindableBeatDivisor.GetDivisorForBeatIndex(beatIndex + placementIndex + 1, beatDivisor.Value), Colours);


### PR DESCRIPTION
Fixes case mentioned in https://github.com/ppy/osu/issues/31909#issuecomment-2672216764.

You can't make this stuff up:

![1740135628](https://github.com/user-attachments/assets/a0af2381-af81-4a34-9d70-7e4709626c1a)

Reluctant to bump this up any further, 1% of a beat already feels significant enough.