### PR TITLE
Fix "spins per minute" shows up early (fix #31173)

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var spinner = (DrawableSpinner)drawable;
 
-            spinner.RotationTracker.Tracking = true;
+            spinner.RotationTracker.Tracking = spinner.RotationTracker.IsSpinnableTime;
 
             // early-return if we were paused to avoid division-by-zero in the subsequent calculations.
             if (Precision.AlmostEquals(spinner.Clock.Rate, 0))

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         /// <summary>
         /// Whether currently in the correct time range to allow spinning.
         /// </summary>
-        private bool isSpinnableTime => drawableSpinner.HitObject.StartTime <= Time.Current && drawableSpinner.HitObject.EndTime > Time.Current;
+        public bool IsSpinnableTime => drawableSpinner.HitObject.StartTime <= Time.Current && drawableSpinner.HitObject.EndTime > Time.Current;
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 lastAngle = thisAngle;
             }
 
-            IsSpinning.Value = isSpinnableTime && Math.Abs(currentRotation - Rotation) > 10f;
+            IsSpinning.Value = IsSpinnableTime && Math.Abs(currentRotation - Rotation) > 10f;
             Rotation = (float)Interpolation.Damp(Rotation, currentRotation, 0.99, Math.Abs(Time.Elapsed));
         }
 
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         /// <param name="delta">The delta angle.</param>
         public void AddRotation(float delta)
         {
-            if (!isSpinnableTime)
+            if (!IsSpinnableTime)
                 return;
 
             if (!rotationTransferred)


### PR DESCRIPTION
Fix #31173

Make `isSpinnableTime` public in `SpinnerRotationTracker` and use it to set Tracking in `OsuModSpunOut`.

`Tracking` was previously set to true, causing the "spins per minute" to appear immediately when the spinner appeared.

## Before: 

https://github.com/user-attachments/assets/5ddb27e4-e430-4b9b-9f72-be23131cd8ac

## After: 

https://github.com/user-attachments/assets/bc1e4c56-3430-4321-a242-a0d7a87be369

Sorry for the low framerate of the videos.
I hope the PR is okay.