### PR TITLE
Fix chevron alignment in dropdown menu items

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -252,6 +252,7 @@ namespace osu.Game.Graphics.UserInterface
                                 Size = new Vector2(8),
                                 Alpha = 0,
                                 X = chevron_offset,
+                                Y = 1,
                                 Margin = new MarginPadding { Left = 3, Right = 3 },
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,


### PR DESCRIPTION
Can't unsee it.

Before:

![CleanShot 2025-03-27 at 23 12 43](https://github.com/user-attachments/assets/9f590b8c-ae94-48e3-9b44-906f2e333b41)

After:

![CleanShot 2025-03-27 at 23 13 07](https://github.com/user-attachments/assets/dc23afd1-1f1f-421f-a127-e80180922a74)
