### PR TITLE
Add ability to sort local scores by metrics other than total score

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboardSorting.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboardSorting.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Select;
+using osu.Game.Tests.Resources;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.SongSelect
+{
+    public partial class TestSceneBeatmapLeaderboardSorting : OsuTestScene
+    {
+        private readonly PlayBeatmapDetailArea playBeatmapDetailArea;
+
+        [Cached(typeof(IDialogOverlay))]
+        private readonly DialogOverlay dialogOverlay;
+
+        private ScoreManager scoreManager = null!;
+        private RulesetStore rulesetStore = null!;
+        private BeatmapManager beatmapManager = null!;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            dependencies.Cache(rulesetStore = new RealmRulesetStore(Realm));
+            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
+            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, Realm, API));
+            Dependencies.Cache(Realm);
+
+            return dependencies;
+        }
+
+        public TestSceneBeatmapLeaderboardSorting()
+        {
+            AddRange(new Drawable[]
+            {
+                dialogOverlay = new DialogOverlay
+                {
+                    Depth = -1
+                },
+                playBeatmapDetailArea = new PlayBeatmapDetailArea
+                {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    Size = new Vector2(550f, 450f),
+                }
+            });
+        }
+
+        [Test]
+        public void TestLocalScoresDisplay()
+        {
+            BeatmapInfo beatmapInfo = null!;
+
+            AddStep(@"Set beatmap", () =>
+            {
+                beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
+                beatmapInfo = beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps.First();
+
+                playBeatmapDetailArea.Leaderboard.BeatmapInfo = beatmapInfo;
+            });
+
+            AddStep(@"Add sample scores", () =>
+            {
+                for (int i = 0; i < 10; i++)
+                    scoreManager.Import(addRandomScore(beatmapInfo));
+            });
+
+            AddStep(@"Add another score", () => scoreManager.Import(addRandomScore(beatmapInfo)));
+
+            clearScores();
+        }
+
+        private void clearScores()
+        {
+            AddStep("Clear all scores", () => scoreManager.Delete());
+        }
+
+        private static ScoreInfo addRandomScore(BeatmapInfo beatmapInfo)
+        {
+            return new ScoreInfo
+            {
+                Rank = ScoreRank.XH,
+                Accuracy = RNG.NextDouble(0, 1),
+                MaxCombo = RNG.Next(0, 1500),
+                TotalScore = RNG.Next(500000, 1200000),
+                Date = DateTime.Now.AddMinutes(RNG.Next(0, 1000) * -1),
+                Statistics = new Dictionary<HitResult, int>
+                {
+                    { HitResult.Miss, RNG.Next(0, 25) },
+                },
+                Ruleset = new OsuRuleset().RulesetInfo,
+                BeatmapInfo = beatmapInfo,
+                BeatmapHash = beatmapInfo.Hash,
+                User = new APIUser
+                {
+                    Id = 2,
+                    Username = @"peppy",
+                    CountryCode = CountryCode.JP,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Local);
             SetDefault(OsuSetting.BeatmapDetailModsFilter, false);
+            SetDefault(OsuSetting.BeatmapDetailScoresSortMode, ScoreSortMode.TotalScore);
 
             SetDefault(OsuSetting.ShowConvertedBeatmaps, true);
             SetDefault(OsuSetting.DisplayStarsMinimum, 0.0, 0, 10, 0.1);
@@ -384,6 +385,7 @@ namespace osu.Game.Configuration
         Prefer24HourTime,
         BeatmapDetailTab,
         BeatmapDetailModsFilter,
+        BeatmapDetailScoresSortMode,
         Username,
         ReleaseStream,
         SavePassword,

--- a/osu.Game/Scoring/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/ScoreInfoExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Scoring
 {
@@ -25,6 +26,35 @@ namespace osu.Game.Scoring
                      .ThenBy(s => s.OnlineID)
                      // Local scores may not have an online ID. Fall back to date in these cases.
                      .ThenBy(s => s.Date);
+
+        /// <summary>
+        /// Orders an array of <see cref="ScoreInfo"/>s by the selected <see cref="ScoreSortMode"/>.
+        /// </summary>
+        /// <param name="scores">The array of <see cref="ScoreInfo"/>s to reorder.</param>
+        /// <param name="scoreSortMode">The attribute to sort the scores by.</param>
+        /// <returns>The given <paramref name="scores"/> ordered by the selected mode.</returns>
+        public static IEnumerable<ScoreInfo> OrderByCriteria(this IEnumerable<ScoreInfo> scores, ScoreSortMode scoreSortMode)
+        {
+            switch (scoreSortMode)
+            {
+                case ScoreSortMode.TotalScore:
+                    return scores.OrderByDescending(s => s.TotalScore);
+
+                case ScoreSortMode.Accuracy:
+                    return scores.OrderByDescending(s => s.Accuracy).ThenByDescending(s => s.TotalScore);
+
+                case ScoreSortMode.Combo:
+                    return scores.OrderByDescending(s => s.MaxCombo).ThenByDescending(s => s.TotalScore);
+
+                case ScoreSortMode.MissCount:
+                    return scores.OrderBy(s => s.Statistics.GetValueOrDefault(HitResult.Miss, 0)).ThenByDescending(s => s.TotalScore);
+
+                case ScoreSortMode.Date:
+                    return scores.OrderByDescending(s => s.Date);
+
+                default: return scores;
+            }
+        }
 
         /// <summary>
         /// Retrieves the maximum achievable combo for the provided score.

--- a/osu.Game/Screens/OnlinePlay/Components/MatchBeatmapDetailArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/MatchBeatmapDetailArea.cs
@@ -10,6 +10,7 @@ using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
 using osuTK;
 using Container = osu.Framework.Graphics.Containers.Container;
 
@@ -83,9 +84,9 @@ namespace osu.Game.Screens.OnlinePlay.Components
         private void updateRoomPlaylist()
             => playlist.Items.ReplaceRange(0, playlist.Items.Count, room.Playlist);
 
-        protected override void OnTabChanged(BeatmapDetailAreaTabItem tab, bool selectedMods)
+        protected override void OnTabChanged(BeatmapDetailAreaTabItem tab, bool selectedMods, ScoreSortMode sortMode)
         {
-            base.OnTabChanged(tab, selectedMods);
+            base.OnTabChanged(tab, selectedMods, sortMode);
 
             switch (tab)
             {

--- a/osu.Game/Screens/Select/BeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailArea.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
+using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select
 {
@@ -33,6 +34,8 @@ namespace osu.Game.Screens.Select
         protected Bindable<BeatmapDetailAreaTabItem> CurrentTab => tabControl.Current;
 
         protected Bindable<bool> CurrentModsFilter => tabControl.CurrentModsFilter;
+
+        protected Bindable<ScoreSortMode> CurrentScoresSortMode => tabControl.CurrentScoreSortMode;
 
         private readonly Container content;
         protected override Container<Drawable> Content => content;
@@ -82,7 +85,8 @@ namespace osu.Game.Screens.Select
         /// </summary>
         /// <param name="tab">The tab that was selected.</param>
         /// <param name="selectedMods">Whether the currently-selected mods should be considered.</param>
-        protected virtual void OnTabChanged(BeatmapDetailAreaTabItem tab, bool selectedMods)
+        /// <param name="sortMode">The currently selected ordering.</param>
+        protected virtual void OnTabChanged(BeatmapDetailAreaTabItem tab, bool selectedMods, ScoreSortMode sortMode)
         {
             switch (tab)
             {

--- a/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
@@ -53,7 +53,6 @@ namespace osu.Game.Screens.Select
         private readonly OsuTabControl<BeatmapDetailAreaTabItem> tabs;
         private readonly SlimEnumDropdown<ScoreSortMode> sortModeDropdown;
         private readonly Container tabsContainer;
-        private readonly Container dropdownContainer;
 
         public BeatmapDetailAreaTabControl()
         {
@@ -88,7 +87,7 @@ namespace osu.Game.Screens.Select
                     AutoSizeAxes = Axes.X,
                     ColumnDimensions = new[]
                     {
-                        new Dimension(),
+                        new Dimension(GridSizeMode.AutoSize),
                         new Dimension(GridSizeMode.AutoSize),
                     },
                     RowDimensions = new[] { new Dimension() },
@@ -98,22 +97,13 @@ namespace osu.Game.Screens.Select
                         {
                             modsCheckbox = new OsuTabControlCheckbox
                             {
-                                Anchor = Anchor.BottomRight,
-                                Origin = Anchor.BottomRight,
                                 Text = @"Selected Mods",
                                 Alpha = 0,
                             },
-                            dropdownContainer = new Container
+                            sortModeDropdown = new SlimEnumDropdown<ScoreSortMode>
                             {
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                RelativeSizeAxes = Axes.Y,
                                 Width = 110,
-                                Child = sortModeDropdown = new SlimEnumDropdown<ScoreSortMode>
-                                {
-                                    RelativeSizeAxes = Axes.X,
-                                    BypassAutoSizeAxes = Axes.Y,
-                                }
+                                BypassAutoSizeAxes = Axes.Y,
                             }
                         }
                     }
@@ -135,28 +125,29 @@ namespace osu.Game.Screens.Select
         {
             OnFilter?.Invoke(tabs.Current.Value, modsCheckbox.Current.Value, sortModeDropdown.Current.Value);
 
-            if (tabs.Current.Value is BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope> leaderboard && leaderboard.Scope == BeatmapLeaderboardScope.Local)
-            {
-                dropdownContainer.ResizeWidthTo(110, 200, Easing.OutQuint);
-                dropdownContainer.FadeTo(1, 200, Easing.OutQuint);
-                modsCheckbox.Padding = new MarginPadding { Right = 5 };
-            }
-            else
-            {
-                dropdownContainer.ResizeWidthTo(0, 200, Easing.OutQuint);
-                dropdownContainer.FadeTo(0, 200, Easing.OutQuint);
-                modsCheckbox.Padding = new MarginPadding();
-            }
-
             if (tabs.Current.Value.FilterableByMods)
             {
                 modsCheckbox.FadeTo(1, 200, Easing.OutQuint);
-                tabsContainer.Padding = new MarginPadding { Right = 215 };
+                tabsContainer.Padding = new MarginPadding { Right = 100 };
             }
             else
             {
                 modsCheckbox.FadeTo(0, 200, Easing.OutQuint);
                 tabsContainer.Padding = new MarginPadding();
+            }
+
+            if (tabs.Current.Value is BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope> leaderboard && leaderboard.Scope == BeatmapLeaderboardScope.Local)
+            {
+                sortModeDropdown.ResizeWidthTo(110, 200, Easing.OutQuint);
+                sortModeDropdown.FadeTo(1, 200, Easing.OutQuint);
+                modsCheckbox.Padding = new MarginPadding { Right = 5 };
+                tabsContainer.Padding = new MarginPadding { Right = 215 };
+            }
+            else
+            {
+                sortModeDropdown.ResizeWidthTo(0, 200, Easing.OutQuint);
+                sortModeDropdown.FadeTo(0, 200, Easing.OutQuint);
+                modsCheckbox.Padding = new MarginPadding();
             }
         }
     }

--- a/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
@@ -7,11 +7,15 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.Select.Leaderboards;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Select
 {
@@ -49,6 +53,7 @@ namespace osu.Game.Screens.Select
         private readonly OsuTabControl<BeatmapDetailAreaTabItem> tabs;
         private readonly SlimEnumDropdown<ScoreSortMode> sortModeDropdown;
         private readonly Container tabsContainer;
+        private readonly Container dropdownContainer;
 
         public BeatmapDetailAreaTabControl()
         {
@@ -56,49 +61,54 @@ namespace osu.Game.Screens.Select
 
             Children = new Drawable[]
             {
+                new Box
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 1,
+                    Colour = Color4.White.Opacity(0.2f),
+                },
+                tabsContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = tabs = new OsuTabControl<BeatmapDetailAreaTabItem>
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        RelativeSizeAxes = Axes.Both,
+                        IsSwitchable = true,
+                    },
+                },
                 new GridContainer
                 {
+                    Origin = Anchor.BottomRight,
+                    Anchor = Anchor.BottomRight,
                     Height = HEIGHT,
-                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.X,
                     ColumnDimensions = new[]
                     {
                         new Dimension(),
                         new Dimension(GridSizeMode.AutoSize),
-                        new Dimension(GridSizeMode.Relative, 0.2f)
                     },
-                    RowDimensions = new[]
-                    {
-                        new Dimension(),
-                    },
+                    RowDimensions = new[] { new Dimension() },
                     Content = new[]
                     {
                         new Drawable[]
                         {
-                            tabsContainer = new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Child = tabs = new OsuTabControl<BeatmapDetailAreaTabItem>
-                                {
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                    RelativeSizeAxes = Axes.Both,
-                                    IsSwitchable = true,
-                                },
-                            },
                             modsCheckbox = new OsuTabControlCheckbox
                             {
-                                Padding = new MarginPadding { Right = 10 },
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,
                                 Text = @"Selected Mods",
                                 Alpha = 0,
                             },
-                            new Container
+                            dropdownContainer = new Container
                             {
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                                Height = HEIGHT,
-                                RelativeSizeAxes = Axes.X,
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                RelativeSizeAxes = Axes.Y,
+                                Width = 110,
                                 Child = sortModeDropdown = new SlimEnumDropdown<ScoreSortMode>
                                 {
                                     RelativeSizeAxes = Axes.X,
@@ -125,16 +135,27 @@ namespace osu.Game.Screens.Select
         {
             OnFilter?.Invoke(tabs.Current.Value, modsCheckbox.Current.Value, sortModeDropdown.Current.Value);
 
+            if (tabs.Current.Value is BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope> leaderboard && leaderboard.Scope == BeatmapLeaderboardScope.Local)
+            {
+                dropdownContainer.ResizeWidthTo(110, 200, Easing.OutQuint);
+                dropdownContainer.FadeTo(1, 200, Easing.OutQuint);
+                modsCheckbox.Padding = new MarginPadding { Right = 5 };
+            }
+            else
+            {
+                dropdownContainer.ResizeWidthTo(0, 200, Easing.OutQuint);
+                dropdownContainer.FadeTo(0, 200, Easing.OutQuint);
+                modsCheckbox.Padding = new MarginPadding();
+            }
+
             if (tabs.Current.Value.FilterableByMods)
             {
                 modsCheckbox.FadeTo(1, 200, Easing.OutQuint);
-                sortModeDropdown.FadeTo(1, 200, Easing.OutQuint);
-                tabsContainer.Padding = new MarginPadding { Right = 20 };
+                tabsContainer.Padding = new MarginPadding { Right = 110 };
             }
             else
             {
                 modsCheckbox.FadeTo(0, 200, Easing.OutQuint);
-                sortModeDropdown.FadeTo(0, 200, Easing.OutQuint);
                 tabsContainer.Padding = new MarginPadding();
             }
         }

--- a/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Screens.Select
             if (tabs.Current.Value.FilterableByMods)
             {
                 modsCheckbox.FadeTo(1, 200, Easing.OutQuint);
-                tabsContainer.Padding = new MarginPadding { Right = 110 };
+                tabsContainer.Padding = new MarginPadding { Right = 215 };
             }
             else
             {

--- a/osu.Game/Screens/Select/Filter/ScoreSortMode.cs
+++ b/osu.Game/Screens/Select/Filter/ScoreSortMode.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.Screens.Select.Filter
+{
+    public enum ScoreSortMode
+    {
+        [Description("Total score")]
+        TotalScore,
+
+        [Description("Accuracy")]
+        Accuracy,
+
+        [Description("Combo")]
+        Combo,
+
+        [Description("Miss count")]
+        MissCount,
+
+        [Description("Date")]
+        Date,
+    }
+}

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -68,17 +68,17 @@ namespace osu.Game.Screens.Select.Leaderboards
             }
         }
 
-        private ScoreSortMode scoresScoreSortMode;
+        private ScoreSortMode scoreSortMode;
 
-        public ScoreSortMode ScoresScoreSortMode
+        public ScoreSortMode ScoreSortMode
         {
-            get => scoresScoreSortMode;
+            get => scoreSortMode;
             set
             {
-                if (value == scoresScoreSortMode)
+                if (value == scoreSortMode)
                     return;
 
-                scoresScoreSortMode = value;
+                scoreSortMode = value;
 
                 RefetchScores();
             }
@@ -236,7 +236,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                     scores = scores.Where(s => selectedMods.SetEquals(s.Mods.Select(m => m.Acronym)));
                 }
 
-                scores = scores.Detach().OrderByCriteria(scoresScoreSortMode);
+                scores = scores.Detach().OrderByCriteria(scoreSortMode);
 
                 SetScores(scores);
             }

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -17,6 +17,7 @@ using osu.Game.Online.Leaderboards;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
+using osu.Game.Screens.Select.Filter;
 using Realms;
 
 namespace osu.Game.Screens.Select.Leaderboards
@@ -62,6 +63,22 @@ namespace osu.Game.Screens.Select.Leaderboards
                     return;
 
                 filterMods = value;
+
+                RefetchScores();
+            }
+        }
+
+        private ScoreSortMode scoresScoreSortMode;
+
+        public ScoreSortMode ScoresScoreSortMode
+        {
+            get => scoresScoreSortMode;
+            set
+            {
+                if (value == scoresScoreSortMode)
+                    return;
+
+                scoresScoreSortMode = value;
 
                 RefetchScores();
             }
@@ -219,7 +236,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                     scores = scores.Where(s => selectedMods.SetEquals(s.Mods.Select(m => m.Acronym)));
                 }
 
-                scores = scores.Detach().OrderByTotalScore();
+                scores = scores.Detach().OrderByCriteria(scoresScoreSortMode);
 
                 SetScores(scores);
             }

--- a/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Select
             base.OnTabChanged(tab, selectedMods, sortMode);
 
             Leaderboard.FilterMods = selectedMods;
-            Leaderboard.ScoresScoreSortMode = sortMode;
+            Leaderboard.ScoreSortMode = sortMode;
 
             switch (tab)
             {

--- a/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.Select.Leaderboards;
 
 namespace osu.Game.Screens.Select
@@ -33,6 +34,8 @@ namespace osu.Game.Screens.Select
 
         private Bindable<bool> selectedModsFilter;
 
+        private Bindable<ScoreSortMode> selectedScoresSortMode;
+
         public PlayBeatmapDetailArea()
         {
             Add(Leaderboard = new BeatmapLeaderboard { RelativeSizeAxes = Axes.Both });
@@ -43,12 +46,16 @@ namespace osu.Game.Screens.Select
         {
             selectedTab = config.GetBindable<TabType>(OsuSetting.BeatmapDetailTab);
             selectedModsFilter = config.GetBindable<bool>(OsuSetting.BeatmapDetailModsFilter);
+            selectedScoresSortMode = config.GetBindable<ScoreSortMode>(OsuSetting.BeatmapDetailScoresSortMode);
 
             selectedTab.BindValueChanged(tab => CurrentTab.Value = getTabItemFromTabType(tab.NewValue), true);
             CurrentTab.BindValueChanged(tab => selectedTab.Value = getTabTypeFromTabItem(tab.NewValue));
 
             selectedModsFilter.BindValueChanged(checkbox => CurrentModsFilter.Value = checkbox.NewValue, true);
             CurrentModsFilter.BindValueChanged(checkbox => selectedModsFilter.Value = checkbox.NewValue);
+
+            selectedScoresSortMode.BindValueChanged(filter => CurrentScoresSortMode.Value = filter.NewValue, true);
+            CurrentScoresSortMode.BindValueChanged(filter => selectedScoresSortMode.Value = filter.NewValue);
         }
 
         public override void Refresh()
@@ -58,11 +65,12 @@ namespace osu.Game.Screens.Select
             Leaderboard.RefetchScores();
         }
 
-        protected override void OnTabChanged(BeatmapDetailAreaTabItem tab, bool selectedMods)
+        protected override void OnTabChanged(BeatmapDetailAreaTabItem tab, bool selectedMods, ScoreSortMode sortMode)
         {
-            base.OnTabChanged(tab, selectedMods);
+            base.OnTabChanged(tab, selectedMods, sortMode);
 
             Leaderboard.FilterMods = selectedMods;
+            Leaderboard.ScoresScoreSortMode = sortMode;
 
             switch (tab)
             {


### PR DESCRIPTION
Adds a dropdown to the local leaderboard tab which lets you sort scores by total score, accuracy, combo, miss count and date.

https://github.com/user-attachments/assets/4194f814-d37a-4e9a-8d5f-3acd9960d2e1

