### PR TITLE
Use more distinctive window title for tournament client

### DIFF
--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -53,6 +53,14 @@ namespace osu.Game.Tournament
             return new ProductionEndpointConfiguration();
         }
 
+        public override void SetHost(GameHost host)
+        {
+            base.SetHost(host);
+
+            if (host.Window != null)
+                host.Window.Title = $"{Name} [tournament client]";
+        }
+
         private TournamentSpriteText initialisationText = null!;
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
This is in response to feedback in https://discord.com/channels/188630481301012481/1097318920991559880/1359117234257268747. The long and short of it is that without a unique title it's a bit hard to tell in software like OBS which window is the game and which window is the tournament client if wanting to run both, which I can agree with.