### PR TITLE
Fix: Preserve multiplayer settings overlay visibility on room updates

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -433,10 +433,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             bool newIsRoomJoined = client.Room != null;
 
+            bool wasSettingsVisible = settingsOverlay.State.Value == Visibility.Visible;
+            bool isStillHost = client.Room?.Host?.User?.Id == client.LocalUser?.User?.Id;
+
             if (newIsRoomJoined)
             {
                 roomContent.Show();
-                settingsOverlay.Hide();
+
+                if (!isStillHost || !wasSettingsVisible)
+                    settingsOverlay.Hide();
+                else
+                    settingsOverlay.Show();
             }
             else if (isRoomJoined)
             {


### PR DESCRIPTION
## Summary

Fixes a UX issue in the multiplayer screen where the settings overlay (opened by the host via "Update Settings") would automatically close when:

- Another user toggles ready/unready
- A user begins downloading the beatmap (causing availability updates)
- Any other room update occurs

This interrupts host workflow and makes room configuration frustrating.

## Fix

The visibility of the overlay is now preserved if:
- The user was the host before the update
- The overlay was already open

## Testing

- Host a multiplayer match
- Open "Update Settings"
- Have another user change their state (e.g. ready, download beatmap)
- Observe that the overlay no longer closes unexpectedly

## Video example

https://github.com/user-attachments/assets/6ddfad13-db31-43b4-b98f-c90e21ee0743


---

Closes UX annoyance in multiplayer match setup.


