### PR TITLE
Add some lenience around mod customisation expanding overlay

### DIFF
--- a/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
+++ b/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
@@ -223,15 +223,28 @@ namespace osu.Game.Overlays.Mods
                 inputManager = GetContainingInputManager()!;
             }
 
+            private double timeUntilCollapse;
+
+            private const double collapse_grace_time = 180;
+            private const float collapse_grace_position = 40;
+
             protected override void Update()
             {
                 base.Update();
 
-                if (ExpandedState.Value == ModCustomisationPanelState.Expanded
-                    && !ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position)
-                    && inputManager.DraggedDrawable == null)
+                if (ExpandedState.Value == ModCustomisationPanelState.Expanded)
                 {
-                    ExpandedState.Value = ModCustomisationPanelState.Collapsed;
+                    bool canCollapse = !DrawRectangle.Inflate(new Vector2(collapse_grace_position)).Contains(ToLocalSpace(inputManager.CurrentState.Mouse.Position))
+                                       && inputManager.DraggedDrawable == null;
+
+                    if (canCollapse)
+                    {
+                        if (timeUntilCollapse <= 0)
+                            ExpandedState.Value = ModCustomisationPanelState.Collapsed;
+                        timeUntilCollapse -= Time.Elapsed;
+                    }
+                    else
+                        timeUntilCollapse = collapse_grace_time;
                 }
             }
         }


### PR DESCRIPTION
It was quite easy to dismiss by accident. I've added some positional and time based lenience with numbers that feel good to me. Open to discussion on whether both are required and if the numbers feel good.

Going forward, at some point, we'll likely want to standardise this across to other expand-on-hover elements (like player load overlays).

Addresses https://github.com/ppy/osu/discussions/32368.