### PR TITLE
Automatically update beatmap hash in `ScoreInfo`

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -1183,8 +1183,7 @@ namespace osu.Game.Tests.Database
                 realm.Add(new ScoreInfo
                 {
                     OnlineID = 2,
-                    BeatmapInfo = beatmap,
-                    BeatmapHash = beatmap.Hash
+                    BeatmapInfo = beatmap
                 });
             });
 

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -181,7 +181,6 @@ namespace osu.Game.Tests.Resources
                 CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
             },
             BeatmapInfo = beatmap,
-            BeatmapHash = beatmap.Hash,
             Ruleset = beatmap.Ruleset,
             Mods = new Mod[] { new TestModHardRock(), new TestModDoubleTime() },
             TotalScore = 284537,

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -333,7 +333,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     },
                     Ruleset = new OsuRuleset().RulesetInfo,
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     User = new APIUser
                     {
                         Id = 6602580,
@@ -350,7 +349,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddSeconds(-30),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
                     User = new APIUser
                     {
@@ -368,7 +366,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddSeconds(-70),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser
@@ -387,7 +384,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddMinutes(-40),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser
@@ -406,7 +402,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddHours(-2),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser
@@ -425,7 +420,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddHours(-25),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser
@@ -444,7 +438,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddHours(-50),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser
@@ -463,7 +456,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddHours(-72),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser
@@ -482,7 +474,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddMonths(-10),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser
@@ -501,7 +492,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Date = DateTime.Now.AddYears(-2),
                     Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
                     BeatmapInfo = beatmapInfo,
-                    BeatmapHash = beatmapInfo.Hash,
                     Ruleset = new OsuRuleset().RulesetInfo,
 
                     User = new APIUser

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -94,7 +94,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         OnlineID = i,
                         BeatmapInfo = beatmapInfo,
-                        BeatmapHash = beatmapInfo.Hash,
                         Accuracy = RNG.NextDouble(),
                         TotalScore = RNG.Next(1, 1000000),
                         MaxCombo = RNG.Next(1, 1000),

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -929,8 +929,10 @@ namespace osu.Game.Database
                     // Add ScoreInfo.BeatmapHash property to ensure scores correspond to the correct version of beatmap.
                     var scores = migration.NewRealm.All<ScoreInfo>();
 
+                    // While this looks meaningless, behind the scene it synchronises BeatmapHash property with BeatmapInfo.Hash
+                    // since BeatmapInfo property now has an underlying field beatmapInfo
                     foreach (var score in scores)
-                        score.BeatmapInfo = score.BeatmapInfo; //While this looks meaningless, behind the scene it syncs BeatmapHash property with BeatmapInfo.Hash
+                        score.BeatmapInfo = score.BeatmapInfo;
 
                     break;
                 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -930,7 +930,7 @@ namespace osu.Game.Database
                     var scores = migration.NewRealm.All<ScoreInfo>();
 
                     foreach (var score in scores)
-                        score.BeatmapHash = score.BeatmapInfo?.Hash ?? string.Empty;
+                        score.BeatmapInfo = score.BeatmapInfo; //While this looks meaningless, behind the scene it syncs BeatmapHash property with BeatmapInfo.Hash
 
                     break;
                 }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -156,7 +156,6 @@ namespace osu.Game.Scoring.Legacy
             // before returning for database import, we must restore the database-sourced BeatmapInfo.
             // if not, the clone operation in GetPlayableBeatmap will cause a dereference and subsequent database exception.
             score.ScoreInfo.BeatmapInfo = workingBeatmap.BeatmapInfo;
-            score.ScoreInfo.BeatmapHash = workingBeatmap.BeatmapInfo.Hash;
 
             return score;
         }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -31,6 +31,9 @@ namespace osu.Game.Scoring
         [PrimaryKey]
         public Guid ID { get; set; }
 
+        [MapTo(nameof(BeatmapInfo))]
+        private BeatmapInfo? beatmapInfo { get; set; }
+
         /// <summary>
         /// The <see cref="BeatmapInfo"/> this score was made against.
         /// </summary>
@@ -44,7 +47,19 @@ namespace osu.Game.Scoring
         /// Due to the above, whenever setting this, make sure to also set <see cref="BeatmapHash"/> to allow relational consistency when a beatmap is potentially changed.
         /// </para>
         /// </remarks>
