### PR TITLE
Fix presenting score potentially dying due to deleted beatmap

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneMissingBeatmapNotification.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneMissingBeatmapNotification.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 AutoSizeAxes = Axes.Y,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Child = new MissingBeatmapNotification(CreateAPIBeatmapSet(Ruleset.Value).Beatmaps.First(), new ImportScoreTest.TestArchiveReader(), "deadbeef")
+                Child = new MissingBeatmapNotification(CreateAPIBeatmapSet(Ruleset.Value).Beatmaps.First(), "deadbeef", new ImportScoreTest.TestArchiveReader())
             };
         }
     }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -744,7 +744,7 @@ namespace osu.Game
         {
             Logger.Log($"Beginning {nameof(PresentScore)} with score {score}");
 
-            Score databasedScore = null;
+            Score databasedScore;
 
             try
             {

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Scoring
                     {
                         // In the case of a missing beatmap, let's attempt to resolve it and show a prompt to the user to download the required beatmap.
                         var req = new GetBeatmapRequest(new BeatmapInfo { MD5Hash = notFound.Hash });
-                        req.Success += res => PostNotification?.Invoke(new MissingBeatmapNotification(res, archive, notFound.Hash));
+                        req.Success += res => PostNotification?.Invoke(new MissingBeatmapNotification(res, notFound.Hash, archive));
                         api.Queue(req);
                     }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27168
- Closes https://github.com/ppy/osu/issues/32930

It's a little manual (if you perform any of the scenarios in the issues above on this branch, the first click will re-import the beatmap but not start the replay, and only the second will play it), but maybe fine?