### PR TITLE
Fix multiplayer join errors potentially not being logged

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -351,7 +351,11 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             {
                 joiningRoomOperation?.Dispose();
                 joiningRoomOperation = null;
-                onFailure?.Invoke(error);
+
+                if (onFailure != null)
+                    onFailure(error);
+                else
+                    Logger.Log(error, level: LogLevel.Error);
             });
         });
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerLoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerLoungeSubScreen.cs
@@ -88,12 +88,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     if (exception?.GetHubExceptionMessage() is string message)
                         onFailure(message);
                     else
-                    {
-                        const string generic_failure_message = "Failed to join multiplayer room.";
-                        if (result.Exception != null)
-                            Logger.Error(result.Exception, generic_failure_message);
-                        onFailure(generic_failure_message);
-                    }
+                        onFailure($"Failed to join multiplayer room: {exception?.Message}");
                 }
             });
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32398

The changes to `MultiplayerLoungeSubScreen` are a red-herring - that path of the condition is _not_ taken in 99.99% of cases, the changes there are only best case to reduce potential double-logging. I don't think that change should be important to review/discuss.

The actual fix is the `LoungeSubScreen` change. Basically, the callback is used by the password popover to display a local message. But, if the error is not related to a passworded room, then the message would just disappear into the ethers.