### PR TITLE
Remove `LeaderboardManager` return value and simplify flow further

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardManager.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardManager.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Online.Leaderboards
         /// Fetch leaderboard content with the new criteria specified in the background.
         /// On completion, <see cref="Scores"/> will be updated with the results from this call (unless a more recent call with a different criteria has completed).
         /// </summary>
-        public void FetchWithCriteria(LeaderboardCriteria newCriteria)
+        public void FetchWithCriteria(LeaderboardCriteria newCriteria, bool forceRefresh = false)
         {
-            if (CurrentCriteria?.Equals(newCriteria) == true && scores.Value?.FailState == null)
+            if (!forceRefresh && CurrentCriteria?.Equals(newCriteria) == true && scores.Value?.FailState == null)
                 return;
 
             CurrentCriteria = newCriteria;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -801,12 +801,7 @@ namespace osu.Game
                     var newLeaderboard = currentLeaderboard != null
                         ? currentLeaderboard with { Beatmap = databasedBeatmap, Ruleset = databasedScore.ScoreInfo.Ruleset }
                         : new LeaderboardCriteria(databasedBeatmap, databasedScore.ScoreInfo.Ruleset, BeatmapLeaderboardScope.Global, null);
-                    LeaderboardManager.FetchWithCriteriaAsync(newLeaderboard)
-                                      .ContinueWith(t =>
-                                      {
-                                          if (t.Exception != null)
-                                              Logger.Log($@"Failed to fetch leaderboards when displaying results: {t.Exception}", LoggingTarget.Network);
-                                      });
+                    LeaderboardManager.FetchWithCriteria(newLeaderboard);
                 }
 
                 switch (presentType)

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -92,6 +92,10 @@ namespace osu.Game.Screens.Select.Leaderboards
             var fetchBeatmapInfo = BeatmapInfo;
             var fetchRuleset = ruleset.Value ?? fetchBeatmapInfo?.Ruleset;
 
+            // Without this check, an initial fetch will be performed and clear global cache.
+            if (fetchBeatmapInfo == null)
+                return null;
+
             leaderboardManager.FetchWithCriteriaAsync(new LeaderboardCriteria(fetchBeatmapInfo, fetchRuleset, Scope, filterMods ? mods.Value.ToArray() : null))
                               .ContinueWith(t =>
                               {

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -97,7 +97,10 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (fetchBeatmapInfo == null)
                 return null;
 
-            leaderboardManager.FetchWithCriteria(new LeaderboardCriteria(fetchBeatmapInfo, fetchRuleset, Scope, filterMods ? mods.Value.ToArray() : null));
+            // For now, we forcefully refresh to keep things simple.
+            // In the future, removing this requirement may be deemed useful, but will need ample testing of edge case scenarios
+            // (like returning from gameplay after setting a new score, returning to song select after main menu).
+            leaderboardManager.FetchWithCriteria(new LeaderboardCriteria(fetchBeatmapInfo, fetchRuleset, Scope, filterMods ? mods.Value.ToArray() : null), forceRefresh: true);
 
             if (!initialFetchComplete)
             {


### PR DESCRIPTION
While working through https://github.com/ppy/osu/pull/32844, it became apparent that both @frenzibyte's copy-pasted code was out of date with recent leaderboard changes, and some refactors I made were only applied local in that branch (and not to the old `Leaderboard`).

This attempts to resolve the issues I came across. See 1e768439caffb050cc96dd187bec1b8be5d073e4 commit message for rationale.