### PR TITLE
Hook up filter control with beatmap carousel

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapFilterControl.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 {
     public partial class TestSceneBeatmapFilterControl : SongSelectComponentsTestScene
     {
+        private FilterControl filterControl = null!;
+
         protected override Anchor ComponentAnchor => Anchor.TopRight;
         protected override float InitialRelativeWidth => 0.7f;
 
@@ -20,12 +22,18 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Child = new FilterControl
+                Child = filterControl = new FilterControl
                 {
                     State = { Value = Visibility.Visible },
                     RelativeSizeAxes = Axes.X,
                 },
             };
         });
+
+        [Test]
+        public void TestSearch()
+        {
+            AddStep("search for text", () => filterControl.Search("test search"));
+        }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -12,13 +12,11 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Database;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
-using osu.Game.Rulesets.Catch;
-using osu.Game.Rulesets.Mania;
+using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
-using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Menu;
@@ -30,10 +28,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
     public partial class TestSceneSongSelect : ScreenTestScene
     {
         [Cached]
-        private readonly ScreenFooter screenScreenFooter;
+        private readonly ScreenFooter screenFooter;
 
         [Cached]
         private readonly OsuLogo logo;
+
+        [Cached(typeof(INotificationOverlay))]
+        private readonly INotificationOverlay notificationOverlay = new NotificationOverlay();
 
         protected override bool UseOnlineAPI => true;
 
@@ -44,16 +45,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 new PopoverContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = screenScreenFooter = new ScreenFooter
+                    Children = new Drawable[]
                     {
-                        OnBack = () => Stack.CurrentScreen.Exit(),
+                        new Toolbar
+                        {
+                            State = { Value = Visibility.Visible },
+                        },
+                        screenFooter = new ScreenFooter
+                        {
+                            OnBack = () => Stack.CurrentScreen.Exit(),
+                        },
+                        logo = new OsuLogo
+                        {
+                            Alpha = 0f,
+                        },
                     },
                 },
-                logo = new OsuLogo
-                {
-                    Alpha = 0f,
-                },
             };
+
+            Stack.Padding = new MarginPadding { Top = Toolbar.HEIGHT };
         }
 
         [BackgroundDependencyLoader]
@@ -80,15 +90,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("load screen", () => Stack.Push(new SoloSongSelect()));
             AddUntilStep("wait for load", () => Stack.CurrentScreen is Screens.SelectV2.SongSelect songSelect && songSelect.IsLoaded);
-        }
-
-        [Test]
-        public void TestRulesets()
-        {
-            AddStep("set osu ruleset", () => Ruleset.Value = new OsuRuleset().RulesetInfo);
-            AddStep("set taiko ruleset", () => Ruleset.Value = new TaikoRuleset().RulesetInfo);
-            AddStep("set catch ruleset", () => Ruleset.Value = new CatchRuleset().RulesetInfo);
-            AddStep("set mania ruleset", () => Ruleset.Value = new ManiaRuleset().RulesetInfo);
         }
 
         #region Footer
@@ -212,13 +213,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             if (newScreen is IOsuScreen osuScreen && osuScreen.ShowFooter)
             {
-                screenScreenFooter.Show();
-                screenScreenFooter.SetButtons(osuScreen.CreateFooterButtons());
+                screenFooter.Show();
+                screenFooter.SetButtons(osuScreen.CreateFooterButtons());
             }
             else
             {
-                screenScreenFooter.Hide();
-                screenScreenFooter.SetButtons(Array.Empty<ScreenFooterButton>());
+                screenFooter.Hide();
+                screenFooter.SetButtons(Array.Empty<ScreenFooterButton>());
             }
         }
     }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -83,20 +83,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             Stack.ScreenExited += updateFooter;
         }
 
