### PR TITLE
Add "strict timing" option to Relax mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -88,14 +88,16 @@ namespace osu.Game.Rulesets.Osu.Mods
             if (hasReplay && !legacyReplay && Strict.Value)
             {
                 List<ReplayFrame> frames = ruleset.ReplayScore.Replay.Frames;
-                //use the last frame in the replay before the current time to avoid replays playing back differently on different framerates
+                //use the last frame in the replay before the current time to avoid replays playing back differently on different framerates (NOT WORKING PERFECTLY)
                 while (lastReplayFrameIndex + 1 < frames.Count && frames[lastReplayFrameIndex + 1].Time < time)
                     lastReplayFrameIndex++;
+                while (lastReplayFrameIndex >= 0 && frames[lastReplayFrameIndex].Time >= time)
+                    lastReplayFrameIndex--;
 
                 foreach (var h in playfield.HitObjectContainer.AliveObjects.OfType<DrawableOsuHitObject>())
                 {
                     // if in strict mode, hitting a circle slightly late is an automatic miss. gives 1 frame of leniency so it's physically possible to hit the circle
-                    // THIS IS CURRENTLY BUSTED!! REPLAYS PLAY BACK DIFFERENT ON DIFFERENT FRAMERATES!! NOT SURE HOW TO FIX!!!
+                    // THIS IS CURRENTLY BUSTED!! REPLAYS CAN OCCASIONALLY PLAY BACK DIFFERENTLY IF YOU SKIP FORWARDS!!! HELP
                     if (Strict.Value && !h.Judged && h.HitObject is HitCircle && frames[lastReplayFrameIndex].Time > h.HitObject.StartTime)
                     {
                         h.MissForcefully();

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -97,6 +97,11 @@ namespace osu.Game.Rulesets.Osu.Mods
                         h.MissForcefully();
                         continue;
                     }
+                    if (h is DrawableSlider s && !s.HeadCircle.Judged && lastFrameTime > s.HeadCircle.HitObject.StartTime)
+                    {
+                        s.HeadCircle.MissForcefully();
+                        continue;
+                    }
                 }
                 return;
             }


### PR DESCRIPTION
This PR adds a "strict timing" option to the Relax mod, which removes all timing leniency.

The Relax mod is the most obvious way to train one's aim, and many new players end up playing it assuming it will improve their non-RX aim. However, normal RX is generally far too lenient to suit that purpose, because aiming very early or late, which would result in misses in normal gameplay, isn't penalized at all in RX. This option fixes that problem, making RX an actually viable way to practice aim.

Unfortunately, strict timing is completely broken in replays when the replayer is running at a different framerate than the player. This is because frames where judgements are forced are not necessarily saved as important in the replay recorder (thanks peppy for pointing that out), but I have no clue how to fix this.

I also didn't write any tests for this, because I don't know if it makes sense to write tests that rely on replay frames when the mod option doesn't work in replays.

![Screenshot 2025-03-21 001100](https://github.com/user-attachments/assets/d2e88f9c-402e-4dff-b618-88a9bb8db11d)
