### PR TITLE
Fix intermittent score panel test

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 showPanel(TestResources.CreateTestScoreInfo(beatmap));
             });
 
-            AddAssert("pp display faded out", () =>
+            AddUntilStep("pp display faded out", () =>
             {
                 var ppDisplay = this.ChildrenOfType<PerformanceStatistic>().Single();
                 return ppDisplay.Alpha == 0.5 && ppDisplay.TooltipText == ResultsScreenStrings.NoPPForUnrankedBeatmaps;
@@ -97,7 +97,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 showPanel(score);
             });
 
-            AddAssert("pp display faded out", () =>
+            AddUntilStep("pp display faded out", () =>
             {
                 var ppDisplay = this.ChildrenOfType<PerformanceStatistic>().Single();
                 return ppDisplay.Alpha == 0.5 && ppDisplay.TooltipText == ResultsScreenStrings.NoPPForUnrankedMods;
@@ -116,7 +116,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 showPanel(score);
             });
 
-            AddAssert("pp display faded out", () => this.ChildrenOfType<PerformanceStatistic>().Single().Alpha == 1);
+            AddUntilStep("pp display faded out", () => this.ChildrenOfType<PerformanceStatistic>().Single().Alpha == 1);
         }
 
         [Test]


### PR DESCRIPTION
Failed more times in recent history than I'm comfortable living with (https://github.com/ppy/osu/pull/32204/checks?check_run_id=38135257562). Surprised we haven't seen this before.

```diff
diff --git a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
index 7d155e32b0..68b41bf9da 100644
--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -49,6 +49,8 @@ private void load(BeatmapDifficultyCache difficultyCache, CancellationToken? can
             {
                 Task.Run(async () =>
                 {
+                    await Task.Delay(2000);
+
                     var attributes = await difficultyCache.GetDifficultyAsync(score.BeatmapInfo!, score.Ruleset, score.Mods, cancellationToken ?? default).ConfigureAwait(false);
                     var performanceCalculator = score.Ruleset.CreateInstance().CreatePerformanceCalculator();
 

```