### PR TITLE
Fix multiplayer results screen displaying same beatmap for all users

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -17,7 +17,6 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Osu;
@@ -416,7 +415,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 RetryOverlay = InternalChildren.OfType<HotkeyRetryOverlay>().SingleOrDefault();
             }
 
-            protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
+            protected override Task<IEnumerable<ScoreInfo>> FetchScores()
             {
                 var scores = new List<ScoreInfo>();
 
@@ -428,9 +427,7 @@ namespace osu.Game.Tests.Visual.Ranking
                     scores.Add(score);
                 }
 
-                scoresCallback.Invoke(scores);
-
-                return null;
+                return Task.FromResult<IEnumerable<ScoreInfo>>(scores);
             }
         }
 
@@ -446,9 +443,9 @@ namespace osu.Game.Tests.Visual.Ranking
                 this.fetchWaitTask = fetchWaitTask ?? Task.CompletedTask;
             }
 
-            protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
+            protected override Task<IEnumerable<ScoreInfo>> FetchScores()
             {
-                Task.Run(async () =>
+                return Task.Run<IEnumerable<ScoreInfo>>(async () =>
                 {
                     await fetchWaitTask;
 
@@ -461,12 +458,10 @@ namespace osu.Game.Tests.Visual.Ranking
                         scores.Add(score);
                     }
 
-                    scoresCallback?.Invoke(scores);
-
                     Schedule(() => FetchCompleted = true);
-                });
 
-                return null;
+                    return scores;
+                });
             }
         }
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -415,19 +414,19 @@ namespace osu.Game.Tests.Visual.Ranking
                 RetryOverlay = InternalChildren.OfType<HotkeyRetryOverlay>().SingleOrDefault();
             }
 
-            protected override Task<IEnumerable<ScoreInfo>> FetchScores()
+            protected override Task<ScoreInfo[]> FetchScores()
             {
-                var scores = new List<ScoreInfo>();
+                var scores = new ScoreInfo[20];
 
-                for (int i = 0; i < 20; i++)
+                for (int i = 0; i < scores.Length; i++)
                 {
                     var score = TestResources.CreateTestScoreInfo();
                     score.TotalScore += 10 - i;
                     score.HasOnlineReplay = true;
-                    scores.Add(score);
+                    scores[i] = score;
                 }
 
-                return Task.FromResult<IEnumerable<ScoreInfo>>(scores);
+                return Task.FromResult(scores);
             }
         }
 
@@ -443,19 +442,19 @@ namespace osu.Game.Tests.Visual.Ranking
                 this.fetchWaitTask = fetchWaitTask ?? Task.CompletedTask;
             }
 
