### PR TITLE
Fix incorrect handling of beatmap with local diffs in metadata wedge

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectComponentsTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectComponentsTestScene.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         };
 
         private Container? resizeContainer;
-        private float relativeWidth;
 
         protected virtual Anchor ComponentAnchor => Anchor.TopLeft;
         protected virtual float InitialRelativeWidth => 0.5f;
@@ -40,7 +39,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     Origin = ComponentAnchor,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Width = relativeWidth,
+                    Width = InitialRelativeWidth,
                     Child = Content
                 }
             };
@@ -49,8 +48,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             {
                 if (resizeContainer != null)
                     resizeContainer.Width = v;
-
-                relativeWidth = v;
             });
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
@@ -148,6 +148,40 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
         }
 
+        [Test]
+        public void TestOnlineAvailability()
+        {
+            AddStep("online beatmapset", () =>
+            {
+                var (working, onlineSet) = createTestBeatmap();
+
+                currentOnlineSet = onlineSet;
+                Beatmap.Value = working;
+            });
+            AddUntilStep("rating wedge visible", () => wedge.RatingsVisible);
+            AddUntilStep("fail time wedge visible", () => wedge.FailRetryVisible);
+            AddStep("online beatmapset with local diff", () =>
+            {
+                var (working, onlineSet) = createTestBeatmap();
+
+                working.BeatmapInfo.ResetOnlineInfo();
+
+                currentOnlineSet = onlineSet;
+                Beatmap.Value = working;
+            });
+            AddUntilStep("rating wedge hidden", () => !wedge.RatingsVisible);
+            AddUntilStep("fail time wedge hidden", () => !wedge.FailRetryVisible);
+            AddStep("local beatmap", () =>
+            {
+                var (working, _) = createTestBeatmap();
+
+                currentOnlineSet = null;
+                Beatmap.Value = working;
+            });
+            AddAssert("rating wedge still hidden", () => !wedge.RatingsVisible);
+            AddAssert("fail time wedge still hidden", () => !wedge.FailRetryVisible);
+        }
+
         private (WorkingBeatmap, APIBeatmapSet) createTestBeatmap()
         {
             var working = CreateWorkingBeatmap(Ruleset.Value);

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -35,6 +35,9 @@ namespace osu.Game.Screens.SelectV2
         private Drawable failRetryWedge = null!;
         private FailRetryDisplay failRetryDisplay = null!;
 
+        public bool RatingsVisible => ratingsWedge.Alpha > 0;
+        public bool FailRetryVisible => failRetryWedge.Alpha > 0;
+
         protected override bool StartHidden => true;
 
         [Resolved]
@@ -250,7 +253,10 @@ namespace osu.Game.Screens.SelectV2
             // We could consider hiding individual wedges based on zero data in the future.
             // Needs some experimentation on what looks good.
 
-            if (State.Value == Visibility.Visible && currentOnlineBeatmapSet != null)
+            var beatmapInfo = beatmap.Value.BeatmapInfo;
+            var currentOnlineBeatmap = currentOnlineBeatmapSet?.Beatmaps.SingleOrDefault(b => b.OnlineID == beatmapInfo.OnlineID);
+
+            if (State.Value == Visibility.Visible && currentOnlineBeatmap != null)
             {
                 ratingsWedge.FadeIn(transition_duration, Easing.OutQuint)
                             .MoveToX(0, transition_duration, Easing.OutQuint);


### PR DESCRIPTION
Noticed on passing. Previously, users that have an online beatmap with a locally created difficulty will notice the metadata wedge displaying incorrect success rate value (and potentially other incorrect metrics if the previous selection was a different beatmapset).

One could argue local difficulties shouldn't even display any of the success rate / ratings and failtime wedges. I could change it as such.