### PR TITLE
Fix multiplayer not joining correct chat channel

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -235,6 +235,7 @@ namespace osu.Game.Online.Multiplayer
                 APIRoom = apiRoom;
 
                 APIRoom.RoomID = joinedRoom.RoomID;
+                APIRoom.ChannelId = joinedRoom.ChannelID;
                 APIRoom.Host = joinedRoom.Host?.User;
                 APIRoom.Playlist = joinedRoom.Playlist.Select(item => new PlaylistItem(item)).ToArray();
                 APIRoom.CurrentPlaylistItem = APIRoom.Playlist.Single(item => item.ID == joinedRoom.Settings.PlaylistItemId);

--- a/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
@@ -59,6 +59,12 @@ namespace osu.Game.Online.Multiplayer
         [Key(7)]
         public IList<MultiplayerCountdown> ActiveCountdowns { get; set; } = new List<MultiplayerCountdown>();
 
+        /// <summary>
+        /// The ID of the chat channel for the room.
+        /// </summary>
+        [Key(8)]
+        public int ChannelID { get; set; }
+
         [JsonConstructor]
         [SerializationConstructor]
         public MultiplayerRoom(long roomId)
@@ -69,6 +75,7 @@ namespace osu.Game.Online.Multiplayer
         public MultiplayerRoom(Room room)
         {
             RoomID = room.RoomID ?? 0;
+            ChannelID = room.ChannelId;
             Settings = new MultiplayerRoomSettings(room);
             Host = room.Host != null ? new MultiplayerRoomUser(room.Host.OnlineID) : null;
             Playlist = room.Playlist.Select(p => new MultiplayerPlaylistItem(p)).ToArray();

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -242,7 +242,7 @@ namespace osu.Game.Online.Rooms
         public int ChannelId
         {
             get => channelId;
-            private set => SetField(ref channelId, value);
+            set => SetField(ref channelId, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32216
Regressed in https://github.com/ppy/osu/pull/31637

Requires a redeploy of `osu-server-spectator` with https://github.com/ppy/osu-server-spectator/pull/275 and this change included.