### PR TITLE
Use actual keybind in multiplayer chat hint

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -34,11 +34,6 @@ namespace osu.Game.Configuration
             Migrate();
         }
 
-        /// <summary>
-        /// For a given <see cref="GlobalAction"/>, return a human-readable string representing the bindings bound to the action.
-        /// </summary>
-        public LocalisableString LookupKeyBindings(GlobalAction action) => LookupKeyBindingsFunc(action);
-
         protected override void InitialiseDefaults()
         {
             // UI/selection defaults
@@ -308,7 +303,7 @@ namespace osu.Game.Configuration
                     string skinName = string.Empty;
 
                     if (Guid.TryParse(skin, out var id))
-                        skinName = LookupSkinNameFunc(id);
+                        skinName = LookupSkinName(id);
 
                     return new SettingDescription(
                         rawValue: skinName,
@@ -329,8 +324,8 @@ namespace osu.Game.Configuration
             };
         }
 
-        public Func<Guid, string> LookupSkinNameFunc { private get; set; } = _ => @"unknown";
-        public Func<GlobalAction, LocalisableString> LookupKeyBindingsFunc { private get; set; } = _ => @"unknown";
+        public Func<Guid, string> LookupSkinName { private get; set; } = _ => @"unknown";
+        public Func<GlobalAction, LocalisableString> LookupKeyBindings { private get; set; } = _ => @"unknown";
 
         IBindable<float> IGameplaySettings.ComboColourNormalisationAmount => GetOriginalBindable<float>(OsuSetting.ComboColourNormalisationAmount);
         IBindable<float> IGameplaySettings.PositionalHitsoundsLevel => GetOriginalBindable<float>(OsuSetting.PositionalHitsoundsLevel);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
@@ -34,6 +33,11 @@ namespace osu.Game.Configuration
         {
             Migrate();
         }
