### PR TITLE
Add `[JsonIgnore]` to `MultiplayerRoom.CurrentPlaylistItem`

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
@@ -85,6 +85,7 @@ namespace osu.Game.Online.Multiplayer
         /// Retrieves the active <see cref="MultiplayerPlaylistItem"/> as determined by the room's current settings.
         /// </summary>
         [IgnoreMember]
+        [JsonIgnore]
         public MultiplayerPlaylistItem CurrentPlaylistItem => Playlist.Single(item => item.ID == Settings.PlaylistItemId);
 
         /// <summary>


### PR DESCRIPTION
The lack of this is [currently failing a unit test on `osu-server-spectator` current master](https://github.com/ppy/osu-server-spectator/actions/runs/14193158383/job/39762243965#step:4:28).

I don't think the failure actually matters because I don't think we're using json serialisation on spectator server side anywhere (used to for iOS at least, but I don't think we do anymore?), but probably better to be safe than sorry.