### PR TITLE
Fix overlay buttons in screen footer not correctly aligned with back button

### DIFF
--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -65,8 +65,6 @@ namespace osu.Game.Screens.Footer
         [BackgroundDependencyLoader]
         private void load()
         {
-            const float footer_button_y_offset = 10;
-
             InternalChildren = new Drawable[]
             {
                 background = new Box
@@ -91,7 +89,7 @@ namespace osu.Game.Screens.Footer
                             {
                                 Anchor = Anchor.BottomLeft,
                                 Origin = Anchor.BottomLeft,
-                                Y = footer_button_y_offset,
+                                Y = ScreenFooterButton.Y_OFFSET,
                                 Direction = FillDirection.Horizontal,
                                 Spacing = new Vector2(7, 0),
                                 AutoSizeAxes = Axes.Both,
@@ -114,7 +112,7 @@ namespace osu.Game.Screens.Footer
                 hiddenButtonsContainer = new Container<ScreenFooterButton>
                 {
                     Margin = new MarginPadding { Left = OsuGame.SCREEN_EDGE_MARGIN + ScreenBackButton.BUTTON_WIDTH + padding },
-                    Y = footer_button_y_offset,
+                    Y = ScreenFooterButton.Y_OFFSET,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     AutoSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Footer
                             footerContentContainer = new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Y = -15f,
+                                Y = -OsuGame.SCREEN_EDGE_MARGIN,
                             },
                         },
                     }

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -65,6 +65,8 @@ namespace osu.Game.Screens.Footer
         [BackgroundDependencyLoader]
         private void load()
         {
+            const float footer_button_y_offset = 10;
+
             InternalChildren = new Drawable[]
             {
                 background = new Box
@@ -75,7 +77,7 @@ namespace osu.Game.Screens.Footer
                 new GridContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Left = 12f + ScreenBackButton.BUTTON_WIDTH + padding },
+                    Padding = new MarginPadding { Left = OsuGame.SCREEN_EDGE_MARGIN + ScreenBackButton.BUTTON_WIDTH + padding },
                     ColumnDimensions = new[]
                     {
                         new Dimension(GridSizeMode.AutoSize),
@@ -89,7 +91,7 @@ namespace osu.Game.Screens.Footer
                             {
                                 Anchor = Anchor.BottomLeft,
                                 Origin = Anchor.BottomLeft,
-                                Y = 10f,
+                                Y = footer_button_y_offset,
                                 Direction = FillDirection.Horizontal,
                                 Spacing = new Vector2(7, 0),
                                 AutoSizeAxes = Axes.Both,
@@ -112,7 +114,7 @@ namespace osu.Game.Screens.Footer
                 hiddenButtonsContainer = new Container<ScreenFooterButton>
                 {
                     Margin = new MarginPadding { Left = OsuGame.SCREEN_EDGE_MARGIN + ScreenBackButton.BUTTON_WIDTH + padding },
-                    Y = 10f,
+                    Y = footer_button_y_offset,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     AutoSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Footer/ScreenFooterButton.cs
+++ b/osu.Game/Screens/Footer/ScreenFooterButton.cs
@@ -25,7 +25,8 @@ namespace osu.Game.Screens.Footer
 {
     public partial class ScreenFooterButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>
     {
-        protected const int CORNER_RADIUS = 10;
+        public const int Y_OFFSET = 10;
+
         protected const int BUTTON_HEIGHT = 75;
         protected const int BUTTON_WIDTH = 116;
 
@@ -87,7 +88,7 @@ namespace osu.Game.Screens.Footer
                     },
                     Shear = OsuGame.SHEAR,
                     Masking = true,
-                    CornerRadius = CORNER_RADIUS,
+                    CornerRadius = 10,
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
@@ -134,7 +135,7 @@ namespace osu.Game.Screens.Footer
                             Shear = -OsuGame.SHEAR,
                             Anchor = Anchor.BottomCentre,
                             Origin = Anchor.Centre,
-                            Y = -CORNER_RADIUS,
+                            Y = -Y_OFFSET,
                             Size = new Vector2(100, 5),
                             Masking = true,
                             CornerRadius = 3,

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Screens.SelectV2
                     Depth = float.MaxValue,
                     Origin = Anchor.BottomLeft,
                     Shear = OsuGame.SHEAR,
-                    CornerRadius = CORNER_RADIUS,
+                    CornerRadius = Y_OFFSET,
                     Size = new Vector2(BUTTON_WIDTH, bar_height),
                     Masking = true,
                     EdgeEffect = new EdgeEffectParameters
@@ -115,7 +115,7 @@ namespace osu.Game.Screens.SelectV2
                         },
                         new Container
                         {
-                            CornerRadius = CORNER_RADIUS,
+                            CornerRadius = Y_OFFSET,
                             RelativeSizeAxes = Axes.Both,
                             Width = mod_display_portion,
                             Masking = true,
@@ -264,7 +264,7 @@ namespace osu.Game.Screens.SelectV2
                 private void load()
                 {
                     AutoSizeAxes = Axes.Both;
-                    CornerRadius = CORNER_RADIUS;
+                    CornerRadius = Y_OFFSET;
                     Masking = true;
 
                     InternalChildren = new Drawable[]
@@ -306,7 +306,7 @@ namespace osu.Game.Screens.SelectV2
                 Depth = float.MaxValue;
                 Origin = Anchor.BottomLeft;
                 Shear = OsuGame.SHEAR;
-                CornerRadius = CORNER_RADIUS;
+                CornerRadius = Y_OFFSET;
                 AutoSizeAxes = Axes.X;
                 Height = bar_height;
                 Masking = true;


### PR DESCRIPTION
Noticed on passing. Regressed in https://github.com/ppy/osu/pull/32819 ...🤷‍♂️

Before:

![CleanShot 2025-04-29 at 03 37 19](https://github.com/user-attachments/assets/871b8d72-9175-43f2-a80e-9330d2272fb6)

After:

![CleanShot 2025-04-29 at 03 36 42](https://github.com/user-attachments/assets/df86ef12-bb23-4118-b2e4-ff2f5f1b4382)
