### PR TITLE
Fix mania columns not handling touch input in gaps

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaTouchInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaTouchInput.cs
@@ -18,7 +18,12 @@ namespace osu.Game.Rulesets.Mania.Tests
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
         [SetUp]
-        public void SetUp() => Schedule(() => toggleTouchControls(false));
+        public void SetUp() => Schedule(() =>
+        {
+            InputManager.EndTouch(new Touch(TouchSource.Touch1, Vector2.Zero));
+            InputManager.EndTouch(new Touch(TouchSource.Touch2, Vector2.Zero));
+            toggleTouchControls(false);
+        });
 
         #region Without touch controls
 
@@ -69,6 +74,35 @@ namespace osu.Game.Rulesets.Mania.Tests
             AddAssert("action released",
                 () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
                 () => Does.Not.Contain(getColumn(0).Action.Value));
+        }
+
+        [Test]
+        public void TestBetweenTwoColumns()
+        {
+            AddStep("touch after column 0", () =>
+            {
+                var column = getColumn(0);
+                InputManager.BeginTouch(new Touch(TouchSource.Touch1, column.ToScreenSpace(new Vector2(column.LayoutSize.X + 0.5f, column.LayoutSize.Y / 2))));
+            });
+            AddAssert("column 0 pressed",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Contain(getColumn(0).Action.Value));
+            AddStep("release finger", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, getColumn(0).ScreenSpaceDrawQuad.Centre)));
+            AddAssert("column 0 released",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Not.Contain(getColumn(0).Action.Value));
+            AddStep("touch before column 1", () =>
+            {
+                var column = getColumn(1);
+                InputManager.BeginTouch(new Touch(TouchSource.Touch1, column.ToScreenSpace(new Vector2(-0.5f, column.LayoutSize.Y / 2))));
+            });
+            AddAssert("column 1 pressed",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Contain(getColumn(1).Action.Value));
+            AddStep("release finger", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, getColumn(0).ScreenSpaceDrawQuad.Centre)));
+            AddAssert("column 1 released",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Not.Contain(getColumn(1).Action.Value));
         }
 
         #endregion
@@ -130,6 +164,38 @@ namespace osu.Game.Rulesets.Mania.Tests
             AddAssert("action not sent",
                 () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
                 () => Does.Not.Contain(getColumn(0).Action.Value));
