### PR TITLE
Make friends display respond to realtime user presence

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual.Online
             });
 
             waitForLoad();
-            assertPanels<UserPanel>(3);
+            assertVisiblePanelCount<UserPanel>(3);
 
             AddStep("remove one friend", () =>
             {
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.Online
             });
 
             waitForLoad();
-            assertPanels<UserPanel>(2);
+            assertVisiblePanelCount<UserPanel>(2);
 
             AddStep("add one friend", () =>
             {
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.Online
             });
 
             waitForLoad();
-            assertPanels<UserPanel>(3);
+            assertVisiblePanelCount<UserPanel>(3);
         }
 
         [Test]
@@ -110,17 +110,17 @@ namespace osu.Game.Tests.Visual.Online
             });
 
             waitForLoad();
-            assertPanels<UserGridPanel>(3);
+            assertVisiblePanelCount<UserGridPanel>(3);
 
             AddStep("set list style", () => this.ChildrenOfType<UserListToolbar>().Single().DisplayStyle.Value = OverlayPanelDisplayStyle.List);
 
             waitForLoad();
-            assertPanels<UserListPanel>(3);
+            assertVisiblePanelCount<UserListPanel>(3);
 
             AddStep("set brick style", () => this.ChildrenOfType<UserListToolbar>().Single().DisplayStyle.Value = OverlayPanelDisplayStyle.Brick);
 
             waitForLoad();
-            assertPanels<UserBrickPanel>(3);
+            assertVisiblePanelCount<UserBrickPanel>(3);
         }
 
         [Test]
@@ -139,10 +139,10 @@ namespace osu.Game.Tests.Visual.Online
             });
 
             waitForLoad();
-            assertPanels<UserPanel>(3);
+            assertVisiblePanelCount<UserPanel>(3);
 
             AddStep("change to online stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.Online);
-            assertPanels<UserPanel>(0);
+            assertVisiblePanelCount<UserPanel>(0);
 
             AddStep("bring a friend online", () =>
             {
@@ -150,10 +150,10 @@ namespace osu.Game.Tests.Visual.Online
                 metadataClient.FriendPresenceUpdated(api.Friends[0].TargetID, new UserPresence { Status = UserStatus.Online });
             });
 
-            assertPanels<UserPanel>(1);
+            assertVisiblePanelCount<UserPanel>(1);
 
             AddStep("change to offline stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.Offline);
-            assertPanels<UserPanel>(2);
+            assertVisiblePanelCount<UserPanel>(2);
 
             AddStep("bring a friend online", () =>
             {
@@ -161,13 +161,20 @@ namespace osu.Game.Tests.Visual.Online
                 metadataClient.FriendPresenceUpdated(api.Friends[1].TargetID, new UserPresence { Status = UserStatus.Online });
             });
 
-            assertPanels<UserPanel>(1);
+            assertVisiblePanelCount<UserPanel>(1);
 
             AddStep("change to online stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.Online);
-            assertPanels<UserPanel>(2);
+            assertVisiblePanelCount<UserPanel>(2);
+
+            AddStep("take friend offline", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                metadataClient.FriendPresenceUpdated(api.Friends[1].TargetID, null);
+            });
+            assertVisiblePanelCount<UserPanel>(1);
 
             AddStep("change to all stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.All);
-            assertPanels<UserPanel>(3);
+            assertVisiblePanelCount<UserPanel>(3);
         }
 
         [Test]
@@ -207,13 +214,13 @@ namespace osu.Game.Tests.Visual.Online
             });
 
             waitForLoad();
-            assertPanels<UserPanel>(3);
+            assertVisiblePanelCount<UserPanel>(3);
         }
 
         private void waitForLoad()
             => AddUntilStep("wait for panels to load", () => this.ChildrenOfType<LoadingSpinner>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
 
-        private void assertPanels<T>(int expectedVisible)
+        private void assertVisiblePanelCount<T>(int expectedVisible)
             where T : UserPanel
         {
             AddAssert($"{typeof(T).ReadableName()}s in list", () => this.ChildrenOfType<FriendsList>().Last().ChildrenOfType<UserPanel>().All(p => p is T));

--- a/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
@@ -5,46 +5,179 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Metadata;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dashboard.Friends;
+using osu.Game.Tests.Visual.Metadata;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
     public partial class TestSceneFriendDisplay : OsuTestScene
     {
-        protected override bool UseOnlineAPI => true;
-
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
-        private FriendDisplay display;
+        private TestMetadataClient metadataClient;
 
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            Child = new BasicScrollContainer
+            Child = new DependencyProvidingContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = display = new FriendDisplay()
+                CachedDependencies =
+                [
+                    (typeof(MetadataClient), metadataClient = new TestMetadataClient())
+                ],
+                Children = new Drawable[]
+                {
+                    metadataClient,
+                    new BasicScrollContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new FriendDisplay()
+                    }
+                }
             };
         });
 
         [Test]
-        public void TestOffline()
+        public void TestAddAndRemoveFriends()
         {
-            // AddStep("Populate with offline test users", () => display.Users = getUsers());
+            AddStep("set friends", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.Clear();
+                api.Friends.AddRange(getUsers().Select(u => new APIRelation
+                {
+                    RelationType = RelationType.Friend,
+                    TargetID = u.OnlineID,
+                    TargetUser = u
+                }));
+            });
+
+            waitForLoad(3);
+
+            AddStep("remove one friend", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.RemoveAt(0);
+            });
+
+            waitForLoad(2);
+
+            AddStep("add one friend", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.AddRange(getUsers().Take(1).Select(u => new APIRelation
+                {
+                    RelationType = RelationType.Friend,
+                    TargetID = u.OnlineID,
+                    TargetUser = u
+                }));
+            });
+
+            waitForLoad(3);
+
+            void waitForLoad(int expectedPanels)
+            {
+                AddUntilStep("wait for friends to load", () => this.ChildrenOfType<FriendsList>().LastOrDefault()?.IsLoaded == true);
+                AddAssert($"{expectedPanels} panels in list", () => this.ChildrenOfType<FriendsList>().Last().ChildrenOfType<UserPanel>().Count(), () => Is.EqualTo(expectedPanels));
+            }
         }
 
         [Test]
