### PR TITLE
Fixed Redundant Difficulty Calculations

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkDifficultyCalculation.cs
+++ b/osu.Game.Benchmarks/BenchmarkDifficultyCalculation.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.IO.Stores;
+using osu.Game.Beatmaps;
+using osu.Game.IO;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Benchmarks
+{
+    public class BenchmarkDifficultyCalculation : BenchmarkTest
+    {
+        private WorkingBeatmap beatmap = null!;
+
+        public override void SetUp()
+        {
+            using var resources = new DllResourceStore(typeof(TestResources).Assembly);
+
+            using var beatmapStream = resources.GetStream("Resources/Within Temptation - The Unforgiving (Armin) [Marathon].osu");
+
+            beatmapStream.Seek(0, SeekOrigin.Begin);
+            using var reader = new LineBufferedReader(beatmapStream);
+
+            var decoder = Beatmaps.Formats.Decoder.GetDecoder<Beatmap>(reader);
+            beatmap = new FlatWorkingBeatmap(decoder.Decode(reader));
+        }
+
+        [Benchmark]
+        public void CalculateDifficultyOsu() => new OsuRuleset().CreateDifficultyCalculator(beatmap).Calculate();
+
+        [Benchmark]
+        public void CalculateDifficultyTaiko() => new TaikoRuleset().CreateDifficultyCalculator(beatmap).Calculate();
+
+        [Benchmark]
+        public void CalculateDifficultyCatch() => new CatchRuleset().CreateDifficultyCalculator(beatmap).Calculate();
+
+        [Benchmark]
+        public void CalculateDifficultyMania() => new ManiaRuleset().CreateDifficultyCalculator(beatmap).Calculate();
+    }
+}

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override double DifficultyValue()
         {
-
             //Check if the difficulty was already calculated and if not calculate it.
             if (Difficulty != 0)
                 return Difficulty;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -32,10 +32,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
 
             //Check if the difficulty was already calculated and if not calculate it.
-            if (difficulty != 0)
-                difficulty = 0;
+            if (Difficulty != 0)
+                return Difficulty;
 
-            double difficulty = 0;
             double weight = 1;
 
             // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
@@ -55,11 +54,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             // We're sorting from highest to lowest strain.
             foreach (double strain in strains.OrderDescending())
             {
-                difficulty += strain * weight;
+                Difficulty += strain * weight;
                 weight *= DecayWeight;
             }
 
-            return difficulty;
+            return Difficulty;
         }
 
         public static double DifficultyToPerformance(double difficulty) => Math.Pow(5.0 * Math.Max(1.0, difficulty / 0.0675) - 4.0, 3.0) / 100000.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -54,6 +54,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                 weight *= DecayWeight;
             }
 
+            double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
+
+            TopWeightedStrains = ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
+
             return difficulty;
         }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -30,6 +30,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override double DifficultyValue()
         {
+
+            //Check if the difficulty was already calculated and if not calculate it.
+            if (difficulty != 0)
+                difficulty = 0;
+
             double difficulty = 0;
             double weight = 1;
 
@@ -53,10 +58,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                 difficulty += strain * weight;
                 weight *= DecayWeight;
             }
-
-            double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
-
-            TopWeightedStrains = ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
         private double currentRhythm;
 
+        private double summedRelevantNoteCount;
+
         protected override int ReducedSectionCount => 5;
 
         public Speed(Mod[] mods)
@@ -46,6 +48,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public double RelevantNoteCount()
         {
+            //Check if the RelevantNote was already calculated and if not calculate it.
+            if (summedRelevantNoteCount != 0)
+                return summedRelevantNoteCount;
+
             if (ObjectStrains.Count == 0)
                 return 0;
 
@@ -53,7 +59,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (maxStrain == 0)
                 return 0;
 
-            return ObjectStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxStrain * 12.0 - 6.0))));
+            summedRelevantNoteCount = ObjectStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxStrain * 12.0 - 6.0))));
+
+            return summedRelevantNoteCount;
         }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         private double currentSectionPeak; // We also keep track of the peak strain level in the current section.
         private double currentSectionEnd;
 
-        protected double difficulty = 0;
+        protected double Difficulty = 0;
 
         private readonly List<double> strainPeaks = new List<double>();
         protected readonly List<double> ObjectStrains = new List<double>(); // Store individual strains
@@ -76,10 +76,10 @@ namespace osu.Game.Rulesets.Difficulty.Skills
                 return 0.0;
 
             //Check if the difficulty was already calculated and if not calculate it.
