### PR TITLE
Add support for team chat channels

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
@@ -115,11 +115,7 @@ namespace osu.Game.Tests.Visual.Online
                     channelList.AddChannel(createRandomPrivateChannel());
             });
 
-            AddStep("Add Team Channels", () =>
-            {
-                for (int i = 0; i < 10; i++)
-                    channelList.AddChannel(createRandomTeamChannel());
-            });
+            AddStep("Add Team Channel", () => channelList.AddChannel(createRandomTeamChannel()));
 
             AddStep("Add Announce Channels", () =>
             {

--- a/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
@@ -115,6 +115,12 @@ namespace osu.Game.Tests.Visual.Online
                     channelList.AddChannel(createRandomPrivateChannel());
             });
 
+            AddStep("Add Team Channels", () =>
+            {
+                for (int i = 0; i < 10; i++)
+                    channelList.AddChannel(createRandomTeamChannel());
+            });
+
             AddStep("Add Announce Channels", () =>
             {
                 for (int i = 0; i < 2; i++)
@@ -186,6 +192,17 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Name = $"Announce {id}",
                 Type = ChannelType.Announce,
+                Id = id,
+            };
+        }
+
+        private Channel createRandomTeamChannel()
+        {
+            int id = TestResources.GetNextTestID();
+            return new Channel
+            {
+                Name = $"Team {id}",
+                Type = ChannelType.Team,
                 Id = id,
             };
         }

--- a/osu.Game/Online/Chat/ChannelType.cs
+++ b/osu.Game/Online/Chat/ChannelType.cs
@@ -14,5 +14,6 @@ namespace osu.Game.Online.Chat
         Group,
         System,
         Announce,
+        Team,
     }
 }

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
@@ -80,11 +81,12 @@ namespace osu.Game.Overlays.Chat.ChannelList
                                     RelativeSizeAxes = Axes.X,
                                 }
                             },
-                            AnnounceChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitleANNOUNCE.ToUpper(), false),
-                            PublicChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitlePUBLIC.ToUpper(), false),
+                            // cross-reference for icons: https://github.com/ppy/osu-web/blob/3c9e99eaf4bd9e73d2712f60d67f5bc95f9dfe2b/resources/js/chat/conversation-list.tsx#L13-L19
+                            AnnounceChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitleANNOUNCE.ToUpper(), FontAwesome.Solid.Bullhorn, false),
+                            PublicChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitlePUBLIC.ToUpper(), FontAwesome.Solid.Comments, false),
                             selector = new ChannelListItem(ChannelListingChannel),
-                            TeamChannelGroup = new ChannelGroup("TEAM", false), // TODO: replace with osu-web localisable string once available
-                            PrivateChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitlePM.ToUpper(), true),
+                            TeamChannelGroup = new ChannelGroup("TEAM", FontAwesome.Solid.Users, false), // TODO: replace with osu-web localisable string once available
+                            PrivateChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitlePM.ToUpper(), FontAwesome.Solid.Envelope, true),
                         },
                     },
                 },
@@ -179,7 +181,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
             private readonly bool sortByRecent;
             public readonly ChannelListItemFlow ItemFlow;
 
-            public ChannelGroup(LocalisableString label, bool sortByRecent)
+            public ChannelGroup(LocalisableString label, IconUsage icon, bool sortByRecent)
             {
                 this.sortByRecent = sortByRecent;
                 Direction = FillDirection.Vertical;
@@ -189,11 +191,26 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
                 Children = new Drawable[]
                 {
-                    new OsuSpriteText
+                    new FillFlowContainer
                     {
-                        Text = label,
-                        Margin = new MarginPadding { Left = 18, Bottom = 5 },
-                        Font = OsuFont.Torus.With(size: 12, weight: FontWeight.SemiBold),
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(5),
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = label,
+                                Margin = new MarginPadding { Left = 18, Bottom = 5 },
+                                Font = OsuFont.Torus.With(size: 12, weight: FontWeight.SemiBold),
+                            },
+                            new SpriteIcon
+                            {
+                                Icon = icon,
+                                Size = new Vector2(12),
+                            },
+                        }
                     },
                     ItemFlow = new ChannelListItemFlow(sortByRecent)
                     {

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
             };
 
             selector.OnRequestSelect += chan => OnRequestSelect?.Invoke(chan);
+            updateVisibility();
         }
 
         public void AddChannel(Channel channel)
