### PR TITLE
Improve group panel design

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselV2GroupPanel.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselV2GroupPanel.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Visual.UserInterface;
 using osuTK;
@@ -14,6 +17,66 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         public TestSceneBeatmapCarouselV2GroupPanel()
             : base(false)
         {
+        }
+
+        [Test]
+        public void TestGeneral()
+        {
+            AddStep("general", () => CreateThemedContent(OverlayColourScheme.Aquamarine));
+        }
+
+        [Test]
+        public void TestStars()
+        {
+            for (int i = 0; i <= 10; i++)
+            {
+                int star = i;
+
+                AddStep($"display {i} star(s)", () =>
+                {
+                    ContentContainer.Child = new DependencyProvidingContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        CachedDependencies = new (Type, object)[]
+                        {
+                            (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Aquamarine))
+                        },
+                        Child = new FillFlowContainer
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Width = 0.5f,
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0f, 5f),
+                            Children = new[]
+                            {
+                                new PanelGroupStarDifficulty
+                                {
+                                    Item = new CarouselItem(new GroupDefinition(star, star.ToString()))
+                                },
+                                new PanelGroupStarDifficulty
+                                {
+                                    Item = new CarouselItem(new GroupDefinition(star, star.ToString())),
+                                    KeyboardSelected = { Value = true },
+                                },
+                                new PanelGroupStarDifficulty
+                                {
+                                    Item = new CarouselItem(new GroupDefinition(star, star.ToString())),
+                                    Expanded = { Value = true },
+                                },
+                                new PanelGroupStarDifficulty
+                                {
+                                    Item = new CarouselItem(new GroupDefinition(star, star.ToString())),
+                                    Expanded = { Value = true },
+                                    KeyboardSelected = { Value = true },
+                                },
+                            },
+                        }
+                    };
+                });
+            }
         }
 
         protected override Drawable CreateContent()
@@ -47,33 +110,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     {
                         Item = new CarouselItem(new GroupDefinition('A', "Group A")),
                         KeyboardSelected = { Value = true },
-                        Expanded = { Value = true }
-                    },
-                    new PanelGroupStarDifficulty
-                    {
-                        Item = new CarouselItem(new GroupDefinition(1, "1"))
-                    },
-                    new PanelGroupStarDifficulty
-                    {
-                        Item = new CarouselItem(new GroupDefinition(3, "3")),
-                        Expanded = { Value = true }
-                    },
-                    new PanelGroupStarDifficulty
-                    {
-                        Item = new CarouselItem(new GroupDefinition(5, "5")),
-                    },
-                    new PanelGroupStarDifficulty
-                    {
-                        Item = new CarouselItem(new GroupDefinition(7, "7")),
-                        Expanded = { Value = true }
-                    },
-                    new PanelGroupStarDifficulty
-                    {
-                        Item = new CarouselItem(new GroupDefinition(8, "8")),
-                    },
-                    new PanelGroupStarDifficulty
-                    {
-                        Item = new CarouselItem(new GroupDefinition(9, "9")),
                         Expanded = { Value = true }
                     },
                 }

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -54,21 +54,6 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditBeatmap => new TranslatableString(getKey(@"edit_beatmap"), @"Edit beatmap");
 
-        /// <summary>
-        /// "Below 1 Star"
-        /// </summary>
-        public static LocalisableString BelowStar => new TranslatableString(getKey(@"below_star"), @"Below 1 Star");
-
-        /// <summary>
-        /// "1 Star"
-        /// </summary>
-        public static LocalisableString Star => new TranslatableString(getKey(@"star"), @"1 Star");
-
-        /// <summary>
-        /// "{0} Stars"
-        /// </summary>
-        public static LocalisableString Stars(int starNumber) => new TranslatableString(getKey(@"stars"), @"{0} Stars", starNumber);
-
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -54,6 +54,21 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditBeatmap => new TranslatableString(getKey(@"edit_beatmap"), @"Edit beatmap");
 
