### PR TITLE
Fix lag when scrolling right-hand toolboxes in editor during long edit session

### DIFF
--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -127,8 +127,6 @@ namespace osu.Game.Graphics.Backgrounds
         {
             base.Update();
 
-            Invalidate(Invalidation.DrawNode);
-
             if (CreateNewTriangles)
                 addTriangles(false);
 
@@ -138,6 +136,10 @@ namespace osu.Game.Graphics.Backgrounds
                 : 1;
 
             float elapsedSeconds = (float)Time.Elapsed / 1000;
+
+            if (elapsedSeconds == 0)
+                return;
+
             // Since position is relative, the velocity needs to scale inversely with DrawHeight.
             // Since we will later multiply by the scale of individual triangles we normalize by
             // dividing by triangleScale.
@@ -157,6 +159,8 @@ namespace osu.Game.Graphics.Backgrounds
                 if (bottomPos < 0)
                     parts.RemoveAt(i);
             }
+
+            Invalidate(Invalidation.DrawNode);
         }
 
         /// <summary>
@@ -183,8 +187,13 @@ namespace osu.Game.Graphics.Backgrounds
 
             int currentCount = parts.Count;
 
+            if (AimCount - currentCount == 0)
+                return;
+
             for (int i = 0; i < AimCount - currentCount; i++)
                 parts.Add(createTriangle(randomY));
+
+            Invalidate(Invalidation.DrawNode);
         }
 
         private TriangleParticle createTriangle(bool randomY)

--- a/osu.Game/Graphics/Backgrounds/TrianglesV2.cs
+++ b/osu.Game/Graphics/Backgrounds/TrianglesV2.cs
@@ -91,12 +91,14 @@ namespace osu.Game.Graphics.Backgrounds
         {
             base.Update();
 
-            Invalidate(Invalidation.DrawNode);
-
             if (CreateNewTriangles)
                 addTriangles(false);
 
             float elapsedSeconds = (float)Time.Elapsed / 1000;
+
+            if (elapsedSeconds == 0)
+                return;
+
             // Since position is relative, the velocity needs to scale inversely with DrawHeight.
             float movedDistance = -elapsedSeconds * Velocity * base_velocity / DrawHeight;
 
@@ -112,6 +114,8 @@ namespace osu.Game.Graphics.Backgrounds
                 if (bottomPos < 0)
                     parts.RemoveAt(i);
             }
+
+            Invalidate(Invalidation.DrawNode);
         }
 
         /// <summary>
@@ -138,8 +142,13 @@ namespace osu.Game.Graphics.Backgrounds
 
             int currentCount = parts.Count;
 
+            if (AimCount - currentCount == 0)
+                return;
+
             for (int i = 0; i < AimCount - currentCount; i++)
                 parts.Add(createTriangle(randomY));
+
+            Invalidate(Invalidation.DrawNode);
         }
 
         private TriangleParticle createTriangle(bool randomY)

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -3,14 +3,13 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Framework.Layout;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -28,8 +27,6 @@ namespace osu.Game.Overlays
         private const float transition_duration = 250;
         private const int header_height = 30;
         private const int corner_radius = 5;
-
-        private readonly Cached headerTextVisibilityCache = new Cached();
 
         protected override Container<Drawable> Content => content;
 
@@ -156,13 +153,9 @@ namespace osu.Game.Overlays
         {
             base.Update();
 
-            if (!headerTextVisibilityCache.IsValid)
-            {
-                // These toolbox grouped may be contracted to only show icons.
-                // For now, let's hide the header to avoid text truncation weirdness in such cases.
-                headerText.FadeTo(headerText.DrawWidth < DrawWidth ? 1 : 0, 150, Easing.OutQuint);
-                headerTextVisibilityCache.Validate();
-            }
+            // These toolbox grouped may be contracted to only show icons.
+            // For now, let's hide the header to avoid text truncation weirdness in such cases.
+            headerText.Alpha = (float)Interpolation.DampContinuously(headerText.Alpha, headerText.DrawWidth < DrawWidth ? 1 : 0, 40, Time.Elapsed);
 
             // Dragged child finished its drag operation.
             if (draggedChild != null && inputManager.DraggedDrawable != draggedChild)
@@ -170,14 +163,6 @@ namespace osu.Game.Overlays
                 draggedChild = null;
                 updateExpandedState(true);
             }
-        }
-
-        protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
-        {
-            if (invalidation.HasFlag(Invalidation.DrawSize))
-                headerTextVisibilityCache.Invalidate();
-
-            return base.OnInvalidate(invalidation, source);
         }
 
         private void updateExpandedState(bool animate)

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -146,22 +146,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
                                 }
                             }
                         },
-                        new Drawable[]
-                        {
-                            new TextFlowContainer(s => s.Font = s.Font.With(size: 14))
-                            {
-                                Padding = new MarginPadding { Horizontal = 15, Vertical = 2 },
-                                Text = "beat snap",
-                                RelativeSizeAxes = Axes.X,
-                                TextAnchor = Anchor.TopCentre,
-                            },
-                        },
                     },
                     RowDimensions = new[]
                     {
                         new Dimension(GridSizeMode.Absolute, 40),
                         new Dimension(GridSizeMode.Absolute, 20),
-                        new Dimension(GridSizeMode.Absolute, 15)
                     }
                 }
             };


### PR DESCRIPTION
This was causing a performance issue due to transforms bunching up for off-screen toolboxes. It's much simpler to just update these values every frame. Note that this issue is also resolved via https://github.com/ppy/osu-framework/pull/6555 but I'd want to also fix this locally because it didn't feel right.

I've included two other commits which clean up every-frame invalidations that didn't need to happen. One is related to text flow (already pinged @bdach regarding it – may be a regression) and the other should hopefully be a trivial change to triangles implementation. Can drop the latter if it's considered non-trivial or breaks something I missed; I mostly made the change to ease debugging the invalidation flows.

Closes https://github.com/ppy/osu/issues/32474.