### PR TITLE
Make editor timeline HitObject blueprint better highlighted

### DIFF
--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// Whether this <see cref="SelectionBlueprint{T}"/> will be used as a preview or not.
         /// </summary>
-        public bool IsPreview { protected get; set; } = false;
+        public bool IsPreview { protected get; set; }
 
         protected SelectionBlueprint(T item)
         {

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -36,6 +36,11 @@ namespace osu.Game.Rulesets.Edit
         public override bool HandlePositionalInput => IsSelectable;
         public override bool RemoveWhenNotAlive => false;
 
+        /// <summary>
+        /// Whether this <see cref="SelectionBlueprint{T}"/> will be used as a preview or not.
+        /// </summary>
+        public bool IsPreview { protected get; set; } = false;
+
         protected SelectionBlueprint(T item)
         {
             Item = item;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 placementBlueprint = CreateBlueprintFor(obj.NewValue).AsNonNull();
 
-                placementBlueprint.Colour = OsuColour.Gray(0.9f);
+                placementBlueprint.IsPreview = true;
 
                 // TODO: this is out of order, causing incorrect stacking height.
                 SelectionBlueprints.Add(placementBlueprint);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -196,7 +196,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     break;
             }
 
-            if (IsSelected)
+            if (IsSelected || IsPreview)
                 border.Show();
             else
                 border.Hide();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cacbf887-598d-4708-855f-0fd3c936b3b2)

This PR makes the blueprint (in the timeline) of the hit object about to be placed better highlighted by showing the border around it instead of darkening it.
Closes #32317.