### PR TITLE
Minor fix to the Easy mod description

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModEasy.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModEasy.cs
@@ -8,6 +8,6 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModEasy : ModEasyWithExtraLives
     {
-        public override LocalisableString Description => @"Larger fruits, more forgiving HP drain, less accuracy required, and three lives!";
+        public override LocalisableString Description => @"Larger fruits, more forgiving HP drain, less accuracy required, and extra lives!";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModEasy.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModEasy.cs
@@ -8,6 +8,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModEasy : ModEasyWithExtraLives
     {
-        public override LocalisableString Description => @"More forgiving HP drain, less accuracy required, and three lives!";
+        public override LocalisableString Description => @"More forgiving HP drain, less accuracy required, and extra lives!";
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModEasy.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModEasy.cs
@@ -8,6 +8,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModEasy : ModEasyWithExtraLives
     {
-        public override LocalisableString Description => @"Larger circles, more forgiving HP drain, less accuracy required, and three lives!";
+        public override LocalisableString Description => @"Larger circles, more forgiving HP drain, less accuracy required, and extra lives!";
     }
 }


### PR DESCRIPTION
Discussed [on Discord](https://discord.com/channels/188630481301012481/188630652340404224/1364293748540047401)

The description states that the easy mod makes you have *three* lives, but we can customize the amount of lives we have anyways, so replacing "three lives" with "extra lives" make more sense.