### PR TITLE
Fix global offset adjust control showing adjustment available when it shouldn't

### DIFF
--- a/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
+++ b/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Tests.Extensions
         [TestCase(-1e-6, false, 6, ExpectedResult = "-0.000001")]
         [TestCase(0, false, 10, ExpectedResult = "0")]
         [TestCase(0, false, 0, ExpectedResult = "0")]
+        [TestCase(double.NegativeZero, false, 0, ExpectedResult = "0")]
         [TestCase(1e-6, false, 0, ExpectedResult = "0")]
         [TestCase(1e-6, false, 6, ExpectedResult = "0.000001")]
         [TestCase(1, false, 0, ExpectedResult = "1")]

--- a/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
+++ b/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Extensions;
+
+namespace osu.Game.Tests.Extensions
+{
+    [TestFixture]
+    public class NumberFormattingExtensionsTest
+    {
+        [TestCase(-1, false, 0, ExpectedResult = "-1")]
+        [TestCase(0, false, 0, ExpectedResult = "0")]
+        [TestCase(1, false, 0, ExpectedResult = "1")]
+        [TestCase(500, false, 10, ExpectedResult = "500")]
+        [TestCase(-1, true, 0, ExpectedResult = "-1%")]
+        [TestCase(0, true, 0, ExpectedResult = "0%")]
+        [TestCase(1, true, 0, ExpectedResult = "1%")]
+        [TestCase(50, true, 0, ExpectedResult = "50%")]
+        public string TestInteger(int input, bool percent, int decimalDigits)
+        {
+            return input.ToStandardFormattedString(decimalDigits, percent);
+        }
+
+        [TestCase(-1, false, 0, ExpectedResult = "-1")]
+        [TestCase(-1e-6, false, 0, ExpectedResult = "0")]
+        [TestCase(-1e-6, false, 6, ExpectedResult = "-0.000001")]
+        [TestCase(0, false, 10, ExpectedResult = "0")]
+        [TestCase(0, false, 0, ExpectedResult = "0")]
+        [TestCase(1e-6, false, 0, ExpectedResult = "0")]
+        [TestCase(1e-6, false, 6, ExpectedResult = "0.000001")]
+        [TestCase(1, false, 0, ExpectedResult = "1")]
+        [TestCase(1.528, false, 2, ExpectedResult = "1.53")]
+        [TestCase(500, false, 10, ExpectedResult = "500")]
+        [TestCase(-0.1, true, 0, ExpectedResult = "-10%")]
+        [TestCase(0, true, 0, ExpectedResult = "0%")]
+        [TestCase(0.4, true, 0, ExpectedResult = "40%")]
+        [TestCase(0.48333, true, 2, ExpectedResult = "48%")]
+        [TestCase(0.48333, true, 4, ExpectedResult = "48.33%")]
+        [TestCase(1, true, 0, ExpectedResult = "100%")]
+        public string TestDouble(double input, bool percent, int decimalDigits)
+        {
+            return input.ToStandardFormattedString(decimalDigits, percent);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -168,6 +168,19 @@ namespace osu.Game.Tests.Visual.Ranking
             };
         });
 
+        public static List<HitEvent> CreateHitEvents(double offset = 0, int count = 50)
+        {
+            var hitEvents = new List<HitEvent>();
+
+            for (int i = 0; i < count; i++)
+            {
+                for (int j = 0; j < count; j++)
+                    hitEvents.Add(new HitEvent(offset, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null));
+            }
+
+            return hitEvents;
+        }
+
         public static List<HitEvent> CreateDistributedHitEvents(double centre = 0, double range = 25)
         {
             var hitEvents = new List<HitEvent>();

--- a/osu.Game/Extensions/NumberFormattingExtensions.cs
+++ b/osu.Game/Extensions/NumberFormattingExtensions.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using System.Numerics;
+using osu.Game.Utils;
+
+namespace osu.Game.Extensions
+{
+    public static class NumberFormattingExtensions
+    {
+        /// <summary>
+        /// For a given numeric type, return a formatted string in the standard format we use for display everywhere.
+        /// </summary>
+        /// <param name="value">The numeric value.</param>
+        /// <param name="maxDecimalDigits">The maximum number of decimals to be considered in the original value.</param>
+        /// <param name="asPercentage">Whether the output should be a percentage. For integer types, 0-100 is mapped to 0-100%; for other types 0-1 is mapped to 0-100%.</param>
+        /// <returns>The formatted output.</returns>
+        public static string ToStandardFormattedString<T>(this T value, int maxDecimalDigits, bool asPercentage) where T : struct, INumber<T>, IMinMaxValue<T>
+        {
+            double floatValue = double.CreateTruncating(value);
+
+            decimal decimalPrecision = normalise(decimal.CreateTruncating(value), maxDecimalDigits);
+
+            // Find the number of significant digits (we could have less than maxDecimalDigits after normalize())
+            int significantDigits = FormatUtils.FindPrecision(decimalPrecision);
+
+            if (asPercentage)
+            {
+                if (value is int)
+                    floatValue /= 100;
+
+                return floatValue.ToString($@"P{Math.Max(0, significantDigits - 2)}");
+            }
+
+            string negativeSign = Math.Round(floatValue, significantDigits) < 0 ? "-" : string.Empty;
+
+            return $"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}")}";
+        }
+
+        /// <summary>
+        /// Removes all non-significant digits, keeping at most a requested number of decimal digits.
+        /// </summary>
+        /// <param name="d">The decimal to normalize.</param>
+        /// <param name="sd">The maximum number of decimal digits to keep. The final result may have fewer decimal digits than this value.</param>
+        /// <returns>The normalised decimal.</returns>
+        private static decimal normalise(decimal d, int sd)
+            => decimal.Parse(Math.Round(d, sd).ToString(string.Concat("0.", new string('#', sd)), CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+    }
+}

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Numerics;
-using System.Globalization;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -11,7 +9,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
-using osu.Game.Utils;
+using osu.Game.Extensions;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -85,35 +83,6 @@ namespace osu.Game.Graphics.UserInterface
             channel.Play();
         }
 
