### PR TITLE
Fix culture variance in new formatting helper

### DIFF
--- a/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
+++ b/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
@@ -43,5 +43,12 @@ namespace osu.Game.Tests.Extensions
         {
             return input.ToStandardFormattedString(decimalDigits, percent);
         }
+
+        [Test]
+        [SetCulture("fr-FR")]
+        public void TestCultureInsensitivity()
+        {
+            Assert.That(0.4.ToStandardFormattedString(maxDecimalDigits: 2, asPercentage: true), Is.EqualTo("40%"));
+        }
     }
 }

--- a/osu.Game/Extensions/NumberFormattingExtensions.cs
+++ b/osu.Game/Extensions/NumberFormattingExtensions.cs
@@ -31,12 +31,12 @@ namespace osu.Game.Extensions
                 if (value is int)
                     floatValue /= 100;
 
-                return floatValue.ToString($@"P{Math.Max(0, significantDigits - 2)}");
+                return floatValue.ToString($@"0.{new string('0', Math.Max(0, significantDigits - 2))}%", CultureInfo.InvariantCulture);
             }
 
             string negativeSign = Math.Round(floatValue, significantDigits) < 0 ? "-" : string.Empty;
 
-            return $"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}")}";
+            return FormattableString.Invariant($"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}")}");
         }
 
         /// <summary>


### PR DESCRIPTION
I was gonna push this straight to master but I had to actually do some meaningful changes to the actual code so I decided I'm not going to. (The `P` standard format specifier - for whatever reason - puts a space between the number and the percent sign when invariant culture is used...)