### PR TITLE
Fix possible crash when scaling objects in editor

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -18,3 +18,6 @@ M:Humanizer.InflectorExtensions.Pascalize(System.String);Humanizer's .Pascalize(
 M:Humanizer.InflectorExtensions.Camelize(System.String);Humanizer's .Camelize() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToCamelCase() instead.
 M:Humanizer.InflectorExtensions.Underscore(System.String);Humanizer's .Underscore() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToSnakeCase() instead.
 M:Humanizer.InflectorExtensions.Kebaberize(System.String);Humanizer's .Kebaberize() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToKebabCase() instead.
+M:osuTK.MathHelper.Clamp(System.Int32,System.Int32,System.Int32)~System.Int32;Use Math.Clamp() instead.
+M:osuTK.MathHelper.Clamp(System.Single,System.Single,System.Single)~System.Single;This osuTK helper has unsafe semantics when one of the bounds provided is NaN. Use Math.Clamp() instead.
+M:osuTK.MathHelper.Clamp(System.Double,System.Double,System.Double)~System.Double;This osuTK helper has unsafe semantics when one of the bounds provided is NaN. Use Math.Clamp() instead.

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -9,7 +10,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Pippidon.Objects;
 using osu.Game.Rulesets.Pippidon.UI;
-using osuTK;
 
 namespace osu.Game.Rulesets.Pippidon.Beatmaps
 {
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Pippidon.Beatmaps
             };
         }
 
