### PR TITLE
Change tooltip text to better cover mod setting scenarios

### DIFF
--- a/osu.Game/Overlays/Mods/AdjustedAttributesTooltip.cs
+++ b/osu.Game/Overlays/Mods/AdjustedAttributesTooltip.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays.Mods
                             {
                                 new OsuSpriteText
                                 {
-                                    Text = "One or more values are being adjusted by mods that change speed.",
+                                    Text = "One or more values are being adjusted by mods.",
                                 },
                                 attributesFillFlow = new FillFlowContainer
                                 {


### PR DESCRIPTION
Mods don't necessarily have to change speed, to change beatmap attributes.
Also, speed mods don't affect beatmap attributes in mania, making the text misleading.