### PR TITLE
Cancel beatmap load in more loops

### DIFF
--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -104,6 +104,8 @@ namespace osu.Game.Rulesets.Objects
         /// <param name="cancellationToken">The cancellation token.</param>
         public void ApplyDefaults(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
             nestedHitObjects.Clear();

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -114,6 +114,8 @@ namespace osu.Game.Rulesets.Objects
             {
                 foreach (HitObject hitObject in nestedHitObjects)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     if (hitObject is IHasComboInformation n)
                     {
                         n.ComboIndexBindable.BindTo(hasCombo.ComboIndexBindable);

--- a/osu.Game/Rulesets/Objects/SliderEventGenerator.cs
+++ b/osu.Game/Rulesets/Objects/SliderEventGenerator.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Rulesets.Objects
 
             for (int span = 0; span < spanCount; span++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 double spanStartTime = startTime + span * spanDuration;
                 bool reversed = span % 2 == 1;
 


### PR DESCRIPTION
Three sequences were provided from internal diffcalc OOM-kills:
```
[03/01/2025 01:35:41]: Threads 0:1754009 1:1754015 2:1607040 3:1754008 4:1754007 5:1754013 6:1754019 7:1754003 8:1753990 9:1754006 
```
```
[03/01/2025 17:22:49]: Threads 0:2352258 1:2351518 2:2351519 3:2351871 4:2352264 5:2352256 6:2352020 7:2225048 8:2352251 9:2352262 
```
```
3001728
```
My general process here was to check the maps which have 0* on the website, and for each one test if each ruleset passes (throws an exception) after 10 seconds. See commit messages for explanation.

Chances are that this won't fix the OOM-kills, because at the end of the day it's based on a 10-sec timeout rather than bytes allocated (which isn't easy to do).