### PR TITLE
Rework multiplayer mod select to use online state

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -37,6 +37,21 @@ namespace osu.Game.Online.Multiplayer
         public virtual event Action? RoomUpdated;
 
         /// <summary>
+        /// Invoked when a user's local style is changed.
+        /// </summary>
+        public event Action<MultiplayerRoomUser>? UserStyleChanged;
+
+        /// <summary>
+        /// Invoked when a user's local mods are changed.
+        /// </summary>
+        public event Action<MultiplayerRoomUser>? UserModsChanged;
+
+        /// <summary>
+        /// Invoked when the room's settings are changed.
+        /// </summary>
+        public event Action<MultiplayerRoomSettings>? SettingsChanged;
+
+        /// <summary>
         /// Invoked when a new user joins the room.
         /// </summary>
         public event Action<MultiplayerRoomUser>? UserJoined;
@@ -710,7 +725,7 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
-        public Task UserStyleChanged(int userId, int? beatmapId, int? rulesetId)
+        Task IMultiplayerClient.UserStyleChanged(int userId, int? beatmapId, int? rulesetId)
         {
             Scheduler.Add(() =>
             {
@@ -723,13 +738,14 @@ namespace osu.Game.Online.Multiplayer
                 user.BeatmapId = beatmapId;
                 user.RulesetId = rulesetId;
 
+                UserStyleChanged?.Invoke(user);
                 RoomUpdated?.Invoke();
             }, false);
 
             return Task.CompletedTask;
         }
 
-        public Task UserModsChanged(int userId, IEnumerable<APIMod> mods)
+        Task IMultiplayerClient.UserModsChanged(int userId, IEnumerable<APIMod> mods)
         {
             Scheduler.Add(() =>
             {
@@ -741,6 +757,7 @@ namespace osu.Game.Online.Multiplayer
 
                 user.Mods = mods;
 
+                UserModsChanged?.Invoke(user);
                 RoomUpdated?.Invoke();
             }, false);
 
@@ -907,6 +924,7 @@ namespace osu.Game.Online.Multiplayer
             APIRoom.CurrentPlaylistItem = APIRoom.Playlist.Single(item => item.ID == settings.PlaylistItemId);
             APIRoom.AutoSkip = Room.Settings.AutoSkip;
 
+            SettingsChanged?.Invoke(settings);
             RoomUpdated?.Invoke();
         }
 

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -27,6 +27,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Utils;
 using Container = osu.Framework.Graphics.Containers.Container;
 
@@ -245,10 +246,8 @@ namespace osu.Game.Screens.OnlinePlay.Match
                 }
             };
 
-            LoadComponent(UserModsSelectOverlay = new RoomModSelectOverlay
+            LoadComponent(UserModsSelectOverlay = new MultiplayerUserModSelectOverlay
             {
-                SelectedItem = { BindTarget = SelectedItem },
-                SelectedMods = { BindTarget = UserMods },
                 IsValidMod = _ => false
             });
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerUserModSelectOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerUserModSelectOverlay.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         }
 
         /// <summary>
