### PR TITLE
Fix edge cases which allow very short slider placement in editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
         {
             base.UpdateHitObjectFromPath(hitObject);
 
-            if (hitObject.Path.ControlPoints.Count <= 1 || !hitObject.Path.HasValidLength)
+            if (hitObject.Path.ControlPoints.Count <= 1 || !hitObject.Path.HasValidLengthForPlacement)
                 EditorBeatmap?.Remove(hitObject);
         }
     }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -484,7 +484,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             // Snap the path to the current beat divisor before checking length validity.
             hitObject.SnapTo(distanceSnapProvider);
 
-            if (!hitObject.Path.HasValidLength)
+            if (!hitObject.Path.HasValidLengthForPlacement)
             {
                 for (int i = 0; i < hitObject.Path.ControlPoints.Count; i++)
                     hitObject.Path.ControlPoints[i].Position = oldControlPoints[i];

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private readonly IncrementalBSplineBuilder bSplineBuilder = new IncrementalBSplineBuilder { Degree = 4 };
 
-        protected override bool IsValidForPlacement => HitObject.Path.HasValidLength;
+        protected override bool IsValidForPlacement => HitObject.Path.HasValidLengthForPlacement;
 
         public SliderPlacementBlueprint()
             : base(new Slider())

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -476,7 +476,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             HitObject.SnapTo(distanceSnapProvider);
 
             // If there are 0 or 1 remaining control points, or the slider has an invalid length, it is in a degenerate form and should be deleted
-            if (controlPoints.Count <= 1 || !HitObject.Path.HasValidLength)
+            if (controlPoints.Count <= 1 || !HitObject.Path.HasValidLengthForPlacement)
             {
                 placementHandler?.Delete(HitObject);
                 return;

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             Quad scaledQuad = GeometryUtils.GetSurroundingQuad(new OsuHitObject[] { slider });
             (bool xInBounds, bool yInBounds) = isQuadInBounds(scaledQuad);
 
-            if (xInBounds && yInBounds && slider.Path.HasValidLength)
+            if (xInBounds && yInBounds && slider.Path.HasValidLengthForPlacement)
                 return;
 
             for (int i = 0; i < slider.Path.ControlPoints.Count; i++)

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -31,7 +31,10 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         public readonly Bindable<double?> ExpectedDistance = new Bindable<double?>();
 
-        public bool HasValidLength => Precision.DefinitelyBigger(Distance, 0);
+        /// <summary>
+        /// Should be used to check whether placement can continue after a user editor operation.
+        /// </summary>
+        public bool HasValidLengthForPlacement => Precision.DefinitelyBigger(Distance, 0, 1);
 
         /// <summary>
         /// The control points of the path.

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -441,7 +441,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                     double lengthOfOneRepeat = repeatHitObject.Duration / (repeatHitObject.RepeatCount + 1);
                                     int proposedCount = Math.Max(0, (int)Math.Round(proposedDuration / lengthOfOneRepeat) - 1);
 
-                                    if (proposedCount == repeatHitObject.RepeatCount || Precision.AlmostEquals(lengthOfOneRepeat, 0))
+                                    if (proposedCount == repeatHitObject.RepeatCount || Precision.AlmostEquals(lengthOfOneRepeat, 0, 1))
                                         return;
 
                                     repeatHitObject.RepeatCount = proposedCount;


### PR DESCRIPTION
Could lead to a game crash.

---

Closes https://github.com/ppy/osu/issues/32295#issuecomment-2709707937.

Addresses both dragging for more repeats on the slider in the provided `.osu` file, as well as getting into that state in the first place.

https://github.com/user-attachments/assets/f7ca9b7e-562d-4bb2-80d2-443a26ba7415