+
+        /// <summary>
+        /// For a given <see cref="GlobalAction"/>, return a human-readable string representing the bindings bound to the action.
+        /// </summary>
+        public LocalisableString LookupKeyBindings(GlobalAction action) => LookupKeyBindingsFunc(action);
 
         protected override void InitialiseDefaults()
         {
@@ -263,10 +267,6 @@ namespace osu.Game.Configuration
 
         public override TrackedSettings CreateTrackedSettings()
         {
-            // these need to be assigned in normal game startup scenarios.
-            Debug.Assert(LookupKeyBindings != null);
-            Debug.Assert(LookupSkinName != null);
-
             return new TrackedSettings
             {
                 new TrackedSetting<bool>(OsuSetting.ShowFpsDisplay, state => new SettingDescription(
@@ -308,7 +308,7 @@ namespace osu.Game.Configuration
                     string skinName = string.Empty;
 
                     if (Guid.TryParse(skin, out var id))
-                        skinName = LookupSkinName(id);
+                        skinName = LookupSkinNameFunc(id);
 
                     return new SettingDescription(
                         rawValue: skinName,
@@ -329,9 +329,8 @@ namespace osu.Game.Configuration
             };
         }
 
-        public Func<Guid, string> LookupSkinName { private get; set; } = _ => @"unknown";
-
-        public Func<GlobalAction, LocalisableString> LookupKeyBindings { get; set; } = _ => @"unknown";
+        public Func<Guid, string> LookupSkinNameFunc { private get; set; } = _ => @"unknown";
+        public Func<GlobalAction, LocalisableString> LookupKeyBindingsFunc { private get; set; } = _ => @"unknown";
 
         IBindable<float> IGameplaySettings.ComboColourNormalisationAmount => GetOriginalBindable<float>(OsuSetting.ComboColourNormalisationAmount);
         IBindable<float> IGameplaySettings.PositionalHitsoundsLevel => GetOriginalBindable<float>(OsuSetting.PositionalHitsoundsLevel);

--- a/osu.Game/Input/RealmKeyBindingStore.cs
+++ b/osu.Game/Input/RealmKeyBindingStore.cs
@@ -5,8 +5,10 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Localisation;
 using osu.Game.Database;
 using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
 using osu.Game.Rulesets;
 using Realms;
 
@@ -21,6 +23,19 @@ namespace osu.Game.Input
         {
             this.realm = realm;
             this.keyCombinationProvider = keyCombinationProvider;
+        }
+
+        /// <summary>
+        /// For a given <see cref="GlobalAction"/>, return a human-readable string representing the bindings bound to the action.
+        /// </summary>
+        public LocalisableString GetBindingsStringFor(GlobalAction globalAction)
+        {
+            var combinations = GetReadableKeyCombinationsFor(globalAction);
+
+            if (combinations.Count == 0)
+                return ToastStrings.NoKeyBound;
+
+            return string.Join(" / ", combinations);
         }
 
         /// <summary>

--- a/osu.Game/Localisation/ChatStrings.cs
+++ b/osu.Game/Localisation/ChatStrings.cs
@@ -25,9 +25,9 @@ namespace osu.Game.Localisation
         public static LocalisableString MentionUser => new TranslatableString(getKey(@"mention_user"), @"Mention");
 
         /// <summary>
-        /// "press enter to chat..."
+        /// "press {0} to chat..."
         /// </summary>
-        public static LocalisableString InGameInputPlaceholder => new TranslatableString(getKey(@"in_game_input_placeholder"), @"press enter to chat...");
+        public static LocalisableString InGameInputPlaceholder(LocalisableString keyBind) => new TranslatableString(getKey(@"in_game_input_placeholder"), @"press {0} to chat...", keyBind);
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -977,20 +977,6 @@ namespace osu.Game
             MultiplayerClient.PostNotification = n => Notifications.Post(n);
             MultiplayerClient.PresentMatch = PresentMultiplayerMatch;
 
-            // make config aware of how to lookup skins for on-screen display purposes.
-            // if this becomes a more common thing, tracked settings should be reconsidered to allow local DI.
-            LocalConfig.LookupSkinNameFunc = id => SkinManager.Query(s => s.ID == id)?.ToString() ?? "Unknown";
-
-            LocalConfig.LookupKeyBindingsFunc = l =>
-            {
-                var combinations = KeyBindingStore.GetReadableKeyCombinationsFor(l);
-
-                if (combinations.Count == 0)
-                    return ToastStrings.NoKeyBound;
-
-                return string.Join(" / ", combinations);
-            };
-
             ScreenFooter.BackReceptor backReceptor;
 
             dependencies.CacheAs(idleTracker = new GameIdleTracker(6000));

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -979,9 +979,9 @@ namespace osu.Game
 
             // make config aware of how to lookup skins for on-screen display purposes.
             // if this becomes a more common thing, tracked settings should be reconsidered to allow local DI.
-            LocalConfig.LookupSkinName = id => SkinManager.Query(s => s.ID == id)?.ToString() ?? "Unknown";
+            LocalConfig.LookupSkinNameFunc = id => SkinManager.Query(s => s.ID == id)?.ToString() ?? "Unknown";
 
-            LocalConfig.LookupKeyBindings = l =>
+            LocalConfig.LookupKeyBindingsFunc = l =>
             {
                 var combinations = KeyBindingStore.GetReadableKeyCombinationsFor(l);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -424,16 +424,8 @@ namespace osu.Game
 
             // make config aware of how to lookup skins for on-screen display purposes.
             // if this becomes a more common thing, tracked settings should be reconsidered to allow local DI.
-            LocalConfig.LookupSkinNameFunc = id => SkinManager.Query(s => s.ID == id)?.ToString() ?? "Unknown";
-            LocalConfig.LookupKeyBindingsFunc = l =>
-            {
-                var combinations = KeyBindingStore.GetReadableKeyCombinationsFor(l);
-
-                if (combinations.Count == 0)
-                    return ToastStrings.NoKeyBound;
-
-                return string.Join(" / ", combinations);
-            };
+            LocalConfig.LookupSkinName = id => SkinManager.Query(s => s.ID == id)?.ToString() ?? "Unknown";
+            LocalConfig.LookupKeyBindings = l => KeyBindingStore.GetBindingsStringFor(l);
         }
 
         private void updateLanguage() => CurrentLanguage.Value = LanguageExtensions.GetLanguageFor(frameworkLocale.Value, localisationParameters.Value);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -421,6 +421,19 @@ namespace osu.Game
 
             Ruleset.BindValueChanged(onRulesetChanged);
             Beatmap.BindValueChanged(onBeatmapChanged);
+
+            // make config aware of how to lookup skins for on-screen display purposes.
+            // if this becomes a more common thing, tracked settings should be reconsidered to allow local DI.
+            LocalConfig.LookupSkinNameFunc = id => SkinManager.Query(s => s.ID == id)?.ToString() ?? "Unknown";
+            LocalConfig.LookupKeyBindingsFunc = l =>
+            {
+                var combinations = KeyBindingStore.GetReadableKeyCombinationsFor(l);
+
+                if (combinations.Count == 0)
+                    return ToastStrings.NoKeyBound;
+
+                return string.Join(" / ", combinations);
+            };
         }
 
         private void updateLanguage() => CurrentLanguage.Value = LanguageExtensions.GetLanguageFor(frameworkLocale.Value, localisationParameters.Value);

--- a/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
+++ b/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
@@ -9,7 +9,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
+using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays.OSD;
@@ -92,9 +92,9 @@ namespace osu.Game.Overlays.Music
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuConfigManager config)
+            private void load(RealmKeyBindingStore keyBindingStore)
             {
-                ShortcutText.Text = config.LookupKeyBindings(action).ToUpper();
+                ShortcutText.Text = keyBindingStore.GetBindingsStringFor(action).ToUpper();
             }
         }
     }

