### PR TITLE
Use new font specifications in beatmap panels and apply minor adjustments

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmap.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmap.cs
@@ -1,17 +1,23 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
+using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Scoring;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual.UserInterface;
@@ -64,6 +70,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         public void TestManiaRuleset()
         {
             AddToggleStep("mania ruleset", v => Ruleset.Value = v ? new ManiaRuleset().RulesetInfo : new OsuRuleset().RulesetInfo);
+        }
+
+        [Test]
+        public void TestLocalRank()
+        {
+            foreach (var rank in Enum.GetValues<ScoreRank>())
+            {
+                AddStep($"set {rank.GetDescription()} rank", () => this.ChildrenOfType<UpdateableRank>().ForEach(p =>
+                {
+                    p.Show();
+                    p.Rank = rank;
+                }));
+            }
         }
 
         protected override Drawable CreateContent()

--- a/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmapStandalone.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmapStandalone.cs
@@ -1,17 +1,23 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
+using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Scoring;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual.UserInterface;
@@ -64,6 +70,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         public void TestManiaRuleset()
         {
             AddToggleStep("mania ruleset", v => Ruleset.Value = v ? new ManiaRuleset().RulesetInfo : new OsuRuleset().RulesetInfo);
+        }
+
+        [Test]
+        public void TestLocalRank()
+        {
+            foreach (var rank in Enum.GetValues<ScoreRank>())
+            {
+                AddStep($"set {rank.GetDescription()} rank", () => this.ChildrenOfType<UpdateableRank>().ForEach(p =>
+                {
+                    p.Show();
+                    p.Rank = rank;
+                }));
+            }
         }
 
         protected override Drawable CreateContent()

