### PR TITLE
Fix slider repeat arrows appearing too early in editor when hit markers are enabled

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -176,9 +176,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 // More or less matches stable (see https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjects/Osu/HitCircleOsu.cs#L336-L338)
                 AccentColour.Value = Color4.White;
                 Alpha = Interpolation.ValueAt(Time.Current, 1f, 0f, HitStateUpdateTime, HitStateUpdateTime + 700);
+                Arrow.Alpha = 0;
             }
-
-            Arrow.Alpha = hit ? 0 : 1;
 
             LifetimeEnd = HitStateUpdateTime + 700;
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32880

Broke in conjunction with https://github.com/ppy/osu/pull/32638 because of transforms not being applied to `DrawableSliderRepeat` but its individual pieces instead.

In cross-checking with stable (visual only) the early fade in of the arrow should still apply, it just shouldn't be instantaneous as is currently ends up being with how the code is structured.