### PR TITLE
Fix incorrect sizing of legacy health display "ki" markers

### DIFF
--- a/osu.Game/Skinning/LegacyHealthDisplay.cs
+++ b/osu.Game/Skinning/LegacyHealthDisplay.cs
@@ -234,14 +234,14 @@ namespace osu.Game.Skinning
             {
                 Bulge();
                 explode.Blending = isEpic ? BlendingParameters.Additive : BlendingParameters.Inherit;
-                explode.ScaleTo(1).Then().ScaleTo(isEpic ? 2 : 1.6f, 120);
-                explode.FadeOutFromOne(120);
+                explode.ScaleTo(1).Then().ScaleTo(isEpic ? 2 : 1.6f, 120, Easing.Out);
+                explode.FadeOutFromOne(120, Easing.Out);
             }
 
             public override void Bulge()
             {
                 base.Bulge();
-                Main.ScaleTo(1.4f).Then().ScaleTo(1, 200, Easing.Out);
+                Main.ScaleTo(1.2f).Then().ScaleTo(0.8f, 150);
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32724.

![Pixelmator Pro 2025-04-08 at 04 50 54](https://github.com/user-attachments/assets/58467a34-020a-4bac-a8de-c777b805bfdc)

Reference: https://github.com/peppy/osu-stable-reference/blob/7519cafd1823f1879c0d9c991ba0e5c7fd3bfa02/osu!/GameModes/Play/Components/HpBar.cs#L288-L292