### PR TITLE
Add display to show completed playlist items

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -106,6 +106,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
+        public void TestMarkCompleted()
+        {
+            createPlaylist();
+            AddStep("mark some items as complete", () =>
+            {
+                playlist.Items[0].MarkCompleted();
+                playlist.Items[2].MarkCompleted();
+                playlist.Items[3].MarkCompleted();
+                playlist.Items[5].MarkCompleted();
+            });
+        }
+
+        [Test]
         public void TestSelectable()
         {
             createPlaylist(p => p.AllowSelection = true);

--- a/osu.Game/Localisation/DrawableRoomPlaylistItemStrings.cs
+++ b/osu.Game/Localisation/DrawableRoomPlaylistItemStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class DrawableRoomPlaylistItemStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.DrawableRoomPlaylistItem";
+
+        /// <summary>
+        /// "You have completed this beatmap"
+        /// </summary>
+        public static LocalisableString CompletedTooltip => new TranslatableString(getKey(@"completed_tooltip"), @"You have completed this beatmap");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Online/Rooms/ItemAttemptsCount.cs
+++ b/osu.Game/Online/Rooms/ItemAttemptsCount.cs
@@ -10,10 +10,22 @@ namespace osu.Game.Online.Rooms
     /// </summary>
     public class ItemAttemptsCount
     {
+        /// <summary>
+        /// The playlist item this object describes.
+        /// </summary>
         [JsonProperty("id")]
         public int PlaylistItemID { get; set; }
 
+        /// <summary>
+        /// The number of times the user attempted the playlist item.
+        /// </summary>
         [JsonProperty("attempts")]
         public int Attempts { get; set; }
+
+        /// <summary>
+        /// Whether the user has a passing score on the playlist item.
+        /// </summary>
+        [JsonProperty("completed")]
+        public bool Completed { get; set; }
     }
 }

--- a/osu.Game/Online/Rooms/ItemAttemptsCount.cs
+++ b/osu.Game/Online/Rooms/ItemAttemptsCount.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Online.Rooms
         /// <summary>
         /// Whether the user has a passing score on the playlist item.
         /// </summary>
-        [JsonProperty("completed")]
-        public bool Completed { get; set; }
+        [JsonProperty("passed")]
+        public bool Passed { get; set; }
     }
 }

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -85,6 +85,11 @@ namespace osu.Game.Online.Rooms
 
         private readonly Bindable<bool> valid = new BindableBool(true);
 
+        [JsonIgnore]
+        public IBindable<bool> Completed => completed;
+
+        private readonly Bindable<bool> completed = new BindableBool(false);
+
         [JsonConstructor]
         private PlaylistItem()
             : this(new APIBeatmap())
@@ -117,6 +122,8 @@ namespace osu.Game.Online.Rooms
         }
 
         public void MarkInvalid() => valid.Value = false;
+
+        public void MarkCompleted() => completed.Value = true;
 
         #region Newtonsoft.Json implicit ShouldSerialize() methods
 

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -31,13 +31,14 @@ using osu.Game.Online.Chat;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapSet;
-using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
+using osu.Game.Localisation;
+using WebLocalisation = osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.OnlinePlay
 {
@@ -76,6 +77,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         private readonly DelayedLoadWrapper onScreenLoader;
         private readonly IBindable<bool> valid = new Bindable<bool>();
+        private readonly IBindable<bool> completed = new Bindable<bool>();
 
         private IBeatmapInfo? beatmap;
         private IRulesetInfo? ruleset;
@@ -128,6 +130,7 @@ namespace osu.Game.Screens.OnlinePlay
             Item = item;
 
             valid.BindTo(item.Valid);
+            completed.BindTo(item.Completed);
         }
 
         [BackgroundDependencyLoader]
