### PR TITLE
Fix song select title wedge not accessing beatmap asynchronously

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -246,25 +248,41 @@ namespace osu.Game.Screens.SelectV2
             updateOnlineDisplay();
         }
 
+        private CancellationTokenSource? lengthBpmCancellationSource;
+
         private void updateLengthAndBpmStatistics()
         {
-            var beatmapInfo = beatmap.Value.BeatmapInfo;
+            lengthBpmCancellationSource?.Cancel();
+            lengthBpmCancellationSource = new CancellationTokenSource();
 
-            double rate = ModUtils.CalculateRateWithMods(mods.Value);
+            var token = lengthBpmCancellationSource.Token;
 
-            int bpmMax = FormatUtils.RoundBPM(beatmap.Value.Beatmap.ControlPointInfo.BPMMaximum, rate);
-            int bpmMin = FormatUtils.RoundBPM(beatmap.Value.Beatmap.ControlPointInfo.BPMMinimum, rate);
-            int mostCommonBPM = FormatUtils.RoundBPM(60000 / beatmap.Value.Beatmap.GetMostCommonBeatLength(), rate);
+            Task.Run(() =>
+            {
+                var beatmapInfo = beatmap.Value.BeatmapInfo;
 
-            double drainLength = Math.Round(beatmap.Value.Beatmap.CalculateDrainLength() / rate);
-            double hitLength = Math.Round(beatmapInfo.Length / rate);
+                double rate = ModUtils.CalculateRateWithMods(mods.Value);
 
-            lengthStatistic.Text = hitLength.ToFormattedDuration();
-            lengthStatistic.TooltipText = BeatmapsetsStrings.ShowStatsTotalLength(drainLength.ToFormattedDuration());
+                int bpmMax = FormatUtils.RoundBPM(beatmap.Value.Beatmap.ControlPointInfo.BPMMaximum, rate);
+                int bpmMin = FormatUtils.RoundBPM(beatmap.Value.Beatmap.ControlPointInfo.BPMMinimum, rate);
+                int mostCommonBPM = FormatUtils.RoundBPM(60000 / beatmap.Value.Beatmap.GetMostCommonBeatLength(), rate);
 
-            bpmStatistic.Text = bpmMin == bpmMax
-                ? $"{bpmMin}"
-                : $"{bpmMin}-{bpmMax} (mostly {mostCommonBPM})";
+                double drainLength = Math.Round(beatmap.Value.Beatmap.CalculateDrainLength() / rate);
+                double hitLength = Math.Round(beatmapInfo.Length / rate);
+
+                Schedule(() =>
+                {
+                    if (token.IsCancellationRequested)
+                        return;
+
+                    lengthStatistic.Text = hitLength.ToFormattedDuration();
+                    lengthStatistic.TooltipText = BeatmapsetsStrings.ShowStatsTotalLength(drainLength.ToFormattedDuration());
+
+                    bpmStatistic.Text = bpmMin == bpmMax
+                        ? $"{bpmMin}"
+                        : $"{bpmMin}-{bpmMax} (mostly {mostCommonBPM})";
+                });
+            }, token);
         }
 
         private void refetchBeatmapSet()

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -285,6 +285,8 @@ namespace osu.Game.Screens.SelectV2
 
                 Task.Run(() =>
                 {
+                    // This can take time as it is a synchronous task.
+                    // TODO: We're calling `GetPlayableBeatmap` multiple times every map load at song select.
                     var playableBeatmap = beatmap.Value.GetPlayableBeatmap(ruleset.Value);
                     var statistics = playableBeatmap.GetStatistics()
                                                     .Select(s => new StatisticDifficulty.Data(s.Name, s.BarDisplayLength ?? 0, s.BarDisplayLength ?? 0, 1, s.Content))

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -241,8 +242,6 @@ namespace osu.Game.Screens.SelectV2
                 cancellationSource?.Cancel();
                 cancellationSource = new CancellationTokenSource();
 
-                computeStarDifficulty(cancellationSource.Token);
-
                 if (beatmap.IsDefault)
                 {
                     ratingAndNameContainer.FadeOut(300, Easing.OutQuint);
@@ -254,15 +253,51 @@ namespace osu.Game.Screens.SelectV2
                     difficultyText.Text = beatmap.Value.BeatmapInfo.DifficultyName;
                     mapperLink.Action = () => linkHandler?.HandleLink(new LinkDetails(LinkAction.OpenUserProfile, beatmap.Value.Metadata.Author));
                     mapperText.Text = beatmap.Value.Metadata.Author.Username;
-
-                    var playableBeatmap = beatmap.Value.GetPlayableBeatmap(ruleset.Value);
-
-                    countStatisticsDisplay.Statistics = playableBeatmap.GetStatistics()
-                                                                       .Select(s => new StatisticDifficulty.Data(s.Name, s.BarDisplayLength ?? 0, s.BarDisplayLength ?? 0, 1, s.Content))
-                                                                       .ToList();
                 }
 
+                updateStarDifficulty(cancellationSource.Token);
+                updateCountStatistics(cancellationSource.Token);
                 updateDifficultyStatistics();
+            }
+
+            private void updateStarDifficulty(CancellationToken cancellationToken)
+            {
+                difficultyCache.GetDifficultyAsync(beatmap.Value.BeatmapInfo, ruleset.Value, mods.Value, cancellationToken)
+                               .ContinueWith(task =>
+                               {
+                                   Schedule(() =>
+                                   {
+                                       if (cancellationToken.IsCancellationRequested)
+                                           return;
+
+                                       starRatingDisplay.Current.Value = task.GetResultSafely() ?? default;
+                                   });
+                               }, cancellationToken);
+            }
+
+            private void updateCountStatistics(CancellationToken cancellationToken)
+            {
+                if (beatmap.IsDefault)
+                {
+                    countStatisticsDisplay.Statistics = Array.Empty<StatisticDifficulty.Data>();
+                    return;
+                }
+
+                Task.Run(() =>
+                {
+                    var playableBeatmap = beatmap.Value.GetPlayableBeatmap(ruleset.Value);
+                    var statistics = playableBeatmap.GetStatistics()
+                                                    .Select(s => new StatisticDifficulty.Data(s.Name, s.BarDisplayLength ?? 0, s.BarDisplayLength ?? 0, 1, s.Content))
+                                                    .ToList();
+
+                    Schedule(() =>
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                            return;
+
+                        countStatisticsDisplay.Statistics = statistics;
+                    });
+                }, cancellationToken);
             }
 
             private void updateDifficultyStatistics() => Scheduler.AddOnce(() =>
@@ -320,21 +355,6 @@ namespace osu.Game.Screens.SelectV2
                     new StatisticDifficulty.Data(BeatmapsetsStrings.ShowStatsAr, baseDifficulty.ApproachRate, rateAdjustedDifficulty.ApproachRate, 10),
                 };
             });
-
-            private void computeStarDifficulty(CancellationToken cancellationToken)
-            {
-                difficultyCache.GetDifficultyAsync(beatmap.Value.BeatmapInfo, ruleset.Value, mods.Value, cancellationToken)
-                               .ContinueWith(task =>
-                               {
-                                   Schedule(() =>
-                                   {
-                                       if (cancellationToken.IsCancellationRequested)
-                                           return;
-
-                                       starRatingDisplay.Current.Value = task.GetResultSafely() ?? default;
-                                   });
-                               }, cancellationToken);
-            }
 
             protected override void Update()
             {


### PR DESCRIPTION
Addresses the first task in https://github.com/ppy/osu/issues/32736. Old song select approaches this by loading the entire wedge asynchronously, and transition from previous to new wedge using generic fade. This has always looked bad, and with the new design it looked much worse (see [discord](https://discord.com/channels/188630481301012481/1359431017680863302/1363280295473840308)).

Instead, each place in the title wedge that directly accesses `Beatmap` is moved to an asynchronous task instead. I've considered adding a loading layer in place of the count statistics but it increased the complexity of the code significantly for no real benefit.