### PR TITLE
Fix initial multiplayer room settings not applied

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -365,8 +365,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 updateRoomMaxParticipants();
                 updateRoomAutoStartDuration();
                 updateRoomPlaylist();
-
-                drawablePlaylist.Items.BindCollectionChanged((_, __) => room.Playlist = drawablePlaylist.Items.ToArray());
             }
 
             private void onRoomPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -470,6 +468,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 }
                 else
                 {
+                    room.Name = NameField.Text;
+                    room.Password = PasswordTextBox.Text;
+                    room.Type = TypePicker.Current.Value;
+                    room.QueueMode = QueueModeDropdown.Current.Value;
+                    room.AutoStartDuration = TimeSpan.FromSeconds((int)startModeDropdown.Current.Value);
+                    room.AutoSkip = AutoSkipCheckbox.Current.Value;
+                    room.Playlist = drawablePlaylist.Items.ToArray();
+
                     client.CreateRoom(room).ContinueWith(t => Schedule(() =>
                     {
                         if (t.IsCompletedSuccessfully)
@@ -505,10 +511,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     const string not_found_prefix = "beatmaps not found:";
 
                     if (message.StartsWith(not_found_prefix, StringComparison.Ordinal))
-                    {
                         ErrorText.Text = "The selected beatmap is not available online.";
-                        room.Playlist.SingleOrDefault()?.MarkInvalid();
-                    }
                     else
                         ErrorText.Text = message;
 


### PR DESCRIPTION
Removed the mark invalid thing (adds a red border around the playlist item), just to keep things consistent with `room.Playlist` now only being set during creation. The display was made more for playlists, but multiplayer only has one playlist item anyway.