### PR TITLE
Adjust user activity updates

### DIFF
--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Online
             (typeof(UserActivity.EditingBeatmap), typeof(UserActivity)),
             (typeof(UserActivity.ModdingBeatmap), typeof(UserActivity)),
             (typeof(UserActivity.TestingBeatmap), typeof(UserActivity)),
+            (typeof(UserActivity.InDailyChallengeLobby), typeof(UserActivity)),
+            (typeof(UserActivity.PlayingDailyChallenge), typeof(UserActivity)),
         };
     }
 }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -39,6 +39,7 @@ using osu.Game.Screens.OnlinePlay.Match;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Screens.Play;
+using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
@@ -106,6 +107,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
         public override bool? ApplyModTrackAdjustments => true;
+
+        protected override UserActivity InitialActivity => new UserActivity.InDailyChallengeLobby();
 
         public DailyChallenge(Room room)
         {
@@ -526,7 +529,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         private void startPlay()
         {
             sampleStart?.Play();
-            this.Push(new PlayerLoader(() => new PlaylistsPlayer(room, playlistItem)
+            this.Push(new PlayerLoader(() => new DailyChallengePlayer(room, playlistItem)
             {
                 Exited = () => Scheduler.AddOnce(() => leaderboard.RefetchScores())
             }));

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengePlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengePlayer.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Playlists;
+using osu.Game.Screens.Play;
+using osu.Game.Users;
+
+namespace osu.Game.Screens.OnlinePlay.DailyChallenge
+{
+    public partial class DailyChallengePlayer : PlaylistsPlayer
+    {
+        protected override UserActivity InitialActivity => new UserActivity.PlayingDailyChallenge(Beatmap.Value.BeatmapInfo, Ruleset.Value);
+
+        public DailyChallengePlayer(Room room, PlaylistItem playlistItem, PlayerConfiguration? configuration = null)
+            : base(room, playlistItem, configuration)
+        {
+        }
+    }
+}

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Users
     [Union(41, typeof(EditingBeatmap))]
     [Union(42, typeof(ModdingBeatmap))]
     [Union(43, typeof(TestingBeatmap))]
+    [Union(51, typeof(InDailyChallengeLobby))]
+    [Union(52, typeof(PlayingDailyChallenge))]
     public abstract class UserActivity
     {
         public abstract string GetStatus(bool hideIdentifiableInformation = false);
@@ -58,6 +60,7 @@ namespace osu.Game.Users
         [Union(23, typeof(InMultiplayerGame))]
         [Union(24, typeof(SpectatingMultiplayerGame))]
         [Union(31, typeof(InPlaylistGame))]
+        [Union(52, typeof(PlayingDailyChallenge))]
         public abstract class InGame : UserActivity
         {
             [Key(0)]
@@ -244,7 +247,7 @@ namespace osu.Game.Users
             [SerializationConstructor]
             public SpectatingMultiplayerGame() { }
 
-            public override string GetStatus(bool hideIdentifiableInformation = false) => $"Watching others {base.GetStatus(hideIdentifiableInformation).ToLowerInvariant()}";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => @"Spectating a multiplayer game";
         }
 
         [MessagePackObject]
@@ -276,6 +279,31 @@ namespace osu.Game.Users
             public override string? GetDetails(bool hideIdentifiableInformation = false) => hideIdentifiableInformation
                 ? null
                 : RoomName;
+        }
+
+        [MessagePackObject]
+        public class InDailyChallengeLobby : UserActivity
+        {
+            [SerializationConstructor]
+            public InDailyChallengeLobby() { }
+
+            public override string GetStatus(bool hideIdentifiableInformation = false) => @"In daily challenge lobby";
+        }
+
+        [MessagePackObject]
+        public class PlayingDailyChallenge : InGame
+        {
+            public PlayingDailyChallenge(IBeatmapInfo beatmapInfo, IRulesetInfo ruleset)
+                : base(beatmapInfo, ruleset)
+            {
+            }
+
+            [SerializationConstructor]
+            public PlayingDailyChallenge()
+            {
+            }
+
+            public override string GetStatus(bool hideIdentifiableInformation = false) => @$"{RulesetPlayingVerb} in daily challenge";
         }
     }
 }


### PR DESCRIPTION
- Changed copy of the multiplayer spectator activity to be ruleset-agnostic, thus I guess closing https://github.com/ppy/osu/issues/32307 maybe? There is still the ruleset icon in discord RPC but that one is taken from the game-global ruleset so it's a bit more involved to fix.

- Added new activities for daily challenge screens, therefore partially addressing https://github.com/ppy/osu/discussions/29200. I didn't add skin editor because (a) it's not easy to make work because skin editor isn't a screen and (b) I'm not sure we want that to begin with? Kind of a weird one.

I've tested backwards compatibility; old server will raise exceptions that then will be logged as unobserved by the clients when receiving the new statuses, and an old client, when given one of the new statuses by a new server, seems to completely ignore it. Seems pretty acceptable to me.