-        public void TestOnline()
+        public void TestChangeDisplayStyle()
         {
-            // No need to do anything, fetch is performed automatically.
+            AddStep("set friends", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.Clear();
+                api.Friends.AddRange(getUsers().Select(u => new APIRelation
+                {
+                    RelationType = RelationType.Friend,
+                    TargetID = u.OnlineID,
+                    TargetUser = u
+                }));
+            });
+
+            waitForLoad<UserGridPanel>();
+
+            AddStep("set list style", () => this.ChildrenOfType<UserListToolbar>().Single().DisplayStyle.Value = OverlayPanelDisplayStyle.List);
+            waitForLoad<UserListPanel>();
+
+            AddStep("set brick style", () => this.ChildrenOfType<UserListToolbar>().Single().DisplayStyle.Value = OverlayPanelDisplayStyle.Brick);
+            waitForLoad<UserBrickPanel>();
+
+            void waitForLoad<T>()
+            {
+                AddUntilStep("wait for friends to load", () => this.ChildrenOfType<FriendsList>().LastOrDefault()?.IsLoaded == true);
+                AddAssert($"3 {typeof(T).ReadableName()} in list", () => this.ChildrenOfType<FriendsList>().Last().ChildrenOfType<T>().Count(), () => Is.EqualTo(3));
+            }
+        }
+
+        [Test]
+        public void TestOnlinePresence()
+        {
+            AddStep("set friends", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.Clear();
+                api.Friends.AddRange(getUsers().Select(u => new APIRelation
+                {
+                    RelationType = RelationType.Friend,
+                    TargetID = u.OnlineID,
+                    TargetUser = u
+                }));
+            });
+
+            AddUntilStep("wait for friends to load", () => this.ChildrenOfType<FriendsList>().LastOrDefault()?.IsLoaded == true);
+            assertVisible(3);
+
+            AddStep("change to online stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.Online);
+            assertVisible(0);
+
+            AddStep("bring a friend online", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                metadataClient.FriendPresenceUpdated(api.Friends[0].TargetID, new UserPresence { Status = UserStatus.Online });
+            });
+
+            assertVisible(1);
+
+            AddStep("change to offline stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.Offline);
+            assertVisible(2);
+
+            AddStep("bring a friend online", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                metadataClient.FriendPresenceUpdated(api.Friends[1].TargetID, new UserPresence { Status = UserStatus.Online });
+            });
+
+            assertVisible(1);
+
+            AddStep("change to online stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.Online);
+            assertVisible(2);
+
+            AddStep("change to all stream", () => this.ChildrenOfType<FriendOnlineStreamControl>().Single().Current.Value = OnlineStatus.All);
+            assertVisible(3);
+
+            void assertVisible(int expectedPanels)
+            {
+                AddAssert($"{expectedPanels} panels visible",
+                    () => this.ChildrenOfType<FriendsList.FilterableUserPanel>().Count(p => p.Alpha > 0),
+                    () => Is.EqualTo(expectedPanels));
+            }
         }
 
         private List<APIUser> getUsers() => new List<APIUser>

--- a/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestOffline()
         {
-            AddStep("Populate with offline test users", () => display.Users = getUsers());
+            // AddStep("Populate with offline test users", () => display.Users = getUsers());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFriendsOnlineStatusControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFriendsOnlineStatusControl.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Metadata;
@@ -73,7 +72,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
         }
 
-        [Solo]
         [Test]
         public void TestChangeOnlineStates()
         {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFriendsOnlineStatusControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFriendsOnlineStatusControl.cs
@@ -1,11 +1,18 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Metadata;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dashboard.Friends;
+using osu.Game.Tests.Visual.Metadata;
+using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -14,14 +21,91 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
+        private TestMetadataClient metadataClient = null!;
+
         [SetUp]
-        public void SetUp() => Schedule(() => Child = new FriendOnlineStreamControl
+        public void SetUp() => Schedule(() =>
         {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            CountAll = { Value = 15 },
-            CountOnline = { Value = 10 },
-            CountOffline = { Value = 5 }
+            Child = new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies =
+                [
+                    (typeof(MetadataClient), metadataClient = new TestMetadataClient())
+                ],
+                Children = new Drawable[]
+                {
+                    metadataClient,
+                    new FriendOnlineStreamControl
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                }
+            };
         });
+
+        [Test]
+        public void TestChangeFriends()
+        {
+            AddStep("set 10 friends", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.Clear();
+                api.Friends.AddRange(Enumerable.Range(1, 10).Select(i => new APIRelation
+                {
+                    RelationType = RelationType.Friend,
+                    TargetID = i,
+                    TargetUser = new APIUser { Id = i },
+                }));
+            });
+
+            AddStep("set 20 friends", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.Clear();
+                api.Friends.AddRange(Enumerable.Range(1, 20).Select(i => new APIRelation
+                {
+                    RelationType = RelationType.Friend,
+                    TargetID = i,
+                    TargetUser = new APIUser { Id = i },
+                }));
+            });
+        }
+
+        [Solo]
+        [Test]
+        public void TestChangeOnlineStates()
+        {
+            AddStep("set 10 friends", () =>
+            {
+                DummyAPIAccess api = (DummyAPIAccess)API;
+                api.Friends.Clear();
+                api.Friends.AddRange(Enumerable.Range(1, 10).Select(i => new APIRelation
+                {
+                    RelationType = RelationType.Friend,
+                    TargetID = i,
+                    TargetUser = new APIUser { Id = i },
+                }));
+            });
+
+            AddStep("make users 1-5 online", () =>
+            {
+                for (int i = 1; i <= 5; i++)
+                    metadataClient.FriendPresenceUpdated(i, new UserPresence { Status = UserStatus.Online });
+            });
+
+            AddStep("make users 1-5 DnD", () =>
+            {
+                for (int i = 1; i <= 5; i++)
+                    metadataClient.FriendPresenceUpdated(i, new UserPresence { Status = UserStatus.DoNotDisturb });
+            });
+
+            AddStep("make users 1-5 offline", () =>
+            {
+                for (int i = 1; i <= 5; i++)
+                    metadataClient.FriendPresenceUpdated(i, null);
+            });
+        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFriendsOnlineStatusControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFriendsOnlineStatusControl.cs
@@ -1,14 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dashboard.Friends;
 
@@ -19,37 +14,14 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
-        private FriendOnlineStreamControl control;
-
         [SetUp]
-        public void SetUp() => Schedule(() => Child = control = new FriendOnlineStreamControl
+        public void SetUp() => Schedule(() => Child = new FriendOnlineStreamControl
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
+            CountAll = { Value = 15 },
+            CountOnline = { Value = 10 },
+            CountOffline = { Value = 5 }
         });
-
-        [Test]
-        public void Populate()
-        {
-            AddStep("Populate", () => control.Populate(new List<APIUser>
-            {
-                new APIUser
-                {
-                    IsOnline = true
-                },
-                new APIUser
-                {
-                    IsOnline = false
-                },
-                new APIUser
-                {
-                    IsOnline = false
-                }
-            }));
-
-            AddAssert("3 users", () => control.Items.FirstOrDefault(item => item.Status == OnlineStatus.All)?.Count == 3);
-            AddAssert("1 online user", () => control.Items.FirstOrDefault(item => item.Status == OnlineStatus.Online)?.Count == 1);
-            AddAssert("2 offline users", () => control.Items.FirstOrDefault(item => item.Status == OnlineStatus.Offline)?.Count == 2);
-        }
     }
 }