--- a/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Beatmaps.Drawables
 
                 Add(countText = new OsuSpriteText
                 {
-                    Font = OsuFont.Default.With(size: 12),
+                    Font = OsuFont.Style.Caption1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Padding = new MarginPadding { Bottom = 1 }

--- a/osu.Game/Graphics/Carousel/CarouselItem.cs
+++ b/osu.Game/Graphics/Carousel/CarouselItem.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Graphics.Carousel
     /// </summary>
     public sealed class CarouselItem : IComparable<CarouselItem>
     {
-        public const float DEFAULT_HEIGHT = 50;
+        public const float DEFAULT_HEIGHT = 45;
 
         /// <summary>
         /// The model this item is representing.

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.SelectV2
 
             Icon = difficultyIcon = new ConstrainedIconContainer
             {
-                Size = new Vector2(20),
+                Size = new Vector2(16f),
                 Margin = new MarginPadding { Horizontal = 5f },
                 Colour = colourProvider.Background5,
             };
@@ -100,12 +100,13 @@ namespace osu.Game.Screens.SelectV2
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
+                                    Scale = new Vector2(0.875f),
                                 },
                                 localRank = new PanelLocalRankDisplay
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
-                                    Scale = new Vector2(0.75f)
+                                    Scale = new Vector2(0.65f)
                                 },
                                 starCounter = new StarCounter
                                 {
@@ -123,22 +124,22 @@ namespace osu.Game.Screens.SelectV2
                             {
                                 keyCountText = new OsuSpriteText
                                 {
-                                    Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                    Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft,
                                     Alpha = 0,
                                 },
                                 difficultyText = new OsuSpriteText
                                 {
-                                    Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                    Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft,
-                                    Margin = new MarginPadding { Right = 8f },
+                                    Margin = new MarginPadding { Right = 5f },
                                 },
                                 authorText = new OsuSpriteText
                                 {
                                     Colour = colourProvider.Content2,
-                                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
+                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold),
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft
                                 }

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.SelectV2
 {
     public partial class PanelBeatmapSet : Panel
     {
-        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.6f;
+        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.7f;
 
         private PanelSetBackground background = null!;
 
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.SelectV2
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Icon = FontAwesome.Solid.ChevronRight,
-                    Size = new Vector2(12),
+                    Size = new Vector2(8),
                     X = 1f,
                     Colour = colourProvider.Background5,
                 },
@@ -77,17 +77,17 @@ namespace osu.Game.Screens.SelectV2
                     {
                         titleText = new OsuSpriteText
                         {
-                            Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 22, italics: true),
+                            Font = OsuFont.Style.Heading1.With(typeface: Typeface.TorusAlternate),
                         },
                         artistText = new OsuSpriteText
                         {
-                            Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 17, italics: true),
+                            Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                         },
                         new FillFlowContainer
                         {
                             Direction = FillDirection.Horizontal,
                             AutoSizeAxes = Axes.Both,
-                            Margin = new MarginPadding { Top = 5f },
+                            Margin = new MarginPadding { Top = 4f },
                             Children = new Drawable[]
                             {
                                 updateButton = new PanelUpdateBeatmapButton
@@ -100,8 +100,7 @@ namespace osu.Game.Screens.SelectV2
                                 {
                                     Origin = Anchor.CentreLeft,
                                     Anchor = Anchor.CentreLeft,
-                                    TextSize = 11,
-                                    TextPadding = new MarginPadding { Horizontal = 8, Vertical = 2 },
+                                    TextSize = OsuFont.Style.Caption2.Size,
                                     Margin = new MarginPadding { Right = 5f },
                                 },
                                 difficultiesDisplay = new DifficultySpectrumDisplay

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.SelectV2
 {
     public partial class PanelBeatmapStandalone : Panel
     {
-        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.6f;
+        public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.7f;
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.SelectV2
 
             Icon = difficultyIcon = new ConstrainedIconContainer
             {
-                Size = new Vector2(20),
+                Size = new Vector2(16),
                 Margin = new MarginPadding { Horizontal = 5f },
                 Colour = colourProvider.Background5,
             };
@@ -95,19 +95,16 @@ namespace osu.Game.Screens.SelectV2
                 {
                     titleText = new OsuSpriteText
                     {
-                        Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 22, italics: true),
-                        Shadow = true,
+                        Font = OsuFont.Style.Heading1.With(typeface: Typeface.TorusAlternate),
                     },
                     artistText = new OsuSpriteText
                     {
-                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 17, italics: true),
-                        Shadow = true,
+                        Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                     },
                     new FillFlowContainer
                     {
                         Direction = FillDirection.Horizontal,
                         AutoSizeAxes = Axes.Both,
-                        Margin = new MarginPadding { Top = 5f },
                         Children = new Drawable[]
                         {
                             updateButton = new PanelUpdateBeatmapButton
@@ -120,8 +117,7 @@ namespace osu.Game.Screens.SelectV2
                             {
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,
-                                TextSize = 11,
-                                TextPadding = new MarginPadding { Horizontal = 8, Vertical = 2 },
+                                TextSize = OsuFont.Style.Caption2.Size,
                                 Margin = new MarginPadding { Right = 5f },
                             },
                             difficultyLine = new FillFlowContainer
@@ -134,19 +130,19 @@ namespace osu.Game.Screens.SelectV2
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
-                                        Scale = new Vector2(8f / 9f),
+                                        Scale = new Vector2(0.875f),
                                         Margin = new MarginPadding { Right = 5f },
                                     },
                                     difficultyRank = new PanelLocalRankDisplay
                                     {
-                                        Scale = new Vector2(8f / 11),
+                                        Scale = new Vector2(0.65f),
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
                                         Margin = new MarginPadding { Right = 5f },
                                     },
                                     difficultyKeyCountText = new OsuSpriteText
                                     {
-                                        Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                        Font = OsuFont.Style.Heading2,
                                         Anchor = Anchor.BottomLeft,
                                         Origin = Anchor.BottomLeft,
                                         Alpha = 0,
@@ -154,7 +150,7 @@ namespace osu.Game.Screens.SelectV2
                                     },
                                     difficultyName = new OsuSpriteText
                                     {
-                                        Font = OsuFont.GetFont(size: 18, weight: FontWeight.SemiBold),
+                                        Font = OsuFont.Style.Heading2,
                                         Origin = Anchor.BottomLeft,
                                         Anchor = Anchor.BottomLeft,
                                         Margin = new MarginPadding { Right = 5f, Bottom = 2f },
@@ -162,7 +158,7 @@ namespace osu.Game.Screens.SelectV2
                                     difficultyAuthor = new OsuSpriteText
                                     {
                                         Colour = colourProvider.Content2,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
+                                        Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold),
                                         Origin = Anchor.BottomLeft,
                                         Anchor = Anchor.BottomLeft,
                                         Margin = new MarginPadding { Right = 5f, Bottom = 2f },

--- a/osu.Game/Screens/SelectV2/PanelUpdateBeatmapButton.cs
+++ b/osu.Game/Screens/SelectV2/PanelUpdateBeatmapButton.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.SelectV2
 
         public PanelUpdateBeatmapButton()
         {
-            Size = new Vector2(75f, 22f);
+            Size = new Vector2(72, 22f);
         }
 
         private Bindable<bool> preferNoVideo = null!;
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.SelectV2
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            const float icon_size = 14;
+            const float icon_size = 12;
 
             preferNoVideo = config.GetBindable<bool>(OsuSetting.PreferNoVideo);
 
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.SelectV2
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                            Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                            Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                             Text = "Update",
                         }
                     }


### PR DESCRIPTION
- Split from https://github.com/ppy/osu/pull/32715 +/- minor adjustments


Before:
![CleanShot 2025-04-18 at 06 13 10](https://github.com/user-attachments/assets/f319f710-fce4-490a-bea9-643a72dabcd4)

After:
![CleanShot 2025-04-18 at 06 12 19](https://github.com/user-attachments/assets/4b728134-743c-45bc-9452-dfc9f6baa261)

Also contains test cases to be able to display local rank in panels, noticed scaling was a bit weird as a result. Final appearance:

![CleanShot 2025-04-18 at 06 17 56](https://github.com/user-attachments/assets/55a993ab-93f2-4481-bcf7-a9dbf7e61eae)
