### PR TITLE
Introduce numeric data in beatmap object count statistics

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
@@ -26,21 +26,21 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                     Name = @"Fruits",
                     Content = fruits.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
-                    Ratio = fruits / (float)sum,
+                    BarDisplayLength = fruits / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Juice Streams",
                     Content = juiceStreams.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
-                    Ratio = juiceStreams / (float)sum,
+                    BarDisplayLength = juiceStreams / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Banana Showers",
                     Content = bananaShowers.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
-                    Ratio = Math.Min(bananaShowers / 10f, 1),
+                    BarDisplayLength = Math.Min(bananaShowers / 10f, 1),
                 }
             };
         }

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -16,6 +17,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             int fruits = HitObjects.Count(s => s is Fruit);
             int juiceStreams = HitObjects.Count(s => s is JuiceStream);
             int bananaShowers = HitObjects.Count(s => s is BananaShower);
+            int sum = Math.Max(1, fruits + juiceStreams + bananaShowers);
 
             return new[]
             {
@@ -24,18 +26,21 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                     Name = @"Fruits",
                     Content = fruits.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
+                    Ratio = fruits / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Juice Streams",
                     Content = juiceStreams.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
+                    Ratio = juiceStreams / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Banana Showers",
                     Content = bananaShowers.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
+                    Ratio = Math.Min(bananaShowers / 10f, 1),
                 }
             };
         }

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             int fruits = HitObjects.Count(s => s is Fruit);
             int juiceStreams = HitObjects.Count(s => s is JuiceStream);
             int bananaShowers = HitObjects.Count(s => s is BananaShower);
-            int sum = Math.Max(1, fruits + juiceStreams + bananaShowers);
+            int sum = Math.Max(1, fruits + juiceStreams);
 
             return new[]
             {

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
@@ -45,14 +45,14 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                     Name = @"Notes",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = notes.ToString(),
-                    Ratio = notes / (float)sum,
+                    BarDisplayLength = notes / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Hold Notes",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = holdNotes.ToString(),
-                    Ratio = holdNotes / (float)sum,
+                    BarDisplayLength = holdNotes / (float)sum,
                 },
             };
         }

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         {
             int notes = HitObjects.Count(s => s is Note);
             int holdNotes = HitObjects.Count(s => s is HoldNote);
+            int sum = Math.Max(1, notes + holdNotes);
 
             return new[]
             {
@@ -44,12 +45,14 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                     Name = @"Notes",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = notes.ToString(),
+                    Ratio = notes / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Hold Notes",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = holdNotes.ToString(),
+                    Ratio = holdNotes / (float)sum,
                 },
             };
         }

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
             int circles = HitObjects.Count(c => c is HitCircle);
             int sliders = HitObjects.Count(s => s is Slider);
             int spinners = HitObjects.Count(s => s is Spinner);
-            int sum = Math.Max(1, circles + sliders + spinners);
+            int sum = Math.Max(1, circles + sliders);
 
             return new[]
             {

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
@@ -25,21 +25,21 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                     Name = "Circles",
                     Content = circles.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
-                    Ratio = circles / (float)sum,
+                    BarDisplayLength = circles / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = "Sliders",
                     Content = sliders.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
-                    Ratio = sliders / (float)sum,
+                    BarDisplayLength = sliders / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Spinners",
                     Content = spinners.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
-                    Ratio = Math.Min(spinners / 10f, 1),
+                    BarDisplayLength = Math.Min(spinners / 10f, 1),
                 }
             };
         }

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -15,6 +16,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
             int circles = HitObjects.Count(c => c is HitCircle);
             int sliders = HitObjects.Count(s => s is Slider);
             int spinners = HitObjects.Count(s => s is Spinner);
+            int sum = Math.Max(1, circles + sliders + spinners);
 
             return new[]
             {
@@ -23,18 +25,21 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                     Name = "Circles",
                     Content = circles.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
+                    Ratio = circles / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = "Sliders",
                     Content = sliders.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
+                    Ratio = sliders / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Spinners",
                     Content = spinners.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
+                    Ratio = Math.Min(spinners / 10f, 1),
                 }
             };
         }

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -15,6 +16,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             int hits = HitObjects.Count(s => s is Hit);
             int drumRolls = HitObjects.Count(s => s is DrumRoll);
             int swells = HitObjects.Count(s => s is Swell);
