### PR TITLE
Fix settings control not visible because of previous search

### DIFF
--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays
             where T : Drawable
         {
             // if search isn't cleared then the target control won't be visible if it doesn't match the query
-            SearchTextBox.Current.Value = "";
+            SearchTextBox.Current.SetDefault();
 
             Show();
 

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -68,6 +68,9 @@ namespace osu.Game.Overlays
         public void ShowAtControl<T>()
             where T : Drawable
         {
+            // if search isn't cleared then the target control won't be visible if it doesn't match the query
+            SearchTextBox.Current.Value = "";
+
             Show();
 
             // wait for load of sections

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays
 
         public SettingsSectionsContainer SectionsContainer { get; private set; }
 
-        protected SeekLimitedSearchTextBox SearchTextBox;
+        protected SeekLimitedSearchTextBox SearchTextBox { get; private set; }
 
         protected override string PopInSampleName => "UI/settings-pop-in";
         protected override double PopInOutSampleBalance => -OsuGameBase.SFX_STEREO_STRENGTH;

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays
 
         public SettingsSectionsContainer SectionsContainer { get; private set; }
 
-        private SeekLimitedSearchTextBox searchTextBox;
+        protected SeekLimitedSearchTextBox SearchTextBox;
 
         protected override string PopInSampleName => "UI/settings-pop-in";
         protected override double PopInOutSampleBalance => -OsuGameBase.SFX_STEREO_STRENGTH;
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays
                         },
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
-                        Child = searchTextBox = new SettingsSearchTextBox
+                        Child = SearchTextBox = new SettingsSearchTextBox
                         {
                             RelativeSizeAxes = Axes.X,
                             Origin = Anchor.TopCentre,
@@ -183,8 +183,8 @@ namespace osu.Game.Overlays
             Sidebar?.MoveToX(0, TRANSITION_LENGTH, Easing.OutQuint);
             this.FadeTo(1, TRANSITION_LENGTH / 2, Easing.OutQuint);
 
-            searchTextBox.TakeFocus();
-            searchTextBox.HoldFocus = true;
+            SearchTextBox.TakeFocus();
+            SearchTextBox.HoldFocus = true;
         }
 
         protected virtual float ExpandedPosition => 0;
@@ -199,8 +199,8 @@ namespace osu.Game.Overlays
             Sidebar?.MoveToX(-sidebar_width, TRANSITION_LENGTH, Easing.OutQuint);
             this.FadeTo(0, TRANSITION_LENGTH / 2, Easing.OutQuint);
 
-            searchTextBox.HoldFocus = false;
-            if (searchTextBox.HasFocus)
+            SearchTextBox.HoldFocus = false;
+            if (SearchTextBox.HasFocus)
                 GetContainingFocusManager()!.ChangeFocus(null);
         }
 
@@ -208,7 +208,7 @@ namespace osu.Game.Overlays
 
         protected override void OnFocus(FocusEvent e)
         {
-            searchTextBox.TakeFocus();
+            SearchTextBox.TakeFocus();
             base.OnFocus(e);
         }
 
@@ -234,7 +234,7 @@ namespace osu.Game.Overlays
 
                 loading.Hide();
 
-                searchTextBox.Current.BindValueChanged(term => SectionsContainer.SearchTerm = term.NewValue, true);
+                SearchTextBox.Current.BindValueChanged(term => SectionsContainer.SearchTerm = term.NewValue, true);
 
                 loadSidebarButtons();
             });


### PR DESCRIPTION
If `SettingsOverlay` is shown as a result of calling `ShowAtControl` and there was something written in the settings search text box previously, it wouldn't show the target control if it doesn't match the query. (#32122)
This PR makes it so the search text box is cleared before showing the settings.

It also makes `SettingsPanel`'s `SearchTextBox` protected from private so that `SettingsOverlay` can access it. But I think that should be fine.

I couldn't find any tests for `SettingsOverlay`, only for `SettingsPanel` so I didn't add any tests for this. Let me know if I should add tests.

Closes #32122 