### PR TITLE
Add PreserveApproachRate option to ModEasy.cs

### DIFF
--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -3,6 +3,8 @@
 
 using System;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 
@@ -17,18 +19,24 @@ namespace osu.Game.Rulesets.Mods
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock), typeof(ModDifficultyAdjust) };
         public override bool Ranked => UsesDefaultConfiguration;
-
+        [SettingSource("Preserve Approach Rate", "Keeps the map's original Approach Rate instead of reducing it.")]
+        public BindableBool PreserveApproachRate { get; } = new BindableBool
+        {
+            Value = false,
+            Default = false
+        };
         public virtual void ReadFromDifficulty(BeatmapDifficulty difficulty)
         {
         }
-
         public virtual void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             const float ratio = 0.5f;
+            
             difficulty.CircleSize *= ratio;
+            if (!PreserveApproachRate.Value)
             difficulty.ApproachRate *= ratio;
             difficulty.DrainRate *= ratio;
             difficulty.OverallDifficulty *= ratio;
-        }
+            }
     }
 }


### PR DESCRIPTION
Adds option to preserve map's original approach rate when using the Easy mod. This option is unranked.