### PR TITLE
Allow beatmap conversion from non-std rulesets

### DIFF
--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Pippidon.Beatmaps
             }
         }
 
-        public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasXPosition && h is IHasYPosition);
+        public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasXPosition || h is IHasYPosition);
 
         protected override IEnumerable<PippidonHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
@@ -43,6 +43,6 @@ namespace osu.Game.Rulesets.Pippidon.Beatmaps
         private int getLane(HitObject hitObject) => (int)Math.Clamp(
             (getUsablePosition(hitObject) - minPosition) / (maxPosition - minPosition) * PippidonPlayfield.LANE_COUNT, 0, PippidonPlayfield.LANE_COUNT - 1);
 
-        private float getUsablePosition(HitObject h) => (h as IHasYPosition)?.Y ?? ((IHasXPosition)h).X;
+        private float getUsablePosition(HitObject h) => (h as IHasXPosition)?.X ?? ((IHasYPosition)h).Y;
     }
 }

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonRulesetConversionSupport.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonRulesetConversionSupport.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Filter;
+
+namespace osu.Game.Rulesets.Pippidon.Beatmaps
+{
+    public class PippidonRulesetConversionSupport : IRulesetConvertSupport
+    {
+        public bool CanBePlayed(RulesetInfo ruleset, bool conversionEnabled)
+        {
+            // Always show ctb maps even without converts, since extensive playtesting has shown that the maps match
+            // pippidon very well and we also don't have many maps to start out with yet.
+            // Show std only when converts are enabled
+            return ruleset.ShortName == "pippidon" || ruleset.ShortName == "fruits" ||
+                   (conversionEnabled && ruleset.ShortName == "osu");
+        }
+    }
+}

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/PippidonRuleset.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/PippidonRuleset.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Pippidon.Beatmaps;
 using osu.Game.Rulesets.Pippidon.Mods;
@@ -36,6 +37,8 @@ namespace osu.Game.Rulesets.Pippidon
                     return Array.Empty<Mod>();
             }
         }
+
+        public override IRulesetConvertSupport GetRulesetMapConvertSupport() => new PippidonRulesetConversionSupport();
 
         public override string ShortName => "pippidon";
 

--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using osu.Framework.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Select;
 
@@ -67,12 +68,15 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Whether gameplay is allowed for this beatmap with the provided ruleset (via conversion or direct compatibility).
         /// </summary>