+        /// <summary>
+        /// "Below 1 Star"
+        /// </summary>
+        public static LocalisableString BelowStar => new TranslatableString(getKey(@"below_star"), @"Below 1 Star");
+
+        /// <summary>
+        /// "1 Star"
+        /// </summary>
+        public static LocalisableString Star => new TranslatableString(getKey(@"star"), @"1 Star");
+
+        /// <summary>
+        /// "{0} Stars"
+        /// </summary>
+        public static LocalisableString Stars(int starNumber) => new TranslatableString(getKey(@"stars"), @"{0} Stars", starNumber);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/SelectV2/PanelBase.cs
+++ b/osu.Game/Screens/SelectV2/PanelBase.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Screens.SelectV2
                     keyboardSelectionLayer = new Box
                     {
                         Alpha = 0,
-                        Colour = colours.Yellow.Opacity(0.1f),
+                        Colour = colourProvider.Highlight1.Opacity(0.1f),
                         Blending = BlendingParameters.Additive,
                         RelativeSizeAxes = Axes.Both,
                     },

--- a/osu.Game/Screens/SelectV2/PanelGroup.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroup.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Screens.SelectV2
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
+                    Font = OsuFont.Style.Heading2,
+                    UseFullGlyphHeight = false,
                     X = 10f,
                 },
                 new CircularContainer
@@ -69,7 +71,7 @@ namespace osu.Game.Screens.SelectV2
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Font = OsuFont.Torus.With(size: 14.4f, weight: FontWeight.Bold),
+                            Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
                             // TODO: requires Carousel/CarouselItem-side implementation
                             Text = "43",
                             UseFullGlyphHeight = false,

--- a/osu.Game/Screens/SelectV2/PanelGroup.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroup.cs
@@ -5,10 +5,12 @@ using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osuTK;
@@ -20,27 +22,56 @@ namespace osu.Game.Screens.SelectV2
     {
         public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.2f;
 
-        private Drawable chevronIcon = null!;
+        private Drawable iconContainer = null!;
         private OsuSpriteText titleText = null!;
+        private TrianglesV2 triangles = null!;
+        private Box glow = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load()
         {
             Height = HEIGHT;
 
-            Icon = chevronIcon = new SpriteIcon
+            Icon = iconContainer = new Container
             {
                 AlwaysPresent = true,
-                Icon = FontAwesome.Solid.ChevronDown,
-                Size = new Vector2(12),
-                Margin = new MarginPadding { Horizontal = 5f },
-                X = 2f,
-                Colour = colourProvider.Background3,
+                RelativeSizeAxes = Axes.Y,
+                Child = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.Solid.ChevronDown,
+                    Size = new Vector2(12),
+                    Colour = colourProvider.Background3,
+                },
             };
-            Background = new Box
+            Background = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = colourProvider.Dark1,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background5,
+                    },
+                    triangles = new TrianglesV2
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Thickness = 0.02f,
+                        SpawnRatio = 0.6f,
+                        Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
+                    },
+                    glow = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Width = 0.5f,
+                        Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                    },
+                },
             };
             AccentColour = colourProvider.Highlight1;
             Content.Children = new Drawable[]
@@ -77,7 +108,7 @@ namespace osu.Game.Screens.SelectV2
                             UseFullGlyphHeight = false,
                         }
                     },
-                }
+                },
             };
         }
 
@@ -92,8 +123,15 @@ namespace osu.Game.Screens.SelectV2
         {
             const float duration = 500;
 
-            chevronIcon.ResizeWidthTo(Expanded.Value ? 12f : 0f, duration, Easing.OutQuint);
-            chevronIcon.FadeTo(Expanded.Value ? 1f : 0f, duration, Easing.OutQuint);
+            iconContainer.ResizeWidthTo(Expanded.Value ? 20f : 5f, duration, Easing.OutQuint);
+            iconContainer.FadeTo(Expanded.Value ? 1f : 0f, duration, Easing.OutQuint);
+
+            ColourInfo colour = Expanded.Value
+                ? ColourInfo.GradientHorizontal(colourProvider.Highlight1.Opacity(0.25f), colourProvider.Highlight1.Opacity(0f))
+                : ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5);
+
+            triangles.FadeColour(colour, duration, Easing.OutQuint);
+            glow.FadeTo(Expanded.Value ? 0.4f : 0, duration, Easing.OutQuint);
         }
 
         protected override void PrepareForUse()