@@ -170,10 +171,8 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
         private void updateVisibility()
         {
-            if (AnnounceChannelGroup.ItemFlow.Children.Count == 0)
-                AnnounceChannelGroup.Hide();
-            else
-                AnnounceChannelGroup.Show();
+            AnnounceChannelGroup.Alpha = AnnounceChannelGroup.ItemFlow.Any() ? 1 : 0;
+            TeamChannelGroup.Alpha = TeamChannelGroup.ItemFlow.Any() ? 1 : 0;
         }
 
         public partial class ChannelGroup : FillFlowContainer

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
         public ChannelGroup AnnounceChannelGroup { get; private set; } = null!;
         public ChannelGroup PublicChannelGroup { get; private set; } = null!;
+        public ChannelGroup TeamChannelGroup { get; private set; } = null!;
         public ChannelGroup PrivateChannelGroup { get; private set; } = null!;
 
         private OsuScrollContainer scroll = null!;
@@ -82,6 +83,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
                             AnnounceChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitleANNOUNCE.ToUpper(), false),
                             PublicChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitlePUBLIC.ToUpper(), false),
                             selector = new ChannelListItem(ChannelListingChannel),
+                            TeamChannelGroup = new ChannelGroup("TEAM", false), // TODO: replace with osu-web localisable string once available
                             PrivateChannelGroup = new ChannelGroup(ChatStrings.ChannelsListTitlePM.ToUpper(), true),
                         },
                     },
@@ -155,6 +157,9 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
                 case ChannelType.Announce:
                     return AnnounceChannelGroup;
+
+                case ChannelType.Team:
+                    return TeamChannelGroup;
 
                 default:
                     return PublicChannelGroup;

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -114,9 +114,13 @@ namespace osu.Game.Overlays.Chat.ChannelList
             if (channelMap.ContainsKey(channel))
                 return;
 
-            ChannelListItem item = new ChannelListItem(channel);
+            ChannelListItem item = new ChannelListItem(channel)
+            {
+                CanLeave = channel.Type != ChannelType.Team
+            };
             item.OnRequestSelect += chan => OnRequestSelect?.Invoke(chan);
-            item.OnRequestLeave += chan => OnRequestLeave?.Invoke(chan);
+            if (item.CanLeave)
+                item.OnRequestLeave += chan => OnRequestLeave?.Invoke(chan);
 
             ChannelGroup group = getGroupFromChannel(channel);
             channelMap.Add(channel, item);

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Overlays.Chat.ChannelList
     public partial class ChannelListItem : OsuClickableContainer, IFilterable
     {
         public event Action<Channel>? OnRequestSelect;
+
+        public bool CanLeave { get; init; } = true;
         public event Action<Channel>? OnRequestLeave;
 
         public readonly Channel Channel;
@@ -160,7 +162,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
         private ChannelListItemCloseButton? createCloseButton()
         {
-            if (isSelector)
+            if (isSelector || !CanLeave)
                 return null;
 
             return new ChannelListItemCloseButton


### PR DESCRIPTION
![osu_2025-02-24_09-45-38](https://github.com/user-attachments/assets/0b2d0385-c66b-477a-9cf0-32304c884218)

---

## [Add "Team" channel type to enum](https://github.com/ppy/osu/commit/d8cb3b68d3ea90268bb142a2ef6e1de782f2040a)

Noticed in staging that the lack of this bricks chat completely due to newtonsoft deserialisation errors:

	2025-02-24 08:32:58 [verbose]: Processing response from https://dev.ppy.sh/api/v2/chat/updates failed with Newtonsoft.Json.JsonSerializationException: Error converting value "TEAM" to type 'osu.Game.Online.Chat.ChannelType'. Path 'presence[39].type', line 1, position 13765.
	2025-02-24 08:32:58 [verbose]: ---> System.ArgumentException: Requested value 'TEAM' was not found.
	2025-02-24 08:32:58 [verbose]: at Newtonsoft.Json.Utilities.EnumUtils.ParseEnum(Type enumType, NamingStrategy namingStrategy, String value, Boolean disallowNumber)
	2025-02-24 08:32:58 [verbose]: at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)

> [!CAUTION]
> This means that team chat channels shouldn't be created in production before this PR makes it into a release! (cc @peppy)

## [Display team chat channel in separate group](https://github.com/ppy/osu/commit/be8ec759488e3bb5e5479341c8de400a80f3e9ec)

Matches the website.

## [Add icons to chat channel group headers](https://github.com/ppy/osu/commit/194f05d2588fa7f23287b85c3968219102e33a51)

Matches web in appearance.

Cross-reference: https://github.com/ppy/osu-web/blob/3c9e99eaf4bd9e73d2712f60d67f5bc95f9dfe2b/resources/js/chat/conversation-list.tsx#L13-L19