+            int sum = Math.Max(1, hits + drumRolls + swells);
 
             return new[]
             {
@@ -23,18 +25,21 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     Name = @"Hits",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = hits.ToString(),
+                    Ratio = hits / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Drumrolls",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = drumRolls.ToString(),
+                    Ratio = drumRolls / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Swells",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                     Content = swells.ToString(),
+                    Ratio = Math.Min(swells / 10f, 1),
                 }
             };
         }

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             int hits = HitObjects.Count(s => s is Hit);
             int drumRolls = HitObjects.Count(s => s is DrumRoll);
             int swells = HitObjects.Count(s => s is Swell);
-            int sum = Math.Max(1, hits + drumRolls + swells);
+            int sum = Math.Max(1, hits + drumRolls);
 
             return new[]
             {

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
@@ -25,21 +25,21 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     Name = @"Hits",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = hits.ToString(),
-                    Ratio = hits / (float)sum,
+                    BarDisplayLength = hits / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Drumrolls",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = drumRolls.ToString(),
-                    Ratio = drumRolls / (float)sum,
+                    BarDisplayLength = drumRolls / (float)sum,
                 },
                 new BeatmapStatistic
                 {
                     Name = @"Swells",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                     Content = swells.ToString(),
-                    Ratio = Math.Min(swells / 10f, 1),
+                    BarDisplayLength = Math.Min(swells / 10f, 1),
                 }
             };
         }

--- a/osu.Game/Beatmaps/BeatmapStatistic.cs
+++ b/osu.Game/Beatmaps/BeatmapStatistic.cs
@@ -27,11 +27,8 @@ namespace osu.Game.Beatmaps
         public string Content;
 
         /// <summary>
-        /// The ratio of this statistic compared to other relevant statistics, or null if not applicable.
+        /// The length of a bar which visually represents this statistic's relevance in the beatmap.
         /// </summary>
-        /// <remarks>
-        /// This is used to display a bar on top of the statistic with the given ratio.
-        /// </remarks>
-        public float? Ratio;
+        public float? BarDisplayLength;
     }
 }

--- a/osu.Game/Beatmaps/BeatmapStatistic.cs
+++ b/osu.Game/Beatmaps/BeatmapStatistic.cs
@@ -16,7 +16,22 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public Func<Drawable> CreateIcon;
 
-        public string Content;
+        /// <summary>
+        /// The name of this statistic.
+        /// </summary>
         public LocalisableString Name;
+
+        /// <summary>
+        /// The text representing the value of this statistic.
+        /// </summary>
+        public string Content;
+
+        /// <summary>
+        /// The ratio of this statistic compared to other relevant statistics, or null if not applicable.
+        /// </summary>
+        /// <remarks>
+        /// This is used to display a bar on top of the statistic with the given ratio.
+        /// </remarks>
+        public float? Ratio;
     }
 }


### PR DESCRIPTION
- [x] Depends on #32764 due to changes to statistics classes

Prerequisite for #32715 to allow displaying bars on top of object count statistics. Notes:
 - The introduced data is made nullable as the model is also used in non-count context, e.g. [here](https://github.com/frenzibyte/osu/blob/e920cfa1872d233f90df27f4db76ffd0e75da6a8/osu.Game/Screens/Select/BeatmapInfoWedge.cs#L414-L419) and [here](https://github.com/frenzibyte/osu/blob/e920cfa1872d233f90df27f4db76ffd0e75da6a8/osu.Game/Screens/Select/BeatmapInfoWedge.cs#L424-L429). In those usages, a "ratio" value is not applicable.
 - I'm not 100% sure about the name chosen for the data (`Ratio`), but it works and doesn't denote that it should be used over `Content` (unlike `Value` for example).
 - Rare object types such as spinner/swell/banana shower have their "ratio" value computed differently: `min(count / 10, 1)`.

Requesting team review since this touches public API.