--- a/osu.Game/Screens/SelectV2/PanelGroup.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroup.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.SelectV2
 {
     public partial class PanelGroup : PanelBase
     {
-        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT;
+        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.2f;
 
         private Drawable chevronIcon = null!;
         private OsuSpriteText titleText = null!;

--- a/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
@@ -15,7 +15,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
-using osu.Game.Localisation;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -147,15 +146,15 @@ namespace osu.Game.Screens.SelectV2
             switch (starNumber)
             {
                 case 0:
-                    starRatingText.Text = SongSelectStrings.BelowStar;
+                    starRatingText.Text = @"Below 1 Star";
                     break;
 
                 case 1:
-                    starRatingText.Text = SongSelectStrings.Star;
+                    starRatingText.Text = @"1 Star";
                     break;
 
                 default:
-                    starRatingText.Text = SongSelectStrings.Stars(starNumber);
+                    starRatingText.Text = $"{starNumber} Stars";
                     break;
             }
 

--- a/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
@@ -177,8 +177,6 @@ namespace osu.Game.Screens.SelectV2
         {
             const float duration = 500;
 
-            Debug.Assert(Item != null);
-
             iconContainer.ResizeWidthTo(Expanded.Value ? 20f : 5f, duration, Easing.OutQuint);
             iconContainer.FadeTo(Expanded.Value ? 1f : 0f, duration, Easing.OutQuint);
 

--- a/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Screens.SelectV2
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Font = OsuFont.Torus.With(size: 14.4f, weight: FontWeight.Bold),
+                            Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
                             // TODO: requires Carousel/CarouselItem-side implementation
                             Text = "43",
                             UseFullGlyphHeight = false,

--- a/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroupStarDifficulty.cs
@@ -5,17 +5,17 @@ using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -27,28 +27,50 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
-        private Drawable chevronIcon = null!;
+        private Drawable iconContainer = null!;
         private Box contentBackground = null!;
-        private StarRatingDisplay starRatingDisplay = null!;
-        private StarCounter starCounter = null!;
+        private OsuSpriteText starRatingText = null!;
+        private TrianglesV2 triangles = null!;
+        private Box glow = null!;
 
         [BackgroundDependencyLoader]
         private void load()
         {
             Height = PanelGroup.HEIGHT;
 
-            Icon = chevronIcon = new SpriteIcon
+            Icon = iconContainer = new Container
             {
                 AlwaysPresent = true,
-                Icon = FontAwesome.Solid.ChevronDown,
-                Size = new Vector2(12),
-                Margin = new MarginPadding { Horizontal = 5f },
-                X = 2f,
+                RelativeSizeAxes = Axes.Y,
+                Child = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.Solid.ChevronDown,
+                    Size = new Vector2(12),
+                },
             };
-            Background = contentBackground = new Box
+            Background = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = colourProvider.Dark1,
+                Children = new Drawable[]
+                {
+                    contentBackground = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    triangles = new TrianglesV2
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Thickness = 0.02f,
+                        SpawnRatio = 0.6f,
+                    },
+                    glow = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Width = 0.5f,
+                    },
+                },
             };
             AccentColour = colourProvider.Highlight1;
             Content.Children = new Drawable[]
@@ -62,17 +84,13 @@ namespace osu.Game.Screens.SelectV2
                     Margin = new MarginPadding { Left = 10f },
                     Children = new Drawable[]
                     {
-                        starRatingDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Small)
+                        starRatingText = new OsuSpriteText
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                        },
-                        starCounter = new StarCounter
-                        {
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                            Scale = new Vector2(8f / 20f),
-                        },
+                            UseFullGlyphHeight = false,
+                            Font = OsuFont.Style.Heading2,
+                        }
                     }
                 },
                 new CircularContainer