-        public static bool AllowGameplayWithRuleset(this IBeatmapInfo beatmap, RulesetInfo ruleset, bool allowConversion)
+        public static bool AllowGameplayWithRuleset(this IBeatmapInfo beatmap, RulesetInfo ruleset, bool allowConversion, IRulesetConvertSupport? convertSupport)
         {
             if (beatmap.Ruleset.ShortName == ruleset.ShortName)
                 return true;
 
             if (allowConversion && beatmap.Ruleset.OnlineID == 0 && ruleset.OnlineID != 0)
+                return true;
+
+            if (convertSupport?.CanBePlayed(ruleset, allowConversion) == true)
                 return true;
 
             return false;

--- a/osu.Game/Rulesets/Filter/IRulesetConvertSupport.cs
+++ b/osu.Game/Rulesets/Filter/IRulesetConvertSupport.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Screens.Select;
+
+namespace osu.Game.Rulesets.Filter
+{
+    /// <summary>
+    /// Allows for changing which beatmap rulesets are displayed in song select (as implemented in <see cref="FilterCriteria"/>)
+    /// with ruleset-specific criteria.
+    /// </summary>
+    public interface IRulesetConvertSupport
+    {
+        /// <summary>
+        /// Checks whether maps from the supplied <paramref name="ruleset"/> may be played with this ruleset with or
+        /// without beatmap conversion enabled.
+        /// </summary>
+        /// <param name="ruleset">The foreign ruleset to check if it may be played.</param>
+        /// <param name="conversionEnabled">Indicates if the player wants converts or not.</param>
+        /// <returns>
+        /// <c>true</c> if the beatmap can be played and should be shown in the beatmap list,
+        /// <c>false</c> otherwise.
+        /// </returns>
+        bool CanBePlayed(RulesetInfo ruleset, bool conversionEnabled);
+    }
+}

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -396,6 +396,13 @@ namespace osu.Game.Rulesets
         public virtual IRulesetFilterCriteria? CreateRulesetFilterCriteria() => null;
 
         /// <summary>
+        /// Creates ruleset-specific conversion support, used in filtering which beatmaps to show based on selected ruleset.
+        /// This interface describes which maps from other rulesets may be used without beatmap conversion enabled and which ones may be used when beatmap conversion is enabled.
+        /// If not set, osu treats this ruleset as the only native format and osu standard as only ruleset that maps can be converted from.
+        /// </summary>
+        public virtual IRulesetConvertSupport? GetRulesetMapConvertSupport() => null;
+
+        /// <summary>
         /// Can be overridden to add ruleset-specific sections to the editor beatmap setup screen.
         /// </summary>
         public virtual IEnumerable<Drawable> CreateEditorSetupSections() =>

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -34,8 +34,10 @@ namespace osu.Game.Screens.Select.Carousel
         {
             bool match =
                 criteria.Ruleset == null ||
-                BeatmapInfo.Ruleset.ShortName == criteria.Ruleset.ShortName ||
-                (BeatmapInfo.Ruleset.OnlineID == 0 && criteria.Ruleset.OnlineID != 0 && criteria.AllowConvertedBeatmaps);
+                (criteria.RulesetConvertSupport?.CanBePlayed(BeatmapInfo.Ruleset, criteria.AllowConvertedBeatmaps) ??
+                 (BeatmapInfo.Ruleset.ShortName == criteria.Ruleset.ShortName ||
+                  (BeatmapInfo.Ruleset.OnlineID == 0 && criteria.Ruleset.OnlineID != 0 &&
+                   criteria.AllowConvertedBeatmaps)));
 
             if (BeatmapInfo.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
             {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -77,7 +77,9 @@ namespace osu.Game.Screens.Select
             if (!maximumStars.IsDefault)
                 criteria.UserStarDifficulty.Max = maximumStars.Value;
 
-            criteria.RulesetCriteria = ruleset.Value.CreateInstance().CreateRulesetFilterCriteria();
+            var rulesetInstance = ruleset.Value.CreateInstance();
+            criteria.RulesetCriteria = rulesetInstance.CreateRulesetFilterCriteria();
+            criteria.RulesetConvertSupport = rulesetInstance.GetRulesetMapConvertSupport();
 
             FilterQueryParser.ApplyQueries(criteria, query);
             return criteria;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -118,6 +118,12 @@ namespace osu.Game.Screens.Select
 
         public IRulesetFilterCriteria? RulesetCriteria { get; set; }
 
+        /// <summary>
+        /// If set, overrides which maps can be played and should be shown, instead of only showing maps from our own
+        /// ruleset and std with map conversion enabled.
+        /// </summary>
+        public IRulesetConvertSupport? RulesetConvertSupport { get; set; }
+
         public readonly struct OptionalSet<T> : IEquatable<OptionalSet<T>>
             where T : struct, Enum
         {

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.SelectV2
 
         private static bool checkCriteriaMatch(BeatmapInfo beatmap, FilterCriteria criteria)
         {
-            bool match = criteria.Ruleset == null || beatmap.AllowGameplayWithRuleset(criteria.Ruleset!, criteria.AllowConvertedBeatmaps);
+            bool match = criteria.Ruleset == null || beatmap.AllowGameplayWithRuleset(criteria.Ruleset!, criteria.AllowConvertedBeatmaps, criteria.RulesetConvertSupport);
 
             if (beatmap.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
             {

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -235,7 +235,9 @@ namespace osu.Game.Screens.SelectV2
             if (!difficultyRangeSlider.UpperBound.IsDefault)
                 criteria.UserStarDifficulty.Max = difficultyRangeSlider.UpperBound.Value;
 
-            criteria.RulesetCriteria = ruleset.Value.CreateInstance().CreateRulesetFilterCriteria();
+            var rulesetInstance = ruleset.Value.CreateInstance();
+            criteria.RulesetCriteria = rulesetInstance.CreateRulesetFilterCriteria();
+            criteria.RulesetConvertSupport = rulesetInstance.GetRulesetMapConvertSupport();
 
             FilterQueryParser.ApplyQueries(criteria, query);
             return criteria;

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -559,7 +559,7 @@ namespace osu.Game.Screens.SelectV2
             if (criteria == null)
                 return false;
 
-            if (!beatmap.AllowGameplayWithRuleset(Ruleset.Value, criteria.AllowConvertedBeatmaps))
+            if (!beatmap.AllowGameplayWithRuleset(Ruleset.Value, criteria.AllowConvertedBeatmaps, criteria.RulesetConvertSupport))
                 return false;
 
             if (beatmap.Hidden)


### PR DESCRIPTION
Supersedes #23875, fix #9263

**Summary:**

This gives rulesets full control which maps to show both with and without map conversion enabled.

For example a 2-player version ruleset of taiko could make taiko maps show without enabling converts, as well as control which ones to support only if conversions are enabled in the settings.

**Design decisions:**

There is a `CanConvert` function in `BeatmapConverter` which I considered using as well. However this class wasn't accessible in the carousel and the implementation may be quite severe on performance impact, since they validate the full map, instead of going from metadata. Consider for example generally converted maps from mania to taiko might be able to usually convert well, but a quality control function inside CanConvert could make the conversion fail if it's unplayable, which will then be shown when trying to start the map.

I did not change how the default rulesets behave, this is just for custom rulesets to be able to play more maps and start off with a larger pool of maps, which I think is an important part of custom ruleset adoption. I adjusted the scrolling example ruleset (pippidon) to include this as well.

During playtesting I personally found adding a ctb -> mania convertor quite fun, but I would not make that part of this PR since the scope would explode when touching the default rulesets. (scoring, pp, web, how to handle changes in a ranked converter, etc.)