### PR TITLE
Re-do user tag voting UI to address user complaints

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -214,14 +214,10 @@ namespace osu.Game.Tests.Visual.Ranking
                             {
                                 Tags =
                                 [
-                                    new APITag { Id = 1, Name = "tech", Description = "Tests uncommon skills.", },
-                                    new APITag
-                                    {
-                                        Id = 2, Name = "alt",
-                                        Description = "Colloquial term for maps which use rhythms that encourage the player to alternate notes. Typically distinct from burst or stream maps.",
-                                    },
-                                    new APITag { Id = 3, Name = "aim", Description = "Category for difficulty relating to cursor movement.", },
-                                    new APITag { Id = 4, Name = "tap", Description = "Category for difficulty relating to tapping input.", },
+                                    new APITag { Id = 1, Name = "song representation/simple", Description = "Accessible and straightforward map design.", },
+                                    new APITag { Id = 2, Name = "style/clean", Description = "Visually uncluttered and organised patterns, often involving few overlaps and equal visual spacing between objects.", },
+                                    new APITag { Id = 3, Name = "aim/aim control", Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern.", },
+                                    new APITag { Id = 4, Name = "tap/bursts", Description = "Patterns requiring continuous movement and alternating, typically 9 notes or less.", },
                                 ]
                             }), 500);
                             return true;

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -26,6 +26,7 @@ using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania;
@@ -51,6 +52,9 @@ namespace osu.Game.Tests.Visual.Ranking
         private ScoreManager scoreManager = null!;
         private RulesetStore rulesetStore = null!;
         private BeatmapManager beatmapManager = null!;
+
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -364,12 +368,16 @@ namespace osu.Game.Tests.Visual.Ranking
 
         private void loadPanel(ScoreInfo score) => AddStep("load panel", () =>
         {
-            Child = new StatisticsPanel
+            Child = new PopoverContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                State = { Value = Visibility.Visible },
-                Score = { Value = score },
-                AchievedScore = score,
+                Child = new StatisticsPanel
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    State = { Value = Visibility.Visible },
+                    Score = { Value = score },
+                    AchievedScore = score,
+                },
             };
         });
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
@@ -36,6 +35,7 @@ namespace osu.Game.Tests.Visual.Ranking
                             {
                                 Tags =
                                 [
+                                    new APITag { Id = 0, Name = "uncategorised tag", Description = "This probably isn't real but could be and should be handled.", },
                                     new APITag { Id = 1, Name = "song representation/simple", Description = "Accessible and straightforward map design.", },
                                     new APITag { Id = 2, Name = "style/clean", Description = "Visually uncluttered and organised patterns, often involving few overlaps and equal visual spacing between objects.", },
                                     new APITag { Id = 3, Name = "aim/aim control", Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern.", },
@@ -69,15 +69,11 @@ namespace osu.Game.Tests.Visual.Ranking
             });
             AddStep("create control", () =>
             {
-                Child = new PopoverContainer
+                Child = new UserTagControl(Beatmap.Value.BeatmapInfo)
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = new UserTagControl(Beatmap.Value.BeatmapInfo)
-                    {
-                        Width = 500,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                    }
+                    Width = 700,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
                 };
             });
         }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
