### PR TITLE
Exclude non-user-playable mods from mod filter in beatmap leaderboard

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             // For now, we forcefully refresh to keep things simple.
             // In the future, removing this requirement may be deemed useful, but will need ample testing of edge case scenarios
             // (like returning from gameplay after setting a new score, returning to song select after main menu).
-            leaderboardManager.FetchWithCriteria(new LeaderboardCriteria(fetchBeatmapInfo, fetchRuleset, Scope, filterMods ? mods.Value.ToArray() : null), forceRefresh: true);
+            leaderboardManager.FetchWithCriteria(new LeaderboardCriteria(fetchBeatmapInfo, fetchRuleset, Scope, filterMods ? mods.Value.Where(m => m.UserPlayable).ToArray() : null), forceRefresh: true);
 
             if (!initialFetchComplete)
             {


### PR DESCRIPTION
For easier understanding, substitute "non-user-playable" with "autoplay".

The reason that I'm bothering to do this is that if you put autoplay on and turn on the "Selected Mods" filter, the request will actually go through and hit web, and web will obviously return no scores. On song select that's *maybe* fine, even though probably unintended still, but now with the leaderboard state being global this also means gameplay gets impacted. Which also means that if you Ctrl-Enter to start a map in autoplay you're not going to get any gameplay leaderboard scores at all.