--- a/osu.Game/Overlays/Changelog/ChangelogUpdateStreamItem.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogUpdateStreamItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Humanizer;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -18,13 +16,11 @@ namespace osu.Game.Overlays.Changelog
         {
             if (stream.IsFeatured)
                 Width *= 2;
+
+            MainText = Value.DisplayName;
+            AdditionalText = Value.LatestBuild.DisplayVersion;
+            InfoText = Value.UserCount > 0 ? $"{"user".ToQuantity(Value.UserCount, "N0")} online" : default(LocalisableString);
         }
-
-        protected override LocalisableString MainText => Value.DisplayName;
-
-        protected override LocalisableString AdditionalText => Value.LatestBuild.DisplayVersion;
-
-        protected override LocalisableString InfoText => Value.UserCount > 0 ? $"{"user".ToQuantity(Value.UserCount, "N0")} online" : null;
 
         protected override Color4 GetBarColour(OsuColour colours) => Value.Colour;
     }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
             apiFriends.BindTo(api.Friends);
             apiFriends.BindCollectionChanged((_, _) => reloadList());
 
-            userListToolbar.DisplayStyle.BindValueChanged(_ => reloadList());
+            userListToolbar.DisplayStyle.BindValueChanged(_ => reloadList(), true);
         }
 
         private void reloadList()

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -1,21 +1,19 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
-using System.Threading;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Metadata;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using osuTK;
@@ -24,32 +22,22 @@ namespace osu.Game.Overlays.Dashboard.Friends
 {
     public partial class FriendDisplay : CompositeDrawable
     {
-        private List<APIUser> users = new List<APIUser>();
-
-        public List<APIUser> Users
-        {
-            get => users;
-            set
-            {
-                users = value;
-                onlineStreamControl.Populate(value);
-            }
-        }
-
-        private CancellationTokenSource cancellationToken;
-
-        [CanBeNull]
-        private SearchContainer currentContent;
-
-        private FriendOnlineStreamControl onlineStreamControl;
-        private Box background;
-        private Box controlBackground;
-        private UserListToolbar userListToolbar;
-        private Container itemsPlaceholder;
-        private LoadingLayer loading;
-        private BasicSearchTextBox searchTextBox;
-
         private readonly IBindableList<APIRelation> apiFriends = new BindableList<APIRelation>();
+        private readonly IBindableDictionary<int, UserPresence> friendPresences = new BindableDictionary<int, UserPresence>();
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private MetadataClient metadataClient { get; set; } = null!;
+
+        private FriendOnlineStreamControl streamControl = null!;
+        private Box background = null!;
+        private Box controlBackground = null!;
+        private UserListToolbar userListToolbar = null!;
+        private LoadingLayer loading = null!;
+        private BasicSearchTextBox searchTextBox = null!;
+        private FriendsSearchContainer panelsContainer = null!;
 
         public FriendDisplay()
         {
@@ -57,8 +45,8 @@ namespace osu.Game.Overlays.Dashboard.Friends
             AutoSizeAxes = Axes.Y;
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(OverlayColourProvider colourProvider, IAPIProvider api)
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
         {
             InternalChild = new FillFlowContainer
             {
@@ -86,7 +74,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                                     Top = 20,
                                     Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING - FriendsOnlineStatusItem.PADDING
                                 },
-                                Child = onlineStreamControl = new FriendOnlineStreamControl(),
+                                Child = streamControl = new FriendOnlineStreamControl(),
                             }
                         }
                     },
@@ -157,11 +145,14 @@ namespace osu.Game.Overlays.Dashboard.Friends
                                         AutoSizeAxes = Axes.Y,
                                         Children = new Drawable[]
                                         {
-                                            itemsPlaceholder = new Container
+                                            panelsContainer = new FriendsSearchContainer
                                             {
                                                 RelativeSizeAxes = Axes.X,
                                                 AutoSizeAxes = Axes.Y,
-                                                Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING }
+                                                Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
+                                                // Todo: Spacing = new Vector2(style == OverlayPanelDisplayStyle.Card ? 10 : 2),
+                                                Spacing = new Vector2(10),
+                                                SortCriteria = { BindTarget = userListToolbar.SortCriteria }
                                             },
                                             loading = new LoadingLayer(true)
                                         }
@@ -175,127 +166,180 @@ namespace osu.Game.Overlays.Dashboard.Friends
 
             background.Colour = colourProvider.Background4;
             controlBackground.Colour = colourProvider.Background5;
