### PR TITLE
Fix menu star fountains getting stuck looping sounds when leaving menu

### DIFF
--- a/osu.Game/Screens/Menu/StarFountainSounds.cs
+++ b/osu.Game/Screens/Menu/StarFountainSounds.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Audio;
 using osu.Game.Skinning;
@@ -22,6 +23,9 @@ namespace osu.Game.Screens.Menu
 
         private ScheduledDelegate? loopFadeDelegate;
         private ScheduledDelegate? loopStopDelegate;
+
+        [Resolved]
+        private GameHost host { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -56,10 +60,11 @@ namespace osu.Game.Screens.Menu
                 }
 
                 // Schedule a volume fadeout, followed by a `Stop()`.
-                loopFadeDelegate = Scheduler.AddDelayed(() =>
+                // Required to be on global scheduler to handle cases like main menu being suspended (resulting in this drawable's schedule not being updated).
+                loopFadeDelegate = host.UpdateThread.Scheduler.AddDelayed(() =>
                 {
                     this.TransformBindableTo(loopSample.Volume, 0, loop_fade_duration);
-                    loopStopDelegate = Scheduler.AddDelayed(() => loopSample.Stop(), loop_fade_duration);
+                    loopStopDelegate = host.UpdateThread.Scheduler.AddDelayed(() => loopSample.Stop(), loop_fade_duration);
                 }, shoot_retrigger_delay);
             }
             finally


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32516. Can test using https://osu.ppy.sh/beatmapsets/1627361#osu/3322364 (end of song has a lot of consecutive kiai time segments).

I originally tried a different direction with an `AllowSamples` flag set from main menu, but ended up with this diff.

If the `GameHost` schedule is not feasible, the here's the alternative that also works:

```diff
diff --git a/osu.Game/Screens/Menu/KiaiMenuFountains.cs b/osu.Game/Screens/Menu/KiaiMenuFountains.cs
index 6e0351f922..6b68da288b 100644
--- a/osu.Game/Screens/Menu/KiaiMenuFountains.cs
+++ b/osu.Game/Screens/Menu/KiaiMenuFountains.cs
@@ -18,6 +18,19 @@ public partial class KiaiMenuFountains : BeatSyncedContainer
         [Resolved]
         private GameHost host { get; set; } = null!;
 
+        private bool allowSamples = true;
+
+        public bool AllowSamples
+        {
+            get => allowSamples;
+            set
+            {
+                allowSamples = value;
+                if (!allowSamples)
+                    sounds.StopAllSamples();
+            }
+        }
+
         private StarFountainSounds sounds = null!;
 
         [BackgroundDependencyLoader]
@@ -82,7 +95,7 @@ public void Shoot()
             }
 
             // Don't play SFX when game is in background, as it can be a bit noisy.
-            if (host.IsActive.Value)
+            if (host.IsActive.Value && AllowSamples)
                 sounds.Play();
         }
     }
diff --git a/osu.Game/Screens/Menu/MainMenu.cs b/osu.Game/Screens/Menu/MainMenu.cs
index 135b3dba17..c48abcbce7 100644
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -176,7 +176,7 @@ private void load(BeatmapListingOverlay beatmapListing, SettingsOverlay settings
                     Margin = new MarginPadding { Right = 15, Top = 5 }
                 },
                 // For now, this is too much alongside the seasonal lighting.
-                SeasonalUIConfig.ENABLED ? Empty() : new KiaiMenuFountains(),
+                SeasonalUIConfig.ENABLED ? Empty() : menuFountains = new KiaiMenuFountains(),
                 bottomElementsFlow = new FillFlowContainer
                 {
                     AutoSizeAxes = Axes.Both,
@@ -263,6 +263,9 @@ public override void OnEntering(ScreenTransitionEvent e)
         [CanBeNull]
         private ScheduledDelegate mobileDisclaimerSchedule;
 
+        [CanBeNull]
+        private KiaiMenuFountains menuFountains;
+
         protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
             base.LogoArriving(logo, resuming);
@@ -369,6 +372,9 @@ public override void OnSuspending(ScreenTransitionEvent e)
 
             supporterDisplay
                 .FadeOut(500, Easing.OutQuint);
+
+            if (menuFountains != null)
+                menuFountains.AllowSamples = false;
         }
 
         public override void OnResuming(ScreenTransitionEvent e)
@@ -379,6 +385,9 @@ public override void OnResuming(ScreenTransitionEvent e)
             Buttons.StopSamplePlayback();
             reappearSampleSwoosh?.Play();
 
+            if (menuFountains != null)
+                menuFountains.AllowSamples = true;
+
             ApplyToBackground(b => (b as BackgroundScreenDefault)?.Next());
 
             musicController.EnsurePlayingSomething();
diff --git a/osu.Game/Screens/Menu/StarFountainSounds.cs b/osu.Game/Screens/Menu/StarFountainSounds.cs
index fbe425cb0f..c1ffaf025d 100644
--- a/osu.Game/Screens/Menu/StarFountainSounds.cs
+++ b/osu.Game/Screens/Menu/StarFountainSounds.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Audio;
 using osu.Game.Skinning;
@@ -24,9 +23,6 @@ public partial class StarFountainSounds : CompositeComponent
         private ScheduledDelegate? loopFadeDelegate;
         private ScheduledDelegate? loopStopDelegate;
 
-        [Resolved]
-        private GameHost host { get; set; } = null!;
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -37,6 +33,12 @@ private void load()
             };
         }
 
+        public void StopAllSamples()
+        {
+            shootSample.Stop();
+            loopSample.Stop();
+        }
+
         public void Play()
         {
             loopFadeDelegate?.Cancel();
@@ -60,11 +62,10 @@ public void Play()
                 }
 
                 // Schedule a volume fadeout, followed by a `Stop()`.
-                // Required to be on global scheduler to handle cases like main menu being suspended (resulting in this drawable's schedule not being updated).
-                loopFadeDelegate = host.UpdateThread.Scheduler.AddDelayed(() =>
+                loopFadeDelegate = Scheduler.AddDelayed(() =>
                 {
                     this.TransformBindableTo(loopSample.Volume, 0, loop_fade_duration);
-                    loopStopDelegate = host.UpdateThread.Scheduler.AddDelayed(() => loopSample.Stop(), loop_fade_duration);
+                    loopStopDelegate = Scheduler.AddDelayed(() => loopSample.Stop(), loop_fade_duration);
                 }, shoot_retrigger_delay);
             }
             finally

```
