### PR TITLE
Fix slider repeat arrow fade in length not matching expectations

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -153,9 +154,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected void ApplyRepeatFadeIn(Drawable target, double fadeTime)
         {
             DrawableSlider slider = (DrawableSlider)ParentHitObject;
+            int repeatIndex = ((SliderEndCircle)HitObject).RepeatIndex;
+
+            Debug.Assert(slider != null);
 
             // When snaking in is enabled, the first end circle needs to be delayed until the snaking completes.
-            bool delayFadeIn = slider!.SliderBody?.SnakingIn.Value == true && ((SliderEndCircle)HitObject).RepeatIndex == 0;
+            bool delayFadeIn = slider.SliderBody?.SnakingIn.Value == true && repeatIndex == 0;
+
+            if (repeatIndex > 0)
+                fadeTime = Math.Min(slider.HitObject.SpanDuration, fadeTime);
 
             target
                 .FadeOut()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -149,5 +149,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected float CalculateDrawableRelativePosition(Drawable drawable) => (drawable.ScreenSpaceDrawQuad.Centre.X - parentScreenSpaceRectangle.X) / parentScreenSpaceRectangle.Width;
 
         protected override JudgementResult CreateResult(Judgement judgement) => new OsuJudgementResult(HitObject, judgement);
+
+        protected void ApplyRepeatFadeIn(Drawable target)
+        {
+            DrawableSlider slider = (DrawableSlider)ParentHitObject;
+
+            // When snaking in is enabled, the first end circle needs to be delayed until the snaking completes.
+            bool delayFadeIn = slider!.SliderBody?.SnakingIn.Value == true && ((SliderEndCircle)HitObject).RepeatIndex == 0;
+
+            target
+                .FadeOut()
+                .Delay(delayFadeIn ? (slider.HitObject.TimePreempt) / 3 : 0)
+                .FadeIn(150);
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override JudgementResult CreateResult(Judgement judgement) => new OsuJudgementResult(HitObject, judgement);
 
-        protected void ApplyRepeatFadeIn(Drawable target)
+        protected void ApplyRepeatFadeIn(Drawable target, double fadeTime)
         {
             DrawableSlider slider = (DrawableSlider)ParentHitObject;
 
@@ -160,7 +160,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             target
                 .FadeOut()
                 .Delay(delayFadeIn ? (slider.HitObject.TimePreempt) / 3 : 0)
-                .FadeIn(150);
+                .FadeIn(fadeTime);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -27,8 +27,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
 
-        private double animDuration;
-
         public SkinnableDrawable CirclePiece { get; private set; }
 
         public SkinnableDrawable Arrow { get; private set; }
@@ -87,20 +85,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override void UpdateInitialTransforms()
         {
-            // When snaking in is enabled, the first end circle needs to be delayed until the snaking completes.
-            bool delayFadeIn = DrawableSlider.SliderBody?.SnakingIn.Value == true && HitObject.RepeatIndex == 0;
-
-            animDuration = Math.Min(300, HitObject.SpanDuration);
-
-            this
-                .FadeOut()
-                .Delay(delayFadeIn ? (Slider?.TimePreempt ?? 0) / 3 : 0)
-                .FadeIn(150);
+            ApplyRepeatFadeIn(this);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
+
+            double animDuration = Math.Min(300, HitObject.SpanDuration);
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             this
                 .FadeOut()
                 .Delay(delayFadeIn ? (Slider?.TimePreempt ?? 0) / 3 : 0)
-                .FadeIn(HitObject.RepeatIndex == 0 ? HitObject.TimeFadeIn : animDuration);
+                .FadeIn(150);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -85,7 +85,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override void UpdateInitialTransforms()
         {
-            ApplyRepeatFadeIn(this);
+            base.UpdateInitialTransforms();
+
+            ApplyRepeatFadeIn(CirclePiece, HitObject.TimeFadeIn);
+            ApplyRepeatFadeIn(Arrow, 150);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -85,14 +85,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
-
-            // When snaking in is enabled, the first end circle needs to be delayed until the snaking completes.
-            bool delayFadeIn = DrawableSlider.SliderBody?.SnakingIn.Value == true && HitObject.RepeatIndex == 0;
-
-            CirclePiece
-                .FadeOut()
-                .Delay(delayFadeIn ? (Slider?.TimePreempt ?? 0) / 3 : 0)
-                .FadeIn(HitObject.TimeFadeIn);
+            ApplyRepeatFadeIn(CirclePiece);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -85,7 +85,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
-            ApplyRepeatFadeIn(CirclePiece);
+
+            ApplyRepeatFadeIn(CirclePiece, HitObject.TimeFadeIn);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)


### PR DESCRIPTION
Raised in email, citing https://github.com/ppy/osu/discussions/25986, which still seems to be a valid concern (was only fixed partially). Recent changes around this code include https://github.com/ppy/osu/pull/23372, which doesn't address the fade length.


https://github.com/user-attachments/assets/beef7a8e-e29c-4183-b45c-ea8e44473d68

Stable reference: https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/GameplayElements/HitObjects/Osu/HitCircleSliderEnd.cs#L38