@@ -110,6 +128,8 @@ namespace osu.Game.Screens.SelectV2
             Expanded.BindValueChanged(_ => onExpanded(), true);
         }
 
+        private Color4 ratingColour;
+
         protected override void PrepareForUse()
         {
             base.PrepareForUse();
@@ -118,25 +138,52 @@ namespace osu.Game.Screens.SelectV2
 
             int starNumber = (int)((GroupDefinition)Item.Model).Data;
 
-            Color4 colour = starNumber >= 9 ? OsuColour.Gray(0.2f) : colours.ForStarDifficulty(starNumber);
-            Color4 contentColour = starNumber >= 7 ? colours.Orange1 : colourProvider.Background5;
+            ratingColour = starNumber >= 9 ? OsuColour.Gray(0.2f) : colours.ForStarDifficulty(starNumber);
 
-            AccentColour = colour;
-            contentBackground.Colour = colour.Darken(0.3f);
+            AccentColour = ratingColour;
+            contentBackground.Colour = ratingColour.Darken(1f);
+            glow.Colour = ColourInfo.GradientHorizontal(ratingColour, ratingColour.Opacity(0f));
 
-            starRatingDisplay.Current.Value = new StarDifficulty(starNumber, 0);
-            starCounter.Current = starNumber;
+            switch (starNumber)
+            {
+                case 0:
+                    starRatingText.Text = SongSelectStrings.BelowStar;
+                    break;
 
-            chevronIcon.Colour = contentColour;
-            starCounter.Colour = contentColour;
+                case 1:
+                    starRatingText.Text = SongSelectStrings.Star;
+                    break;
+
+                default:
+                    starRatingText.Text = SongSelectStrings.Stars(starNumber);
+                    break;
+            }
+
+            iconContainer.Colour = starNumber >= 7 ? colourProvider.Content1 : colourProvider.Background5;
+            starRatingText.Colour = colourProvider.Content1;
+
+            ColourInfo colour;
+
+            if (starNumber >= 8)
+                colour = ColourInfo.GradientHorizontal(ratingColour, ratingColour.Darken(0.2f));
+            else
+                colour = ColourInfo.GradientHorizontal(ratingColour.Darken(0.6f), ratingColour.Darken(0.8f));
+
+            triangles.Colour = colour;
+
+            onExpanded();
         }
 
         private void onExpanded()
         {
             const float duration = 500;
 
-            chevronIcon.ResizeWidthTo(Expanded.Value ? 12f : 0f, duration, Easing.OutQuint);
-            chevronIcon.FadeTo(Expanded.Value ? 1f : 0f, duration, Easing.OutQuint);
+            Debug.Assert(Item != null);
+
+            iconContainer.ResizeWidthTo(Expanded.Value ? 20f : 5f, duration, Easing.OutQuint);
+            iconContainer.FadeTo(Expanded.Value ? 1f : 0f, duration, Easing.OutQuint);
+
+            glow.FadeTo(Expanded.Value ? 0.4f : 0, duration, Easing.OutQuint);
         }
     }
 }


### PR DESCRIPTION
- [x] Depends on #32764 

Made to match latest iteration in figma, deemed better than what we currently had. Also:
 - Adjusted height to 60px and increased text font size (now uses `Heading2`)
 - Updated keyboard selection highlight colour to `Highlight1` of aquamarine, following [discussion](https://discord.com/channels/188630481301012481/1359431017680863302/1360182542552141874) on how yellow looked terrible.
 - Updated design of star rating groups to be more similar to stable (basically knocking sense to it).
   - There is something going on with the glow on stars >= 8, but I honestly don't have a solution for that and I don't want to spend extra time on this so I'm leaving it be for now.

https://github.com/user-attachments/assets/17001f6a-def0-477f-bd24-b30c1462f513

