### PR TITLE
Adjust leaderboard score design slightly

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -395,7 +395,7 @@ namespace osu.Game.Online.Leaderboards
                             Origin = Anchor.CentreLeft,
                             Text = statistic.Value,
                             Spacing = new Vector2(-1, 0),
-                            Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold, fixedWidth: true)
+                            Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold, fixedWidth: true)
                         },
                     },
                 };
@@ -426,7 +426,7 @@ namespace osu.Game.Online.Leaderboards
             public DateLabel(DateTimeOffset date)
                 : base(date)
             {
-                Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold);
+                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold);
             }
 
             protected override string Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -271,6 +271,7 @@ namespace osu.Game.Online.Leaderboards
                                             Anchor = Anchor.CentreRight,
                                             Origin = Anchor.CentreRight,
                                             AutoSizeAxes = Axes.Both,
+                                            Spacing = new Vector2(-10, 0),
                                             Direction = FillDirection.Horizontal,
                                             ChildrenEnumerable = Score.Mods.AsOrdered().Select(mod => new ModIcon(mod) { Scale = new Vector2(0.34f) })
                                         },
@@ -425,7 +426,7 @@ namespace osu.Game.Online.Leaderboards
             public DateLabel(DateTimeOffset date)
                 : base(date)
             {
-                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold, italics: true);
+                Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold);
             }
 
             protected override string Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));


### PR DESCRIPTION
This design is about to get replaced, so I'm just making some minor adjustments since a lot of people complained about the font size in the last update.

Of note, I'm only changing the font size which is one pt size lower than we'd usually use. Also overlapping the mod icons to create a bit more space (since there's already cases where they don't fit).

0.8x:

![osu_2025-03-06_12-43-15](https://github.com/user-attachments/assets/5c7891da-f876-4f5c-a111-11214c90a2c8)

1.0x:

![osu_2025-03-06_12-43-06](https://github.com/user-attachments/assets/6adb51e8-943f-4162-aea4-c6c68058b962)

---

Closes https://github.com/ppy/osu/issues/32055 as far as I'm concerned. I can read everything fine at 0.8x UI scale.


