### PR TITLE
Re-fetch status of any beatmaps stuck in qualified status

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -125,9 +125,10 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Reset any fetched online linking information (and history).
         /// </summary>
-        public void ResetOnlineInfo()
+        public void ResetOnlineInfo(bool resetOnlineId = true)
         {
-            OnlineID = -1;
+            if (resetOnlineId)
+                OnlineID = -1;
             LastOnlineUpdate = null;
             OnlineMD5Hash = string.Empty;
             if (Status != BeatmapOnlineStatus.LocallyModified)

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -97,8 +97,9 @@ namespace osu.Game.Database
         /// 45   2024-12-23    Change beat snap divisor adjust defaults to be Ctrl+Scroll instead of Ctrl+Shift+Scroll, if not already changed by user.
         /// 46   2024-12-26    Change beat snap divisor bindings to match stable directionality ¯\_(ツ)_/¯.
         /// 47   2025-01-21    Remove right mouse button binding for absolute scroll. Never use mouse buttons (or scroll) for global actions.
+        /// 48   2025-03-19    Clear online status for all qualified beatmaps (some were stuck in a qualified state due to local caching issues).
         /// </summary>
-        private const int schema_version = 47;
+        private const int schema_version = 48;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -1245,6 +1246,15 @@ namespace osu.Game.Database
 
                     break;
                 }
+
+                case 48:
+                    const int qualified = (int)BeatmapOnlineStatus.Qualified;
+
+                    var beatmaps = migration.NewRealm.All<BeatmapInfo>().Where(b => b.StatusInt == qualified);
+
+                    foreach (var beatmap in beatmaps)
+                        beatmap.ResetOnlineInfo(resetOnlineId: false);
+                    break;
             }
 
             Logger.Log($"Migration completed in {stopwatch.ElapsedMilliseconds}ms");


### PR DESCRIPTION
---

Best we do this rather than leaving it up to users to fix their broken beatmaps.

https://github.com/ppy/osu/discussions/32406
https://github.com/ppy/osu/discussions/32431

To hopefully alleviate testing overhead, here's a video showing things working. Of note, I made a hack since realm studio isn't opening for me – v47 migration sets all ranked maps to qualified for testing purposes:

 

https://github.com/user-attachments/assets/d388753c-3fe5-4462-b2db-2ba4979b9ad0

