### PR TITLE
Adjust scale and display of rooms in multiplayer lounge

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomListing.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomListing.cs
@@ -45,14 +45,20 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         private readonly ScrollContainer<Drawable> scroll;
         private readonly FillFlowContainer<DrawableLoungeRoom> roomFlow;
 
+        private const float display_scale = 0.8f;
+
         // handle deselection
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         public RoomListing()
         {
-            InternalChild = scroll = new OsuScrollContainer
+            InternalChild = scroll = new Scroll
             {
+                Masking = false,
                 RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                Width = display_scale,
                 ScrollbarOverlapsContent = false,
                 Padding = new MarginPadding { Right = 5 },
                 Child = new OsuContextMenuContainer
@@ -64,10 +70,16 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(10),
+                        Spacing = new Vector2(5),
+                        Margin = new MarginPadding { Vertical = 10 },
                     }
                 }
             };
+        }
+
+        private partial class Scroll : OsuScrollContainer
+        {
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
         }
 
         protected override void LoadComplete()
@@ -171,7 +183,14 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         {
             foreach (var room in rooms)
             {
-                var drawableRoom = new DrawableLoungeRoom(room) { SelectedRoom = selectedRoom };
+                var drawableRoom = new DrawableLoungeRoom(room)
+                {
+                    SelectedRoom = selectedRoom,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(display_scale),
+                    Width = 1 / display_scale,
+                };
 
                 roomFlow.Add(drawableRoom);
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -8,9 +8,12 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
@@ -27,6 +30,7 @@ using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.OnlinePlay.Match;
 using osu.Game.Users;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Lounge
 {
@@ -85,10 +89,14 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         [BackgroundDependencyLoader(true)]
         private void load()
         {
+            Masking = true;
+
             const float controls_area_height = 25f;
 
             if (idleTracker != null)
                 isIdle.BindTo(idleTracker.IsIdle);
+
+            Color4 bg = Color4Extensions.FromHex("#070405");
 
             InternalChildren = new Drawable[]
             {
@@ -113,56 +121,80 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                     }
                 },
                 loadingLayer = new LoadingLayer(true),
-                new FillFlowContainer
+                new Container
                 {
-                    Name = @"Header area flow",
+                    Name = "Header area",
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.WIDTH_PADDING },
-                    Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        new Container
+                        new Box
                         {
-                            RelativeSizeAxes = Axes.X,
-                            Height = Header.HEIGHT,
-                            Child = searchTextBox = new BasicSearchTextBox
-                            {
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                RelativeSizeAxes = Axes.X,
-                                Width = 0.6f,
-                            },
+                            Colour = ColourInfo.GradientVertical(bg, bg.Opacity(0.75f)),
+                            RelativeSizeAxes = Axes.Both,
+                            Height = 0.8f,
                         },
-                        new Container
+                        new Box
                         {
+                            Colour = ColourInfo.GradientVertical(bg.Opacity(0.75f), bg.Opacity(0)),
+                            RelativeSizeAxes = Axes.Both,
+                            RelativePositionAxes = Axes.Both,
+                            Y = 0.8f,
+                            // Intentionally taller than the header for a more gradual fade
+                            Height = 0.5f,
+                        },
+                        new FillFlowContainer
+                        {
+                            Name = @"Header area flow",
                             RelativeSizeAxes = Axes.X,
-                            Height = controls_area_height,
+                            AutoSizeAxes = Axes.Y,
+                            Padding = new MarginPadding { Horizontal = WaveOverlayContainer.WIDTH_PADDING },
+                            Direction = FillDirection.Vertical,
                             Children = new Drawable[]
                             {
-                                Buttons.WithChild(CreateNewRoomButton().With(d =>
+                                new Container
                                 {
-                                    d.Anchor = Anchor.BottomLeft;
-                                    d.Origin = Anchor.BottomLeft;
-                                    d.Size = new Vector2(150, 37.5f);
-                                    d.Action = () => Open();
-                                })),
-                                new FillFlowContainer
-                                {
-                                    Anchor = Anchor.TopRight,
-                                    Origin = Anchor.TopRight,
-                                    AutoSizeAxes = Axes.Both,
-                                    Direction = FillDirection.Horizontal,
-                                    Spacing = new Vector2(10),
-                                    ChildrenEnumerable = CreateFilterControls().Select(f => f.With(d =>
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = Header.HEIGHT,
+                                    Child = searchTextBox = new BasicSearchTextBox
                                     {
-                                        d.Anchor = Anchor.TopRight;
-                                        d.Origin = Anchor.TopRight;
-                                    }))
+                                        Anchor = Anchor.CentreRight,
+                                        Origin = Anchor.CentreRight,
+                                        RelativeSizeAxes = Axes.X,
+                                        Width = 0.6f,
+                                    },
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = controls_area_height,
+                                    Children = new Drawable[]
+                                    {
+                                        Buttons.WithChild(CreateNewRoomButton().With(d =>
+                                        {
+                                            d.Anchor = Anchor.BottomLeft;
+                                            d.Origin = Anchor.BottomLeft;
+                                            d.Size = new Vector2(150, 37.5f);
+                                            d.Action = () => Open();
+                                        })),
+                                        new FillFlowContainer
+                                        {
+                                            Anchor = Anchor.TopRight,
+                                            Origin = Anchor.TopRight,
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Horizontal,
+                                            Spacing = new Vector2(10),
+                                            ChildrenEnumerable = CreateFilterControls().Select(f => f.With(d =>
+                                            {
+                                                d.Anchor = Anchor.TopRight;
+                                                d.Origin = Anchor.TopRight;
+                                            }))
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                    },
+                            },
+                        },
+                    }
                 },
             };
         }


### PR DESCRIPTION
Just a quick pass because the rooms were definitely larger than they should be.

| Before | After |
| :---: | :---: |
| ![osu! 2025-03-04 at 06 57 19](https://github.com/user-attachments/assets/12a85ca9-6ef8-494a-ab11-253b29873c5f) | ![osu! 2025-03-04 at 06 56 52](https://github.com/user-attachments/assets/e193ec50-cba4-4590-b1bf-bdb8b85d3a42) |

Also made scrolling feel a bit better by replacing the hard masking with a gradient:

https://github.com/user-attachments/assets/ecfaf838-eb94-414e-9e1b-9581dd455772

---

This isn't intended to align with any future design direction (I didn't even check figma). Just changing things to what feels right.