### PR TITLE
Fix thread-race leading to `OnScreenDisplay` crash

### DIFF
--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -5,9 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
@@ -60,6 +62,8 @@ namespace osu.Game.Overlays
         /// <returns>An object representing the registration, that may be disposed to stop tracking the <see cref="ConfigManager{T}"/>.</returns>
         public IDisposable BeginTracking(object source, ITrackableConfigManager configManager)
         {
+            Debug.Assert(ThreadSafety.IsUpdateThread);
+
             ArgumentNullException.ThrowIfNull(configManager);
 
             if (trackedConfigManagers.ContainsKey((source, configManager)))

--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
 using osu.Framework.Graphics;
@@ -56,7 +57,8 @@ namespace osu.Game.Overlays
         /// <param name="configManager">The <see cref="ConfigManager{T}"/> to be tracked.</param>
         /// <exception cref="ArgumentNullException">If <paramref name="configManager"/> is null.</exception>
         /// <exception cref="InvalidOperationException">If <paramref name="configManager"/> is already being tracked from the same <paramref name="source"/>.</exception>
-        public void BeginTracking(object source, ITrackableConfigManager configManager)
+        /// <returns>An object representing the registration, that may be disposed to stop tracking the <see cref="ConfigManager{T}"/>.</returns>
+        public IDisposable BeginTracking(object source, ITrackableConfigManager configManager)
         {
             ArgumentNullException.ThrowIfNull(configManager);
 
@@ -65,32 +67,18 @@ namespace osu.Game.Overlays
 
             var trackedSettings = configManager.CreateTrackedSettings();
             if (trackedSettings == null)
-                return;
+                return new InvokeOnDisposal(() => { });
 
             configManager.LoadInto(trackedSettings);
             trackedSettings.SettingChanged += displayTrackedSettingChange;
-
             trackedConfigManagers.Add((source, configManager), trackedSettings);
-        }
 
-        /// <summary>
-        /// Unregisters a <see cref="ConfigManager{T}"/> from having its settings tracked by this <see cref="OnScreenDisplay"/>.
-        /// </summary>
-        /// <param name="source">The object that registered the <see cref="ConfigManager{T}"/> to be tracked.</param>
-        /// <param name="configManager">The <see cref="ConfigManager{T}"/> that is being tracked.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="configManager"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">If <paramref name="configManager"/> is not being tracked from the same <paramref name="source"/>.</exception>
-        public void StopTracking(object source, ITrackableConfigManager configManager)
-        {
-            ArgumentNullException.ThrowIfNull(configManager);
-
-            if (!trackedConfigManagers.TryGetValue((source, configManager), out var existing))
-                return;
-
-            existing.Unload();
-            existing.SettingChanged -= displayTrackedSettingChange;
-
-            trackedConfigManagers.Remove((source, configManager));
+            return new InvokeOnDisposal(() =>
+            {
+                trackedSettings.Unload();
+                trackedSettings.SettingChanged -= displayTrackedSettingChange;
+                trackedConfigManagers.Remove((source, configManager));
+            });
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -54,7 +54,12 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// The key conversion input manager for this DrawableRuleset.
         /// </summary>
-        protected PassThroughInputManager KeyBindingInputManager;
+        protected PassThroughInputManager KeyBindingInputManager { get; }
+
+        /// <summary>
+        /// This configuration for this DrawableRuleset.
+        /// </summary>
+        protected IRulesetConfigManager Config { get; private set; }
 
         public override double GameplayStartTime => Objects.FirstOrDefault()?.StartTime - 2000 ?? 0;
 
@@ -77,7 +82,25 @@ namespace osu.Game.Rulesets.UI
 
         public override IFrameStableClock FrameStableClock => frameStabilityContainer;
 
+        public override IEnumerable<HitObject> Objects => Beatmap.HitObjects;
+
+        /// <summary>
+        /// The beatmap.
+        /// </summary>
+        [Cached(typeof(IBeatmap))]
+        public readonly Beatmap<TObject> Beatmap;
+
+        [Cached(typeof(IReadOnlyList<Mod>))]
+        public sealed override IReadOnlyList<Mod> Mods { get; }
+
+        [Resolved(CanBeNull = true)]
+        private OnScreenDisplay onScreenDisplay { get; set; }
+
         private readonly PlayfieldAdjustmentContainer playfieldAdjustmentContainer;
+
+        private IDisposable configTracker;
+        private FrameStabilityContainer frameStabilityContainer;
+        private DrawableRulesetDependencies dependencies;
 
         private bool allowBackwardsSeeks;
 
@@ -104,25 +127,6 @@ namespace osu.Game.Rulesets.UI
                     frameStabilityContainer.FrameStablePlayback = value;
             }
         }
