### PR TITLE
Add taskbar flashing when a multiplayer game is starting

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
 
+        [Resolved]
+        private OsuGame? game { get; set; }
+
         private IBindable<bool> isConnected = null!;
 
         private readonly TaskCompletionSource<bool> resultsReady = new TaskCompletionSource<bool>();
@@ -142,6 +145,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             if (client.LocalUser?.State == MultiplayerUserState.Loaded)
             {
+                game?.Window?.Flash();
                 loadingDisplay.Show();
                 client.ChangeState(MultiplayerUserState.ReadyForGameplay);
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -30,9 +30,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
 
-        [Resolved]
-        private OsuGame? game { get; set; }
-
         private IBindable<bool> isConnected = null!;
 
         private readonly TaskCompletionSource<bool> resultsReady = new TaskCompletionSource<bool>();
@@ -145,7 +142,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             if (client.LocalUser?.State == MultiplayerUserState.Loaded)
             {
-                game?.Window?.Flash();
                 loadingDisplay.Show();
                 client.ChangeState(MultiplayerUserState.ReadyForGameplay);
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -18,6 +18,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient multiplayerClient { get; set; } = null!;
 
+        [Resolved]
+        private OsuGame? game { get; set; }
+
         private Player? player;
 
         public MultiplayerPlayerLoader(Func<Player> createPlayer)
@@ -38,6 +41,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         protected override void OnPlayerLoaded()
         {
             base.OnPlayerLoaded();
+
+            game?.Window?.Flash();
 
             multiplayerClient.ChangeState(MultiplayerUserState.Loaded)
                              .ContinueWith(task => failAndBail(task.Exception?.Message ?? "Server error"), TaskContinuationOptions.NotOnRanToCompletion);


### PR DESCRIPTION
I'm not sure if this was implemented in stable, but it's something that I feel is missing from multiplayer right now. I normally tab out of the lobby while waiting for people to ready up, and so having the indicator makes it easier to do that without the match starting without me.

https://github.com/user-attachments/assets/694e4e73-3b8b-4a32-8f32-753e7c4e809d

