### PR TITLE
Add new icons, font templates, statistics naming changes and colour updates

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
@@ -21,19 +21,19 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = @"Fruit Count",
+                    Name = @"Fruits",
                     Content = fruits.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Juice Stream Count",
+                    Name = @"Juice Streams",
                     Content = juiceStreams.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Banana Shower Count",
+                    Name = @"Banana Showers",
                     Content = bananaShowers.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                 }

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
@@ -41,13 +41,13 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = @"Note Count",
+                    Name = @"Notes",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = notes.ToString(),
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Hold Note Count",
+                    Name = @"Hold Notes",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = holdNotes.ToString(),
                 },

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
-using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Beatmaps
@@ -21,19 +20,19 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = BeatmapsetsStrings.ShowStatsCountCircles,
+                    Name = "Circles",
                     Content = circles.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                 },
                 new BeatmapStatistic
                 {
-                    Name = BeatmapsetsStrings.ShowStatsCountSliders,
+                    Name = "Sliders",
                     Content = sliders.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Spinner Count",
+                    Name = @"Spinners",
                     Content = spinners.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                 }

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
@@ -20,19 +20,19 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = @"Hit Count",
+                    Name = @"Hits",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = hits.ToString(),
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Drumroll Count",
+                    Name = @"Drumrolls",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = drumRolls.ToString(),
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Swell Count",
+                    Name = @"Swells",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                     Content = swells.ToString(),
                 }

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Graphics
 
         public static readonly (float, Color4)[] STAR_DIFFICULTY_SPECTRUM =
         {
-            (0.0f, Color4Extensions.FromHex("4290fb")),
+            (0.1f, Color4Extensions.FromHex("aaaaaa")),
             (0.1f, Color4Extensions.FromHex("4290fb")),
             (1.25f, Color4Extensions.FromHex("4fc0ff")),
             (2.0f, Color4Extensions.FromHex("4fffd5")),
@@ -40,13 +40,7 @@ namespace osu.Game.Graphics
         /// <summary>
         /// Retrieves the colour for a given point in the star range.
         /// </summary>
-        public Color4 ForStarDifficulty(double starDifficulty, bool showGrayOnZero = true)
-        {
-            if (showGrayOnZero && starDifficulty < 0.1f)
-                return Color4Extensions.FromHex("aaaaaa");
-
-            return ColourUtils.SampleFromLinearGradient(STAR_DIFFICULTY_SPECTRUM, (float)Math.Round(starDifficulty, 2, MidpointRounding.AwayFromZero));
-        }
+        public Color4 ForStarDifficulty(double starDifficulty) => ColourUtils.SampleFromLinearGradient(STAR_DIFFICULTY_SPECTRUM, (float)Math.Round(starDifficulty, 2, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Retrieves the colour for a <see cref="ScoreRank"/>.

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Graphics
         /// <summary>
         /// Retrieves the colour for a given point in the star range.
         /// </summary>
+        // todo: fix stupid array
         public Color4 ForStarDifficulty(double starDifficulty) => ColourUtils.SampleFromLinearGradient(new[]
         {
             (0.1f, Color4Extensions.FromHex("aaaaaa")),
@@ -402,6 +403,12 @@ namespace osu.Game.Graphics
         public readonly Color4 Orange2 = Color4Extensions.FromHex(@"ebc247");
         public readonly Color4 Orange3 = Color4Extensions.FromHex(@"cca633");
         public readonly Color4 Orange4 = Color4Extensions.FromHex(@"6b5c2e");
+
+        public readonly Color4 DarkOrange0 = Color4Extensions.FromHex(@"ffbb99");
+        public readonly Color4 DarkOrange1 = Color4Extensions.FromHex(@"ff9966");
+        public readonly Color4 DarkOrange2 = Color4Extensions.FromHex(@"eb7e47");
+        public readonly Color4 DarkOrange3 = Color4Extensions.FromHex(@"cc6633");
+        public readonly Color4 DarkOrange4 = Color4Extensions.FromHex(@"6b422e");
 
         public readonly Color4 Red0 = Color4Extensions.FromHex(@"ff9b9b");
         public readonly Color4 Red1 = Color4Extensions.FromHex(@"ff6666");

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -20,13 +20,9 @@ namespace osu.Game.Graphics
         public static Color4 Gray(float amt) => new Color4(amt, amt, amt, 1f);
         public static Color4 Gray(byte amt) => new Color4(amt, amt, amt, 255);
 
-        /// <summary>
-        /// Retrieves the colour for a given point in the star range.
-        /// </summary>
-        // todo: fix stupid array
-        public Color4 ForStarDifficulty(double starDifficulty) => ColourUtils.SampleFromLinearGradient(new[]
+        public static readonly (float, Color4)[] STAR_DIFFICULTY_SPECTRUM =
         {
-            (0.1f, Color4Extensions.FromHex("aaaaaa")),
+            (0.0f, Color4Extensions.FromHex("4290fb")),
             (0.1f, Color4Extensions.FromHex("4290fb")),
             (1.25f, Color4Extensions.FromHex("4fc0ff")),
             (2.0f, Color4Extensions.FromHex("4fffd5")),
@@ -38,7 +34,19 @@ namespace osu.Game.Graphics
             (6.7f, Color4Extensions.FromHex("6563de")),
             (7.7f, Color4Extensions.FromHex("18158e")),
             (9.0f, Color4.Black),
-        }, (float)Math.Round(starDifficulty, 2, MidpointRounding.AwayFromZero));
+            (10.0f, Color4.Black),
+        };
+
+        /// <summary>
+        /// Retrieves the colour for a given point in the star range.
+        /// </summary>
+        public Color4 ForStarDifficulty(double starDifficulty, bool showGrayOnZero = true)
+        {
+            if (showGrayOnZero && starDifficulty < 0.1f)
+                return Color4Extensions.FromHex("aaaaaa");
+
+            return ColourUtils.SampleFromLinearGradient(STAR_DIFFICULTY_SPECTRUM, (float)Math.Round(starDifficulty, 2, MidpointRounding.AwayFromZero));
+        }
 
         /// <summary>
         /// Retrieves the colour for a <see cref="ScoreRank"/>.

--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -16,14 +16,64 @@ namespace osu.Game.Graphics
         public const float DEFAULT_FONT_SIZE = 16;
 
         /// <summary>
+        /// Template font styles which should be preferred whenever possible for UI elements.
+        /// </summary>
+        public static class Style
+        {
+            /// <summary>
+            /// Equivalent to Torus with 32px size and semi-bold weight.
+            /// </summary>
+            public static FontUsage Title => GetFont(Typeface.TorusAlternate, size: 32, weight: FontWeight.Regular);
+
+            /// <summary>
+            /// Torus with 28px size and semi-bold weight.
+            /// </summary>
+            public static FontUsage Subtitle => GetFont(size: 28, weight: FontWeight.Regular);
+
+            /// <summary>
+            /// Torus with 22px size and bold weight.
+            /// </summary>
+            public static FontUsage Heading1 => GetFont(size: 22, weight: FontWeight.Bold);
+
+            /// <summary>
+            /// Torus with 18px size and semi-bold weight.
+            /// </summary>
+            public static FontUsage Heading2 => GetFont(size: 18, weight: FontWeight.SemiBold);
+
+            /// <summary>
+            /// Torus with 16px size and regular weight.
+            /// </summary>
+            public static FontUsage Body => GetFont(size: DEFAULT_FONT_SIZE, weight: FontWeight.Regular);
+
+            /// <summary>
+            /// Torus with 14px size and regular weight.
+            /// </summary>
+            public static FontUsage Caption1 => GetFont(size: 14, weight: FontWeight.Regular);
+
+            /// <summary>
+            /// Torus with 12px size and regular weight.
+            /// </summary>
+            public static FontUsage Caption2 => GetFont(size: 12, weight: FontWeight.Regular);
+        }
+
+        /// <summary>
         /// The default font.
         /// </summary>
-        public static FontUsage Default => GetFont();
+        public static FontUsage Default => GetFont(weight: FontWeight.Medium);
 
+        /// <summary>
+        /// Font face for numeric display.
+        /// </summary>
         public static FontUsage Numeric => GetFont(Typeface.Venera, weight: FontWeight.Bold);
 
+        /// <summary>
+        /// Default font face for UI and game elements.
+        /// </summary>
         public static FontUsage Torus => GetFont(Typeface.Torus, weight: FontWeight.Regular);
 
+        /// <summary>
+        /// Default font face with alternate character set for headings and flair text.
+        /// </summary>
         public static FontUsage TorusAlternate => GetFont(Typeface.TorusAlternate, weight: FontWeight.Regular);
 
         public static FontUsage Inter => GetFont(Typeface.Inter, weight: FontWeight.Regular);

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -115,6 +115,7 @@ namespace osu.Game.Graphics
         public static IconUsage ChangelogB => get(OsuIconMapping.ChangelogB);
         public static IconUsage Chat => get(OsuIconMapping.Chat);
         public static IconUsage CheckCircle => get(OsuIconMapping.CheckCircle);
+        public static IconUsage Clock => get(OsuIconMapping.Clock);
         public static IconUsage CollapseA => get(OsuIconMapping.CollapseA);
         public static IconUsage Collections => get(OsuIconMapping.Collections);
         public static IconUsage Cross => get(OsuIconMapping.Cross);
@@ -141,6 +142,7 @@ namespace osu.Game.Graphics
         public static IconUsage Input => get(OsuIconMapping.Input);
         public static IconUsage Maintenance => get(OsuIconMapping.Maintenance);
         public static IconUsage Megaphone => get(OsuIconMapping.Megaphone);
+        public static IconUsage Metronome => get(OsuIconMapping.Metronome);
         public static IconUsage Music => get(OsuIconMapping.Music);
         public static IconUsage News => get(OsuIconMapping.News);
         public static IconUsage Next => get(OsuIconMapping.Next);
@@ -203,6 +205,9 @@ namespace osu.Game.Graphics
 
             [Description(@"check-circle")]
             CheckCircle,
+
+            [Description(@"clock")]
+            Clock,
 
             [Description(@"collapse-a")]
             CollapseA,
@@ -281,6 +286,9 @@ namespace osu.Game.Graphics
 
             [Description(@"megaphone")]
             Megaphone,
+
+            [Description(@"metronome")]
+            Metronome,
 
             [Description(@"music")]
             Music,


### PR DESCRIPTION
These are all extracted from song select changes made by @frenzibyte. The goal is to get review eyes on pieces which have scope larger than song select v2 itself, and to reduce the number of external files touched by the main changes.

Of note, I am interested in others' opinions on the font styles. Once this PR is approved, I would be looking to replace all existing usages with the template versions (as a follow-up change).

