### PR TITLE
Remove unused virtual method after refactor the scale handling.

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -152,14 +152,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public virtual SelectionRotationHandler CreateRotationHandler() => new SelectionRotationHandler();
 
         /// <summary>
-        /// Handles the selected items being scaled.
-        /// </summary>
-        /// <param name="scale">The delta scale to apply, in local coordinates.</param>
-        /// <param name="anchor">The point of reference where the scale is originating from.</param>
-        /// <returns>Whether any items could be scaled.</returns>
-        public virtual bool HandleScale(Vector2 scale, Anchor anchor) => false;
-
-        /// <summary>
         /// Creates the handler to use for scale operations.
         /// </summary>
         public virtual SelectionScaleHandler CreateScaleHandler() => new SelectionScaleHandler();


### PR DESCRIPTION
After #26643 merged, this method is not being used anymore.