### PR TITLE
Fix drain length calculation helper method being able to return negative durations

### DIFF
--- a/osu.Game.Tests/Beatmaps/BeatmapExtensionsTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapExtensionsTest.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    public class BeatmapExtensionsTest
+    {
+        [Test]
+        public void TestLengthCalculations()
+        {
+            var beatmap = new Beatmap
+            {
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 5_000 },
+                    new HitCircle { StartTime = 300_000 },
+                    new Spinner { StartTime = 280_000, Duration = 40_000 }
+                },
+                Breaks =
+                {
+                    new BreakPeriod(50_000, 75_000),
+                    new BreakPeriod(100_000, 150_000),
+                }
+            };
+
+            Assert.That(beatmap.CalculatePlayableBounds(), Is.EqualTo((5_000, 320_000)));
+            Assert.That(beatmap.CalculatePlayableLength(), Is.EqualTo(315_000)); // 320_000 - 5_000
+            Assert.That(beatmap.CalculateDrainLength(), Is.EqualTo(240_000)); // 315_000 - (25_000 + 50_000) = 315_000 - 75_000
+        }
+
+        [Test]
+        public void TestDrainLengthCannotGoNegative()
+        {
+            var beatmap = new Beatmap
+            {
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 5_000 },
+                    new HitCircle { StartTime = 300_000 },
+                    new Spinner { StartTime = 280_000, Duration = 40_000 }
+                },
+                Breaks =
+                {
+                    new BreakPeriod(0, 350_000),
+                }
+            };
+
+            Assert.That(beatmap.CalculatePlayableBounds(), Is.EqualTo((5_000, 320_000)));
+            Assert.That(beatmap.CalculatePlayableLength(), Is.EqualTo(315_000)); // 320_000 - 5_000
+            Assert.That(beatmap.CalculateDrainLength(), Is.EqualTo(0)); // break period encompasses entire beatmap
+        }
+    }
+}

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Find the total milliseconds between the first and last hittable objects, excluding any break time.
         /// </summary>
-        public static double CalculateDrainLength(this IBeatmap beatmap) => CalculatePlayableLength(beatmap.HitObjects) - beatmap.TotalBreakTime;
+        public static double CalculateDrainLength(this IBeatmap beatmap) => Math.Max(CalculatePlayableLength(beatmap.HitObjects) - beatmap.TotalBreakTime, 0);
 
         /// <summary>
         /// Find the timestamps in milliseconds of the start and end of the playable region.


### PR DESCRIPTION
This is the principal failure behind https://github.com/ppy/osu-server-beatmap-submission/issues/40.

[Compare web-10.](https://github.com/peppy/osu-web-10/blob/466291788ab74605ffd100a24a939c2dbd10ef4a/www/web/osu-osz2-bmsubmit-upload.php#L148)