### PR TITLE
Refresh mod panel active states when recreated

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -1003,6 +1003,35 @@ namespace osu.Game.Tests.Visual.UserInterface
                 AddAssert("search still not focused", () => !this.ChildrenOfType<ShearedSearchTextBox>().Single().HasFocus);
         }
 
+        /// <summary>
+        /// Tests that recreating the mod panels (by setting the global available mods) also refreshes the active states.
+        /// </summary>
+        [Test]
+        public void TestActiveStatesRefreshedOnPanelsCreated()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            Bindable<IReadOnlyList<Mod>> selectedMods = null!;
+
+            AddStep("bind mods to local bindable", () =>
+            {
+                selectedMods = new Bindable<IReadOnlyList<Mod>>([]);
+
+                modSelectOverlay.SelectedMods.UnbindFrom(SelectedMods);
+                modSelectOverlay.SelectedMods.BindTo(selectedMods);
+            });
+
+            AddStep("activate PF", () => selectedMods.Value = [new OsuModPerfect()]);
+            AddAssert("OsuModPerfect panel active", () => getPanelForMod(typeof(OsuModPerfect)).Active.Value);
+
+            changeRuleset(1);
+            AddAssert("TaikoModPerfect panel not active", () => !getPanelForMod(typeof(TaikoModPerfect)).Active.Value);
+
+            changeRuleset(0);
+            AddAssert("OsuModPerfect panel active", () => getPanelForMod(typeof(OsuModPerfect)).Active.Value);
+        }
+
         private void waitForColumnLoad() => AddUntilStep("all column content loaded", () =>
             modSelectOverlay.ChildrenOfType<ModColumn>().Any()
             && modSelectOverlay.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded)

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -353,7 +353,10 @@ namespace osu.Game.Overlays.Mods
                                     .ToArray();
 
                 foreach (var modState in modStates)
+                {
+                    modState.Active.Value = SelectedMods.Value.Any(selected => selected.GetType() == modState.Mod.GetType());
                     modState.Active.BindValueChanged(_ => updateFromInternalSelection());
+                }
 
                 newLocalAvailableMods[modType] = modStates;
             }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32605

This overlay probably shouldn't be binding to global mod availability in multi/playlists, but breaking that relationship seems much more difficult.

Enumeration condition taken from a bit further below:

https://github.com/ppy/osu/blob/c69e0cbb7363258283745137dd5b0afa6de5af90/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L426-L442