### PR TITLE
Display separate design for beatmap panels on difficulty sort mode

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -30,32 +30,32 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestOpenCloseGroupWithNoSelectionMouse()
         {
-            AddAssert("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmap>().Count(p => p.Alpha > 0), () => Is.Zero);
+            AddAssert("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmapStandalone>().Count(p => p.Alpha > 0), () => Is.Zero);
             CheckNoSelection();
 
             ClickVisiblePanel<PanelGroupStarDifficulty>(0);
-            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmap>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
+            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmapStandalone>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
             CheckNoSelection();
 
             ClickVisiblePanel<PanelGroupStarDifficulty>(0);
-            AddUntilStep("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmap>().Count(p => p.Alpha > 0), () => Is.Zero);
+            AddUntilStep("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmapStandalone>().Count(p => p.Alpha > 0), () => Is.Zero);
             CheckNoSelection();
         }
 
         [Test]
         public void TestOpenCloseGroupWithNoSelectionKeyboard()
         {
-            AddAssert("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmap>().Count(p => p.Alpha > 0), () => Is.Zero);
+            AddAssert("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmapStandalone>().Count(p => p.Alpha > 0), () => Is.Zero);
             CheckNoSelection();
 
             SelectNextPanel();
             Select();
-            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmap>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
+            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmapStandalone>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
             AddAssert("keyboard selected is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
             CheckNoSelection();
 
             Select();
-            AddUntilStep("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmap>().Count(p => p.Alpha > 0), () => Is.Zero);
+            AddUntilStep("no beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmapStandalone>().Count(p => p.Alpha > 0), () => Is.Zero);
             AddAssert("keyboard selected is collapsed", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.False);
             CheckNoSelection();
         }
@@ -121,8 +121,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextGroup();
             WaitForGroupSelection(0, 0);
 
-            AddAssert("keyboard selected panel is beatmap", GetKeyboardSelectedPanel, Is.TypeOf<PanelBeatmap>);
-            AddAssert("selected panel is beatmap", GetSelectedPanel, Is.TypeOf<PanelBeatmap>);
+            AddAssert("keyboard selected panel is beatmap", GetKeyboardSelectedPanel, Is.TypeOf<PanelBeatmapStandalone>);
+            AddAssert("selected panel is beatmap", GetSelectedPanel, Is.TypeOf<PanelBeatmapStandalone>);
 
             ClickVisiblePanel<PanelGroupStarDifficulty>(0);
             AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, Is.TypeOf<PanelGroupStarDifficulty>);
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, Is.TypeOf<PanelGroupStarDifficulty>);
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
 
-            AddAssert("selected panel is still beatmap", GetSelectedPanel, Is.TypeOf<PanelBeatmap>);
+            AddAssert("selected panel is still beatmap", GetSelectedPanel, Is.TypeOf<PanelBeatmapStandalone>);
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             // open first group
             Select();
             CheckNoSelection();
-            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmap>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
+            AddUntilStep("some beatmaps visible", () => Carousel.ChildrenOfType<PanelBeatmapStandalone>().Count(p => p.Alpha > 0), () => Is.GreaterThan(0));
 
             SelectNextPanel();
             Select();
@@ -172,24 +172,24 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestInputHandlingWithinGaps()
         {
-            AddAssert("no beatmaps visible", () => !GetVisiblePanels<PanelBeatmap>().Any());
+            AddAssert("no beatmaps visible", () => !GetVisiblePanels<PanelBeatmapStandalone>().Any());
 
             // Clicks just above the first group panel should not actuate any action.
             ClickVisiblePanelWithOffset<PanelGroupStarDifficulty>(0, new Vector2(0, -(PanelGroupStarDifficulty.HEIGHT / 2 + 1)));
 
-            AddAssert("no beatmaps visible", () => !GetVisiblePanels<PanelBeatmap>().Any());
+            AddAssert("no beatmaps visible", () => !GetVisiblePanels<PanelBeatmapStandalone>().Any());
 
             // add lenience to avoid floating-point inaccuracies at edge.
             ClickVisiblePanelWithOffset<PanelGroupStarDifficulty>(0, new Vector2(0, -(PanelGroup.HEIGHT / 2 - 1)));
 
-            AddUntilStep("wait for beatmaps visible", () => GetVisiblePanels<PanelBeatmap>().Any());
+            AddUntilStep("wait for beatmaps visible", () => GetVisiblePanels<PanelBeatmapStandalone>().Any());
             CheckNoSelection();
 
             // Beatmap panels expand their selection area to cover holes from spacing.
-            ClickVisiblePanelWithOffset<PanelBeatmap>(0, new Vector2(0, -(CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
+            ClickVisiblePanelWithOffset<PanelBeatmapStandalone>(0, new Vector2(0, -(CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
             WaitForGroupSelection(0, 0);
 
-            ClickVisiblePanelWithOffset<PanelBeatmap>(1, new Vector2(0, (CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
+            ClickVisiblePanelWithOffset<PanelBeatmapStandalone>(1, new Vector2(0, (CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
             WaitForGroupSelection(0, 1);
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -257,7 +257,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
-        [Ignore("Difficulty sorting is broken when set headers are included.")] // todo: fix.
         public void TestSortingWithDifficultyFiltered()
         {
             const int diffs_per_set = 3;
@@ -279,17 +278,16 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SortBy(SortMode.Difficulty);
             WaitForFiltering();
 
-            CheckDisplayedBeatmapSetsCount(3);
             CheckDisplayedBeatmapsCount(local_set_count * diffs_per_set);
 
             ApplyToFilter("filter to normal", c => c.SearchText = "Normal");
+            WaitForFiltering();
 
-            CheckDisplayedBeatmapSetsCount(local_set_count);
             CheckDisplayedBeatmapsCount(local_set_count);
 
             ApplyToFilter("filter to insane", c => c.SearchText = "Insane");
+            WaitForFiltering();
 
-            CheckDisplayedBeatmapSetsCount(local_set_count);
             CheckDisplayedBeatmapsCount(local_set_count);
         }
     }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
+using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 using osuTK;
 using osuTK.Input;
@@ -234,6 +235,28 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             ClickVisiblePanelWithOffset<PanelBeatmap>(3, new Vector2(0, (CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
             WaitForSelection(0, 3);
+        }
+
+        [Test]
+        public void TestDifficultySortingWithNoGroups()
+        {
+            AddBeatmaps(2, 3);
+            WaitForDrawablePanels();
+
+            SortAndGroupBy(SortMode.Difficulty, GroupMode.All);
+            WaitForFiltering();
+
+            AddUntilStep("standalone panels displayed", () => GetVisiblePanels<PanelBeatmapStandalone>().Any());
+
+            SelectNextGroup();
+            WaitForSelection(0, 0);
+
+            SelectNextGroup();
+            WaitForSelection(1, 0);
+
+            SelectNextPanel();
+            Select();
+            WaitForSelection(0, 1);
         }
 
         private void checkSelectionIterating(bool isIterating)

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.SelectV2
                 return SPACING * 2;
 
             // Beatmap difficulty panels do not overlap with themselves or any other panel.
-            if (top.Model is BeatmapInfo || bottom.Model is BeatmapInfo)
+            if (grouping.BeatmapSetsGroupedTogether && (top.Model is BeatmapInfo || bottom.Model is BeatmapInfo))
                 return SPACING;
 
             return -SPACING;
@@ -365,6 +365,7 @@ namespace osu.Game.Screens.SelectV2
         #region Drawable pooling
 
         private readonly DrawablePool<PanelBeatmap> beatmapPanelPool = new DrawablePool<PanelBeatmap>(100);
+        private readonly DrawablePool<PanelBeatmapStandalone> standalonePanelPool = new DrawablePool<PanelBeatmapStandalone>(100);
         private readonly DrawablePool<PanelBeatmapSet> setPanelPool = new DrawablePool<PanelBeatmapSet>(100);
         private readonly DrawablePool<PanelGroup> groupPanelPool = new DrawablePool<PanelGroup>(100);
         private readonly DrawablePool<PanelGroupStarDifficulty> starsGroupPanelPool = new DrawablePool<PanelGroupStarDifficulty>(11);
@@ -374,6 +375,7 @@ namespace osu.Game.Screens.SelectV2
             AddInternal(starsGroupPanelPool);
             AddInternal(groupPanelPool);
             AddInternal(beatmapPanelPool);
+            AddInternal(standalonePanelPool);
             AddInternal(setPanelPool);
         }
 
@@ -406,8 +408,9 @@ namespace osu.Game.Screens.SelectV2
                     return groupPanelPool.Get();
 
                 case BeatmapInfo:
-                    // TODO: if beatmap is a group selection target, it needs to be a different drawable
-                    // with more information attached.
+                    if (!grouping.BeatmapSetsGroupedTogether)
+                        return standalonePanelPool.Get();
+
                     return beatmapPanelPool.Get();
 
                 case BeatmapSetInfo:

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.SelectV2
                 HashSet<CarouselItem>? currentGroupItems = null;
                 HashSet<CarouselItem>? currentSetItems = null;
 
-                BeatmapSetsGroupedTogether = criteria.Group != GroupMode.Difficulty;
+                BeatmapSetsGroupedTogether = criteria.Sort != SortMode.Difficulty;
 
                 foreach (var item in items)
                 {
@@ -100,6 +100,8 @@ namespace osu.Game.Screens.SelectV2
                     {
                         if (lastGroupItem != null)
                             lastGroupItem.NestedItemCount++;
+
+                        item.DrawHeight = PanelBeatmapStandalone.HEIGHT;
                     }
 
                     addItem(item);


### PR DESCRIPTION
Also removes ignore from filtering test case and updates it to match desired behaviour in this PR.

Preview (by locally modifying song select to sort by difficulty, ignore filter control):

https://github.com/user-attachments/assets/aeccddfb-fb8e-4db4-8c52-72208cbdb66e