-        private int getLane(HitObject hitObject) => (int)MathHelper.Clamp(
+        private int getLane(HitObject hitObject) => (int)Math.Clamp(
             (getUsablePosition(hitObject) - minPosition) / (maxPosition - minPosition) * PippidonPlayfield.LANE_COUNT, 0, PippidonPlayfield.LANE_COUNT - 1);
 
         private float getUsablePosition(HitObject h) => (h as IHasYPosition)?.Y ?? ((IHasXPosition)h).X;

--- a/osu.Game.Rulesets.Catch/Skinning/Argon/ArgonBananaPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Argon/ArgonBananaPiece.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -110,7 +111,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Argon
 
             double duration = ObjectState.HitObject.StartTime - ObjectState.DisplayStartTime;
 
-            fadeContent.Alpha = MathHelper.Clamp(
+            fadeContent.Alpha = Math.Clamp(
                 Interpolation.ValueAt(
                     Time.Current, 1f, 0f,
                     ObjectState.DisplayStartTime + duration * lens_flare_start,

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/Components/HitCircleOverlapMarker.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/Components/HitCircleOverlapMarker.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -76,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components
             if (hasReachedObject && showHitMarkers.Value)
             {
                 float alpha = Interpolation.ValueAt(editorTime, 0, 1f, hitObjectTime, hitObjectTime + FADE_OUT_EXTENSION, Easing.In);
-                float ringScale = MathHelper.Clamp(Interpolation.ValueAt(editorTime, 0, 1f, hitObjectTime, hitObjectTime + FADE_OUT_EXTENSION / 2, Easing.OutQuint), 0, 1);
+                float ringScale = Math.Clamp(Interpolation.ValueAt(editorTime, 0, 1f, hitObjectTime, hitObjectTime + FADE_OUT_EXTENSION / 2, Easing.OutQuint), 0, 1);
 
                 ring.Scale = new Vector2(1 + 0.1f * ringScale);
                 content.Alpha = 0.9f * (1 - alpha);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -270,14 +270,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (adjustVelocity)
             {
                 proposedVelocity = proposedDistance / oldDuration;
-                proposedDistance = MathHelper.Clamp(proposedDistance, 0.1 * oldDuration, 10 * oldDuration);
+                proposedDistance = Math.Clamp(proposedDistance, 0.1 * oldDuration, 10 * oldDuration);
             }
             else
             {
                 double minDistance = distanceSnapProvider?.GetBeatSnapDistance() * oldVelocityMultiplier ?? 1;
                 // Add a small amount to the proposed distance to make it easier to snap to the full length of the slider.
                 proposedDistance = distanceSnapProvider?.FindSnappedDistance((float)proposedDistance + 1, HitObject.StartTime, HitObject) ?? proposedDistance;
-                proposedDistance = MathHelper.Clamp(proposedDistance, minDistance, HitObject.Path.CalculatedDistance);
+                proposedDistance = Math.Clamp(proposedDistance, minDistance, HitObject.Path.CalculatedDistance);
             }
 
             if (Precision.AlmostEquals(proposedDistance, HitObject.Path.Distance) && Precision.AlmostEquals(proposedVelocity, HitObject.SliderVelocityMultiplier))

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
@@ -263,12 +263,12 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     case Axes.X:
                         (sLowerBound, sUpperBound) = computeBounds(lowerBounds - b, upperBounds - b, a);
-                        s.X = MathHelper.Clamp(s.X, sLowerBound, sUpperBound);
+                        s.X = Math.Clamp(s.X, sLowerBound, sUpperBound);
                         break;
 
                     case Axes.Y:
                         (sLowerBound, sUpperBound) = computeBounds(lowerBounds - a, upperBounds - a, b);
-                        s.Y = MathHelper.Clamp(s.Y, sLowerBound, sUpperBound);
+                        s.Y = Math.Clamp(s.Y, sLowerBound, sUpperBound);
                         break;
 
                     case Axes.Both:
@@ -276,11 +276,11 @@ namespace osu.Game.Rulesets.Osu.Edit
                         // Therefore the ratio s.X / s.Y will be maintained
                         (sLowerBound, sUpperBound) = computeBounds(lowerBounds, upperBounds, a * s.X + b * s.Y);
                         s.X = s.X < 0
-                            ? MathHelper.Clamp(s.X, s.X * sUpperBound, s.X * sLowerBound)
-                            : MathHelper.Clamp(s.X, s.X * sLowerBound, s.X * sUpperBound);
+                            ? Math.Clamp(s.X, s.X * sUpperBound, s.X * sLowerBound)
+                            : Math.Clamp(s.X, s.X * sLowerBound, s.X * sUpperBound);
                         s.Y = s.Y < 0
-                            ? MathHelper.Clamp(s.Y, s.Y * sUpperBound, s.Y * sLowerBound)
-                            : MathHelper.Clamp(s.Y, s.Y * sLowerBound, s.Y * sUpperBound);
+                            ? Math.Clamp(s.Y, s.Y * sUpperBound, s.Y * sLowerBound)
+                            : Math.Clamp(s.Y, s.Y * sLowerBound, s.Y * sUpperBound);
                         break;
                 }
 

--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Overlays
                 }
 
                 height = toastFlow.DrawHeight + 120;
-                alpha = MathHelper.Clamp(toastFlow.DrawHeight / 41, 0, 1) * maxNotificationAlpha;
+                alpha = Math.Clamp(toastFlow.DrawHeight / 41, 0, 1) * maxNotificationAlpha;
             }
 
             toastContentBackground.Height = (float)Interpolation.DampContinuously(toastContentBackground.Height, height, 10, Clock.ElapsedFrameTime);

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -277,17 +277,17 @@ namespace osu.Game.Screens.Play
             if (rulesetComponents != null)
                 processDrawables(rulesetComponents);
 
-            if (lowestTopScreenSpaceRight.HasValue)
+            if (lowestTopScreenSpaceRight.HasValue && DrawHeight - TopRightElements.DrawHeight > 0)
                 TopRightElements.Y = Math.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceRight.Value)).Y, 0, DrawHeight - TopRightElements.DrawHeight);
             else
                 TopRightElements.Y = 0;
 