+        }
+
+        [Test]
+        public void TestTouchControlBetweenTwoColumns()
+        {
+            AddStep("enable touch controls", () => toggleTouchControls(true));
+
+            AddStep("touch after receptor 0", () =>
+            {
+                var column = getReceptor(0);
+                InputManager.BeginTouch(new Touch(TouchSource.Touch1, column.ToScreenSpace(new Vector2(column.LayoutSize.X + 1f, column.LayoutSize.Y / 2))));
+            });
+
+            AddAssert("column 0 pressed",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Contain(getReceptor(0).Action.Value));
+            AddStep("release finger", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, getReceptor(0).ScreenSpaceDrawQuad.Centre)));
+            AddAssert("column 0 released",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Not.Contain(getReceptor(0).Action.Value));
+            AddStep("touch before receptor 1", () =>
+            {
+                var column = getReceptor(1);
+                InputManager.BeginTouch(new Touch(TouchSource.Touch1, column.ToScreenSpace(new Vector2(-1f, column.LayoutSize.Y / 2))));
+            });
+            AddAssert("column 1 pressed",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Contain(getReceptor(1).Action.Value));
+            AddStep("release finger", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, getReceptor(0).ScreenSpaceDrawQuad.Centre)));
+            AddAssert("column 1 released",
+                () => this.ChildrenOfType<ManiaInputManager>().SelectMany(m => m.KeyBindingContainer.PressedActions),
+                () => Does.Not.Contain(getReceptor(1).Action.Value));
         }
 
         #endregion

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -131,8 +131,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
                 switch (maniaLookup.Lookup)
                 {
-                    case LegacyManiaSkinConfigurationLookups.ColumnSpacing:
-                        return SkinUtils.As<TValue>(new Bindable<float>(2));
+                    case LegacyManiaSkinConfigurationLookups.LeftColumnSpacing:
+                    case LegacyManiaSkinConfigurationLookups.RightColumnSpacing:
+                        return SkinUtils.As<TValue>(new Bindable<float>(1));
 
                     case LegacyManiaSkinConfigurationLookups.StagePaddingBottom:
                     case LegacyManiaSkinConfigurationLookups.StagePaddingTop:
@@ -146,7 +147,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                         return SkinUtils.As<TValue>(new Bindable<float>(width));
 
                     case LegacyManiaSkinConfigurationLookups.ColumnBackgroundColour:
-
                         var colour = getColourForLayout(columnIndex, stage);
 
                         return SkinUtils.As<TValue>(new Bindable<Color4>(colour));

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -60,6 +60,9 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private IBindable<ManiaMobileLayout> mobilePlayStyle = null!;
 
+        private float leftColumnSpacing;
+        private float rightColumnSpacing;
+
         public Column(int index, bool isSpecial)
         {
             Index = index;
@@ -126,6 +129,14 @@ namespace osu.Game.Rulesets.Mania.UI
         private void onSourceChanged()
         {
             AccentColour.Value = skin.GetManiaSkinConfig<Color4>(LegacyManiaSkinConfigurationLookups.ColumnBackgroundColour, Index)?.Value ?? Color4.Black;
+
+            leftColumnSpacing = skin.GetConfig<ManiaSkinConfigurationLookup, float>(
+                                        new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.LeftColumnSpacing, Index))
+                                    ?.Value ?? Stage.COLUMN_SPACING;
+
+            rightColumnSpacing = skin.GetConfig<ManiaSkinConfigurationLookup, float>(
+                                         new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.RightColumnSpacing, Index))
+                                     ?.Value ?? Stage.COLUMN_SPACING;
         }
 
         protected override void LoadComplete()
@@ -187,8 +198,11 @@ namespace osu.Game.Rulesets.Mania.UI
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
-            // This probably shouldn't exist as is, but the columns in the stage are separated by a 1px border
-            => DrawRectangle.Inflate(new Vector2(Stage.COLUMN_SPACING / 2, 0)).Contains(ToLocalSpace(screenSpacePos));
+        {
+            // Extend input coverage to the gaps close to this column.
+            var spacingInflation = new MarginPadding { Left = leftColumnSpacing, Right = rightColumnSpacing };
+            return DrawRectangle.Inflate(spacingInflation).Contains(ToLocalSpace(screenSpacePos));
+        }
 
         #region Touch Input
 

--- a/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
+++ b/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
@@ -124,14 +124,15 @@ namespace osu.Game.Rulesets.Mania.UI
 
             for (int i = 0; i < stageDefinition.Columns; i++)
             {
-                if (i > 0)
-                {
-                    float spacing = skin.GetConfig<ManiaSkinConfigurationLookup, float>(
-                                            new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.ColumnSpacing, i - 1))
+                float leftSpacing = skin.GetConfig<ManiaSkinConfigurationLookup, float>(
+                                            new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.LeftColumnSpacing, i))
                                         ?.Value ?? Stage.COLUMN_SPACING;
 
-                    columns[i].Margin = new MarginPadding { Left = spacing };
-                }
+                float rightSpacing = skin.GetConfig<ManiaSkinConfigurationLookup, float>(
+                                             new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.RightColumnSpacing, i))
+                                         ?.Value ?? Stage.COLUMN_SPACING;
+
+                columns[i].Margin = new MarginPadding { Left = leftSpacing, Right = rightSpacing };
 
                 float? width = skin.GetConfig<ManiaSkinConfigurationLookup, float>(
                                        new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.ColumnWidth, i))

