### PR TITLE
Improve visibility of setting adjustments on mod icons

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -37,22 +37,11 @@ namespace osu.Game.Rulesets.Catch.Mods
         [SettingSource("Spicy Patterns", "Adjust the patterns as if Hard Rock is enabled.")]
         public BindableBool HardRockOffsets { get; } = new BindableBool();
 
-        public override int AdjustedSettingsCount
-        {
-            get
-            {
-                int count = base.AdjustedSettingsCount;
-                if (!ApproachRate.IsDefault) count++;
-                if (!CircleSize.IsDefault) count++;
-                return count;
-            }
-        }
-
         public override string ExtendedIconInformation
         {
             get
             {
-                if (AdjustedSettingsCount != 1)
+                if (UserAdjustedSettingsCount != 1)
                     return string.Empty;
 
                 if (!CircleSize.IsDefault) return format("CS", CircleSize);

--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Rulesets.Catch.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
@@ -35,6 +36,35 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         [SettingSource("Spicy Patterns", "Adjust the patterns as if Hard Rock is enabled.")]
         public BindableBool HardRockOffsets { get; } = new BindableBool();
+
+        public override int AdjustedSettingsCount
+        {
+            get
+            {
+                int count = base.AdjustedSettingsCount;
+                if (!ApproachRate.IsDefault) count++;
+                if (!CircleSize.IsDefault) count++;
+                return count;
+            }
+        }
+
+        public override string ExtendedIconInformation
+        {
+            get
+            {
+                if (AdjustedSettingsCount != 1)
+                    return string.Empty;
+
+                if (!CircleSize.IsDefault) return format("CS", CircleSize);
+                if (!ApproachRate.IsDefault) return format("AR", ApproachRate);
+                if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
+                if (!DrainRate.IsDefault) return format("HP", DrainRate);
+
+                return string.Empty;
+
+                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+            }
+        }
 
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -7,6 +7,7 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
@@ -35,6 +36,35 @@ namespace osu.Game.Rulesets.Osu.Mods
             ExtendedMaxValue = 11,
             ReadCurrentFromDifficulty = diff => diff.ApproachRate,
         };
+
+        public override int AdjustedSettingsCount
+        {
+            get
+            {
+                int count = base.AdjustedSettingsCount;
+                if (!ApproachRate.IsDefault) count++;
+                if (!CircleSize.IsDefault) count++;
+                return count;
+            }
+        }
+
+        public override string ExtendedIconInformation
+        {
+            get
+            {
+                if (AdjustedSettingsCount != 1)
+                    return string.Empty;
+
+                if (!CircleSize.IsDefault) return format("CS", CircleSize);
+                if (!ApproachRate.IsDefault) return format("AR", ApproachRate);
+                if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
+                if (!DrainRate.IsDefault) return format("HP", DrainRate);
+
+                return string.Empty;
+
+                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+            }
+        }
 
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -37,22 +37,11 @@ namespace osu.Game.Rulesets.Osu.Mods
             ReadCurrentFromDifficulty = diff => diff.ApproachRate,
         };
 