@@ -525,9 +528,27 @@ namespace osu.Game.Screens.OnlinePlay
 
         private IEnumerable<Drawable> createButtons() => new[]
         {
-            beatmap == null ? Empty() : new PlaylistDownloadButton(beatmap),
+            new CompletionIcon
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Visible = { BindTarget = completed }
+            },
+            beatmap == null
+                ? Empty().With(d =>
+                {
+                    d.Anchor = Anchor.Centre;
+                    d.Origin = Anchor.Centre;
+                })
+                : new PlaylistDownloadButton(beatmap)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
             showResultsButton = new GrayButton(FontAwesome.Solid.ChartPie)
             {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
                 Size = new Vector2(30, 30),
                 Action = () => RequestResults?.Invoke(Item),
                 Alpha = AllowShowingResults ? 1 : 0,
@@ -535,13 +556,17 @@ namespace osu.Game.Screens.OnlinePlay
             },
             editButton = new PlaylistEditButton
             {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
                 Size = new Vector2(30, 30),
                 Alpha = AllowEditing ? 1 : 0,
                 Action = () => RequestEdit?.Invoke(Item),
-                TooltipText = CommonStrings.ButtonsEdit
+                TooltipText = WebLocalisation.CommonStrings.ButtonsEdit
             },
             removeButton = new PlaylistRemoveButton
             {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
                 Size = new Vector2(30, 30),
                 Alpha = AllowDeletion ? 1 : 0,
                 Action = () => RequestDeletion?.Invoke(Item),
@@ -767,6 +792,65 @@ namespace osu.Game.Screens.OnlinePlay
             {
                 this.allowInteraction = allowInteraction;
             }
+        }
+
+        private partial class CompletionIcon : CompositeDrawable, IHasTooltip
+        {
+            public readonly BindableBool Visible = new BindableBool();
+
+            [Resolved]
+            private OsuColour colours { get; set; } = null!;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                InternalChild = new CircularContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(16),
+                    Masking = true,
+                    Colour = colours.Lime0,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        },
+                        new SpriteIcon
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            RelativeSizeAxes = Axes.Both,
+                            Scale = new Vector2(0.5f),
+                            Colour = OsuColour.Gray(0.5f),
+                            Icon = FontAwesome.Solid.Check
+                        }
+                    }
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                Visible.BindValueChanged(onVisibleChanged, true);
+            }
+
+            private void onVisibleChanged(ValueChangedEvent<bool> visible)
+            {
+                if (visible.NewValue)
+                {
+                    Size = new Vector2(16);
+                    Alpha = 1;
+                }
+                else
+                {
+                    Size = Vector2.Zero;
+                    Alpha = 0;
+                }
+            }
+
+            public LocalisableString TooltipText => DrawableRoomPlaylistItemStrings.CompletedTooltip;
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -38,7 +38,6 @@ using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Localisation;
-using WebLocalisation = osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.OnlinePlay
 {
@@ -561,7 +560,7 @@ namespace osu.Game.Screens.OnlinePlay
                 Size = new Vector2(30, 30),
                 Alpha = AllowEditing ? 1 : 0,
                 Action = () => RequestEdit?.Invoke(Item),
-                TooltipText = WebLocalisation.CommonStrings.ButtonsEdit
+                TooltipText = Resources.Localisation.Web.CommonStrings.ButtonsEdit
             },
             removeButton = new PlaylistRemoveButton
             {

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -465,6 +465,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             });
 
             updateSetupState();
+            updateUserScore();
             updateGameplayState();
         }
 
@@ -479,6 +480,10 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             {
                 case nameof(Room.RoomID):
                     updateSetupState();
+                    break;
+
+                case nameof(Room.UserScore):
+                    updateUserScore();
                     break;
             }
         }
@@ -507,9 +512,29 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     progressSection.Alpha = room.MaxAttempts != null ? 1 : 0;
                     drawablePlaylist.Items.ReplaceRange(0, drawablePlaylist.Items.Count, room.Playlist);
 
+                    updateUserScore();
+
                     // Select an initial item for the user to help them get into a playable state quicker.
                     SelectedItem.Value = room.Playlist.FirstOrDefault();
                 });
+            }
+        }
+
+        /// <summary>
+        /// Responds to changes in <see cref="Room.UserScore"/> to mark playlist items as completed.
+        /// </summary>
+        private void updateUserScore()
+        {
+            if (room.UserScore == null)
+                return;
+
+            if (drawablePlaylist.Items.Count == 0)
+                return;
+
+            foreach (var item in room.UserScore.PlaylistItemAttempts)
+            {
+                if (item.Completed)
+                    drawablePlaylist.Items.Single(i => i.ID == item.PlaylistItemID).MarkCompleted();
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -533,7 +533,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             foreach (var item in room.UserScore.PlaylistItemAttempts)
             {
-                if (item.Completed)
+                if (item.Passed)
                     drawablePlaylist.Items.Single(i => i.ID == item.PlaylistItemID).MarkCompleted();
             }
         }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/discussions/32739
- [x] Depends on https://github.com/ppy/osu-web/pull/12094

https://github.com/user-attachments/assets/709e4526-7dbb-4a73-aeb5-de6695252b35

Please don't look at the structure of the code all that much. This component is a true horror.

As for message passing - I'm using a similar pathway to `MarkInvalid()`, which means that half the state is going through `PlaylistItem` even though I've said in the past this shouldn't be done. This is just the easiest way to get things into this component without spending too much time on it.