-            if (difficulty == 0)
-                difficulty = DifficultyValue();
+            if (Difficulty == 0)
+                Difficulty = DifficultyValue();
 
-            double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
+            double consistentTopStrain = Difficulty / 10; // What would the top strain be if all strain values were identical
 
             if (consistentTopStrain == 0)
                 return ObjectStrains.Count;
@@ -128,8 +128,8 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         public override double DifficultyValue()
         {
             //Check if the difficulty was already calculated and if not calculate it.
-            if (difficulty != 0)
-                difficulty = 0;
+            if (Difficulty != 0)
+                Difficulty = 0;
 
             double weight = 1;
 
@@ -141,11 +141,11 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             // We're sorting from highest to lowest strain.
             foreach (double strain in peaks.OrderDescending())
             {
-                difficulty += strain * weight;
+                Difficulty += strain * weight;
                 weight *= DecayWeight;
             }
 
-            return difficulty;
+            return Difficulty;
         }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         private double currentSectionPeak; // We also keep track of the peak strain level in the current section.
         private double currentSectionEnd;
 
+        protected double TopWeightedStrains = 0;
+
         private readonly List<double> strainPeaks = new List<double>();
         protected readonly List<double> ObjectStrains = new List<double>(); // Store individual strains
 
@@ -70,16 +72,9 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public virtual double CountTopWeightedStrains()
         {
-            if (ObjectStrains.Count == 0)
-                return 0.0;
-
-            double consistentTopStrain = DifficultyValue() / 10; // What would the top strain be if all strain values were identical
-
-            if (consistentTopStrain == 0)
-                return ObjectStrains.Count;
-
-            // Use a weighted sum of all strains. Constants are arbitrary and give nice values
-            return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
+            if (TopWeightedStrains == 0)
+                DifficultyValue();
+            return TopWeightedStrains;
         }
 
         /// <summary>
@@ -135,6 +130,10 @@ namespace osu.Game.Rulesets.Difficulty.Skills
                 difficulty += strain * weight;
                 weight *= DecayWeight;
             }
+
+            double consistentTopStrain = difficulty / 10; // What would the top strain be if all strain values were identical
+
+            TopWeightedStrains = ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
 
             return difficulty;
         }

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Difficulty.Skills
 
         protected double Difficulty = 0;
 
+        private double summedObjectStrains = 0;
+
         private readonly List<double> strainPeaks = new List<double>();
         protected readonly List<double> ObjectStrains = new List<double>(); // Store individual strains
 
@@ -72,20 +74,22 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public virtual double CountTopWeightedStrains()
         {
+            //Check if the TopWeightedStrains was already calculated and if not calculate it.
+            if (summedObjectStrains != 0)
+                return summedObjectStrains;
+
             if (ObjectStrains.Count == 0)
                 return 0.0;
 
-            //Check if the difficulty was already calculated and if not calculate it.
-            if (Difficulty == 0)
-                Difficulty = DifficultyValue();
-
-            double consistentTopStrain = Difficulty / 10; // What would the top strain be if all strain values were identical
+            double consistentTopStrain = DifficultyValue() / 10; // What would the top strain be if all strain values were identical
 
             if (consistentTopStrain == 0)
                 return ObjectStrains.Count;
 
+            summedObjectStrains = ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
+
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values
-            return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
+            return summedObjectStrains;
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -28,10 +28,9 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         private double currentSectionPeak; // We also keep track of the peak strain level in the current section.
         private double currentSectionEnd;
 
-        protected double Difficulty = 0;
+        protected double Difficulty;
 
-        private double summedObjectStrains = 0;
-
+        private double summedObjectStrains;
         private readonly List<double> strainPeaks = new List<double>();
         protected readonly List<double> ObjectStrains = new List<double>(); // Store individual strains
 
@@ -133,7 +132,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         {
             //Check if the difficulty was already calculated and if not calculate it.
             if (Difficulty != 0)
-                Difficulty = 0;
+                return Difficulty;
 
             double weight = 1;
 


### PR DESCRIPTION
Fixed multiple calculations where difficulty had already been calculated.

- Added Variable for Difficulty Value.

- Added a check to verify if DifficultyValue has already been calculated; if not, it calculates and stores the value to prevent redundant calculations.

- If CountTopWeightedStrains() or RelevantNoteCount() is called, it checks if they have already been calculated; if not, it recalculates and stores the value.