### PR TITLE
Fix startup "welcome" sound sometimes not loading from skin for supporters

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -225,6 +225,8 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorSubmissionNotifyOnDiscussionReplies, true);
             SetDefault(OsuSetting.EditorSubmissionLoadInBrowserAfterSubmission, true);
+
+            SetDefault(OsuSetting.WasSupporter, false);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -466,5 +468,11 @@ namespace osu.Game.Configuration
         EditorShowStoryboard,
         EditorSubmissionNotifyOnDiscussionReplies,
         EditorSubmissionLoadInBrowserAfterSubmission,
+
+        /// <summary>
+        /// Cached state of whether local user is a supporter.
+        /// Used to allow early checks (ie for startup samples) to be in the correct state, even if the API authentication process has not completed.
+        /// </summary>
+        WasSupporter
     }
 }

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -72,6 +72,8 @@ namespace osu.Game.Online.API
         protected bool HasLogin => authentication.Token.Value != null || (!string.IsNullOrEmpty(ProvidedUsername) && !string.IsNullOrEmpty(password));
 
         private readonly Bindable<UserStatus> configStatus = new Bindable<UserStatus>();
+        private readonly Bindable<bool> configSupporter = new Bindable<bool>();
+
         private readonly CancellationTokenSource cancellationToken = new CancellationTokenSource();
         private readonly Logger log;
 
@@ -104,6 +106,7 @@ namespace osu.Game.Online.API
             authentication.Token.ValueChanged += onTokenChanged;
 
             config.BindWith(OsuSetting.UserOnlineStatus, configStatus);
+            config.BindWith(OsuSetting.WasSupporter, configSupporter);
 
             if (HasLogin)
             {
@@ -333,6 +336,7 @@ namespace osu.Game.Online.API
                         Debug.Assert(ThreadSafety.IsUpdateThread);
 
                         localUser.Value = me;
+                        configSupporter.Value = me.IsSupporter;
                         state.Value = me.SessionVerified ? APIState.Online : APIState.RequiresSecondFactorAuth;
                         failureCount = 0;
                     };
@@ -368,7 +372,8 @@ namespace osu.Game.Online.API
 
             localUser.Value = new APIUser
             {
-                Username = ProvidedUsername
+                Username = ProvidedUsername,
+                IsSupporter = configSupporter.Value,
             };
         }
 
@@ -607,6 +612,7 @@ namespace osu.Game.Online.API
             Schedule(() =>
             {
                 localUser.Value = createGuestUser();
+                configSupporter.Value = false;
                 friends.Clear();
             });
 


### PR DESCRIPTION
Fixes startup sounds from potentially being fetched from the wrong source if API connection establishment takes longer than the intro screen takes to load.

Tested manually because adding test coverage for this seems hard or impossible.

Closes https://github.com/ppy/osu/issues/22492.