### PR TITLE
Refuse to import scores specifying incompatible mods

### DIFF
--- a/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
+++ b/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
@@ -216,6 +216,35 @@ namespace osu.Game.Tests.Scores.IO
         }
 
         [Test]
+        public void TestScoreWithInvalidModCombinationsWillNotImport()
+        {
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+            {
+                try
+                {
+                    var osu = LoadOsuIntoHost(host, true);
+
+                    var beatmap = BeatmapImportHelper.LoadOszIntoOsu(osu, TestResources.GetQuickTestBeatmapForImport()).GetResultSafely();
+
+                    var toImport = new ScoreInfo
+                    {
+                        User = new APIUser { Username = "Test user" },
+                        BeatmapInfo = beatmap.Beatmaps.First(),
+                        Ruleset = new OsuRuleset().RulesetInfo,
+                        ClientVersion = "12345",
+                        Mods = new Mod[] { new OsuModHalfTime(), new OsuModDoubleTime() },
+                    };
+
+                    Assert.Throws<InvalidOperationException>(() => LoadScoreIntoOsu(osu, toImport));
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
         public void TestImportStatistics()
         {
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost())

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -342,7 +342,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Mods = new Mod[]
                     {
                         new OsuModHidden(),
-                        new OsuModHardRock(),
                         new OsuModFlashlight
                         {
                             FollowDelay = { Value = 200 },

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -17,6 +17,7 @@ using osu.Game.Scoring.Legacy;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Utils;
 using Realms;
 
 namespace osu.Game.Scoring
@@ -89,6 +90,9 @@ namespace osu.Game.Scoring
             // Under no circumstance do we want these to be written to realm as null.
             ArgumentNullException.ThrowIfNull(model.BeatmapInfo);
             ArgumentNullException.ThrowIfNull(model.Ruleset);
+
+            if (!ModUtils.CheckCompatibleSet(model.Mods))
+                throw new InvalidOperationException(@"The score specifies an incompatible set of mods!");
 
             if (string.IsNullOrEmpty(model.StatisticsJson))
                 model.StatisticsJson = JsonConvert.SerializeObject(model.Statistics);


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu/pull/32817.

The messaging of the failure to the user is maybe not the cleanest, but I'm not sure it's worth putting time in to improve it?

![image](https://github.com/user-attachments/assets/04362a7b-0f7e-42d5-9de7-208d023ca2f4)

Example replay to test with (specifies DT and HT): [spaceman_atlas2_old playing joeyclassic - seal.mp4 (StarrStyx) [Seal] (2025-03-25_13-33).osr.zip](https://github.com/user-attachments/files/19790821/spaceman_atlas2_old.playing.joeyclassic.-.seal.mp4.StarrStyx.Seal.2025-03-25_13-33.osr.zip)
