### PR TITLE
Change mod select colour scheme to aquamarine in new song select

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.SelectV2
     {
         private const float logo_scale = 0.4f;
 
-        private readonly ModSelectOverlay modSelectOverlay = new ModSelectOverlay
+        private readonly ModSelectOverlay modSelectOverlay = new ModSelectOverlay(OverlayColourScheme.Aquamarine)
         {
             ShowPresets = true,
         };


### PR DESCRIPTION
New song select uses aquamarine colours for its components, and, as discussed, aquamarine and green don't go well together. The future of variable colour schemes is unknown, but let's at least match mod select with song select so it doesn't feel eye-soaring.