### PR TITLE
Define standard font specifications and update new beatmap panel designs accordingly

### DIFF
--- a/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Beatmaps.Drawables
 
                 Add(countText = new OsuSpriteText
                 {
-                    Font = OsuFont.Default.With(size: 12),
+                    Font = OsuFont.Caption,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Padding = new MarginPadding { Bottom = 1 }

--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -20,6 +20,41 @@ namespace osu.Game.Graphics
         /// </summary>
         public static FontUsage Default => GetFont();
 
+        /// <summary>
+        /// Equivalent to Torus with 32px size and semi-bold weight.
+        /// </summary>
+        public static FontUsage Display => GetFont(size: 32, weight: FontWeight.SemiBold);
+
+        /// <summary>
+        /// Equivalent to Torus with 28px size and semi-bold weight.
+        /// </summary>
+        public static FontUsage Subdisplay => GetFont(size: 28, weight: FontWeight.SemiBold);
+
+        /// <summary>
+        /// Equivalent to Torus with 22px size and semi-bold weight.
+        /// </summary>
+        public static FontUsage Heading => GetFont(size: 22, weight: FontWeight.SemiBold);
+
+        /// <summary>
+        /// Equivalent to Torus with 18px size and semi-bold weight.
+        /// </summary>
+        public static FontUsage Subheading => GetFont(size: 18, weight: FontWeight.SemiBold);
+
+        /// <summary>
+        /// Equivalent to Torus with 16px size and regular weight.
+        /// </summary>
+        public static FontUsage Body => GetFont(size: 16, weight: FontWeight.Regular);
+
+        /// <summary>
+        /// Equivalent to Torus with 14px size and regular weight.
+        /// </summary>
+        public static FontUsage Caption => GetFont(size: 14, weight: FontWeight.Regular);
+
+        /// <summary>
+        /// Equivalent to Torus with 12px size and regular weight.
+        /// </summary>
+        public static FontUsage Tiny => GetFont(size: 12, weight: FontWeight.Regular);
+
         public static FontUsage Numeric => GetFont(Typeface.Venera, weight: FontWeight.Bold);
 
         public static FontUsage Torus => GetFont(Typeface.Torus, weight: FontWeight.Regular);

--- a/osu.Game/Screens/SelectV2/CarouselItem.cs
+++ b/osu.Game/Screens/SelectV2/CarouselItem.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Screens.SelectV2
     /// </summary>
     public sealed class CarouselItem : IComparable<CarouselItem>
     {
-        public const float DEFAULT_HEIGHT = 50;
+        public const float DEFAULT_HEIGHT = 45;
 
         /// <summary>
         /// The model this item is representing.

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.SelectV2
 
             Icon = difficultyIcon = new ConstrainedIconContainer
             {
-                Size = new Vector2(20),
+                Size = new Vector2(16f),
                 Margin = new MarginPadding { Horizontal = 5f },
                 Colour = colourProvider.Background5,
             };
@@ -99,12 +99,13 @@ namespace osu.Game.Screens.SelectV2
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
+                                    Scale = new Vector2(OsuFont.Caption.Size / OsuFont.Body.Size),
                                 },
                                 difficultyRank = new TopLocalRank
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
-                                    Scale = new Vector2(0.75f)
+                                    Scale = new Vector2(0.5f)
                                 },
                                 starCounter = new StarCounter
                                 {
@@ -122,22 +123,22 @@ namespace osu.Game.Screens.SelectV2
                             {
                                 keyCountText = new OsuSpriteText
                                 {
-                                    Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                    Font = OsuFont.Body.With(weight: FontWeight.SemiBold),
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft,
                                     Alpha = 0,
                                 },
                                 difficultyText = new OsuSpriteText
                                 {
-                                    Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                    Font = OsuFont.Body.With(weight: FontWeight.SemiBold),
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft,
-                                    Margin = new MarginPadding { Right = 8f },
+                                    Margin = new MarginPadding { Right = 5f },
                                 },
                                 authorText = new OsuSpriteText
                                 {
                                     Colour = colourProvider.Content2,
-                                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
+                                    Font = OsuFont.Caption.With(weight: FontWeight.SemiBold),
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft
                                 }

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.SelectV2
                     {
                         titleText = new OsuSpriteText
                         {
-                            Font = OsuFont.Heading,
+                            Font = OsuFont.Heading.With(typeface: Typeface.TorusAlternate),
                         },
                         artistText = new OsuSpriteText
                         {

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.SelectV2
 {
     public partial class PanelBeatmapSet : PanelBase
     {
-        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.6f;
+        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.7f;
 
         private BeatmapSetPanelBackground background = null!;
 
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.SelectV2
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Icon = FontAwesome.Solid.ChevronRight,
-                    Size = new Vector2(12),
+                    Size = new Vector2(8),
                     X = 1f,
                     Colour = colourProvider.Background5,
                 },
@@ -76,17 +76,17 @@ namespace osu.Game.Screens.SelectV2
                     {
                         titleText = new OsuSpriteText
                         {
-                            Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 22, italics: true),
+                            Font = OsuFont.Heading,
                         },
                         artistText = new OsuSpriteText
                         {
-                            Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 17, italics: true),
+                            Font = OsuFont.Body.With(weight: FontWeight.SemiBold),
                         },
                         new FillFlowContainer
                         {
                             Direction = FillDirection.Horizontal,
                             AutoSizeAxes = Axes.Both,
-                            Margin = new MarginPadding { Top = 5f },
+                            Margin = new MarginPadding { Top = 4f },
                             Children = new Drawable[]
                             {
                                 updateButton = new UpdateBeatmapSetButton
@@ -100,8 +100,7 @@ namespace osu.Game.Screens.SelectV2
                                     AutoSizeAxes = Axes.Both,
                                     Origin = Anchor.CentreLeft,
                                     Anchor = Anchor.CentreLeft,
-                                    TextSize = 11,
-                                    TextPadding = new MarginPadding { Horizontal = 8, Vertical = 2 },
+                                    TextSize = OsuFont.Tiny.Size,
                                     Margin = new MarginPadding { Right = 5f },
                                 },
                                 difficultiesDisplay = new DifficultySpectrumDisplay

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.SelectV2
 {
     public partial class PanelBeatmapStandalone : PanelBase
     {
-        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.6f;
+        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.7f;
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.SelectV2
 
             Icon = difficultyIcon = new ConstrainedIconContainer
             {
-                Size = new Vector2(20),
+                Size = new Vector2(16),
                 Margin = new MarginPadding { Horizontal = 5f },
                 Colour = colourProvider.Background5,
             };
@@ -94,19 +94,16 @@ namespace osu.Game.Screens.SelectV2
                 {
                     titleText = new OsuSpriteText
                     {
-                        Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 22, italics: true),
-                        Shadow = true,
+                        Font = OsuFont.Heading.With(typeface: Typeface.TorusAlternate),
                     },
                     artistText = new OsuSpriteText
                     {
-                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 17, italics: true),
-                        Shadow = true,
+                        Font = OsuFont.Body.With(weight: FontWeight.SemiBold),
                     },
                     new FillFlowContainer
                     {
                         Direction = FillDirection.Horizontal,
                         AutoSizeAxes = Axes.Both,
-                        Margin = new MarginPadding { Top = 5f },
                         Children = new Drawable[]
                         {
                             updateButton = new UpdateBeatmapSetButton
@@ -120,8 +117,7 @@ namespace osu.Game.Screens.SelectV2
                                 AutoSizeAxes = Axes.Both,
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,
-                                TextSize = 11,
-                                TextPadding = new MarginPadding { Horizontal = 8, Vertical = 2 },
+                                TextSize = OsuFont.Tiny.Size,
                                 Margin = new MarginPadding { Right = 5f },
                             },
                             difficultyLine = new FillFlowContainer
@@ -146,7 +142,7 @@ namespace osu.Game.Screens.SelectV2
                                     },
                                     difficultyKeyCountText = new OsuSpriteText
                                     {
-                                        Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                        Font = OsuFont.Subheading,
                                         Anchor = Anchor.BottomLeft,
                                         Origin = Anchor.BottomLeft,
                                         Alpha = 0,
@@ -154,7 +150,7 @@ namespace osu.Game.Screens.SelectV2
                                     },
                                     difficultyName = new OsuSpriteText
                                     {
-                                        Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                        Font = OsuFont.Subheading,
                                         Origin = Anchor.BottomLeft,
                                         Anchor = Anchor.BottomLeft,
                                         Margin = new MarginPadding { Right = 5f, Bottom = 2f },
@@ -162,7 +158,7 @@ namespace osu.Game.Screens.SelectV2
                                     difficultyAuthor = new OsuSpriteText
                                     {
                                         Colour = colourProvider.Content2,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
+                                        Font = OsuFont.Subheading,
                                         Origin = Anchor.BottomLeft,
                                         Anchor = Anchor.BottomLeft,
                                         Margin = new MarginPadding { Right = 5f, Bottom = 2f },

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.SelectV2
                                     difficultyAuthor = new OsuSpriteText
                                     {
                                         Colour = colourProvider.Content2,
-                                        Font = OsuFont.Subheading,
+                                        Font = OsuFont.Caption.With(weight: FontWeight.SemiBold),
                                         Origin = Anchor.BottomLeft,
                                         Anchor = Anchor.BottomLeft,
                                         Margin = new MarginPadding { Right = 5f, Bottom = 2f },

--- a/osu.Game/Screens/SelectV2/UpdateBeatmapSetButton.cs
+++ b/osu.Game/Screens/SelectV2/UpdateBeatmapSetButton.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.SelectV2
 
         public UpdateBeatmapSetButton()
         {
-            Size = new Vector2(75f, 22f);
+            Size = new Vector2(72, 22f);
         }
 
         private Bindable<bool> preferNoVideo = null!;
@@ -63,13 +63,12 @@ namespace osu.Game.Screens.SelectV2
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            const float icon_size = 14;
+            const float icon_size = 12;
 
             preferNoVideo = config.GetBindable<bool>(OsuSetting.PreferNoVideo);
 
             Content.Anchor = Anchor.Centre;
             Content.Origin = Anchor.Centre;
-            Content.Shear = new Vector2(OsuGame.SHEAR, 0);
 
             Content.AddRange(new Drawable[]
             {
@@ -87,7 +86,6 @@ namespace osu.Game.Screens.SelectV2
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(4),
-                    Shear = new Vector2(-OsuGame.SHEAR, 0),
                     Children = new Drawable[]
                     {
                         new Container
@@ -110,7 +108,7 @@ namespace osu.Game.Screens.SelectV2
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                            Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                            Font = OsuFont.Body.With(weight: FontWeight.SemiBold),
                             Text = "Update",
                         }
                     }


### PR DESCRIPTION
This PR features an important change meant to be eventually applied throughout the game. That is, `OsuFont` now contains standard font size definitions that should be used appropriately to keep a form of consistency in the scaling of all game components (whereas currently, some components appear larger than others, such as context menus in online overlays for example). For now, these definitions are only used on the implementation of the new song select screen, but they shall later on be expanded to cover the entire codebase.

This PR also features a minor change applied to the beatmap card title, where it's displayed in alternate/styled typeface similar to the wedge title.

Before:

![CleanShot 2025-04-04 at 02 32 49](https://github.com/user-attachments/assets/85c0bd9d-4ccf-4172-93eb-70ebfd1f5ac3)

After:

![CleanShot 2025-04-04 at 02 44 57](https://github.com/user-attachments/assets/43e2582f-9ac5-4ca9-8c39-f234886fa152)
