### PR TITLE
Fix storyboard videos not displaying

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
@@ -2,12 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -48,7 +50,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestVideoSize()
+        public void TestVideo()
         {
             AddStep("load storyboard with only video", () =>
             {
@@ -56,6 +58,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 loadStoryboard("storyboard_only_video.osu", s => s.Beatmap.WidescreenStoryboard = false);
             });
 
+            AddAssert("storyboard video present in hierarchy", () => this.ChildrenOfType<DrawableStoryboardVideo>().Any());
             AddAssert("storyboard is correct width", () => Precision.AlmostEquals(storyboard?.Width ?? 0f, 480 * 16 / 9f));
         }
 

--- a/osu.Game/Storyboards/StoryboardSprite.cs
+++ b/osu.Game/Storyboards/StoryboardSprite.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Storyboards
         private readonly List<StoryboardTriggerGroup> triggerGroups = new List<StoryboardTriggerGroup>();
 
         public string Path { get; }
-        public bool IsDrawable => HasCommands;
+        public virtual bool IsDrawable => HasCommands;
 
         public Anchor Origin;
         public Vector2 InitialPosition;

--- a/osu.Game/Storyboards/StoryboardVideo.cs
+++ b/osu.Game/Storyboards/StoryboardVideo.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Storyboards
 
         public override double StartTime { get; }
 
+        public override bool IsDrawable => true;
+
         public override Drawable CreateDrawable() => new DrawableStoryboardVideo(this);
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32846.

Regressed with https://github.com/ppy/osu/commit/102085668f84bd80f1717f101adc22fc7075e7fa because the stupid magic alpha transform addition was also implicitly changing the value of `IsDrawable` from false to true because that property checks for presence of any commands.

https://github.com/ppy/osu/blob/5791375b38bb16838e897f8935c4564661425cdf/osu.Game/Storyboards/StoryboardSprite.cs#L20

https://github.com/ppy/osu/blob/5791375b38bb16838e897f8935c4564661425cdf/osu.Game/Storyboards/StoryboardSprite.cs#L111

Apparently past me, in his infinite wisdom, did not decide it pertinent to test that change against, you know, *a beatmap with a storyboard video*. Great job, past me, good show all around.