-        /// Updates the selected mods from the online state if the server is authoritative.
+        /// Updates the selected mods from the online state if there are no changes pending on the server to process.
         /// </summary>
         private void updateFromOnlineState()
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerUserModSelectOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerUserModSelectOverlay.cs
@@ -1,0 +1,210 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Threading;
+using osu.Game.Configuration;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
+{
+    public partial class MultiplayerUserModSelectOverlay : UserModSelectOverlay
+    {
+        private const double flush_debounce_time = 500;
+
+        [Resolved]
+        private MultiplayerClient client { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        private ModSettingChangeTracker? modSettingChangeTracker;
+
+        public MultiplayerUserModSelectOverlay()
+            : base(OverlayColourScheme.Plum)
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            client.UserStyleChanged += onUserStyleChanged;
+            client.UserModsChanged += onUserModsChanged;
+            client.ItemChanged += onPlaylistItemChanged;
+            client.SettingsChanged += onSettingsChanged;
+
+            SelectedMods.BindValueChanged(onSelectedModsChanged);
+
+            updateFromOnlineState();
+        }
+
+        /// <summary>
+        /// The last selected playlist item.
+        /// </summary>
+        private long lastPlaylistItemId;
+
+        /// <summary>
+        /// The current debounced <see cref="flushPendingChanges"/> operation resulting from a change in a mod's settings.
+        /// </summary>
+        private ScheduledDelegate? scheduledFlush;
+
+        /// <summary>
+        /// The number of pending changes to the local selection that have not yet been processed by the server.
+        /// </summary>
+        private int countPendingChanges;
+
+        /// <summary>
+        /// Responds to changes in the local user's style to take on the server-side state.
+        /// </summary>
+        private void onUserStyleChanged(MultiplayerRoomUser user) => Scheduler.Add(() =>
+        {
+            if (user.Equals(client.LocalUser))
+                updateFromOnlineState();
+        });
+
+        /// <summary>
+        /// Responds to changes in the local user's mods to take on the server-side state.
+        /// </summary>
+        private void onUserModsChanged(MultiplayerRoomUser user) => Scheduler.Add(() =>
+        {
+            if (user.Equals(client.LocalUser))
+                updateFromOnlineState();
+        });
+
+        /// <summary>
+        /// Responds to changes in the current playlist item to take on the server-side state,
+        /// potentially also changing the visible mod panels depending on the new item state.
+        /// </summary>
+        private void onPlaylistItemChanged(MultiplayerPlaylistItem item) => Scheduler.Add(() =>
+        {
+            if (item.ID == client.Room?.Settings.PlaylistItemId)
+                updateFromOnlineState();
+        });
+
+        /// <summary>
+        /// Responds to changes in the current playlist item to take on the server-side state,
+        /// potentially also changing the visible mod panels depending on the new item state.
+        /// </summary>
+        private void onSettingsChanged(MultiplayerRoomSettings settings) => Scheduler.Add(() =>
+        {
+            if (settings.PlaylistItemId != lastPlaylistItemId)
+            {
+                updateFromOnlineState();
+                lastPlaylistItemId = settings.PlaylistItemId;
+            }
+        });
+
+        /// <summary>
+        /// Tracks changes to the local selected mods to notify the server of any changes.
+        /// </summary>
+        private void onSelectedModsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        {
+            // Process changes to the selection immediately because these occur somewhat infrequently.
+            flushPendingChanges();
+
+            modSettingChangeTracker?.Dispose();
+            modSettingChangeTracker = new ModSettingChangeTracker(mods.NewValue);
+            modSettingChangeTracker.SettingChanged += _ =>
+            {
+                // Debounce changes to mod settings because these can be continuous (e.g. moving a slider bar).
+                scheduledFlush ??= Scheduler.AddDelayed(flushPendingChanges, flush_debounce_time);
+            };
+        }
+
+        /// <summary>
+        /// Notifies the server of changes to the selected mods.
+        /// </summary>
+        private void flushPendingChanges()
+        {
+            scheduledFlush?.Cancel();
+            scheduledFlush = null;
+
+            if (client.Room == null)
+                return;
+
+            countPendingChanges++;
+
+            client.ChangeUserMods(SelectedMods.Value)
+                  .FireAndForget(endChange, _ => endChange());
+
+            void endChange() => Scheduler.Add(() =>
+            {
+                countPendingChanges--;
+                updateFromOnlineState();
+            });
+        }
+
+        /// <summary>
+        /// Updates the selected mods from the online state if the server is authoritative.
+        /// </summary>
+        private void updateFromOnlineState()
+        {
+            if (client.Room == null || client.LocalUser == null)
+                return;
+
+            // Check if there are any pending changes, in which case we should prefer the local state.
+            if (countPendingChanges > 0 || scheduledFlush != null)
+                return;
+
+            MultiplayerPlaylistItem currentItem = client.Room.CurrentPlaylistItem;
+            Ruleset ruleset = rulesets.GetRuleset(client.LocalUser.RulesetId ?? currentItem.RulesetID)!.CreateInstance();
+            Mod[] allowedMods = currentItem.Freestyle
+                ? ruleset.AllMods.OfType<Mod>().Where(m => ModUtils.IsValidFreeModForMatchType(m, client.Room.Settings.MatchType)).ToArray()
+                : currentItem.AllowedMods.Select(m => m.ToMod(ruleset)).ToArray();
+
+            // Update the mod panels to reflect the ones which are valid for selection.
+            IsValidMod = allowedMods.Length > 0
+                ? m => allowedMods.Any(a => a.GetType() == m.GetType())
+                : _ => false;
+
+            // Update the selection to reflect the server's current state.
+            Mod[] userMods = client.LocalUser.Mods.Select(m => m.ToMod(ruleset)).ToArray();
+
+            if (!userMods.SequenceEqual(SelectedMods.Value))
+            {
+                SelectedMods.ValueChanged -= onSelectedModsChanged;
+                SelectedMods.Value = userMods;
+                SelectedMods.ValueChanged += onSelectedModsChanged;
+            }
+
+            ActiveMods.Value = ComputeActiveMods();
+        }
+
+        protected override IReadOnlyList<Mod> ComputeActiveMods()
+        {
+            if (client.Room == null || client.LocalUser == null)
+                return [];
+
+            MultiplayerPlaylistItem currentItem = client.Room.CurrentPlaylistItem;
+            Ruleset ruleset = rulesets.GetRuleset(currentItem.RulesetID)!.CreateInstance();
+
+            return currentItem.RequiredMods.Select(m => m.ToMod(ruleset)).Concat(base.ComputeActiveMods()).ToArray();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (client.IsNotNull())
+            {
+                client.UserStyleChanged -= onUserStyleChanged;
+                client.UserModsChanged -= onUserModsChanged;
+                client.ItemChanged -= onPlaylistItemChanged;
+                client.SettingsChanged -= onSettingsChanged;
+            }
+
+            modSettingChangeTracker?.Dispose();
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -11,9 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
-using osu.Framework.Threading;
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online;
 using osu.Game.Online.API;
@@ -23,7 +20,6 @@ using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Match;
 using osu.Game.Screens.OnlinePlay.Match.Components;
@@ -64,7 +60,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             base.LoadComplete();
 
             BeatmapAvailability.BindValueChanged(updateBeatmapAvailability, true);
-            UserMods.BindValueChanged(onUserModsChanged);
 
             client.LoadRequested += onLoadRequested;
             client.RoomUpdated += onRoomUpdated;
@@ -307,35 +302,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         protected override void PartRoom() => client.LeaveRoom();
 
-        private ModSettingChangeTracker? modSettingChangeTracker;
-        private ScheduledDelegate? debouncedModSettingsUpdate;
-
-        private void onUserModsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
-        {
-            modSettingChangeTracker?.Dispose();
-
-            if (client.Room == null)
-                return;
-
-            client.ChangeUserMods(mods.NewValue).FireAndForget();
-
-            modSettingChangeTracker = new ModSettingChangeTracker(mods.NewValue);
-            modSettingChangeTracker.SettingChanged += onModSettingsChanged;
-        }
-
-        private void onModSettingsChanged(Mod mod)
-        {
-            // Debounce changes to mod settings so as to not thrash the network.
-            debouncedModSettingsUpdate?.Cancel();
-            debouncedModSettingsUpdate = Scheduler.AddDelayed(() =>
-            {
-                if (client.Room == null)
-                    return;
-
-                client.ChangeUserMods(UserMods.Value).FireAndForget();
-            }, 500);
-        }
-
         private void updateBeatmapAvailability(ValueChangedEvent<BeatmapAvailability> availability)
         {
             if (client.Room == null)
@@ -463,8 +429,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 client.RoomUpdated -= onRoomUpdated;
                 client.LoadRequested -= onLoadRequested;
             }
-
-            modSettingChangeTracker?.Dispose();
         }
 
         public partial class AddItemButton : PurpleRoundedButton


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/32250, but heavily modified.

In the process of splitting this out, I've taken another look at it from the perspective of minimising the implementation and hopefully making it as straightforward as possible. Because tests for this aren't super simple to write, my hope is for the code to be logical and simple to follow enough on its own to resolve the concerns of https://github.com/ppy/osu/pull/32250/files#r1998421648.  
If any brains are still shutting down reading this PR, then I have failed in this effort so please assist me in making it easier to understand for everyone's future benefit (I don't intend to make code complicated in general, but I'm explicitly going for simplicity here).

Of course, I will be writing tests if things break.

## Overview

The primary purpose of this is to remove the dependence on the `UserMods` bindable which is slated to be removed, i.e. this line:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/d9695591-deb5-4842-af46-07346eec09c6" />

This is a bit of a special overlay which has no "loading layer" and committing of changes - it's all expected to work in the background. Thus, I conceptualise the operation as:
1. While the client has pending changes (e.g. mods have changed), the overlay follows whatever state the client's local mods represent.
2. If there are no pending changes, the overlay follows whatever state the server gives it.

## When could the server give the client a state it doesn't have?

The most common case is going to be when the server re-validates the user's mods against the new playlist item/ruleset - [this code](https://github.com/ppy/osu-server-spectator/blob/c1f33672cc2245614bdcfeb3109801b20a89c709/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs#L206-L210) is expected to trigger and preserve mods like HR between rulesets that support it.

How does this currently work? It doesn't. Because the client is [matching on `Mod` types](https://github.com/ppy/osu/blob/f4c96ecb54ff7650e617597faa583f1f40ce323b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs#L445-L447), it is _not_ able to preserve mods between rulesets, and so it ends up doing the following two queries:
1. ChangeUserStyle(newRuleset, ...)
2. ChangeUserMods(Empty());

Example (notice disappearance of HR):

https://github.com/user-attachments/assets/21a5019a-78d5-4dc2-99c1-c3009509c7d8

In a way, the actual failure here is a bit hidden by luck - that the client doesn't respond to the server's mod states in any way whatsoever. It just so happens that clearing the mods puts both systems on the right track again.

Compare that to the implementation in this PR, which correctly responds to the server-side state:

https://github.com/user-attachments/assets/1393ab65-2cea-4825-992d-12c28b1c6947

As always, the disclaimer: as I'm splitting this PR out, I'm going to treat `RoomSubScreen` as if it's already `MultiplayerMatchSubScreen`, as that is its only remaining inheritor.