### PR TITLE
Add more test cases covering correct legacy replay playback with respect to hitwindow treatment with mods active

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
@@ -297,34 +297,202 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 3.1f, -123d, HitResult.Miss },
         };
 
+        private static readonly object[][] score_v1_non_convert_hard_rock_test_cases =
+        {
+            // OD = 5 test cases.
+            // This leads to "effective" OD of 7.
+            // PERFECT hit window is [-11ms, 11ms]
+            // GREAT   hit window is [-35ms, 35ms]
+            // GOOD    hit window is [-58ms, 58ms]
+            // OK      hit window is [-80ms, 80ms) <- not a typo, this side of the interval is OPEN!
+            // MEH     hit window is [-97ms, ----) <- it is NOT POSSIBLE to get a MEH result on a late hit!
+            new object[] { 5f, -10d, HitResult.Perfect },
+            new object[] { 5f, -11d, HitResult.Perfect },
+            new object[] { 5f, -12d, HitResult.Great },
+            new object[] { 5f, -13d, HitResult.Great },
+            new object[] { 5f, -34d, HitResult.Great },
+            new object[] { 5f, -35d, HitResult.Great },
+            new object[] { 5f, -36d, HitResult.Good },
+            new object[] { 5f, -37d, HitResult.Good },
+            new object[] { 5f, -57d, HitResult.Good },
+            new object[] { 5f, -58d, HitResult.Good },
+            new object[] { 5f, -59d, HitResult.Ok },
+            new object[] { 5f, -60d, HitResult.Ok },
+            new object[] { 5f, -79d, HitResult.Ok },
+            new object[] { 5f, -80d, HitResult.Ok },
+            new object[] { 5f, -81d, HitResult.Meh },
+            new object[] { 5f, -82d, HitResult.Meh },
+            new object[] { 5f, -96d, HitResult.Meh },
+            new object[] { 5f, -97d, HitResult.Meh },
+            new object[] { 5f, -98d, HitResult.Miss },
+            new object[] { 5f, -99d, HitResult.Miss },
+            new object[] { 5f, 79d, HitResult.Ok },
+            new object[] { 5f, 80d, HitResult.Miss },
+            new object[] { 5f, 81d, HitResult.Miss },
+            new object[] { 5f, 82d, HitResult.Miss },
+            new object[] { 5f, 96d, HitResult.Miss },
+            new object[] { 5f, 97d, HitResult.Miss },
+            new object[] { 5f, 98d, HitResult.Miss },
+            new object[] { 5f, 99d, HitResult.Miss },
+
+            // OD = 9.3 test cases.
+            // This leads to "effective" OD of 13.02.
+            // Note that contrary to other rulesets this does NOT cap out to OD 10!
+            // PERFECT hit window is [-11ms, 11ms]
+            // GREAT   hit window is [-25ms, 25ms]
+            // GOOD    hit window is [-49ms, 49ms]
+            // OK      hit window is [-70ms, 70ms) <- not a typo, this side of the interval is OPEN!
+            // MEH     hit window is [-87ms, ----) <- it is NOT POSSIBLE to get a MEH result on a late hit!
+            new object[] { 9.3f, 10d, HitResult.Perfect },
+            new object[] { 9.3f, 11d, HitResult.Perfect },
+            new object[] { 9.3f, 12d, HitResult.Great },
+            new object[] { 9.3f, 13d, HitResult.Great },
+            new object[] { 9.3f, 24d, HitResult.Great },
+            new object[] { 9.3f, 25d, HitResult.Great },
+            new object[] { 9.3f, 26d, HitResult.Good },
+            new object[] { 9.3f, 27d, HitResult.Good },
+            new object[] { 9.3f, 48d, HitResult.Good },
+            new object[] { 9.3f, 49d, HitResult.Good },
+            new object[] { 9.3f, 50d, HitResult.Ok },
+            new object[] { 9.3f, 51d, HitResult.Ok },
+            new object[] { 9.3f, 69d, HitResult.Ok },
+            new object[] { 9.3f, 70d, HitResult.Miss },
+            new object[] { 9.3f, 71d, HitResult.Miss },
+            new object[] { 9.3f, 72d, HitResult.Miss },
+            new object[] { 9.3f, 86d, HitResult.Miss },
+            new object[] { 9.3f, 87d, HitResult.Miss },
+            new object[] { 9.3f, 88d, HitResult.Miss },
+            new object[] { 9.3f, 89d, HitResult.Miss },
+            new object[] { 9.3f, -69d, HitResult.Ok },
+            new object[] { 9.3f, -70d, HitResult.Ok },
+            new object[] { 9.3f, -71d, HitResult.Meh },
+            new object[] { 9.3f, -72d, HitResult.Meh },
+            new object[] { 9.3f, -86d, HitResult.Meh },
+            new object[] { 9.3f, -87d, HitResult.Meh },
+            new object[] { 9.3f, -88d, HitResult.Miss },
+            new object[] { 9.3f, -89d, HitResult.Miss },
+        };
+
+        private static readonly object[][] score_v1_non_convert_easy_test_cases =
+        {
+            // Assume OD = 5 (other values are not tested, even OD 5 is enough to exercise the flooring logic).
+            // PERFECT hit window is [ -22ms,  22ms]
+            // GREAT   hit window is [ -68ms,  68ms]
+            // GOOD    hit window is [-114ms, 114ms]
+            // OK      hit window is [-156ms, 156ms) <- not a typo, this side of the interval is OPEN!
+            // MEH     hit window is [-190ms, -----) <- it is NOT POSSIBLE to get a MEH result on a late hit!
+            new object[] { 5f, -21d, HitResult.Perfect },
+            new object[] { 5f, -22d, HitResult.Perfect },
+            new object[] { 5f, -23d, HitResult.Great },
+            new object[] { 5f, -24d, HitResult.Great },
+            new object[] { 5f, -67d, HitResult.Great },
+            new object[] { 5f, -68d, HitResult.Great },
+            new object[] { 5f, -69d, HitResult.Good },
+            new object[] { 5f, -70d, HitResult.Good },
+            new object[] { 5f, -113d, HitResult.Good },
+            new object[] { 5f, -114d, HitResult.Good },
+            new object[] { 5f, -115d, HitResult.Ok },
+            new object[] { 5f, -116d, HitResult.Ok },
+            new object[] { 5f, -155d, HitResult.Ok },
+            new object[] { 5f, -156d, HitResult.Ok },
+            new object[] { 5f, -157d, HitResult.Meh },
+            new object[] { 5f, -158d, HitResult.Meh },
+            new object[] { 5f, -189d, HitResult.Meh },
+            new object[] { 5f, -190d, HitResult.Meh },
+            new object[] { 5f, -191d, HitResult.Miss },
+            new object[] { 5f, -192d, HitResult.Miss },
+            new object[] { 5f, 155d, HitResult.Ok },
+            new object[] { 5f, 156d, HitResult.Miss },
+            new object[] { 5f, 157d, HitResult.Miss },
+            new object[] { 5f, 158d, HitResult.Miss },
+            new object[] { 5f, 189d, HitResult.Miss },
+            new object[] { 5f, 190d, HitResult.Miss },
+            new object[] { 5f, 191d, HitResult.Miss },
+            new object[] { 5f, 192d, HitResult.Miss },
+        };
+
+        private static readonly object[][] score_v1_non_convert_double_time_test_cases =
+        {
+            // Assume OD = 5 (other values are not tested, even OD 5 is enough to exercise the flooring logic).
+            // PERFECT hit window is [ -24ms,  24ms]
+            // GREAT   hit window is [ -73ms,  73ms]
+            // GOOD    hit window is [-123ms, 123ms]
+            // OK      hit window is [-168ms, 168ms) <- not a typo, this side of the interval is OPEN!
+            // MEH     hit window is [-204ms, -----) <- it is NOT POSSIBLE to get a MEH result on a late hit!
+            new object[] { 5f, -23d, HitResult.Perfect },
+            new object[] { 5f, -24d, HitResult.Perfect },
+            new object[] { 5f, -25d, HitResult.Great },
+            new object[] { 5f, -26d, HitResult.Great },
+            new object[] { 5f, -72d, HitResult.Great },
+            new object[] { 5f, -73d, HitResult.Great },
+            new object[] { 5f, -74d, HitResult.Good },
+            new object[] { 5f, -75d, HitResult.Good },
+            new object[] { 5f, -122d, HitResult.Good },
+            new object[] { 5f, -123d, HitResult.Good },
+            new object[] { 5f, -124d, HitResult.Ok },
+            new object[] { 5f, -125d, HitResult.Ok },
+            new object[] { 5f, -167d, HitResult.Ok },
+            new object[] { 5f, -168d, HitResult.Ok },
+            new object[] { 5f, -169d, HitResult.Meh },
+            new object[] { 5f, -170d, HitResult.Meh },
+            new object[] { 5f, -203d, HitResult.Meh },
+            new object[] { 5f, -204d, HitResult.Meh },
+            new object[] { 5f, -205d, HitResult.Miss },
+            new object[] { 5f, -206d, HitResult.Miss },
+            new object[] { 5f, 167d, HitResult.Ok },
+            new object[] { 5f, 168d, HitResult.Miss },
+            new object[] { 5f, 169d, HitResult.Miss },
+            new object[] { 5f, 170d, HitResult.Miss },
+            new object[] { 5f, 203d, HitResult.Miss },
+            new object[] { 5f, 204d, HitResult.Miss },
+            new object[] { 5f, 205d, HitResult.Miss },
+            new object[] { 5f, 206d, HitResult.Miss },
+        };
+
+        private static readonly object[][] score_v1_non_convert_half_time_test_cases =
+        {
+            // Assume OD = 5 (other values are not tested, even OD 5 is enough to exercise the flooring logic).
+            // PERFECT hit window is [ -12ms,  12ms]
+            // GREAT   hit window is [ -36ms,  36ms]
+            // GOOD    hit window is [ -61ms,  61ms]
+            // OK      hit window is [ -84ms,  84ms) <- not a typo, this side of the interval is OPEN!
+            // MEH     hit window is [-102ms, -----) <- it is NOT POSSIBLE to get a MEH result on a late hit!
+            new object[] { 5f, -11d, HitResult.Perfect },
+            new object[] { 5f, -12d, HitResult.Perfect },
+            new object[] { 5f, -13d, HitResult.Great },
+            new object[] { 5f, -14d, HitResult.Great },
+            new object[] { 5f, -35d, HitResult.Great },
+            new object[] { 5f, -36d, HitResult.Great },
+            new object[] { 5f, -37d, HitResult.Good },
+            new object[] { 5f, -38d, HitResult.Good },
+            new object[] { 5f, -60d, HitResult.Good },
+            new object[] { 5f, -61d, HitResult.Good },
+            new object[] { 5f, -62d, HitResult.Ok },
+            new object[] { 5f, -63d, HitResult.Ok },
+            new object[] { 5f, -83d, HitResult.Ok },
+            new object[] { 5f, -84d, HitResult.Ok },
+            new object[] { 5f, -85d, HitResult.Meh },
+            new object[] { 5f, -86d, HitResult.Meh },
+            new object[] { 5f, -101d, HitResult.Meh },
+            new object[] { 5f, -102d, HitResult.Meh },
+            new object[] { 5f, -103d, HitResult.Miss },
+            new object[] { 5f, -104d, HitResult.Miss },
+            new object[] { 5f, 83d, HitResult.Ok },
+            new object[] { 5f, 84d, HitResult.Miss },
+            new object[] { 5f, 85d, HitResult.Miss },
+            new object[] { 5f, 86d, HitResult.Miss },
+            new object[] { 5f, 101d, HitResult.Miss },
+            new object[] { 5f, 102d, HitResult.Miss },
+            new object[] { 5f, 103d, HitResult.Miss },
+            new object[] { 5f, 104d, HitResult.Miss },
+        };
+
+        private const double note_time = 300;
+
         [TestCaseSource(nameof(score_v2_test_cases))]
         public void TestHitWindowTreatmentWithScoreV2(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
-            const double note_time = 300;
-
-            var cpi = new ControlPointInfo();
-            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
-            var beatmap = new ManiaBeatmap(new StageDefinition(1))
-            {
-                HitObjects =
-                {
-                    new Note
-                    {
-                        StartTime = note_time,
-                        Column = 0,
-                    }
-                },
-                Difficulty = new BeatmapDifficulty
-                {
-                    OverallDifficulty = overallDifficulty,
-                    CircleSize = 1,
-                },
-                BeatmapInfo =
-                {
-                    Ruleset = new ManiaRuleset().RulesetInfo,
-                },
-                ControlPointInfo = cpi,
-            };
+            var beatmap = createNonConvertBeatmap(overallDifficulty);
 
             var replay = new Replay
             {
@@ -352,31 +520,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [TestCaseSource(nameof(score_v1_non_convert_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1NonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
-            const double note_time = 300;
-
-            var cpi = new ControlPointInfo();
-            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
-            var beatmap = new ManiaBeatmap(new StageDefinition(1))
-            {
-                HitObjects =
-                {
-                    new Note
-                    {
-                        StartTime = note_time,
-                        Column = 0,
-                    }
-                },
-                Difficulty = new BeatmapDifficulty
-                {
-                    OverallDifficulty = overallDifficulty,
-                    CircleSize = 1,
-                },
-                BeatmapInfo =
-                {
-                    Ruleset = new ManiaRuleset().RulesetInfo,
-                },
-                ControlPointInfo = cpi,
-            };
+            var beatmap = createNonConvertBeatmap(overallDifficulty);
 
             var replay = new Replay
             {
@@ -403,29 +547,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [TestCaseSource(nameof(score_v1_convert_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1Convert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
-            const double note_time = 300;
-
-            var cpi = new ControlPointInfo();
-            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
-            var beatmap = new Beatmap
-            {
-                HitObjects =
-                {
-                    new FakeCircle
-                    {
-                        StartTime = note_time,
-                    }
-                },
-                Difficulty = new BeatmapDifficulty
-                {
-                    OverallDifficulty = overallDifficulty,
-                },
-                BeatmapInfo =
-                {
-                    Ruleset = new RulesetInfo { OnlineID = 0 }
-                },
-                ControlPointInfo = cpi,
-            };
+            var beatmap = createConvertBeatmap(overallDifficulty);
 
             var replay = new Replay
             {
@@ -448,6 +570,172 @@ namespace osu.Game.Rulesets.Mania.Tests
             };
 
             RunTest($@"SV1 convert single note @ OD{overallDifficulty}", beatmap, $@"SV1 convert {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        [TestCaseSource(nameof(score_v1_non_convert_hard_rock_test_cases))]
+        public void TestHitWindowTreatmentWithScoreV1AndHardRockNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            var beatmap = createNonConvertBeatmap(overallDifficulty);
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new ManiaReplayFrame(0),
+                    new ManiaReplayFrame(note_time + hitOffset, ManiaAction.Key1),
+                    new ManiaReplayFrame(note_time + hitOffset + 20),
+                }
+            };
+
+            var score = new Score
+            {
+                Replay = replay,
+                ScoreInfo = new ScoreInfo
+                {
+                    Ruleset = CreateRuleset().RulesetInfo,
+                    Mods = [new ManiaModHardRock()],
+                }
+            };
+
+            RunTest($@"SV1+HR single note @ OD{overallDifficulty}", beatmap, $@"SV1+HR {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        [TestCaseSource(nameof(score_v1_non_convert_easy_test_cases))]
+        public void TestHitWindowTreatmentWithScoreV1AndEasyNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            var beatmap = createNonConvertBeatmap(overallDifficulty);
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new ManiaReplayFrame(0),
+                    new ManiaReplayFrame(note_time + hitOffset, ManiaAction.Key1),
+                    new ManiaReplayFrame(note_time + hitOffset + 20),
+                }
+            };
+
+            var score = new Score
+            {
+                Replay = replay,
+                ScoreInfo = new ScoreInfo
+                {
+                    Ruleset = CreateRuleset().RulesetInfo,
+                    Mods = [new ManiaModEasy()],
+                }
+            };
+
+            RunTest($@"SV1+EZ single note @ OD{overallDifficulty}", beatmap, $@"SV1+EZ {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        [TestCaseSource(nameof(score_v1_non_convert_double_time_test_cases))]
+        public void TestHitWindowTreatmentWithScoreV1AndDoubleTimeNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            var beatmap = createNonConvertBeatmap(overallDifficulty);
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new ManiaReplayFrame(0),
+                    new ManiaReplayFrame(note_time + hitOffset, ManiaAction.Key1),
+                    new ManiaReplayFrame(note_time + hitOffset + 20),
+                }
+            };
+
+            var score = new Score
+            {
+                Replay = replay,
+                ScoreInfo = new ScoreInfo
+                {
+                    Ruleset = CreateRuleset().RulesetInfo,
+                    Mods = [new ManiaModDoubleTime()],
+                }
+            };
+
+            RunTest($@"SV1+DT single note @ OD{overallDifficulty}", beatmap, $@"SV1+DT {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        [TestCaseSource(nameof(score_v1_non_convert_half_time_test_cases))]
+        public void TestHitWindowTreatmentWithScoreV1AndHalfTimeNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            var beatmap = createNonConvertBeatmap(overallDifficulty);
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new ManiaReplayFrame(0),
+                    new ManiaReplayFrame(note_time + hitOffset, ManiaAction.Key1),
+                    new ManiaReplayFrame(note_time + hitOffset + 20),
+                }
+            };
+
+            var score = new Score
+            {
+                Replay = replay,
+                ScoreInfo = new ScoreInfo
+                {
+                    Ruleset = CreateRuleset().RulesetInfo,
+                    Mods = [new ManiaModHalfTime()],
+                }
+            };
+
+            RunTest($@"SV1+HT single note @ OD{overallDifficulty}", beatmap, $@"SV1+HT {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        private static ManiaBeatmap createNonConvertBeatmap(float overallDifficulty)
+        {
+            var cpi = new ControlPointInfo();
+            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
+            var beatmap = new ManiaBeatmap(new StageDefinition(1))
+            {
+                HitObjects =
+                {
+                    new Note
+                    {
+                        StartTime = note_time,
+                        Column = 0,
+                    }
+                },
+                Difficulty = new BeatmapDifficulty
+                {
+                    OverallDifficulty = overallDifficulty,
+                    CircleSize = 1,
+                },
+                BeatmapInfo =
+                {
+                    Ruleset = new ManiaRuleset().RulesetInfo,
+                },
+                ControlPointInfo = cpi,
+            };
+            return beatmap;
+        }
+
+        private static Beatmap createConvertBeatmap(float overallDifficulty)
+        {
+            var cpi = new ControlPointInfo();
+            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
+            var beatmap = new Beatmap
+            {
+                HitObjects =
+                {
+                    new FakeCircle
+                    {
+                        StartTime = note_time,
+                    }
+                },
+                Difficulty = new BeatmapDifficulty
+                {
+                    OverallDifficulty = overallDifficulty,
+                },
+                BeatmapInfo =
+                {
+                    Ruleset = new RulesetInfo { OnlineID = 0 }
+                },
+                ControlPointInfo = cpi,
+            };
+            return beatmap;
         }
 
         private class FakeCircle : HitObject, IHasPosition

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneLegacyReplayPlayback.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneLegacyReplayPlayback.cs
@@ -7,6 +7,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Beatmaps;
+using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Replays;
 using osu.Game.Scoring;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         protected override Ruleset CreateRuleset() => new TaikoRuleset();
 
-        private static readonly object[][] test_cases =
+        private static readonly object[][] no_mod_test_cases =
         {
             // With respect to notation,
             // square brackets `[]` represent *closed* or *inclusive* bounds,
@@ -52,30 +53,58 @@ namespace osu.Game.Rulesets.Taiko.Tests
             new object[] { 7.8f, -64d, HitResult.Miss },
         };
 
-        [TestCaseSource(nameof(test_cases))]
+        private static readonly object[][] hard_rock_test_cases =
+        {
+            // OD = 5 test cases.
+            // This leads to "effective" OD of 7.
+            // GREAT hit window is (-29ms, 29ms)
+            // OK    hit window is (-68ms, 68ms)
+            new object[] { 5f, -27d, HitResult.Great },
+            new object[] { 5f, -28d, HitResult.Great },
+            new object[] { 5f, -29d, HitResult.Ok },
+            new object[] { 5f, -30d, HitResult.Ok },
+            new object[] { 5f, -66d, HitResult.Ok },
+            new object[] { 5f, -67d, HitResult.Ok },
+            new object[] { 5f, -68d, HitResult.Miss },
+            new object[] { 5f, -69d, HitResult.Miss },
+
+            // OD = 7.8 test cases.
+            // This would lead to "effective" OD of 10.92,
+            // but the effects are capped to OD 10.
+            // GREAT hit window is (-20ms, 20ms)
+            // OK    hit window is (-50ms, 50ms)
+            new object[] { 7.8f, -18d, HitResult.Great },
+            new object[] { 7.8f, -19d, HitResult.Great },
+            new object[] { 7.8f, -20d, HitResult.Ok },
+            new object[] { 7.8f, -21d, HitResult.Ok },
+            new object[] { 7.8f, -48d, HitResult.Ok },
+            new object[] { 7.8f, -49d, HitResult.Ok },
+            new object[] { 7.8f, -50d, HitResult.Miss },
+            new object[] { 7.8f, -51d, HitResult.Miss },
+        };
+
+        private static readonly object[][] easy_test_cases =
+        {
+            // OD = 5 test cases.
+            // This leads to "effective" OD of 2.5.
+            // GREAT hit window is ( -42ms,  42ms)
+            // OK    hit window is (-100ms, 100ms)
+            new object[] { 5f, -40d, HitResult.Great },
+            new object[] { 5f, -41d, HitResult.Great },
+            new object[] { 5f, -42d, HitResult.Ok },
+            new object[] { 5f, -43d, HitResult.Ok },
+            new object[] { 5f, -98d, HitResult.Ok },
+            new object[] { 5f, -99d, HitResult.Ok },
+            new object[] { 5f, -100d, HitResult.Miss },
+            new object[] { 5f, -101d, HitResult.Miss },
+        };
+
+        private const double hit_time = 100;
+
+        [TestCaseSource(nameof(no_mod_test_cases))]
         public void TestHitWindowTreatment(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
-            const double hit_time = 100;
-
-            var cpi = new ControlPointInfo();
-            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
-            var beatmap = new TaikoBeatmap
-            {
-                HitObjects =
-                {
-                    new Hit
-                    {
-                        StartTime = hit_time,
-                        Type = HitType.Centre,
-                    }
-                },
-                Difficulty = new BeatmapDifficulty { OverallDifficulty = overallDifficulty },
-                BeatmapInfo =
-                {
-                    Ruleset = new TaikoRuleset().RulesetInfo,
-                },
-                ControlPointInfo = cpi,
-            };
+            var beatmap = createBeatmap(overallDifficulty);
 
             var replay = new Replay
             {
@@ -97,6 +126,86 @@ namespace osu.Game.Rulesets.Taiko.Tests
             };
 
             RunTest($@"single hit @ OD{overallDifficulty}", beatmap, $@"{hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        [TestCaseSource(nameof(hard_rock_test_cases))]
+        public void TestHitWindowTreatmentWithHardRock(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            var beatmap = createBeatmap(overallDifficulty);
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new TaikoReplayFrame(0),
+                    new TaikoReplayFrame(hit_time + hitOffset, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(hit_time + hitOffset + 20),
+                }
+            };
+
+            var score = new Score
+            {
+                Replay = replay,
+                ScoreInfo = new ScoreInfo
+                {
+                    Ruleset = CreateRuleset().RulesetInfo,
+                    Mods = [new TaikoModHardRock()]
+                }
+            };
+
+            RunTest($@"HR single hit @ OD{overallDifficulty}", beatmap, $@"HR {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        [TestCaseSource(nameof(easy_test_cases))]
+        public void TestHitWindowTreatmentWithEasy(float overallDifficulty, double hitOffset, HitResult expectedResult)
+        {
+            var beatmap = createBeatmap(overallDifficulty);
+
+            var replay = new Replay
+            {
+                Frames =
+                {
+                    new TaikoReplayFrame(0),
+                    new TaikoReplayFrame(hit_time + hitOffset, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(hit_time + hitOffset + 20),
+                }
+            };
+
+            var score = new Score
+            {
+                Replay = replay,
+                ScoreInfo = new ScoreInfo
+                {
+                    Ruleset = CreateRuleset().RulesetInfo,
+                    Mods = [new TaikoModHardRock()]
+                }
+            };
+
+            RunTest($@"EZ single hit @ OD{overallDifficulty}", beatmap, $@"EZ {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
+        }
+
+        private static TaikoBeatmap createBeatmap(float overallDifficulty)
+        {
+            var cpi = new ControlPointInfo();
+            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
+            var beatmap = new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new Hit
+                    {
+                        StartTime = hit_time,
+                        Type = HitType.Centre,
+                    }
+                },
+                Difficulty = new BeatmapDifficulty { OverallDifficulty = overallDifficulty },
+                BeatmapInfo =
+                {
+                    Ruleset = new TaikoRuleset().RulesetInfo,
+                },
+                ControlPointInfo = cpi,
+            };
+            return beatmap;
         }
     }
 }


### PR DESCRIPTION
Even more tests. Covers stable behaviour of the following mods:

- osu!:
  - Easy - [multiplies OD by 0.5](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManager.cs#L317-L319). (The code says `min(0, od / 2)` but that min does nothing because the OD is already clamped to [0, 10].)
  - Hard Rock - [multiplies OD by 1.4, but to no more than 10.](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManager.cs#L320-L322) This means that the effect of the mod caps out at base OD of around ~7.14.
- taiko:
  - Easy - [multiplies OD by 0.5](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManager.cs#L317-L319). (The code says `min(0, od / 2)` but that min does nothing because the OD is already clamped to [0, 10].)
  - Hard Rock - [multiplies OD by 1.4, but to no more than 10.](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManager.cs#L320-L322) This means that the effect of the mod caps out at base OD of around ~7.14.
- taiko:
  - Double Time/Half Time - [manipulates hit windows in "track time" to be instead independent of track playback rate and instead be constant in "wall clock time"](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManagerMania.cs#L151-L160).
  - Easy - [*multiplies the hit windows by a flat constant of 1.4 before flooring*](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManagerMania.cs#L149-L150), which is completely different than what the other rulesets do
  - Hard Rock - [*divides the hit windows by a flat constant of 1.4 before flooring*](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManagerMania.cs#L149-L150)

The corollary here is that mania's implementation of Easy and Hard Rock **are completely wrong** with respect to hit windows. Hard Rock is unranked so it's kinda whatever, but Easy is ranked. So that's yet another fun bucket of worms to have to chow down.