### PR TITLE
Use `Precision.AlmostEquals` to compare deviation lower bound

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Utils;
@@ -409,7 +410,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double limitValue = okHitWindow / Math.Sqrt(3);
 
             // If precision is not enough to compute true deviation - use limit value
-            if (pLowerBound == 0 || randomValue >= 1 || deviation > limitValue)
+            if (Precision.AlmostEquals(pLowerBound, 0.0) || randomValue >= 1 || deviation > limitValue)
                 deviation = limitValue;
 
             // Then compute the variance for mehs.


### PR DESCRIPTION
Reference score: https://osu.ppy.sh/scores/3675318982

`pLowerBound` is `-0.000000000000000003469446951953614`

PP value is unchanged, presumedly because this score isn't hitting the threshold for an improper tapping nerf in the first place. Will run a sheet to see if there's any other cases of this.

Before:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/66193cb0-4ff8-4588-ad81-2b837b8773bc" />

After:
<img width="665" alt="image" src="https://github.com/user-attachments/assets/ea332740-631d-4ec9-8b75-1033a8d5b753" />