### PR TITLE
Fix error message on invalid room password

### DIFF
--- a/osu.Game/Online/Multiplayer/InvalidPasswordException.cs
+++ b/osu.Game/Online/Multiplayer/InvalidPasswordException.cs
@@ -9,5 +9,9 @@ namespace osu.Game.Online.Multiplayer
     [Serializable]
     public class InvalidPasswordException : HubException
     {
+        public InvalidPasswordException()
+            : base("Invalid password")
+        {
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerLoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerLoungeSubScreen.cs
@@ -84,12 +84,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     onSuccess(room);
                 else
                 {
-                    const string message = "Failed to join multiplayer room.";
+                    Exception? exception = result.Exception?.AsSingular();
 
-                    if (result.Exception != null)
-                        Logger.Error(result.Exception, message);
-
-                    onFailure.Invoke(result.Exception?.AsSingular().Message ?? message);
+                    if (exception?.GetHubExceptionMessage() is string message)
+                        onFailure(message);
+                    else
+                    {
+                        const string generic_failure_message = "Failed to join multiplayer room.";
+                        if (result.Exception != null)
+                            Logger.Error(result.Exception, generic_failure_message);
+                        onFailure(generic_failure_message);
+                    }
                 }
             });
         }


### PR DESCRIPTION
This requires a new `osu-server-spectator` deploy due to the change in `InvalidPasswordException`.

Currently displays the default exception message ("failed to invoke JoinRoomWithPassword on server ...").