### PR TITLE
Add filtering and minimised "eager" selection support in new carousel

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -20,6 +20,7 @@ using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Resources;
@@ -127,9 +128,23 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     },
                 };
             });
+
+            // Prefer title sorting so that order of carousel panels match order of BeatmapSets bindable.
+            SortBy(SortMode.Title);
         }
 
-        protected void SortBy(FilterCriteria criteria) => AddStep($"sort:{criteria.Sort} group:{criteria.Group}", () => Carousel.Filter(criteria));
+        protected void SortBy(SortMode mode) => ApplyToFilter($"sort by {mode.ToString().ToLowerInvariant()}", c => c.Sort = mode);
+        protected void GroupBy(GroupMode mode) => ApplyToFilter($"group by {mode.ToString().ToLowerInvariant()}", c => c.Group = mode);
+
+        protected void ApplyToFilter(string description, Action<FilterCriteria>? apply)
+        {
+            AddStep(description, () =>
+            {
+                var criteria = Carousel.Criteria;
+                apply?.Invoke(criteria);
+                Carousel.Filter(criteria);
+            });
+        }
 
         protected void WaitForDrawablePanels() => AddUntilStep("drawable panels loaded", () => Carousel.ChildrenOfType<ICarouselPanel>().Count(), () => Is.GreaterThan(0));
         protected void WaitForFiltering() => AddUntilStep("filtering finished", () => Carousel.IsFiltering, () => Is.False);

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         protected void SortBy(FilterCriteria criteria) => AddStep($"sort:{criteria.Sort} group:{criteria.Group}", () => Carousel.Filter(criteria));
 
         protected void WaitForDrawablePanels() => AddUntilStep("drawable panels loaded", () => Carousel.ChildrenOfType<ICarouselPanel>().Count(), () => Is.GreaterThan(0));
-        protected void WaitForSorting() => AddUntilStep("sorting finished", () => Carousel.IsFiltering, () => Is.False);
+        protected void WaitForFiltering() => AddUntilStep("filtering finished", () => Carousel.IsFiltering, () => Is.False);
         protected void WaitForScrolling() => AddUntilStep("scroll finished", () => Scroll.Current, () => Is.EqualTo(Scroll.Target));
 
         protected void SelectNextPanel() => AddStep("select next panel", () => InputManager.Key(Key.Down));

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -157,8 +157,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         protected void Select() => AddStep("select", () => InputManager.Key(Key.Enter));
 
