### PR TITLE
Add basic support for beatmap updates in `BeatmapCarousel`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(1, 3);
             AddStep("generate and add test beatmap", () =>
             {
-                baseTestBeatmap = TestResources.CreateTestBeatmapSetInfo();
+                baseTestBeatmap = TestResources.CreateTestBeatmapSetInfo(3);
 
                 var metadata = new BeatmapMetadata
                 {
@@ -82,6 +82,22 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("drawables changed", () => Carousel.ChildrenOfType<Panel>(), () => Is.Not.EqualTo(originalDrawables));
         }
 
+        [Test]
+        public void TestSelectionHeld()
+        {
+            SelectPrevGroup();
+
+            WaitForSelection(1, 0);
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+
+            updateBeatmap();
+            WaitForSorting();
+
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+        }
+
         private void updateBeatmap(Action<BeatmapInfo>? updateBeatmap = null, Action<BeatmapSetInfo>? updateSet = null)
         {
             AddStep("update beatmap with different reference", () =>
@@ -89,7 +105,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 var updatedSet = new BeatmapSetInfo
                 {
                     ID = baseTestBeatmap.ID,
-                    OnlineID = baseTestBeatmap.OnlineID,
+                    OnlineID = 99999, // this is just for tracking / debug purposes at the moment.
                     DateAdded = baseTestBeatmap.DateAdded,
                     DateSubmitted = baseTestBeatmap.DateSubmitted,
                     DateRanked = baseTestBeatmap.DateRanked,

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -1,0 +1,137 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Extensions;
+using osu.Game.Screens.SelectV2;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    [TestFixture]
+    public partial class TestSceneBeatmapCarouselUpdateHandling : BeatmapCarouselTestScene
+    {
+        private BeatmapSetInfo baseTestBeatmap = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            RemoveAllBeatmaps();
+            CreateCarousel();
+            AddBeatmaps(1, 3);
+            AddStep("generate and add test beatmap", () =>
+            {
+                baseTestBeatmap = TestResources.CreateTestBeatmapSetInfo();
+
+                var metadata = new BeatmapMetadata
+                {
+                    Artist = "update test",
+                    Title = "beatmap",
+                };
+
+                foreach (var b in baseTestBeatmap.Beatmaps)
+                    b.Metadata = metadata;
+                BeatmapSets.Add(baseTestBeatmap);
+            });
+
+            WaitForSorting();
+        }
+
+        [Test]
+        public void TestBeatmapSetUpdatedNoop()
+        {
+            List<Panel> originalDrawables = new List<Panel>();
+
+            AddStep("store drawable references", () =>
+            {
+                originalDrawables.Clear();
+                originalDrawables.AddRange(Carousel.ChildrenOfType<Panel>().ToList());
+            });
+
+            AddStep("update beatmap with same reference", () => BeatmapSets.ReplaceRange(1, 1, [baseTestBeatmap]));
+
+            WaitForSorting();
+            AddAssert("drawables unchanged", () => Carousel.ChildrenOfType<Panel>(), () => Is.EqualTo(originalDrawables));
+        }
+
+        [Test]
+        public void TestBeatmapSetMetadataUpdated()
+        {
+            var metadata = new BeatmapMetadata
+            {
+                Artist = "updated test",
+                Title = "new beatmap title",
+            };
+
+            List<Panel> originalDrawables = new List<Panel>();
+
+            AddStep("store drawable references", () =>
+            {
+                originalDrawables.Clear();
+                originalDrawables.AddRange(Carousel.ChildrenOfType<Panel>().ToList());
+            });
+
+            updateBeatmap(b => b.Metadata = metadata);
+
+            WaitForSorting();
+            AddAssert("drawables changed", () => Carousel.ChildrenOfType<Panel>(), () => Is.Not.EqualTo(originalDrawables));
+        }
+
+        private void updateBeatmap(Action<BeatmapInfo>? updateBeatmap = null, Action<BeatmapSetInfo>? updateSet = null)
+        {
+            AddStep("update beatmap with different reference", () =>
+            {
+                var updatedSet = new BeatmapSetInfo
+                {
+                    ID = baseTestBeatmap.ID,
+                    OnlineID = baseTestBeatmap.OnlineID,
+                    DateAdded = baseTestBeatmap.DateAdded,
+                    DateSubmitted = baseTestBeatmap.DateSubmitted,
+                    DateRanked = baseTestBeatmap.DateRanked,
+                    Status = baseTestBeatmap.Status,
+                    StatusInt = baseTestBeatmap.StatusInt,
+                    DeletePending = baseTestBeatmap.DeletePending,
+                    Hash = baseTestBeatmap.Hash,
+                    Protected = baseTestBeatmap.Protected,
+                };
+
+                updateSet?.Invoke(updatedSet);
+
+                var updatedBeatmaps = baseTestBeatmap.Beatmaps.Select(b =>
+                {
+                    var updatedBeatmap = new BeatmapInfo
+                    {
+                        ID = b.ID,
+                        Metadata = b.Metadata,
+                        Ruleset = b.Ruleset,
+                        DifficultyName = b.DifficultyName,
+                        BeatmapSet = updatedSet,
+                        Status = b.Status,
+                        OnlineID = b.OnlineID,
+                        Length = b.Length,
+                        BPM = b.BPM,
+                        Hash = b.Hash,
+                        StarRating = b.StarRating,
+                        MD5Hash = b.MD5Hash,
+                        OnlineMD5Hash = b.OnlineMD5Hash,
+                    };
+
+                    updateBeatmap?.Invoke(updatedBeatmap);
+
+                    return updatedBeatmap;
+                }).ToList();
+
+                updatedSet.Beatmaps.AddRange(updatedBeatmaps);
+
+                int originalIndex = BeatmapSets.IndexOf(baseTestBeatmap);
+
+                BeatmapSets.ReplaceRange(originalIndex, 1, [updatedSet]);
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -98,6 +98,38 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
+        [Test] // Checks that we keep selection based on online ID where possible.
+        public void TestSelectionHeldDifficultyNameChanged()
+        {
+            SelectPrevGroup();
+
+            WaitForSelection(1, 0);
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+
+            updateBeatmap(b => b.DifficultyName = "new name");
+            WaitForSorting();
+
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+        }
+
+        [Test] // Checks that we fallback to keeping selection based on difficulty name.
+        public void TestSelectionHeldDifficultyOnlineIDChanged()
+        {
+            SelectPrevGroup();
+
+            WaitForSelection(1, 0);
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+
+            updateBeatmap(b => b.OnlineID = b.OnlineID + 1);
+            WaitForSorting();
+
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+        }
+
         private void updateBeatmap(Action<BeatmapInfo>? updateBeatmap = null, Action<BeatmapSetInfo>? updateSet = null)
         {
             AddStep("update beatmap with different reference", () =>
@@ -105,7 +137,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 var updatedSet = new BeatmapSetInfo
                 {
                     ID = baseTestBeatmap.ID,
-                    OnlineID = 99999, // this is just for tracking / debug purposes at the moment.
+                    OnlineID = baseTestBeatmap.OnlineID,
                     DateAdded = baseTestBeatmap.DateAdded,
                     DateSubmitted = baseTestBeatmap.DateSubmitted,
                     DateRanked = baseTestBeatmap.DateRanked,

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -496,10 +496,10 @@ namespace osu.Game.Graphics.Carousel
                 updateItemYPosition(item, ref lastVisible, ref yPos);
 
                 if (CheckModelEquality(item.Model, currentKeyboardSelection.Model!))
-                    currentKeyboardSelection = new Selection(item.Model, item, item.CarouselYPosition, i);
+                    currentKeyboardSelection = new Selection(currentKeyboardSelection.Model, item, item.CarouselYPosition, i);
 
                 if (CheckModelEquality(item.Model, currentSelection.Model!))
-                    currentSelection = new Selection(item.Model, item, item.CarouselYPosition, i);
+                    currentSelection = new Selection(currentSelection.Model, item, item.CarouselYPosition, i);
             }
 
             // If a keyboard selection is currently made, we want to keep the view stable around the selection.

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -167,6 +167,11 @@ namespace osu.Game.Graphics.Carousel
         protected virtual Task FilterAsync() => filterTask = performFilter();
 
         /// <summary>
+        /// Check whether two models are the same for display purposes.
+        /// </summary>
+        protected virtual bool CheckModelEquality(object x, object y) => ReferenceEquals(x, y);
+
+        /// <summary>
         /// Create a drawable for the given carousel item so it can be displayed.
         /// </summary>
         /// <remarks>
@@ -490,10 +495,10 @@ namespace osu.Game.Graphics.Carousel
 
                 updateItemYPosition(item, ref lastVisible, ref yPos);
 
-                if (ReferenceEquals(item.Model, currentKeyboardSelection.Model))
+                if (CheckModelEquality(item.Model, currentKeyboardSelection.Model!))
                     currentKeyboardSelection = new Selection(item.Model, item, item.CarouselYPosition, i);
 
-                if (ReferenceEquals(item.Model, currentSelection.Model))
+                if (CheckModelEquality(item.Model, currentSelection.Model!))
                     currentSelection = new Selection(item.Model, item, item.CarouselYPosition, i);
             }
 
@@ -578,7 +583,7 @@ namespace osu.Game.Graphics.Carousel
 
                 panel.X = GetPanelXOffset(panel);
 
-                c.Selected.Value = c.Item == currentSelection?.CarouselItem;
+                c.Selected.Value = currentSelection?.CarouselItem != null && CheckModelEquality(c.Item, currentSelection.CarouselItem);
                 c.KeyboardSelected.Value = c.Item == currentKeyboardSelection?.CarouselItem;
                 c.Expanded.Value = c.Item.IsExpanded;
             }
@@ -644,7 +649,10 @@ namespace osu.Game.Graphics.Carousel
 
                 // The case where we're intending to display this panel, but it's already displayed.
                 // Note that we **must compare the model here** as the CarouselItems may be fresh instances due to a filter operation.
-                var existing = toDisplay.FirstOrDefault(i => i.Model == carouselPanel.Item!.Model);
+                //
+                // Reference equality is used here instead of CheckModelEquality intentionally. In order to switch to `CheckModelEquality`,
+                // we need a way to signal to the drawable panels that there is an update.
+                var existing = toDisplay.FirstOrDefault(i => ReferenceEquals(i.Model, carouselPanel.Item!.Model));
 
                 if (existing != null)
                 {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.SelectV2
                         Debug.Assert(previousIndex >= 0);
 
                         BeatmapInfo? matchingNewBeatmap =
-                            newSetBeatmaps.SingleOrDefault(b => b.OnlineID == beatmap.OnlineID) ??
+                            newSetBeatmaps.SingleOrDefault(b => b.OnlineID > 0 && b.OnlineID == beatmap.OnlineID) ??
                             newSetBeatmaps.SingleOrDefault(b => b.DifficultyName == beatmap.DifficultyName && b.Ruleset.Equals(beatmap.Ruleset));
 
                         if (matchingNewBeatmap != null)

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.SelectV2
                     var newSetBeatmaps = newItems!.Single().Beatmaps.ToList();
 
                     // Handling replace operations is a touch manual, as we need to locally diff the beatmaps of each version of the beatmap set.
-                    // Matching is done based on difficulty names as these are the most stable thing between updates (which are usually triggered
+                    // Matching is done based on online IDs, then difficulty names as these are the most stable thing between updates (which are usually triggered
                     // by users editing the beatmap or by difficulty/metadata recomputation).
                     //
                     // In the case of difficulty reprocessing, this will trigger multiple times per beatmap as it's always triggering a set update.
@@ -113,7 +113,9 @@ namespace osu.Game.Screens.SelectV2
                         int previousIndex = Items.IndexOf(beatmap);
                         Debug.Assert(previousIndex >= 0);
 
-                        BeatmapInfo? matchingNewBeatmap = newSetBeatmaps.SingleOrDefault(b => b.DifficultyName == beatmap.DifficultyName && b.Ruleset.Equals(beatmap.Ruleset));
+                        BeatmapInfo? matchingNewBeatmap =
+                            newSetBeatmaps.SingleOrDefault(b => b.OnlineID == beatmap.OnlineID) ??
+                            newSetBeatmaps.SingleOrDefault(b => b.DifficultyName == beatmap.DifficultyName && b.Ruleset.Equals(beatmap.Ruleset));
 
                         if (matchingNewBeatmap != null)
                         {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -355,7 +355,13 @@ namespace osu.Game.Screens.SelectV2
 
         protected override bool CheckModelEquality(object x, object y)
         {
-            // TODO: this doesn't check online ID. probably need to account for that.
+            // In the confines of the carousel logic, we assume that CurrentSelection (and all items) are using non-stale
+            // BeatmapInfo reference, and that we can match based on beatmap / beatmapset (GU)IDs.
+            //
+            // If there's a case where updates don't come in as expected, diagnosis should start from BeatmapStore, ensuring
+            // it is doing a Replace operation on the list. If it is, then check the local handling in beatmapSetsChanged
+            // before changing matching requirements here.
+
             if (x is BeatmapSetInfo beatmapSetX && y is BeatmapSetInfo beatmapSetY)
                 return beatmapSetX.Equals(beatmapSetY);
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Screens.SelectV2
                     return;
 
                 case BeatmapInfo beatmapInfo:
-                    if (ReferenceEquals(CurrentSelection, beatmapInfo))
+                    if (CurrentSelection != null && CheckModelEquality(CurrentSelection, beatmapInfo))
                     {
                         RequestPresentBeatmap?.Invoke(beatmapInfo);
                         return;
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.SelectV2
 
                 case BeatmapInfo beatmapInfo:
                     // Find any containing group. There should never be too many groups so iterating is efficient enough.
-                    GroupDefinition? containingGroup = grouping.GroupItems.SingleOrDefault(kvp => kvp.Value.Any(i => ReferenceEquals(i.Model, beatmapInfo))).Key;
+                    GroupDefinition? containingGroup = grouping.GroupItems.SingleOrDefault(kvp => kvp.Value.Any(i => CheckModelEquality(i.Model, beatmapInfo))).Key;
 
                     if (containingGroup != null)
                         setExpandedGroup(containingGroup);
@@ -309,6 +309,17 @@ namespace osu.Game.Screens.SelectV2
             AddInternal(groupPanelPool);
             AddInternal(beatmapPanelPool);
             AddInternal(setPanelPool);
+        }
+
+        protected override bool CheckModelEquality(object x, object y)
+        {
+            if (x is BeatmapSetInfo beatmapSetX && y is BeatmapSetInfo beatmapSetY)
+                return beatmapSetX.Equals(beatmapSetY);
+
+            if (x is BeatmapInfo beatmapX && y is BeatmapInfo beatmapY)
+                return beatmapX.Equals(beatmapY);
+
+            return base.CheckModelEquality(x, y);
         }
 
         protected override Drawable GetDrawableForDisplay(CarouselItem item)

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -117,6 +117,11 @@ namespace osu.Game.Screens.SelectV2
 
                         if (matchingNewBeatmap != null)
                         {
+                            // TODO: should this exist in song select instead of here?
+                            // we need to ensure the global beatmap is also updated alongside changes.
+                            if (CurrentSelection != null && CheckModelEquality(beatmap, CurrentSelection))
+                                CurrentSelection = matchingNewBeatmap;
+
                             Items.ReplaceRange(previousIndex, 1, [matchingNewBeatmap]);
                             newSetBeatmaps.Remove(matchingNewBeatmap);
                         }
@@ -348,6 +353,7 @@ namespace osu.Game.Screens.SelectV2
 
         protected override bool CheckModelEquality(object x, object y)
         {
+            // TODO: this doesn't check online ID. probably need to account for that.
             if (x is BeatmapSetInfo beatmapSetX && y is BeatmapSetInfo beatmapSetY)
                 return beatmapSetX.Equals(beatmapSetY);
 


### PR DESCRIPTION
This is the barebones support required to make beatmap updates possible rather than crashing out. It behaves like previous carousel where drawables will be recreated if there's any change detected (I have a PoC which allows updating drawables without this recycle process, but that's for another time).

The complexity here comes from needing to support non-reference comparisons in order to maintain selection and consistency in visual display when only a handful of items change.

A bit of a RFC to see is this is legible. But it does work and is mergeable if agreeable code-wise.