### PR TITLE
Attempt to fix common editor test failures

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -533,8 +533,6 @@ namespace osu.Game.Tests.Visual.Editing
 
             ensureEditorLoaded();
 
-            ensureEditorLoaded();
-
             AddStep("set difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = duplicate_difficulty_name);
             AddStep("try to save beatmap", () => Editor.Save());
             AddAssert("beatmap set not corrupted", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -171,6 +171,8 @@ namespace osu.Game.Tests.Visual.Editing
                 return difficultyName != null && difficultyName != firstDifficultyName;
             });
 
+            ensureEditorLoaded();
+
             AddAssert("created difficulty has timing point", () =>
             {
                 var timingPoint = EditorBeatmap.ControlPointInfo.TimingPoints.Single();
@@ -215,6 +217,8 @@ namespace osu.Game.Tests.Visual.Editing
                 return difficultyName != null && difficultyName != previousDifficultyName;
             });
 
+            ensureEditorLoaded();
+
             AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = previousDifficultyName = Guid.NewGuid().ToString());
             AddStep("add timing point", () => EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 }));
             AddStep("add effect points", () =>
@@ -238,6 +242,8 @@ namespace osu.Game.Tests.Visual.Editing
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != previousDifficultyName;
             });
+
+            ensureEditorLoaded();
 
             AddAssert("created difficulty has timing point", () =>
             {
@@ -286,6 +292,8 @@ namespace osu.Game.Tests.Visual.Editing
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != firstDifficultyName;
             });
+
+            ensureEditorLoaded();
 
             AddAssert("created difficulty has timing point", () =>
             {
@@ -367,6 +375,8 @@ namespace osu.Game.Tests.Visual.Editing
                 return difficultyName != null && difficultyName != originalDifficultyName;
             });
 
+            ensureEditorLoaded();
+
             AddAssert("created difficulty has copy suffix in name", () => EditorBeatmap.BeatmapInfo.DifficultyName == copyDifficultyName);
             AddAssert("created difficulty has timing point", () =>
             {
@@ -377,7 +387,9 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("approach rate correctly copied", () => EditorBeatmap.Difficulty.ApproachRate == 4);
             AddAssert("combo colours correctly copied", () => EditorBeatmap.BeatmapSkin.AsNonNull().ComboColours.Count == 2);
 
+            ensureEditorLoaded();
             AddAssert("status is modified", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified);
+
             AddAssert("online ID not copied", () => EditorBeatmap.BeatmapInfo.OnlineID == -1);
 
             AddStep("save beatmap", () => Editor.Save());
@@ -440,6 +452,8 @@ namespace osu.Game.Tests.Visual.Editing
                 return difficultyName != null && difficultyName != originalDifficultyName;
             });
 
+            ensureEditorLoaded();
+
             AddStep("save without changes", () => Editor.Save());
 
             AddAssert("collection still points to old beatmap", () => !collection.BeatmapMD5Hashes.Contains(EditorBeatmap.BeatmapInfo.MD5Hash)
@@ -477,6 +491,9 @@ namespace osu.Game.Tests.Visual.Editing
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != "New Difficulty";
             });
+
+            ensureEditorLoaded();
+
             AddAssert("new difficulty has correct name", () => EditorBeatmap.BeatmapInfo.DifficultyName == "New Difficulty (1)");
             AddAssert("new difficulty persisted", () =>
             {
@@ -514,6 +531,10 @@ namespace osu.Game.Tests.Visual.Editing
                 return difficultyName != null && difficultyName != duplicate_difficulty_name;
             });
 
+            ensureEditorLoaded();
+
+            ensureEditorLoaded();
+
             AddStep("set difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = duplicate_difficulty_name);
             AddStep("try to save beatmap", () => Editor.Save());
             AddAssert("beatmap set not corrupted", () =>
@@ -540,6 +561,8 @@ namespace osu.Game.Tests.Visual.Editing
                 return set != null && set.PerformRead(s => s.Beatmaps.Count == 1 && s.Files.Count == 1);
             });
 
+            ensureEditorLoaded();
+
             AddStep("create new difficulty", () => Editor.CreateNewDifficulty(new CatchRuleset().RulesetInfo));
 
             AddUntilStep("wait for created", () =>
@@ -547,7 +570,8 @@ namespace osu.Game.Tests.Visual.Editing
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != duplicate_difficulty_name;
             });
-            AddUntilStep("wait for editor load", () => Editor.IsLoaded && DialogOverlay.IsLoaded);
+
+            ensureEditorLoaded();
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[]
             {
@@ -584,6 +608,9 @@ namespace osu.Game.Tests.Visual.Editing
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName == "New Difficulty";
             });
+
+            ensureEditorLoaded();
+
             AddAssert("new difficulty persisted", () =>
             {
                 var set = beatmapManager.QueryBeatmapSet(s => s.ID == setId);
@@ -610,6 +637,9 @@ namespace osu.Game.Tests.Visual.Editing
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName == "New Difficulty (1)";
             });
+
+            ensureEditorLoaded();
+
             AddAssert("new difficulty persisted", () =>
             {
                 var set = beatmapManager.QueryBeatmapSet(s => s.ID == setId);
@@ -735,6 +765,8 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("other audio not removed", () => Beatmap.Value.BeatmapSetInfo.Files.Any(f => f.Filename == "audio (1).mp3"));
         }
 
+        private void ensureEditorLoaded() => AddUntilStep("wait for editor load", () => Editor.IsLoaded && DialogOverlay.IsLoaded);
+
         private void createNewDifficulty()
         {
             string? currentDifficulty = null;
@@ -748,13 +780,14 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddUntilStep("wait for dialog", () => DialogOverlay.CurrentDialog is CreateNewDifficultyDialog);
             AddStep("confirm creation with no objects", () => DialogOverlay.CurrentDialog!.PerformOkAction());
+
             AddUntilStep("wait for created", () =>
             {
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != currentDifficulty;
             });
+            ensureEditorLoaded();
 
-            AddUntilStep("wait for editor load", () => Editor.IsLoaded);
             AddStep("enter setup mode", () => Editor.Mode.Value = EditorScreenMode.SongSetup);
             AddUntilStep("wait for load", () => Editor.ChildrenOfType<SetupScreen>().Any());
         }
@@ -765,7 +798,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep($"switch to difficulty #{index + 1}", () =>
                 Editor.SwitchToDifficulty(Beatmap.Value.BeatmapSetInfo.Beatmaps.ElementAt(index)));
 
-            AddUntilStep("wait for editor load", () => Editor.IsLoaded);
+            ensureEditorLoaded();
             AddStep("enter setup mode", () => Editor.Mode.Value = EditorScreenMode.SongSetup);
             AddUntilStep("wait for load", () => Editor.ChildrenOfType<SetupScreen>().Any());
         }


### PR DESCRIPTION
See https://github.com/ppy/osu/actions/runs/13623586844/job/38143232417?pr=32180 for one example.

Arguably the bindable usage in [`ControlPointPart`](https://github.com/ppy/osu/blob/2365b065a4994f38fe67bab7d193e5a09bee538c/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointPart.cs#L24-L26) is dangerous, but it's only dangerous in tests (because control points aren't mutated outside the editor) so I'm willing to turn a blind eye for now to favour async loading support.

The fix here is to ensure the editor has reloaded after creating a new difficulty before mutating the control points in the tests.