### PR TITLE
Adjust song select beatmap background transition to better support transparent backgrounds

### DIFF
--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -108,12 +108,14 @@ namespace osu.Game.Screens.Backgrounds
             if (Background != null)
             {
                 newDepth = Background.Depth + 1;
-                Background.FinishTransforms();
                 Background.FadeOut(250);
                 Background.Expire();
             }
 
             b.Depth = newDepth;
+            b.Anchor = b.Origin = Anchor.Centre;
+            b.FadeInFromZero(500, Easing.OutQuint);
+            b.ScaleTo(1.02f).ScaleTo(1, 3500, Easing.OutQuint);
             dimmable.Background = Background = b;
         }
 


### PR DESCRIPTION
The "new" beatmap's background now briefly fades in. The reason we didn't do this to date is that there could be a perceived decrease in brightness as the old and new background transition through opacity.

But a quick fade in, it doesn't seem to cause much (if any) distracting visual artifacting.

I've also added a scale effect because it felt quite nice. Willing to pull that if anyone has an issue with it, but it's a step in the direction of "adding more motion to song select", which is still an area I see lacking greatly – even compared to stable.

Closes https://github.com/ppy/osu/issues/33020.