### PR TITLE
Fix play count statistic hiding on local difficulties instead of showing `-`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             {
                 var (working, onlineSet) = createTestBeatmap();
 
-                onlineSet.Beatmaps = Array.Empty<APIBeatmap>();
+                working.BeatmapInfo.ResetOnlineInfo();
 
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -308,18 +308,7 @@ namespace osu.Game.Screens.SelectV2
                 var onlineBeatmapSet = currentOnlineBeatmapSet;
                 var onlineBeatmap = currentOnlineBeatmapSet.Beatmaps.SingleOrDefault(b => b.OnlineID == beatmap.Value.BeatmapInfo.OnlineID);
 
-                if (onlineBeatmap != null)
-                {
-                    playCount.FadeIn(300, Easing.OutQuint);
-                    playCount.Value = new StatisticPlayCount.Data(onlineBeatmap.PlayCount, onlineBeatmap.UserPlayCount);
-                }
-                else
-                {
-                    playCount.FadeOut(300, Easing.OutQuint);
-                    playCount.Value = null;
-                }
-
-                favouritesStatistic.FadeIn(300, Easing.OutQuint);
+                playCount.Value = new StatisticPlayCount.Data(onlineBeatmap?.PlayCount ?? -1, onlineBeatmap?.UserPlayCount ?? -1);
                 favouritesStatistic.Text = onlineBeatmapSet.FavouriteCount.ToLocalisableString(@"N0");
             }
         }


### PR DESCRIPTION
Noticed while working towards supporting user tags.

Before:

https://github.com/user-attachments/assets/0afd1301-304e-42c2-9097-4c016afd0c6a

After:

https://github.com/user-attachments/assets/34fc791d-f45f-476e-8726-6a8df93f2ecd

