### PR TITLE
fixed issue #32962 - Thai language users can now properly upload audi…

### DIFF
--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -114,9 +114,8 @@ namespace osu.Game.Screens.Edit.Setup
                 Logger.Error(e, "The selected audio track appears to be corrupted. Please select another one.");
                 return false;
             }
-            finally {
-                System.Threading.Thread.CurrentThread.CurrentCulture = original;
-            }
+            System.Threading.Thread.CurrentThread.CurrentCulture = original;
+
 
             changeResource(source, applyToAllDifficulties, @"audio",
                 metadata => metadata.AudioFile,

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -104,6 +104,7 @@ namespace osu.Game.Screens.Edit.Setup
             // had problems because of the 'th' value of CurrentCulture. Switch to InvariantCulture while parsing the data.
             // Alternatively: Provide MIME type of data in TagLib.File.Create()
             var original = System.Threading.Thread.CurrentThread.CurrentCulture;
+
             try
             {
                 System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
@@ -114,8 +115,8 @@ namespace osu.Game.Screens.Edit.Setup
                 Logger.Error(e, "The selected audio track appears to be corrupted. Please select another one.");
                 return false;
             }
-            System.Threading.Thread.CurrentThread.CurrentCulture = original;
 
+            System.Threading.Thread.CurrentThread.CurrentCulture = original;
 
             changeResource(source, applyToAllDifficulties, @"audio",
                 metadata => metadata.AudioFile,

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -100,14 +100,22 @@ namespace osu.Game.Screens.Edit.Setup
 
             TagLib.File? tagSource;
 
+            // Thai language users had trouble uploading songs because the automatic parsing of TagLib#
+            // had problems because of the 'th' value of CurrentCulture. Switch to InvariantCulture while parsing the data.
+            // Alternatively: Provide MIME type of data in TagLib.File.Create()
+            var original = System.Threading.Thread.CurrentThread.CurrentCulture;
             try
             {
+                System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
                 tagSource = TagLib.File.Create(source.FullName);
             }
             catch (Exception e)
             {
                 Logger.Error(e, "The selected audio track appears to be corrupted. Please select another one.");
                 return false;
+            }
+            finally {
+                System.Threading.Thread.CurrentThread.CurrentCulture = original;
             }
 
             changeResource(source, applyToAllDifficulties, @"audio",


### PR DESCRIPTION
When the application interface is set to Thai, users were unable to add an audio track and got displayed the corrupt audio track error message. It seems there were problems with parsing the path due to the culture. An alternative fix is to skip TagLib#'s automatic detection and immediately supply the correct MIME type, i.e. "audio/mp3".