### PR TITLE
Fix osu!taiko mobile scaling not being accurate

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Taiko.Beatmaps;
@@ -19,9 +18,6 @@ namespace osu.Game.Rulesets.Taiko.UI
         private const float stable_gamefield_height = 480f;
 
         public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
-
-        [Resolved]
-        private OsuGame? osuGame { get; set; }
 
         public TaikoPlayfieldAdjustmentContainer()
         {

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -60,19 +59,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Limit the maximum relative height of the playfield to one-third of available area to avoid it masking out on extreme resolutions.
             relativeHeight = Math.Min(relativeHeight, 1f / 3f);
 
-            Scale = new Vector2(Math.Max((Parent!.ChildSize.Y / 768f) * (relativeHeight / base_relative_height), 1f));
-
-            // on mobile platforms where the base aspect ratio is wider, the taiko playfield
-            // needs to be scaled down to remain playable.
-            if (RuntimeInfo.IsMobile && osuGame != null)
-            {
-                const float base_aspect_ratio = 1024f / 768f;
-                float gameAspectRatio = osuGame.ScalingContainerTargetDrawSize.X / osuGame.ScalingContainerTargetDrawSize.Y;
-                // this magic scale is unexplainable, but required so the playfield doesn't become too zoomed out as the aspect ratio increases.
-                const float magic_scale = 1.25f;
-                Scale *= magic_scale * new Vector2(base_aspect_ratio / gameAspectRatio);
-            }
-
+            Scale = new Vector2(Parent!.ChildSize.Y / 768f * (relativeHeight / base_relative_height));
             Width = 1 / Scale.X;
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/32147

This should mathematically bring osu!taiko scaling back to match previous releases. There isn't supposed to be manual handling for mobile in osu!taiko scaling logic since the container enforces the playfield to be agnostic to UI scaling ([by doing `Scaling = new Vector2(height / 768f)`](https://github.com/ppy/osu/blob/ad04b5b1af9b68dded95cb6fb6293fbdcf15d349/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs#L63)).

The actual reason why a difference occurred since the mobile scaling PR is because of the usage of the `max` function in the scale computation. When the aspect ratio in phones has been essentially adjusted from `1024/768` to `1024/474`, the taiko playfield is supposed to accommodate that by downscaling itself by `474/768` in [here](https://github.com/ppy/osu/blob/ad04b5b1af9b68dded95cb6fb6293fbdcf15d349/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs#L63) (`Parent!.ChildSize.Y = 474`). But due to the presence of the max function, no downscaling occurs, and the extra logic added in https://github.com/ppy/osu/pull/31968 is mathematically inaccurate (this explains why a magic constant was necessary).

TL;DR: osu!taiko should be fixed now, sorry for the long wait.