-        public override int AdjustedSettingsCount
-        {
-            get
-            {
-                int count = base.AdjustedSettingsCount;
-                if (!ApproachRate.IsDefault) count++;
-                if (!CircleSize.IsDefault) count++;
-                return count;
-            }
-        }
-
         public override string ExtendedIconInformation
         {
             get
             {
-                if (AdjustedSettingsCount != 1)
+                if (UserAdjustedSettingsCount != 1)
                     return string.Empty;
 
                 if (!CircleSize.IsDefault) return format("CS", CircleSize);

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -21,21 +21,11 @@ namespace osu.Game.Rulesets.Taiko.Mods
             ReadCurrentFromDifficulty = _ => 1,
         };
 
-        public override int AdjustedSettingsCount
-        {
-            get
-            {
-                int count = base.AdjustedSettingsCount;
-                if (!ScrollSpeed.IsDefault) count++;
-                return count;
-            }
-        }
-
         public override string ExtendedIconInformation
         {
             get
             {
-                if (AdjustedSettingsCount != 1)
+                if (UserAdjustedSettingsCount != 1)
                     return string.Empty;
 
                 if (!ScrollSpeed.IsDefault) return format("SC", ScrollSpeed);

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Taiko.Mods
@@ -19,6 +20,33 @@ namespace osu.Game.Rulesets.Taiko.Mods
             MaxValue = 4,
             ReadCurrentFromDifficulty = _ => 1,
         };
+
+        public override int AdjustedSettingsCount
+        {
+            get
+            {
+                int count = base.AdjustedSettingsCount;
+                if (!ScrollSpeed.IsDefault) count++;
+                return count;
+            }
+        }
+
+        public override string ExtendedIconInformation
+        {
+            get
+            {
+                if (AdjustedSettingsCount != 1)
+                    return string.Empty;
+
+                if (!ScrollSpeed.IsDefault) return format("SC", ScrollSpeed);
+                if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
+                if (!DrainRate.IsDefault) return format("HP", DrainRate);
+
+                return string.Empty;
+
+                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+            }
+        }
 
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
         {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
@@ -71,7 +71,22 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             AddStep("create mod icons", () =>
             {
-                addRange(Ruleset.Value.CreateInstance().CreateAllMods());
+                addRange(Ruleset.Value.CreateInstance().CreateAllMods().Select(m =>
+                {
+                    if (m is OsuModFlashlight fl)
+                        fl.FollowDelay.Value = 1245;
+
+                    if (m is OsuModDaycore dc)
+                        dc.SpeedChange.Value = 0.74f;
+
+                    if (m is OsuModDifficultyAdjust da)
+                        da.CircleSize.Value = 8.2f;
+
+                    if (m is ModAdaptiveSpeed ad)
+                        ad.AdjustPitch.Value = false;
+
+                    return m;
+                }));
             });
 
             AddStep("toggle selected", () =>

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
@@ -12,22 +12,66 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play.HUD;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     public partial class TestSceneModIcon : OsuTestScene
     {
+        private FillFlowContainer spreadOutFlow = null!;
+        private ModDisplay modDisplay = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create flows", () =>
+            {
+                Child = new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    RowDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.Relative, 0.5f),
+                        new Dimension(GridSizeMode.Relative, 0.5f),
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            modDisplay = new ModDisplay
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            }
+                        },
+                        new Drawable[]
+                        {
+                            spreadOutFlow = new FillFlowContainer
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Full,
+                            }
+                        }
+                    }
+                };
+            });
+        }
+
+        private void addRange(IEnumerable<IMod> mods)
+        {
+            spreadOutFlow.AddRange(mods.Select(m => new ModIcon(m)));
+            modDisplay.Current.Value = modDisplay.Current.Value.Concat(mods.OfType<Mod>()).ToList();
+        }
+
         [Test]
         public void TestShowAllMods()
         {
             AddStep("create mod icons", () =>
             {
-                Child = new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Direction = FillDirection.Full,
-                    ChildrenEnumerable = Ruleset.Value.CreateInstance().CreateAllMods().Select(m => new ModIcon(m)),
-                };
+                addRange(Ruleset.Value.CreateInstance().CreateAllMods());
             });
 
             AddStep("toggle selected", () =>
@@ -42,26 +86,22 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             AddStep("create mod icons", () =>
             {
-                Child = new FillFlowContainer
+                var rateAdjustMods = Ruleset.Value.CreateInstance().CreateAllMods()
+                                            .OfType<ModRateAdjust>();
+
+                addRange(rateAdjustMods.SelectMany(m =>
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Direction = FillDirection.Full,
-                    ChildrenEnumerable = Ruleset.Value.CreateInstance().CreateAllMods()
-                                                .OfType<ModRateAdjust>()
-                                                .SelectMany(m =>
-                                                {
-                                                    List<ModIcon> icons = new List<ModIcon> { new ModIcon(m) };
+                    List<Mod> mods = new List<Mod> { m };
 
-                                                    for (double i = m.SpeedChange.MinValue; i < m.SpeedChange.MaxValue; i += m.SpeedChange.Precision * 10)
-                                                    {
-                                                        m = (ModRateAdjust)m.DeepClone();
-                                                        m.SpeedChange.Value = i;
-                                                        icons.Add(new ModIcon(m));
-                                                    }
+                    for (double i = m.SpeedChange.MinValue; i < m.SpeedChange.MaxValue; i += m.SpeedChange.Precision * 10)
+                    {
+                        m = (ModRateAdjust)m.DeepClone();
+                        m.SpeedChange.Value = i;
+                        mods.Add(m);
+                    }
 
-                                                    return icons;
-                                                }),
-                };
+                    return mods;
+                }));
             });
 
             AddStep("adjust rates", () =>
@@ -81,21 +121,25 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestChangeModType()
         {
-            ModIcon icon = null!;
-
-            AddStep("create mod icon", () => Child = icon = new ModIcon(new OsuModDoubleTime()));
-            AddStep("change mod", () => icon.Mod = new OsuModEasy());
+            AddStep("create mod icon", () => addRange([new OsuModDoubleTime()]));
+            AddStep("change mod", () =>
+            {
+                foreach (var modIcon in this.ChildrenOfType<ModIcon>())
+                    modIcon.Mod = new OsuModEasy();
+            });
         }
 
         [Test]
         public void TestInterfaceModType()
         {
-            ModIcon icon = null!;
-
             var ruleset = new OsuRuleset();
 
-            AddStep("create mod icon", () => Child = icon = new ModIcon(ruleset.AllMods.First(m => m.Acronym == "DT")));
-            AddStep("change mod", () => icon.Mod = ruleset.AllMods.First(m => m.Acronym == "EZ"));
+            AddStep("create mod icon", () => addRange([ruleset.AllMods.First(m => m.Acronym == "DT")]));
+            AddStep("change mod", () =>
+            {
+                foreach (var modIcon in this.ChildrenOfType<ModIcon>())
+                    modIcon.Mod = ruleset.AllMods.First(m => m.Acronym == "EZ");
+            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
@@ -141,5 +141,30 @@ namespace osu.Game.Tests.Visual.UserInterface
                     modIcon.Mod = ruleset.AllMods.First(m => m.Acronym == "EZ");
             });
         }
+
+        [Test]
+        public void TestDifficultyAdjust()
+        {
+            AddStep("create icons", () =>
+            {
+                addRange([
+                    new OsuModDifficultyAdjust
+                    {
+                        CircleSize = { Value = 8 }
+                    },
+                    new OsuModDifficultyAdjust
+                    {
+                        CircleSize = { Value = 5.5f }
+                    },
+                    new OsuModDifficultyAdjust
+                    {
+                        CircleSize = { Value = 8 },
+                        ApproachRate = { Value = 8 },
+                        OverallDifficulty = { Value = 8 },
+                        DrainRate = { Value = 8 },
+                    }
+                ]);
+            });
+        }
     }
 }

