### PR TITLE
Fix exception cancelling disposed cancellation token

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
@@ -317,6 +317,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
             beatmapLookupCancellation?.Cancel();
             beatmapLookupCancellation?.Dispose();
+            beatmapLookupCancellation = null;
 
             if (item.NewValue?.Beatmap == null)
             {


### PR DESCRIPTION
Randomly encountered this one.

```
[runtime] 2025-04-09 05:53:29 [error]: An unhandled error has occurred.
[runtime] 2025-04-09 05:53:29 [error]: System.ObjectDisposedException: The CancellationTokenSource has been disposed.
[runtime] 2025-04-09 05:53:29 [error]: at System.Threading.CancellationTokenSource.Cancel()
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Screens.OnlinePlay.Lounge.Components.RoomPanel.onSelectedItemChanged(ValueChangedEvent`1 item)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Framework.Bindables.Bindable`1.set_Value(T value)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Screens.OnlinePlay.Lounge.LoungeRoomPanel.updateSelectedItem()
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Screens.OnlinePlay.Lounge.LoungeRoomPanel.onRoomPropertyChanged(Object sender, PropertyChangedEventArgs e)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Online.Rooms.Room.OnPropertyChanged(String propertyName)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Online.Rooms.Room.SetField[T](T& field, T value, String propertyName)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Online.Rooms.Room.set_CurrentPlaylistItem(PlaylistItem value)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Online.Rooms.Room.CopyFrom(Room other)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Screens.OnlinePlay.Lounge.LoungeSubScreen.onListingReceived(Room[] result)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Screens.OnlinePlay.Lounge.LoungeListingPoller.<>c__DisplayClass10_0.<Poll>b__0(List`1 result)
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Online.API.APIRequest`1.<.ctor>b__8_0()
[runtime] 2025-04-09 05:53:29 [error]: at osu.Game.Online.API.APIRequest.<TriggerSuccess>b__25_0()
```