### PR TITLE
Ignore "image proxying" test scene

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneImageProxying.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneImageProxying.cs
@@ -12,6 +12,7 @@ using osu.Game.Overlays.Comments;
 
 namespace osu.Game.Tests.Visual.Online
 {
+    [Ignore("This test hits online resources (and online retrieval can fail at any time), and also performs network calls to the production instance of the website. Un-ignore this test when it's actually actively needed.")]
     public partial class TestSceneImageProxying : OsuTestScene
     {
         [Test]


### PR DESCRIPTION
Because it just failed thrice (https://github.com/ppy/osu/runs/41775675413#r0) and to me it seems like a profoundly bad idea.

I considered having it retry like the framework precedent of this (https://github.com/ppy/osu-framework/blob/dd2b701ed84c687ff71f5c50338d3b325159ee45/osu.Framework.Tests/IO/TestWebRequest.cs#L69) before I noticed that it was also hitting hardcoded production endpoints https://github.com/ppy/osu/blob/9fb4ca7a95fdf69fd75ee0e047952ae9917dfe12/osu.Game/Graphics/Containers/Markdown/OsuMarkdownImage.cs#L16 at which point I decided it was just too weird to live.

I'm open to discussion of any of the points above or alternative solutions, but I want *something* done about this test.