### PR TITLE
Fix free mod selection sub-button being clickable even if the main button isn't

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -6,8 +6,12 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -16,10 +20,12 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual.OnlinePlay;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -153,9 +159,39 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
         }
 
+        [Test]
+        public void TestFreeModSelectionDisable()
+        {
+            FooterButtonFreeMods freeMods = null!;
+
+            AddAssert("freestyle enabled", () => songSelect.Freestyle.Value, () => Is.True);
+            AddStep("click icon in free mods button", () =>
+            {
+                freeMods = this.ChildrenOfType<FooterButtonFreeMods>().Single();
+                InputManager.MoveMouseTo(freeMods.ChildrenOfType<SpriteIcon>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("mod select not visible", () => this.ChildrenOfType<FreeModSelectOverlay>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
+
+            AddStep("toggle freestyle off", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<FooterButtonFreestyle>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("freestyle disabled", () => songSelect.Freestyle.Value, () => Is.False);
+            AddStep("click icon in free mods button", () =>
+            {
+                InputManager.MoveMouseTo(freeMods.ChildrenOfType<SpriteIcon>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("mod select visible", () => this.ChildrenOfType<FreeModSelectOverlay>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+
         private partial class TestPlaylistsSongSelect : PlaylistsSongSelect
         {
             public new MatchBeatmapDetailArea BeatmapDetails => (MatchBeatmapDetailArea)base.BeatmapDetails;
+
+            public new IBindable<bool> Freestyle => base.Freestyle;
 
             public TestPlaylistsSongSelect(Room room)
                 : base(room)

--- a/osu.Game/Screens/OnlinePlay/FooterButtonFreeMods.cs
+++ b/osu.Game/Screens/OnlinePlay/FooterButtonFreeMods.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Screens.OnlinePlay
                     Origin = Anchor.Centre,
                     Scale = new Vector2(0.8f),
                     Icon = FontAwesome.Solid.Bars,
+                    Enabled = { BindTarget = Enabled },
                     Action = () => freeModSelectOverlay.ToggleVisibility()
                 }
             });


### PR DESCRIPTION
See test attached for explanation.

Noticed in passing when testing https://github.com/ppy/osu/pull/32674.