-            protected override Task<IEnumerable<ScoreInfo>> FetchScores()
+            protected override Task<ScoreInfo[]> FetchScores()
             {
-                return Task.Run<IEnumerable<ScoreInfo>>(async () =>
+                return Task.Run(async () =>
                 {
                     await fetchWaitTask;
 
-                    var scores = new List<ScoreInfo>();
+                    var scores = new ScoreInfo[20];
 
-                    for (int i = 0; i < 20; i++)
+                    for (int i = 0; i < scores.Length; i++)
                     {
                         var score = TestResources.CreateTestScoreInfo();
                         score.TotalScore += 10 - i;
-                        scores.Add(score);
+                        scores[i] = score;
                     }
 
                     Schedule(() => FetchCompleted = true);

--- a/osu.Game/Online/Rooms/MultiplayerScore.cs
+++ b/osu.Game/Online/Rooms/MultiplayerScore.cs
@@ -80,6 +80,9 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("ruleset_id")]
         public int RulesetId { get; set; }
 
+        [JsonProperty("beatmap_id")]
+        public int BeatmapId { get; set; }
+
         public ScoreInfo CreateScoreInfo(ScoreManager scoreManager, RulesetStore rulesets, [NotNull] BeatmapInfo beatmap)
         {
             var ruleset = rulesets.GetRuleset(RulesetId);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
@@ -22,8 +21,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             Scheduler.AddDelayed(() => StatisticsPanel.ToggleVisibility(), 1000);
         }
 
-        protected override Task<IEnumerable<ScoreInfo>> FetchScores() => Task.FromResult<IEnumerable<ScoreInfo>>([]);
+        protected override Task<ScoreInfo[]> FetchScores() => Task.FromResult<ScoreInfo[]>([]);
 
-        protected override Task<IEnumerable<ScoreInfo>> FetchNextPage(int direction) => Task.FromResult<IEnumerable<ScoreInfo>>([]);
+        protected override Task<ScoreInfo[]> FetchNextPage(int direction) => Task.FromResult<ScoreInfo[]>([]);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
@@ -1,9 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
-using osu.Game.Online.API;
+using System.Threading.Tasks;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 
@@ -23,8 +22,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             Scheduler.AddDelayed(() => StatisticsPanel.ToggleVisibility(), 1000);
         }
 
-        protected override APIRequest? FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
+        protected override Task<IEnumerable<ScoreInfo>> FetchScores() => Task.FromResult<IEnumerable<ScoreInfo>>([]);
 
-        protected override APIRequest? FetchNextPage(int direction, Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
+        protected override Task<IEnumerable<ScoreInfo>> FetchNextPage(int direction) => Task.FromResult<IEnumerable<ScoreInfo>>([]);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Models;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
@@ -222,6 +223,14 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                 beatmapsById[beatmap.OnlineID] = new BeatmapInfo
                 {
                     Difficulty = new BeatmapDifficulty(beatmap.Difficulty),
+                    Metadata =
+                    {
+                        Author = new RealmUser
+                        {
+                            Username = beatmap.Metadata.Author.Username,
+                            OnlineID = beatmap.Metadata.Author.OnlineID,
+                        }
+                    },
                     DifficultyName = beatmap.DifficultyName,
                     StarRating = beatmap.StarRating,
                     Length = beatmap.Length,

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -223,6 +223,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     Difficulty = new BeatmapDifficulty(beatmap.Difficulty),
                     Metadata =
                     {
+                        Artist = beatmap.Metadata.Artist,
+                        Title = beatmap.Metadata.Title,
                         Author = new RealmUser
                         {
                             Username = beatmap.Metadata.Author.Username,

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -135,10 +135,6 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             {
                 return await fetchScoresAround().ConfigureAwait(false);
             }
-            finally
-            {
-                Schedule(() => hideLoadingSpinners());
-            }
         }
 
         protected override async Task<ScoreInfo[]> FetchNextPage(int direction)
@@ -196,10 +192,6 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             {
                 return [];
             }
-            finally
-            {
-                Schedule(() => hideLoadingSpinners(pivot));
-            }
         }
 
         /// <summary>
@@ -228,14 +220,13 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                    .ToArray();
         }
 
-        private void hideLoadingSpinners(MultiplayerScores? pivot = null)
+        protected override void OnScoresAdded(ScoreInfo[] scores)
         {
-            CentreSpinner.Hide();
+            base.OnScoresAdded(scores);
 
-            if (pivot == lowerScores)
-                RightSpinner.Hide();
-            else if (pivot == higherScores)
-                LeftSpinner.Hide();
+            CentreSpinner.Hide();
+            RightSpinner.Hide();
+            LeftSpinner.Hide();
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             try
             {
-                var userScore = await requestTaskSource.Task;
+                var userScore = await requestTaskSource.Task.ConfigureAwait(false);
                 var allScores = new List<MultiplayerScore> { userScore };
 
                 // Other scores could have arrived between score submission and entering the results screen. Ensure the local player score position is up to date.
@@ -125,7 +125,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     setPositions(lowerScores, userScore.Position.Value, 1);
                 }
 
-                return await transformScores(allScores);
+                return await transformScores(allScores).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             }
             catch
             {
-                return await fetchScoresAround();
+                return await fetchScoresAround().ConfigureAwait(false);
             }
             finally
             {
@@ -157,7 +157,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     RightSpinner.Show();
             });
 
-            return await fetchScoresAround(pivot);
+            return await fetchScoresAround(pivot).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             try
             {
-                var index = await requestTaskSource.Task;
+                var index = await requestTaskSource.Task.ConfigureAwait(false);
 
                 if (pivot == lowerScores)
                 {
@@ -190,7 +190,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     setPositions(index, pivot, -1);
                 }
 
-                return await transformScores(index.Scores);
+                return await transformScores(index.Scores).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -208,7 +208,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         /// <param name="scores">The <see cref="MultiplayerScore"/>s that were retrieved from <see cref="APIRequest"/>s.</param>
         private async Task<ScoreInfo[]> transformScores(List<MultiplayerScore> scores)
         {
-            APIBeatmap?[] beatmaps = await beatmapLookupCache.GetBeatmapsAsync(scores.Select(s => s.BeatmapId).Distinct().ToArray());
+            APIBeatmap?[] beatmaps = await beatmapLookupCache.GetBeatmapsAsync(scores.Select(s => s.BeatmapId).Distinct().ToArray()).ConfigureAwait(false);
 
             // Minimal data required to get various components in this screen to display correctly.
             Dictionary<int, BeatmapInfo> beatmapsById = beatmaps.Where(b => b != null).ToDictionary(b => b!.OnlineID, b => new BeatmapInfo

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     setPositions(lowerScores, userScore.Position.Value, 1);
                 }
 
-                return await TransformScores(allScores);
+                return await transformScores(allScores);
             }
             catch (OperationCanceledException)
             {
@@ -190,7 +190,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     setPositions(index, pivot, -1);
                 }
 
-                return await TransformScores(index.Scores, index);
+                return await transformScores(index.Scores);
             }
             catch (OperationCanceledException)
             {
@@ -203,11 +203,10 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         }
 
         /// <summary>
-        /// Transforms returned <see cref="MultiplayerScores"/> into <see cref="ScoreInfo"/>s, ensure the <see cref="ScorePanelList"/> is put into a sane state, and invokes a given success callback.
+        /// Transforms returned <see cref="MultiplayerScores"/> into <see cref="ScoreInfo"/>s.
         /// </summary>
         /// <param name="scores">The <see cref="MultiplayerScore"/>s that were retrieved from <see cref="APIRequest"/>s.</param>
-        /// <param name="pivot">An optional pivot around which the scores were retrieved.</param>
-        protected virtual async Task<ScoreInfo[]> TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
+        private async Task<ScoreInfo[]> transformScores(List<MultiplayerScore> scores)
         {
             APIBeatmap?[] beatmaps = await beatmapLookupCache.GetBeatmapsAsync(scores.Select(s => s.BeatmapId).Distinct().ToArray());
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected abstract APIRequest<MultiplayerScore> CreateScoreRequest();
 
-        protected override async Task<IEnumerable<ScoreInfo>> FetchScores()
+        protected override async Task<ScoreInfo[]> FetchScores()
         {
             // This performs two requests:
             // 1. A request to show the relevant score (and scores around).
@@ -141,7 +141,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             }
         }
 
-        protected override async Task<IEnumerable<ScoreInfo>> FetchNextPage(int direction)
+        protected override async Task<ScoreInfo[]> FetchNextPage(int direction)
         {
             Debug.Assert(direction == 1 || direction == -1);
 
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         /// </summary>
         /// <remarks>Does not queue the request.</remarks>
         /// <param name="pivot">An optional score pivot to retrieve scores around. Can be null to retrieve scores from the highest score.</param>
-        private async Task<IEnumerable<ScoreInfo>> fetchScoresAround(MultiplayerScores? pivot = null)
+        private async Task<ScoreInfo[]> fetchScoresAround(MultiplayerScores? pivot = null)
         {
             var requestTaskSource = new TaskCompletionSource<IndexedMultiplayerScores>();
             var indexReq = pivot != null

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
@@ -31,11 +30,10 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistScoreRequest(RoomId, PlaylistItem.ID, scoreId);
 
-        protected override async Task<ScoreInfo[]> TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
+        protected override void OnScoresAdded(IEnumerable<ScoreInfo> scores)
         {
-            var scoreInfos = await base.TransformScores(scores, pivot);
-            Schedule(() => SelectedScore.Value ??= scoreInfos.SingleOrDefault(s => s.OnlineID == scoreId));
-            return scoreInfos;
+            base.OnScoresAdded(scores);
+            SelectedScore.Value ??= scores.SingleOrDefault(s => s.OnlineID == scoreId);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
@@ -30,7 +29,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistScoreRequest(RoomId, PlaylistItem.ID, scoreId);
 
-        protected override void OnScoresAdded(IEnumerable<ScoreInfo> scores)
+        protected override void OnScoresAdded(ScoreInfo[] scores)
         {
             base.OnScoresAdded(scores);
             SelectedScore.Value ??= scores.SingleOrDefault(s => s.OnlineID == scoreId);

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Online.API;
@@ -31,9 +30,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistScoreRequest(RoomId, PlaylistItem.ID, scoreId);
 
-        protected override ScoreInfo[] PerformSuccessCallback(Action<IEnumerable<ScoreInfo>> callback, List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
+        protected override ScoreInfo[] TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
         {
-            var scoreInfos = base.PerformSuccessCallback(callback, scores, pivot);
+            var scoreInfos = base.TransformScores(scores, pivot);
             Schedule(() => SelectedScore.Value ??= scoreInfos.SingleOrDefault(s => s.OnlineID == scoreId));
             return scoreInfos;
         }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
@@ -30,9 +31,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistScoreRequest(RoomId, PlaylistItem.ID, scoreId);
 
-        protected override ScoreInfo[] TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
+        protected override async Task<ScoreInfo[]> TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
         {
-            var scoreInfos = base.TransformScores(scores, pivot);
+            var scoreInfos = await base.TransformScores(scores, pivot);
             Schedule(() => SelectedScore.Value ??= scoreInfos.SingleOrDefault(s => s.OnlineID == scoreId));
             return scoreInfos;
         }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
@@ -24,9 +25,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistUserScoreRequest(RoomId, PlaylistItem.ID, userId);
 
-        protected override ScoreInfo[] TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
+        protected override async Task<ScoreInfo[]> TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
         {
-            var scoreInfos = base.TransformScores(scores, pivot);
+            var scoreInfos = await base.TransformScores(scores, pivot);
 
             Schedule(() =>
             {

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
@@ -24,7 +23,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistUserScoreRequest(RoomId, PlaylistItem.ID, userId);
 
-        protected override void OnScoresAdded(IEnumerable<ScoreInfo> scores)
+        protected override void OnScoresAdded(ScoreInfo[] scores)
         {
             base.OnScoresAdded(scores);
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
@@ -25,17 +24,12 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistUserScoreRequest(RoomId, PlaylistItem.ID, userId);
 
-        protected override async Task<ScoreInfo[]> TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
+        protected override void OnScoresAdded(IEnumerable<ScoreInfo> scores)
         {
-            var scoreInfos = await base.TransformScores(scores, pivot);
+            base.OnScoresAdded(scores);
 
-            Schedule(() =>
-            {
-                // Prefer selecting the local user's score, or otherwise default to the first visible score.
-                SelectedScore.Value ??= scoreInfos.FirstOrDefault(s => s.UserID == userId) ?? scoreInfos.FirstOrDefault();
-            });
-
-            return scoreInfos;
+            // Prefer selecting the local user's score, or otherwise default to the first visible score.
+            SelectedScore.Value ??= scores.FirstOrDefault(s => s.UserID == userId) ?? scores.FirstOrDefault();
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Online.API;
@@ -25,9 +24,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistUserScoreRequest(RoomId, PlaylistItem.ID, userId);
 
-        protected override ScoreInfo[] PerformSuccessCallback(Action<IEnumerable<ScoreInfo>> callback, List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
+        protected override ScoreInfo[] TransformScores(List<MultiplayerScore> scores, MultiplayerScores? pivot = null)
         {
-            var scoreInfos = base.PerformSuccessCallback(callback, scores, pivot);
+            var scoreInfos = base.TransformScores(scores, pivot);
 
             Schedule(() =>
             {

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,6 +14,7 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -41,10 +40,10 @@ namespace osu.Game.Screens.Ranking.Expanded
 
         private readonly List<StatisticDisplay> statisticDisplays = new List<StatisticDisplay>();
 
-        private RollingCounter<long> scoreCounter;
+        private RollingCounter<long> scoreCounter = null!;
 
         [Resolved]
-        private ScoreManager scoreManager { get; set; }
+        private ScoreManager scoreManager { get; set; } = null!;
 
         /// <summary>
         /// Creates a new <see cref="ExpandedPanelMiddleContent"/>.
@@ -63,11 +62,18 @@ namespace osu.Game.Screens.Ranking.Expanded
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapDifficultyCache beatmapDifficultyCache)
+        private void load(RealmAccess realmAccess, BeatmapDifficultyCache beatmapDifficultyCache)
         {
             var beatmap = score.BeatmapInfo!;
             var metadata = beatmap.BeatmapSet?.Metadata ?? beatmap.Metadata;
             string creator = metadata.Author.Username;
+
+            StarDifficulty starDifficulty = new StarDifficulty(beatmap.StarRating, 0);
+
+            // In some cases, the beatmap ferried through ScoreInfo actually represents an online beatmap.
+            // If it isn't, we may be able to compute a more accuracy difficulty from the ruleset and mods.
+            if (realmAccess.Run(r => r.Find<BeatmapInfo>(score.BeatmapInfo!.ID)) != null)
+                starDifficulty = beatmapDifficultyCache.GetDifficultyAsync(score.BeatmapInfo!, score.Ruleset, score.Mods).GetResultSafely() ?? starDifficulty;
 
             var topStatistics = new List<StatisticDisplay>
             {
@@ -146,7 +152,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                 Spacing = new Vector2(5, 0),
                                 Children = new Drawable[]
                                 {
-                                    new StarRatingDisplay(beatmapDifficultyCache.GetDifficultyAsync(beatmap, score.Ruleset, score.Mods).GetResultSafely() ?? default)
+                                    new StarRatingDisplay(starDifficulty)
                                     {
                                         Anchor = Anchor.CentreLeft,
                                         Origin = Anchor.CentreLeft

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.Ranking.Expanded
             StarDifficulty starDifficulty = new StarDifficulty(beatmap.StarRating, 0);
 
             // In some cases, the beatmap ferried through ScoreInfo actually represents an online beatmap.
-            // If it isn't, we may be able to compute a more accuracy difficulty from the ruleset and mods.
+            // If it isn't, we may be able to compute a more accurate difficulty from the ruleset and mods.
             if (realmAccess.Run(r => r.Find<BeatmapInfo>(score.BeatmapInfo!.ID)) != null)
                 starDifficulty = beatmapDifficultyCache.GetDifficultyAsync(score.BeatmapInfo!, score.Ruleset, score.Mods).GetResultSafely() ?? starDifficulty;
 

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Screens.Ranking
                     nextPageTask = FetchNextPage(1);
 
                 if (nextPageTask != null)
-                    lastFetchTask = Task.Run(async () => await addScores(await nextPageTask).ConfigureAwait(false));
+                    lastFetchTask = Task.Run(async () => await addScores(await nextPageTask.ConfigureAwait(false)).ConfigureAwait(false));
             }
         }
 

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -357,7 +357,17 @@ namespace osu.Game.Screens.Ranking
                 // This can happen if for example a beatmap that is part of a playlist hasn't been played yet.
                 VerticalScrollContent.Add(new MessagePlaceholder(LeaderboardStrings.NoRecordsYet));
             }
+
+            OnScoresAdded(scores);
         });
+
+        /// <summary>
+        /// Invoked after online scores are fetched and added to the list.
+        /// </summary>
+        /// <param name="scores">The scores that were added.</param>
+        protected virtual void OnScoresAdded(IEnumerable<ScoreInfo> scores)
+        {
+        }
 
         public override void OnEntering(ScreenTransitionEvent e)
         {

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -246,7 +246,7 @@ namespace osu.Game.Screens.Ranking
 
             if (lastFetchCompleted)
             {
-                Task<IEnumerable<ScoreInfo>> nextPageTask = Task.FromResult<IEnumerable<ScoreInfo>>([]);
+                Task<ScoreInfo[]> nextPageTask = Task.FromResult<ScoreInfo[]>([]);
 
                 if (ScorePanelList.IsScrolledToStart)
                     nextPageTask = FetchNextPage(-1);
@@ -322,13 +322,13 @@ namespace osu.Game.Screens.Ranking
         /// <summary>
         /// Performs a fetch/refresh of scores to be displayed.
         /// </summary>
-        protected virtual Task<IEnumerable<ScoreInfo>> FetchScores() => Task.FromResult<IEnumerable<ScoreInfo>>([]);
+        protected virtual Task<ScoreInfo[]> FetchScores() => Task.FromResult<ScoreInfo[]>([]);
 
         /// <summary>
         /// Performs a fetch of the next page of scores. This is invoked every frame.
         /// </summary>
         /// <param name="direction">The fetch direction. -1 to fetch scores greater than the current start of the list, and 1 to fetch scores lower than the current end of the list.</param>
-        protected virtual Task<IEnumerable<ScoreInfo>> FetchNextPage(int direction) => Task.FromResult<IEnumerable<ScoreInfo>>([]);
+        protected virtual Task<ScoreInfo[]> FetchNextPage(int direction) => Task.FromResult<ScoreInfo[]>([]);
 
         /// <summary>
         /// Creates the <see cref="Statistics.StatisticsPanel"/> to be used to display extended information about scores.
@@ -340,7 +340,7 @@ namespace osu.Game.Screens.Ranking
                 : new StatisticsPanel();
         }
 
-        private void addScores(IEnumerable<ScoreInfo> scores) => Schedule(() =>
+        private void addScores(ScoreInfo[] scores) => Schedule(() =>
         {
             foreach (var s in scores)
             {
@@ -365,7 +365,7 @@ namespace osu.Game.Screens.Ranking
         /// Invoked after online scores are fetched and added to the list.
         /// </summary>
         /// <param name="scores">The scores that were added.</param>
-        protected virtual void OnScoresAdded(IEnumerable<ScoreInfo> scores)
+        protected virtual void OnScoresAdded(ScoreInfo[] scores)
         {
         }
 

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Ranking
         {
         }
 
-        protected override async Task<IEnumerable<ScoreInfo>> FetchScores()
+        protected override async Task<ScoreInfo[]> FetchScores()
         {
             Debug.Assert(Score != null);
 
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Ranking
                     }
                 }
 
-                return toDisplay;
+                return toDisplay.ToArray();
             }
             catch (OperationCanceledException)
             {

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Ranking
 
             try
             {
-                var scores = await requestTaskSource.Task;
+                var scores = await requestTaskSource.Task.ConfigureAwait(false);
                 var toDisplay = new List<ScoreInfo>();
 
                 for (int i = 0; i < scores.Scores.Count; ++i)

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
@@ -72,8 +73,9 @@ namespace osu.Game.Screens.Ranking
 
                 return toDisplay.ToArray();
             }
-            catch (OperationCanceledException)
+            catch (Exception ex)
             {
+                Logger.Log($"Failed to fetch scores (beatmap: {Score.BeatmapInfo}, ruleset: {Score.Ruleset}): {ex}");
                 return [];
             }
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/31951
Fixes https://github.com/ppy/osu/issues/16480

Three important changes are made here...

## Refactoring results screens to use `Task`s

On `master`, results screens are very closely tied to their API requests. Implementations are required to return an `APIRequest` to be handled by the base class, which doesn't work well when the playlists implementation needs to do a second lookup for the beatmaps:

https://github.com/ppy/osu/blob/38d807e846656be1e4a4e386effa1610722f7493/osu.Game/Screens/Ranking/ResultsScreen.cs#L240-L243

Furthermore, callbacks are passed around that are expected to be called in _just the right way_ by _implementations_ to actually add new scores to the list:

https://github.com/ppy/osu/blob/38d807e846656be1e4a4e386effa1610722f7493/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs#L116-L120

This abstraction turned out to be quite a mess that refactoring it to use `Task`s seemed appropriate. Now, the `FetchScores()` methods both return a `Task<ScoreInfo[]>` which also indicates the completion, allowing removal of the extra [`lastFetchCompleted`](https://github.com/ppy/osu/blob/38d807e846656be1e4a4e386effa1610722f7493/osu.Game/Screens/Ranking/ResultsScreen.cs#L71) state.

**Important things to look out for**: The code for querying when scrolled to the left/right of the list has changed significantly. There should be no functional changes.

## Making `PlaylistItemResultsScreen` query beatmaps

Aside from querying scores appropriately, this screen also handles transforming from `MultiplayerScore` models to `ScoreInfo`. The former model contains a `BeatmapId` parameter that was previously unused.

Now, the screen will perform a second request to fetch corresponding beatmaps before performing the transformation. **Of particular importance**:
- Local beatmaps are preferred if they exist.
- Online beatmaps are allowed to return `null`, in which case the score will default to displaying the global beatmap while logging an error. This is done primarily to simplify testing flows, and I don't expect this to be hit in practice.

## Making score panel difficulty rating display not depend on local beatmap availability

Hopefully the explanation in https://github.com/ppy/osu/commit/90290997a7b754a2506a4c10a8cc28cb3a0e33bd is sufficient, but the gist is that getting this to work means essentially ferrying `APIBeatmap` through `BeatmapInfo` so that it can be attached to a `ScoreInfo`. `BeatmapDifficultyCache` does not understand this scenario and will not return the expected [fallback value](https://github.com/ppy/osu/blob/38d807e846656be1e4a4e386effa1610722f7493/osu.Game/Beatmaps/BeatmapDifficultyCache.cs#L135-L140), as it expects `BeatmapInfo` to always represent a database-local model.

I've experimented with making it understand this scenario in https://github.com/smoogipoo/osu/tree/fix-bdc-fallback, but I'm unsure of that path.

# Testing

I've updated `TestScenePlaylistsResultsScreen` to show multiple beatmaps, but most of my testing has been on the live servers. In particular:
- The [ongoing FA playlist](https://osu.ppy.sh/multiplayer/rooms/1167845) to ensure scrolling/basic lookups are still working as expected.
- [This](https://osu.ppy.sh/multiplayer/rooms/1181352) freestyle room to check that multiple beatmaps are displayed correctly on the screen.