-
-            apiFriends.BindTo(api.Friends);
-            apiFriends.BindCollectionChanged((_, _) => Schedule(() => Users = apiFriends.Select(f => f.TargetUser).ToList()), true);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            onlineStreamControl.Current.BindValueChanged(_ => recreatePanels());
-            userListToolbar.DisplayStyle.BindValueChanged(_ => recreatePanels());
-            userListToolbar.SortCriteria.BindValueChanged(_ => recreatePanels());
-            searchTextBox.Current.BindValueChanged(_ =>
-            {
-                if (currentContent.IsNotNull())
-                    currentContent.SearchTerm = searchTextBox.Current.Value;
-            });
+            apiFriends.BindTo(api.Friends);
+            apiFriends.BindCollectionChanged(onFriendsChanged, true);
+
+            friendPresences.BindTo(metadataClient.FriendPresences);
+            friendPresences.BindCollectionChanged(onFriendPresencesChanged, true);
+
+            searchTextBox.Current.BindValueChanged(onSearchChanged);
+            streamControl.Current.BindValueChanged(onFriendsStreamChanged);
         }
 
-        private void recreatePanels()
+        private void onFriendsChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            if (!users.Any())
-                return;
-
-            cancellationToken?.Cancel();
-
-            if (itemsPlaceholder.Any())
-                loading.Show();
-
-            var sortedUsers = sortUsers(getUsersInCurrentGroup());
-
-            LoadComponentAsync(createTable(sortedUsers), addContentToPlaceholder, (cancellationToken = new CancellationTokenSource()).Token);
-        }
-
-        private List<APIUser> getUsersInCurrentGroup()
-        {
-            switch (onlineStreamControl.Current.Value?.Status)
+            switch (e.Action)
             {
-                default:
-                case OnlineStatus.All:
-                    return users;
-
-                case OnlineStatus.Offline:
-                    return users.Where(u => !u.IsOnline).ToList();
-
-                case OnlineStatus.Online:
-                    return users.Where(u => u.IsOnline).ToList();
-            }
-        }
-
-        private void addContentToPlaceholder(SearchContainer content)
-        {
-            loading.Hide();
-
-            var lastContent = currentContent;
-
-            if (lastContent != null)
-            {
-                lastContent.FadeOut(100, Easing.OutQuint).Expire();
-                lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y);
-            }
-
-            itemsPlaceholder.Add(currentContent = content);
-            currentContent.FadeIn(200, Easing.OutQuint);
-        }
-
-        private SearchContainer createTable(List<APIUser> users)
-        {
-            var style = userListToolbar.DisplayStyle.Value;
-
-            return new SearchContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Spacing = new Vector2(style == OverlayPanelDisplayStyle.Card ? 10 : 2),
-                Children = users.Select(u => createUserPanel(u, style)).ToList(),
-                SearchTerm = searchTextBox.Current.Value,
-            };
-        }
-
-        private UserPanel createUserPanel(APIUser user, OverlayPanelDisplayStyle style)
-        {
-            switch (style)
-            {
-                default:
-                case OverlayPanelDisplayStyle.Card:
-                    return new UserGridPanel(user).With(panel =>
+                case NotifyCollectionChangedAction.Add:
+                    foreach (APIRelation relation in e.NewItems!.OfType<APIRelation>())
                     {
-                        panel.Anchor = Anchor.TopCentre;
-                        panel.Origin = Anchor.TopCentre;
-                        panel.Width = 290;
-                    });
+                        panelsContainer.Add(new FilterableUserPanel(new UserGridPanel(relation.TargetUser!).With(panel =>
+                        {
+                            panel.Anchor = Anchor.TopCentre;
+                            panel.Origin = Anchor.TopCentre;
+                            panel.Width = 290;
+                        })));
+                    }
 
-                case OverlayPanelDisplayStyle.List:
-                    return new UserListPanel(user);
+                    break;
 
-                case OverlayPanelDisplayStyle.Brick:
-                    return new UserBrickPanel(user);
+                case NotifyCollectionChangedAction.Remove:
+                    foreach (APIRelation relation in e.OldItems!.OfType<APIRelation>())
+                        panelsContainer.RemoveAll(panel => panel.User.Equals(relation.TargetUser), true);
+
+                    break;
             }
+
+            updateStatusCounts();
         }
 
-        private List<APIUser> sortUsers(List<APIUser> unsorted)
+        private void onFriendPresencesChanged(object? sender, NotifyDictionaryChangedEventArgs<int, UserPresence> e)
         {
-            switch (userListToolbar.SortCriteria.Value)
+            switch (e.Action)
             {
-                default:
-                case UserSortCriteria.LastVisit:
-                    return unsorted.OrderByDescending(u => u.LastVisit).ToList();
-
-                case UserSortCriteria.Rank:
-                    return unsorted.OrderByDescending(u => u.Statistics.GlobalRank.HasValue).ThenBy(u => u.Statistics.GlobalRank ?? 0).ToList();
-
-                case UserSortCriteria.Username:
-                    return unsorted.OrderBy(u => u.Username).ToList();
+                case NotifyDictionaryChangedAction.Add:
+                case NotifyDictionaryChangedAction.Remove:
+                    updatePanelVisibilities();
+                    updateStatusCounts();
+                    break;
             }
         }
 
