### PR TITLE
Fix saving via ctrl+s while metadata textbox is focused not saving changes

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneMetadataSection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneMetadataSection.cs
@@ -65,10 +65,10 @@ namespace osu.Game.Tests.Visual.Editing
                 InputManager.Keys(PlatformAction.Paste);
             });
 
-            assertArtistMetadata("Example Artist");
+            assertArtistMetadata("Example ArtistExample Artist");
 
             // It's important values are committed immediately on focus loss so the editor exit sequence detects them.
-            AddAssert("value immediately changed on focus loss", () =>
+            AddAssert("value still changed after focus loss", () =>
             {
                 ((IFocusManager)InputManager).TriggerFocusContention(metadataSection);
                 return editorBeatmap.Metadata.Artist;
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Visual.Editing
                 InputManager.Keys(PlatformAction.Paste);
             });
 
-            assertArtistMetadata("Example Artist");
+            assertArtistMetadata("Example ArtistExample Artist");
 
             AddStep("commit", () => InputManager.Key(Key.Enter));
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -573,6 +573,9 @@ namespace osu.Game.Screens.Edit
             return true;
         }
 
+        [CanBeNull]
+        internal event Action Saved;
+
         /// <summary>
         /// Saves the currently edited beatmap.
         /// </summary>
@@ -601,6 +604,7 @@ namespace osu.Game.Screens.Edit
             isNewBeatmap = false;
             updateLastSavedHash();
             onScreenDisplay?.Display(new BeatmapEditorToast(ToastStrings.BeatmapSaved, editorBeatmap.BeatmapInfo.GetDisplayTitle()));
+            Saved?.Invoke();
             return true;
         }
 

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.Edit.Setup
         public override LocalisableString Title => EditorSetupStrings.MetadataHeader;
 
         [Resolved]
-        private Editor editor { get; set; } = null!;
+        private Editor? editor { get; set; }
 
         [BackgroundDependencyLoader]
         private void load(SetupScreen? setupScreen)
@@ -83,7 +83,8 @@ namespace osu.Game.Screens.Edit.Setup
                 };
             }
 
-            editor.Saved += () => dirty = false;
+            if (editor != null)
+                editor.Saved += () => dirty = false;
 
             updateReadOnlyState();
         }

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.Edit.Setup
         public override LocalisableString Title => EditorSetupStrings.MetadataHeader;
 
         [Resolved]
-        private Editor editor { get; set; }
+        private Editor editor { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load(SetupScreen? setupScreen)

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -25,7 +25,12 @@ namespace osu.Game.Screens.Edit.Setup
         private FormTextBox sourceTextBox = null!;
         private FormTextBox tagsTextBox = null!;
 
+        private bool dirty = false;
+
         public override LocalisableString Title => EditorSetupStrings.MetadataHeader;
+
+        [Resolved]
+        private Editor editor { get; set; }
 
         [BackgroundDependencyLoader]
         private void load(SetupScreen? setupScreen)
@@ -73,10 +78,12 @@ namespace osu.Game.Screens.Edit.Setup
                 item.Current.BindValueChanged(_ => applyMetadata());
                 item.OnCommit += (_, newText) =>
                 {
-                    if (newText)
+                    if (newText && dirty)
                         Beatmap.SaveState();
                 };
             }
+
+            editor.Saved += () => dirty = false;
 
             updateReadOnlyState();
         }
@@ -124,6 +131,8 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.BeatmapInfo.DifficultyName = difficultyTextBox.Current.Value;
             Beatmap.Metadata.Source = sourceTextBox.Current.Value;
             Beatmap.Metadata.Tags = tagsTextBox.Current.Value;
+
+            dirty = true;
         }
 
         private partial class FormRomanisedTextBox : FormTextBox

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Edit.Setup
         private FormTextBox sourceTextBox = null!;
         private FormTextBox tagsTextBox = null!;
 
-        private bool dirty = false;
+        private bool dirty;
 
         public override LocalisableString Title => EditorSetupStrings.MetadataHeader;
 

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -71,6 +71,11 @@ namespace osu.Game.Screens.Edit.Setup
                 // Apply immediately on any change to ensure that if the user hits Ctrl+S after making a change (without committing)
                 // it will still apply to the beatmap.
                 item.Current.BindValueChanged(_ => applyMetadata());
+                item.OnCommit += (_, newText) =>
+                {
+                    if (newText)
+                        Beatmap.SaveState();
+                };
             }
 
             updateReadOnlyState();


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32365.

Addressed as per discussion in that issue thread (commit no longer does anything special – changes are applied immediately).