### PR TITLE
Fix beatmap title wedge sheared incorrectly in test scene

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
@@ -65,6 +65,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
+                    Shear = OsuGame.SHEAR,
                     Children = new Drawable[]
                     {
                         titleWedge = new BeatmapTitleWedge


### PR DESCRIPTION
Was supposed to be included in #32854. Shear specification has been moved away from `BeatmapTitleWedge` to the parenting flow container in `SongSelect` to be able to align the title wedge with the details area below it.