### PR TITLE
Prevent showing "use these mods" context menu option on broken scores

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneLeaderboardScore.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneLeaderboardScore.cs
@@ -168,6 +168,63 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("mods did not receive SV2", () => !score.SelectedMods.Value.Any(m => m is ModScoreV2));
         }
 
+        [Test]
+        public void TestUseTheseModsDoesNotCopyInvalidModCombinations()
+        {
+            LeaderboardScoreV2 score = null!;
+
+            AddStep("create content", () =>
+            {
+                Children = new Drawable[]
+                {
+                    fillFlow = new FillFlowContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(0f, 2f),
+                        Shear = new Vector2(OsuGame.SHEAR, 0)
+                    },
+                    drawWidthText = new OsuSpriteText(),
+                };
+
+                var scoreInfo = new ScoreInfo
+                {
+                    Position = 999,
+                    Rank = ScoreRank.X,
+                    Accuracy = 1,
+                    MaxCombo = 244,
+                    TotalScore = RNG.Next(1_800_000, 2_000_000),
+                    MaximumStatistics = { { HitResult.Great, 3000 } },
+                    Mods = new Mod[] { new OsuModDoubleTime(), new OsuModHalfTime(), },
+                    Ruleset = new OsuRuleset().RulesetInfo,
+                    User = new APIUser
+                    {
+                        Id = 6602580,
+                        Username = @"waaiiru",
+                        CountryCode = CountryCode.ES,
+                        CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c1.jpg",
+                    },
+                    Date = DateTimeOffset.Now.AddYears(-2),
+                };
+
+                fillFlow.Add(score = new LeaderboardScoreV2(scoreInfo)
+                {
+                    Rank = scoreInfo.Position,
+                    Shear = Vector2.Zero,
+                });
+
+                score.Show();
+            });
+            AddStep("right click panel", () =>
+            {
+                InputManager.MoveMouseTo(score);
+                InputManager.Click(MouseButton.Right);
+            });
+            AddAssert("use these mods not available", () => !this.ChildrenOfType<DrawableOsuMenuItem>().Any());
+        }
+
         public override void SetUpSteps()
         {
             AddToggleStep("toggle scoring mode", v => config.SetValue(OsuSetting.ScoreDisplayMode, v ? ScoringMode.Classic : ScoringMode.Standardised));

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -455,7 +455,7 @@ namespace osu.Game.Online.Leaderboards
                 // system mods should never be copied across regardless of anything.
                 var copyableMods = Score.Mods.Where(m => m.Type != ModType.System).ToArray();
 
-                if (copyableMods.Length > 0 && songSelect != null)
+                if (copyableMods.Length > 0 && ModUtils.CheckCompatibleSet(copyableMods) && songSelect != null)
                     items.Add(new OsuMenuItem("Use these mods", MenuItemType.Highlighted, () => songSelect.Mods.Value = copyableMods));
 
                 if (Score.OnlineID > 0)

--- a/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
+++ b/osu.Game/Screens/SelectV2/Leaderboards/LeaderboardScoreV2.cs
@@ -786,7 +786,7 @@ namespace osu.Game.Screens.SelectV2.Leaderboards
                 // system mods should never be copied across regardless of anything.
                 var copyableMods = score.Mods.Where(m => IsValidMod.Invoke(m) && m.Type != ModType.System).ToArray();
 
-                if (copyableMods.Length > 0)
+                if (copyableMods.Length > 0 && ModUtils.CheckCompatibleSet(copyableMods))
                     items.Add(new OsuMenuItem("Use these mods", MenuItemType.Highlighted, () => SelectedMods.Value = copyableMods));
 
                 if (score.OnlineID > 0)


### PR DESCRIPTION
(Badly) reported at https://discord.com/channels/188630481301012481/1097318920991559880/1361710380002578464.

Could be argued that such replays should maybe just refuse to import? Not sure.