### PR TITLE
Add sheared "range" slider bar

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneShearedRangeSlider.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneShearedRangeSlider.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public partial class TestSceneShearedRangeSlider : ThemeComparisonTestScene
+    {
+        private readonly BindableNumber<double> customStart = new BindableNumber<double>
+        {
+            MinValue = 0,
+            MaxValue = 10,
+            Precision = 0.1f
+        };
+
+        private readonly BindableNumber<double> customEnd = new BindableNumber<double>(10)
+        {
+            MinValue = 0,
+            MaxValue = 10,
+            Precision = 0.1f
+        };
+
+        private ShearedRangeSlider shearedRangeSlider = null!;
+
+        public TestSceneShearedRangeSlider()
+            : base(false)
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            CreateThemedContent(OverlayColourScheme.Aquamarine);
+        }
+
+        protected override Drawable CreateContent() => new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Black.Opacity(0.5f),
+                },
+                shearedRangeSlider = new ShearedRangeSlider("Test")
+                {
+                    Width = 600,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(1),
+                    LowerBound = customStart,
+                    UpperBound = customEnd,
+                    TooltipSuffix = "suffix",
+                    NubWidth = 32,
+                    DefaultStringLowerBound = "0.0",
+                    DefaultStringUpperBound = "∞",
+                    MinRange = 0.1f,
+                }
+            }
+        };
+
+        [Test]
+        public void TestAdjustRange()
+        {
+            AddAssert("Initial lower bound is correct", () => shearedRangeSlider.LowerBound.Value, () => Is.EqualTo(0).Within(0.1f));
+            AddAssert("Initial upper bound is correct", () => shearedRangeSlider.UpperBound.Value, () => Is.EqualTo(10).Within(0.1f));
+
+            AddStep("Adjust range", () =>
+            {
+                customStart.Value = 5;
+                customEnd.Value = 7.5;
+            });
+
+            AddAssert("Adjusted lower bound is correct", () => shearedRangeSlider.LowerBound.Value, () => Is.EqualTo(5).Within(0.1f));
+            AddAssert("Adjusted upper bound is correct", () => shearedRangeSlider.UpperBound.Value, () => Is.EqualTo(7.5).Within(0.1f));
+
+            AddStep("Test nub pushing", () =>
+            {
+                customStart.Value = 9;
+            });
+
+            AddAssert("Pushed lower bound is correct", () => shearedRangeSlider.LowerBound.Value, () => Is.EqualTo(9).Within(0.1f));
+            AddAssert("Pushed upper bound is correct", () => shearedRangeSlider.UpperBound.Value, () => Is.EqualTo(9.1).Within(0.1f));
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
@@ -196,8 +196,6 @@ namespace osu.Game.Graphics.UserInterface
 
             public float NubWidth { get; set; } = ShearedNub.HEIGHT;
 
-            public new float NormalizedValue => base.NormalizedValue;
-
             public override LocalisableString TooltipText =>
                 (Current.IsDefault ? DefaultTooltip : Current.Value.ToString($@"0.## {TooltipSuffix}")) ?? Current.Value.ToString($@"0.## {TooltipSuffix}");
 
@@ -259,6 +257,18 @@ namespace osu.Game.Graphics.UserInterface
                     return screenSpacePos.X > rangeSlider.ScreenSpaceHalfwayPoint.X;
 
                 return screenSpacePos.X <= rangeSlider.ScreenSpaceHalfwayPoint.X;
+            }
+
+            protected override void UpdateAfterChildren()
+            {
+                base.UpdateAfterChildren();
+
+                if (isUpper)
+                {
+                    // Only draw left box where required to avoid masking bleed issues.
+                    LeftBox.X = ToParentSpace(ToLocalSpace(rangeSlider.LowerBoundSlider.Nub.ScreenSpaceDrawQuad.Centre)).X;
+                    LeftBox.Size -= new Vector2(LeftBox.X, 0);
+                }
             }
 
             protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
@@ -92,10 +92,6 @@ namespace osu.Game.Graphics.UserInterface
             this.label = label;
         }
 
-        // Special case: we want to limit input to the bounds of this control but not enable masking (which would break with shear).
-        protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos)
-            => ReceivePositionalInputAt(screenSpacePos);
-
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
@@ -254,9 +250,9 @@ namespace osu.Game.Graphics.UserInterface
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
             {
                 if (isUpper)
-                    return screenSpacePos.X > rangeSlider.ScreenSpaceHalfwayPoint.X;
+                    return base.ReceivePositionalInputAt(screenSpacePos) && screenSpacePos.X > rangeSlider.ScreenSpaceHalfwayPoint.X;
 
-                return screenSpacePos.X <= rangeSlider.ScreenSpaceHalfwayPoint.X;
+                return base.ReceivePositionalInputAt(screenSpacePos) && screenSpacePos.X <= rangeSlider.ScreenSpaceHalfwayPoint.X;
             }
 
             protected override void UpdateAfterChildren()