-        protected override void Dispose(bool isDisposing)
+        private void onFriendsStreamChanged(ValueChangedEvent<OnlineStatus> stream)
         {
-            cancellationToken?.Cancel();
-            base.Dispose(isDisposing);
+            updatePanelVisibilities();
+        }
+
+        private void onSearchChanged(ValueChangedEvent<string> search)
+        {
+            panelsContainer.SearchTerm = search.NewValue;
+        }
+
+        private void updatePanelVisibilities()
+        {
+            foreach (var panel in panelsContainer)
+            {
+                switch (streamControl.Current.Value)
+                {
+                    case OnlineStatus.All:
+                        panel.CanBeShown.Value = true;
+                        break;
+
+                    case OnlineStatus.Online:
+                        panel.CanBeShown.Value = friendPresences.ContainsKey(panel.User.OnlineID);
+                        break;
+
+                    case OnlineStatus.Offline:
+                        panel.CanBeShown.Value = !friendPresences.ContainsKey(panel.User.OnlineID);
+                        break;
+                }
+            }
+        }
+
+        private void updateStatusCounts()
+        {
+            int countOnline = 0;
+            int countOffline = 0;
+
+            foreach (var user in apiFriends)
+            {
+                if (friendPresences.TryGetValue(user.TargetID, out _))
+                    countOnline++;
+                else
+                    countOffline++;
+            }
+
+            streamControl.CountAll.Value = apiFriends.Count;
+            streamControl.CountOnline.Value = countOnline;
+            streamControl.CountOffline.Value = countOffline;
+        }
+
+        private class FriendsSearchContainer : SearchContainer<FilterableUserPanel>
+        {
+            public readonly IBindable<UserSortCriteria> SortCriteria = new Bindable<UserSortCriteria>();
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                SortCriteria.BindValueChanged(_ => InvalidateLayout(), true);
+            }
+
+            public override IEnumerable<Drawable> FlowingChildren
+            {
+                get
+                {
+                    IEnumerable<FilterableUserPanel> panels = base.FlowingChildren.OfType<FilterableUserPanel>();
+
+                    switch (SortCriteria.Value)
+                    {
+                        default:
+                        case UserSortCriteria.LastVisit:
+                            return panels.OrderByDescending(panel => panel.User.LastVisit);
+
+                        case UserSortCriteria.Rank:
+                            return panels.OrderByDescending(panel => panel.User.Statistics.GlobalRank.HasValue).ThenBy(panel => panel.User.Statistics.GlobalRank ?? 0);
+
+                        case UserSortCriteria.Username:
+                            return panels.OrderBy(panel => panel.User.Username);
+                    }
+                }
+            }
+        }
+
+        private class FilterableUserPanel : CompositeDrawable, IConditionalFilterable
+        {
+            public readonly Bindable<bool> CanBeShown = new Bindable<bool>();
+
+            public APIUser User => panel.User;
+
+            private readonly UserPanel panel;
+
+            public FilterableUserPanel(UserPanel panel)
+            {
+                this.panel = panel;
+
+                Anchor = panel.Anchor;
+                Origin = panel.Origin;
+                RelativeSizeAxes = panel.RelativeSizeAxes;
+                AutoSizeAxes = panel.AutoSizeAxes;
+                Width = panel.Width;
+                Height = panel.Height;
+
+                InternalChild = panel;
+            }
+
+            IBindable<bool> IConditionalFilterable.CanBeShown => CanBeShown;
+
+            IEnumerable<LocalisableString> IHasFilterTerms.FilterTerms => panel.FilterTerms;
+
+            bool IFilterable.MatchingFilter
+            {
+                set
+                {
+                    if (value)
+                        Show();
+                    else
+                        Hide();
+                }
+            }
+
+            bool IFilterable.FilteringActive { set { } }
         }
     }
 }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -198,5 +198,13 @@ namespace osu.Game.Overlays.Dashboard.Friends
                 newList.FadeIn(200, Easing.OutQuint);
             }
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            listLoadCancellation?.Cancel();
+            listLoadCancellation?.Dispose();
+        }
     }
 }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -260,7 +260,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
 
             foreach (var user in apiFriends)
             {
-                if (friendPresences.TryGetValue(user.TargetID, out _))
+                if (friendPresences.ContainsKey(user.TargetID))
                     countOnline++;
                 else
                     countOffline++;

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -206,6 +206,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                     break;
             }
 
+            updatePanelVisibilities();
             updateStatusCounts();
         }
 

--- a/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
@@ -2,15 +2,28 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Metadata;
+using osu.Game.Users;
 
 namespace osu.Game.Overlays.Dashboard.Friends
 {
     public partial class FriendOnlineStreamControl : OverlayStreamControl<OnlineStatus>
     {
-        public readonly BindableInt CountAll = new BindableInt();
-        public readonly BindableInt CountOnline = new BindableInt();
-        public readonly BindableInt CountOffline = new BindableInt();
+        private readonly IBindableDictionary<int, UserPresence> friendPresences = new BindableDictionary<int, UserPresence>();
+        private readonly IBindableList<APIRelation> apiFriends = new BindableList<APIRelation>();
+        private readonly BindableInt countAll = new BindableInt();
+        private readonly BindableInt countOnline = new BindableInt();
+        private readonly BindableInt countOffline = new BindableInt();
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private MetadataClient metadataClient { get; set; } = null!;
 
         public FriendOnlineStreamControl()
         {
@@ -22,18 +35,57 @@ namespace osu.Game.Overlays.Dashboard.Friends
             ];
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            apiFriends.BindTo(api.Friends);
+            apiFriends.BindCollectionChanged((_, _) => updateCounts());
+
+            friendPresences.BindTo(metadataClient.FriendPresences);
+            friendPresences.BindCollectionChanged(onFriendPresencesChanged);
+
+            updateCounts();
+        }
+
+        private void onFriendPresencesChanged(object? sender, NotifyDictionaryChangedEventArgs<int, UserPresence> e)
+        {
+            switch (e.Action)
+            {
+                case NotifyDictionaryChangedAction.Add:
+                case NotifyDictionaryChangedAction.Remove:
+                    updateCounts();
+                    break;
+            }
+        }
+
+        private void updateCounts()
+        {
+            countAll.Value = apiFriends.Count;
+            countOnline.Value = 0;
+            countOffline.Value = 0;
+
+            foreach (var user in apiFriends)
+            {
+                if (friendPresences.ContainsKey(user.TargetID))
+                    countOnline.Value++;
+                else
+                    countOffline.Value++;
+            }
+        }
+
         protected override OverlayStreamItem<OnlineStatus> CreateStreamItem(OnlineStatus value)
         {
             switch (value)
             {
                 case OnlineStatus.All:
-                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = CountAll } };
+                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = countAll } };
 
                 case OnlineStatus.Online:
-                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = CountOnline } };
+                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = countOnline } };
 
                 case OnlineStatus.Offline:
-                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = CountOffline } };
+                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = countOffline } };
 
                 default:
                     throw new ArgumentException(nameof(value));

