### PR TITLE
Remove pre-rate rounding in BPM display

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -163,8 +163,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         [TestCase(120, 125, null, "120-125 (mostly 120)")]
         [TestCase(120, 120.6, null, "120-121 (mostly 120)")]
         [TestCase(120, 120.4, null, "120")]
-        [TestCase(120, 120.6, "DT", "180-182 (mostly 180)")]
-        [TestCase(120, 120.4, "DT", "180")]
+        [TestCase(120, 120.6, "DT", "180-181 (mostly 180)")]
+        [TestCase(120, 120.4, "DT", "180-181 (mostly 180)")]
         public void TestVaryingBPM(double commonBpm, double otherBpm, string? mod, string expectedDisplay)
         {
             IBeatmap beatmap = CreateTestBeatmap(new OsuRuleset().RulesetInfo);

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
@@ -118,8 +118,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [TestCase(120, 125, null, "120-125 (mostly 120)")]
         [TestCase(120, 120.6, null, "120-121 (mostly 120)")]
         [TestCase(120, 120.4, null, "120")]
-        [TestCase(120, 120.6, "DT", "180-182 (mostly 180)")]
-        [TestCase(120, 120.4, "DT", "180")]
+        [TestCase(120, 120.6, "DT", "180-181 (mostly 180)")]
+        [TestCase(120, 120.4, "DT", "180-181 (mostly 180)")]
         public void TestVaryingBPM(double commonBpm, double otherBpm, string? mod, string expectedDisplay)
         {
             IBeatmap beatmap = TestSceneBeatmapInfoWedge.CreateTestBeatmap(new OsuRuleset().RulesetInfo);

--- a/osu.Game/Utils/FormatUtils.cs
+++ b/osu.Game/Utils/FormatUtils.cs
@@ -59,11 +59,8 @@ namespace osu.Game.Utils
         /// <summary>
         /// Applies rounding to the given BPM value.
         /// </summary>
-        /// <remarks>
-        /// Double-rounding is applied intentionally (see https://github.com/ppy/osu/pull/18345#issue-1243311382 for rationale).
-        /// </remarks>
         /// <param name="baseBpm">The base BPM to round.</param>
         /// <param name="rate">Rate adjustment, if applicable.</param>
-        public static int RoundBPM(double baseBpm, double rate = 1) => (int)Math.Round(Math.Round(baseBpm) * rate);
+        public static int RoundBPM(double baseBpm, double rate = 1) => (int)Math.Round(baseBpm * rate);
     }
 }


### PR DESCRIPTION
- Closes #32811 

As discussed, there is no reason / it's incorrect to round BPM before multiplying by rate, even if it changes `120 - 120.4` BPM range from `"180"` to `"180-181 (mostly 180)"` when DT is applied. It makes sense to show the latter from a mathematical perspective.