### PR TITLE
Fix potential crashes due to asynchronous `BindableList` usage

### DIFF
--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -38,6 +38,9 @@ namespace osu.Game.Online.Chat
         private ChannelManager channelManager { get; set; }
 
         [Resolved]
+        private IAPIProvider api { get; set; }
+
+        [Resolved]
         private GameHost host { get; set; }
 
         private Bindable<bool> notifyOnUsername;
@@ -47,19 +50,19 @@ namespace osu.Game.Online.Chat
         private readonly IBindableList<Channel> joinedChannels = new BindableList<Channel>();
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, IAPIProvider api)
+        private void load(OsuConfigManager config)
         {
             notifyOnUsername = config.GetBindable<bool>(OsuSetting.NotifyOnUsernameMentioned);
             notifyOnPrivateMessage = config.GetBindable<bool>(OsuSetting.NotifyOnPrivateMessage);
-
-            localUser.BindTo(api.LocalUser);
-            joinedChannels.BindTo(channelManager.JoinedChannels);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
             joinedChannels.BindCollectionChanged(channelsChanged, true);
+
+            localUser.BindTo(api.LocalUser);
+            joinedChannels.BindTo(channelManager.JoinedChannels);
         }
 
         private void channelsChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
@@ -62,8 +62,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api, INotificationOverlay? notifications)
+        private void load(INotificationOverlay? notifications)
         {
             localUser.BindTo(api.LocalUser);
 
@@ -72,15 +75,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 updateIcon();
                 updateColor();
             });
-
-            User.BindValueChanged(u =>
-            {
-                followerCount = u.NewValue?.User.FollowerCount ?? 0;
-                updateStatus();
-            }, true);
-
-            apiFriends.BindTo(api.Friends);
-            apiFriends.BindCollectionChanged((_, _) => Schedule(updateStatus));
 
             Action += () =>
             {
@@ -124,6 +118,20 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
                 api.Queue(req);
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            apiFriends.BindTo(api.Friends);
+            apiFriends.BindCollectionChanged((_, _) => Schedule(updateStatus));
+
+            User.BindValueChanged(u =>
+            {
+                followerCount = u.NewValue?.User.FollowerCount ?? 0;
+                updateStatus();
+            }, true);
         }
 
         protected override bool OnHover(HoverEvent e)


### PR DESCRIPTION
Band-aid fix for https://github.com/ppy/osu/issues/32671.

I've removed all `BindableList.BindTo` usage from `load()` methods (except one editor one which looks safe and is kinda hard to fix without moving drawable load to a blocking operation).

Better than crashing out, probably. Doesn't address concerns about thread safety in general.