### PR TITLE
Add multiplayer-specific implementation for user mod display

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerUserModDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerUserModDisplay.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Online.API;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.OnlinePlay.Multiplayer;
+
+namespace osu.Game.Tests.Visual.Multiplayer
+{
+    public partial class TestSceneMultiplayerUserModDisplay : MultiplayerTestScene
+    {
+        private MultiplayerUserModDisplay modDisplay = null!;
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            WaitForJoined();
+
+            AddStep("add display", () => Child = modDisplay = new MultiplayerUserModDisplay
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            });
+        }
+
+        [Test]
+        public void TestChangeMods()
+        {
+            AddStep("set DT", () => MultiplayerClient.ChangeUserMods([new OsuModDoubleTime()]).WaitSafely());
+            AddUntilStep("mod displayed", () => modDisplay.ChildrenOfType<ModIcon>().Count() == 1);
+
+            AddStep("set DT, HR", () => MultiplayerClient.ChangeUserMods([new OsuModDoubleTime(), new OsuModHardRock()]).WaitSafely());
+            AddUntilStep("mods displayed", () => modDisplay.ChildrenOfType<ModIcon>().Count() == 2);
+
+            AddStep("set no mods", () => MultiplayerClient.ChangeUserMods(Enumerable.Empty<APIMod>()).WaitSafely());
+            AddUntilStep("no mods displayed", () => !modDisplay.ChildrenOfType<ModIcon>().Any());
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -31,7 +31,6 @@ using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Participants;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
 using osuTK;
 using ParticipantsList = osu.Game.Screens.OnlinePlay.Multiplayer.Participants.ParticipantsList;
@@ -180,11 +179,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                             Text = "Select",
                                                             Action = ShowUserModSelect,
                                                         },
-                                                        new ModDisplay
+                                                        new MultiplayerUserModDisplay
                                                         {
                                                             Anchor = Anchor.CentreLeft,
                                                             Origin = Anchor.CentreLeft,
-                                                            Current = UserMods,
                                                             Scale = new Vector2(0.8f),
                                                         },
                                                     }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerUserModDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerUserModDisplay.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Play.HUD;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer
+{
+    public partial class MultiplayerUserModDisplay : CompositeDrawable
+    {
+        [Resolved]
+        private MultiplayerClient client { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        private ModDisplay modDisplay = null!;
+
+        public MultiplayerUserModDisplay()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = modDisplay = new ModDisplay();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            client.RoomUpdated += onRoomUpdated;
+            onRoomUpdated();
+        }
+
+        private void onRoomUpdated() => Scheduler.AddOnce(() =>
+        {
+            if (client.Room == null || client.LocalUser == null)
+                return;
+
+            MultiplayerPlaylistItem currentItem = client.Room.CurrentPlaylistItem;
+            Ruleset ruleset = rulesets.GetRuleset(client.LocalUser.RulesetId ?? currentItem.RulesetID)!.CreateInstance();
+            Mod[] userMods = client.LocalUser.Mods.Select(m => m.ToMod(ruleset)).ToArray();
+
+            if (!userMods.SequenceEqual(modDisplay.Current.Value))
+                modDisplay.Current.Value = userMods;
+        });
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (client.IsNotNull())
+                client.RoomUpdated -= onRoomUpdated;
+        }
+    }
+}


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/32250

The important achievement here is to remove the binding to `UserMods`.

This applies the [suggestion](https://github.com/ppy/osu/pull/32250#discussion_r1998415357) to encapsulate behaviour in a `CompositeDrawable` rather than hiding base implementations.