### PR TITLE
Use `score.MaximumStatistics` in places which assume the entire beatmap was played

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         private int countOk;
         private int countMeh;
         private int countMiss;
+        private int totalPlayableHits;
 
         /// <summary>
         /// Missed slider ticks that includes missed reverse arrows. Will only be correct on non-classic scores
@@ -75,6 +76,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             countSliderEndsDropped = osuAttributes.SliderCount - score.Statistics.GetValueOrDefault(HitResult.SliderTailHit);
             countSliderTickMiss = score.Statistics.GetValueOrDefault(HitResult.LargeTickMiss);
             effectiveMissCount = countMiss;
+            totalPlayableHits = score.MaximumStatistics.Where(x => x.Key.IsBasic()).Sum(x => x.Value);
 
             var difficulty = score.BeatmapInfo!.Difficulty.Clone();
 
@@ -130,8 +132,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (score.Mods.Any(m => m is OsuModNoFail))
                 multiplier *= Math.Max(0.90, 1.0 - 0.02 * effectiveMissCount);
 
-            if (score.Mods.Any(m => m is OsuModSpunOut) && totalHits > 0)
-                multiplier *= 1.0 - Math.Pow((double)osuAttributes.SpinnerCount / totalHits, 0.85);
+            if (score.Mods.Any(m => m is OsuModSpunOut) && totalPlayableHits > 0)
+                multiplier *= 1.0 - Math.Pow((double)osuAttributes.SpinnerCount / totalPlayableHits, 0.85);
 
             if (score.Mods.Any(h => h is OsuModRelax))
             {
@@ -273,7 +275,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             speedValue *= speedHighDeviationMultiplier;
 
             // Calculate accuracy assuming the worst case scenario
-            double relevantTotalDiff = Math.Max(0, totalHits - attributes.SpeedNoteCount);
+            double relevantTotalDiff = totalPlayableHits - attributes.SpeedNoteCount;
             double relevantCountGreat = Math.Max(0, countGreat - relevantTotalDiff);
             double relevantCountOk = Math.Max(0, countOk - Math.Max(0, relevantTotalDiff - countGreat));
             double relevantCountMeh = Math.Max(0, countMeh - Math.Max(0, relevantTotalDiff - countGreat - countOk));
@@ -297,7 +299,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 amountHitObjectsWithAccuracy += attributes.SliderCount;
 
             if (amountHitObjectsWithAccuracy > 0)
-                betterAccuracyPercentage = ((countGreat - Math.Max(totalHits - amountHitObjectsWithAccuracy, 0)) * 6 + countOk * 2 + countMeh) / (double)(amountHitObjectsWithAccuracy * 6);
+                betterAccuracyPercentage = ((countGreat - (totalPlayableHits - amountHitObjectsWithAccuracy)) * 6 + countOk * 2 + countMeh) / (double)(amountHitObjectsWithAccuracy * 6);
             else
                 betterAccuracyPercentage = 0;
 
@@ -360,7 +362,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Calculate accuracy assuming the worst case scenario
             double speedNoteCount = attributes.SpeedNoteCount;
-            speedNoteCount += (totalHits - attributes.SpeedNoteCount) * 0.1;
+            speedNoteCount += (totalPlayableHits - attributes.SpeedNoteCount) * 0.1;
 
             // Assume worst case: all mistakes were on speed notes
             double relevantCountMiss = Math.Min(countMiss, speedNoteCount);
@@ -368,7 +370,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double relevantCountOk = Math.Min(countOk, speedNoteCount - relevantCountMiss - relevantCountMeh);
             double relevantCountGreat = Math.Max(0, speedNoteCount - relevantCountMiss - relevantCountMeh - relevantCountOk);
 
-            return calculateDeviation(attributes, relevantCountGreat, relevantCountOk, relevantCountMeh, relevantCountMiss);
+            return calculateDeviation(relevantCountGreat, relevantCountOk, relevantCountMeh, relevantCountMiss);
         }
 
         /// <summary>
@@ -377,7 +379,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         /// will always return the same deviation. Misses are ignored because they are usually due to misaiming.
         /// Greats and oks are assumed to follow a normal distribution, whereas mehs are assumed to follow a uniform distribution.
         /// </summary>
-        private double? calculateDeviation(OsuDifficultyAttributes attributes, double relevantCountGreat, double relevantCountOk, double relevantCountMeh, double relevantCountMiss)
+        private double? calculateDeviation(double relevantCountGreat, double relevantCountOk, double relevantCountMeh, double relevantCountMiss)
         {
             if (relevantCountGreat + relevantCountOk + relevantCountMeh <= 0)
                 return null;


### PR DESCRIPTION
`totalPlayableHits` is a new field which uses `MaximumStatistics` to sum the amount of hits in the beatmap, regardless of how far into the beatmap the given score was. My assumption is that using `IsBasic` is good enough to get what is effectively a sum of the circles, sliders and spinners in a beatmap - based on reading that appears to be true, but please scrutinise this line of code.

This allows for a proper fix of what was attempted in https://github.com/ppy/osu/pull/31741 as it prevents the cases where these variables could go negative, rather than just pushing them to zero if it happened.

My logic for where I kept `totalHits` was that those places are better using the hits in the score thus far - miss penalty, length bonus etc. all make sense to react to the amount of hits the score actually achieved rather than what's in the beatmap.

Testing against the replay provided in the attached PR still gives zero with the relevant guards removed due to these changes, and I'll run a sheet to confirm that this doesn't affect submitted plays. PP counter in-game also appears to progress as expected.