### PR TITLE
Always end first chunk `SectionLength`ms after the first difficulty object

### DIFF
--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -46,9 +46,11 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public sealed override void Process(DifficultyHitObject current)
         {
-            // The first object doesn't generate a strain, so we begin with an incremented section end
+            // In order to ensure all sections begin correctly from the first note
+            // We ensure the first section ends exactly `SectionLength` after the first object
+            // This means any offset applied to the beatmap cannot affect difficulty outputs
             if (current.Index == 0)
-                currentSectionEnd = Math.Ceiling(current.StartTime / SectionLength) * SectionLength;
+                currentSectionEnd = current.StartTime + SectionLength;
 
             while (current.StartTime > currentSectionEnd)
             {


### PR DESCRIPTION
RFC.

This change ensures the first chunk always starts where the first object begins, preventing an existing scenario where the offset of a beatmap can increase or decrease star rating as it may shift what chunks objects end up in.

This isn't a stellar fix for chunking in general, and will cause what appears to be random increases or decreases depending on how ""optimised"" a beatmap's offset is with this current flaw.

Note this unintentionally affects all rulesets since this is defined in the general `StrainSkill`. If this is decided as a way-to-go for the osu ruleset, then I will consult with the other PP committees to see if this logic should be moved to only affect the osu ruleset.