### PR TITLE
Fix progressively worsening performance on taiko argon skin

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonCirclePiece.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Shapes;
@@ -111,6 +112,14 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Argon
                     .Then()
                     .FadeOut(timingPoint.BeatLength * 0.75, Easing.OutSine);
             }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableHitObject.IsNotNull())
+                drawableHitObject.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
@@ -201,6 +202,14 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
                 .FadeEdgeEffectTo(1, pre_beat_transition_time, Easing.OutQuint)
                 .Then()
                 .FadeEdgeEffectTo(edge_alpha_kiai, duration, Easing.OutQuint);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableHitObject.IsNotNull())
+                drawableHitObject.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -17,12 +17,14 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     internal partial class LegacyKiaiGlow : BeatSyncedContainer
     {
-        private bool isKiaiActive;
+        [Resolved]
+        private HealthProcessor? healthProcessor { get; set; }
 
+        private bool isKiaiActive;
         private Sprite sprite = null!;
 
-        [BackgroundDependencyLoader(true)]
-        private void load(ISkinSource skin, HealthProcessor? healthProcessor)
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skin)
         {
             Child = sprite = new Sprite
             {
@@ -33,6 +35,11 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 Scale = new Vector2(TaikoLegacyHitTarget.SCALE),
                 Colour = new Colour4(255, 228, 0, 255),
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
 
             if (healthProcessor != null)
                 healthProcessor.NewJudgement += onNewJudgement;
@@ -60,6 +67,14 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
             sprite.ScaleTo(TaikoLegacyHitTarget.SCALE + 0.15f).Then()
                   .ScaleTo(TaikoLegacyHitTarget.SCALE, 80, Easing.OutQuad);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (healthProcessor != null)
+                healthProcessor.NewJudgement -= onNewJudgement;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32743

This is a special case in taiko... See the following code:

https://github.com/ppy/osu/blob/e1d112ce3dac6e6d1a588b8762ea3c4ccaecc2b4/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs#L144-L161

I believe this was an issue with the triangles skin too (does anyone use that?). Legacy/classic skins are already handled properly.

Note: While I've gone through every class to look for other bad cases, I haven't updated them to adhere to the most recent usage guidelines (binding in `LoadComplete` / etc).