### PR TITLE
Fix osu!mania beatmap objects getting corrupted when updating beatmap background

### DIFF
--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -192,7 +192,7 @@ namespace osu.Game.Screens.Edit.Setup
                     // note that this triggers a full save flow, including triggering a difficulty calculation.
                     // this is not a cheap operation and should be reconsidered in the future.
                     var beatmapWorking = beatmaps.GetWorkingBeatmap(b);
-                    beatmaps.Save(b, beatmapWorking.Beatmap, beatmapWorking.GetSkin());
+                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset), beatmapWorking.GetSkin());
                 }
             }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32825.

Tested manually to fix the issue. Setting up test coverage for this is going to likely take over an hour compared to the 30 second fix, so please advise if required. I couldn't find any existing tests which perform this flow.