### PR TITLE
Show true beatmap background when viewing historical multiplayer results

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -19,6 +19,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
+using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Ranking;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
@@ -34,6 +35,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         private MultiplayerScores? higherScores;
         private MultiplayerScores? lowerScores;
+        private WorkingBeatmap itemBeatmap = null!;
 
         [Resolved]
         protected IAPIProvider API { get; private set; } = null!;
@@ -60,6 +62,10 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         [BackgroundDependencyLoader]
         private void load()
         {
+            var localBeatmap = beatmapManager.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}",
+                PlaylistItem.Beatmap.OnlineID);
+            itemBeatmap = beatmapManager.GetWorkingBeatmap(localBeatmap);
+
             AddInternal(new Container
             {
                 RelativeSizeAxes = Axes.Both,
@@ -306,6 +312,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                 s.Position = pivotPosition;
             }
         }
+
+        protected override BackgroundScreen CreateBackground() => new BackgroundScreenBeatmap(itemBeatmap);
 
         private partial class PanelListLoadingSpinner : LoadingSpinner
         {

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
@@ -2,9 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
+using osu.Game.Screens.Backgrounds;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
 {
@@ -14,11 +17,19 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
     public partial class PlaylistItemUserBestResultsScreen : PlaylistItemResultsScreen
     {
         private readonly int userId;
+        private WorkingBeatmap itemBeatmap = null!;
 
         public PlaylistItemUserBestResultsScreen(long roomId, PlaylistItem playlistItem, int userId)
             : base(null, roomId, playlistItem)
         {
             this.userId = userId;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(BeatmapManager beatmaps)
+        {
+            var localBeatmap = beatmaps.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", PlaylistItem.Beatmap.OnlineID);
+            itemBeatmap = beatmaps.GetWorkingBeatmap(localBeatmap);
         }
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistUserScoreRequest(RoomId, PlaylistItem.ID, userId);
@@ -30,5 +41,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             // Prefer selecting the local user's score, or otherwise default to the first visible score.
             SelectedScore.Value ??= scores.FirstOrDefault(s => s.UserID == userId) ?? scores.FirstOrDefault();
         }
+
+        protected override BackgroundScreen CreateBackground() => new BackgroundScreenBeatmap(itemBeatmap);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemUserBestResultsScreen.cs
@@ -2,12 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Allocation;
-using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
-using osu.Game.Screens.Backgrounds;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
 {
@@ -17,19 +14,11 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
     public partial class PlaylistItemUserBestResultsScreen : PlaylistItemResultsScreen
     {
         private readonly int userId;
-        private WorkingBeatmap itemBeatmap = null!;
 
         public PlaylistItemUserBestResultsScreen(long roomId, PlaylistItem playlistItem, int userId)
             : base(null, roomId, playlistItem)
         {
             this.userId = userId;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(BeatmapManager beatmaps)
-        {
-            var localBeatmap = beatmaps.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", PlaylistItem.Beatmap.OnlineID);
-            itemBeatmap = beatmaps.GetWorkingBeatmap(localBeatmap);
         }
 
         protected override APIRequest<MultiplayerScore> CreateScoreRequest() => new ShowPlaylistUserScoreRequest(RoomId, PlaylistItem.ID, userId);
@@ -41,7 +30,5 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             // Prefer selecting the local user's score, or otherwise default to the first visible score.
             SelectedScore.Value ??= scores.FirstOrDefault(s => s.UserID == userId) ?? scores.FirstOrDefault();
         }
-
-        protected override BackgroundScreen CreateBackground() => new BackgroundScreenBeatmap(itemBeatmap);
     }
 }


### PR DESCRIPTION
Re-resolves https://github.com/ppy/osu/issues/32786

This combines the second path I previously explored in https://github.com/ppy/osu/pull/32823. Also affects playlists.