### PR TITLE
Add test cases for lazer-specific replay instability due to truncation issue

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -19d, HitResult.Perfect },
             new object[] { 5f, -19.2d, HitResult.Perfect },
             new object[] { 5f, -19.38d, HitResult.Perfect },
+            // new object[] { 5f, -19.4d, HitResult.Perfect }, <- in theory this should work, in practice it does not (fails even before encode & rounding due to floating point precision issues)
             new object[] { 5f, -19.44d, HitResult.Great },
             new object[] { 5f, -19.7d, HitResult.Great },
             new object[] { 5f, -20d, HitResult.Great },
@@ -69,6 +70,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 9.3f, 14d, HitResult.Perfect },
             new object[] { 9.3f, 14.2d, HitResult.Perfect },
             new object[] { 9.3f, 14.6d, HitResult.Perfect },
+            // new object[] { 9.3f, 14.67d, HitResult.Perfect }, <- in theory this should work, in practice it does not (fails even before encode & rounding due to floating point precision issues)
             new object[] { 9.3f, 14.7d, HitResult.Great },
             new object[] { 9.3f, 15d, HitResult.Great },
             new object[] { 9.3f, 35d, HitResult.Great },

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mania.Tests
     [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneReplayStability : ReplayStabilityTestScene
     {
-        private static readonly object[][] test_cases = new[]
+        private static readonly object[][] test_cases =
         {
             // OD = 5 test cases.
             // PERFECT hit window is [ -19.4ms,  19.4ms]
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             {
                 HitObjects =
                 {
-                    new Note()
+                    new Note
                     {
                         StartTime = note_time,
                         Column = 0,

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
@@ -1,0 +1,143 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Mania.Tests
+{
+    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
+    public partial class TestSceneReplayStability : ReplayStabilityTestScene
+    {
+        private static readonly object[][] test_cases = new[]
+        {
+            // OD = 5 test cases.
+            // PERFECT hit window is [ -19.4ms,  19.4ms]
+            // GREAT   hit window is [ -49.0ms,  49.0ms]
+            // GOOD    hit window is [ -82.0ms,  82.0ms]
+            // OK      hit window is [-112.0ms, 112.0ms]
+            // MEH     hit window is [-136.0ms, 136.0ms]
+            // MISS    hit window is [-173.0ms, 173.0ms]
+            new object[] { 5f, -19d, HitResult.Perfect },
+            new object[] { 5f, -19.2d, HitResult.Perfect },
+            new object[] { 5f, -19.38d, HitResult.Perfect },
+            new object[] { 5f, -19.44d, HitResult.Great },
+            new object[] { 5f, -19.7d, HitResult.Great },
+            new object[] { 5f, -20d, HitResult.Great },
+            new object[] { 5f, -48d, HitResult.Great },
+            new object[] { 5f, -48.4d, HitResult.Great },
+            new object[] { 5f, -48.7d, HitResult.Great },
+            new object[] { 5f, -49d, HitResult.Great },
+            new object[] { 5f, -49.2d, HitResult.Good },
+            new object[] { 5f, -49.7d, HitResult.Good },
+            new object[] { 5f, -50d, HitResult.Good },
+            new object[] { 5f, -81d, HitResult.Good },
+            new object[] { 5f, -81.2d, HitResult.Good },
+            new object[] { 5f, -81.7d, HitResult.Good },
+            new object[] { 5f, -82d, HitResult.Good },
+            new object[] { 5f, -82.2d, HitResult.Ok },
+            new object[] { 5f, -82.7d, HitResult.Ok },
+            new object[] { 5f, -83d, HitResult.Ok },
+            new object[] { 5f, -111d, HitResult.Ok },
+            new object[] { 5f, -111.2d, HitResult.Ok },
+            new object[] { 5f, -111.7d, HitResult.Ok },
+            new object[] { 5f, -112d, HitResult.Ok },
+            new object[] { 5f, -112.2d, HitResult.Meh },
+            new object[] { 5f, -112.7d, HitResult.Meh },
+            new object[] { 5f, -113d, HitResult.Meh },
+            new object[] { 5f, -135d, HitResult.Meh },
+            new object[] { 5f, -135.2d, HitResult.Meh },
+            new object[] { 5f, -135.8d, HitResult.Meh },
+            new object[] { 5f, -136d, HitResult.Meh },
+            new object[] { 5f, -136.2d, HitResult.Miss },
+            new object[] { 5f, -136.7d, HitResult.Miss },
+            new object[] { 5f, -137d, HitResult.Miss },
+
+            // OD = 9.3 test cases.
+            // PERFECT hit window is [ -14.67ms,  14.67ms]
+            // GREAT   hit window is [ -36.10ms,  36.10ms]
+            // GOOD    hit window is [ -69.10ms,  69.10ms]
+            // OK      hit window is [ -99.10ms,  99.10ms]
+            // MEH     hit window is [-123.10ms, 123.10ms]
+            // MISS    hit window is [-160.10ms, 160.10ms]
+            new object[] { 9.3f, 14d, HitResult.Perfect },
+            new object[] { 9.3f, 14.2d, HitResult.Perfect },
+            new object[] { 9.3f, 14.6d, HitResult.Perfect },
+            new object[] { 9.3f, 14.7d, HitResult.Great },
+            new object[] { 9.3f, 15d, HitResult.Great },
+            new object[] { 9.3f, 35d, HitResult.Great },
+            new object[] { 9.3f, 35.3d, HitResult.Great },
+            new object[] { 9.3f, 35.8d, HitResult.Great },
+            new object[] { 9.3f, 36.05d, HitResult.Great },
+            new object[] { 9.3f, 36.3d, HitResult.Good },
+            new object[] { 9.3f, 36.7d, HitResult.Good },
+            new object[] { 9.3f, 37d, HitResult.Good },
+            new object[] { 9.3f, 68d, HitResult.Good },
+            new object[] { 9.3f, 68.4d, HitResult.Good },
+            new object[] { 9.3f, 68.9d, HitResult.Good },
+            new object[] { 9.3f, 69.07d, HitResult.Good },
+            new object[] { 9.3f, 69.25d, HitResult.Ok },
+            new object[] { 9.3f, 69.85d, HitResult.Ok },
+            new object[] { 9.3f, 70d, HitResult.Ok },
+            new object[] { 9.3f, 98d, HitResult.Ok },
+            new object[] { 9.3f, 98.3d, HitResult.Ok },
+            new object[] { 9.3f, 98.6d, HitResult.Ok },
+            new object[] { 9.3f, 99d, HitResult.Ok },
+            new object[] { 9.3f, 99.3d, HitResult.Meh },
+            new object[] { 9.3f, 99.7d, HitResult.Meh },
+            new object[] { 9.3f, 100d, HitResult.Meh },
+            new object[] { 9.3f, 122d, HitResult.Meh },
+            new object[] { 9.3f, 122.34d, HitResult.Meh },
+            new object[] { 9.3f, 122.57d, HitResult.Meh },
+            new object[] { 9.3f, 123.04d, HitResult.Meh },
+            new object[] { 9.3f, 123.45d, HitResult.Miss },
+            new object[] { 9.3f, 123.95d, HitResult.Miss },
+            new object[] { 9.3f, 124d, HitResult.Miss },
+        };
+
+        [TestCaseSource(nameof(test_cases))]
+        public void TestHitWindowStability(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            const double note_time = 100;
+
+            var beatmap = new ManiaBeatmap(new StageDefinition(1))
+            {
+                HitObjects =
+                {
+                    new Note()
+                    {
+                        StartTime = note_time,
+                        Column = 0,
+                    }
+                },
+                Difficulty = new BeatmapDifficulty
+                {
+                    OverallDifficulty = overallDifficulty,
+                    CircleSize = 1,
+                },
+                BeatmapInfo =
+                {
+                    Ruleset = new ManiaRuleset().RulesetInfo,
+                },
+            };
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new ManiaReplayFrame(0),
+                    new ManiaReplayFrame(note_time + hitOffset, ManiaAction.Key1),
+                    new ManiaReplayFrame(note_time + hitOffset + 20),
+                }
+            };
+
+            RunTest(beatmap, replay, [expectedResult]);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Tests
     [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneReplayStability : ReplayStabilityTestScene
     {
-        private static readonly object[][] test_cases = new[]
+        private static readonly object[][] test_cases =
         {
             // OD = 5 test cases.
             // GREAT hit window is [ -50ms,  50ms]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
@@ -1,0 +1,187 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [TestFixture]
+    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
+    public partial class TestSceneReplayStability : RateAdjustedBeatmapTestScene
+    {
+        private ReplayPlayer currentPlayer = null!;
+        private readonly List<JudgementResult> results = new List<JudgementResult>();
+
+        private static readonly object[][] test_cases = new[]
+        {
+            // OD = 5 test cases.
+            // GREAT hit window is [ -50ms,  50ms]
+            // OK    hit window is [-100ms, 100ms]
+            // MEH   hit window is [-150ms, 150ms]
+            // MISS  hit window is [-400ms, 400ms]
+            new object[] { 5f, 49d, HitResult.Great },
+            new object[] { 5f, 49.2d, HitResult.Great },
+            new object[] { 5f, 49.7d, HitResult.Great },
+            new object[] { 5f, 50d, HitResult.Great },
+            new object[] { 5f, 50.4d, HitResult.Ok },
+            new object[] { 5f, 50.9d, HitResult.Ok },
+            new object[] { 5f, 51d, HitResult.Ok },
+            new object[] { 5f, 99d, HitResult.Ok },
+            new object[] { 5f, 99.2d, HitResult.Ok },
+            new object[] { 5f, 99.7d, HitResult.Ok },
+            new object[] { 5f, 100d, HitResult.Ok },
+            new object[] { 5f, 100.4d, HitResult.Meh },
+            new object[] { 5f, 100.9d, HitResult.Meh },
+            new object[] { 5f, 101d, HitResult.Meh },
+            new object[] { 5f, 149d, HitResult.Meh },
+            new object[] { 5f, 149.2d, HitResult.Meh },
+            new object[] { 5f, 149.7d, HitResult.Meh },
+            new object[] { 5f, 150d, HitResult.Meh },
+            new object[] { 5f, 150.4d, HitResult.Miss },
+            new object[] { 5f, 150.9d, HitResult.Miss },
+            new object[] { 5f, 151d, HitResult.Miss },
+
+            // OD = 5.7 test cases.
+            // GREAT hit window is [ -45.8ms,  45.8ms]
+            // OK    hit window is [ -94.4ms,  94.4ms]
+            // MEH   hit window is [-143.0ms, 143.0ms]
+            // MISS  hit window is [-400.0ms, 400.0ms]
+            new object[] { 5.7f, 45d, HitResult.Great },
+            new object[] { 5.7f, 45.2d, HitResult.Great },
+            new object[] { 5.7f, 45.8d, HitResult.Great },
+            new object[] { 5.7f, 45.9d, HitResult.Ok },
+            new object[] { 5.7f, 46d, HitResult.Ok },
+            new object[] { 5.7f, 46.4d, HitResult.Ok },
+            new object[] { 5.7f, 94d, HitResult.Ok },
+            new object[] { 5.7f, 94.2d, HitResult.Ok },
+            new object[] { 5.7f, 94.4d, HitResult.Ok },
+            new object[] { 5.7f, 94.48d, HitResult.Ok },
+            new object[] { 5.7f, 94.9d, HitResult.Meh },
+            new object[] { 5.7f, 95d, HitResult.Meh },
+            new object[] { 5.7f, 95.4d, HitResult.Meh },
+            new object[] { 5.7f, 142d, HitResult.Meh },
+            new object[] { 5.7f, 142.7d, HitResult.Meh },
+            new object[] { 5.7f, 143d, HitResult.Meh },
+            new object[] { 5.7f, 143.4d, HitResult.Miss },
+            new object[] { 5.7f, 143.9d, HitResult.Miss },
+            new object[] { 5.7f, 144d, HitResult.Miss },
+        };
+
+        [TestCaseSource(nameof(test_cases))]
+        public void TestHitWindowStability(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            const double hit_circle_time = 100;
+
+            Score originalScore = null!;
+            Score decodedScore = null!;
+            IBeatmap beatmap = null!;
+
+            AddStep("create beatmap", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(beatmap = new OsuBeatmap
+                {
+                    HitObjects =
+                    {
+                        new HitCircle
+                        {
+                            StartTime = hit_circle_time,
+                            Position = OsuPlayfield.BASE_SIZE / 2
+                        }
+                    },
+                    Difficulty = new BeatmapDifficulty { OverallDifficulty = overallDifficulty },
+                    BeatmapInfo =
+                    {
+                        Ruleset = new OsuRuleset().RulesetInfo,
+                    },
+                });
+            });
+            AddStep("create replay", () =>
+            {
+                originalScore = new Score
+                {
+                    Replay = new Replay
+                    {
+                        Frames =
+                        {
+                            new OsuReplayFrame(0, OsuPlayfield.BASE_SIZE / 2),
+                            new OsuReplayFrame(hit_circle_time + hitOffset, OsuPlayfield.BASE_SIZE / 2, OsuAction.LeftButton),
+                            new OsuReplayFrame(hit_circle_time + hitOffset + 20, OsuPlayfield.BASE_SIZE / 2),
+                        }
+                    }
+                };
+            });
+
+            AddStep("push player", () => pushNewPlayer(originalScore));
+
+            AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep("Wait for completion", () => currentPlayer.GameplayState.HasCompleted);
+            AddAssert("Collected one judgement result", () => results, () => Has.Count.EqualTo(1));
+            AddAssert("Judgement result is correct", () => results.Single().Type, () => Is.EqualTo(expectedResult));
+
+            AddStep("exit player", () => currentPlayer.Exit());
+
+            AddStep("encode and decode score", () =>
+            {
+                var encoder = new LegacyScoreEncoder(originalScore, beatmap);
+
+                using (var stream = new MemoryStream())
+                {
+                    encoder.Encode(stream, leaveOpen: true);
+                    stream.Position = 0;
+                    decodedScore = new TestScoreDecoder(Beatmap.Value).Parse(stream);
+                }
+            });
+
+            AddStep("push player", () => pushNewPlayer(decodedScore));
+
+            AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep("Wait for completion", () => currentPlayer.GameplayState.HasCompleted);
+            AddAssert("Collected one judgement result", () => results, () => Has.Count.EqualTo(1));
+            AddAssert("Judgement result is correct", () => results.Single().Type, () => Is.EqualTo(expectedResult));
+        }
+
+        private void pushNewPlayer(Score score)
+        {
+            var player = new ReplayPlayer(score);
+            player.OnLoadComplete += _ =>
+            {
+                player.GameplayState.ScoreProcessor.NewJudgement += result =>
+                {
+                    if (currentPlayer == player)
+                        results.Add(result);
+                };
+            };
+            LoadScreen(currentPlayer = player);
+            results.Clear();
+        }
+
+        private class TestScoreDecoder : LegacyScoreDecoder
+        {
+            private readonly WorkingBeatmap beatmap;
+
+            public TestScoreDecoder(WorkingBeatmap beatmap)
+            {
+                this.beatmap = beatmap;
+            }
+
+            protected override Ruleset GetRuleset(int rulesetId) => new OsuRuleset();
+            protected override WorkingBeatmap GetBeatmap(string md5Hash) => beatmap;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
     [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneReplayStability : ReplayStabilityTestScene
     {
-        private static readonly object[][] test_cases = new[]
+        private static readonly object[][] test_cases =
         {
             // OD = 5 test cases.
             // GREAT hit window is [-35ms, 35ms]
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             const double hit_time = 100;
 
-            var beatmap = new TaikoBeatmap()
+            var beatmap = new TaikoBeatmap
             {
                 HitObjects =
                 {

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Beatmaps;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Replays;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
+    public partial class TestSceneReplayStability : ReplayStabilityTestScene
+    {
+        private static readonly object[][] test_cases = new[]
+        {
+            // OD = 5 test cases.
+            // GREAT hit window is [-35ms, 35ms]
+            // OK    hit window is [-80ms, 80ms]
+            // MISS  hit window is [-95ms, 95ms]
+            new object[] { 5f, -34d, HitResult.Great },
+            new object[] { 5f, -34.2d, HitResult.Great },
+            new object[] { 5f, -34.7d, HitResult.Great },
+            new object[] { 5f, -35d, HitResult.Great },
+            new object[] { 5f, -35.2d, HitResult.Ok },
+            new object[] { 5f, -35.8d, HitResult.Ok },
+            new object[] { 5f, -36d, HitResult.Ok },
+            new object[] { 5f, -79d, HitResult.Ok },
+            new object[] { 5f, -79.3d, HitResult.Ok },
+            new object[] { 5f, -79.7d, HitResult.Ok },
+            new object[] { 5f, -80d, HitResult.Ok },
+            new object[] { 5f, -80.2d, HitResult.Miss },
+            new object[] { 5f, -80.8d, HitResult.Miss },
+            new object[] { 5f, -81d, HitResult.Miss },
+
+            // OD = 7.8 test cases.
+            // GREAT hit window is [-26.6ms, 26.6ms]
+            // OK    hit window is [-63.2ms, 63.2ms]
+            // MISS  hit window is [-81.0ms, 81.0ms]
+            new object[] { 7.8f, -26d, HitResult.Great },
+            new object[] { 7.8f, -26.4d, HitResult.Great },
+            new object[] { 7.8f, -26.59d, HitResult.Great },
+            new object[] { 7.8f, -26.8d, HitResult.Ok },
+            new object[] { 7.8f, -27d, HitResult.Ok },
+            new object[] { 7.8f, -27.1d, HitResult.Ok },
+            new object[] { 7.8f, -63d, HitResult.Ok },
+            new object[] { 7.8f, -63.18d, HitResult.Ok },
+            new object[] { 7.8f, -63.4d, HitResult.Ok },
+            new object[] { 7.8f, -63.7d, HitResult.Miss },
+            new object[] { 7.8f, -64d, HitResult.Miss },
+            new object[] { 7.8f, -64.2d, HitResult.Miss },
+        };
+
+        [TestCaseSource(nameof(test_cases))]
+        public void TestHitWindowStability(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            const double hit_time = 100;
+
+            var beatmap = new TaikoBeatmap()
+            {
+                HitObjects =
+                {
+                    new Hit
+                    {
+                        StartTime = hit_time,
+                        Type = HitType.Centre,
+                    }
+                },
+                Difficulty = new BeatmapDifficulty { OverallDifficulty = overallDifficulty },
+                BeatmapInfo =
+                {
+                    Ruleset = new TaikoRuleset().RulesetInfo,
+                },
+            };
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new TaikoReplayFrame(0),
+                    new TaikoReplayFrame(hit_time + hitOffset, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(hit_time + hitOffset + 20),
+                }
+            };
+
+            RunTest(beatmap, replay, [expectedResult]);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public bool HasQuit { get; set; }
 
+        public bool HasCompleted => HasPassed || HasFailed || HasQuit;
+
         /// <summary>
         /// A bindable tracking the last judgement result applied to any hit object.
         /// </summary>

--- a/osu.Game/Tests/Visual/ReplayStabilityTestScene.cs
+++ b/osu.Game/Tests/Visual/ReplayStabilityTestScene.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Replays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Tests.Visual
+{
+    /// <summary>
+    /// The goal of this abstract test class is to ensure that the process of exporting of a replay does not affect its playback.
+    /// Use <see cref="RunTest"/> to exercise that property.
+    /// </summary>
+    [HeadlessTest]
+    [TestFixture]
+    public abstract partial class ReplayStabilityTestScene : RateAdjustedBeatmapTestScene
+    {
+        private ReplayPlayer currentPlayer = null!;
+        private readonly List<JudgementResult> results = new List<JudgementResult>();
+
+        /// <summary>
+        /// Runs <paramref name="replay"/> against the supplied <paramref name="beatmap"/>
+        /// and checks that the judgement results recorded match <paramref name="expectedResults"/>.
+        /// Then, encodes the <paramref name="replay"/>, decodes the result of encoding, runs the result of decoding against the supplied <paramref name="beatmap"/>,
+        /// and checks that the judgement results recorded still match <paramref name="expectedResults"/>.
+        /// </summary>
+        protected void RunTest(IBeatmap beatmap, Replay replay, IEnumerable<HitResult> expectedResults)
+        {
+            Score originalScore = null!;
+            Score decodedScore = null!;
+
+            AddStep(@"create replay", () => originalScore = new Score
+            {
+                Replay = replay,
+                ScoreInfo = new ScoreInfo()
+            });
+
+            AddStep(@"set beatmap", () => Beatmap.Value = CreateWorkingBeatmap(beatmap));
+            AddStep(@"set ruleset", () => Ruleset.Value = beatmap.BeatmapInfo.Ruleset);
+            AddStep(@"push player", () => pushNewPlayer(originalScore));
+
+            AddUntilStep(@"wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep(@"wait for completion", () => currentPlayer.GameplayState.HasCompleted);
+            AddAssert(@"judgement results before encode are correct", () => results.Select(r => r.Type), () => Is.EquivalentTo(expectedResults));
+
+            AddStep(@"exit player", () => currentPlayer.Exit());
+
+            AddStep(@"encode and decode score", () =>
+            {
+                var encoder = new LegacyScoreEncoder(originalScore, beatmap);
+
+                using (var stream = new MemoryStream())
+                {
+                    encoder.Encode(stream, leaveOpen: true);
+                    stream.Position = 0;
+                    decodedScore = new TestScoreDecoder(Beatmap.Value).Parse(stream);
+                }
+            });
+
+            AddStep(@"push player", () => pushNewPlayer(decodedScore));
+
+            AddUntilStep(@"Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep(@"Wait for completion", () => currentPlayer.GameplayState.HasCompleted);
+            AddAssert(@"judgement results after encode are correct", () => results.Select(r => r.Type), () => Is.EquivalentTo(expectedResults));
+        }
+
+        private void pushNewPlayer(Score score)
+        {
+            var player = new ReplayPlayer(score);
+            player.OnLoadComplete += _ =>
+            {
+                player.GameplayState.ScoreProcessor.NewJudgement += result =>
+                {
+                    if (currentPlayer == player)
+                        results.Add(result);
+                };
+            };
+            LoadScreen(currentPlayer = player);
+            results.Clear();
+        }
+
+        private class TestScoreDecoder : LegacyScoreDecoder
+        {
+            private readonly WorkingBeatmap beatmap;
+
+            public TestScoreDecoder(WorkingBeatmap beatmap)
+            {
+                this.beatmap = beatmap;
+            }
+
+            protected override Ruleset GetRuleset(int rulesetId) => beatmap.BeatmapInfo.Ruleset.CreateInstance();
+            protected override WorkingBeatmap GetBeatmap(string md5Hash) => beatmap;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds (ignored-because-failing) test cases which cover an existing issue with replay encoding which is likely the biggest (but probably not only) issue affecting incorrect playback of replays recorded in lazer. The issue is caused by the encoder rounding frame times to the nearest integer, which makes it possible for a judgement to switch to a better or worse one because of comparing rounded frame times post-encode to unrounded hit window bounds.

A second PR like this will follow, covering correctness of playback of stable replays with respect to hit window limits. It will work via generating beatmaps and replays on them that can be exported and played back in stable to verify ground truth (like [I asked for a year plus ago](https://github.com/ppy/osu/pull/26419#issuecomment-1880590970) but was rebuffed with some wall of text).

There are existing community PRs that attempted to do things to hit windows to fix replay playback (https://github.com/ppy/osu/pull/26452, https://github.com/ppy/osu/pull/30244), but the amount of testing done in both was on the level of "trust me bro", i.e. either nothing, or replays taken from nowhere that cannot be easily cross-checked. I am not willing to touch hit windows in any way before having a proper test harness in place, and even if one of the aforementioned PRs is going to end up matching the eventual direction to fix the replay issues in question, I consider this a hard prerequisite for any of them.

You may think that the extent of coverage is excessive (with it covering every ruleset individually, and additionally with a bunch of data points around each hit window bound), but from [my research](https://gist.github.com/bdach/8c6ae831d3a75c4ecd7eed9650252548) I would wager that it is more likely to be *insufficient* than excessive. The amount of edgecasery around hit window treatment in stable is staggering.