### PR TITLE
Add "discard unsaved changes" operation to beatmap editor

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaEditorSaving.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaEditorSaving.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             {
                 keyCount.Current.Value = 8;
             });
-            AddUntilStep("dialog visible", () => Game.ChildrenOfType<IDialogOverlay>().SingleOrDefault()?.CurrentDialog, Is.InstanceOf<ReloadEditorDialog>);
+            AddUntilStep("dialog visible", () => Game.ChildrenOfType<IDialogOverlay>().SingleOrDefault()?.CurrentDialog, Is.InstanceOf<SaveAndReloadEditorDialog>);
             AddStep("refuse", () => InputManager.Key(Key.Number2));
             AddAssert("key count is 5", () => keyCount.Current.Value, () => Is.EqualTo(5));
 
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             {
                 keyCount.Current.Value = 8;
             });
-            AddUntilStep("dialog visible", () => Game.ChildrenOfType<IDialogOverlay>().Single().CurrentDialog, Is.InstanceOf<ReloadEditorDialog>);
+            AddUntilStep("dialog visible", () => Game.ChildrenOfType<IDialogOverlay>().Single().CurrentDialog, Is.InstanceOf<SaveAndReloadEditorDialog>);
             AddStep("acquiesce", () => InputManager.Key(Key.Number1));
             AddUntilStep("beatmap became 8K", () => Game.Beatmap.Value.BeatmapInfo.Difficulty.CircleSize, () => Is.EqualTo(8));
         }

--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
 
             updatingKeyCount = true;
 
-            editor.Reload().ContinueWith(t =>
+            editor.SaveAndReload().ContinueWith(t =>
             {
                 if (!t.GetResultSafely())
                 {

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -155,6 +155,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.B }, GlobalAction.EditorRemoveClosestBookmark),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Left }, GlobalAction.EditorSeekToPreviousBookmark),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Right }, GlobalAction.EditorSeekToNextBookmark),
+            new KeyBinding(new[] { InputKey.Control, InputKey.L }, GlobalAction.EditorDiscardUnsavedChanges),
         };
 
         private static IEnumerable<KeyBinding> editorTestPlayKeyBindings => new[]
@@ -502,6 +503,9 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorToggleMoveControl))]
         EditorToggleMoveControl,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDiscardUnsavedChanges))]
+        EditorDiscardUnsavedChanges,
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/EditorDialogsStrings.cs
+++ b/osu.Game/Localisation/EditorDialogsStrings.cs
@@ -54,6 +54,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditorReloadDialogHeader => new TranslatableString(getKey(@"editor_reload_dialog_header"), @"The editor must be reloaded to apply this change. The beatmap will be saved.");
 