--- a/osu.Game/Extensions/NumberFormattingExtensions.cs
+++ b/osu.Game/Extensions/NumberFormattingExtensions.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Extensions
         /// <param name="maxDecimalDigits">The maximum number of decimals to be considered in the original value.</param>
         /// <param name="asPercentage">Whether the output should be a percentage. For integer types, 0-100 is mapped to 0-100%; for other types 0-1 is mapped to 0-100%.</param>
         /// <returns>The formatted output.</returns>
-        public static string ToStandardFormattedString<T>(this T value, int maxDecimalDigits, bool asPercentage) where T : struct, INumber<T>, IMinMaxValue<T>
+        public static string ToStandardFormattedString<T>(this T value, int maxDecimalDigits, bool asPercentage = false) where T : struct, INumber<T>, IMinMaxValue<T>
         {
             double floatValue = double.CreateTruncating(value);
 

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -87,6 +87,10 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// Whether any user adjustable setting attached to this mod has a non-default value.
         /// </summary>
+        /// <remarks>
+        /// This returns the instantaneous state of this mod. It may change over time.
+        /// For tracking changes on a dynamic display, make sure to setup a <see cref="ModSettingChangeTracker"/>.
+        /// </remarks>
         bool HasNonDefaultSettings
         {
             get

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -81,5 +83,29 @@ namespace osu.Game.Rulesets.Mods
         /// Create a fresh <see cref="Mod"/> instance based on this mod.
         /// </summary>
         Mod CreateInstance() => (Mod)Activator.CreateInstance(GetType())!;
+
+        /// <summary>
+        /// Whether any user adjustable setting attached to this mod has a non-default value.
+        /// </summary>
+        bool HasNonDefaultSettings
+        {
+            get
+            {
+                bool hasAdjustments = false;
+
+                foreach (var (_, property) in this.GetSettingsSourceProperties())
+                {
+                    var bindable = (IBindable)property.GetValue(this)!;
+
+                    if (!bindable.IsDefault)
+                    {
+                        hasAdjustments = true;
+                        break;
+                    }
+                }
+
+                return hasAdjustments;
+            }
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -76,6 +76,27 @@ namespace osu.Game.Rulesets.Mods
         }
 
         /// <summary>
+        /// The number of settings on this mod instance which have been adjusted by the user from their default values.
+        /// </summary>
+        public int UserAdjustedSettingsCount
+        {
+            get
+            {
+                int count = 0;
+
+                foreach (var (_, property) in this.GetSettingsSourceProperties())
+                {
+                    var bindable = (IBindable)property.GetValue(this)!;
+
+                    if (!bindable.IsDefault)
+                        count++;
+                }
+
+                return count;
+            }
+        }
+
+        /// <summary>
         /// The score multiplier of this mod.
         /// </summary>
         [JsonIgnore]

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -76,27 +76,6 @@ namespace osu.Game.Rulesets.Mods
         }
 
         /// <summary>
-        /// The number of settings on this mod instance which have been adjusted by the user from their default values.
-        /// </summary>
-        public int UserAdjustedSettingsCount
-        {
-            get
-            {
-                int count = 0;
-
-                foreach (var (_, property) in this.GetSettingsSourceProperties())
-                {
-                    var bindable = (IBindable)property.GetValue(this)!;
-
-                    if (!bindable.IsDefault)
-                        count++;
-                }
-
-                return count;
-            }
-        }
-
-        /// <summary>
         /// The score multiplier of this mod.
         /// </summary>
         [JsonIgnore]

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -111,5 +111,26 @@ namespace osu.Game.Rulesets.Mods
             if (DrainRate.Value != null) difficulty.DrainRate = DrainRate.Value.Value;
             if (OverallDifficulty.Value != null) difficulty.OverallDifficulty = OverallDifficulty.Value.Value;
         }
