### PR TITLE
Fix argon reverse arrow animating weirdly after hit

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
@@ -85,9 +85,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             {
                 double animDuration = Math.Min(300, drawableRepeat.HitObject.SpanDuration);
                 Scale = new Vector2(Interpolation.ValueAt(Time.Current, 1, 1.5f, drawableRepeat.HitStateUpdateTime, drawableRepeat.HitStateUpdateTime + animDuration, Easing.Out));
+
+                // When hit, don't animate further. This avoids a scale being applied on a scale and looking very weird.
+                return;
             }
-            else
-                Scale = Vector2.One;
+
+            Scale = Vector2.One;
 
             const float move_distance = -12;
             const float scale_amount = 1.3f;


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/02752dee-3e98-40e9-9415-ce2a2c196e66

After

https://github.com/user-attachments/assets/62649df1-0e43-49fa-a04f-c6b134f923aa