-        [SetUpSteps]
-        public override void SetUpSteps()
-        {
-            base.SetUpSteps();
-
-            AddStep("load screen", () => Stack.Push(new SoloSongSelect()));
-            AddUntilStep("wait for load", () => Stack.CurrentScreen is Screens.SelectV2.SongSelect songSelect && songSelect.IsLoaded);
-        }
-
         #region Footer
 
         [Test]
         public void TestMods()
         {
+            loadSongSelect();
+
             AddStep("one mod", () => SelectedMods.Value = new List<Mod> { new OsuModHidden() });
             AddStep("two mods", () => SelectedMods.Value = new List<Mod> { new OsuModHidden(), new OsuModHardRock() });
             AddStep("three mods", () => SelectedMods.Value = new List<Mod> { new OsuModHidden(), new OsuModHardRock(), new OsuModDoubleTime() });
@@ -124,6 +117,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestShowOptions()
         {
+            loadSongSelect();
+
             AddStep("enable options", () =>
             {
                 var optionsButton = this.ChildrenOfType<ScreenFooterButton>().Last();
@@ -136,6 +131,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestState()
         {
+            loadSongSelect();
+
             AddToggleStep("set options enabled state", state => this.ChildrenOfType<ScreenFooterButton>().Last().Enabled.Value = state);
         }
 
@@ -143,6 +140,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         // [Test]
         // public void TestFooterRandom()
         // {
+        //     loadSongSelect();
+        //
         //     AddStep("press F2", () => InputManager.Key(Key.F2));
         //     AddAssert("next random invoked", () => nextRandomCalled && !previousRandomCalled);
         // }
@@ -150,6 +149,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         // [Test]
         // public void TestFooterRandomViaMouse()
         // {
+        //     loadSongSelect();
+        //
         //     AddStep("click button", () =>
         //     {
         //         InputManager.MoveMouseTo(randomButton);
@@ -161,6 +162,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         // [Test]
         // public void TestFooterRewind()
         // {
+        //     loadSongSelect();
+        //
         //     AddStep("press Shift+F2", () =>
         //     {
         //         InputManager.PressKey(Key.LShift);
@@ -174,6 +177,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         // [Test]
         // public void TestFooterRewindViaShiftMouseLeft()
         // {
+        //     loadSongSelect();
+        //
         //     AddStep("shift + click button", () =>
         //     {
         //         InputManager.PressKey(Key.LShift);
@@ -187,6 +192,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         // [Test]
         // public void TestFooterRewindViaMouseRight()
         // {
+        //     loadSongSelect();
+        //
         //     AddStep("right click button", () =>
         //     {
         //         InputManager.MoveMouseTo(randomButton);
@@ -198,6 +205,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestOverlayPresent()
         {
+            loadSongSelect();
+
             AddStep("Press F1", () =>
             {
                 InputManager.MoveMouseTo(this.ChildrenOfType<FooterButtonMods>().Single());
@@ -208,6 +217,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         #endregion
+
+        private void loadSongSelect()
+        {
+            AddStep("load screen", () => Stack.Push(new SoloSongSelect()));
+            AddUntilStep("wait for load", () => Stack.CurrentScreen is Screens.SelectV2.SongSelect songSelect && songSelect.IsLoaded);
+        }
 
         private void updateFooter(IScreen? _, IScreen? newScreen)
         {

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -36,8 +36,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
     public partial class TestSceneSongSelectFiltering : ScreenTestScene
     {
         private BeatmapManager manager = null!;
-        private RulesetStore rulesets = null!;
-        private MusicController music = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
         private OsuConfigManager config = null!;
 
         private SoloSongSelect songSelect = null!;
@@ -91,15 +93,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             // These DI caches are required to ensure for interactive runs this test scene doesn't nuke all user beatmaps in the local install.
             // At a point we have isolated interactive test runs enough, this can likely be removed.
-            Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
-            Dependencies.Cache(Realm);
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, Audio, Resources, host, Beatmap.Default));
             Dependencies.CacheAs<BeatmapStore>(beatmapStore = new RealmDetachedBeatmapStore());
 
-            Dependencies.Cache(music = new MusicController());
-
-            // required to get bindables attached
-            Add(music);
             Add(beatmapStore);
 
             Dependencies.Cache(config = new OsuConfigManager(LocalStorage));

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -1,0 +1,336 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Input;
+using osu.Framework.Platform;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Toolbar;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens;
+using osu.Game.Screens.Footer;
+using osu.Game.Screens.Menu;
+using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    public partial class TestSceneSongSelectFiltering : ScreenTestScene
+    {
+        private BeatmapManager manager = null!;
+        private RulesetStore rulesets = null!;
+        private MusicController music = null!;
+        private OsuConfigManager config = null!;
+
+        private SoloSongSelect songSelect = null!;
+        private BeatmapCarousel carousel => songSelect.ChildrenOfType<BeatmapCarousel>().Single();
+
+        private FilterControl filter => songSelect.ChildrenOfType<FilterControl>().Single();
+        private ShearedFilterTextBox filterTextBox => songSelect.ChildrenOfType<ShearedFilterTextBox>().Single();
+        private int filterOperationsCount;
+
+        [Cached]
+        private readonly ScreenFooter screenFooter;
+
+        [Cached]
+        private readonly OsuLogo logo;
+
+        [Cached(typeof(INotificationOverlay))]
+        private readonly INotificationOverlay notificationOverlay = new NotificationOverlay();
+
+        public TestSceneSongSelectFiltering()
+        {
+            Children = new Drawable[]
+            {
+                new PopoverContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Toolbar
+                        {
+                            State = { Value = Visibility.Visible },
+                        },
+                        screenFooter = new ScreenFooter
+                        {
+                            OnBack = () => Stack.CurrentScreen.Exit(),
+                        },
+                        logo = new OsuLogo
+                        {
+                            Alpha = 0f,
+                        },
+                    },
+                },
+            };
+
+            Stack.Padding = new MarginPadding { Top = Toolbar.HEIGHT };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            RealmDetachedBeatmapStore beatmapStore;
+
+            // These DI caches are required to ensure for interactive runs this test scene doesn't nuke all user beatmaps in the local install.
+            // At a point we have isolated interactive test runs enough, this can likely be removed.
+            Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
+            Dependencies.Cache(Realm);
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, Audio, Resources, host, Beatmap.Default));
+            Dependencies.CacheAs<BeatmapStore>(beatmapStore = new RealmDetachedBeatmapStore());
+
+            Dependencies.Cache(music = new MusicController());
+
+            // required to get bindables attached
+            Add(music);
+            Add(beatmapStore);
+
+            Dependencies.Cache(config = new OsuConfigManager(LocalStorage));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Stack.ScreenPushed += updateFooter;
+            Stack.ScreenExited += updateFooter;
+        }
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("reset defaults", () =>
+            {
+                Ruleset.Value = new OsuRuleset().RulesetInfo;
+
+                Beatmap.SetDefault();
+                SelectedMods.SetDefault();
+
+                config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Title);
+                config.SetValue(OsuSetting.SongSelectGroupingMode, GroupMode.All);
+
+                songSelect = null!;
+                filterOperationsCount = 0;
+            });
+
+            AddStep("delete all beatmaps", () => manager.Delete());
+        }
+
+        [Test]
+        public void TestSingleFilterOnEnter()
+        {
+            importBeatmapForRuleset(0);
+            importBeatmapForRuleset(0);
+
+            loadSongSelect();
+
+            AddAssert("filter count is 0", () => filterOperationsCount, () => Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestNoFilterOnSimpleResume()
+        {
+            importBeatmapForRuleset(0);
+            importBeatmapForRuleset(0);
+
+            loadSongSelect();
+
+            AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
+            waitForSuspension();
+
+            AddStep("return", () => songSelect.MakeCurrent());
+            AddUntilStep("wait for current", () => songSelect.IsCurrentScreen());
+            AddAssert("filter count is 0", () => filterOperationsCount, () => Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestFilterOnResumeAfterChange()
+        {
+            importBeatmapForRuleset(0);
+            importBeatmapForRuleset(0);
+
+            AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, false));
+
+            loadSongSelect();
+
+            AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
+            waitForSuspension();
+
+            AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
+
+            AddStep("return", () => songSelect.MakeCurrent());
+            AddUntilStep("wait for current", () => songSelect.IsCurrentScreen());
+            AddAssert("filter count is 1", () => filterOperationsCount, () => Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestSorting()
+        {
+            loadSongSelect();
+            addManyTestMaps();
+
+            // TODO: old test has this step, but there doesn't seem to be any purpose for it.
+            // AddUntilStep("random map selected", () => Beatmap.Value != defaultBeatmap);
+
+            AddStep(@"Sort by Artist", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Artist));
+            AddStep(@"Sort by Title", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Title));
+            AddStep(@"Sort by Author", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Author));
+            AddStep(@"Sort by DateAdded", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.DateAdded));
+            AddStep(@"Sort by BPM", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.BPM));
+            AddStep(@"Sort by Length", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Length));
+            AddStep(@"Sort by Difficulty", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Difficulty));
+            AddStep(@"Sort by Source", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Source));
+        }
+
+        [Test]
+        public void TestCutInFilterTextBox()
+        {
+            loadSongSelect();
+
+            AddStep("set filter text", () => filterTextBox.Current.Value = "nonono");
+            AddStep("select all", () => InputManager.Keys(PlatformAction.SelectAll));
+            AddStep("press ctrl/cmd-x", () => InputManager.Keys(PlatformAction.Cut));
+
+            AddAssert("filter text cleared", () => filterTextBox.Current.Value, () => Is.Empty);
+        }
+
+        [Test]
+        public void TestNonFilterableModChange()
+        {
+            importBeatmapForRuleset(0);
+
+            loadSongSelect();
+
+            // Mod that is guaranteed to never re-filter.
+            AddStep("add non-filterable mod", () => SelectedMods.Value = new Mod[] { new OsuModCinema() });
+            AddAssert("filter count is 0", () => filterOperationsCount, () => Is.EqualTo(0));
+
+            // Removing the mod should still not re-filter.
+            AddStep("remove non-filterable mod", () => SelectedMods.Value = Array.Empty<Mod>());
+            AddAssert("filter count is 0", () => filterOperationsCount, () => Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestFilterableModChange()
+        {
+            importBeatmapForRuleset(3);
+
+            loadSongSelect();
+
+            // Change to mania ruleset.
+            AddStep("filter to mania ruleset", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.OnlineID == 3));
+            AddAssert("filter count is 1", () => filterOperationsCount, () => Is.EqualTo(1));
+
+            // Apply a mod, but this should NOT re-filter because there's no search text.
+            AddStep("add filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModKey3() });
+            AddAssert("filter count is 1", () => filterOperationsCount, () => Is.EqualTo(1));
+
+            // Set search text. Should re-filter.
+            AddStep("set search text to match mods", () => filterTextBox.Current.Value = "keys=3");
+            AddAssert("filter count is 2", () => filterOperationsCount, () => Is.EqualTo(2));
+
+            // Change filterable mod. Should re-filter.
+            AddStep("change new filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModKey5() });
+            AddAssert("filter count is 3", () => filterOperationsCount, () => Is.EqualTo(3));
+
+            // Add non-filterable mod. Should NOT re-filter.
+            AddStep("apply non-filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModNoFail(), new ManiaModKey5() });
+            AddAssert("filter count is 3", () => filterOperationsCount, () => Is.EqualTo(3));
+
+            // Remove filterable mod. Should re-filter.
+            AddStep("remove filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModNoFail() });
+            AddAssert("filter count is 4", () => filterOperationsCount, () => Is.EqualTo(4));
+
+            // Remove non-filterable mod. Should NOT re-filter.
+            AddStep("remove non-filterable mod", () => SelectedMods.Value = Array.Empty<Mod>());
+            AddAssert("filter count is 4", () => filterOperationsCount, () => Is.EqualTo(4));
+
+            // Add filterable mod. Should re-filter.
+            AddStep("add filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModKey3() });
+            AddAssert("filter count is 5", () => filterOperationsCount, () => Is.EqualTo(5));
+        }
+
+        private void loadSongSelect()
+        {
+            AddStep("load screen", () => Stack.Push(songSelect = new SoloSongSelect()));
+            AddUntilStep("wait for load", () => Stack.CurrentScreen == songSelect && songSelect.IsLoaded);
+            AddStep("hook events", () =>
+            {
+                filterOperationsCount = 0;
+                filter.CriteriaChanged += _ => filterOperationsCount++;
+            });
+        }
+
+        private void importBeatmapForRuleset(int rulesetId)
+        {
+            int beatmapsCount = 0;
+
+            AddStep($"import test map for ruleset {rulesetId}", () =>
+            {
+                beatmapsCount = songSelect.IsNull() ? 0 : carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single().SetItems.Count;
+                manager.Import(TestResources.CreateTestBeatmapSetInfo(3, rulesets.AvailableRulesets.Where(r => r.OnlineID == rulesetId).ToArray()));
+            });
+
+            // This is specifically for cases where the add is happening post song select load.
+            // For cases where song select is null, the assertions are provided by the load checks.
+            AddUntilStep("wait for imported to arrive in carousel", () => songSelect.IsNull() || carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single().SetItems.Count > beatmapsCount);
+        }
+
+        private void changeRuleset(int rulesetId)
+        {
+            AddStep($"change ruleset to {rulesetId}", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.OnlineID == rulesetId));
+        }
+
+        /// <summary>
+        /// Imports test beatmap sets to show in the carousel.
+        /// </summary>
+        /// <param name="difficultyCountPerSet">
+        /// The exact count of difficulties to create for each beatmap set.
+        /// A <see langword="null"/> value causes the count of difficulties to be selected randomly.
+        /// </param>
+        private void addManyTestMaps(int? difficultyCountPerSet = null)
+        {
+            AddStep("import test maps", () =>
+            {
+                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
+
+                for (int i = 0; i < 10; i++)
+                    manager.Import(TestResources.CreateTestBeatmapSetInfo(difficultyCountPerSet, usableRulesets));
+            });
+        }
+
+        private void waitForSuspension() => AddUntilStep("wait for not current", () => !songSelect.AsNonNull().IsCurrentScreen());
+
+        private void updateFooter(IScreen? _, IScreen? newScreen)
+        {
+            if (newScreen is IOsuScreen osuScreen && osuScreen.ShowFooter)
+            {
+                screenFooter.Show();
+                screenFooter.SetButtons(osuScreen.CreateFooterButtons());
+            }
+            else
+            {
+                screenFooter.Hide();
+                screenFooter.SetButtons(Array.Empty<ScreenFooterButton>());
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Graphics.Carousel
         public int ItemsTracked => Items.Count;
 
         /// <summary>
-        /// The number of carousel items currently in rotation for display.
+        /// The items currently in rotation for display.
         /// </summary>
         public int DisplayableItems => carouselItems?.Count ?? 0;
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
+using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -331,11 +332,21 @@ namespace osu.Game.Screens.SelectV2
 
         public FilterCriteria Criteria { get; private set; } = new FilterCriteria();
 
+        private ScheduledDelegate? loadingDebounce;
+
         public void Filter(FilterCriteria criteria)
         {
             Criteria = criteria;
-            loading.Show();
-            FilterAsync().ContinueWith(_ => Schedule(() => loading.Hide()));
+
+            loadingDebounce ??= Scheduler.AddDelayed(() => loading.Show(), 250);
+
+            FilterAsync().ContinueWith(_ => Schedule(() =>
+            {
+                loadingDebounce?.Cancel();
+                loadingDebounce = null;
+
+                loading.Hide();
+            }));
         }
 
         #endregion

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -2,15 +2,23 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
 
@@ -23,11 +31,31 @@ namespace osu.Game.Screens.SelectV2
 
         private const float corner_radius = 8;
 
+        private SongSelectSearchTextBox searchTextBox = null!;
         private ShearedToggleButton showConvertedBeatmapsButton = null!;
         private DifficultyRangeSlider difficultyRangeSlider = null!;
+        private ShearedDropdown<SortMode> sortDropdown = null!;
+        private ShearedDropdown<GroupMode> groupDropdown = null!;
+        private CollectionDropdown collectionDropdown = null!;
+
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
+
+        public LocalisableString InformationalNote
+        {
+            get => searchTextBox.FilterText;
+            set => searchTextBox.FilterText = value;
+        }
+
+        public event Action<FilterCriteria>? CriteriaChanged;
+
+        private FilterCriteria currentCriteria = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -65,12 +93,10 @@ namespace osu.Game.Screens.SelectV2
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
                             Shear = -OsuGame.SHEAR,
-                            Child = new SongSelectSearchTextBox
+                            Child = searchTextBox = new SongSelectSearchTextBox
                             {
                                 RelativeSizeAxes = Axes.X,
                                 HoldFocus = true,
-                                // TODO: pending implementation
-                                FilterText = "12345 matches",
                             },
                         },
                         new GridContainer
@@ -123,20 +149,20 @@ namespace osu.Game.Screens.SelectV2
                             {
                                 new[]
                                 {
-                                    new ShearedDropdown<SortMode>(SortStrings.Default)
+                                    sortDropdown = new ShearedDropdown<SortMode>(SortStrings.Default)
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         Items = Enum.GetValues<SortMode>(),
                                     },
                                     Empty(),
                                     // todo: pending localisation
-                                    new ShearedDropdown<GroupMode>("Group by")
+                                    groupDropdown = new ShearedDropdown<GroupMode>("Group by")
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         Items = Enum.GetValues<GroupMode>(),
                                     },
                                     Empty(),
-                                    new CollectionDropdown
+                                    collectionDropdown = new CollectionDropdown
                                     {
                                         RelativeSizeAxes = Axes.X,
                                     },
@@ -155,6 +181,78 @@ namespace osu.Game.Screens.SelectV2
             difficultyRangeSlider.LowerBound = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum);
             difficultyRangeSlider.UpperBound = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
             config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmapsButton.Active);
+            config.BindWith(OsuSetting.SongSelectSortingMode, sortDropdown.Current);
+            config.BindWith(OsuSetting.SongSelectGroupingMode, groupDropdown.Current);
+
+            ruleset.BindValueChanged(_ => updateCriteria());
+            mods.BindValueChanged(m =>
+            {
+                // The following is a note carried from old song select and may not be a valid reason anymore:
+                // // Mods are updated once by the mod select overlay when song select is entered,
+                // // regardless of if there are any mods or any changes have taken place.
+                // // Updating the criteria here so early triggers a re-ordering of panels on song select, via... some mechanism.
+                // // Todo: Investigate/fix and potentially remove this.
+                // TODO: this might be simply removable with the new song select & carousel code.
+                if (m.NewValue.SequenceEqual(m.OldValue))
+                    return;
+
+                var rulesetCriteria = currentCriteria.RulesetCriteria;
+                if (rulesetCriteria?.FilterMayChangeFromMods(m) == true)
+                    updateCriteria();
+            });
+
+            searchTextBox.Current.BindValueChanged(_ => updateCriteria());
+            difficultyRangeSlider.LowerBound.BindValueChanged(_ => updateCriteria());
+            difficultyRangeSlider.UpperBound.BindValueChanged(_ => updateCriteria());
+            showConvertedBeatmapsButton.Active.BindValueChanged(_ => updateCriteria());
+            sortDropdown.Current.BindValueChanged(_ => updateCriteria());
+            groupDropdown.Current.BindValueChanged(_ => updateCriteria());
+            collectionDropdown.Current.BindValueChanged(_ => updateCriteria());
+            updateCriteria();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="FilterCriteria"/> based on the current state of the controls.
+        /// </summary>
+        public FilterCriteria CreateCriteria()
+        {
+            string query = searchTextBox.Current.Value;
+
+            var criteria = new FilterCriteria
+            {
+                Sort = sortDropdown.Current.Value,
+                Group = groupDropdown.Current.Value,
+                AllowConvertedBeatmaps = showConvertedBeatmapsButton.Active.Value,
+                Ruleset = ruleset.Value,
+                Mods = mods.Value,
+                CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToImmutableHashSet()
+            };
+
+            if (!difficultyRangeSlider.LowerBound.IsDefault)
+                criteria.UserStarDifficulty.Min = difficultyRangeSlider.LowerBound.Value;
+
+            if (!difficultyRangeSlider.UpperBound.IsDefault)
+                criteria.UserStarDifficulty.Max = difficultyRangeSlider.UpperBound.Value;
+
+            criteria.RulesetCriteria = ruleset.Value.CreateInstance().CreateRulesetFilterCriteria();
+
+            FilterQueryParser.ApplyQueries(criteria, query);
+            return criteria;
+        }
+
+        private void updateCriteria()
+        {
+            currentCriteria = CreateCriteria();
+            CriteriaChanged?.Invoke(currentCriteria);
+        }
+
+        /// <summary>
+        /// Set the query to the search text box.
+        /// </summary>
+        /// <param name="query">The string to search.</param>
+        public void Search(string query)
+        {
+            searchTextBox.Current.Value = query;
         }
 
         protected override void PopIn()


### PR DESCRIPTION
Visual side still needs more work done. Two major issues that can be noticed by testing this:
 - The panel transitions are sometimes odd. Difficulty panels flying out of nowhere when selecting a different set, see also [discord](https://discord.com/channels/188630481301012481/1359431017680863302/1369292905516236983)
 - Carousel doesn't always scroll to selection, specifically when selection is changed from a filter operation

Also note that not all sorting/grouping mode works currently, they haven't been implemented yet.