+
+        /// <summary>
+        /// The number of settings on this mod instance which have been adjusted by the user from their default values.
+        /// </summary>
+        protected int UserAdjustedSettingsCount
+        {
+            get
+            {
+                int count = 0;
+
+                foreach (var (_, property) in this.GetSettingsSourceProperties())
+                {
+                    var bindable = (IBindable)property.GetValue(this)!;
+
+                    if (!bindable.IsDefault)
+                        count++;
+                }
+
+                return count;
+            }
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -64,6 +65,33 @@ namespace osu.Game.Rulesets.Mods
             {
                 if (property.GetValue(this) is DifficultyBindable diffAdjustBindable)
                     diffAdjustBindable.ExtendedLimits.BindTo(ExtendedLimits);
+            }
+        }
+
+        public virtual int AdjustedSettingsCount
+        {
+            get
+            {
+                int count = 0;
+                if (!DrainRate.IsDefault) count++;
+                if (!OverallDifficulty.IsDefault) count++;
+                return count;
+            }
+        }
+
+        public override string ExtendedIconInformation
+        {
+            get
+            {
+                if (AdjustedSettingsCount != 1)
+                    return string.Empty;
+
+                if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
+                if (!DrainRate.IsDefault) return format("HP", DrainRate);
+
+                return string.Empty;
+
+                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
             }
         }
 

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -68,22 +68,11 @@ namespace osu.Game.Rulesets.Mods
             }
         }
 
