### PR TITLE
Add SFX for kiai/star fountain activation

### DIFF
--- a/osu.Game/Screens/Menu/KiaiMenuFountains.cs
+++ b/osu.Game/Screens/Menu/KiaiMenuFountains.cs
@@ -3,6 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
@@ -14,8 +16,11 @@ namespace osu.Game.Screens.Menu
         private StarFountain leftFountain = null!;
         private StarFountain rightFountain = null!;
 
+        private Sample? sample;
+        private SampleChannel? sampleChannel;
+
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             RelativeSizeAxes = Axes.Both;
 
@@ -34,6 +39,8 @@ namespace osu.Game.Screens.Menu
                     X = -250,
                 },
             };
+
+            sample = audio.Samples.Get(@"Gameplay/fountain-shoot");
         }
 
         private bool isTriggered;
@@ -73,6 +80,11 @@ namespace osu.Game.Screens.Menu
                     rightFountain.Shoot(1);
                     break;
             }
+
+            // Track sample channel to avoid overlapping playback
+            sampleChannel?.Stop();
+            sampleChannel = sample?.GetChannel();
+            sampleChannel?.Play();
         }
     }
 }

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -3,6 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
@@ -19,8 +21,11 @@ namespace osu.Game.Screens.Play
 
         private Bindable<bool> kiaiStarFountains = null!;
 
+        private Sample? sample;
+        private SampleChannel? sampleChannel;
+
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, AudioManager audio)
         {
             kiaiStarFountains = config.GetBindable<bool>(OsuSetting.StarFountains);
 
@@ -41,6 +46,8 @@ namespace osu.Game.Screens.Play
                     X = -75,
                 },
             };
+
+            sample = audio.Samples.Get(@"Gameplay/fountain-shoot");
         }
 
         private bool isTriggered;
@@ -66,6 +73,11 @@ namespace osu.Game.Screens.Play
         {
             leftFountain.Shoot(1);
             rightFountain.Shoot(-1);
+
+            // Track sample channel to avoid overlapping playback
+            sampleChannel?.Stop();
+            sampleChannel = sample?.GetChannel();
+            sampleChannel?.Play();
         }
 
         public partial class GameplayStarFountain : StarFountain

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.225.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.217.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.303.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
https://github.com/user-attachments/assets/5930e592-9a57-4d5b-b737-35a116836b0d

https://github.com/user-attachments/assets/278a72d1-26c3-4152-b9cd-69bce8137d9a

Went back and forth quite a bit on how audible to make this. I felt that adding low-end to the impact helped it cut through better on louder/busier beatmaps, resulting in something that sounds closer to 'fireworks' than the original 'confetti cannon' direction I started with.

Doesn't play if "Star fountains" are disabled under options. As usual, will monitor feedback and adjust as necessary.

---

- [x] depends on ppy/osu-resources#355