--- a/osu.Game.Rulesets.Mania/UI/ManiaTouchInputArea.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaTouchInputArea.cs
@@ -74,6 +74,7 @@ namespace osu.Game.Rulesets.Mania.UI
                     receptorGridContent.Add(new ColumnInputReceptor
                     {
                         Action = { BindTarget = column.Action },
+                        Spacing = { BindTarget = Spacing },
                     });
                     receptorGridDimensions.Add(new Dimension());
 
@@ -122,6 +123,7 @@ namespace osu.Game.Rulesets.Mania.UI
         public partial class ColumnInputReceptor : CompositeDrawable
         {
             public readonly IBindable<ManiaAction> Action = new Bindable<ManiaAction>();
+            public readonly IBindable<float> Spacing = new BindableFloat();
 
             private readonly Box highlightOverlay;
 
@@ -158,6 +160,10 @@ namespace osu.Game.Rulesets.Mania.UI
                     }
                 };
             }
+
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+                // Extend input coverage to the gaps close to this receptor.
+                => DrawRectangle.Inflate(new Vector2(Spacing.Value / 2, 0)).Contains(ToLocalSpace(screenSpacePos));
 
             protected override bool OnTouchDown(TouchDownEvent e)
             {

--- a/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
@@ -38,8 +38,6 @@ namespace osu.Game.Skinning
     {
         ColumnWidth,
         LightImage,
-        LeftLineWidth,
-        RightLineWidth,
         HitPosition,
         ComboPosition,
         ScorePosition,
@@ -55,10 +53,8 @@ namespace osu.Game.Skinning
         HoldNoteTailImage,
         HoldNoteBodyImage,
         HoldNoteLightImage,
-        HoldNoteLightScale,
         WidthForNoteHeightScale,
         ExplosionImage,
-        ExplosionScale,
         ColumnLineColour,
         JudgementLineColour,
         ColumnBackgroundColour,
@@ -83,7 +79,15 @@ namespace osu.Game.Skinning
         KeysUnderNotes,
         NoteBodyStyle,
         LightFramePerSecond,
+
+        // The following lookup entries are not directly tied to skin.ini settings
+        // but are defined to simplify the process of determining such values.
+
         LeftColumnSpacing,
         RightColumnSpacing,
+        LeftLineWidth,
+        RightLineWidth,
+        ExplosionScale,
+        HoldNoteLightScale,
     }
 }

--- a/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Skinning
     public enum LegacyManiaSkinConfigurationLookups
     {
         ColumnWidth,
-        ColumnSpacing,
         LightImage,
         LeftLineWidth,
         RightLineWidth,
@@ -83,6 +82,8 @@ namespace osu.Game.Skinning
         Hit0,
         KeysUnderNotes,
         NoteBodyStyle,
-        LightFramePerSecond
+        LightFramePerSecond,
+        LeftColumnSpacing,
+        RightColumnSpacing,
     }
 }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -166,17 +166,6 @@ namespace osu.Game.Skinning
                 case LegacyManiaSkinConfigurationLookups.ExplosionImage:
                     return SkinUtils.As<TValue>(getManiaImage(existing, "LightingN"));
 
