### PR TITLE
Fix editor setup screen sliders not having correct keyboard steps

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Setup/CatchDifficultySection.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Setup/CatchDifficultySection.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Setup
                 {
                     Caption = EditorSetupStrings.BaseVelocity,
                     HintText = EditorSetupStrings.BaseVelocityDescription,
+                    KeyboardStep = 0.1f,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderMultiplier)
                     {
                         Default = 1.4,
@@ -89,6 +90,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Setup
                 {
                     Caption = EditorSetupStrings.TickRate,
                     HintText = EditorSetupStrings.TickRateDescription,
+                    KeyboardStep = 1,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderTickRate)
                     {
                         Default = 1,

--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
@@ -89,6 +89,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
                 {
                     Caption = EditorSetupStrings.BaseVelocity,
                     HintText = EditorSetupStrings.BaseVelocityDescription,
+                    KeyboardStep = 0.1f,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderMultiplier)
                     {
                         Default = 1.4,
@@ -103,6 +104,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
                 {
                     Caption = EditorSetupStrings.TickRate,
                     HintText = EditorSetupStrings.TickRateDescription,
+                    KeyboardStep = 1,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderTickRate)
                     {
                         Default = 1,

--- a/osu.Game.Rulesets.Osu/Edit/Setup/OsuDifficultySection.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Setup/OsuDifficultySection.cs
@@ -91,6 +91,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Setup
                 {
                     Caption = EditorSetupStrings.BaseVelocity,
                     HintText = EditorSetupStrings.BaseVelocityDescription,
+                    KeyboardStep = 0.1f,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderMultiplier)
                     {
                         Default = 1.4,
@@ -105,6 +106,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Setup
                 {
                     Caption = EditorSetupStrings.TickRate,
                     HintText = EditorSetupStrings.TickRateDescription,
+                    KeyboardStep = 1,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderTickRate)
                     {
                         Default = 1,
@@ -119,6 +121,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Setup
                 {
                     Caption = "Stack Leniency",
                     HintText = "In play mode, osu! automatically stacks notes which occur at the same location. Increasing this value means it is more likely to snap notes of further time-distance.",
+                    KeyboardStep = 0.1f,
                     Current = new BindableFloat(Beatmap.StackLeniency)
                     {
                         Default = 0.7f,

--- a/osu.Game.Rulesets.Taiko/Edit/Setup/TaikoDifficultySection.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Setup/TaikoDifficultySection.cs
@@ -60,6 +60,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Setup
                 {
                     Caption = EditorSetupStrings.BaseVelocity,
                     HintText = EditorSetupStrings.BaseVelocityDescription,
+                    KeyboardStep = 0.1f,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderMultiplier)
                     {
                         Default = 1.4,
@@ -74,6 +75,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Setup
                 {
                     Caption = EditorSetupStrings.TickRate,
                     HintText = EditorSetupStrings.TickRateDescription,
+                    KeyboardStep = 1,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderTickRate)
                     {
                         Default = 1,

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -68,6 +68,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public LocalisableString HintText { get; init; }
 
+        /// <summary>
+        /// A custom step value for each key press which actuates a change on this control.
+        /// </summary>
+        public float KeyboardStep { get; init; }
+
         private Box background = null!;
         private Box flashLayer = null!;
         private FormTextBox.InnerTextBox textBox = null!;
@@ -140,6 +145,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             Origin = Anchor.CentreRight,
                             RelativeSizeAxes = Axes.X,
                             Width = 0.5f,
+                            KeyboardStep = KeyboardStep,
                             Current = currentNumberInstantaneous,
                             OnCommit = () => current.Value = currentNumberInstantaneous.Value,
                         }
@@ -306,6 +312,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Height = 40;
                 RelativeSizeAxes = Axes.X;
                 RangePadding = nub_width / 2;
+
                 Children = new Drawable[]
                 {
                     new Container

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -103,6 +103,7 @@ namespace osu.Game.Screens.Edit.Setup
                 {
                     Caption = EditorSetupStrings.TickRate,
                     HintText = EditorSetupStrings.TickRateDescription,
+                    KeyboardStep = 1,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderTickRate)
                     {
                         Default = 1,


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32691.

Fixes some extra cases of failure that aren't pointed out in the issue.