### PR TITLE
Change global shear definition to be a `Vector2`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneLeaderboardScore.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneLeaderboardScore.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Spacing = new Vector2(0f, 2f),
-                        Shear = new Vector2(OsuGame.SHEAR, 0)
+                        Shear = OsuGame.SHEAR,
                     },
                     drawWidthText = new OsuSpriteText(),
                 };
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Spacing = new Vector2(0f, 2f),
-                        Shear = new Vector2(OsuGame.SHEAR, 0)
+                        Shear = OsuGame.SHEAR,
                     },
                     drawWidthText = new OsuSpriteText(),
                 };

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Graphics.UserInterface
                                 Radius = 5,
                             },
                             Colour = ButtonColour,
-                            Shear = new Vector2(0.2f, 0),
+                            Shear = OsuGame.SHEAR,
                             Children = new Drawable[]
                             {
                                 new Box
@@ -149,7 +149,7 @@ namespace osu.Game.Graphics.UserInterface
                                             RelativeSizeAxes = Axes.Both,
                                             TriangleScale = 4,
                                             ColourDark = OsuColour.Gray(0.88f),
-                                            Shear = new Vector2(-0.2f, 0),
+                                            Shear = -OsuGame.SHEAR,
                                             ClampAxes = Axes.Y
                                         },
                                     },

--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -11,7 +11,6 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
-using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -66,8 +65,6 @@ namespace osu.Game.Graphics.UserInterface
         private readonly Box background;
         private readonly OsuSpriteText text;
 
-        private const float shear = OsuGame.SHEAR;
-
         private Colour4? darkerColour;
         private Colour4? lighterColour;
         private Colour4? textColour;