--- a/osu.Game/Overlays/OSD/SpeedChangeToast.cs
+++ b/osu.Game/Overlays/OSD/SpeedChangeToast.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Configuration;
+using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 
@@ -9,8 +9,8 @@ namespace osu.Game.Overlays.OSD
 {
     public partial class SpeedChangeToast : Toast
     {
-        public SpeedChangeToast(OsuConfigManager config, double newSpeed)
-            : base(ModSelectOverlayStrings.ModCustomisation, ToastStrings.SpeedChangedTo(newSpeed), config.LookupKeyBindings(GlobalAction.IncreaseModSpeed) + " / " + config.LookupKeyBindings(GlobalAction.DecreaseModSpeed))
+        public SpeedChangeToast(RealmKeyBindingStore keyBindingStore, double newSpeed)
+            : base(ModSelectOverlayStrings.ModCustomisation, ToastStrings.SpeedChangedTo(newSpeed), keyBindingStore.GetBindingsStringFor(GlobalAction.IncreaseModSpeed) + " / " + keyBindingStore.GetBindingsStringFor(GlobalAction.DecreaseModSpeed))
         {
         }
     }

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -14,9 +14,9 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
-using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Overlays.OSD;
@@ -312,9 +312,9 @@ namespace osu.Game.Rulesets.Edit
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuConfigManager config)
+            private void load(RealmKeyBindingStore keyBindingStore)
             {
-                ShortcutText.Text = config.LookupKeyBindings(getAction(change)).ToUpper();
+                ShortcutText.Text = keyBindingStore.GetBindingsStringFor(getAction(change)).ToUpper();
             }
 
             private static GlobalAction getAction(ValueChangedEvent<double> change) => change.NewValue - change.OldValue > 0

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -44,13 +44,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder(config.LookupKeyBindings(GlobalAction.ToggleChatFocus));
+            resetPlaceholderText();
             TextBox.Focus = () => TextBox.PlaceholderText = Resources.Localisation.Web.ChatStrings.InputPlaceholder;
             TextBox.FocusLost = () =>
             {
-                TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder(config.LookupKeyBindings(GlobalAction.ToggleChatFocus));
+                resetPlaceholderText();
                 expandedFromTextBoxFocus.Value = false;
             };
+
+            void resetPlaceholderText() => TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder(config.LookupKeyBindings(GlobalAction.ToggleChatFocus));
         }
 
         protected override bool OnHover(HoverEvent e) => true; // use UI mouse cursor.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -6,10 +6,10 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Configuration;
+using osu.Game.Input;
 using osu.Game.Input.Bindings;
-using osu.Game.Localisation;
 using osu.Game.Online.Rooms;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.Play;
 
