### PR TITLE
Fix editor crashing if beatmap does not have a mode explicitly specified in the `.osu`

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var working = new TestWorkingBeatmap(decoder.Decode(stream));
 
                 Assert.AreEqual(6, working.Beatmap.BeatmapVersion);
+                Assert.That(working.Beatmap.BeatmapInfo.Ruleset.Name, Is.Not.EqualTo("null placeholder ruleset"));
                 Assert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapVersion);
             }
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -193,6 +193,7 @@ namespace osu.Game.Beatmaps.Formats
         internal static void ApplyLegacyDefaults(Beatmap beatmap)
         {
             beatmap.WidescreenStoryboard = false;
+            beatmap.BeatmapInfo.Ruleset = RulesetStore?.GetRuleset(0) ?? throw new ArgumentException("osu! ruleset is not available locally.");
         }
 
         protected override void ParseLine(Beatmap beatmap, Section section, string line)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -193,7 +193,10 @@ namespace osu.Game.Beatmaps.Formats
         internal static void ApplyLegacyDefaults(Beatmap beatmap)
         {
             beatmap.WidescreenStoryboard = false;
-            beatmap.BeatmapInfo.Ruleset = RulesetStore?.GetRuleset(0) ?? throw new ArgumentException("osu! ruleset is not available locally.");
+            // in a perfect world this would throw if osu! ruleset couldn't be found,
+            // but unfortunately there are "legitimate" cases where it's not there (i.e. ruleset test projects),
+            // so attempt to trudge on with whatever it is that's in `BeatmapInfo` if the lookup fails.
+            beatmap.BeatmapInfo.Ruleset = RulesetStore?.GetRuleset(0) ?? beatmap.BeatmapInfo.Ruleset;
         }
 
         protected override void ParseLine(Beatmap beatmap, Section section, string line)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32440.

Probably another "regression" from https://github.com/ppy/osu/pull/32315.

Trying very hard not to type out any hyperbolic rants here.