### PR TITLE
Fix `osu.Game.Tests` tests running twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,18 @@ jobs:
         run: dotnet build -c Debug -warnaserror osu.Desktop.slnf
 
       - name: Test
-        run: dotnet test $pwd/**/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx" -- NUnit.ConsoleOut=0
-        shell: pwsh
+        run: >
+          dotnet test
+          osu.Game.Tests/bin/**/osu.Game.Tests.dll
+          osu.Game.Rulesets.Osu.Tests/bin/**/osu.Game.Rulesets.Osu.Tests.dll
+          osu.Game.Rulesets.Taiko.Tests/bin/**/osu.Game.Rulesets.Taiko.Tests.dll
+          osu.Game.Rulesets.Catch.Tests/bin/**/osu.Game.Rulesets.Catch.Tests.dll
+          osu.Game.Rulesets.Mania.Tests/bin/**/osu.Game.Rulesets.Mania.Tests.dll
+          osu.Game.Tournament.Tests/bin/**/osu.Game.Tournament.Tests.dll
+          Templates/**/*.Tests/bin/**/*.Tests.dll
+          --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx"
+          --
+          NUnit.ConsoleOut=0
 
       # Attempt to upload results even if test fails.
       # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always


### PR DESCRIPTION
`osu.Game.Rulesets.Taiko` references `osu.Game.Tests`, copying the latter assembly to its output. The globbing pattern here therefore discovers the latter project twice, effectively doubling every test run to-date:

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/d98113c2-b95f-4182-872e-329e88837c6c" />

This changes the globbing pattern to be per-project.

## Q: Why not use `dotnet test osu.Desktop.slnf`?

Good question!

By using `.dll`s, we are actually calling into the VSTest host, which has one very important distinction for us: it merges resultant `.trx` files.

By using `.slnf` or `.csproj`, we'd call into the "dotnet test host" which runs one host per assembly. Unlike the VSTest host, this would result in ~50 `.trx` files and unfortunately, there is no sane way to deal with this.

[This](https://github.com/smoogipoo/osu/actions/runs/13994137671/job/39187181646) is an example of what our test reports would end up looking like. _Minor_ adjustments would be possible, but we'd lose:
- `.trx` file merging, so we'd always have this gigantic table.
- _Either_ assembly name _or_ platform + threading mode prefix.

While there may be external tools to facilitate merging `.trx` files, and while I could write a `sh` script to deal with post processing, I didn't even consider these options as they add failure points. So this keeps it simple by just changing the globbing.