+        /// <summary>
+        /// "Discard all unsaved changes? This cannot be undone."
+        /// </summary>
+        public static LocalisableString DiscardUnsavedChangesDialogHeader => new TranslatableString(getKey(@"discard_unsaved_changes_dialog_header"), @"Discard all unsaved changes? This cannot be undone.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -459,6 +459,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditorToggleMoveControl => new TranslatableString(getKey(@"editor_toggle_move_control"), @"Toggle movement control");
 
+        /// <summary>
+        /// "Discard unsaved changes"
+        /// </summary>
+        public static LocalisableString EditorDiscardUnsavedChanges => new TranslatableString(getKey(@"editor_discard_unsaved_changes"), @"Discard unsaved changes");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Edit/DiscardUnsavedChangesDialog.cs
+++ b/osu.Game/Screens/Edit/DiscardUnsavedChangesDialog.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Dialog;
+
+namespace osu.Game.Screens.Edit
+{
+    public partial class DiscardUnsavedChangesDialog : PopupDialog
+    {
+        public DiscardUnsavedChangesDialog(Action exit)
+        {
+            HeaderText = EditorDialogsStrings.DiscardUnsavedChangesDialogHeader;
+
+            Icon = FontAwesome.Solid.Trash;
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogDangerousButton
+                {
+                    Text = EditorDialogsStrings.ForgetAllChanges,
+                    Action = exit
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = EditorDialogsStrings.ContinueEditing,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -392,10 +392,6 @@ namespace osu.Game.Screens.Edit
                                         {
                                             undoMenuItem = new EditorMenuItem(CommonStrings.Undo, MenuItemType.Standard, Undo) { Hotkey = new Hotkey(PlatformAction.Undo) },
                                             redoMenuItem = new EditorMenuItem(CommonStrings.Redo, MenuItemType.Standard, Redo) { Hotkey = new Hotkey(PlatformAction.Redo) },
-                                            discardChangesMenuItem = new EditorMenuItem(GlobalActionKeyBindingStrings.EditorDiscardUnsavedChanges, MenuItemType.Destructive, DiscardUnsavedChanges)
-                                            {
-                                                Hotkey = new Hotkey(GlobalAction.EditorDiscardUnsavedChanges)
-                                            },
                                             new OsuMenuItemSpacer(),
                                             cutMenuItem = new EditorMenuItem(CommonStrings.Cut, MenuItemType.Standard, Cut) { Hotkey = new Hotkey(PlatformAction.Cut) },
                                             copyMenuItem = new EditorMenuItem(CommonStrings.Copy, MenuItemType.Standard, Copy) { Hotkey = new Hotkey(PlatformAction.Copy) },
@@ -1272,6 +1268,11 @@ namespace osu.Game.Screens.Edit
             var save = new EditorMenuItem(WebCommonStrings.ButtonsSave, MenuItemType.Standard, () => attemptMutationOperation(Save)) { Hotkey = new Hotkey(PlatformAction.Save) };
             saveRelatedMenuItems.Add(save);
             yield return save;
+
+            yield return discardChangesMenuItem = new EditorMenuItem(GlobalActionKeyBindingStrings.EditorDiscardUnsavedChanges, MenuItemType.Destructive, DiscardUnsavedChanges)
+            {
+                Hotkey = new Hotkey(GlobalAction.EditorDiscardUnsavedChanges)
+            };
 
             if (RuntimeInfo.OS != RuntimeInfo.Platform.Android)
             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -392,7 +392,7 @@ namespace osu.Game.Screens.Edit
                                         {
                                             undoMenuItem = new EditorMenuItem(CommonStrings.Undo, MenuItemType.Standard, Undo) { Hotkey = new Hotkey(PlatformAction.Undo) },
                                             redoMenuItem = new EditorMenuItem(CommonStrings.Redo, MenuItemType.Standard, Redo) { Hotkey = new Hotkey(PlatformAction.Redo) },
-                                            discardChangesMenuItem = new EditorMenuItem("Discard unsaved changes", MenuItemType.Destructive, DiscardUnsavedChanges)
+                                            discardChangesMenuItem = new EditorMenuItem(GlobalActionKeyBindingStrings.EditorDiscardUnsavedChanges, MenuItemType.Destructive, DiscardUnsavedChanges)
                                             {
                                                 Hotkey = new Hotkey(GlobalAction.EditorDiscardUnsavedChanges)
                                             },

--- a/osu.Game/Screens/Edit/SaveAndReloadEditorDialog.cs
+++ b/osu.Game/Screens/Edit/SaveAndReloadEditorDialog.cs
@@ -8,9 +8,9 @@ using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
-    public partial class ReloadEditorDialog : PopupDialog
+    public partial class SaveAndReloadEditorDialog : PopupDialog
     {
-        public ReloadEditorDialog(Action reload, Action cancel)
+        public SaveAndReloadEditorDialog(Action reload, Action cancel)
         {
             HeaderText = EditorDialogsStrings.EditorReloadDialogHeader;
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/554d0911-95fe-4854-a17f-e48a314373bf

Apparently useful in modding workflows when you want to test out a few different variants of a thing.

Re-uses `Ctrl-L` binding from stable. Some folks may argue that the dialog makes the hotkey pointless, but I really do want to protect users from accidental data loss, and also if you want to power through it quickly, you can hit the 1 key when the dialog shows, which will bypass the hold-to-activate period (which wasn't intentional, but so many people want a bypass at this point that we're probably keeping that behaviour for power users).

---