@@ -2,12 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens.Ranking;
@@ -16,6 +19,9 @@ namespace osu.Game.Tests.Visual.Ranking
 {
     public partial class TestSceneUserTagControl : OsuTestScene
     {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
+
         private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
 
         [SetUpSteps]
@@ -35,8 +41,15 @@ namespace osu.Game.Tests.Visual.Ranking
                                 [
                                     new APITag { Id = 0, Name = "uncategorised tag", Description = "This probably isn't real but could be and should be handled.", },
                                     new APITag { Id = 1, Name = "song representation/simple", Description = "Accessible and straightforward map design.", },
-                                    new APITag { Id = 2, Name = "style/clean", Description = "Visually uncluttered and organised patterns, often involving few overlaps and equal visual spacing between objects.", },
-                                    new APITag { Id = 3, Name = "aim/aim control", Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern.", },
+                                    new APITag
+                                    {
+                                        Id = 2, Name = "style/clean",
+                                        Description = "Visually uncluttered and organised patterns, often involving few overlaps and equal visual spacing between objects.",
+                                    },
+                                    new APITag
+                                    {
+                                        Id = 3, Name = "aim/aim control", Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern.",
+                                    },
                                     new APITag { Id = 4, Name = "tap/bursts", Description = "Patterns requiring continuous movement and alternating, typically 9 notes or less.", },
                                     new APITag { Id = 5, Name = "style/mono-heavy", Description = "Features monos used in large amounts.", RulesetId = 1, },
                                 ]
@@ -84,11 +97,15 @@ namespace osu.Game.Tests.Visual.Ranking
 
         private void recreateControl()
         {
-            Child = new UserTagControl(Beatmap.Value.BeatmapInfo)
+            Child = new PopoverContainer
             {
-                Width = 700,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Child = new UserTagControl(Beatmap.Value.BeatmapInfo)
+                {
+                    Width = 700,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
             };
         }
     }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
@@ -36,10 +36,10 @@ namespace osu.Game.Tests.Visual.Ranking
                             {
                                 Tags =
                                 [
-                                    new APITag { Id = 1, Name = "tech", Description = "Tests uncommon skills.", },
-                                    new APITag { Id = 2, Name = "alt", Description = "Colloquial term for maps which use rhythms that encourage the player to alternate notes. Typically distinct from burst or stream maps.", },
-                                    new APITag { Id = 3, Name = "aim", Description = "Category for difficulty relating to cursor movement.", },
-                                    new APITag { Id = 4, Name = "tap", Description = "Category for difficulty relating to tapping input.", },
+                                    new APITag { Id = 1, Name = "song representation/simple", Description = "Accessible and straightforward map design.", },
+                                    new APITag { Id = 2, Name = "style/clean", Description = "Visually uncluttered and organised patterns, often involving few overlaps and equal visual spacing between objects.", },
+                                    new APITag { Id = 3, Name = "aim/aim control", Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern.", },
+                                    new APITag { Id = 4, Name = "tap/bursts", Description = "Patterns requiring continuous movement and alternating, typically 9 notes or less.", },
                                 ]
                             }), 500);
                             return true;

--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Graphics.UserInterface
 
         private Color4 hoverColour = Color4.White.Opacity(0.1f);
 
+        protected float ScaleOnMouseDown { get; init; } = 0.75f;
+
         /// <summary>
         /// The background colour of the <see cref="OsuAnimatedButton"/> while it is hovered.
         /// </summary>
@@ -119,7 +121,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            Content.ScaleTo(0.75f, 2000, Easing.OutQuint);
+            Content.ScaleTo(ScaleOnMouseDown, 2000, Easing.OutQuint);
             return base.OnMouseDown(e);
         }
 

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -86,6 +86,9 @@ namespace osu.Game.Screens.Ranking
 
         private Sample? popInSample;
 
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
+
         protected ResultsScreen(ScoreInfo? score)
         {
             Score = score;

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using osuTK;
 
 namespace osu.Game.Screens.Ranking.Statistics
 {
@@ -53,7 +50,9 @@ namespace osu.Game.Screens.Ranking.Statistics
                         Padding = new MarginPadding(5),
                         Children = new[]
                         {
-                            createHeader(item),
+                            LocalisableString.IsNullOrEmpty(item.Name)
+                                ? Empty()
+                                : new StatisticItemHeader { Text = item.Name },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.X,
@@ -63,38 +62,6 @@ namespace osu.Game.Screens.Ranking.Statistics
                             }
                         }
                     },
-                }
-            };
-        }
-
-        private static Drawable createHeader(StatisticItem item)
-        {
-            if (LocalisableString.IsNullOrEmpty(item.Name))
-                return Empty();
-
-            return new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 20,
-                Direction = FillDirection.Horizontal,
-                Spacing = new Vector2(5, 0),
-                Children = new Drawable[]
-                {
-                    new Circle
-                    {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Height = 9,
-                        Width = 4,
-                        Colour = Color4Extensions.FromHex("#00FFAA")
-                    },
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Text = item.Name,
-                        Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold),
-                    }
                 }
             };
         }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemHeader.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemHeader.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Screens.Ranking.Statistics
