### PR TITLE
Prevent closing team chat channels via Ctrl-W

### DIFF
--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -228,7 +228,8 @@ namespace osu.Game.Overlays
                     return true;
 
                 case PlatformAction.DocumentClose:
-                    channelManager.LeaveChannel(currentChannel.Value);
+                    if (currentChannel.Value?.Type != ChannelType.Team)
+                        channelManager.LeaveChannel(currentChannel.Value);
                     return true;
 
                 case PlatformAction.TabRestore:


### PR DESCRIPTION
As pointed out in https://github.com/ppy/osu/pull/32079#issuecomment-2680297760.

The comment suggested putting that logic in `ChannelManager` but honestly I kinda don't see it working out. It'd probably be multiple boolean arguments for `leaveChannel()` (because `sendLeaveRequest` or whatever already exists), and then there's this one usage in tournament client:

https://github.com/ppy/osu/blob/31aded69714cf205c215893368d1f148c9a73319/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs#L57-L58

I'm not sure how that would interact with this particular change, but I think there is a nonzero possibility that it would interact badly. So in general I kinda just prefer steering clear of all that and adding a local one-liner.