### PR TITLE
Fix multiple issues with editor ternary toggle state management

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -281,6 +281,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             SelectionAdditionBanksEnabled.Value = true;
             SelectionBankStates[HIT_BANK_AUTO].Value = TernaryState.True;
             SelectionAdditionBankStates[HIT_BANK_AUTO].Value = TernaryState.True;
+            foreach (var (_, sampleState) in SelectionSampleStates)
+                sampleState.Value = TernaryState.False;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -318,7 +318,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private void onSelectedItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             // Reset the ternary states when the selection is cleared.
-            if (e.OldStartingIndex >= 0 && e.NewStartingIndex < 0)
+            if (SelectedItems.Count == 0)
                 Scheduler.AddOnce(resetTernaryStates);
             else
                 Scheduler.AddOnce(UpdateTernaryStates);


### PR DESCRIPTION
## [Reset sample ternary states on deselection](https://github.com/ppy/osu/commit/5c04f427a584546fe1abd26e8233ef54ffc42a10)

Closes https://github.com/ppy/osu/issues/32928.

Appears to match stable ([relevant method](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameModes/Edit/Modes/EditorModeCompose.cs#L4137-L4143), [call site 1](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameModes/Edit/Modes/EditorModeCompose.cs#L1615-L1618), [call site 2](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameModes/Edit/Modes/EditorModeCompose.cs#L4323)).

## [Fix deselecting single item from a multiple selection not updating ternary states correctly](https://github.com/ppy/osu/commit/5a3ff11710dfbc2983313477b051d06408a727f9)

I'm not sure why this condition was written this obtusely, but importantly it was also wrong. It also fires when the selection contains multiple items and only some are removed from it, like when ctrl-click-unselecting an item from a multiple selection.

Blames back to 154a3eebc666a7856aaaecbacb72c2ded417aebd. cc @OliBomby