-
-        /// <summary>
-        /// The beatmap.
-        /// </summary>
-        [Cached(typeof(IBeatmap))]
-        public readonly Beatmap<TObject> Beatmap;
-
-        public override IEnumerable<HitObject> Objects => Beatmap.HitObjects;
-
-        protected IRulesetConfigManager Config { get; private set; }
-
-        [Cached(typeof(IReadOnlyList<Mod>))]
-        public sealed override IReadOnlyList<Mod> Mods { get; }
-
-        private FrameStabilityContainer frameStabilityContainer;
-
-        private OnScreenDisplay onScreenDisplay;
-
-        private DrawableRulesetDependencies dependencies;
 
         /// <summary>
         /// Creates a ruleset visualisation for the provided ruleset and beatmap.
@@ -156,6 +160,8 @@ namespace osu.Game.Rulesets.UI
         {
             base.LoadComplete();
 
+            configTracker = onScreenDisplay?.BeginTracking(this, Config);
+
             IsPaused.ValueChanged += paused =>
             {
                 if (HasReplayLoaded.Value)
@@ -168,13 +174,7 @@ namespace osu.Game.Rulesets.UI
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             dependencies = new DrawableRulesetDependencies(Ruleset, base.CreateChildDependencies(parent));
-
             Config = dependencies.RulesetConfigManager;
-
-            onScreenDisplay = dependencies.Get<OnScreenDisplay>();
-            if (Config != null)
-                onScreenDisplay?.BeginTracking(this, Config);
-
             return dependencies;
         }
 
@@ -404,11 +404,7 @@ namespace osu.Game.Rulesets.UI
         {
             base.Dispose(isDisposing);
 
-            if (Config != null)
-            {
-                onScreenDisplay?.StopTracking(this, Config);
-                Config = null;
-            }
+            configTracker?.Dispose();
 
             // Dispose the components created by this dependency container.
             dependencies?.Dispose();

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -160,7 +160,8 @@ namespace osu.Game.Rulesets.UI
         {
             base.LoadComplete();
 
-            configTracker = onScreenDisplay?.BeginTracking(this, Config);
+            if (Config != null)
+                configTracker = onScreenDisplay?.BeginTracking(this, Config);
 
             IsPaused.ValueChanged += paused =>
             {


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/ppy/osu/issues/31895#issuecomment-2778675275

Excerpt from `1743588461.runtime.log`:
```
2025-04-02 10:16:36 [error]: An unhandled error has occurred.
2025-04-02 10:16:36 [error]: System.IndexOutOfRangeException: Index was outside the bounds of the array.
2025-04-02 10:16:36 [error]: at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
2025-04-02 10:16:36 [error]: at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
2025-04-02 10:16:36 [error]: at osu.Game.Overlays.OnScreenDisplay.BeginTracking(Object source, ITrackableConfigManager configManager)
2025-04-02 10:16:36 [error]: at osu.Game.Rulesets.UI.DrawableRuleset`1.CreateChildDependencies(IReadOnlyDependencyContainer parent)
```