--- a/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
@@ -1,0 +1,253 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public partial class ShearedRangeSlider : CompositeDrawable
+    {
+        private readonly LocalisableString label;
+
+        private readonly BindableNumberWithCurrent<double> lowerBound = new BindableNumberWithCurrent<double>();
+
+        /// <summary>
+        /// The lower limiting value.
+        /// </summary>
+        public Bindable<double> LowerBound
+        {
+            get => lowerBound.Current;
+            set => lowerBound.Current = value;
+        }
+
+        private readonly BindableNumberWithCurrent<double> upperBound = new BindableNumberWithCurrent<double>();
+
+        /// <summary>
+        /// The upper limiting value.
+        /// </summary>
+        public Bindable<double> UpperBound
+        {
+            get => upperBound.Current;
+            set => upperBound.Current = value;
+        }
+
+        public float NubWidth { get; init; }
+
+        /// <summary>
+        /// Minimum difference between the lower bound and higher bound
+        /// </summary>
+        public float MinRange
+        {
+            set => minRange = value;
+        }
+
+        /// <summary>
+        /// Lower bound display for when it is set to its default value.
+        /// </summary>
+        public string DefaultStringLowerBound { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Upper bound display for when it is set to its default value.
+        /// </summary>
+        public string DefaultStringUpperBound { get; init; } = string.Empty;
+
+        public LocalisableString DefaultTooltipLowerBound { get; init; } = string.Empty;
+
+        public LocalisableString DefaultTooltipUpperBound { get; init; } = string.Empty;
+
+        public string TooltipSuffix { get; init; } = string.Empty;
+
+        private float minRange = 0.1f;
+
+        protected Container SliderContainer { get; private set; } = null!;
+        protected BoundSliderBar LowerBoundSlider { get; private set; } = null!;
+        protected BoundSliderBar UpperBoundSlider { get; private set; } = null!;
+
+        public ShearedRangeSlider(LocalisableString label)
+        {
+            this.label = label;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            Height = ShearedNub.HEIGHT;
+
+            InternalChild = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                ColumnDimensions = new[]
+                {
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(),
+                },
+                Content = new[]
+                {
+                    new[]
+                    {
+                        new Container
+                        {
+                            AutoSizeAxes = Axes.X,
+                            RelativeSizeAxes = Axes.Y,
+                            Masking = true,
+                            CornerRadius = 5f,
+                            Shear = OsuGame.SHEAR,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = colourProvider.Background3,
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Text = label,
+                                    Shear = -OsuGame.SHEAR,
+                                    Margin = new MarginPadding { Horizontal = 12, Vertical = 5 },
+                                    Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
+                                },
+                            },
+                        },
+                        SliderContainer = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Left = -10 },
+                            Children = new[]
+                            {
+                                UpperBoundSlider = CreateBoundSlider(true).With(d =>
+                                {
+                                    d.KeyboardStep = 0.1f;
+                                    d.RelativeSizeAxes = Axes.X;
+                                    d.TooltipSuffix = TooltipSuffix;
+                                    d.DefaultString = DefaultStringUpperBound;
+                                    d.DefaultTooltip = DefaultTooltipUpperBound;
+                                    d.NubWidth = NubWidth;
+                                    d.Current = upperBound;
+                                }),
+                                LowerBoundSlider = CreateBoundSlider(false).With(d =>
+                                {
+                                    d.KeyboardStep = 0.1f;
+                                    d.RelativeSizeAxes = Axes.X;
+                                    d.TooltipSuffix = TooltipSuffix;
+                                    d.DefaultString = DefaultStringLowerBound;
+                                    d.DefaultTooltip = DefaultTooltipLowerBound;
+                                    d.NubWidth = NubWidth;
+                                    d.Current = lowerBound;
+                                }),
+                                UpperBoundSlider.Nub.CreateProxy(),
+                                LowerBoundSlider.Nub.CreateProxy(),
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            LowerBoundSlider.Current.ValueChanged += min => UpperBoundSlider.Current.Value = Math.Max(min.NewValue + minRange, UpperBoundSlider.Current.Value);
+            UpperBoundSlider.Current.ValueChanged += max => LowerBoundSlider.Current.Value = Math.Min(max.NewValue - minRange, LowerBoundSlider.Current.Value);
+        }
+
+        protected virtual BoundSliderBar CreateBoundSlider(bool isUpper) => new BoundSliderBar(isUpper);
+
+        protected partial class BoundSliderBar : ShearedSliderBar<double>
+        {
+            private readonly bool isUpper;
+
+            public new ShearedNub Nub => base.Nub;
+
+            public string? DefaultString;
+            public LocalisableString? DefaultTooltip;
+            public string? TooltipSuffix;
+
+            public float NubWidth { get; set; } = ShearedNub.HEIGHT;
+
+            public new float NormalizedValue => base.NormalizedValue;
+
+            public override LocalisableString TooltipText =>
+                (Current.IsDefault ? DefaultTooltip : Current.Value.ToString($@"0.## {TooltipSuffix}")) ?? Current.Value.ToString($@"0.## {TooltipSuffix}");
+
+            protected OsuSpriteText NubText { get; private set; } = null!;
+
+            public override bool AcceptsFocus => false;
+
+            public BoundSliderBar(bool isUpper)
+            {
+                this.isUpper = isUpper;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                Nub.Width = NubWidth;
+                RangePadding = Nub.Width / 2;
+
+                Nub.Add(NubText = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    X = -3,
+                    UseFullGlyphHeight = false,
+                    Colour = OsuColour.ForegroundTextColourFor(colourProvider.Light1),
+                    Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
+                });
+
+                AccentColour = colourProvider.Highlight1.Darken(0.1f);
+                Nub.AccentColour = colourProvider.Highlight1;
+                Nub.GlowingAccentColour = colourProvider.Highlight1;
+                Nub.GlowColour = colourProvider.Highlight1;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                if (!isUpper)
+                {
+                    AccentColour = BackgroundColour;
+                    BackgroundColour = Color4.Transparent;
+                }
+
+                Current.BindValueChanged(current => UpdateDisplay(current.NewValue), true);
+                FinishTransforms(true);
+            }
+
+            protected virtual void UpdateDisplay(double value)
+            {
+                string defaultString = DefaultString ?? value.ToString("N1");
+                NubText.Text = Current.IsDefault ? defaultString : value.ToString("N1");
+            }
+
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+            {
+                if (isUpper)
+                    return base.ReceivePositionalInputAt(screenSpacePos) && screenSpacePos.X >= Nub.ScreenSpaceDrawQuad.TopLeft.X;
+
+                return base.ReceivePositionalInputAt(screenSpacePos) && screenSpacePos.X <= Nub.ScreenSpaceDrawQuad.TopRight.X;
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                base.OnHover(e);
+                return true; // Make sure only one nub shows hover effect at once.
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ShearedSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSliderBar.cs
@@ -73,33 +73,25 @@ namespace osu.Game.Graphics.UserInterface
                 mainContent = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    CornerRadius = 5,
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    Child = new Container
+                    Masking = true,
+                    CornerRadius = 5,
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Masking = true,
-                        CornerRadius = 5,
-                        Children = new Drawable[]
+                        LeftBox = new Box
                         {
-                            LeftBox = new Box
-                            {
-                                EdgeSmoothness = new Vector2(0, 0.5f),
-                                RelativeSizeAxes = Axes.Y,
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                            },
-                            RightBox = new Box
-                            {
-                                EdgeSmoothness = new Vector2(0, 0.5f),
-                                RelativeSizeAxes = Axes.Y,
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                            },
+                            EdgeSmoothness = new Vector2(0, 0.5f),
+                            RelativeSizeAxes = Axes.Y,
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                        },
+                        RightBox = new Box
+                        {
+                            EdgeSmoothness = new Vector2(0, 0.5f),
+                            RelativeSizeAxes = Axes.Y,
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.CentreRight,
                         },
                     },
                 },
@@ -200,8 +192,9 @@ namespace osu.Game.Graphics.UserInterface
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
-            LeftBox.Scale = new Vector2(Math.Clamp(RangePadding + Nub.DrawPosition.X - Nub.DrawWidth / 2f + ShearedNub.CORNER_RADIUS - 0.5f, 0, Math.Max(0, DrawWidth)), 1);
-            RightBox.Scale = new Vector2(Math.Clamp(DrawWidth - RangePadding - Nub.DrawPosition.X - Nub.DrawWidth / 2f + ShearedNub.CORNER_RADIUS - 0.5f, 0, Math.Max(0, DrawWidth)), 1);
+
+            LeftBox.Size = new Vector2(Math.Clamp(RangePadding + Nub.DrawPosition.X - Nub.DrawWidth / 2f + ShearedNub.CORNER_RADIUS - 0.5f, 0, Math.Max(0, DrawWidth)), 1);
+            RightBox.Size = new Vector2(Math.Clamp(DrawWidth - RangePadding - Nub.DrawPosition.X - Nub.DrawWidth / 2f + ShearedNub.CORNER_RADIUS - 0.5f, 0, Math.Max(0, DrawWidth)), 1);
         }
 
         protected override void UpdateValue(float value)


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/32847
- Split from https://github.com/ppy/osu/pull/32715

To be used in new song select's filter control for star rating filtering.

Preview:

https://github.com/user-attachments/assets/efeb5891-478f-476f-8264-67f93217fc28

Notes:
 - There seem to be masking-related issues with the left background of the range slider having a light outline. Not quite sure how to fix, and is not that visible in the star rating variant.