### PR TITLE
Fix initial multiplayer room items not having freestyle

### DIFF
--- a/osu.Game/Online/Rooms/MultiplayerPlaylistItem.cs
+++ b/osu.Game/Online/Rooms/MultiplayerPlaylistItem.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Online.Rooms
             PlaylistOrder = item.PlaylistOrder ?? 0;
             PlayedAt = item.PlayedAt;
             StarRating = item.Beatmap.StarRating;
+            Freestyle = item.Freestyle;
         }
     }
 }


### PR DESCRIPTION
Only affects initial population of the items (from creating the room) as far as I can tell.

Does not need a new server deploy.