### PR TITLE
Remove JSON property attributes from non-databased taiko difficulty attributes

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -13,25 +13,21 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// <summary>
         /// The difficulty corresponding to the rhythm skill.
         /// </summary>
-        [JsonProperty("rhythm_difficulty")]
         public double RhythmDifficulty { get; set; }
 
         /// <summary>
         /// The difficulty corresponding to the reading skill.
         /// </summary>
-        [JsonProperty("reading_difficulty")]
         public double ReadingDifficulty { get; set; }
 
         /// <summary>
         /// The difficulty corresponding to the colour skill.
         /// </summary>
-        [JsonProperty("colour_difficulty")]
         public double ColourDifficulty { get; set; }
 
         /// <summary>
         /// The difficulty corresponding to the stamina skill.
         /// </summary>
-        [JsonProperty("stamina_difficulty")]
         public double StaminaDifficulty { get; set; }
 
         /// <summary>
@@ -40,13 +36,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("mono_stamina_factor")]
         public double MonoStaminaFactor { get; set; }
 
-        [JsonProperty("rhythm_difficult_strains")]
         public double RhythmTopStrains { get; set; }
 
-        [JsonProperty("colour_difficult_strains")]
         public double ColourTopStrains { get; set; }
 
-        [JsonProperty("stamina_difficult_strains")]
         public double StaminaTopStrains { get; set; }
 
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()


### PR DESCRIPTION
Intentionally pointed at `master` instead of `pp-dev`.

For consumers of the difficulty attributes API endpoint, having these marked as JSON properties is wildly confusing. Since they're not databased, they're not set when getting a response from `osu-beatmap-difficulty-lookup-cache` so they just get returned as zeros always. These attributes exist despite being databased so that they're visible in osu-tools, but outside of that they don't really serve a purpose. JSON members are opt-in on difficulty attributes, so we can just remove these and makes more sense.

When the next release happens, this will need a package bump on `osu-beatmap-difficulty-lookup-cache` in order to stop serving these properties in API responses.

Related: https://github.com/ppy/osu-web/issues/11990