### PR TITLE
Fix daily challenge marker text spacing

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFPSCounter.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFPSCounter.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
@@ -14,6 +16,9 @@ namespace osu.Game.Tests.Visual.UserInterface
 {
     public partial class TestSceneFPSCounter : OsuTestScene
     {
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
+
         [SetUpSteps]
         public void SetUpSteps()
         {
@@ -41,6 +46,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     },
                 };
             });
+            AddToggleStep("toggle show", b => config.SetValue(OsuSetting.ShowFpsDisplay, b));
         }
 
         [Test]

--- a/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
@@ -44,7 +44,8 @@ namespace osu.Game.Graphics.UserInterface
                     AutoSizeAxes = Axes.Both,
                     TextAnchor = Anchor.TopRight,
                     Margin = new MarginPadding { Left = 5, Vertical = 10 },
-                    Text = string.Join('\n', gameHost.Threads.Select(t => t.Name))
+                    Text = string.Join('\n', gameHost.Threads.Select(t => t.Name)),
+                    ParagraphSpacing = 0,
                 },
                 textFlow = new OsuTextFlowContainer(cp =>
                 {
@@ -56,6 +57,7 @@ namespace osu.Game.Graphics.UserInterface
                     Margin = new MarginPadding { Left = 35, Right = 10, Vertical = 10 },
                     AutoSizeAxes = Axes.Y,
                     TextAnchor = Anchor.TopRight,
+                    ParagraphSpacing = 0,
                 },
             };
         }

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             AutoSizeAxes = Axes.Both;
 
+            OsuTextFlowContainer label;
+
             InternalChildren = new Drawable[]
             {
                 content = new Container
@@ -69,12 +71,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             Direction = FillDirection.Horizontal,
                             Children = new Drawable[]
                             {
-                                new OsuTextFlowContainer(s => s.Font = OsuFont.GetFont(size: 12))
+                                label = new OsuTextFlowContainer(s => s.Font = OsuFont.GetFont(size: 12))
                                 {
                                     AutoSizeAxes = Axes.Both,
-                                    // can't use this because osu-web does weird stuff with \\n.
-                                    // Text = UsersStrings.ShowDailyChallengeTitle.,
-                                    Text = "Daily\nChallenge",
                                     Margin = new MarginPadding { Horizontal = 5f, Bottom = 2f },
                                 },
                                 new Container
@@ -129,6 +128,10 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     }
                 },
             };
+
+            // can't use this because osu-web does weird stuff with \\n.
+            // Text = UsersStrings.ShowDailyChallengeTitle.,
+            label.AddParagraph("Daily\nChallenge");
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32908.

Have you ever been in a situation wherein you find out you fixed a bug that you didn't know existed, but that makes *another* bug appear because it was relying on the other bug? This is where I'm at right now.

But, to start from the top.

`TextFlowContainer.Text` (the setter) is a convenience property that you use to set the text in one go. [Internally it uses `AddText()`](https://github.com/ppy/osu-framework/blob/681900ffb70adfeede4e3fa32a69da66252691ee/osu.Framework/Graphics/Containers/TextFlowContainer.cs#L81-L94).

`AddText()`'s xmldoc [says](https://github.com/ppy/osu-framework/blob/681900ffb70adfeede4e3fa32a69da66252691ee/osu.Framework/Graphics/Containers/TextFlowContainer.cs#L226-L239):

	The \n character will create a new paragraph, not just a line break.
	If you need \n to be a line break, use <see cref="AddParagraph{TSpriteText}(LocalisableString, Action{TSpriteText})"/> instead.

That's right. This portion of xmldoc was *straight up false* and *silently broken* before https://github.com/ppy/osu-framework/pull/6556. If you want to check that out yourself, apply the following patch to framework:

```diff
diff --git a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
index 464f47c2c..e1ad521a7 100644
--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -180,6 +180,22 @@ public void TestAlignmentIsCorrectWhenLineBreaksAtLastWordOfParagraph(Anchor tex
             });
         }
 
+        [Test]
+        public void TestSetTextWithNewLine()
+        {
+            AddStep("set text", () => textContainer.Text = "this text\nhas a newline");
+            AddStep("clear and add text", () =>
+            {
+                textContainer.Clear();
+                textContainer.AddText("this text\nhas a newline");
+            });
+            AddStep("clear and add paragraph", () =>
+            {
+                textContainer.Clear();
+                textContainer.AddParagraph("this text\nhas a newline");
+            });
+        }
+
         private void assertSpriteTextCount(int count)
             => AddAssert($"text flow has {count} sprite texts", () => textContainer.ChildrenOfType<SpriteText>().Count() == count);
 

```

On `master`, there will be a difference between the first two steps, and the third. On `2025.321.0`, *there will be none*.

My working theory as to why this was always busted is that [the corresponding code that was there before](https://github.com/bdach/osu-framework/blob/c31a48178889ca2f9b4d257d2d64915eee90338a/osu.Framework/Graphics/Containers/TextFlowContainer.cs#L454-L458) just straight up ran too late. *The height of the container is being changed after the flow has laid itself out, without adjusting subsequent children in any way.*

There is potentially a discussion to be had as to whether the emergent behaviour of `TextFlowContainer.Text` with respect to `\n` character is correct, but I'm just going to start with this diff and see what the reaction is.