### PR TITLE
Move osu!catch movement diffcalc to an evaluator

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Catch.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+
+namespace osu.Game.Rulesets.Catch.Difficulty.Evaluators
+{
+    public static class MovementEvaluator
+    {
+        private const double direction_change_bonus = 21.0;
+
+        public static double EvaluateDifficultyOf(DifficultyHitObject current, double catcherSpeedMultiplier)
+        {
+            var catchCurrent = (CatchDifficultyHitObject)current;
+            var catchLast = (CatchDifficultyHitObject)current.Previous(0);
+            var catchLastLast = (CatchDifficultyHitObject)current.Previous(1);
+
+            double weightedStrainTime = catchCurrent.StrainTime + 13 + (3 / catcherSpeedMultiplier);
+
+            double distanceAddition = (Math.Pow(Math.Abs(catchCurrent.DistanceMoved), 1.3) / 510);
+            double sqrtStrain = Math.Sqrt(weightedStrainTime);
+
+            double edgeDashBonus = 0;
+
+            // Direction change bonus.
+            if (Math.Abs(catchCurrent.DistanceMoved) > 0.1)
+            {
+                if (current.Index >= 1 && Math.Abs(catchLast.DistanceMoved) > 0.1 && Math.Sign(catchCurrent.DistanceMoved) != Math.Sign(catchLast.DistanceMoved))
+                {
+                    double bonusFactor = Math.Min(50, Math.Abs(catchCurrent.DistanceMoved)) / 50;
+                    double antiflowFactor = Math.Max(Math.Min(70, Math.Abs(catchLast.DistanceMoved)) / 70, 0.38);
+
+                    distanceAddition += direction_change_bonus / Math.Sqrt(catchLast.StrainTime + 16) * bonusFactor * antiflowFactor * Math.Max(1 - Math.Pow(weightedStrainTime / 1000, 3), 0);
+                }
+
+                // Base bonus for every movement, giving some weight to streams.
+                distanceAddition += 12.5 * Math.Min(Math.Abs(catchCurrent.DistanceMoved), CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 2)
+                                    / (CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 6) / sqrtStrain;
+            }
+
+            // Bonus for edge dashes.
+            if (catchCurrent.LastObject.DistanceToHyperDash <= 20.0f)
+            {
+                if (!catchCurrent.LastObject.HyperDash)
+                    edgeDashBonus += 5.7;
+
+                distanceAddition *= 1.0 + edgeDashBonus * ((20 - catchCurrent.LastObject.DistanceToHyperDash) / 20)
+                                                        * Math.Pow((Math.Min(catchCurrent.StrainTime * catcherSpeedMultiplier, 265) / 265), 1.5); // Edge Dashes are easier at lower ms values
+            }
+
+            // There is an edge case where horizontal back and forth sliders create "buzz" patterns which are repeated "movements" with a distance lower than
+            // the platter's width but high enough to be considered a movement due to the absolute_player_positioning_error and NORMALIZED_HALF_CATCHER_WIDTH offsets
+            // We are detecting this exact scenario. The first back and forth is counted but all subsequent ones are nullified.
+            // To achieve that, we need to store the exact distances (distance ignoring absolute_player_positioning_error and NORMALIZED_HALF_CATCHER_WIDTH)
+            if (current.Index >= 2 && Math.Abs(catchCurrent.ExactDistanceMoved) <= CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 2
+                                   && catchCurrent.ExactDistanceMoved == -catchLast.ExactDistanceMoved && catchLast.ExactDistanceMoved == -catchLastLast.ExactDistanceMoved
+                                   && catchCurrent.StrainTime == catchLast.StrainTime && catchLast.StrainTime == catchLastLast.StrainTime)
+                distanceAddition = 0;
+
+            return distanceAddition / weightedStrainTime;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
@@ -18,12 +18,40 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Preprocessing
 
         public new PalpableCatchHitObject LastObject => (PalpableCatchHitObject)base.LastObject;
 
+        /// <summary>
+        /// Normalized position of <see cref="BaseObject"/>.
+        /// </summary>
         public readonly float NormalizedPosition;
+
+        /// <summary>
+        /// Normalized position of <see cref="LastObject"/>.
+        /// </summary>
         public readonly float LastNormalizedPosition;
 
+        /// <summary>
+        /// Normalized position of the player required to catch <see cref="BaseObject"/>, assuming the player moves as little as possible.
+        /// </summary>
         public float PlayerPosition { get; private set; }
+
+        /// <summary>
+        /// Normalized position of the player after catching <see cref="LastObject"/>.
+        /// </summary>
         public float LastPlayerPosition { get; private set; }
+
+        /// <summary>
+        /// Normalized distance between <see cref="LastPlayerPosition"/> and <see cref="PlayerPosition"/>.
+        /// </summary>
+        /// <remarks>
+        /// The sign of the value indicates the direction of the movement: negative is left and positive is right.
+        /// </remarks>
         public float DistanceMoved { get; private set; }
+
+        /// <summary>
+        /// Normalized distance the player has to move from <see cref="LastPlayerPosition"/> in order to catch <see cref="BaseObject"/> at its <see cref="NormalizedPosition"/>.
+        /// </summary>
+        /// <remarks>
+        /// The sign of the value indicates the direction of the movement: negative is left and positive is right.
+        /// </remarks>
         public float ExactDistanceMoved { get; private set; }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
@@ -1,8 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using osu.Game.Rulesets.Catch.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Catch.Difficulty.Evaluators;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
@@ -11,8 +10,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
 {
     public class Movement : StrainDecaySkill
     {
-        private const double direction_change_bonus = 21.0;
-
         protected override double SkillMultiplier => 1;
         protected override double StrainDecayBase => 0.2;
 
@@ -21,8 +18,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
         protected override int SectionLength => 750;
 
         protected readonly float HalfCatcherWidth;
-
-        private bool isInBuzzSection;
 
         /// <summary>
         /// The speed multiplier applied to the player's catcher.
@@ -43,60 +38,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
 
         protected override double StrainValueOf(DifficultyHitObject current)
         {
-            var catchCurrent = (CatchDifficultyHitObject)current;
-            var catchLast = (CatchDifficultyHitObject)current.Previous(0);
-
-            double weightedStrainTime = catchCurrent.StrainTime + 13 + (3 / catcherSpeedMultiplier);
-
-            double distanceAddition = (Math.Pow(Math.Abs(catchCurrent.DistanceMoved), 1.3) / 510);
-            double sqrtStrain = Math.Sqrt(weightedStrainTime);
-
-            double edgeDashBonus = 0;
-
-            // Direction change bonus.
-            if (Math.Abs(catchCurrent.DistanceMoved) > 0.1)
-            {
-                if (current.Index >= 1 && Math.Abs(catchLast.DistanceMoved) > 0.1 && Math.Sign(catchCurrent.DistanceMoved) != Math.Sign(catchLast.DistanceMoved))
-                {
-                    double bonusFactor = Math.Min(50, Math.Abs(catchCurrent.DistanceMoved)) / 50;
-                    double antiflowFactor = Math.Max(Math.Min(70, Math.Abs(catchLast.DistanceMoved)) / 70, 0.38);
-
-                    distanceAddition += direction_change_bonus / Math.Sqrt(catchLast.StrainTime + 16) * bonusFactor * antiflowFactor * Math.Max(1 - Math.Pow(weightedStrainTime / 1000, 3), 0);
-                }
-
-                // Base bonus for every movement, giving some weight to streams.
-                distanceAddition += 12.5 * Math.Min(Math.Abs(catchCurrent.DistanceMoved), CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 2)
-                                    / (CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 6) / sqrtStrain;
-            }
-
-            // Bonus for edge dashes.
-            if (catchCurrent.LastObject.DistanceToHyperDash <= 20.0f)
-            {
-                if (!catchCurrent.LastObject.HyperDash)
-                    edgeDashBonus += 5.7;
-
-                distanceAddition *= 1.0 + edgeDashBonus * ((20 - catchCurrent.LastObject.DistanceToHyperDash) / 20)
-                                                        * Math.Pow((Math.Min(catchCurrent.StrainTime * catcherSpeedMultiplier, 265) / 265), 1.5); // Edge Dashes are easier at lower ms values
-            }
-
-            // There is an edge case where horizontal back and forth sliders create "buzz" patterns which are repeated "movements" with a distance lower than
-            // the platter's width but high enough to be considered a movement due to the absolute_player_positioning_error and NORMALIZED_HALF_CATCHER_WIDTH offsets
-            // We are detecting this exact scenario. The first back and forth is counted but all subsequent ones are nullified.
-            // To achieve that, we need to store the exact distances (distance ignoring absolute_player_positioning_error and NORMALIZED_HALF_CATCHER_WIDTH)
-            if (current.Index >= 1 && Math.Abs(catchCurrent.ExactDistanceMoved) <= CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 2
-                                   && catchCurrent.ExactDistanceMoved == -catchLast.ExactDistanceMoved && catchCurrent.StrainTime == catchLast.StrainTime)
-            {
-                if (isInBuzzSection)
-                    distanceAddition = 0;
-                else
-                    isInBuzzSection = true;
-            }
-            else
-            {
-                isInBuzzSection = false;
-            }
-
-            return distanceAddition / weightedStrainTime;
+            return MovementEvaluator.EvaluateDifficultyOf(current, catcherSpeedMultiplier);
         }
     }
 }


### PR DESCRIPTION
This PR aims to make the osu!catch diffcalc code more in line with the other game modes by porting the `Movement` skill to an evaluator.

The state that was in `Movement` is moved into `CatchDifficultyHitObject`. If it's undesirable, the alternative is to calculate the state inside the evaluator. However, that requires some complex backtracking in order to accurately determine the player positions.

The algorithm stayed functionally the same, there should be no SR changes.