-            if (lowestTopScreenSpaceLeft.HasValue)
+            if (lowestTopScreenSpaceLeft.HasValue && DrawHeight - LeaderboardFlow.DrawHeight > 0)
                 LeaderboardFlow.Y = Math.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceLeft.Value)).Y, 0, DrawHeight - LeaderboardFlow.DrawHeight);
             else
                 LeaderboardFlow.Y = 0;
 
-            if (highestBottomScreenSpace.HasValue)
+            if (highestBottomScreenSpace.HasValue && DrawHeight - bottomRightElements.DrawHeight > 0)
                 bottomRightElements.Y = BottomScoringElementsHeight = -Math.Clamp(DrawHeight - ToLocalSpace(highestBottomScreenSpace.Value).Y, 0, DrawHeight - bottomRightElements.DrawHeight);
             else
                 bottomRightElements.Y = 0;

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -278,17 +278,17 @@ namespace osu.Game.Screens.Play
                 processDrawables(rulesetComponents);
 
             if (lowestTopScreenSpaceRight.HasValue)
-                TopRightElements.Y = MathHelper.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceRight.Value)).Y, 0, DrawHeight - TopRightElements.DrawHeight);
+                TopRightElements.Y = Math.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceRight.Value)).Y, 0, DrawHeight - TopRightElements.DrawHeight);
             else
                 TopRightElements.Y = 0;
 
             if (lowestTopScreenSpaceLeft.HasValue)
-                LeaderboardFlow.Y = MathHelper.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceLeft.Value)).Y, 0, DrawHeight - LeaderboardFlow.DrawHeight);
+                LeaderboardFlow.Y = Math.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceLeft.Value)).Y, 0, DrawHeight - LeaderboardFlow.DrawHeight);
             else
                 LeaderboardFlow.Y = 0;
 
             if (highestBottomScreenSpace.HasValue)
-                bottomRightElements.Y = BottomScoringElementsHeight = -MathHelper.Clamp(DrawHeight - ToLocalSpace(highestBottomScreenSpace.Value).Y, 0, DrawHeight - bottomRightElements.DrawHeight);
+                bottomRightElements.Y = BottomScoringElementsHeight = -Math.Clamp(DrawHeight - ToLocalSpace(highestBottomScreenSpace.Value).Y, 0, DrawHeight - bottomRightElements.DrawHeight);
             else
                 bottomRightElements.Y = 0;
 

--- a/osu.Game/Screens/Utility/CircleGameplay.cs
+++ b/osu.Game/Screens/Utility/CircleGameplay.cs
@@ -201,8 +201,8 @@ namespace osu.Game.Screens.Utility
                 {
                     double preempt = (float)IBeatmapDifficultyInfo.DifficultyRange(SampleApproachRate.Value, 1800, 1200, 450);
 
-                    approach.Scale = new Vector2(1 + 4 * (float)MathHelper.Clamp((HitTime - Clock.CurrentTime) / preempt, 0, 100));
-                    Alpha = (float)MathHelper.Clamp((Clock.CurrentTime - HitTime + 600) / 400, 0, 1);
+                    approach.Scale = new Vector2(1 + 4 * (float)Math.Clamp((HitTime - Clock.CurrentTime) / preempt, 0, 100));
+                    Alpha = (float)Math.Clamp((Clock.CurrentTime - HitTime + 600) / 400, 0, 1);
 
                     if (Clock.CurrentTime > HitTime + duration)
                         Expire();

--- a/osu.Game/Screens/Utility/SampleComponents/LatencyMovableBox.cs
+++ b/osu.Game/Screens/Utility/SampleComponents/LatencyMovableBox.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
@@ -55,22 +56,22 @@ namespace osu.Game.Screens.Utility.SampleComponents
                     {
                         case Key.F:
                         case Key.Up:
-                            box.Y = MathHelper.Clamp(box.Y - movementAmount, 0.1f, 0.9f);
+                            box.Y = Math.Clamp(box.Y - movementAmount, 0.1f, 0.9f);
                             break;
 
                         case Key.J:
                         case Key.Down:
-                            box.Y = MathHelper.Clamp(box.Y + movementAmount, 0.1f, 0.9f);
+                            box.Y = Math.Clamp(box.Y + movementAmount, 0.1f, 0.9f);
                             break;
 
                         case Key.Z:
                         case Key.Left:
-                            box.X = MathHelper.Clamp(box.X - movementAmount, 0.1f, 0.9f);
+                            box.X = Math.Clamp(box.X - movementAmount, 0.1f, 0.9f);
                             break;
 
                         case Key.X:
                         case Key.Right:
-                            box.X = MathHelper.Clamp(box.X + movementAmount, 0.1f, 0.9f);
+                            box.X = Math.Clamp(box.X + movementAmount, 0.1f, 0.9f);
                             break;
                     }
                 }