-        public BeatmapInfo? BeatmapInfo { get; set; }
+        public BeatmapInfo? BeatmapInfo
+        {
+            get => beatmapInfo;
+            set
+            {
+                beatmapInfo = value;
+
+                if (value != null)
+                {
+                    BeatmapHash = value.Hash;
+                }
+            }
+        }
 
         /// <summary>
         /// The version of the client this score was set using.
@@ -55,7 +70,7 @@ namespace osu.Game.Scoring
         /// <summary>
         /// The <see cref="osu.Game.Beatmaps.BeatmapInfo.Hash"/> at the point in time when the score was set.
         /// </summary>
-        public string BeatmapHash { get; set; } = string.Empty;
+        public string BeatmapHash { get; private set; } = string.Empty;
 
         public RulesetInfo Ruleset { get; set; } = null!;
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -49,12 +49,15 @@ namespace osu.Game.Scoring
             get => beatmapInfo;
             set
             {
+                // Detach beatmapInfo from score if it's not avaliable locally
                 if (value == null)
                 {
                     beatmapInfo = null;
                     return;
                 }
 
+                // Empty BeatmapHash indicates that this score was set before realm v26 and needs to be populated.
+                // BeatmapInfo.Hash and BeatmapHash must be the same for beatmap to re-attach.
                 if (string.IsNullOrEmpty(BeatmapHash) || value.Hash == BeatmapHash)
                 {
                     beatmapInfo = value;

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Localisation;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Models;

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Localisation;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Models;
@@ -44,23 +46,17 @@ namespace osu.Game.Scoring
         /// The property will only link to a <see cref="BeatmapInfo"/> if its <see cref="Beatmaps.BeatmapInfo.Hash"/> matches <see cref="BeatmapHash"/>.
         /// </para>
         /// </remarks>
+        [Ignored]
         public BeatmapInfo? BeatmapInfo
         {
             get => beatmapInfo;
             set
             {
-                // Detach beatmapInfo from score if it's not avaliable locally
-                if (value == null)
-                {
-                    beatmapInfo = null;
-                    return;
-                }
+                beatmapInfo = value;
 
-                // Empty BeatmapHash indicates that this score was set before realm v26 and needs to be populated.
-                // BeatmapInfo.Hash and BeatmapHash must be the same for beatmap to re-attach.
-                if (string.IsNullOrEmpty(BeatmapHash) || value.Hash == BeatmapHash)
+                // Safe first beatmap hash for score validation
+                if (value != null && string.IsNullOrEmpty(BeatmapHash))
                 {
-                    beatmapInfo = value;
                     BeatmapHash = value.Hash;
                 }
             }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -43,9 +43,6 @@ namespace osu.Game.Scoring
         /// e.g. due to online updates, or local modifications to the beatmap.
         /// The property will only link to a <see cref="BeatmapInfo"/> if its <see cref="Beatmaps.BeatmapInfo.Hash"/> matches <see cref="BeatmapHash"/>.
         /// </para>
-        /// <para>
-        /// Due to the above, whenever setting this, make sure to also set <see cref="BeatmapHash"/> to allow relational consistency when a beatmap is potentially changed.
-        /// </para>
         /// </remarks>
         public BeatmapInfo? BeatmapInfo
         {

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -49,10 +49,15 @@ namespace osu.Game.Scoring
             get => beatmapInfo;
             set
             {
-                beatmapInfo = value;
-
-                if (value != null)
+                if (value == null)
                 {
+                    beatmapInfo = null;
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(BeatmapHash) || value.Hash == BeatmapHash)
+                {
+                    beatmapInfo = value;
                     BeatmapHash = value.Hash;
                 }
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -268,7 +268,6 @@ namespace osu.Game.Screens.Play
 
             // ensure the score is in a consistent state with the current player.
             Score.ScoreInfo.BeatmapInfo = Beatmap.Value.BeatmapInfo;
-            Score.ScoreInfo.BeatmapHash = Beatmap.Value.BeatmapInfo.Hash;
             Score.ScoreInfo.Ruleset = ruleset.RulesetInfo;
             Score.ScoreInfo.Mods = gameplayMods;
 


### PR DESCRIPTION
Since `Realm` fixed the issue with private fields mapping we can now handle `BeatmapHash` updates automatically. This PR does exactly that. 
All the behaviour stayed unchanged, we just don't have to worry about setting `BeatmapHash` anymore. Since the behaviour hasn't changed there is no new unit test for this PR, only test data tweaks (aka removal of manual `BeatmapHash` setting)