### PR TITLE
Fix hash comparison being case sensitive when choosing files for partial beatmap submission

### DIFF
--- a/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
+++ b/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
@@ -285,7 +285,7 @@ namespace osu.Game.Screens.Edit.Submission
                     continue;
                 }
 
-                if (localHash != onlineHash)
+                if (!localHash.Equals(onlineHash, StringComparison.OrdinalIgnoreCase))
                     filesToUpdate.Add(filename);
             }
 


### PR DESCRIPTION
Noticed when investigating https://github.com/ppy/osu/issues/32059, and also a likely cause for user reports like https://discord.com/channels/188630481301012481/1097318920991559880/1342962553101357066.

Honestly I have no solid defence, Your Honour. I guess this just must not have been tested properly full-stack, only relied on server-side testing.