### PR TITLE
Reduce relax Ok miss multiplier

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -136,10 +136,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (score.Mods.Any(h => h is OsuModRelax))
             {
-                // https://www.desmos.com/calculator/bc9eybdthb
+                // https://www.desmos.com/calculator/vspzsop6td
                 // we use OD13.3 as maximum since it's the value at which great hitwidow becomes 0
                 // this is well beyond currently maximum achievable OD which is 12.17 (DTx2 + DA with OD11)
-                double okMultiplier = Math.Max(0.0, overallDifficulty > 0.0 ? 1 - Math.Pow(overallDifficulty / 13.33, 1.8) : 1.0);
+                double okMultiplier = 0.75 * Math.Max(0.0, overallDifficulty > 0.0 ? 1 - overallDifficulty / 13.33 : 1.0);
                 double mehMultiplier = Math.Max(0.0, overallDifficulty > 0.0 ? 1 - Math.Pow(overallDifficulty / 13.33, 5) : 1.0);
 
                 // As we're adding Oks and Mehs to an approximated number of combo breaks the result can be higher than total hits in specific scenarios (which breaks some calculations) so we need to clamp it.


### PR DESCRIPTION
This changes Ok multiplier so that it is never a full miss and is less harsh overall. It's mostly a blind adjustment towards better values and not a set in stone solution

![image](https://github.com/user-attachments/assets/afc13462-aaa0-4f73-b138-cbf36f8f7a67)
https://www.desmos.com/calculator/bhnwk3zupt

Since it's impossible to test using normal tools I've also made a separate version that's using [rx vault](https://rx.stanr.info) as the api source, you can use that to see what this change actually does: https://github.com/stanriders/osu-tools/tree/rxvault

![image](https://github.com/user-attachments/assets/e14b7b40-29a2-498a-b152-abea8c44a3ff)
