### PR TITLE
Fix difficulty stats not showing in playlists

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -442,6 +442,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             {
                 SelectedItem = { BindTarget = SelectedItem },
                 SelectedMods = { BindTarget = UserMods },
+                Beatmap = { BindTarget = Beatmap },
                 IsValidMod = _ => false
             });
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32740

I also made the same mistake in multiplayer and documented the fix in https://github.com/ppy/osu/pull/32669#discussion_r2027967751, didn't realise it had to be bound.