### PR TITLE
Consolidate spinner tracking state management

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var spinner = (DrawableSpinner)drawable;
 
-            spinner.RotationTracker.Tracking = spinner.RotationTracker.IsSpinnableTime;
+            spinner.RotationTracker.Tracking = true;
 
             // early-return if we were paused to avoid division-by-zero in the subsequent calculations.
             if (Precision.AlmostEquals(spinner.Clock.Rate, 0))

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -21,11 +21,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
     {
         public override bool IsPresent => true; // handle input when hidden
 
+        private readonly Bindable<bool> isSpinning = new Bindable<bool>();
         private readonly DrawableSpinner drawableSpinner;
 
         private Vector2? mousePosition;
         private float? lastAngle;
 
+        private bool tracking;
         private float currentRotation;
         private bool rotationTransferred;
 
@@ -40,19 +42,26 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             RelativeSizeAxes = Axes.Both;
         }
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
-
-        public bool Tracking { get; set; }
+        /// <summary>
+        /// Whether the user is currently providing motion input to this tracker.
+        /// </summary>
+        public bool Tracking
+        {
+            get => tracking;
+            set => tracking = IsSpinnableTime && value;
+        }
 
         /// <summary>
-        /// Whether the spinning is spinning at a reasonable speed to be considered visually spinning.
+        /// Whether the spinner is spinning at a reasonable speed to be considered visually spinning.
         /// </summary>
-        public readonly BindableBool IsSpinning = new BindableBool();
+        public IBindable<bool> IsSpinning => isSpinning;
 
         /// <summary>
         /// Whether currently in the correct time range to allow spinning.
         /// </summary>
         public bool IsSpinnableTime => drawableSpinner.HitObject.StartTime <= Time.Current && drawableSpinner.HitObject.EndTime > Time.Current;
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
@@ -79,7 +88,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 lastAngle = thisAngle;
             }
 
-            IsSpinning.Value = IsSpinnableTime && Math.Abs(currentRotation - Rotation) > 10f;
+            isSpinning.Value = IsSpinnableTime && Math.Abs(currentRotation - Rotation) > 10f;
             Rotation = (float)Interpolation.Damp(Rotation, currentRotation, 0.99, Math.Abs(Time.Elapsed));
         }
 
@@ -113,7 +122,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         private void resetState(DrawableHitObject obj)
         {
             Tracking = false;
-            IsSpinning.Value = false;
+            isSpinning.Value = false;
             mousePosition = null;
             lastAngle = null;
             currentRotation = 0;


### PR DESCRIPTION
Follows on from additional review on https://github.com/ppy/osu/pull/32796. This reverts the functional part of the fix made in that PR, while ensuring `Tracking` can't be set to `true` while not in the correct tracking time region.

As for the double conditionals, I've gone with the inner one which is the one that determines whether to "add rotations" at the end of the day.