### PR TITLE
Localise skin rename/export/delete buttons in settings

### DIFF
--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -40,9 +40,19 @@ namespace osu.Game.Localisation
         public static LocalisableString Default => new TranslatableString(getKey(@"default"), @"Default");
 
         /// <summary>
+        /// "Rename"
+        /// </summary>
+        public static LocalisableString Rename => new TranslatableString(getKey(@"rename"), @"Rename");
+
+        /// <summary>
         /// "Export"
         /// </summary>
         public static LocalisableString Export => new TranslatableString(getKey(@"export"), @"Export");
+
+        /// <summary>
+        /// "Delete"
+        /// </summary>
+        public static LocalisableString Delete => new TranslatableString(getKey(@"delete"), @"Delete");
 
         /// <summary>
         /// "Width"

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -50,11 +50,6 @@ namespace osu.Game.Localisation
         public static LocalisableString Export => new TranslatableString(getKey(@"export"), @"Export");
 
         /// <summary>
-        /// "Delete"
-        /// </summary>
-        public static LocalisableString Delete => new TranslatableString(getKey(@"delete"), @"Delete");
-
-        /// <summary>
         /// "Width"
         /// </summary>
         public static LocalisableString Width => new TranslatableString(getKey(@"width"), @"Width");

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -27,6 +27,7 @@ using osu.Game.Screens.Select;
 using osu.Game.Skinning;
 using osuTK;
 using Realms;
+using WebCommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
@@ -231,7 +232,7 @@ namespace osu.Game.Overlays.Settings.Sections
             [BackgroundDependencyLoader]
             private void load()
             {
-                Text = CommonStrings.Delete;
+                Text = WebCommonStrings.ButtonsDelete;
                 Action = delete;
             }
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.Settings.Sections
             [BackgroundDependencyLoader]
             private void load()
             {
-                Text = "Rename";
+                Text = CommonStrings.Rename;
                 Action = this.ShowPopover;
             }
 
@@ -193,7 +193,7 @@ namespace osu.Game.Overlays.Settings.Sections
             [BackgroundDependencyLoader]
             private void load()
             {
-                Text = "Export";
+                Text = CommonStrings.Export;
                 Action = export;
             }
 
@@ -231,7 +231,7 @@ namespace osu.Game.Overlays.Settings.Sections
             [BackgroundDependencyLoader]
             private void load()
             {
-                Text = "Delete";
+                Text = CommonStrings.Delete;
                 Action = delete;
             }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a714d92e-f480-4a85-994d-2ba2055d359f)

This PR adds localisation support to the Rename, Export, and Delete buttons in the skin section of the settings menu.

I have added the localisation strings in `CommonStrings.cs` instead of `SkinSettingsStrings.cs` because I think "Rename" and "Delete" are so general that they can be used in other places, following "Export" which was already there.