### PR TITLE
Fix slider placement not working correctly with UI button clicks

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             Content.ScaleTo(ScaleOnMouseDown, 2000, Easing.OutQuint);
-            return base.OnMouseDown(e);
+            return true;
         }
 
         protected override void OnMouseUp(MouseUpEvent e)

--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             Content.ScaleTo(ScaleOnMouseDown, 2000, Easing.OutQuint);
-            return true;
+            return base.OnMouseDown(e);
         }
 
         protected override void OnMouseUp(MouseUpEvent e)

--- a/osu.Game/Screens/Edit/BottomBar.cs
+++ b/osu.Game/Screens/Edit/BottomBar.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
+using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Components;
@@ -92,5 +93,8 @@ namespace osu.Game.Screens.Edit
                 }
             }, true);
         }
+
+        protected override bool OnMouseDown(MouseDownEvent e) => true;
+        protected override bool OnClick(ClickEvent e) => true;
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -167,6 +167,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }, true);
         }
 
+        protected override bool OnMouseDown(MouseDownEvent e) => true;
+        protected override bool OnClick(ClickEvent e) => true;
+
         private void cycleDivisorType(int direction)
         {
             int totalTypes = Enum.GetValues<BeatDivisorType>().Length;
@@ -470,7 +473,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 marker.Active = true;
                 handleMouseInput(e.ScreenSpaceMousePosition);
-                return true;
+                return base.OnMouseDown(e);
             }
 
             protected override void OnMouseUp(MouseUpEvent e)

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -470,7 +470,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 marker.Active = true;
                 handleMouseInput(e.ScreenSpaceMousePosition);
-                return base.OnMouseDown(e);
+                return true;
             }
 
             protected override void OnMouseUp(MouseUpEvent e)


### PR DESCRIPTION
Buttons weren't blocking `MouseDown` events, which means anything that actions on mouse down would incorrectly fire even though a button with input priority was being pressed.

Closes https://github.com/ppy/osu/issues/32704.