### PR TITLE
Improve handling for top-anchored judgement positions in osu!mania

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonJudgementPiece.cs
@@ -53,7 +53,11 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             }
         }
 
-        private void onDirectionChanged() => Y = direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position;
+        private void onDirectionChanged()
+        {
+            Anchor = direction.Value == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
+            Y = direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position;
+        }
 
         protected override SpriteText CreateJudgementText() =>
             new OsuSpriteText

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyManiaJudgementPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyManiaJudgementPiece.cs
@@ -24,7 +24,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
             this.result = result;
             this.animation = animation;
 
-            Anchor = Anchor.BottomCentre;
             Origin = Anchor.Centre;
 
             AutoSizeAxes = Axes.Both;
@@ -53,10 +52,18 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
             float hitPosition = skin.GetManiaSkinConfig<float>(LegacyManiaSkinConfigurationLookups.HitPosition)?.Value ?? 0;
             float scorePosition = skin.GetManiaSkinConfig<float>(LegacyManiaSkinConfigurationLookups.ScorePosition)?.Value ?? 0;
 
-            float absoluteHitPosition = 480f * LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR - hitPosition;
-            float finalPosition = scorePosition - absoluteHitPosition;
+            float hitPositionFromTop = 480f * LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR - hitPosition;
 
-            Y = direction.Value == ScrollingDirection.Up ? -finalPosition : finalPosition;
+            if (scorePosition > hitPositionFromTop / 2f)
+            {
+                Anchor = direction.Value == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
+                Y = direction.Value == ScrollingDirection.Up ? hitPositionFromTop - scorePosition : scorePosition - hitPositionFromTop;
+            }
+            else
+            {
+                Anchor = direction.Value == ScrollingDirection.Up ? Anchor.BottomCentre : Anchor.TopCentre;
+                Y = direction.Value == ScrollingDirection.Up ? -scorePosition : scorePosition;
+            }
         }
 
         public void PlayAnimation()

--- a/osu.Game.Rulesets.Mania/UI/DefaultManiaJudgementPiece.cs
+++ b/osu.Game.Rulesets.Mania/UI/DefaultManiaJudgementPiece.cs
@@ -29,7 +29,11 @@ namespace osu.Game.Rulesets.Mania.UI
             direction.BindValueChanged(_ => onDirectionChanged(), true);
         }
 
-        private void onDirectionChanged() => Y = direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position;
+        private void onDirectionChanged()
+        {
+            Anchor = direction.Value == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
+            Y = direction.Value == ScrollingDirection.Up ? -judgement_y_position : judgement_y_position;
+        }
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -3,30 +3,23 @@
 
 #nullable disable
 
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
     public partial class DrawableManiaJudgement : DrawableJudgement
     {
-        private IBindable<ScrollingDirection> direction;
-
-        [BackgroundDependencyLoader]
-        private void load(IScrollingInfo scrollingInfo)
+        public DrawableManiaJudgement()
         {
-            direction = scrollingInfo.Direction.GetBoundCopy();
-            direction.BindValueChanged(_ => onDirectionChanged(), true);
-        }
-
-        private void onDirectionChanged()
-        {
-            Anchor = direction.Value == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
-            Origin = Anchor.Centre;
+            // Extend the dimensions of this drawable to the entire parenting container.
+            // This allows skin implementations (i.e. LegacyManiaJudgementPiece) to freely choose the anchor based on skin settings.
+            Anchor = Anchor.TopLeft;
+            Origin = Anchor.TopLeft;
+            RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(1f);
         }
 
         protected override Drawable CreateDefaultJudgement(HitResult result) => new DefaultManiaJudgementPiece(result);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/32172

Preview:

https://github.com/user-attachments/assets/d4d11197-a696-4e0a-bbfc-dfe7967617f4

(notice when given `ScorePosition = 100`, the judgement is now anchored to the top rather than the bottom)