### PR TITLE
Attempt to fix intermittent BackgroundDataStoreProcessor tests

### DIFF
--- a/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
+++ b/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
@@ -62,12 +62,11 @@ namespace osu.Game.Tests.Database
                 });
             });
 
-            AddStep("Run background processor", () =>
-            {
-                Add(new TestBackgroundDataStoreProcessor());
-            });
+            TestBackgroundDataStoreProcessor processor = null!;
+            AddStep("Run background processor", () => Add(processor = new TestBackgroundDataStoreProcessor()));
+            AddUntilStep("Wait for completion", () => processor.Completed);
 
-            AddUntilStep("wait for difficulties repopulated", () =>
+            AddAssert("Difficulties repopulated", () =>
             {
                 return Realm.Run(r =>
                 {
@@ -101,13 +100,10 @@ namespace osu.Game.Tests.Database
                 });
             });
 
-            AddStep("Run background processor", () =>
-            {
-                Add(new TestBackgroundDataStoreProcessor());
-            });
+            TestBackgroundDataStoreProcessor processor = null!;
+            AddStep("Run background processor", () => Add(processor = new TestBackgroundDataStoreProcessor()));
 
             AddWaitStep("wait some", 500);
-
             AddAssert("Difficulty still not populated", () =>
             {
                 return Realm.Run(r =>
@@ -118,8 +114,9 @@ namespace osu.Game.Tests.Database
             });
 
             AddStep("Set not playing", () => isPlaying.Value = LocalUserPlayingState.NotPlaying);
+            AddUntilStep("Wait for completion", () => processor.Completed);
 
-            AddUntilStep("wait for difficulties repopulated", () =>
+            AddAssert("Difficulties repopulated", () =>
             {
                 return Realm.Run(r =>
                 {
@@ -151,9 +148,11 @@ namespace osu.Game.Tests.Database
                 });
             });
 
-            AddStep("Run background processor", () => Add(new TestBackgroundDataStoreProcessor()));
+            TestBackgroundDataStoreProcessor processor = null!;
+            AddStep("Run background processor", () => Add(processor = new TestBackgroundDataStoreProcessor()));
+            AddUntilStep("Wait for completion", () => processor.Completed);
 
-            AddUntilStep("Score version upgraded", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.TotalScoreVersion), () => Is.EqualTo(LegacyScoreEncoder.LATEST_VERSION));
+            AddAssert("Score version upgraded", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.TotalScoreVersion), () => Is.EqualTo(LegacyScoreEncoder.LATEST_VERSION));
             AddAssert("Score not marked as failed", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.BackgroundReprocessingFailed), () => Is.False);
         }
 
@@ -183,7 +182,7 @@ namespace osu.Game.Tests.Database
             AddStep("Run background processor", () => Add(processor = new TestBackgroundDataStoreProcessor()));
             AddUntilStep("Wait for completion", () => processor.Completed);
 
-            AddUntilStep("Score marked as failed", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.BackgroundReprocessingFailed), () => Is.True);
+            AddAssert("Score marked as failed", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.BackgroundReprocessingFailed), () => Is.True);
             AddAssert("Score version not upgraded", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.TotalScoreVersion), () => Is.EqualTo(scoreVersion));
         }
 


### PR DESCRIPTION
Has been happening extremely frequently lately... https://github.com/ppy/osu/actions/runs/13983234448?pr=32486

Since I can't repro, I'm not sure if this will fix it. But it would make sense as to why these tests are intermittent.