### PR TITLE
Unrank Taiko HD and HR

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Rulesets.Taiko.Mods
         /// </remarks>
         private const double slider_multiplier = 1.4 * 4 / 3;
 
+        public override bool Ranked => false;
+
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -18,6 +18,9 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override LocalisableString Description => @"Beats fade out before you hit them!";
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
+        // HD playfield size is fixed to the equivalent of 4:3 in stable but adjusted based on
+        // screen resolution in lazer, making lazer HD difficulty impossible to evaluate.
+        public override bool Ranked => false;
 
         /// <summary>
         /// How far away from the hit target should hitobjects start to fade out.


### PR DESCRIPTION
In stable, playfield size depends on screen resolution in nomod.

It's always fixed to 4:3 when HD is enabled. This means that even if you play with 16:9, the time after fadeout is the same as someone who plays on 4:3, and you will initially see the notes at the same time as someone who plays on 4:3.

When HR is enabled, scroll speed multiplier scales with resolution - so 1.4 on 4:3, 1.86666 on 16:9, etc.

Initially (when this mod was implemented in lazer), playfield size was fixed to 16:9, but the mod increased scroll speed to be the equivalent of stable 4:3. Later, scroll speed adjustment was disabled by someone, so the mod became much harder than stable on low scroll speed and much easier on high scroll speed. This was still fine, as the performance calculator can look at the presence of CL mod and adjust the buffs accordingly.

But later playfield size became adjustable following complaints from stable 4:3 players (since 4:3 makes reading easier on dense maps, and 4:3 players find 16:9 much harder to read). The most significant consequence of that is that mods became completely broken, they simply cannot be judged fairly.

I see two ways of fixing this:

- Make playfield size only adjustable with classic mod
- Unrank lazer HD and HR until a proper fix is found (I know that there is little interest in the lazer dev team of engaging with these issues, so this sounds like a decent bandaid fix)