### PR TITLE
Allow grid spacing setting up to 256 pixels

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         public BindableFloat Spacing { get; } = new BindableFloat(4f)
         {
             MinValue = 4f,
-            MaxValue = 128f,
+            MaxValue = 256f,
             Precision = 0.01f,
         };
 


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/29713.

I think there's valid uses of this apart from just hiding (ie values between 128 and 256) so let's just get this in.