### PR TITLE
Ensure that star rating reprocessing does not incur online lookup requests

### DIFF
--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -160,7 +160,17 @@ namespace osu.Game.Database
             int processedCount = 0;
             int failedCount = 0;
 
-            foreach (var id in beatmapIds)
+            Dictionary<string, Ruleset> rulesetCache = new Dictionary<string, Ruleset>();
+
+            Ruleset getRuleset(RulesetInfo rulesetInfo)
+            {
+                if (!rulesetCache.TryGetValue(rulesetInfo.ShortName, out var ruleset))
+                    ruleset = rulesetCache[rulesetInfo.ShortName] = rulesetInfo.CreateInstance();
+
+                return ruleset;
+            }
+
+            foreach (Guid id in beatmapIds)
             {
                 if (notification?.State == ProgressNotificationState.Cancelled)
                     break;
@@ -179,7 +189,7 @@ namespace osu.Game.Database
                     try
                     {
                         var working = beatmapManager.GetWorkingBeatmap(beatmap);
-                        var ruleset = working.BeatmapInfo.Ruleset.CreateInstance();
+                        var ruleset = getRuleset(working.BeatmapInfo.Ruleset);
 
                         Debug.Assert(ruleset != null);
 


### PR DESCRIPTION
Yesterday after the lazer release there was a bit of a spike in the number of osu-web requests pointed at `/api/v2/beatmaps/lookup` specifically. The most likely reason for this is that prior to this commit, the star rating recalculation was fully performed by the `BeatmapUpdater.Process()` flow.

This process does full metadata lookups, and while it *will* attempt to use the local `online.db` metadata cache, it *will* also fall back to API requests if the local metadata fetch fails. While that means that the local cache likely saved us from a doomsday scenario here, it *also* is the case that all of that metadata lookup stuff is *entirely unnecessary* when wanting to just update star ratings.

Therefore, this splits out only the part relevant to star ratings as a separate background process, so that it can run completely locally.