-        protected void CheckNoSelection() => AddAssert("has no selection", () => Carousel.CurrentSelection, () => Is.Null);
-        protected void CheckHasSelection() => AddAssert("has selection", () => Carousel.CurrentSelection, () => Is.Not.Null);
+        protected void CheckNoSelection() => AddUntilStep("has no selection", () => Carousel.CurrentSelection, () => Is.Null);
+        protected void CheckHasSelection() => AddUntilStep("has selection", () => Carousel.CurrentSelection, () => Is.Not.Null);
 
         protected ICarouselPanel? GetSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.Selected.Value);
         protected ICarouselPanel? GetKeyboardSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.KeyboardSelected.Value);

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -296,7 +296,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             createHeader("carousel");
             stats.AddParagraph($"""
                                 sorting: {Carousel.IsFiltering}
-                                tracked: {Carousel.ItemsTracked}
+                                tracked: {Carousel.ModelsTracked}
                                 displayable: {Carousel.DisplayableItems}
                                 displayed: {Carousel.VisibleItems}
                                 selected: {Carousel.CurrentSelection}

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -160,6 +160,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         protected void CheckNoSelection() => AddUntilStep("has no selection", () => Carousel.CurrentSelection, () => Is.Null);
         protected void CheckHasSelection() => AddUntilStep("has selection", () => Carousel.CurrentSelection, () => Is.Not.Null);
 
+        protected void CheckVisibleBeatmapsCount(int count) => AddUntilStep($"{count} diffs displayed", () => Carousel.BeatmapsCount, () => Is.EqualTo(count));
+        protected void CheckVisibleBeatmapSetsCount(int count) => AddUntilStep($"{count} sets displayed", () => Carousel.BeatmapSetsCount, () => Is.EqualTo(count));
+        protected void CheckVisibleGroupsCount(int count) => AddUntilStep($"{count} groups displayed", () => Carousel.GroupsCount, () => Is.EqualTo(count));
+
         protected ICarouselPanel? GetSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.Selected.Value);
         protected ICarouselPanel? GetKeyboardSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.KeyboardSelected.Value);
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
-using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Tests.Resources;
 
@@ -34,9 +33,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Explicit]
         public void TestSorting()
         {
-            SortBy(new FilterCriteria { Sort = SortMode.Artist });
-            SortBy(new FilterCriteria { Group = GroupMode.Difficulty, Sort = SortMode.Difficulty });
-            SortBy(new FilterCriteria { Group = GroupMode.Artist, Sort = SortMode.Artist });
+            SortBy(SortMode.Artist);
+            GroupBy(GroupMode.All);
+
+            SortBy(SortMode.Difficulty);
+            GroupBy(GroupMode.Difficulty);
+
+            SortBy(SortMode.Artist);
+            GroupBy(GroupMode.Artist);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 
@@ -19,7 +18,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             RemoveAllBeatmaps();
             CreateCarousel();
-            SortBy(new FilterCriteria { Group = GroupMode.Artist, Sort = SortMode.Artist });
+
+            SortBy(SortMode.Artist);
+            GroupBy(GroupMode.Artist);
 
             AddBeatmaps(10, 3, true);
             WaitForDrawablePanels();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -158,5 +158,36 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextGroup();
             WaitForGroupSelection(1, 1);
         }
+
+        [Test]
+        public void TestBasicFiltering()
+        {
+            SelectNextPanel();
+            Select();
+
+            ApplyToFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
+            WaitForFiltering();
+
+            CheckVisibleGroupsCount(1);
+            CheckVisibleBeatmapSetsCount(1);
+            CheckVisibleBeatmapsCount(3);
+            WaitForSelection(2, 0);
+
+            for (int i = 0; i < 5; i++)
+                SelectNextPanel();
+
+            Select();
+            SelectNextPanel();
+            Select();
+
+            WaitForSelection(2, 1);
+
+            ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
+            WaitForFiltering();
+
+            CheckVisibleGroupsCount(5);
+            CheckVisibleBeatmapSetsCount(10);
+            CheckVisibleBeatmapsCount(30);
+        }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
-using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 using osuTK;
@@ -21,7 +20,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             RemoveAllBeatmaps();
             CreateCarousel();
-            SortBy(new FilterCriteria { Group = GroupMode.Difficulty, Sort = SortMode.Difficulty });
+
+            SortBy(SortMode.Difficulty);
+            GroupBy(GroupMode.Difficulty);
 
             AddBeatmaps(10, 3);
             WaitForDrawablePanels();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -181,5 +181,34 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             ClickVisiblePanelWithOffset<PanelBeatmap>(1, new Vector2(0, (CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
             WaitForGroupSelection(0, 1);
         }
+
+        [Test]
+        public void TestBasicFiltering()
+        {
+            SelectNextPanel();
+            Select();
+
+            ApplyToFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
+            WaitForFiltering();
+
+            CheckVisibleGroupsCount(3);
+            CheckVisibleBeatmapsCount(3);
+            WaitForSelection(2, 0);
+
+            for (int i = 0; i < 5; i++)
+                SelectNextPanel();
+
+            Select();
+            SelectNextPanel();
+            Select();
+
+            WaitForSelection(2, 1);
+
+            ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
+            WaitForFiltering();
+
+            CheckVisibleGroupsCount(3);
+            CheckVisibleBeatmapsCount(30);
+        }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -1,0 +1,361 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    [TestFixture]
+    public partial class TestSceneBeatmapCarouselFiltering : BeatmapCarouselTestScene
+    {
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            RemoveAllBeatmaps();
+            CreateCarousel();
+        }
+
+        [Test]
+        public void TestBasicFiltering()
+        {
+            AddBeatmaps(10, 3);
+            WaitForDrawablePanels();
+
+            SelectNextPanel();
+            Select();
+
+            ApplyToFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
+            WaitForFiltering();
+
+            CheckVisibleBeatmapsCount(3);
+            CheckVisibleBeatmapSetsCount(1);
+            WaitForSelection(2, 0);
+
+            for (int i = 0; i < 5; i++)
+                SelectNextPanel();
+
+            Select();
+            WaitForSelection(2, 1);
+
+            ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
+            WaitForFiltering();
+
+            CheckVisibleBeatmapsCount(30);
+            CheckVisibleBeatmapSetsCount(10);
+        }
+
+        [Test]
+        public void TestFilteringByUserStarDifficulty()
+        {
+            AddStep("add mixed difficulty set", () =>
+            {
+                var set = TestResources.CreateTestBeatmapSetInfo(1);
+                set.Beatmaps.Clear();
+
+                for (int i = 1; i <= 15; i++)
+                {
+                    set.Beatmaps.Add(new BeatmapInfo(new OsuRuleset().RulesetInfo, new BeatmapDifficulty(), new BeatmapMetadata())
+                    {
+                        BeatmapSet = set,
+                        DifficultyName = $"Stars: {i}",
+                        StarRating = i,
+                    });
+                }
+
+                BeatmapSets.Add(set);
+            });
+
+            WaitForDrawablePanels();
+
+            ApplyToFilter("filter [5..]", c =>
+            {
+                c.UserStarDifficulty.Min = 5;
+                c.UserStarDifficulty.Max = null;
+            });
+            WaitForFiltering();
+            CheckVisibleBeatmapsCount(11);
+
+            ApplyToFilter("filter to [0..7]", c =>
+            {
+                c.UserStarDifficulty.Min = null;
+                c.UserStarDifficulty.Max = 7;
+            });
+            WaitForFiltering();
+            CheckVisibleBeatmapsCount(7);
+
+            ApplyToFilter("filter to [5..7]", c =>
+            {
+                c.UserStarDifficulty.Min = 5;
+                c.UserStarDifficulty.Max = 7;
+            });
+
+            WaitForFiltering();
+            CheckVisibleBeatmapsCount(3);
+
+            ApplyToFilter("filter to [2..2]", c =>
+            {
+                c.UserStarDifficulty.Min = 2;
+                c.UserStarDifficulty.Max = 2;
+            });
+
+            WaitForFiltering();
+            CheckVisibleBeatmapsCount(1);
+
+            ApplyToFilter("filter to [0..]", c =>
+            {
+                c.UserStarDifficulty.Min = 0;
+                c.UserStarDifficulty.Max = null;
+            });
+            WaitForFiltering();
+            CheckVisibleBeatmapsCount(15);
+        }
+
+        [Test]
+        public void TestCarouselRemembersSelection()
+        {
+            Guid selectedID = Guid.Empty;
+
+            AddBeatmaps(50, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            SelectNextPanel();
+            Select();
+
+            AddStep("record selection", () => selectedID = ((BeatmapInfo)Carousel.CurrentSelection!).ID);
+
+            for (int i = 0; i < 5; i++)
+            {
+                ApplyToFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
+                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+                ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
+                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+            }
+        }
+
+        [Test]
+        public void TestCarouselRemembersSelectionDifficultySort()
+        {
+            Guid selectedID = Guid.Empty;
+
+            AddBeatmaps(50, 3);
+            WaitForDrawablePanels();
+
+            SortBy(SortMode.Difficulty);
+
+            SelectNextGroup();
+
+            AddStep("record selection", () => selectedID = ((BeatmapInfo)Carousel.CurrentSelection!).ID);
+
+            for (int i = 0; i < 5; i++)
+            {
+                ApplyToFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
+                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+                ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
+                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+            }
+        }
+
+        [Test]
+        public void TestCarouselRetainsSelectionFromDifficultySort()
+        {
+            AddBeatmaps(50, 3);
+            WaitForDrawablePanels();
+
+            BeatmapInfo chosenBeatmap = null!;
+
+            for (int i = 0; i < 3; i++)
+            {
+                int diff = i;
+
+                AddStep($"select diff {diff}", () => Carousel.CurrentSelection = chosenBeatmap = BeatmapSets[20].Beatmaps[diff]);
+                AddUntilStep("selection changed", () => Carousel.CurrentSelection, () => Is.EqualTo(chosenBeatmap));
+
+                SortBy(SortMode.Difficulty);
+                AddAssert("selection retained", () => Carousel.CurrentSelection, () => Is.EqualTo(chosenBeatmap));
+
+                SortBy(SortMode.Title);
+                AddAssert("selection retained", () => Carousel.CurrentSelection, () => Is.EqualTo(chosenBeatmap));
+            }
+        }
+
+        [Test]
+        public void TestExternalRulesetChange()
+        {
+            ApplyToFilter("allow converted beatmaps", c => c.AllowConvertedBeatmaps = true);
+            ApplyToFilter("filter to osu", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(0));
+
+            WaitForFiltering();
+
+            AddStep("add mixed ruleset beatmapset", () =>
+            {
+                var testMixed = TestResources.CreateTestBeatmapSetInfo(3);
+
+                for (int i = 0; i <= 2; i++)
+                    testMixed.Beatmaps[i].Ruleset = rulesets.AvailableRulesets.ElementAt(i);
+
+                BeatmapSets.Add(testMixed);
+            });
+            WaitForDrawablePanels();
+
+            AddUntilStep("wait for filtered difficulties", () =>
+            {
+                var visibleBeatmapPanels = GetVisiblePanels<PanelBeatmap>();
+
+                return visibleBeatmapPanels.Count() == 1
+                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 0) == 1;
+            });
+
+            ApplyToFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
+
+            WaitForFiltering();
+
+            AddUntilStep("wait for filtered difficulties", () =>
+            {
+                var visibleBeatmapPanels = GetVisiblePanels<PanelBeatmap>();
+
+                return visibleBeatmapPanels.Count() == 2
+                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 0) == 1
+                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 1) == 1;
+            });
+
+            ApplyToFilter("filter to catch", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(2));
+
+            WaitForFiltering();
+
+            AddUntilStep("wait for filtered difficulties", () =>
+            {
+                var visibleBeatmapPanels = GetVisiblePanels<PanelBeatmap>();
+
+                return visibleBeatmapPanels.Count() == 2
+                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 0) == 1
+                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 2) == 1;
+            });
+        }
+
+        [Test]
+        public void TestSortingWithDifficultyFiltered()
+        {
+            const int diffs_per_set = 3;
+            const int local_set_count = 2;
+
+            AddStep("populate beatmap sets", () =>
+            {
+                for (int i = 0; i < local_set_count; i++)
+                {
+                    var set = TestResources.CreateTestBeatmapSetInfo(diffs_per_set);
+                    set.Beatmaps[0].StarRating = 3 - i;
+                    set.Beatmaps[0].DifficultyName += $" ({3 - i}*)";
+                    set.Beatmaps[1].StarRating = 6 + i;
+                    set.Beatmaps[1].DifficultyName += $" ({6 + i}*)";
+                    BeatmapSets.Add(set);
+                }
+            });
+
+            SortBy(SortMode.Difficulty);
+
+            CheckVisibleBeatmapSetsCount(3);
+            CheckVisibleBeatmapsCount(local_set_count * diffs_per_set);
+
+            ApplyToFilter("filter to normal", c => c.SearchText = "Normal");
+
+            CheckVisibleBeatmapSetsCount(local_set_count);
+            CheckVisibleBeatmapsCount(local_set_count);
+
+            ApplyToFilter("filter to insane", c => c.SearchText = "Insane");
+
+            CheckVisibleBeatmapSetsCount(local_set_count);
+            CheckVisibleBeatmapsCount(local_set_count);
+        }
+
+        [Test]
+        public void TestSelectionEnteringFromEmptyRuleset()
+        {
+            ApplyToFilter("filter to osu", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(0));
+            AddStep("create beatmaps for taiko only", () =>
+            {
+                var rulesetBeatmapSet = TestResources.CreateTestBeatmapSetInfo(1);
+                var taikoRuleset = rulesets.AvailableRulesets.ElementAt(1);
+                rulesetBeatmapSet.Beatmaps.ForEach(b => b.Ruleset = taikoRuleset);
+
+                BeatmapSets.Add(rulesetBeatmapSet);
+            });
+
+            AddAssert("selection is null", () => Carousel.CurrentSelection == null);
+
+            ApplyToFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
+            AddUntilStep("selection is not null", () => Carousel.CurrentSelection != null);
+        }
+
+        [Test]
+        public void TestSelectingFilteredRuleset()
+        {
+            AddStep("add mixed ruleset beatmapset", () =>
+            {
+                var testMixed = TestResources.CreateTestBeatmapSetInfo(3);
+
+                for (int i = 0; i <= 2; i++)
+                    testMixed.Beatmaps[i].Ruleset = rulesets.AvailableRulesets.ElementAt(i);
+
+                BeatmapSets.Add(testMixed);
+            });
+
+            ApplyToFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
+            AddUntilStep("taiko difficulty selected", () => ((BeatmapInfo?)Carousel.CurrentSelection)?.Ruleset.OnlineID == 1);
+            ApplyToFilter("filter to osu", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(0));
+            AddUntilStep("osu difficulty selected", () => ((BeatmapInfo?)Carousel.CurrentSelection)?.Ruleset.OnlineID == 0);
+
+            RemoveAllBeatmaps();
+
+            AddStep("add single ruleset beatmapset", () =>
+            {
+                var testSingle = TestResources.CreateTestBeatmapSetInfo(3);
+                testSingle.Beatmaps.ForEach(b => b.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
+                BeatmapSets.Add(testSingle);
+            });
+            ApplyToFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
+            AddUntilStep("taiko difficulty selected", () => ((BeatmapInfo?)Carousel.CurrentSelection)?.Ruleset.OnlineID == 1);
+            ApplyToFilter("filter to osu", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(0));
+            AddUntilStep("no difficulty selected", () => Carousel.CurrentSelection == null);
+            ApplyToFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
+            AddUntilStep("taiko difficulty selected", () => ((BeatmapInfo?)Carousel.CurrentSelection)?.Ruleset.OnlineID == 1);
+        }
+
+        [Test]
+        public void TestSelectionChangedOnRemoval()
+        {
+            AddBeatmaps(2, 3);
+            WaitForDrawablePanels();
+
+            AddStep("select second set", () => Carousel.CurrentSelection = BeatmapSets[1].Beatmaps[0]);
+            WaitForSelection(1, 0);
+
+            AddStep("remove second beatmap", () => BeatmapSets.RemoveAt(1));
+
+            WaitForSelection(0, 0);
+            AddStep("remove remaining beatmap", () => BeatmapSets.RemoveAt(0));
+
+            CheckNoSelection();
+
+            AddBeatmaps(1, 3);
+            WaitForSelection(0, 0);
+
+            AddBeatmaps(5, 3);
+            WaitForSelection(0, 0);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -6,8 +6,6 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
-using osu.Game.Screens.Select;
-using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 using osuTK;
 using osuTK.Input;
@@ -22,7 +20,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             RemoveAllBeatmaps();
             CreateCarousel();
-            SortBy(new FilterCriteria { Sort = SortMode.Title });
         }
 
         /// <summary>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Testing;
-using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 
 namespace osu.Game.Tests.Visual.SongSelectV2
@@ -18,7 +18,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             RemoveAllBeatmaps();
             CreateCarousel();
-            SortBy(new FilterCriteria());
+
+            SortBy(SortMode.Artist);
 
             AddBeatmaps(10);
             WaitForDrawablePanels();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("save selected screen position", () => positionBefore = Carousel.ChildrenOfType<PanelBeatmap>().FirstOrDefault(p => p.Selected.Value)!.ScreenSpaceDrawQuad);
 
             RemoveFirstBeatmap();
-            WaitForSorting();
+            WaitForFiltering();
 
             AddAssert("select screen position unchanged", () => Carousel.ChildrenOfType<PanelBeatmap>().Single(p => p.Selected.Value).ScreenSpaceDrawQuad,
                 () => Is.EqualTo(positionBefore));
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("save selected screen position", () => positionBefore = Carousel.ChildrenOfType<PanelBeatmap>().FirstOrDefault(p => p.Selected.Value)!.ScreenSpaceDrawQuad);
 
             RemoveFirstBeatmap();
-            WaitForSorting();
+            WaitForFiltering();
             AddAssert("select screen position unchanged", () => Carousel.ChildrenOfType<PanelBeatmap>().Single(p => p.Selected.Value).ScreenSpaceDrawQuad,
                 () => Is.EqualTo(positionBefore));
         }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 BeatmapSets.Add(baseTestBeatmap);
             });
 
-            WaitForSorting();
+            WaitForFiltering();
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("update beatmap with same reference", () => BeatmapSets.ReplaceRange(1, 1, [baseTestBeatmap]));
 
-            WaitForSorting();
+            WaitForFiltering();
             AddAssert("drawables unchanged", () => Carousel.ChildrenOfType<Panel>(), () => Is.EqualTo(originalDrawables));
         }
 
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             updateBeatmap(b => b.Metadata = metadata);
 
-            WaitForSorting();
+            WaitForFiltering();
             AddAssert("drawables changed", () => Carousel.ChildrenOfType<Panel>(), () => Is.Not.EqualTo(originalDrawables));
         }
 
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap();
-            WaitForSorting();
+            WaitForFiltering();
 
             AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
@@ -108,7 +108,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b => b.DifficultyName = "new name");
-            WaitForSorting();
+            WaitForFiltering();
 
             AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
@@ -124,7 +124,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b => b.OnlineID = b.OnlineID + 1);
-            WaitForSorting();
+            WaitForFiltering();
 
             AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -23,7 +23,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             RemoveAllBeatmaps();
             CreateCarousel();
+
             AddBeatmaps(1, 3);
+            WaitForSelection(0, 0);
+
             AddStep("generate and add test beatmap", () =>
             {
                 baseTestBeatmap = TestResources.CreateTestBeatmapSetInfo(3);
@@ -85,6 +88,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestSelectionHeld()
         {
+            WaitForSelection(0, 0);
             SelectPrevGroup();
 
             WaitForSelection(1, 0);
@@ -101,6 +105,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test] // Checks that we keep selection based on online ID where possible.
         public void TestSelectionHeldDifficultyNameChanged()
         {
+            WaitForSelection(0, 0);
             SelectPrevGroup();
 
             WaitForSelection(1, 0);

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// The number of carousel items currently in rotation for display.
         /// </summary>
-        public int DisplayableItems => carouselItems?.Count ?? 0;
+        public int DisplayableItems => Items.Count;
 
         /// <summary>
         /// The number of items currently actualised into drawables.
@@ -162,6 +162,11 @@ namespace osu.Game.Graphics.Carousel
         protected readonly BindableList<T> Models = new BindableList<T>();
 
         /// <summary>
+        /// The list of displayable items with the active filter criteria.
+        /// </summary>
+        protected IReadOnlyList<CarouselItem> Items => carouselItems ?? (IReadOnlyList<CarouselItem>)Array.Empty<CarouselItem>();
+
+        /// <summary>
         /// Queue an asynchronous filter operation.
         /// </summary>
         protected virtual Task FilterAsync() => filterTask = performFilter();
@@ -222,6 +227,12 @@ namespace osu.Game.Graphics.Carousel
         /// </remarks>
         /// <param name="item">The carousel item which was activated.</param>
         protected virtual void HandleItemActivated(CarouselItem item) { }
+
+        /// <summary>
+        /// Called when the list of carousel items have changed as a result of a filter operation or change in <see cref="Models"/> bindable.
+        /// The new list of carousel items can be accessed through <see cref="Items"/>.
+        /// </summary>
+        protected virtual void HandleItemsChanged() { }
 
         #endregion
 
@@ -294,6 +305,8 @@ namespace osu.Game.Graphics.Carousel
                 log("Items ready for display");
                 carouselItems = items.ToList();
                 displayedRange = null;
+
+                HandleItemsChanged();
 
                 // Need to call this to ensure correct post-selection logic is handled on the new items list.
                 HandleItemSelected(currentSelection.Model);

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// The number of displayable items currently being tracked (before filtering).
         /// </summary>
-        public int ItemsTracked => Items.Count;
+        public int ModelsTracked => Models.Count;
 
         /// <summary>
         /// The number of carousel items currently in rotation for display.
@@ -159,7 +159,7 @@ namespace osu.Game.Graphics.Carousel
         /// <remarks>
         /// Note that an <see cref="ICarouselFilter"/> may add new items which are displayed but not tracked in this list.
         /// </remarks>
-        protected readonly BindableList<T> Items = new BindableList<T>();
+        protected readonly BindableList<T> Models = new BindableList<T>();
 
         /// <summary>
         /// Queue an asynchronous filter operation.
@@ -237,7 +237,7 @@ namespace osu.Game.Graphics.Carousel
                 RelativeSizeAxes = Axes.Both,
             };
 
-            Items.BindCollectionChanged((_, _) => FilterAsync());
+            Models.BindCollectionChanged((_, _) => FilterAsync());
         }
 
         #endregion
@@ -265,7 +265,7 @@ namespace osu.Game.Graphics.Carousel
 
             // Copy must be performed on update thread for now (see ConfigureAwait above).
             // Could potentially be optimised in the future if it becomes an issue.
-            IEnumerable<CarouselItem> items = new List<CarouselItem>(Items.Select(m => new CarouselItem(m)));
+            IEnumerable<CarouselItem> items = new List<CarouselItem>(Models.Select(m => new CarouselItem(m)));
 
             await Task.Run(async () =>
             {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -170,8 +170,8 @@ namespace osu.Game.Screens.SelectV2
                     return;
 
                 case BeatmapSetInfo setInfo:
-                    // Selecting a set isn't valid – let's re-select the first difficulty.
-                    CurrentSelection = setInfo.Beatmaps.First();
+                    // Selecting a set isn't valid – let's re-select the first difficulty visible.
+                    CurrentSelection = grouping.SetItems[setInfo].ElementAt(1).Model;
                     return;
 
                 case BeatmapInfo beatmapInfo:

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Screens.SelectV2
             Filters = new ICarouselFilter[]
             {
                 new BeatmapCarouselFilterSorting(() => Criteria),
+                new BeatmapCarouselFilterMatching(() => Criteria),
                 grouping = new BeatmapCarouselFilterGrouping(() => Criteria),
             };
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -23,9 +23,26 @@ namespace osu.Game.Screens.SelectV2
     [Cached]
     public partial class BeatmapCarousel : Carousel<BeatmapInfo>
     {
-        public Action<BeatmapInfo>? RequestPresentBeatmap { private get; init; }
-
         public const float SPACING = 3f;
+
+        /// <summary>
+        /// The total number of beatmap difficulties selectable in this carousel.
+        /// </summary>
+        public int BeatmapsCount => Items.Count(i => i.Model is BeatmapInfo);
+
+        /// <summary>
+        /// The total number of beatmap sets displayed in this carousel.
+        /// This will be zero when the selected sorting/grouping combination disables set headers.
+        /// </summary>
+        public int BeatmapSetsCount => Items.Count(i => i.Model is BeatmapSetInfo);
+
+        /// <summary>
+        /// The total number of groups displayed in this carousel.
+        /// This will be zero when no grouping mode is selected.
+        /// </summary>
+        public int GroupsCount => Items.Count(i => i.Model is GroupDefinition);
+
+        public Action<BeatmapInfo>? RequestPresentBeatmap { private get; init; }
 
         private IBindableList<BeatmapSetInfo> detachedBeatmaps = null!;
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -81,14 +81,14 @@ namespace osu.Game.Screens.SelectV2
             switch (changed.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    Items.AddRange(newItems!.SelectMany(s => s.Beatmaps));
+                    Models.AddRange(newItems!.SelectMany(s => s.Beatmaps));
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
                     foreach (var set in oldItems!)
                     {
                         foreach (var beatmap in set.Beatmaps)
-                            Items.RemoveAll(i => i is BeatmapInfo bi && beatmap.Equals(bi));
+                            Models.RemoveAll(i => i is BeatmapInfo bi && beatmap.Equals(bi));
                     }
 
                     break;
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.SelectV2
                     // have been processed) if it becomes an issue for animation or performance reasons.
                     foreach (var beatmap in oldSetBeatmaps)
                     {
-                        int previousIndex = Items.IndexOf(beatmap);
+                        int previousIndex = Models.IndexOf(beatmap);
                         Debug.Assert(previousIndex >= 0);
 
                         BeatmapInfo? matchingNewBeatmap =
@@ -124,23 +124,23 @@ namespace osu.Game.Screens.SelectV2
                             if (CurrentSelection != null && CheckModelEquality(beatmap, CurrentSelection))
                                 CurrentSelection = matchingNewBeatmap;
 
-                            Items.ReplaceRange(previousIndex, 1, [matchingNewBeatmap]);
+                            Models.ReplaceRange(previousIndex, 1, [matchingNewBeatmap]);
                             newSetBeatmaps.Remove(matchingNewBeatmap);
                         }
                         else
                         {
-                            Items.RemoveAt(previousIndex);
+                            Models.RemoveAt(previousIndex);
                         }
                     }
 
                     // Add any items which weren't found in the previous pass (difficulty names didn't match).
                     foreach (var beatmap in newSetBeatmaps)
-                        Items.Add(beatmap);
+                        Models.Add(beatmap);
 
                     break;
 
                 case NotifyCollectionChangedAction.Reset:
-                    Items.Clear();
+                    Models.Clear();
                     break;
             }
         }

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -1,0 +1,122 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.Carousel;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public class BeatmapCarouselFilterMatching : ICarouselFilter
+    {
+        private readonly Func<FilterCriteria> getCriteria;
+
+        public BeatmapCarouselFilterMatching(Func<FilterCriteria> getCriteria)
+        {
+            this.getCriteria = getCriteria;
+        }
+
+        public async Task<IEnumerable<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                var criteria = getCriteria();
+                return matchItems(items, criteria);
+            }, cancellationToken).ConfigureAwait(false);
+        }
+
+        private IEnumerable<CarouselItem> matchItems(IEnumerable<CarouselItem> items, FilterCriteria criteria)
+        {
+            foreach (var item in items)
+            {
+                var beatmap = (BeatmapInfo)item.Model;
+
+                if (checkMatch(beatmap, criteria))
+                    yield return item;
+            }
+        }
+
+        /// <summary>
+        /// Whether the given beatmap is valid for selection / playable under the specified filter criteria.
+        /// This mainly checks whether the given beatmap is playable on the active ruleset.
+        /// </summary>
+        public static bool IsValidForSelection(BeatmapInfo beatmap, FilterCriteria criteria)
+        {
+            return criteria.Ruleset == null ||
+                   beatmap.Ruleset.ShortName == criteria.Ruleset.ShortName ||
+                   (beatmap.Ruleset.OnlineID == 0 && criteria.Ruleset.OnlineID != 0 && criteria.AllowConvertedBeatmaps);
+        }
+
+        private static bool checkMatch(BeatmapInfo beatmap, FilterCriteria criteria)
+        {
+            bool match = IsValidForSelection(beatmap, criteria);
+
+            if (beatmap.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
+            {
+                // only check ruleset equality or convertability for selected beatmap
+                return match;
+            }
+
+            if (!match) return false;
+
+            if (criteria.SearchTerms.Length > 0)
+            {
+                match = beatmap.Match(criteria.SearchTerms);
+
+                // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
+                // this should be done after text matching so we can prioritise matching numbers in metadata.
+                if (!match && criteria.SearchNumber.HasValue)
+                {
+                    match = (beatmap.OnlineID == criteria.SearchNumber.Value) ||
+                            (beatmap.BeatmapSet?.OnlineID == criteria.SearchNumber.Value);
+                }
+            }
+
+            if (!match) return false;
+
+            match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(beatmap.StarRating);
+            match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(beatmap.Difficulty.ApproachRate);
+            match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(beatmap.Difficulty.DrainRate);
+            match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(beatmap.Difficulty.CircleSize);
+            match &= !criteria.OverallDifficulty.HasFilter || criteria.OverallDifficulty.IsInRange(beatmap.Difficulty.OverallDifficulty);
+            match &= !criteria.Length.HasFilter || criteria.Length.IsInRange(beatmap.Length);
+            match &= !criteria.LastPlayed.HasFilter || criteria.LastPlayed.IsInRange(beatmap.LastPlayed ?? DateTimeOffset.MinValue);
+            match &= !criteria.DateRanked.HasFilter || (beatmap.BeatmapSet?.DateRanked != null && criteria.DateRanked.IsInRange(beatmap.BeatmapSet.DateRanked.Value));
+            match &= !criteria.DateSubmitted.HasFilter || (beatmap.BeatmapSet?.DateSubmitted != null && criteria.DateSubmitted.IsInRange(beatmap.BeatmapSet.DateSubmitted.Value));
+            match &= !criteria.BPM.HasFilter || criteria.BPM.IsInRange(beatmap.BPM);
+
+            match &= !criteria.BeatDivisor.HasFilter || criteria.BeatDivisor.IsInRange(beatmap.BeatDivisor);
+            match &= !criteria.OnlineStatus.HasFilter || criteria.OnlineStatus.IsInRange(beatmap.Status);
+
+            if (!match) return false;
+
+            match &= !criteria.Creator.HasFilter || criteria.Creator.Matches(beatmap.Metadata.Author.Username);
+            match &= !criteria.Artist.HasFilter || criteria.Artist.Matches(beatmap.Metadata.Artist) ||
+                     criteria.Artist.Matches(beatmap.Metadata.ArtistUnicode);
+            match &= !criteria.Title.HasFilter || criteria.Title.Matches(beatmap.Metadata.Title) ||
+                     criteria.Title.Matches(beatmap.Metadata.TitleUnicode);
+            match &= !criteria.DifficultyName.HasFilter || criteria.DifficultyName.Matches(beatmap.DifficultyName);
+            match &= !criteria.Source.HasFilter || criteria.Source.Matches(beatmap.Metadata.Source);
+            match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(beatmap.StarRating);
+
+            if (!match) return false;
+
+            match &= criteria.CollectionBeatmapMD5Hashes?.Contains(beatmap.MD5Hash) ?? true;
+            if (match && criteria.RulesetCriteria != null)
+                match &= criteria.RulesetCriteria.Matches(beatmap, criteria);
+
+            if (match && criteria.HasOnlineID == true)
+                match &= beatmap.OnlineID >= 0;
+
+            if (match && criteria.BeatmapSetId != null)
+                match &= criteria.BeatmapSetId == beatmap.BeatmapSet?.OnlineID;
+
+            return match;
+        }
+    }
+}


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/33037

The type of "eager" selection implemented here roughly matches stable. It maintains the selected beatmap regardless of any change to the filter criteria, unless:
 1. The selected beatmap has been deleted (no longer tracked, in carousel terms).
 2. The ruleset has changed and the selected beatmap cannot be played on the new ruleset.
 3. The applied filter criteria resulted in beatmaps of a particular set, at which point selection should change to that set (matching stable).

Heavy amount of test coverage has been updated with the implementation of "eager" selection, mainly because all tests were written under the fact that there's no selection active at first.