--- a/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
@@ -1,30 +1,43 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System.Collections.Generic;
-using System.Linq;
-using osu.Game.Online.API.Requests.Responses;
+using System;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Overlays.Dashboard.Friends
 {
-    public partial class FriendOnlineStreamControl : OverlayStreamControl<FriendStream>
+    public partial class FriendOnlineStreamControl : OverlayStreamControl<OnlineStatus>
     {
-        protected override OverlayStreamItem<FriendStream> CreateStreamItem(FriendStream value) => new FriendsOnlineStatusItem(value);
+        public readonly BindableInt CountAll = new BindableInt();
+        public readonly BindableInt CountOnline = new BindableInt();
+        public readonly BindableInt CountOffline = new BindableInt();
 
-        public void Populate(List<APIUser> users)
+        public FriendOnlineStreamControl()
         {
-            Clear();
+            Items =
+            [
+                OnlineStatus.All,
+                OnlineStatus.Online,
+                OnlineStatus.Offline
+            ];
+        }
 
-            int userCount = users.Count;
-            int onlineUsersCount = users.Count(user => user.IsOnline);
+        protected override OverlayStreamItem<OnlineStatus> CreateStreamItem(OnlineStatus value)
+        {
+            switch (value)
+            {
+                case OnlineStatus.All:
+                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = CountAll } };
 
-            AddItem(new FriendStream(OnlineStatus.All, userCount));
-            AddItem(new FriendStream(OnlineStatus.Online, onlineUsersCount));
-            AddItem(new FriendStream(OnlineStatus.Offline, userCount - onlineUsersCount));
+                case OnlineStatus.Online:
+                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = CountOnline } };
 
-            Current.Value = Items.FirstOrDefault();
+                case OnlineStatus.Offline:
+                    return new FriendsOnlineStatusItem(value) { UserCount = { BindTarget = CountOffline } };
+
+                default:
+                    throw new ArgumentException(nameof(value));
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendStream.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendStream.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
+
 namespace osu.Game.Overlays.Dashboard.Friends
 {
     public class FriendStream
     {
-        public OnlineStatus Status { get; }
+        public readonly BindableInt UserCount = new BindableInt();
+        public readonly OnlineStatus Status;
 
-        public int Count { get; }
-
-        public FriendStream(OnlineStatus status, int count)
+        public FriendStream(OnlineStatus status)
         {
             Status = status;
-            Count = count;
         }
     }
 }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
             }
         }
 
