### PR TITLE
Ensure qualified beatmaps are never looked up on stale cache source

### DIFF
--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -277,7 +277,11 @@ namespace osu.Game.Beatmaps
                 FROM `osu_beatmaps` AS `b`
                 JOIN `osu_beatmapsets` AS `s` ON `s`.`beatmapset_id` = `b`.`beatmapset_id`
                 WHERE `b`.`checksum` = @MD5Hash OR `b`.`filename` = @Path
+                AND `b`.`approved` in (1, 2, 4)
                 """;
+            // approved conditional can theoretically be removed as it was fixed in
+            // https://github.com/ppy/osu-onlinedb-generator/commit/489ac000775c3ff63bc914efb83cad0f6fbde261
+            // but it's also safe to leave it (should not affect performance).
 
             cmd.Parameters.Add(new SqliteParameter(@"@MD5Hash", beatmapInfo.MD5Hash));
             cmd.Parameters.Add(new SqliteParameter(@"@Path", beatmapInfo.Path));

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -276,7 +276,7 @@ namespace osu.Game.Beatmaps
                 SELECT `b`.`beatmapset_id`, `b`.`beatmap_id`, `b`.`approved`, `b`.`user_id`, `b`.`checksum`, `b`.`last_update`, `s`.`submit_date`, `s`.`approved_date`
                 FROM `osu_beatmaps` AS `b`
                 JOIN `osu_beatmapsets` AS `s` ON `s`.`beatmapset_id` = `b`.`beatmapset_id`
-                WHERE `b`.`checksum` = @MD5Hash OR `b`.`filename` = @Path
+                WHERE (`b`.`checksum` = @MD5Hash OR `b`.`filename` = @Path)
                 AND `b`.`approved` in (1, 2, 4)
                 """;
             // approved conditional can theoretically be removed as it was fixed in


### PR DESCRIPTION
As [i proposed here](https://github.com/ppy/osu/issues/32320#issuecomment-2712823260).

I experimented with nuking the local database immediately, but this seems cleaner and less prone to fail.