### PR TITLE
Fix multiplayer background changing in results screen

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -1092,7 +1092,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddAssert("global beatmap still matches first playlist item", () => Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(multiplayerClient.ClientRoom!.Playlist[0].BeatmapID));
             AddStep("return to match", () => multiplayerComponents.Exit());
-            AddAssert("global beatmap still matches first playlist item", () => Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(multiplayerClient.ClientRoom!.Playlist[1].BeatmapID));
+            AddAssert("global beatmap matches second playlist item", () => Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(multiplayerClient.ClientRoom!.Playlist[1].BeatmapID));
         }
 
         private void enterGameplay()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -1056,6 +1056,45 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("hidden is selected", () => SelectedMods.Value, () => Has.One.TypeOf(typeof(OsuModHidden)));
         }
 
+        [FlakyTest]
+        [Test]
+        public void TestGlobalBeatmapDoesNotChangeAtResults()
+        {
+            createRoom(() => new Room
+            {
+                Name = "Test Room",
+                QueueMode = QueueMode.AllPlayers,
+                Playlist =
+                [
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
+                    {
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                        AllowedMods = new[] { new APIMod { Acronym = "HD" } },
+                    },
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 1)).BeatmapInfo)
+                    {
+                        RulesetID = new TaikoRuleset().RulesetInfo.OnlineID,
+                        AllowedMods = new[] { new APIMod { Acronym = "HD" } },
+                    },
+                ]
+            });
+
+            enterGameplay();
+
+            // Gameplay runs in real-time, so we need to incrementally check if gameplay has finished in order to not time out.
+            for (double i = 1000; i < TestResources.QUICK_BEATMAP_LENGTH; i += 1000)
+            {
+                double time = i;
+                AddUntilStep($"wait for time > {i}", () => this.ChildrenOfType<GameplayClockContainer>().SingleOrDefault()?.CurrentTime > time);
+            }
+
+            AddUntilStep("wait for results", () => multiplayerComponents.CurrentScreen is ResultsScreen);
+
+            AddAssert("global beatmap still matches first playlist item", () => Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(multiplayerClient.ClientRoom!.Playlist[0].BeatmapID));
+            AddStep("return to match", () => multiplayerComponents.Exit());
+            AddAssert("global beatmap still matches first playlist item", () => Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(multiplayerClient.ClientRoom!.Playlist[1].BeatmapID));
+        }
+
         private void enterGameplay()
         {
             pressReadyButton();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -467,7 +467,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             if (settings.PlaylistItemId != lastPlaylistItemId)
             {
-                updateGameplayState();
+                Scheduler.AddOnce(updateGameplayState);
                 lastPlaylistItemId = settings.PlaylistItemId;
             }
 
@@ -480,7 +480,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private void onItemChanged(MultiplayerPlaylistItem item)
         {
             if (item.ID == client.Room?.Settings.PlaylistItemId)
-                updateGameplayState();
+                Scheduler.AddOnce(updateGameplayState);
         }
 
         /// <summary>
@@ -489,7 +489,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private void onUserStyleChanged(MultiplayerRoomUser user)
         {
             if (user.Equals(client.LocalUser))
-                updateGameplayState();
+                Scheduler.AddOnce(updateGameplayState);
         }
 
         /// <summary>
@@ -498,7 +498,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private void onUserModsChanged(MultiplayerRoomUser user)
         {
             if (user.Equals(client.LocalUser))
-                updateGameplayState();
+                Scheduler.AddOnce(updateGameplayState);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/32786

Considered two other paths here:
 - Prevent changing when not appropriate local to `MultiplayerRoomBackgroundScreen`. Doesn't work because the results screen creates its own `BackgroundScreenBeatmap` that replaces it.
 - Make `MultiplayerResultsScreen` screen keep the same `WorkingBeatmap` for its background. This works but the global beatmap still changes and so still affects the music controller, which I gather would come up as an evolution of the issue.

Scheduling these updates is probably the easiest way - which I've done local to methods responding to online state changes so as to not deal with too many scheduling shenanigans.