### PR TITLE
Fix test in old song select not working on Apple platforms

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -1277,12 +1277,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("set filter text", () => songSelect!.FilterControl.ChildrenOfType<FilterControl.FilterControlTextBox>().First().Text = "nonono");
             AddStep("select all", () => InputManager.Keys(PlatformAction.SelectAll));
-            AddStep("press ctrl-x", () =>
-            {
-                InputManager.PressKey(Key.ControlLeft);
-                InputManager.Key(Key.X);
-                InputManager.ReleaseKey(Key.ControlLeft);
-            });
+            AddStep("press ctrl/cmd-x", () => InputManager.Keys(PlatformAction.Cut));
 
             AddAssert("filter text cleared", () => songSelect!.FilterControl.ChildrenOfType<FilterControl.FilterControlTextBox>().First().Text, () => Is.Empty);
         }


### PR DESCRIPTION
Ctrl-x is not recognized on Apple platforms, Cmd-x should be pressed instead. This is shortened by just correctly using the `Keys` helper method instead.