### PR TITLE
Keep multiplayer settings open during room updates

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -426,6 +426,31 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("countdown started", () => MultiplayerClient.ServerRoom!.ActiveCountdowns.Any());
         }
 
+        [Test]
+        public void TestSettingsRemainsOpenOnRoomUpdate()
+        {
+            AddStep("set playlist", () =>
+            {
+                room.Playlist =
+                [
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First()).BeatmapInfo)
+                    {
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                    }
+                ];
+            });
+
+            ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
+
+            AddUntilStep("wait for room join", () => RoomJoined);
+
+            AddStep("open settings", () => this.ChildrenOfType<MultiplayerMatchSettingsOverlay>().Single().Show());
+            AddAssert("settings opened", () => this.ChildrenOfType<MultiplayerMatchSettingsOverlay>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+
+            AddStep("trigger room update", () => MultiplayerClient.AddPlaylistItem(MultiplayerClient.ServerRoom!.Playlist[0].Clone()));
+            AddAssert("settings still open", () => this.ChildrenOfType<MultiplayerMatchSettingsOverlay>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+
         private partial class TestMultiplayerMatchSubScreen : MultiplayerMatchSubScreen
         {
             [Resolved(canBeNull: true)]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -431,14 +430,25 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// </summary>
         private void onRoomUpdated() => Scheduler.AddOnce(() =>
         {
-            bool newIsRoomJoined = client.Room != null;
+            bool wasRoomJoined = isRoomJoined;
+            isRoomJoined = client.Room != null;
 
-            if (newIsRoomJoined)
+            // Creating a room.
+            if (!wasRoomJoined && !isRoomJoined)
+            {
+                roomContent.Hide();
+                settingsOverlay.Show();
+            }
+
+            // Joining a room.
+            if (!wasRoomJoined && isRoomJoined)
             {
                 roomContent.Show();
                 settingsOverlay.Hide();
             }
-            else if (isRoomJoined)
+
+            // Leaving a room.
+            if (wasRoomJoined && !isRoomJoined)
             {
                 Logger.Log($"{this} exiting due to loss of room or connection");
 
@@ -447,17 +457,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 else
                     ValidForResume = false;
             }
-            else
-            {
-                Debug.Assert(!isRoomJoined && !newIsRoomJoined);
-
-                // A new room is being created.
-                // The main content should be hidden until the settings overlay is hidden, signaling the room is ready to be displayed.
-                roomContent.Hide();
-                settingsOverlay.Show();
-            }
-
-            isRoomJoined = newIsRoomJoined;
         });
 
         /// <summary>


### PR DESCRIPTION
Supersedes / closes https://github.com/ppy/osu/pull/32921

I explored the possibility of adding `RoomJoined`/`RoomParted` events, but it's a bit more involved because the room is sometimes already joined when entering the screen. Want to avoid bindables as much as possible.