### PR TITLE
Fix images embedded in comments not displaying

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneImageProxying.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneImageProxying.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Game.Graphics.Containers.Markdown;
+using osu.Game.Overlays.Comments;
 
 namespace osu.Game.Tests.Visual.Online
 {
@@ -28,6 +29,19 @@ namespace osu.Game.Tests.Visual.Online
             AddAssert("image not loaded", () => markdown.ChildrenOfType<Sprite>().SingleOrDefault()?.Texture == null);
 
             AddStep("load external with proxying", () => Child = markdown = new OsuMarkdownContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Text = "![](https://github.com/ppy/osu-wiki/blob/master/wiki/Announcement_messages/img/notification.png?raw=true)",
+            });
+            AddUntilStep("image loaded", () => markdown.ChildrenOfType<Sprite>().SingleOrDefault()?.Texture != null);
+        }
+
+        [Test]
+        public void TestExternalImageLinkInComments()
+        {
+            MarkdownContainer markdown = null!;
+
+            AddStep("load external with proxying", () => Child = markdown = new CommentMarkdownContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Text = "![](https://github.com/ppy/osu-wiki/blob/master/wiki/Announcement_messages/img/notification.png?raw=true)",

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownImage.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownImage.cs
@@ -13,12 +13,9 @@ namespace osu.Game.Graphics.Containers.Markdown
         public LocalisableString TooltipText { get; }
 
         public OsuMarkdownImage(LinkInline linkInline)
-            : base(linkInline.Url)
+            : base($"https://osu.ppy.sh/media-url?url={linkInline.Url}")
         {
             TooltipText = linkInline.Title;
         }
-
-        protected override ImageContainer CreateImageContainer(string url)
-            => base.CreateImageContainer($@"https://osu.ppy.sh/media-url?url={url}");
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/32514

Comments have a specific implementation for markdown images and it bypassed the proxy logic (see `CommentMarkdownImage`). Since the entire class depends on the URL specified to the base constructor, it should be enough of a fix to insert the proxy there rather than in a method override.