### PR TITLE
Remove end note conversion in mania invert mod (causing unwanted jacks)

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -42,8 +42,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                 var locations = column.OfType<Note>().Select(n => (startTime: n.StartTime, samples: n.Samples))
                                       .Concat(column.OfType<HoldNote>().SelectMany(h => new[]
                                       {
-                                          (startTime: h.StartTime, samples: h.GetNodeSamples(0)),
-                                          (startTime: h.EndTime, samples: h.GetNodeSamples(1))
+                                          (startTime: h.StartTime, samples: h.GetNodeSamples(0))
                                       }))
                                       .OrderBy(h => h.startTime).ToList();
 


### PR DESCRIPTION
Resolves #25212
Supersedes / closes https://github.com/ppy/osu/pull/27508

Beatmap: https://osu.ppy.sh/beatmapsets/2128147#mania/4474060

Original map (without invert):
https://github.com/user-attachments/assets/2aaab7a1-1c71-40d1-8635-e8cb24638b6b

Before:
https://github.com/user-attachments/assets/0ef4a2ad-68e9-41c7-9b42-a41032662fdc

After:
https://github.com/user-attachments/assets/dfb8200b-c982-4906-af84-5f7917da9695





