### PR TITLE
Fix thread safety when kicking multiplayer users

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -28,10 +28,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void onRoomUpdated()
         {
-            if (client.Room == null)
+            if (client.Room == null || client.LocalUser == null)
                 return;
-
-            Debug.Assert(client.LocalUser != null);
 
             // If the user exits gameplay before score submission completes, we'll transition to idle when results has been prepared.
             if (client.LocalUser.State == MultiplayerUserState.Results && this.IsCurrentScreen())
@@ -62,10 +60,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.OnResuming(e);
 
-            if (client.Room == null)
+            if (client.Room == null || client.LocalUser == null)
                 return;
-
-            Debug.Assert(client.LocalUser != null);
 
             if (!(e.Last is MultiplayerPlayerLoader playerLoader))
                 return;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32129

Not much thought has gone into the null checks, but I've tested a few situations:
- Being kicked while in the room.
- Being kicked while in gameplay and returning to room (returns to lounge).