-        private class FilterableUserPanel : CompositeDrawable, IConditionalFilterable
+        public class FilterableUserPanel : CompositeDrawable, IConditionalFilterable
         {
             public readonly Bindable<bool> CanBeShown = new Bindable<bool>();
 

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
@@ -152,9 +152,11 @@ namespace osu.Game.Overlays.Dashboard.Friends
                     {
                         default:
                         case UserSortCriteria.LastVisit:
+                            // Todo: Last visit time is not currently updated according to realtime user presence.
                             return panels.OrderByDescending(panel => panel.User.LastVisit);
 
                         case UserSortCriteria.Rank:
+                            // Todo: Statistics are not currently updated according to realtime user statistics, but it's also not currently displayed in the panels.
                             return panels.OrderByDescending(panel => panel.User.Statistics.GlobalRank.HasValue).ThenBy(panel => panel.User.Statistics.GlobalRank ?? 0);
 
                         case UserSortCriteria.Username:

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
             base.LoadComplete();
 
             friendPresences.BindTo(metadataClient.FriendPresences);
-            friendPresences.BindCollectionChanged(onFriendPresencesChanged, true);
+            friendPresences.BindCollectionChanged(onFriendPresencesChanged);
 
             SearchText.BindValueChanged(onSearchTextChanged, true);
             OnlineStream.BindValueChanged(onFriendsStreamChanged, true);

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
@@ -47,7 +47,6 @@ namespace osu.Game.Overlays.Dashboard.Friends
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
                 Spacing = new Vector2(style == OverlayPanelDisplayStyle.Card ? 10 : 2),
                 SortCriteria = { BindTarget = SortCriteria },
                 ChildrenEnumerable = friends.Select(createUserPanel)

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
@@ -16,7 +16,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.Dashboard.Friends
 {
-    public class FriendsList : CompositeDrawable
+    public partial class FriendsList : CompositeDrawable
     {
         public readonly IBindable<OnlineStatus> OnlineStream = new Bindable<OnlineStatus>();
         public readonly IBindable<UserSortCriteria> SortCriteria = new Bindable<UserSortCriteria>();
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
             return new FilterableUserPanel(panel);
         }
 
-        private class FriendsSearchContainer : SearchContainer<FilterableUserPanel>
+        private partial class FriendsSearchContainer : SearchContainer<FilterableUserPanel>
         {
             public readonly IBindable<UserSortCriteria> SortCriteria = new Bindable<UserSortCriteria>();
 
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
             }
         }
 
-        public class FilterableUserPanel : CompositeDrawable, IConditionalFilterable
+        public partial class FilterableUserPanel : CompositeDrawable, IConditionalFilterable
         {
             public readonly Bindable<bool> CanBeShown = new Bindable<bool>();
 

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsList.cs
@@ -1,0 +1,212 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Metadata;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Game.Overlays.Dashboard.Friends
+{
+    public class FriendsList : CompositeDrawable
+    {
+        public readonly IBindable<OnlineStatus> OnlineStream = new Bindable<OnlineStatus>();
+        public readonly IBindable<UserSortCriteria> SortCriteria = new Bindable<UserSortCriteria>();
+        public readonly IBindable<string> SearchText = new Bindable<string>();
+
+        [Resolved]
+        private MetadataClient metadataClient { get; set; } = null!;
+
+        private readonly IBindableDictionary<int, UserPresence> friendPresences = new BindableDictionary<int, UserPresence>();
+        private readonly OverlayPanelDisplayStyle style;
+        private readonly APIUser[] friends;
+
+        private FriendsSearchContainer searchContainer = null!;
+
+        public FriendsList(OverlayPanelDisplayStyle style, APIUser[] friends)
+        {
+            this.style = style;
+            this.friends = friends;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = searchContainer = new FriendsSearchContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
+                Spacing = new Vector2(style == OverlayPanelDisplayStyle.Card ? 10 : 2),
+                SortCriteria = { BindTarget = SortCriteria },
+                ChildrenEnumerable = friends.Select(createUserPanel)
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            friendPresences.BindTo(metadataClient.FriendPresences);
+            friendPresences.BindCollectionChanged(onFriendPresencesChanged, true);
+
+            SearchText.BindValueChanged(onSearchTextChanged, true);
+            OnlineStream.BindValueChanged(onFriendsStreamChanged, true);
+        }
+
+        private void onFriendPresencesChanged(object? sender, NotifyDictionaryChangedEventArgs<int, UserPresence> e)
+        {
+            switch (e.Action)
+            {
+                case NotifyDictionaryChangedAction.Add:
+                case NotifyDictionaryChangedAction.Remove:
+                    updatePanelVisibilities();
+                    break;
+            }
+        }
+
+        private void onSearchTextChanged(ValueChangedEvent<string> search)
+        {
+            searchContainer.SearchTerm = search.NewValue;
+        }
+
+        private void onFriendsStreamChanged(ValueChangedEvent<OnlineStatus> stream)
+        {
+            updatePanelVisibilities();
+        }
+
+        private void updatePanelVisibilities()
+        {
+            foreach (var panel in searchContainer)
+            {
+                switch (OnlineStream.Value)
+                {
+                    case OnlineStatus.All:
+                        panel.CanBeShown.Value = true;
+                        break;
+
+                    case OnlineStatus.Online:
+                        panel.CanBeShown.Value = friendPresences.ContainsKey(panel.User.OnlineID);
+                        break;
+
+                    case OnlineStatus.Offline:
+                        panel.CanBeShown.Value = !friendPresences.ContainsKey(panel.User.OnlineID);
+                        break;
+                }
+            }
+        }
+
+        private FilterableUserPanel createUserPanel(APIUser user)
+        {
+            UserPanel panel;
+
+            switch (style)
+            {
+                default:
+                case OverlayPanelDisplayStyle.Card:
+                    panel = new UserGridPanel(user);
+                    panel.Anchor = Anchor.TopCentre;
+                    panel.Origin = Anchor.TopCentre;
+                    panel.Width = 290;
+                    break;
+
+                case OverlayPanelDisplayStyle.List:
+                    panel = new UserListPanel(user);
+                    break;
+
+                case OverlayPanelDisplayStyle.Brick:
+                    panel = new UserBrickPanel(user);
+                    break;
+            }
+
+            return new FilterableUserPanel(panel);
+        }
+
+        private class FriendsSearchContainer : SearchContainer<FilterableUserPanel>
+        {
+            public readonly IBindable<UserSortCriteria> SortCriteria = new Bindable<UserSortCriteria>();
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                SortCriteria.BindValueChanged(_ => InvalidateLayout(), true);
+            }
+
+            public override IEnumerable<Drawable> FlowingChildren
+            {
+                get
+                {
+                    IEnumerable<FilterableUserPanel> panels = base.FlowingChildren.OfType<FilterableUserPanel>();
+
+                    switch (SortCriteria.Value)
+                    {
+                        default:
+                        case UserSortCriteria.LastVisit:
+                            return panels.OrderByDescending(panel => panel.User.LastVisit);
+
+                        case UserSortCriteria.Rank:
+                            return panels.OrderByDescending(panel => panel.User.Statistics.GlobalRank.HasValue).ThenBy(panel => panel.User.Statistics.GlobalRank ?? 0);
+
+                        case UserSortCriteria.Username:
+                            return panels.OrderBy(panel => panel.User.Username);
+                    }
+                }
+            }
+        }
+
+        private class FilterableUserPanel : CompositeDrawable, IConditionalFilterable
+        {
+            public readonly Bindable<bool> CanBeShown = new Bindable<bool>();
+
+            public APIUser User => panel.User;
+
+            private readonly UserPanel panel;
+
+            public FilterableUserPanel(UserPanel panel)
+            {
+                this.panel = panel;
+
+                Anchor = panel.Anchor;
+                Origin = panel.Origin;
+                RelativeSizeAxes = panel.RelativeSizeAxes;
+                AutoSizeAxes = panel.AutoSizeAxes;
+
+                if (!AutoSizeAxes.HasFlagFast(Axes.X))
+                    Width = panel.Width;
+
+                if (!AutoSizeAxes.HasFlagFast(Axes.Y))
+                    Height = panel.Height;
+
+                InternalChild = panel;
+            }
+
+            IBindable<bool> IConditionalFilterable.CanBeShown => CanBeShown;
+
+            IEnumerable<LocalisableString> IHasFilterTerms.FilterTerms => panel.FilterTerms;
+
+            bool IFilterable.MatchingFilter
+            {
+                set
+                {
+                    if (value)
+                        Show();
+                    else
+                        Hide();
+                }
+            }
+
+            bool IFilterable.FilteringActive { set { } }
+        }
+    }
+}

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsOnlineStatusItem.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsOnlineStatusItem.cs
@@ -2,27 +2,32 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
-using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Dashboard.Friends
 {
-    public partial class FriendsOnlineStatusItem : OverlayStreamItem<FriendStream>
+    public partial class FriendsOnlineStatusItem : OverlayStreamItem<OnlineStatus>
     {
-        public FriendsOnlineStatusItem(FriendStream value)
+        public readonly IBindable<int> UserCount = new Bindable<int>();
+
+        public FriendsOnlineStatusItem(OnlineStatus value)
             : base(value)
         {
+            MainText = value.GetLocalisableDescription();
         }
 
-        protected override LocalisableString MainText => Value.Status.GetLocalisableDescription();
-
-        protected override LocalisableString AdditionalText => Value.Count.ToString();
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            UserCount.BindValueChanged(count => AdditionalText = count.NewValue.ToString(), true);
+        }
 
         protected override Color4 GetBarColour(OsuColour colours)
         {
-            switch (Value.Status)
+            switch (Value)
             {
                 case OnlineStatus.All:
                     return Color4.White;
@@ -34,7 +39,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                     return Color4.Black;
 
                 default:
-                    throw new ArgumentException($@"{Value.Status} status does not provide a colour in {nameof(GetBarColour)}.");
+                    throw new ArgumentException($@"{Value} status does not provide a colour in {nameof(GetBarColour)}.");
             }
         }
     }

--- a/osu.Game/Overlays/OverlayStreamItem.cs
+++ b/osu.Game/Overlays/OverlayStreamItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Graphics.UserInterface;
@@ -22,7 +20,9 @@ namespace osu.Game.Overlays
 {
     public abstract partial class OverlayStreamItem<T> : TabItem<T>
     {
-        public readonly Bindable<T> SelectedItem = new Bindable<T>();
+        public const float PADDING = 5;
+
+        public readonly Bindable<T?> SelectedItem = new Bindable<T?>();
 
         private bool userHoveringArea;
 
@@ -38,10 +38,12 @@ namespace osu.Game.Overlays
             }
         }
 
-        private FillFlowContainer<SpriteText> text;
-        private ExpandingBar expandingBar;
-
-        public const float PADDING = 5;
+        private FillFlowContainer<SpriteText> text = null!;
+        private ExpandingBar expandingBar = null!;
+        private Sample selectSample = null!;
+        private OsuSpriteText? mainTextPiece;
+        private OsuSpriteText? additionalTextPiece;
+        private OsuSpriteText? infoTextPiece;
 
         protected OverlayStreamItem(T value)
             : base(value)
@@ -50,8 +52,6 @@ namespace osu.Game.Overlays
             Width = 90;
             Margin = new MarginPadding(PADDING);
         }
-
-        private Sample selectSample;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider, OsuColour colours, AudioManager audio)
@@ -65,17 +65,17 @@ namespace osu.Game.Overlays
                     Margin = new MarginPadding { Top = 6 },
                     Children = new[]
                     {
-                        new OsuSpriteText
+                        mainTextPiece = new OsuSpriteText
                         {
                             Text = MainText,
                             Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
                         },
-                        new OsuSpriteText
+                        additionalTextPiece = new OsuSpriteText
                         {
                             Text = AdditionalText,
                             Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular),
                         },
