### PR TITLE
Adjust menu tips and supporter display to not overlap

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Screens.Menu
         private SongTicker songTicker;
         private Container logoTarget;
         private OnlineMenuBanner onlineMenuBanner;
-        private MenuTip menuTip;
+        private MenuTipDisplay menuTipDisplay;
         private FillFlowContainer bottomElementsFlow;
         private SupporterDisplay supporterDisplay;
 
@@ -191,7 +191,7 @@ namespace osu.Game.Screens.Menu
                     Spacing = new Vector2(5),
                     Children = new Drawable[]
                     {
-                        menuTip = new MenuTip
+                        menuTipDisplay = new MenuTipDisplay
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
@@ -206,8 +206,8 @@ namespace osu.Game.Screens.Menu
                 supporterDisplay = new SupporterDisplay
                 {
                     Margin = new MarginPadding(5),
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
                 },
                 holdToExitGameOverlay?.CreateProxy() ?? Empty()
             });
@@ -391,7 +391,7 @@ namespace osu.Game.Screens.Menu
             musicController.EnsurePlayingSomething();
 
             // Cycle tip on resuming
-            menuTip.ShowNextTip();
+            menuTipDisplay.ShowNextTip();
 
             bottomElementsFlow
                 .ScaleTo(1, 1000, Easing.OutQuint)

--- a/osu.Game/Screens/Menu/MenuTipDisplay.cs
+++ b/osu.Game/Screens/Menu/MenuTipDisplay.cs
@@ -18,7 +18,7 @@ using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Menu
 {
-    public partial class MenuTip : CompositeDrawable
+    public partial class MenuTipDisplay : CompositeDrawable
     {
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
@@ -86,7 +86,12 @@ namespace osu.Game.Screens.Menu
             textFlow.AddParagraph(MenuTipStrings.MenuTipTitle, formatSemiBold);
             textFlow.AddParagraph(tip, formatRegular);
 
-            this.FadeInFromZero(200, Easing.OutQuint)
+            this
+                .FadeOut()
+                .ScaleTo(0.9f)
+                .Delay(600)
+                .FadeInFromZero(800, Easing.OutQuint)
+                .ScaleTo(1, 800, Easing.OutElasticHalf)
                 .Delay(1000 + 80 * tip.ToString().Length)
                 .Then()
                 .FadeOutFromOne(2000, Easing.OutQuint);

--- a/osu.Game/Screens/Menu/SupporterDisplay.cs
+++ b/osu.Game/Screens/Menu/SupporterDisplay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
@@ -53,7 +54,7 @@ namespace osu.Game.Screens.Menu
                 backgroundBox = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Alpha = 0.4f,
+                    Alpha = 0.6f,
                 },
                 supportFlow = new LinkFlowContainer
                 {
@@ -111,7 +112,7 @@ namespace osu.Game.Screens.Menu
 
             this
                 .FadeOut()
-                .Delay(1000)
+                .Delay(RNG.Next(800, 4000))
                 .FadeInFromZero(800, Easing.OutQuint);
 
             scheduleDismissal();
@@ -128,13 +129,13 @@ namespace osu.Game.Screens.Menu
 
         protected override bool OnHover(HoverEvent e)
         {
-            backgroundBox.FadeTo(0.6f, 500, Easing.OutQuint);
+            backgroundBox.FadeTo(0.8f, 500, Easing.OutQuint);
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            backgroundBox.FadeTo(0.4f, 500, Easing.OutQuint);
+            backgroundBox.FadeTo(0.6f, 500, Easing.OutQuint);
             base.OnHoverLost(e);
         }
 
@@ -160,7 +161,7 @@ namespace osu.Game.Screens.Menu
                 this
                     .Delay(200)
                     .FadeOut(750, Easing.Out);
-            }, 6000);
+            }, 8000);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32684.

This annoys me every time I start the game, and now that someone else noticed it I couldn't leave it unfixed. Easiest way is to move the supporter display away from the tips. Top left seems unused (for now) and the perfect place for it to live.

Also did a very brief pass on timings and animations.