+{
+    public partial class StatisticItemHeader : CompositeDrawable, IHasText
+    {
+        public LocalisableString Text
+        {
+            get => text;
+            set
+            {
+                if (text == value) return;
+
+                text = value;
+                if (IsLoaded)
+                    spriteText.Text = value;
+            }
+        }
+
+        private LocalisableString text;
+        private OsuSpriteText spriteText = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 20,
+                Direction = FillDirection.Horizontal,
+                Spacing = new Vector2(5, 0),
+                Children = new Drawable[]
+                {
+                    new Circle
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Height = 9,
+                        Width = 4,
+                        Colour = Color4Extensions.FromHex("#00FFAA")
+                    },
+                    spriteText = new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = text,
+                        Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold),
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -304,7 +304,10 @@ namespace osu.Game.Screens.Ranking.Statistics
             this.FadeOut(250, Easing.OutQuint);
 
             if (wasOpened)
+            {
                 popOutSample?.Play();
+                this.HidePopover(); // targeted at the user tag control
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Ranking/UserTag.cs
+++ b/osu.Game/Screens/Ranking/UserTag.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Screens.Ranking
 
         public BindableInt VoteCount { get; } = new BindableInt();
         public BindableBool Voted { get; } = new BindableBool();
+        public BindableBool Updating { get; } = new BindableBool();
 
         public UserTag(APITag tag)
         {

--- a/osu.Game/Screens/Ranking/UserTag.cs
+++ b/osu.Game/Screens/Ranking/UserTag.cs
@@ -9,7 +9,9 @@ namespace osu.Game.Screens.Ranking
     public record UserTag
     {
         public long Id { get; }
-        public string Name { get; }
+        public string FullName { get; }
+        public string? GroupName { get; }
+        public string DisplayName { get; }
         public string Description { get; }
 
         public BindableInt VoteCount { get; } = new BindableInt();
@@ -18,8 +20,12 @@ namespace osu.Game.Screens.Ranking
         public UserTag(APITag tag)
         {
             Id = tag.Id;
-            Name = tag.Name;
+            FullName = tag.Name;
             Description = tag.Description;
+
+            string[] splitName = FullName.Split('/');
+            GroupName = splitName.Length > 1 ? splitName[0] : null;
+            DisplayName = splitName[^1];
         }
     }
 }

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -511,6 +511,7 @@ namespace osu.Game.Screens.Ranking
                 AllowableAnchors = new[]
                 {
                     Anchor.TopCentre,
+                    Anchor.BottomCentre,
                 };
 
                 Children = new Drawable[]

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -319,6 +319,8 @@ namespace osu.Game.Screens.Ranking
                 voted.BindTo(userTag.Voted);
 
                 AutoSizeAxes = Axes.Both;
+
+                ScaleOnMouseDown = 0.95f;
             }
 
             [BackgroundDependencyLoader]
@@ -654,6 +656,8 @@ namespace osu.Game.Screens.Ranking
 
                     RelativeSizeAxes = Axes.X;
                     AutoSizeAxes = Axes.Y;
+
+                    ScaleOnMouseDown = 0.95f;
                 }
 
                 [Resolved]
@@ -735,15 +739,6 @@ namespace osu.Game.Screens.Ranking
                         votedIcon.FadeColour(voted.Value ? Colour4.Black : Colour4.White, 250, Easing.OutQuint);
                     }, true);
                     FinishTransforms(true);
-                }
-
-                protected override bool OnMouseDown(MouseDownEvent e)
-                {
-                    bool result = base.OnMouseDown(e);
-                    // slightly dodgy way of overriding the amount of scale-on-click (the default is way too much in this case)
-                    ClearTransforms(targetMember: nameof(Scale));
-                    Content.ScaleTo(0.95f, 2000, Easing.OutQuint);
-                    return result;
                 }
             }
         }

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -17,8 +17,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
@@ -26,12 +28,12 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Screens.Ranking.Statistics;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Screens.Ranking
 {
@@ -288,6 +290,10 @@ namespace osu.Game.Screens.Ranking
 
         protected override bool OnClick(ClickEvent e) => true;
 
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+
         private partial class DrawableUserTag : OsuAnimatedButton
         {
             public readonly UserTag UserTag;
@@ -444,7 +450,7 @@ namespace osu.Game.Screens.Ranking
             }
         }
 
-        private partial class TagList : CompositeDrawable
+        private partial class TagList : CompositeDrawable, IKeyBindingHandler<GlobalAction>
         {
             private SearchTextBox searchBox = null!;
             private SearchContainer searchContainer = null!;
@@ -532,20 +538,24 @@ namespace osu.Game.Screens.Ranking
                 }
             }
 
