### PR TITLE
Add support for legacy osu!mania barline height and colour spec

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
@@ -26,10 +26,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             : base(barLine)
         {
             RelativeSizeAxes = Axes.X;
-            AutoSizeAxes = Axes.Y;
+            Height = 1;
         }
 
-        [BackgroundDependencyLoader]
+        [BackgroundDependencyLoader(true)]
         private void load()
         {
             AddInternal(new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.BarLine), _ => new DefaultBarLine())

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             : base(barLine)
         {
             RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
         }
 
         [BackgroundDependencyLoader]
@@ -36,8 +37,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             });
-
-            Major.BindValueChanged(major => Height = major.NewValue ? 1.7f : 1.2f, true);
         }
 
         protected override void OnApply()

--- a/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject drawableHitObject)
         {
-            RelativeSizeAxes = Axes.Both;
+            RelativeSizeAxes = Axes.X;
 
             // Avoid flickering due to no anti-aliasing of boxes by default.
             var edgeSmoothness = new Vector2(0.3f);
@@ -75,6 +75,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
 
         private void updateMajor(ValueChangedEvent<bool> major)
         {
+            Height = major.NewValue ? 1.7f : 1.2f;
+
             mainLine.Alpha = major.NewValue ? 0.5f : 0.2f;
             leftAnchor.Alpha = rightAnchor.Alpha = major.NewValue ? mainLine.Alpha * 0.3f : 0;
         }

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBarLine.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Legacy
+{
+    public partial class LegacyBarLine : CompositeDrawable
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = 1.2f;
+
+            // Avoid flickering due to no anti-aliasing of boxes by default.
+            var edgeSmoothness = new Vector2(0.3f);
+
+            AddInternal(new Box
+            {
+                Name = "Bar line",
+                EdgeSmoothness = edgeSmoothness,
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.Both,
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBarLine.cs
@@ -5,17 +5,22 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
     public partial class LegacyBarLine : CompositeDrawable
     {
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(ISkinSource skin)
         {
+            float skinHeight = skin.GetManiaSkinConfig<float>(LegacyManiaSkinConfigurationLookups.BarLineHeight)?.Value ?? 1;
+
             RelativeSizeAxes = Axes.X;
-            Height = 1.2f;
+            Height = 1.2f * skinHeight;
+            Colour = skin.GetManiaSkinConfig<Color4>(LegacyManiaSkinConfigurationLookups.BarLineColour)?.Value ?? Color4.White;
 
             // Avoid flickering due to no anti-aliasing of boxes by default.
             var edgeSmoothness = new Vector2(0.3f);

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                             return new LegacyStageForeground();
 
                         case ManiaSkinComponents.BarLine:
-                            return null; // Not yet implemented.
+                            return new LegacyBarLine();
 
                         default:
                             throw new UnsupportedSkinComponentException(lookup);

--- a/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Skinning
         public float LightPosition = (480 - 413) * POSITION_SCALE_FACTOR;
         public float ComboPosition = 111 * POSITION_SCALE_FACTOR;
         public float ScorePosition = 300 * POSITION_SCALE_FACTOR;
+        public float BarLineHeight = 1;
         public bool ShowJudgementLine = true;
         public bool KeysUnderNotes;
         public int LightFramePerSecond = 60;

--- a/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
@@ -70,6 +70,9 @@ namespace osu.Game.Skinning
         RightStageImage,
         BottomStageImage,
 
+        BarLineHeight,
+        BarLineColour,
+
         // ReSharper disable once InconsistentNaming
         Hit300g,
 

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -86,6 +86,10 @@ namespace osu.Game.Skinning
                         parseArrayValue(pair.Value, currentConfig.ColumnWidth);
                         break;
 
+                    case "BarlineHeight":
+                        currentConfig.BarLineHeight = float.Parse(pair.Value, CultureInfo.InvariantCulture);
+                        break;
+
                     case "HitPosition":
                         currentConfig.HitPosition = (480 - Math.Clamp(float.Parse(pair.Value, CultureInfo.InvariantCulture), 240, 480)) * LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
                         break;

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -198,8 +198,14 @@ namespace osu.Game.Skinning
                 case LegacyManiaSkinConfigurationLookups.ComboBreakColour:
                     return SkinUtils.As<TValue>(getCustomColour(existing, "ColourBreak"));
 
+                case LegacyManiaSkinConfigurationLookups.BarLineColour:
+                    return SkinUtils.As<TValue>(getCustomColour(existing, "ColourBarline"));
+
                 case LegacyManiaSkinConfigurationLookups.MinimumColumnWidth:
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.MinimumColumnWidth));
+
+                case LegacyManiaSkinConfigurationLookups.BarLineHeight:
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.BarLineHeight));
 
                 case LegacyManiaSkinConfigurationLookups.NoteBodyStyle:
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21907.

Can be tested with attached skin (makes barlines thick and red on 4K play).

[ddr red thick.osk.zip](https://github.com/user-attachments/files/19023033/ddr.red.thick.osk.zip)
