### PR TITLE
Fix slider tooltip text not updating with current value

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -83,6 +83,6 @@ namespace osu.Game.Graphics.UserInterface
             channel.Play();
         }
 
-        public LocalisableString GetDisplayableValue(T value) => CurrentNumber.Value.ToStandardFormattedString(max_decimal_digits, DisplayAsPercentage);
+        public LocalisableString GetDisplayableValue(T value) => value.ToStandardFormattedString(max_decimal_digits, DisplayAsPercentage);
     }
 }


### PR DESCRIPTION
Fixes #32878.

All instances of `OsuSliderBar` (and classes which inherit from it) were not updating their tooltip text properly if the slider had the `TransferValueOnCommit` property set to `true` because of the wrong value being used to create the formatted tooltip text.