### PR TITLE
Ensure carousel filters are manifested to lists at each step

### DIFF
--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -274,13 +274,12 @@ namespace osu.Game.Graphics.Carousel
                     foreach (var filter in Filters)
                     {
                         log($"Performing {filter.GetType().ReadableName()}");
-                        var filteredItems = await filter.Run(items, cts.Token).ConfigureAwait(false);
+                        items = await filter.Run(items, cts.Token).ConfigureAwait(false);
 
                         // To avoid shooting ourselves in the foot, ensure that we manifest a list after each filter.
                         //
                         // A future improvement may be passing a reference list through each filter rather than copying each time,
                         // but this is the safest approach.
-                        items = filteredItems as List<CarouselItem> ?? filteredItems.ToList();
                     }
 
                     log("Updating Y positions");

--- a/osu.Game/Graphics/Carousel/ICarouselFilter.cs
+++ b/osu.Game/Graphics/Carousel/ICarouselFilter.cs
@@ -18,6 +18,6 @@ namespace osu.Game.Graphics.Carousel
         /// <param name="items">The items to be filtered.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The post-filtered items.</returns>
-        Task<IEnumerable<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken);
+        Task<List<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken);
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.SelectV2
             this.getCriteria = getCriteria;
         }
 
-        public async Task<IEnumerable<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken)
+        public async Task<List<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken)
         {
             return await Task.Run(() =>
             {

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterSorting.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterSorting.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.SelectV2
             this.getCriteria = getCriteria;
         }
 
-        public async Task<IEnumerable<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken) => await Task.Run(() =>
+        public async Task<List<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken) => await Task.Run(() =>
         {
             var criteria = getCriteria();
 
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.SelectV2
                 }
 
                 return comparison;
-            }));
+            })).ToList();
         }, cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
The original `IEnumerable` flow prioritised slight performance gains, but a filter's implementation could actually make this detrimental to overall performance.

I noticed in passing that there were already potentially multiple enumerations, via `updateYPositions` and the final `ToList` call. Rather than faffing around, let's keep things simple and require lists.

In benchmarking, the difference is (currently) negiligible. Slight improvement if anything.