--- a/osu.Game/Screens/Utility/ScrollingGameplay.cs
+++ b/osu.Game/Screens/Utility/ScrollingGameplay.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.Utility
                 {
                     double preempt = (float)IBeatmapDifficultyInfo.DifficultyRange(SampleApproachRate.Value, 1800, 1200, 450);
 
-                    Alpha = (float)MathHelper.Clamp((Clock.CurrentTime - HitTime + 600) / 400, 0, 1);
+                    Alpha = (float)Math.Clamp((Clock.CurrentTime - HitTime + 600) / 400, 0, 1);
                     Y = judgement_position - (float)((HitTime - Clock.CurrentTime) / preempt);
 
                     if (Clock.CurrentTime > HitTime + duration)


### PR DESCRIPTION
## [Fix possible crash when scaling objects in editor](https://github.com/ppy/osu/commit/ffef6ae1853d84120abf52f3c93382b4863bd556)

Closes https://github.com/ppy/osu/issues/32150.

The specific fail case here is when `s.{X,Y}` is 0, and `s{Lower,Upper}Bound` is `Infinity`. Because IEEE math is IEEE math, `0 * Infinity` is `NaN`.

`MathHelper.Clamp()` [is written the following way](https://github.com/ppy/osuTK/blob/af742f1afd01828efc7bc9fe77536b54aab8b419/src/osuTK/Math/MathHelper.cs#L284-L306), using `Math.{Min,Max}`. `Math.{Min,Max}` are [both](https://learn.microsoft.com/en-us/dotnet/api/system.math.min?view=net-8.0#system-math-min(system-single-system-single)) [documented](https://learn.microsoft.com/en-us/dotnet/api/system.math.max?view=net-8.0#system-math-max(system-single-system-single)) as reporting `NaN` when any of their operands are `NaN`, which means that if a `NaN` happens to sneak into the bounds, it will start spreading outwards in an uncontrolled manner, and likely crash things.

In contrast, the standard library provided `Math.Clamp()` is written [like so](https://github.com/dotnet/runtime/blob/577c36cee56480dec4d4610b35605b5d5836888b/src/libraries/System.Private.CoreLib/src/System/Math.cs#L711-L729). With this implementation, if either bound is `NaN`, it will essentially not be checked (because any and all comparisons involving `NaN` return false). This prevents the spread of `NaN`s, all the way to positions of hitobjects, and thus fixes the crash.

## [Mark `MathHelper.Clamp()` as banned API](https://github.com/ppy/osu/commit/068a9e30c0067e9ebf312d22fc40923ce9fe1846)

See above for partial rationale.

There's an argument to be made about the `NaN`-spreading semantics being desirable because at least something will loudly fail in that case, but I'm not so sure about that these days. It feels like either way if `NaN`s are produced, then things are outside of any control, and chances are the game can probably continue without crashing if the `NaN`s are *not* produced. And, this move reduces our dependence on osuTK, which has already been living on borrowed time for years now and is only awaiting someone brave to go excise it.