@@ -42,17 +42,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(RealmKeyBindingStore keyBindingStore)
         {
             resetPlaceholderText();
-            TextBox.Focus = () => TextBox.PlaceholderText = Resources.Localisation.Web.ChatStrings.InputPlaceholder;
+            TextBox.Focus = () => TextBox.PlaceholderText = ChatStrings.InputPlaceholder;
             TextBox.FocusLost = () =>
             {
                 resetPlaceholderText();
                 expandedFromTextBoxFocus.Value = false;
             };
 
-            void resetPlaceholderText() => TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder(config.LookupKeyBindings(GlobalAction.ToggleChatFocus));
+            void resetPlaceholderText() => TextBox.PlaceholderText = Localisation.ChatStrings.InGameInputPlaceholder(keyBindingStore.GetBindingsStringFor(GlobalAction.ToggleChatFocus));
         }
 
         protected override bool OnHover(HoverEvent e) => true; // use UI mouse cursor.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Configuration;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Online.Rooms;
@@ -37,14 +38,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             : base(room, leaveChannelOnDispose: false)
         {
             RelativeSizeAxes = Axes.X;
-
             Background.Alpha = 0.2f;
+        }
 
-            TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder;
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder(config.LookupKeyBindings(GlobalAction.ToggleChatFocus));
             TextBox.Focus = () => TextBox.PlaceholderText = Resources.Localisation.Web.ChatStrings.InputPlaceholder;
             TextBox.FocusLost = () =>
             {
-                TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder;
+                TextBox.PlaceholderText = ChatStrings.InGameInputPlaceholder(config.LookupKeyBindings(GlobalAction.ToggleChatFocus));
                 expandedFromTextBoxFocus.Value = false;
             };
         }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Configuration;
+using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
@@ -195,7 +196,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, INotificationOverlay notificationOverlay)
+        private void load(OsuConfigManager config, RealmKeyBindingStore keyBindingStore, INotificationOverlay notificationOverlay)
         {
             if (drawableRuleset != null)
             {
@@ -214,7 +215,7 @@ namespace osu.Game.Screens.Play
 
                 notificationOverlay?.Post(new SimpleNotification
                 {
-                    Text = NotificationsStrings.ScoreOverlayDisabled(config.LookupKeyBindings(GlobalAction.ToggleInGameInterface))
+                    Text = NotificationsStrings.ScoreOverlayDisabled(keyBindingStore.GetBindingsStringFor(GlobalAction.ToggleInGameInterface))
                 });
             }
 

--- a/osu.Game/Screens/Select/ModSpeedHotkeyHandler.cs
+++ b/osu.Game/Screens/Select/ModSpeedHotkeyHandler.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
+using osu.Game.Input;
 using osu.Game.Overlays;
 using osu.Game.Overlays.OSD;
 using osu.Game.Rulesets.Mods;
@@ -21,7 +22,7 @@ namespace osu.Game.Screens.Select
         private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
 
         [Resolved]
-        private OsuConfigManager config { get; set; } = null!;
+        private RealmKeyBindingStore keyBindingStore { get; set; } = null!;
 
         [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
@@ -55,7 +56,7 @@ namespace osu.Game.Screens.Select
             if (Precision.AlmostEquals(targetSpeed, 1, 0.005))
             {
                 selectedMods.Value = selectedMods.Value.Where(m => m is not ModRateAdjust).ToList();
-                onScreenDisplay?.Display(new SpeedChangeToast(config, targetSpeed));
+                onScreenDisplay?.Display(new SpeedChangeToast(keyBindingStore, targetSpeed));
                 return true;
             }
 
@@ -108,7 +109,7 @@ namespace osu.Game.Screens.Select
                 return false;
 
             selectedMods.Value = intendedMods;
-            onScreenDisplay?.Display(new SpeedChangeToast(config, targetMod.SpeedChange.Value));
+            onScreenDisplay?.Display(new SpeedChangeToast(keyBindingStore, targetMod.SpeedChange.Value));
             return true;
         }
     }


### PR DESCRIPTION
Resolves #32722

| before | after (default) | after (modified) |
|--------|--------|--------|
| ![before](https://github.com/user-attachments/assets/845845f8-8e64-4b54-8d01-9f00f555181e)|![after2](https://github.com/user-attachments/assets/b47aef9d-9954-40e7-8304-9b29572fc5f4) | ![after2](https://github.com/user-attachments/assets/942ad5c0-f0a9-4a2f-b475-280657cd2b97) |

As for `TestSceneGameplayChatDisplay`, I tried but failed to get it to display the default keybind ("Enter") there. The tests still work as intended.