### PR TITLE
Do not give swell ticks any visual representation

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -4,9 +4,7 @@
 #nullable disable
 
 using JetBrains.Annotations;
-using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
-using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
@@ -25,8 +23,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
         }
 
-        protected override void UpdateInitialTransforms() => this.FadeOut();
-
         public void TriggerResult(bool hit)
         {
             HitObject.StartTime = Time.Current;
@@ -43,7 +39,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick),
-            _ => new TickPiece());
+        protected override SkinnableDrawable CreateMainPiece() => null;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -154,9 +154,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (MainPiece != null)
                 Content.Remove(MainPiece, true);
 
-            Content.Add(MainPiece = CreateMainPiece());
+            MainPiece = CreateMainPiece();
+
+            if (MainPiece != null)
+                Content.Add(MainPiece);
         }
 
+        [CanBeNull]
         protected abstract SkinnableDrawable CreateMainPiece();
     }
 }


### PR DESCRIPTION
Why is this a thing at all? How has it survived this long? I don't know.

As far as I can tell this only manifests on selected beatmaps with "slow swells" that spend the entire beatmap moving in the background. On other beatmaps the tick is faded out, probably due to the initial transform application that normally "works" but fails hard on these slow swells.

Can be seen on https://osu.ppy.sh/beatmapsets/1432454#taiko/2948222:

![osu_2025-02-24_15-35-09](https://github.com/user-attachments/assets/8021f0b6-288c-47fa-a172-7b20df63d614)
