### PR TITLE
Allow tagging already played beatmaps without playing another time

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -298,7 +298,6 @@ namespace osu.Game.Tests.Visual.Ranking
         public void TestTaggingInteractionWithLocalScores()
         {
             BeatmapInfo beatmapInfo = null!;
-            string originalHash = string.Empty;
 
             AddStep(@"Import beatmap", () =>
             {


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/32568#discussioncomment-12610577.

No changes in criteria (yet?), just allowing locally imported plays to count the same way as full beatmap completion does.

The test scene is a bit rough / semi-manual but dealing with score imports is a bit of a pain in general. The way to semi-manually test with the test scene is to import a subset of scores, then recreate the statistics panel, and observe behaviour. I'm not sure it's worth it to be putting subscriptions in there, so the full recreation of the panel is necessary.