-                case LegacyManiaSkinConfigurationLookups.ExplosionScale:
-                    Debug.Assert(maniaLookup.ColumnIndex != null);
-
-                    if (GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value < 2.5m)
-                        return SkinUtils.As<TValue>(new Bindable<float>(1));
-
-                    if (existing.ExplosionWidth[maniaLookup.ColumnIndex.Value] != 0)
-                        return SkinUtils.As<TValue>(new Bindable<float>(existing.ExplosionWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
-
-                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
-
                 case LegacyManiaSkinConfigurationLookups.ColumnLineColour:
                     return SkinUtils.As<TValue>(getCustomColour(existing, "ColourColumnLine"));
 
@@ -232,17 +221,6 @@ namespace osu.Game.Skinning
                 case LegacyManiaSkinConfigurationLookups.HoldNoteLightImage:
                     return SkinUtils.As<TValue>(getManiaImage(existing, "LightingL"));
 
-                case LegacyManiaSkinConfigurationLookups.HoldNoteLightScale:
-                    Debug.Assert(maniaLookup.ColumnIndex != null);
-
-                    if (GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value < 2.5m)
-                        return SkinUtils.As<TValue>(new Bindable<float>(1));
-
-                    if (existing.HoldNoteLightWidth[maniaLookup.ColumnIndex.Value] != 0)
-                        return SkinUtils.As<TValue>(new Bindable<float>(existing.HoldNoteLightWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
-
-                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
-
                 case LegacyManiaSkinConfigurationLookups.KeyImage:
                     Debug.Assert(maniaLookup.ColumnIndex != null);
                     return SkinUtils.As<TValue>(getManiaImage(existing, $"KeyImage{maniaLookup.ColumnIndex}"));
@@ -266,13 +244,19 @@ namespace osu.Game.Skinning
                 case LegacyManiaSkinConfigurationLookups.HitTargetImage:
                     return SkinUtils.As<TValue>(getManiaImage(existing, "StageHint"));
 
-                case LegacyManiaSkinConfigurationLookups.LeftLineWidth:
-                    Debug.Assert(maniaLookup.ColumnIndex != null);
-                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnLineWidth[maniaLookup.ColumnIndex.Value]));
+                case LegacyManiaSkinConfigurationLookups.Hit0:
+                case LegacyManiaSkinConfigurationLookups.Hit50:
+                case LegacyManiaSkinConfigurationLookups.Hit100:
+                case LegacyManiaSkinConfigurationLookups.Hit200:
+                case LegacyManiaSkinConfigurationLookups.Hit300:
+                case LegacyManiaSkinConfigurationLookups.Hit300g:
+                    return SkinUtils.As<TValue>(getManiaImage(existing, maniaLookup.Lookup.ToString()));
 
-                case LegacyManiaSkinConfigurationLookups.RightLineWidth:
-                    Debug.Assert(maniaLookup.ColumnIndex != null);
-                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnLineWidth[maniaLookup.ColumnIndex.Value + 1]));
+                case LegacyManiaSkinConfigurationLookups.KeysUnderNotes:
+                    return SkinUtils.As<TValue>(new Bindable<bool>(existing.KeysUnderNotes));
+
+                case LegacyManiaSkinConfigurationLookups.LightFramePerSecond:
+                    return SkinUtils.As<TValue>(new Bindable<int>(existing.LightFramePerSecond));
 
                 case LegacyManiaSkinConfigurationLookups.LeftColumnSpacing:
                     Debug.Assert(maniaLookup.ColumnIndex != null);
@@ -288,19 +272,35 @@ namespace osu.Game.Skinning
 
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnSpacing[maniaLookup.ColumnIndex.Value] / 2));
 
-                case LegacyManiaSkinConfigurationLookups.Hit0:
-                case LegacyManiaSkinConfigurationLookups.Hit50:
-                case LegacyManiaSkinConfigurationLookups.Hit100:
-                case LegacyManiaSkinConfigurationLookups.Hit200:
-                case LegacyManiaSkinConfigurationLookups.Hit300:
-                case LegacyManiaSkinConfigurationLookups.Hit300g:
-                    return SkinUtils.As<TValue>(getManiaImage(existing, maniaLookup.Lookup.ToString()));
+                case LegacyManiaSkinConfigurationLookups.LeftLineWidth:
+                    Debug.Assert(maniaLookup.ColumnIndex != null);
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnLineWidth[maniaLookup.ColumnIndex.Value]));
 
