### PR TITLE
Disable user customisation of spectator list font / colour

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorList.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorList.cs
@@ -75,8 +75,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddRepeatStep("remove random user", () => ((ISpectatorClient)spectatorClient).UserEndedWatching(
                 spectatorClient.WatchingUsers[RNG.Next(spectatorClient.WatchingUsers.Count)].OnlineID), 5);
 
-            AddStep("change font to venera", () => list.Font.Value = Typeface.Venera);
-            AddStep("change font to torus", () => list.Font.Value = Typeface.Torus);
+            AddStep("change font to venera", () => list.HeaderFont.Value = Typeface.Venera);
+            AddStep("change font to torus", () => list.HeaderFont.Value = Typeface.Torus);
             AddStep("change header colour", () => list.HeaderColour.Value = new Colour4(RNG.NextSingle(), RNG.NextSingle(), RNG.NextSingle(), 1));
 
             AddStep("enter break", () => playingState.Value = LocalUserPlayingState.Break);

--- a/osu.Game/Screens/Play/HUD/SpectatorList.cs
+++ b/osu.Game/Screens/Play/HUD/SpectatorList.cs
@@ -13,12 +13,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
-using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Online.Chat;
 using osu.Game.Localisation.HUD;
-using osu.Game.Localisation.SkinComponents;
+using osu.Game.Online.Chat;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Spectator;
 using osu.Game.Skinning;
@@ -31,10 +29,7 @@ namespace osu.Game.Screens.Play.HUD
     {
         private const int max_spectators_displayed = 10;
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font), nameof(SkinnableComponentStrings.FontDescription))]
-        public Bindable<Typeface> Font { get; } = new Bindable<Typeface>(Typeface.Torus);
-
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.TextColour), nameof(SkinnableComponentStrings.TextColourDescription))]
+        public Bindable<Typeface> HeaderFont { get; } = new Bindable<Typeface>(Typeface.Torus);
         public BindableColour4 HeaderColour { get; } = new BindableColour4(Colour4.White);
 
         private BindableList<SpectatorUser> watchingUsers { get; } = new BindableList<SpectatorUser>();
@@ -97,7 +92,7 @@ namespace osu.Game.Screens.Play.HUD
             watchingUsers.BindCollectionChanged(onSpectatorsChanged, true);
             userPlayingState.BindValueChanged(_ => updateVisibility());
 
-            Font.BindValueChanged(_ => updateAppearance());
+            HeaderFont.BindValueChanged(_ => updateAppearance());
             HeaderColour.BindValueChanged(_ => updateAppearance(), true);
             FinishTransforms(true);
 
@@ -198,7 +193,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private void updateAppearance()
         {
-            header.Font = OsuFont.GetFont(Font.Value, 12, FontWeight.Bold);
+            header.Font = OsuFont.GetFont(HeaderFont.Value, 12, FontWeight.Bold);
             header.Colour = HeaderColour.Value;
 
             Width = header.DrawWidth;

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Skinning
 
                                 if (spectatorList != null)
                                 {
-                                    spectatorList.Font.Value = Typeface.Venera;
+                                    spectatorList.HeaderFont.Value = Typeface.Venera;
                                     spectatorList.HeaderColour.Value = new OsuColour().BlueLighter;
                                     spectatorList.Anchor = Anchor.BottomLeft;
                                     spectatorList.Origin = Anchor.BottomLeft;


### PR DESCRIPTION
It's all a bit weird so let's just disable it for now. For instance, this is exposed as "text" font / colour but only affects the header. Also, no other headers are cusotmisable in similar components.

Closes https://github.com/ppy/osu/issues/32275.