@@ -91,10 +88,10 @@ namespace osu.Game.Graphics.UserInterface
         public ShearedButton(float? width = null, float height = DEFAULT_HEIGHT)
         {
             Height = height;
-            Padding = new MarginPadding { Horizontal = shear * height };
+            Padding = new MarginPadding { Horizontal = OsuGame.SHEAR.X * height };
 
             Content.CornerRadius = CORNER_RADIUS;
-            Content.Shear = new Vector2(shear, 0);
+            Content.Shear = OsuGame.SHEAR;
             Content.Masking = true;
             Content.Anchor = Content.Origin = Anchor.Centre;
 
@@ -117,7 +114,7 @@ namespace osu.Game.Graphics.UserInterface
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             AutoSizeAxes = Axes.Both,
-                            Shear = new Vector2(-shear, 0),
+                            Shear = -OsuGame.SHEAR,
                             Child = text = new OsuSpriteText
                             {
                                 Font = OsuFont.TorusAlternate.With(size: 17),

--- a/osu.Game/Graphics/UserInterface/ShearedNub.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedNub.cs
@@ -26,8 +26,6 @@ namespace osu.Game.Graphics.UserInterface
         public const int HEIGHT = 30;
         public const float EXPANDED_SIZE = 50;
 
-        public static readonly Vector2 SHEAR = new Vector2(0.15f, 0);
-
         private readonly Box fill;
         private readonly Container main;
 
@@ -40,7 +38,7 @@ namespace osu.Game.Graphics.UserInterface
             Size = new Vector2(EXPANDED_SIZE, HEIGHT);
             InternalChild = main = new Container
             {
-                Shear = SHEAR,
+                Shear = OsuGame.SHEAR,
                 BorderColour = Colour4.White,
                 BorderThickness = BORDER_WIDTH,
                 Masking = true,

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Graphics.UserInterface
         public ShearedSearchTextBox()
         {
             Height = 42;
-            Shear = new Vector2(OsuGame.SHEAR, 0);
+            Shear = OsuGame.SHEAR;
             Masking = true;
             CornerRadius = corner_radius;
 
@@ -115,7 +115,7 @@ namespace osu.Game.Graphics.UserInterface
                 PlaceholderText = CommonStrings.InputSearch;
 
                 CornerRadius = corner_radius;
-                TextContainer.Shear = new Vector2(-OsuGame.SHEAR, 0);
+                TextContainer.Shear = -OsuGame.SHEAR;
             }
 
             protected override SpriteText CreatePlaceholder() => new SearchPlaceholder();

--- a/osu.Game/Graphics/UserInterface/ShearedSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSliderBar.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Graphics.UserInterface
 
         public ShearedSliderBar()
         {
-            Shear = SHEAR;
+            Shear = OsuGame.SHEAR;
             Height = HEIGHT;
             RangePadding = EXPANDED_SIZE / 2;
             Children = new Drawable[]
@@ -98,11 +98,11 @@ namespace osu.Game.Graphics.UserInterface
                 },
                 nubContainer = new Container
                 {
-                    Shear = -SHEAR,
+                    Shear = -OsuGame.SHEAR,
                     RelativeSizeAxes = Axes.Both,
                     Child = Nub = new ShearedNub
                     {
-                        X = -SHEAR.X * HEIGHT / 2f,
+                        X = -OsuGame.SHEAR.X * HEIGHT / 2f,
                         Origin = Anchor.TopCentre,
                         RelativePositionAxes = Axes.X,
                         Current = { Value = true },

--- a/osu.Game/Graphics/UserInterfaceV2/ShearedDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ShearedDropdown.cs
@@ -62,8 +62,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         protected partial class ShearedDropdownMenu : OsuDropdown<T>.OsuDropdownMenu
         {
-            private readonly Vector2 shear = new Vector2(OsuGame.SHEAR, 0);
-
             public new MarginPadding Padding
             {
                 get => base.Padding;
@@ -72,7 +70,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             public ShearedDropdownMenu()
             {
-                Shear = shear;
+                Shear = OsuGame.SHEAR;
                 Margin = new MarginPadding { Top = 5f };
             }
 
@@ -84,12 +82,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             public partial class ShearedMenuItem : DrawableOsuDropdownMenuItem
             {
-                private readonly Vector2 shear = new Vector2(OsuGame.SHEAR, 0);
-
                 public ShearedMenuItem(MenuItem item)
                     : base(item)
                 {
-                    Foreground.Shear = -shear;
+                    Foreground.Shear = -OsuGame.SHEAR;
                 }
             }
         }
@@ -125,14 +121,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
             public ShearedDropdown<T> Dropdown = null!;
             private ShearedDropdownSearchBar searchBar = null!;
 
-            private readonly Vector2 shear = new Vector2(OsuGame.SHEAR, 0);
-
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
 
             public ShearedDropdownHeader()
             {
-                Shear = shear;
+                Shear = OsuGame.SHEAR;
                 CornerRadius = corner_radius;
                 Masking = true;
 
@@ -167,7 +161,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                         {
                                             Margin = new MarginPadding { Horizontal = 10f, Vertical = 8f },
                                             Font = OsuFont.Torus.With(size: 16.8f, weight: FontWeight.SemiBold),
-                                            Shear = -shear,
+                                            Shear = -OsuGame.SHEAR,
                                         },
                                     },
                                 },
@@ -178,7 +172,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                     Padding = new MarginPadding { Horizontal = 10f },
-                                    Shear = -shear,
+                                    Shear = -OsuGame.SHEAR,
                                     Children = new Drawable[]
                                     {
                                         valueText = new TruncatingSpriteText
@@ -286,12 +280,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                 private partial class DropdownSearchTextBox : OsuTextBox
                 {
-                    private readonly Vector2 shear = new Vector2(OsuGame.SHEAR, 0);
-
                     [BackgroundDependencyLoader]
                     private void load(OverlayColourProvider? colourProvider)
                     {
-                        TextContainer.Shear = -shear;
+                        TextContainer.Shear = -OsuGame.SHEAR;
                         BackgroundUnfocused = colourProvider?.Background5 ?? new Color4(10, 10, 10, 255);
                         BackgroundFocused = colourProvider?.Background5 ?? new Color4(10, 10, 10, 255);
                     }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -102,7 +102,7 @@ namespace osu.Game
         /// <summary>
         /// A common shear factor applied to most components of the game.
         /// </summary>
-        public const float SHEAR = 0.2f;
+        public static readonly Vector2 SHEAR = new Vector2(0.2f, 0);
 
         public Toolbar Toolbar { get; private set; }
 

--- a/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
@@ -20,7 +20,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Utils;
-using osuTK;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -66,21 +65,19 @@ namespace osu.Game.Overlays.Mods
         [BackgroundDependencyLoader]
         private void load()
         {
-            const float shear = OsuGame.SHEAR;
-
             LeftContent.AddRange(new Drawable[]
             {
                 starRatingDisplay = new StarRatingDisplay(default, animated: true)
                 {
                     Origin = Anchor.CentreLeft,
                     Anchor = Anchor.CentreLeft,
-                    Shear = new Vector2(-shear, 0),
+                    Shear = -OsuGame.SHEAR,
                 },
                 bpmDisplay = new BPMDisplay
                 {
                     Origin = Anchor.CentreLeft,
                     Anchor = Anchor.CentreLeft,
-                    Shear = new Vector2(-shear, 0),
+                    Shear = -OsuGame.SHEAR,
                     AutoSizeAxes = Axes.Y,
                     Width = 75,
                 }
@@ -89,10 +86,10 @@ namespace osu.Game.Overlays.Mods
             RightContent.Alpha = 0;
             RightContent.AddRange(new Drawable[]
             {
-                circleSizeDisplay = new VerticalAttributeDisplay("CS") { Shear = new Vector2(-shear, 0), },
-                drainRateDisplay = new VerticalAttributeDisplay("HP") { Shear = new Vector2(-shear, 0), },
-                overallDifficultyDisplay = new VerticalAttributeDisplay("OD") { Shear = new Vector2(-shear, 0), },
-                approachRateDisplay = new VerticalAttributeDisplay("AR") { Shear = new Vector2(-shear, 0), },
+                circleSizeDisplay = new VerticalAttributeDisplay("CS") { Shear = -OsuGame.SHEAR, },
+                drainRateDisplay = new VerticalAttributeDisplay("HP") { Shear = -OsuGame.SHEAR, },
+                overallDifficultyDisplay = new VerticalAttributeDisplay("OD") { Shear = -OsuGame.SHEAR, },
+                approachRateDisplay = new VerticalAttributeDisplay("AR") { Shear = -OsuGame.SHEAR, },
             });
         }
 

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Overlays.Mods
                     Origin = Anchor.CentreLeft,
                     Scale = new Vector2(0.8f),
                     RelativeSizeAxes = Axes.X,
-                    Shear = new Vector2(-OsuGame.SHEAR, 0)
+                    Shear = -OsuGame.SHEAR
                 });
                 ItemsFlow.Padding = new MarginPadding
                 {

--- a/osu.Game/Overlays/Mods/ModFooterInformationDisplay.cs
+++ b/osu.Game/Overlays/Mods/ModFooterInformationDisplay.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Mods
                 Anchor = Anchor.BottomRight,
                 AutoSizeAxes = Axes.X,
                 Height = ShearedButton.DEFAULT_HEIGHT,
-                Shear = new Vector2(OsuGame.SHEAR, 0),
+                Shear = OsuGame.SHEAR,
                 CornerRadius = ShearedButton.CORNER_RADIUS,
                 BorderThickness = ShearedButton.BORDER_THICKNESS,
                 Masking = true,

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Mods
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Active = { BindTarget = Active },
-                Shear = new Vector2(-OsuGame.SHEAR, 0),
+                Shear = -OsuGame.SHEAR,
                 Scale = new Vector2(HEIGHT / ModSwitchSmall.DEFAULT_SIZE)
             };
         }

--- a/osu.Game/Overlays/Mods/ModSelectColumn.cs
+++ b/osu.Game/Overlays/Mods/ModSelectColumn.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays.Mods
         {
             Width = WIDTH;
             RelativeSizeAxes = Axes.Y;
-            Shear = new Vector2(OsuGame.SHEAR, 0);
+            Shear = OsuGame.SHEAR;
 
             InternalChildren = new Drawable[]
             {
@@ -96,7 +96,7 @@ namespace osu.Game.Overlays.Mods
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     Height = header_height,
-                                    Shear = new Vector2(-OsuGame.SHEAR, 0),
+                                    Shear = -OsuGame.SHEAR,
                                     Velocity = 0.7f,
                                     ClampAxes = Axes.Y
                                 },
@@ -111,7 +111,7 @@ namespace osu.Game.Overlays.Mods
                                     AutoSizeAxes = Axes.Y,
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
-                                    Shear = new Vector2(-OsuGame.SHEAR, 0),
+                                    Shear = -OsuGame.SHEAR,
                                     Padding = new MarginPadding
                                     {
                                         Horizontal = 17,

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Overlays.Mods
                                         Anchor = Anchor.BottomLeft,
                                         Origin = Anchor.BottomLeft,
                                         Direction = FillDirection.Horizontal,
-                                        Shear = new Vector2(OsuGame.SHEAR, 0),
+                                        Shear = OsuGame.SHEAR,
                                         RelativeSizeAxes = Axes.Y,
                                         AutoSizeAxes = Axes.X,
                                         Margin = new MarginPadding { Horizontal = 70 },
@@ -726,7 +726,7 @@ namespace osu.Game.Overlays.Mods
                     // DrawWidth/DrawPosition do not include shear effects, and we want to know the full extents of the columns post-shear,
                     // so we have to manually compensate.
                     var topLeft = column.ToSpaceOfOtherDrawable(Vector2.Zero, ScrollContent);
-                    var bottomRight = column.ToSpaceOfOtherDrawable(new Vector2(column.DrawWidth - column.DrawHeight * OsuGame.SHEAR, 0), ScrollContent);
+                    var bottomRight = column.ToSpaceOfOtherDrawable(new Vector2(column.DrawWidth - column.DrawHeight * OsuGame.SHEAR.X, 0), ScrollContent);
 
                     bool isCurrentlyVisible = Precision.AlmostBigger(topLeft.X, leftVisibleBound)
                                               && Precision.DefinitelyBigger(rightVisibleBound, bottomRight.X);

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -20,7 +20,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
 
@@ -87,7 +86,7 @@ namespace osu.Game.Overlays.Mods
             Content.CornerRadius = CORNER_RADIUS;
             Content.BorderThickness = 2;
 
-            Shear = new Vector2(OsuGame.SHEAR, 0);
+            Shear = OsuGame.SHEAR;
 
             Children = new Drawable[]
             {
@@ -128,10 +127,10 @@ namespace osu.Game.Overlays.Mods
                                     {
                                         Font = OsuFont.TorusAlternate.With(size: 18, weight: FontWeight.SemiBold),
                                         RelativeSizeAxes = Axes.X,
-                                        Shear = new Vector2(-OsuGame.SHEAR, 0),
+                                        Shear = -OsuGame.SHEAR,
                                         Margin = new MarginPadding
                                         {
-                                            Left = -18 * OsuGame.SHEAR
+                                            Left = -18 * OsuGame.SHEAR.X
                                         },
                                         ShowTooltip = false, // Tooltip is handled by `IncompatibilityDisplayingModPanel`.
                                     },
@@ -139,7 +138,7 @@ namespace osu.Game.Overlays.Mods
                                     {
                                         Font = OsuFont.Default.With(size: 12),
                                         RelativeSizeAxes = Axes.X,
-                                        Shear = new Vector2(-OsuGame.SHEAR, 0),
+                                        Shear = -OsuGame.SHEAR,
                                         ShowTooltip = false, // Tooltip is handled by `IncompatibilityDisplayingModPanel`.
                                     }
                                 }

--- a/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
+++ b/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
@@ -15,7 +15,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Utils;
-using osuTK;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -52,7 +51,7 @@ namespace osu.Game.Overlays.Mods
                 Anchor = Anchor.BottomRight,
                 Origin = Anchor.BottomRight,
                 RelativeSizeAxes = Axes.Both,
-                Shear = new Vector2(OsuGame.SHEAR, 0),
+                Shear = OsuGame.SHEAR,
                 CornerRadius = ShearedButton.CORNER_RADIUS,
                 Masking = true,
                 Children = new Drawable[]
@@ -79,7 +78,7 @@ namespace osu.Game.Overlays.Mods
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Shear = new Vector2(-OsuGame.SHEAR, 0),
+                        Shear = -OsuGame.SHEAR,
                         Font = OsuFont.Default.With(size: 17, weight: FontWeight.SemiBold)
                     }
                 }
@@ -94,7 +93,7 @@ namespace osu.Game.Overlays.Mods
                 Origin = Anchor.Centre,
                 Child = counter = new EffectCounter
                 {
-                    Shear = new Vector2(-OsuGame.SHEAR, 0),
+                    Shear = -OsuGame.SHEAR,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Current = { BindTarget = ModMultiplier }

--- a/osu.Game/Screens/Footer/ScreenFooterButton.cs
+++ b/osu.Game/Screens/Footer/ScreenFooterButton.cs
@@ -25,15 +25,11 @@ namespace osu.Game.Screens.Footer
 {
     public partial class ScreenFooterButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>
     {
-        private const float shear = OsuGame.SHEAR;
-
         protected const int CORNER_RADIUS = 10;
         protected const int BUTTON_HEIGHT = 75;
         protected const int BUTTON_WIDTH = 116;
 
         public Bindable<Visibility> OverlayState = new Bindable<Visibility>();
-
-        protected static readonly Vector2 BUTTON_SHEAR = new Vector2(shear, 0);
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -89,7 +85,7 @@ namespace osu.Game.Screens.Footer
                         Colour = Colour4.Black.Opacity(0.25f),
                         Offset = new Vector2(0, 2),
                     },
-                    Shear = BUTTON_SHEAR,
+                    Shear = OsuGame.SHEAR,
                     Masking = true,
                     CornerRadius = CORNER_RADIUS,
                     RelativeSizeAxes = Axes.Both,
@@ -108,7 +104,7 @@ namespace osu.Game.Screens.Footer
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                            Shear = -BUTTON_SHEAR,
+                            Shear = -OsuGame.SHEAR,
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
@@ -135,7 +131,7 @@ namespace osu.Game.Screens.Footer
                         },
                         new Container
                         {
-                            Shear = -BUTTON_SHEAR,
+                            Shear = -OsuGame.SHEAR,
                             Anchor = Anchor.BottomCentre,
                             Origin = Anchor.Centre,
                             Y = -CORNER_RADIUS,

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Shear = new Vector2(OsuGame.SHEAR, 0f),
+                    Shear = OsuGame.SHEAR,
                     Children = new Drawable[]
                     {
                         titleContainer = new Container
@@ -147,7 +147,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                             Origin = Anchor.Centre,
                                             Text = "Today's Challenge",
                                             Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
-                                            Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                            Shear = -OsuGame.SHEAR,
                                             Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
                                         },
                                     }
@@ -173,7 +173,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                             Origin = Anchor.Centre,
                                             Text = room.Name.Split(':', StringSplitOptions.TrimEntries).Last(),
                                             Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
-                                            Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                            Shear = -OsuGame.SHEAR,
                                             Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
                                         },
                                     }
@@ -246,7 +246,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                                 {
                                                     Anchor = Anchor.TopCentre,
                                                     Origin = Anchor.TopCentre,
-                                                    Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                                    Shear = -OsuGame.SHEAR,
                                                     MaxWidth = horizontal_info_size,
                                                     Text = beatmap.BeatmapSet!.Metadata.GetDisplayTitleRomanisable(false),
                                                     Padding = new MarginPadding { Horizontal = 5f },
@@ -257,7 +257,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                                     Text = $"Difficulty: {beatmap.DifficultyName}",
                                                     Font = OsuFont.GetFont(size: 20, italics: true),
                                                     MaxWidth = horizontal_info_size,
-                                                    Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                                    Shear = -OsuGame.SHEAR,
                                                     Anchor = Anchor.TopCentre,
                                                     Origin = Anchor.TopCentre,
                                                 },
@@ -266,13 +266,13 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                                     Text = $"by {beatmap.Metadata.Author.Username}",
                                                     Font = OsuFont.GetFont(size: 16, italics: true),
                                                     MaxWidth = horizontal_info_size,
-                                                    Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                                    Shear = -OsuGame.SHEAR,
                                                     Anchor = Anchor.TopCentre,
                                                     Origin = Anchor.TopCentre,
                                                 },
                                                 starRatingDisplay = new StarRatingDisplay(default)
                                                 {
-                                                    Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                                    Shear = -OsuGame.SHEAR,
                                                     Margin = new MarginPadding(5),
                                                     Anchor = Anchor.TopCentre,
                                                     Origin = Anchor.TopCentre,
@@ -301,7 +301,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                             Anchor = Anchor.TopCentre,
                                             Origin = Anchor.TopCentre,
                                             AutoSizeAxes = Axes.Both,
-                                            Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                            Shear = -OsuGame.SHEAR,
                                             Current =
                                             {
                                                 Value = item.RequiredMods.Select(m => m.ToMod(ruleset)).ToArray()
@@ -329,7 +329,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                 Origin = Anchor.Centre,
                 FillMode = FillMode.Fit,
                 Scale = new Vector2(1.2f),
-                Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                Shear = -OsuGame.SHEAR,
             }, c =>
             {
                 beatmapBackground.Add(c);

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Screens.Select.Options
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Shear = new Vector2(0.2f, 0f),
+                    Shear = OsuGame.SHEAR,
                     Masking = true,
                     EdgeEffect = new EdgeEffectParameters
                     {

--- a/osu.Game/Screens/SelectV2/Footer/ScreenFooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/Footer/ScreenFooterButtonMods.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Screens.SelectV2.Footer
                     Y = -5f,
                     Depth = float.MaxValue,
                     Origin = Anchor.BottomLeft,
-                    Shear = BUTTON_SHEAR,
+                    Shear = OsuGame.SHEAR,
                     CornerRadius = CORNER_RADIUS,
                     Size = new Vector2(BUTTON_WIDTH, bar_height),
                     Masking = true,
@@ -108,7 +108,7 @@ namespace osu.Game.Screens.SelectV2.Footer
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                Shear = -BUTTON_SHEAR,
+                                Shear = -OsuGame.SHEAR,
                                 UseFullGlyphHeight = false,
                                 Font = OsuFont.Torus.With(size: 14f, weight: FontWeight.Bold)
                             }
@@ -130,7 +130,7 @@ namespace osu.Game.Screens.SelectV2.Footer
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
-                                    Shear = -BUTTON_SHEAR,
+                                    Shear = -OsuGame.SHEAR,
                                     Scale = new Vector2(0.5f),
                                     Current = { BindTarget = Current },
                                     ExpansionMode = ExpansionMode.AlwaysContracted,
@@ -139,7 +139,7 @@ namespace osu.Game.Screens.SelectV2.Footer
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
-                                    Shear = -BUTTON_SHEAR,
+                                    Shear = -OsuGame.SHEAR,
                                     Font = OsuFont.Torus.With(size: 14f, weight: FontWeight.Bold),
                                     Mods = { BindTarget = Current },
                                 }
@@ -305,7 +305,7 @@ namespace osu.Game.Screens.SelectV2.Footer
                 Y = -5f;
                 Depth = float.MaxValue;
                 Origin = Anchor.BottomLeft;
-                Shear = BUTTON_SHEAR;
+                Shear = OsuGame.SHEAR;
                 CornerRadius = CORNER_RADIUS;
                 AutoSizeAxes = Axes.X;
                 Height = bar_height;
@@ -329,7 +329,7 @@ namespace osu.Game.Screens.SelectV2.Footer
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Shear = -BUTTON_SHEAR,
+                        Shear = -OsuGame.SHEAR,
                         Text = ModSelectOverlayStrings.Unranked.ToUpper(),
                         Margin = new MarginPadding { Horizontal = 15 },
                         UseFullGlyphHeight = false,

--- a/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
+++ b/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
             this.score = score;
             this.sheared = sheared;
 
-            Shear = new Vector2(sheared ? OsuGame.SHEAR : 0, 0);
+            Shear = sheared ? OsuGame.SHEAR : Vector2.Zero;
             RelativeSizeAxes = Axes.X;
             Height = height;
         }
@@ -255,7 +255,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                 {
                     RelativeSizeAxes = Axes.Both,
                     User = score.User,
-                    Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     Colour = ColourInfo.GradientHorizontal(Colour4.White.Opacity(0.5f), Colour4.FromHex(@"222A27").Opacity(1)),
@@ -286,7 +286,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                                             Anchor = Anchor.Centre,
                                             Origin = Anchor.Centre,
                                             Scale = new Vector2(1.1f),
-                                            Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                                            Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                             RelativeSizeAxes = Axes.Both,
                                         })
                                     {
@@ -326,7 +326,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                                 {
                                     flagBadgeAndDateContainer = new FillFlowContainer
                                     {
-                                        Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                         Direction = FillDirection.Horizontal,
                                         Spacing = new Vector2(5),
                                         AutoSizeAxes = Axes.Both,
@@ -356,7 +356,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                                     nameLabel = new TruncatingSpriteText
                                     {
                                         RelativeSizeAxes = Axes.X,
-                                        Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                         Text = user.Username,
                                         Font = OsuFont.GetFont(size: 20, weight: FontWeight.SemiBold)
                                     }
@@ -372,7 +372,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                                     Name = @"Statistics container",
                                     Padding = new MarginPadding { Right = 40 },
                                     Spacing = new Vector2(25, 0),
-                                    Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
                                     AutoSizeAxes = Axes.Both,
@@ -430,7 +430,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                     },
                     RankContainer = new Container
                     {
-                        Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                         RelativeSizeAxes = Axes.Y,
@@ -488,7 +488,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                                             Anchor = Anchor.TopRight,
                                             Origin = Anchor.TopRight,
                                             UseFullGlyphHeight = false,
-                                            Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                                            Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                             Current = scoreManager.GetBindableTotalScoreString(score),
                                             Font = OsuFont.GetFont(size: 30, weight: FontWeight.Light),
                                         },
@@ -496,7 +496,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                                         {
                                             Anchor = Anchor.TopRight,
                                             Origin = Anchor.TopRight,
-                                            Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                                            Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                             AutoSizeAxes = Axes.Both,
                                             Direction = FillDirection.Horizontal,
                                             Spacing = new Vector2(2f, 0f),
@@ -704,7 +704,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
 
                 Child = new OsuSpriteText
                 {
-                    Shear = new Vector2(sheared ? -OsuGame.SHEAR : 0, 0),
+                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Font = OsuFont.GetFont(size: 20, weight: FontWeight.SemiBold, italics: true),

--- a/osu.Game/Screens/SelectV2/UpdateBeatmapSetButton.cs
+++ b/osu.Game/Screens/SelectV2/UpdateBeatmapSetButton.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Screens.SelectV2
 
             Content.Anchor = Anchor.Centre;
             Content.Origin = Anchor.Centre;
-            Content.Shear = new Vector2(OsuGame.SHEAR, 0);
+            Content.Shear = OsuGame.SHEAR;
 
             Content.AddRange(new Drawable[]
             {
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.SelectV2
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(4),
-                    Shear = new Vector2(-OsuGame.SHEAR, 0),
+                    Shear = -OsuGame.SHEAR,
                     Children = new Drawable[]
                     {
                         new Container


### PR DESCRIPTION
Saves having this defined in 20+ places. If we ever make any changes to shear, it's 100% going to need to be applied to every usage (there will never be a case of multiple different shears in the game).

Also fixes a mismatching definition in `ShearedNub`.

Soft prereq for https://github.com/ppy/osu/pull/32715 because that PR added a lot more local definitions of this which I've nuked.