-                        new OsuSpriteText
+                        infoTextPiece = new OsuSpriteText
                         {
                             Text = InfoText,
                             Font = OsuFont.GetFont(size: 10),
@@ -99,11 +99,47 @@ namespace osu.Game.Overlays
             SelectedItem.BindValueChanged(_ => updateState(), true);
         }
 
-        protected abstract LocalisableString MainText { get; }
+        private LocalisableString mainText;
 
-        protected abstract LocalisableString AdditionalText { get; }
+        protected LocalisableString MainText
+        {
+            get => mainText;
+            set
+            {
+                mainText = value;
 
-        protected virtual LocalisableString InfoText => string.Empty;
+                if (mainTextPiece != null)
+                    mainTextPiece.Text = value;
+            }
+        }
+
+        private LocalisableString additionalText;
+
+        protected LocalisableString AdditionalText
+        {
+            get => additionalText;
+            set
+            {
+                additionalText = value;
+
+                if (additionalTextPiece != null)
+                    additionalTextPiece.Text = value;
+            }
+        }
+
+        private LocalisableString infoText;
+
+        protected LocalisableString InfoText
+        {
+            get => infoText;
+            set
+            {
+                infoText = value;
+
+                if (infoTextPiece != null)
+                    infoTextPiece.Text = value;
+            }
+        }
 
         protected abstract Color4 GetBarColour(OsuColour colours);
 

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -22,6 +22,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Localisation;
+using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
@@ -75,6 +76,9 @@ namespace osu.Game.Users
 
         [Resolved]
         private MultiplayerClient? multiplayerClient { get; set; }
+
+        [Resolved]
+        private MetadataClient? metadataClient { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -153,7 +157,7 @@ namespace osu.Game.Users
                     chatOverlay?.Show();
                 }));
 
-                if (User.IsOnline)
+                if (metadataClient?.GetPresence(User.OnlineID) != null)
                 {
                     items.Add(new OsuMenuItem(ContextMenuStrings.SpectatePlayer, MenuItemType.Standard, () =>
                     {

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -157,20 +157,28 @@ namespace osu.Game.Users
                     chatOverlay?.Show();
                 }));
 
-                if (metadataClient?.GetPresence(User.OnlineID) != null)
+                if (isUserOnline())
                 {
                     items.Add(new OsuMenuItem(ContextMenuStrings.SpectatePlayer, MenuItemType.Standard, () =>
                     {
-                        performer?.PerformFromScreen(s => s.Push(new SoloSpectatorScreen(User)));
+                        if (isUserOnline())
+                            performer?.PerformFromScreen(s => s.Push(new SoloSpectatorScreen(User)));
                     }));
 
-                    if (multiplayerClient?.Room?.Users.All(u => u.UserID != User.Id) == true)
+                    if (canInviteUser())
                     {
-                        items.Add(new OsuMenuItem(ContextMenuStrings.InvitePlayer, MenuItemType.Standard, () => multiplayerClient.InvitePlayer(User.Id)));
+                        items.Add(new OsuMenuItem(ContextMenuStrings.InvitePlayer, MenuItemType.Standard, () =>
+                        {
+                            if (canInviteUser())
+                                multiplayerClient!.InvitePlayer(User.Id);
+                        }));
                     }
                 }
 
                 return items.ToArray();
+
+                bool isUserOnline() => metadataClient?.GetPresence(User.OnlineID) != null;
+                bool canInviteUser() => isUserOnline() && multiplayerClient?.Room?.Users.All(u => u.UserID != User.Id) == true;
             }
         }
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/31966

This is almost an entire rewrite of the overlay and its components. Nothing was really set up to handle states changing, including `FriendOnlineStreamControl` which was recreating its tabs in order to update the counts. For this reason, I suggest a fresh look at every component touched.

General overview:
- In order to not recreate tabs, `FriendOnlineStreamControl` has a bindable count passed between the model and drawable. It manages its counts internally.
- `FriendDisplay` has been split into `FriendsList` which contains the user panels in a particular display style (grid/list/brick).
- `FriendDisplay` mostly only handles (re-)loading of the `FriendsList` when the display style or friends change (as a result of adding/removing friends).
- `FriendsList` takes care of all filtering and sorting within its contained panels. This also means that changing the filters (stream/sorting) no longer recreates the panels.

Future work: `FriendsList` is "static" right now, meaning it doesn't support adding/removing friends. This will need a bit more consideration in particular surrounding the `LoadComponentAsync()` of `FriendDisplay`. The way I foresee this working is for `FriendsList` to internally handle any _changes_ to the user's friends and `FriendDisplay` to handle async load + spinner display during the initial bulk. If we even want to keep the bulk async load at all.