-            protected override bool OnKeyDown(KeyDownEvent e)
+            public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
             {
-                if (e.Key == Key.Enter)
+                if (e.Action == GlobalAction.Select && !e.Repeat)
                 {
                     attemptSelect();
                     return true;
                 }
 
-                return base.OnKeyDown(e);
+                return false;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+            {
             }
 
             private void attemptSelect()
             {
-                var visibleItems = searchContainer.OfType<DrawableAddableTag>().Where(d => d.IsPresent).ToArray();
+                var visibleItems = searchContainer.ChildrenOfType<DrawableAddableTag>().Where(d => d.IsPresent).ToArray();
 
                 if (visibleItems.Length == 1)
                     OnSelected?.Invoke(visibleItems.Single().Tag);

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Ranking
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         AutoSizeAxes = Axes.Y,
-                                        Direction = FillDirection.Full,
+                                        Direction = FillDirection.Vertical,
                                         LayoutDuration = 300,
                                         LayoutEasing = Easing.OutQuint,
                                         Spacing = new Vector2(4),

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -249,6 +249,7 @@ namespace osu.Game.Screens.Ranking
 
             private Box mainBackground = null!;
             private Box voteBackground = null!;
+            private OsuSpriteText tagCategoryText = null!;
             private OsuSpriteText tagNameText = null!;
             private OsuSpriteText voteCountText = null!;
             private LoadingSpinner spinner = null!;
@@ -276,6 +277,8 @@ namespace osu.Game.Screens.Ranking
             [BackgroundDependencyLoader]
             private void load()
             {
+                string[] tagParts = UserTag.Name.Split('/');
+
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
                 CornerRadius = 8;
@@ -297,21 +300,42 @@ namespace osu.Game.Screens.Ranking
                     {
                         AutoSizeAxes = Axes.Both,
                         Direction = FillDirection.Horizontal,
-                        Padding = new MarginPadding { Left = 6, Right = 3, Vertical = 3, },
-                        Spacing = new Vector2(5),
                         Children = new Drawable[]
                         {
-                            tagNameText = new OsuSpriteText
+                            tagCategoryText = new OsuSpriteText
                             {
-                                Text = UserTag.Name,
+                                Alpha = tagParts.Length > 1 ? 0.6f : 0,
+                                Text = tagParts[0],
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
+                                Margin = new MarginPadding { Horizontal = 6 }
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Y,
+                                AutoSizeAxes = Axes.X,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Alpha = 0.1f,
+                                        Blending = BlendingParameters.Additive,
+                                    },
+                                    tagNameText = new OsuSpriteText
+                                    {
+                                        Text = tagParts[^1],
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Margin = new MarginPadding { Horizontal = 6 }
+                                    },
+                                }
                             },
                             new Container
                             {
                                 AutoSizeAxes = Axes.Both,
-                                CornerRadius = 5,
-                                Masking = true,
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                                 Children = new Drawable[]
@@ -353,7 +377,7 @@ namespace osu.Game.Screens.Ranking
                 {
                     if (v.NewValue)
                     {
-                        voteBackground.FadeColour(colours.Lime3, transition_duration, Easing.OutQuint);
+                        voteBackground.FadeColour(colours.Lime2, transition_duration, Easing.OutQuint);
                         voteCountText.FadeColour(Colour4.Black, transition_duration, Easing.OutQuint);
                     }
                     else
@@ -366,13 +390,15 @@ namespace osu.Game.Screens.Ranking
                 {
                     if (c.NewValue)
                     {
-                        mainBackground.FadeColour(colours.Lime1, transition_duration, Easing.OutQuint);
+                        mainBackground.FadeColour(colours.Lime2, transition_duration, Easing.OutQuint);
+                        tagCategoryText.FadeColour(Colour4.Black, transition_duration, Easing.OutQuint);
                         tagNameText.FadeColour(Colour4.Black, transition_duration, Easing.OutQuint);
                         FadeEdgeEffectTo(0.5f, transition_duration, Easing.OutQuint);
                     }
                     else
                     {
                         mainBackground.FadeColour(colours.Gray4, transition_duration, Easing.OutQuint);
+                        tagCategoryText.FadeColour(Colour4.White, transition_duration, Easing.OutQuint);
                         tagNameText.FadeColour(Colour4.White, transition_duration, Easing.OutQuint);
                         FadeEdgeEffectTo(0f, transition_duration, Easing.OutQuint);
                     }

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -370,6 +370,7 @@ namespace osu.Game.Screens.Ranking
                                     tagNameText = new OsuSpriteText
                                     {
                                         Text = UserTag.DisplayName,
+                                        Font = OsuFont.Default.With(weight: FontWeight.SemiBold),
                                         Anchor = Anchor.CentreLeft,
                                         Origin = Anchor.CentreLeft,
                                         Margin = new MarginPadding { Horizontal = 6 }
@@ -698,7 +699,7 @@ namespace osu.Game.Screens.Ranking
                             Padding = new MarginPadding(5) { Right = 35 },
                             Children = new Drawable[]
                             {
-                                new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(weight: FontWeight.Bold))
+                                new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(weight: FontWeight.SemiBold))
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -56,8 +56,6 @@ namespace osu.Game.Screens.Ranking
 
         private readonly Bindable<APIBeatmap?> apiBeatmap = new Bindable<APIBeatmap?>();
 
-        private APIRequest? requestInFlight;
-
         private AddNewTagUserTag addNewTagUserTag = null!;
 
         [Resolved]
@@ -215,7 +213,7 @@ namespace osu.Game.Screens.Ranking
 
         private void toggleVote(UserTag tag)
         {
-            if (requestInFlight != null)
+            if (tag.Updating.Value)
                 return;
 
             tag.Updating.Value = true;
@@ -247,17 +245,10 @@ namespace osu.Game.Screens.Ranking
                     break;
             }
 
-            request.Success += () =>
-            {
-                tag.Updating.Value = false;
-                requestInFlight = null;
-            };
-            request.Failure += _ =>
-            {
-                tag.Updating.Value = false;
-                requestInFlight = null;
-            };
-            api.Queue(requestInFlight = request);
+            request.Success += () => tag.Updating.Value = false;
+            request.Failure += _ => tag.Updating.Value = false;
+
+            api.Queue(request);
         }
 
         private void voteCountChanged(ValueChangedEvent<int> _)

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -324,7 +324,7 @@ namespace osu.Game.Screens.Ranking
             {
                 Anchor = Anchor.CentreLeft;
                 Origin = Anchor.CentreLeft;
-                CornerRadius = 8;
+                CornerRadius = 5;
                 Masking = true;
                 EdgeEffect = new EdgeEffectParameters
                 {

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -98,8 +98,6 @@ namespace osu.Game.Screens.Ranking
                                         RelativeSizeAxes = Axes.X,
                                         AutoSizeAxes = Axes.Y,
                                         Direction = FillDirection.Full,
-                                        LayoutDuration = 300,
-                                        LayoutEasing = Easing.OutQuint,
                                         Spacing = new Vector2(4),
                                     },
                                 },
@@ -326,8 +324,6 @@ namespace osu.Game.Screens.Ranking
             [BackgroundDependencyLoader]
             private void load()
             {
-                Anchor = Anchor.CentreLeft;
-                Origin = Anchor.CentreLeft;
                 CornerRadius = 5;
                 Masking = true;
                 EdgeEffect = new EdgeEffectParameters

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.Ranking
                     Padding = new MarginPadding(10),
                     ColumnDimensions =
                     [
-                        new Dimension(GridSizeMode.Absolute, 300),
+                        new Dimension(GridSizeMode.Absolute, 350),
                         new Dimension()
                     ],
                     RowDimensions = [new Dimension(GridSizeMode.AutoSize, minSize: 250)],
@@ -614,7 +614,7 @@ namespace osu.Game.Screens.Ranking
                                     Colour = colours.Lime1,
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
-                                    Margin = new MarginPadding { Right = 5 },
+                                    Margin = new MarginPadding { Right = 10 },
                                 }
                             }
                         },

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -9,10 +9,8 @@ using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
@@ -589,7 +587,8 @@ namespace osu.Game.Screens.Ranking
             {
                 public readonly UserTag Tag;
 
-                private Container votedIndicator = null!;
+                private Box votedBackground = null!;
+                private SpriteIcon votedIcon = null!;
 
                 private readonly Bindable<bool> voted = new Bindable<bool>();
 
@@ -601,8 +600,11 @@ namespace osu.Game.Screens.Ranking
                     AutoSizeAxes = Axes.Y;
                 }
 
+                [Resolved]
+                private OsuColour colours { get; set; } = null!;
+
                 [BackgroundDependencyLoader]
-                private void load(OsuColour colours)
+                private void load()
                 {
                     Content.AddRange(new Drawable[]
                     {
@@ -612,28 +614,25 @@ namespace osu.Game.Screens.Ranking
                             Colour = colours.Gray6,
                             Depth = float.MaxValue,
                         },
-                        votedIndicator = new Container
+                        new Container
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Width = 0.1f,
+                            RelativeSizeAxes = Axes.Y,
+                            Width = 30,
                             Anchor = Anchor.CentreRight,
                             Origin = Anchor.CentreRight,
                             Depth = float.MaxValue,
                             Children = new Drawable[]
                             {
-                                new Box
+                                votedBackground = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = ColourInfo.GradientHorizontal(colours.Lime1.Opacity(0), colours.Lime1.Opacity(0.4f)),
                                 },
-                                new SpriteIcon
+                                votedIcon = new SpriteIcon
                                 {
                                     Size = new Vector2(16),
                                     Icon = FontAwesome.Solid.ThumbsUp,
-                                    Colour = colours.Lime1,
-                                    Anchor = Anchor.CentreRight,
-                                    Origin = Anchor.CentreRight,
-                                    Margin = new MarginPadding { Right = 10 },
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
                                 }
                             }
                         },
@@ -641,10 +640,9 @@ namespace osu.Game.Screens.Ranking
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Width = 0.9f,
                             Direction = FillDirection.Vertical,
                             Spacing = new Vector2(2),
-                            Padding = new MarginPadding(5),
+                            Padding = new MarginPadding(5) { Right = 35 },
                             Children = new Drawable[]
                             {
                                 new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(weight: FontWeight.Bold))
@@ -677,7 +675,8 @@ namespace osu.Game.Screens.Ranking
 
                     voted.BindValueChanged(_ =>
                     {
-                        votedIndicator.FadeTo(voted.Value ? 1 : 0, 250, Easing.OutQuint);
+                        votedBackground.FadeColour(voted.Value ? colours.Lime2 : colours.Gray2, 250, Easing.OutQuint);
+                        votedIcon.FadeColour(voted.Value ? Colour4.Black : Colour4.White, 250, Easing.OutQuint);
                     }, true);
                     FinishTransforms(true);
                 }

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -604,6 +604,15 @@ namespace osu.Game.Screens.Ranking
 
                 public bool MatchingFilter { set => Alpha = value ? 1 : 0; }
                 public bool FilteringActive { set { } }
+
+                protected override bool OnMouseDown(MouseDownEvent e)
+                {
+                    bool result = base.OnMouseDown(e);
+                    // slightly dodgy way of overriding the amount of scale-on-click (the default is way too much in this case)
+                    ClearTransforms(targetMember: nameof(Scale));
+                    Content.ScaleTo(0.95f, 2000, Easing.OutQuint);
+                    return result;
+                }
             }
         }
     }

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -329,7 +329,7 @@ namespace osu.Game.Screens.Ranking
                 EdgeEffect = new EdgeEffectParameters
                 {
                     Colour = colours.Lime1,
-                    Radius = 5,
+                    Radius = 6,
                     Type = EdgeEffectType.Glow,
                 };
                 Content.AddRange(new Drawable[]
@@ -432,7 +432,7 @@ namespace osu.Game.Screens.Ranking
                         mainBackground.FadeColour(colours.Lime2, transition_duration, Easing.OutQuint);
                         tagCategoryText.FadeColour(Colour4.Black, transition_duration, Easing.OutQuint);
                         tagNameText.FadeColour(Colour4.Black, transition_duration, Easing.OutQuint);
-                        FadeEdgeEffectTo(0.5f, transition_duration, Easing.OutQuint);
+                        FadeEdgeEffectTo(0.3f, transition_duration, Easing.OutQuint);
                     }
                     else
                     {


### PR DESCRIPTION
https://github.com/user-attachments/assets/c457fd75-ad3a-4706-8a50-975fdfa27359

Main points this intends to hit:

- The popover is replaced by a drawer type view due to complaints that the popover was too small, and that adding multiple tags in one go was cumbersome because the popover closed every time. (The second part may seem like a weak reason to do this - after all, you could make the popover *not* close - however, the hidden reason to do this is that the popover was attached to the plus button, which was under the tag flow, which meant as you add more tags, the flow can shift downwards, and therefore so can the popover, all of which sucks)
- Better organisation by grouping & sorting alphabetically
- The tags no longer move from the right list to the left - the right list always has the full list of tags (avoids confusion of "where is XYZ tag that I'm looking for"). The left list shows most popular tags, and the right list shows everything.
- Voting is possible from both lists, and both lists show the voted status.

---

- Intended to address https://github.com/ppy/osu/discussions/32568#discussioncomment-12612884
- Closes https://github.com/ppy/osu/issues/32630, I guess
- [x] Depends on https://github.com/ppy/osu/pull/32657