### PR TITLE
Add diffcalc considerations for Magnetised mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -139,6 +139,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (mods.Any(m => m is OsuModRelax))
                 aimRating *= 0.9;
 
+            if (mods.Any(m => m is OsuModMagnetised))
+            {
+                float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;
+                aimRating *= 1.0 - magnetisedStrength;
+            }
+
             double ratingMultiplier = 1.0;
 
             double approachRateLengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
@@ -176,6 +182,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(m => m is OsuModAutopilot))
                 speedRating *= 0.5;
+
+            if (mods.Any(m => m is OsuModMagnetised))
+            {
+                // reduce speed rating because of the speed distance scaling
+                speedRating *= 0.9;
+            }
 
             double ratingMultiplier = 1.0;
 
@@ -216,6 +228,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 flashlightRating *= 0.7;
             else if (mods.Any(m => m is OsuModAutopilot))
                 flashlightRating *= 0.4;
+
+            if (mods.Any(m => m is OsuModMagnetised))
+            {
+                float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;
+                flashlightRating *= 1.0 - magnetisedStrength;
+            }
 
             double ratingMultiplier = 1.0;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -185,8 +185,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(m => m is OsuModMagnetised))
             {
-                // reduce speed rating because of the speed distance scaling
-                speedRating *= 0.9;
+                // reduce speed rating because of the speed distance scaling, with maximum reduction being 0.7x
+                float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;
+                speedRating *= 1.0 - magnetisedStrength * 0.3;
             }
 
             double ratingMultiplier = 1.0;


### PR DESCRIPTION
While this mod isn't ranked I've came across a few silly scores that had like 3k pp on the pp counter with no cursor movement at all, so this PR is here to fix it being _too_ silly. This isn't a complete solution in any way, but there's no real need for anything more than a few small tweaks for now anyway.

For example a DTx2 CS10 score on [c-type](https://osu.ppy.sh/beatmapsets/757146#osu/1592916) goes from ~6.5k pp down to ~1k on half-power magnetised and 280pp at full power