-        public LocalisableString GetDisplayableValue(T value)
-        {
-            if (CurrentNumber.IsInteger)
-                return int.CreateTruncating(value).ToString("N0");
-
-            double floatValue = double.CreateTruncating(value);
-
-            decimal decimalPrecision = normalise(decimal.CreateTruncating(CurrentNumber.Precision), max_decimal_digits);
-
-            // Find the number of significant digits (we could have less than 5 after normalize())
-            int significantDigits = FormatUtils.FindPrecision(decimalPrecision);
-
-            if (DisplayAsPercentage)
-            {
-                return floatValue.ToString($@"P{Math.Max(0, significantDigits - 2)}");
-            }
-
-            string negativeSign = Math.Round(floatValue, significantDigits) < 0 ? "-" : string.Empty;
-
-            return $"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}")}";
-        }
-
-        /// <summary>
-        /// Removes all non-significant digits, keeping at most a requested number of decimal digits.
-        /// </summary>
-        /// <param name="d">The decimal to normalize.</param>
-        /// <param name="sd">The maximum number of decimal digits to keep. The final result may have fewer decimal digits than this value.</param>
-        /// <returns>The normalised decimal.</returns>
-        private decimal normalise(decimal d, int sd)
-            => decimal.Parse(Math.Round(d, sd).ToString(string.Concat("0.", new string('#', sd)), CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+        public LocalisableString GetDisplayableValue(T value) => CurrentNumber.Value.ToStandardFormattedString(max_decimal_digits, DisplayAsPercentage);
     }
 }

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -70,6 +70,11 @@ namespace osu.Game.Localisation
         public static LocalisableString SuggestedOffsetNote => new TranslatableString(getKey(@"suggested_offset_note"), @"Play a few beatmaps to receive a suggested offset!");
 
         /// <summary>
+        /// "Based on the last {0} play(s), your offset is set correctly!"
+        /// </summary>
+        public static LocalisableString SuggestedOffsetCorrect(int plays) => new TranslatableString(getKey(@"suggested_offset_correct"), @"Based on the last {0} play(s), your offset is set correctly!", plays);
+
+        /// <summary>
         /// "Based on the last {0} play(s), the suggested offset is {1} ms."
         /// </summary>
         public static LocalisableString SuggestedOffsetValueReceived(int plays, LocalisableString value) => new TranslatableString(getKey(@"suggested_offset_value_received"), @"Based on the last {0} play(s), the suggested offset is {1} ms.", plays, value);

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
@@ -8,13 +8,13 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 else
                 {
                     applySuggestion.Enabled.Value = true;
-                    hintText.Text = AudioSettingsStrings.SuggestedOffsetValueReceived(averageHitErrorHistory.Count, SuggestedOffset.Value.ToLocalisableString(@"N0"));
+                    hintText.Text = AudioSettingsStrings.SuggestedOffsetValueReceived(averageHitErrorHistory.Count, SuggestedOffset.Value.Value.ToStandardFormattedString(0, false));
                 }
             }
 


### PR DESCRIPTION

Audio offset is integer based in configuration, so let's make sure not to show that there's an applicable offset when the value difference is too low.

I've also fixed rounding to match expectations (`AudioOffset` is precision limited to integer), and handled the case where a user adjusts the slider but also has a suggested offset – previously it would not enable the button after slider adjustments but now it will work as expected.

Closes https://github.com/ppy/osu/issues/32761.