### PR TITLE
Only use hidden if OnlyFadeApproachCircles is not enabled

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         public const double PERFORMANCE_BASE_MULTIPLIER = 1.15; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
         private bool usingClassicSliderAccuracy;
+        private bool usingHidden;
 
         private double accuracy;
         private int scoreMaxCombo;
@@ -65,6 +66,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             var osuAttributes = (OsuDifficultyAttributes)attributes;
 
             usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value);
+            usingHidden = score.Mods.OfType<OsuModHidden>().All(m => !m.OnlyFadeApproachCircles.Value) || score.Mods.Any(m => m is OsuModTraceable);
 
             accuracy = score.Accuracy;
             scoreMaxCombo = score.MaxCombo;
@@ -222,7 +224,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (score.Mods.Any(m => m is OsuModBlinds))
                 aimValue *= 1.3 + (totalHits * (0.0016 / (1 + 2 * effectiveMissCount)) * Math.Pow(accuracy, 16)) * (1 - 0.003 * attributes.DrainRate * attributes.DrainRate);
-            else if (score.Mods.Any(m => m is OsuModHidden || m is OsuModTraceable))
+            else if (usingHidden)
             {
                 // We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
                 aimValue *= 1.0 + 0.04 * (12.0 - approachRate);
@@ -263,7 +265,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 // Increasing the speed value by object count for Blinds isn't ideal, so the minimum buff is given.
                 speedValue *= 1.12;
             }
-            else if (score.Mods.Any(m => m is OsuModHidden || m is OsuModTraceable))
+            else if (usingHidden)
             {
                 // We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
                 speedValue *= 1.0 + 0.04 * (12.0 - approachRate);
@@ -315,7 +317,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // Increasing the accuracy value by object count for Blinds isn't ideal, so the minimum buff is given.
             if (score.Mods.Any(m => m is OsuModBlinds))
                 accuracyValue *= 1.14;
-            else if (score.Mods.Any(m => m is OsuModHidden || m is OsuModTraceable))
+            else if (usingHidden)
                 accuracyValue *= 1.08;
 
             if (score.Mods.Any(m => m is OsuModFlashlight))

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         public Flashlight(Mod[] mods)
             : base(mods)
         {
-            hasHiddenMod = mods.Any(m => m is OsuModHidden);
+            hasHiddenMod = mods.OfType<OsuModHidden>().All(m => !m.OnlyFadeApproachCircles.Value);
         }
 
         private double skillMultiplier => 0.05512;


### PR DESCRIPTION
That option removes the main sources of difficulty for hd (pp wise), so it shouldn't give pp.

Specifically targets these twitter clips where someone gains absurd amounts of pp because they're playing low ar with "hd" https://x.com/zTarax/status/1903173463969546708

I don't think it's unreasonable to say that low ar hd isn't nearly as hard when you can see the circles.