### PR TITLE
Add minimal slider body transparency to "Argon" skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
@@ -3,12 +3,16 @@
 
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Rulesets.Osu.Skinning.Default;
+using osu.Game.Skinning;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
     public partial class ArgonSliderBody : PlaySliderBody
     {
+        // Eventually this would be a user setting.
+        public float BodyAlpha { get; init; } = 1;
+
         protected override void LoadComplete()
         {
             const float path_radius = ArgonMainCirclePiece.OUTER_GRADIENT_SIZE / 2;
@@ -25,6 +29,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         }
 
         protected override Default.DrawableSliderPath CreateSliderPath() => new DrawableSliderPath();
+
+        protected override Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour)
+        {
+            return base.GetBodyAccentColour(skin, hitObjectAccentColour).Opacity(BodyAlpha);
+        }
 
         private partial class DrawableSliderPath : Default.DrawableSliderPath
         {

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -16,13 +16,15 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
+            bool isPro = Skin is ArgonProSkin;
+
             switch (lookup)
             {
                 case SkinComponentLookup<HitResult> resultComponent:
                     HitResult result = resultComponent.Component;
 
                     // This should eventually be moved to a skin setting, when supported.
-                    if (Skin is ArgonProSkin && (result == HitResult.Great || result == HitResult.Perfect))
+                    if (isPro && (result == HitResult.Great || result == HitResult.Perfect))
                         return Drawable.Empty();
 
                     switch (result)
@@ -46,7 +48,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                             return new ArgonMainCirclePiece(false);
 
                         case OsuSkinComponents.SliderBody:
-                            return new ArgonSliderBody();
+                            return new ArgonSliderBody
+                            {
+                                BodyAlpha = isPro ? 0.92f : 0.98f
+                            };
 
                         case OsuSkinComponents.SliderBall:
                             return new ArgonSliderBall();


### PR DESCRIPTION
Addresses concerns in https://github.com/ppy/osu/discussions/24226.

I basically adjusted opacity down until it started to visually detract from the skin. The pro level is lower than I'd want to see, but feels like a midpoint that some users may find usable.

This is a band-aid fix until we can get proper support for settings like this into the skin editor.

| standard | pro |
| :---: | :---: |
| ![osu! 2025-05-07 at 04 25 25](https://github.com/user-attachments/assets/5b03dcf5-09da-4435-bea7-f76888dd391b) | ![osu! 2025-05-07 at 04 25 15](https://github.com/user-attachments/assets/c37c6e9a-3c21-448d-a565-2afd2c719781) |