### PR TITLE
Fix miscellaneous text flow container breakage

### DIFF
--- a/osu.Game/Graphics/Containers/OsuTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuTextFlowContainer.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Graphics.Containers
 
         private partial class ArbitraryDrawableWrapper : Container, IHasLineBaseHeight
         {
-            public float LineBaseHeight => DrawHeight;
+            public float LineBaseHeight => (Child as IHasLineBaseHeight)?.LineBaseHeight ?? DrawHeight;
 
             public ArbitraryDrawableWrapper()
             {

--- a/osu.Game/Overlays/Comments/CommentReportButton.cs
+++ b/osu.Game/Overlays/Comments/CommentReportButton.cs
@@ -1,13 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -19,7 +22,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.Comments
 {
-    public partial class CommentReportButton : CompositeDrawable, IHasPopover
+    public partial class CommentReportButton : CompositeDrawable, IHasPopover, IHasLineBaseHeight
     {
         private readonly Comment comment;
 
@@ -88,5 +91,7 @@ namespace osu.Game.Overlays.Comments
 
             api.Queue(request);
         }
+
+        public float LineBaseHeight => link.ChildrenOfType<IHasLineBaseHeight>().FirstOrDefault()?.LineBaseHeight ?? DrawHeight;
     }
 }

--- a/osu.Game/Overlays/MedalSplash/DrawableMedal.cs
+++ b/osu.Game/Overlays/MedalSplash/DrawableMedal.cs
@@ -107,12 +107,7 @@ namespace osu.Game.Overlays.MedalSplash
                 },
             };
 
-            description.AddText(medal.Description, s =>
-            {
-                s.Anchor = Anchor.TopCentre;
-                s.Origin = Anchor.TopCentre;
-                s.Font = s.Font.With(size: 16);
-            });
+            description.AddText(medal.Description, s => s.Font = s.Font.With(size: 16));
 
             medalContainer.OnLoadComplete += _ =>
             {

--- a/osu.Game/Screens/Menu/SupporterDisplay.cs
+++ b/osu.Game/Screens/Menu/SupporterDisplay.cs
@@ -100,7 +100,6 @@ namespace osu.Game.Screens.Menu
 
                     t.Padding = new MarginPadding { Left = 5, Top = 1 };
                     t.Font = t.Font.With(size: font_size);
-                    t.Origin = Anchor.Centre;
                     t.Colour = colours.Pink;
 
                     Schedule(() =>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32405

- [x] probably get in https://github.com/ppy/osu-framework/pull/6553 too

## [Fix broken text alignment in medal display](https://github.com/ppy/osu/commit/64c726334234ca01b9b2c2bad501a54f8e849e67)

Bit unfortunate that this is code that can be written and do stupid things. Unsure if additional API protections against this are desired framework-side.

## [Fix broken text alignment in supporter display](https://github.com/ppy/osu/commit/427f75a7035cb9444e6d9382675ad476b6bfe5f2)

See previous commit.

## [Fix baseline misalignment in drawable comment link section](https://github.com/ppy/osu/commit/3954d8f3bea48ae8995544c308454e1957a42f68)

`CommentReportButton` is pretty cursed but I guess I can see why it is like it is. Short of inlining it into `DrawableComment` this is probably the best escape hatch (which I wouldn't be against doing, by the way, just not sure it's the most productive use of time unless review feedback comes in saying that would be a better path forward).