### PR TITLE
Fix metadata subwedges pop out transition being back-to-front

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -261,12 +261,12 @@ namespace osu.Game.Screens.SelectV2
             }
             else
             {
-                ratingsWedge.FadeOut(transition_duration, Easing.OutQuint)
-                            .MoveToX(-50, transition_duration, Easing.OutQuint);
-
-                failRetryWedge.Delay(100)
-                              .FadeOut(transition_duration, Easing.OutQuint)
+                failRetryWedge.FadeOut(transition_duration, Easing.OutQuint)
                               .MoveToX(-50, transition_duration, Easing.OutQuint);
+
+                ratingsWedge.Delay(100)
+                            .FadeOut(transition_duration, Easing.OutQuint)
+                            .MoveToX(-50, transition_duration, Easing.OutQuint);
             }
         }
 


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/fc4b0bda-e085-410d-bb77-02885b76ec41

After:

https://github.com/user-attachments/assets/b1d2c27e-5ccf-4f89-9d51-b3c4e9833844

