### PR TITLE
Decrease minimum allowed beat length for `TimingControlPoint`

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -58,13 +58,14 @@ namespace osu.Game.Beatmaps.ControlPoints
         }
 
         public const double DEFAULT_BEAT_LENGTH = 1000;
+        public const double MIN_BEAT_LENGTH = 0.00001;
 
         /// <summary>
         /// The beat length at this control point.
         /// </summary>
         public readonly BindableDouble BeatLengthBindable = new BindableDouble(DEFAULT_BEAT_LENGTH)
         {
-            MinValue = 6,
+            MinValue = MIN_BEAT_LENGTH,
             MaxValue = 60000
         };
 

--- a/osu.Game/Rulesets/Objects/BarLineGenerator.cs
+++ b/osu.Game/Rulesets/Objects/BarLineGenerator.cs
@@ -45,10 +45,13 @@ namespace osu.Game.Rulesets.Objects
                 // Of note, this will still differ from stable if the first timing control point is t<0 and is not near the first hitobject.
                 double generationStartTime = Math.Min(0, firstHitTime);
 
-                // Stop on the next timing point, or if there is no next timing point stop slightly past the last object
-                double endTime = i < timingPoints.Count - 1 ? timingPoints[i + 1].Time : lastHitTime + currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
+                // Limit beat length to limit barline count generation
+                double beatLength = Math.Max(currentTimingPoint.BeatLength, 6);
 
-                double barLength = currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
+                // Stop on the next timing point, or if there is no next timing point stop slightly past the last object
+                double endTime = i < timingPoints.Count - 1 ? timingPoints[i + 1].Time : lastHitTime + beatLength * currentTimingPoint.TimeSignature.Numerator;
+
+                double barLength = beatLength * currentTimingPoint.TimeSignature.Numerator;
 
                 double startTime;
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -115,6 +115,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             for (int i = 0; i < beatmap.ControlPointInfo.TimingPoints.Count; i++)
             {
                 var point = beatmap.ControlPointInfo.TimingPoints[i];
+
+                // Do not display ticks if BPM > 10000
+                if (point.BeatLength < 6)
+                    continue;
+
                 double until = i + 1 < beatmap.ControlPointInfo.TimingPoints.Count ? beatmap.ControlPointInfo.TimingPoints[i + 1].Time : working.Value.Track.Length;
 
                 int beat = 0;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30554, closes https://github.com/ppy/osu/issues/30348, closes https://github.com/ppy/osu/issues/29661

Partially affetcs:
- https://github.com/ppy/osu/issues/20108 (one of the two provided maps fixed)
- https://github.com/ppy/osu/issues/25853 (SV is fixed I believe but barlines aren't the same. Though I think this is a separate issue with the generator algo)

While allowing any positive number would be the best - there are some issues with that.
* With `double.epsilon` `ScrollingHitObjectContainer` breaks on some maps.
* There are far more issues with the editor (and I'm not sure in which way they should be handled)

Why this exact number then? It solves most cases and I don't believe we need to go any lower. Also BPM in `BeatmapInfoWedge` caps to int max value, which we can probably use in the future to display infinity or something.
Editor crashing was caused by a ton of generated timeline ticks which I'm disabling after a certain threshold (stable does so too as far as I can tell and I don't think they are needed at that point)

Some cool comparison footage with [mania SV map](https://osu.ppy.sh/beatmapsets/1236952#mania/2571106)
https://streamable.com/mck02x