### PR TITLE
Allow kiai/star-fountain activation SFX to be skinnable

### DIFF
--- a/osu.Game/Screens/Menu/KiaiMenuFountains.cs
+++ b/osu.Game/Screens/Menu/KiaiMenuFountains.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osu.Framework.Utils;
@@ -21,18 +20,14 @@ namespace osu.Game.Screens.Menu
         [Resolved]
         private GameHost host { get; set; } = null!;
 
-        [Resolved]
-        private ISkinSource skin { get; set; } = null!;
-
-        private ISample? sample;
-        private SampleChannel? sampleChannel;
+        private SkinnableSound? sample;
 
         [BackgroundDependencyLoader]
         private void load()
         {
             RelativeSizeAxes = Axes.Both;
 
-            Children = new[]
+            Children = new Drawable[]
             {
                 leftFountain = new StarFountain
                 {
@@ -46,9 +41,8 @@ namespace osu.Game.Screens.Menu
                     Origin = Anchor.BottomRight,
                     X = -250,
                 },
+                sample = new SkinnableSound(new SampleInfo("Gameplay/fountain-shoot"))
             };
-
-            sample = skin.GetSample(new SampleInfo(@"Gameplay/fountain-shoot"));
         }
 
         private bool isTriggered;
@@ -89,13 +83,9 @@ namespace osu.Game.Screens.Menu
                     break;
             }
 
-            // Don't play SFX when game is in background
-            if (!host.IsActive.Value) return;
-
-            // Track sample channel to avoid overlapping playback
-            sampleChannel?.Stop();
-            sampleChannel = sample?.GetChannel();
-            sampleChannel?.Play();
+            // Don't play SFX when game is in background as it can be a bit noisy.
+            if (host.IsActive.Value)
+                sample?.Play();
         }
     }
 }

--- a/osu.Game/Screens/Menu/KiaiMenuFountains.cs
+++ b/osu.Game/Screens/Menu/KiaiMenuFountains.cs
@@ -3,11 +3,12 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Audio;
 using osu.Game.Graphics.Containers;
+using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Menu
 {
@@ -16,11 +17,14 @@ namespace osu.Game.Screens.Menu
         private StarFountain leftFountain = null!;
         private StarFountain rightFountain = null!;
 
-        private Sample? sample;
+        [Resolved]
+        private ISkinSource skin { get; set; } = null!;
+
+        private ISample? sample;
         private SampleChannel? sampleChannel;
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        private void load()
         {
             RelativeSizeAxes = Axes.Both;
 
@@ -40,7 +44,7 @@ namespace osu.Game.Screens.Menu
                 },
             };
 
-            sample = audio.Samples.Get(@"Gameplay/fountain-shoot");
+            sample = skin.GetSample(new SampleInfo(@"Gameplay/fountain-shoot"));
         }
 
         private bool isTriggered;

--- a/osu.Game/Screens/Menu/KiaiMenuFountains.cs
+++ b/osu.Game/Screens/Menu/KiaiMenuFountains.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
+using osu.Framework.Platform;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Graphics.Containers;
@@ -16,6 +17,9 @@ namespace osu.Game.Screens.Menu
     {
         private StarFountain leftFountain = null!;
         private StarFountain rightFountain = null!;
+
+        [Resolved]
+        private GameHost host { get; set; } = null!;
 
         [Resolved]
         private ISkinSource skin { get; set; } = null!;
@@ -84,6 +88,9 @@ namespace osu.Game.Screens.Menu
                     rightFountain.Shoot(1);
                     break;
             }
+
+            // Don't play SFX when game is in background
+            if (!host.IsActive.Value) return;
 
             // Track sample channel to avoid overlapping playback
             sampleChannel?.Stop();

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -3,14 +3,15 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Audio;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Menu;
+using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play
 {
@@ -21,11 +22,14 @@ namespace osu.Game.Screens.Play
 
         private Bindable<bool> kiaiStarFountains = null!;
 
-        private Sample? sample;
+        [Resolved]
+        private ISkinSource skin { get; set; } = null!;
+
+        private ISample? sample;
         private SampleChannel? sampleChannel;
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, AudioManager audio)
+        private void load(OsuConfigManager config)
         {
             kiaiStarFountains = config.GetBindable<bool>(OsuSetting.StarFountains);
 
@@ -47,7 +51,7 @@ namespace osu.Game.Screens.Play
                 },
             };
 
-            sample = audio.Samples.Get(@"Gameplay/fountain-shoot");
+            sample = skin.GetSample(new SampleInfo(@"Gameplay/fountain-shoot"));
         }
 
         private bool isTriggered;

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
@@ -22,11 +21,7 @@ namespace osu.Game.Screens.Play
 
         private Bindable<bool> kiaiStarFountains = null!;
 
-        [Resolved]
-        private ISkinSource skin { get; set; } = null!;
-
-        private ISample? sample;
-        private SampleChannel? sampleChannel;
+        private SkinnableSound? sample;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
@@ -35,7 +30,7 @@ namespace osu.Game.Screens.Play
 
             RelativeSizeAxes = Axes.Both;
 
-            Children = new[]
+            Children = new Drawable[]
             {
                 leftFountain = new GameplayStarFountain
                 {
@@ -49,9 +44,8 @@ namespace osu.Game.Screens.Play
                     Origin = Anchor.BottomRight,
                     X = -75,
                 },
+                sample = new SkinnableSound(new SampleInfo("Gameplay/fountain-shoot"))
             };
-
-            sample = skin.GetSample(new SampleInfo(@"Gameplay/fountain-shoot"));
         }
 
         private bool isTriggered;
@@ -78,10 +72,7 @@ namespace osu.Game.Screens.Play
             leftFountain.Shoot(1);
             rightFountain.Shoot(-1);
 
-            // Track sample channel to avoid overlapping playback
-            sampleChannel?.Stop();
-            sampleChannel = sample?.GetChannel();
-            sampleChannel?.Play();
+            sample?.Play();
         }
 
         public partial class GameplayStarFountain : StarFountain

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.225.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.303.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.307.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
 - limits playback to the Argon skins by default (and any user skins that add a `fountain-shoot` sample)
 - prevents sample from firing at the menu, while the game is in the background

---

- [x] depends on ppy/osu-resources#358
- resolves #32258
- resolves (partially?) #32264