### PR TITLE
Add Alt + mousewheel volume adjustment on result screens

### DIFF
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -26,6 +26,7 @@ using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.Placeholders;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Volume;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking.Expanded.Accuracy;
@@ -122,6 +123,7 @@ namespace osu.Game.Screens.Ranking
                                     RelativeSizeAxes = Axes.Both,
                                     Children = new Drawable[]
                                     {
+                                        new GlobalScrollAdjustsVolume(),
                                         StatisticsPanel = createStatisticsPanel().With(panel =>
                                         {
                                             panel.RelativeSizeAxes = Axes.Both;
@@ -503,11 +505,23 @@ namespace osu.Game.Screens.Ranking
         {
         }
 
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            // Match stable behaviour of only alt-scroll adjusting volume.
+            // This is the same behaviour as the song selection screen.
+            if (!e.CurrentState.Keyboard.AltPressed)
+                return true;
+
+            return base.OnScroll(e);
+        }
+
         protected partial class VerticalScrollContainer : OsuScrollContainer
         {
             protected override Container<Drawable> Content => content;
 
             private readonly Container content;
+
+            protected override bool OnScroll(ScrollEvent e) => !e.ControlPressed && !e.AltPressed && !e.ShiftPressed && !e.SuperPressed;
 
             public VerticalScrollContainer()
             {


### PR DESCRIPTION
A small patch to fix #31860 and match the behaviors with stable.

https://github.com/user-attachments/assets/078c1577-1b0a-4fed-9105-df1c213706ed

Most of the code is copy-pasted from `SongSelect.cs`:

https://github.com/ppy/osu/blob/e9b815409005cf5656c5e8acd1f2b5a25d1f5c12/osu.Game/Screens/Select/SongSelect.cs#L1142-L1145

The inserted `GlobalScrollAdjustVolume` resides in a `VerticalScrollContainer`, and I do not know whether it is a good practice or not.