### PR TITLE
Disable osu!catch catching animations in editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Edit
     public partial class CatchEditorPlayfield : CatchPlayfield
     {
         public CatchEditorPlayfield(IBeatmapDifficultyInfo difficulty)
-            : base(difficulty)
+            : base(difficulty, transferToCatcher: false)
         {
         }
 
@@ -19,8 +19,6 @@ namespace osu.Game.Rulesets.Catch.Edit
 
             // TODO: honor "hit animation" setting?
             Catcher.CatchFruitOnPlate = false;
-
-            // TODO: disable hit lighting as well
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -46,9 +46,12 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private readonly IBeatmapDifficultyInfo difficulty;
 
-        public CatchPlayfield(IBeatmapDifficultyInfo difficulty)
+        private readonly bool transferToCatcher;
+
+        public CatchPlayfield(IBeatmapDifficultyInfo difficulty, bool transferToCatcher = true)
         {
             this.difficulty = difficulty;
+            this.transferToCatcher = transferToCatcher;
         }
 
         protected override GameplayCursorContainer CreateCursor() => new CatchCursorContainer();
@@ -108,9 +111,15 @@ namespace osu.Game.Rulesets.Catch.UI
         private bool checkIfWeCanCatch(CatchHitObject obj) => Catcher.CanCatch(obj);
 
         private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
-            => CatcherArea.OnNewResult((DrawableCatchHitObject)judgedObject, result);
+        {
+            if (transferToCatcher)
+                CatcherArea.OnNewResult((DrawableCatchHitObject)judgedObject, result);
+        }
 
         private void onRevertResult(JudgementResult result)
-            => CatcherArea.OnRevertResult(result);
+        {
+            if (transferToCatcher)
+                CatcherArea.OnRevertResult(result);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32615.

We'll see what mappers say to this. I'm guessing no one will complain as it makes the editor less busy with lighting flashes and combo counters.