-                case LegacyManiaSkinConfigurationLookups.KeysUnderNotes:
-                    return SkinUtils.As<TValue>(new Bindable<bool>(existing.KeysUnderNotes));
+                case LegacyManiaSkinConfigurationLookups.RightLineWidth:
+                    Debug.Assert(maniaLookup.ColumnIndex != null);
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnLineWidth[maniaLookup.ColumnIndex.Value + 1]));
 
-                case LegacyManiaSkinConfigurationLookups.LightFramePerSecond:
-                    return SkinUtils.As<TValue>(new Bindable<int>(existing.LightFramePerSecond));
+                case LegacyManiaSkinConfigurationLookups.ExplosionScale:
+                    Debug.Assert(maniaLookup.ColumnIndex != null);
+
+                    if (GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value < 2.5m)
+                        return SkinUtils.As<TValue>(new Bindable<float>(1));
+
+                    if (existing.ExplosionWidth[maniaLookup.ColumnIndex.Value] != 0)
+                        return SkinUtils.As<TValue>(new Bindable<float>(existing.ExplosionWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
+
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
+
+                case LegacyManiaSkinConfigurationLookups.HoldNoteLightScale:
+                    Debug.Assert(maniaLookup.ColumnIndex != null);
+
+                    if (GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value < 2.5m)
+                        return SkinUtils.As<TValue>(new Bindable<float>(1));
+
+                    if (existing.HoldNoteLightWidth[maniaLookup.ColumnIndex.Value] != 0)
+                        return SkinUtils.As<TValue>(new Bindable<float>(existing.HoldNoteLightWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
+
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnWidth[maniaLookup.ColumnIndex.Value] / LegacyManiaSkinConfiguration.DEFAULT_COLUMN_SIZE));
             }
 
             return null;

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -148,10 +148,6 @@ namespace osu.Game.Skinning
                     Debug.Assert(maniaLookup.ColumnIndex != null);
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.WidthForNoteHeightScale));
 
-                case LegacyManiaSkinConfigurationLookups.ColumnSpacing:
-                    Debug.Assert(maniaLookup.ColumnIndex != null);
-                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnSpacing[maniaLookup.ColumnIndex.Value]));
-
                 case LegacyManiaSkinConfigurationLookups.HitPosition:
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.HitPosition));
 
@@ -277,6 +273,20 @@ namespace osu.Game.Skinning
                 case LegacyManiaSkinConfigurationLookups.RightLineWidth:
                     Debug.Assert(maniaLookup.ColumnIndex != null);
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnLineWidth[maniaLookup.ColumnIndex.Value + 1]));
+
+                case LegacyManiaSkinConfigurationLookups.LeftColumnSpacing:
+                    Debug.Assert(maniaLookup.ColumnIndex != null);
+                    if (maniaLookup.ColumnIndex == 0)
+                        return SkinUtils.As<TValue>(new Bindable<float>());
+
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnSpacing[maniaLookup.ColumnIndex.Value - 1] / 2));
+
+                case LegacyManiaSkinConfigurationLookups.RightColumnSpacing:
+                    Debug.Assert(maniaLookup.ColumnIndex != null);
+                    if (maniaLookup.ColumnIndex == existing.ColumnSpacing.Length)
+                        return SkinUtils.As<TValue>(new Bindable<float>());
+
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnSpacing[maniaLookup.ColumnIndex.Value] / 2));
 
                 case LegacyManiaSkinConfigurationLookups.Hit0:
                 case LegacyManiaSkinConfigurationLookups.Hit50:


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/32476

Taps now reach the nearest column. This applies to both columns and touch overlay receptors. The logic for columns specifically is slightly more involved due to columns supporting variable spacing between, I've had to apply a minor refactor to the columns spacing lookup logic to be able to look it up without adding edge cases for first and last columns (which is not easy to do).

I've manually tested variable spacing as in the video below:

https://github.com/user-attachments/assets/ec965c5c-5697-4cee-967e-1e0e1c831768