-        public virtual int AdjustedSettingsCount
-        {
-            get
-            {
-                int count = 0;
-                if (!DrainRate.IsDefault) count++;
-                if (!OverallDifficulty.IsDefault) count++;
-                return count;
-            }
-        }
-
         public override string ExtendedIconInformation
         {
             get
             {
-                if (AdjustedSettingsCount != 1)
+                if (UserAdjustedSettingsCount != 1)
                     return string.Empty;
 
                 if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -8,6 +8,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
@@ -81,6 +82,8 @@ namespace osu.Game.Rulesets.UI
 
         private Container extendedContent = null!;
 
+        private Drawable adjustmentMarker = null!;
+
         private ModSettingChangeTracker? modSettingsChangeTracker;
 
         /// <summary>
@@ -139,7 +142,7 @@ namespace osu.Game.Rulesets.UI
                     Origin = Anchor.CentreLeft,
                     Name = "main content",
                     Size = MOD_ICON_SIZE,
-                    Children = new Drawable[]
+                    Children = new[]
                     {
                         background = new Sprite
                         {
@@ -164,6 +167,31 @@ namespace osu.Game.Rulesets.UI
                             Anchor = Anchor.Centre,
                             Size = new Vector2(45),
                             Icon = FontAwesome.Solid.Question
+                        },
+                        adjustmentMarker = new Container
+                        {
+                            Size = new Vector2(20),
+                            Origin = Anchor.Centre,
+                            Position = new Vector2(64, 14),
+                            Children = new Drawable[]
+                            {
+                                new Circle
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Colour = colours.YellowLight,
+                                    RelativeSizeAxes = Axes.Both,
+                                },
+                                new SpriteIcon
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Icon = FontAwesome.Solid.Cog,
+                                    Colour = colours.YellowDark,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.7f),
+                                }
+                            }
                         },
                     }
                 },
@@ -206,6 +234,11 @@ namespace osu.Game.Rulesets.UI
 
             backgroundColour = colours.ForModType(value.Type);
             updateColour();
+
+            if (mod.HasNonDefaultSettings)
+                adjustmentMarker.Show();
+            else
+                adjustmentMarker.Hide();
 
             updateExtendedInformation();
         }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -84,6 +84,9 @@ namespace osu.Game.Rulesets.UI
 
         private Drawable adjustmentMarker = null!;
 
+        private Circle cogBackground = null!;
+        private SpriteIcon cog = null!;
+
         private ModSettingChangeTracker? modSettingsChangeTracker;
 
         /// <summary>
@@ -175,21 +178,19 @@ namespace osu.Game.Rulesets.UI
                             Position = new Vector2(64, 14),
                             Children = new Drawable[]
                             {
-                                new Circle
+                                cogBackground = new Circle
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
-                                    Colour = colours.YellowLight,
                                     RelativeSizeAxes = Axes.Both,
                                 },
-                                new SpriteIcon
+                                cog = new SpriteIcon
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Cog,
-                                    Colour = colours.YellowDark,
                                     RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.7f),
+                                    Size = new Vector2(0.6f),
                                 }
                             }
                         },
@@ -254,6 +255,8 @@ namespace osu.Game.Rulesets.UI
         private void updateColour()
         {
             modAcronym.Colour = modIcon.Colour = Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, backgroundColour, 0, 1);
+            cogBackground.Colour = Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, backgroundColour, 0, 1);
+            cog.Colour = backgroundColour;
 
             extendedText.Colour = background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
             extendedBackground.Colour = Selected.Value ? backgroundColour.Darken(2.4f) : backgroundColour.Darken(2.8f);

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -236,11 +236,6 @@ namespace osu.Game.Rulesets.UI
             backgroundColour = colours.ForModType(value.Type);
             updateColour();
 
-            if (mod.HasNonDefaultSettings)
-                adjustmentMarker.Show();
-            else
-                adjustmentMarker.Hide();
-
             updateExtendedInformation();
         }
 
@@ -250,6 +245,11 @@ namespace osu.Game.Rulesets.UI
 
             extendedContent.Alpha = showExtended ? 1 : 0;
             extendedText.Text = mod.ExtendedIconInformation;
+
+            if (mod.HasNonDefaultSettings)
+                adjustmentMarker.Show();
+            else
+                adjustmentMarker.Hide();
         }
 
         private void updateColour()


### PR DESCRIPTION
This adds two improvements:

## Show marker icon when any setting is non-default

![osu Game Tests 2025-04-28 at 09 09 31](https://github.com/user-attachments/assets/35b1f993-f87e-4304-a3ee-dbd72c02e57a)

![osu! 2025-04-28 at 09 11 36](https://github.com/user-attachments/assets/2a363eb5-062a-422c-ac7e-3baaf9c212dc)

## Show inline text when a single setting is adjusted via difficulty adjust mode

![osu Game Tests 2025-04-28 at 09 10 34](https://github.com/user-attachments/assets/6bff1229-804f-4107-a403-e4ecaf38856f)

![osu! 2025-04-28 at 09 12 43](https://github.com/user-attachments/assets/16b9d7b7-b54c-492d-bcf0-9bb2a2e7d69d)

---