### PR TITLE
Improve logging and errors around beatmap submission process

### DIFF
--- a/osu.Game/Screens/Edit/Submission/SubmissionBeatmapExporter.cs
+++ b/osu.Game/Screens/Edit/Submission/SubmissionBeatmapExporter.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.Edit.Submission
                 }
 
                 if (playableBeatmap.BeatmapInfo.OnlineID > 0)
-                    throw new InvalidOperationException(@"Encountered beatmap with ID that has not been assigned to it by the server!");
+                    throw new InvalidOperationException($@"Difficulty ""{playableBeatmap.BeatmapInfo.DifficultyName}"" has BeatmapID {playableBeatmap.BeatmapInfo.OnlineID} that has not been assigned to it by the server!");
 
                 if (allocatedBeatmapIds.Count == 0)
                     throw new InvalidOperationException(@"Ran out of new beatmap IDs to assign to unsubmitted beatmaps!");


### PR DESCRIPTION
There have been weird reports flying around every now and then from people that I cannot really corroborate well because people are mixing stable and lazer in weird ways and then trying fifteen magic ID fixes from stable by themselves and only *then* after all that coming to places I can see to ask for help, without being able to provide before/after snapshots of what they precisely did, at which point the perp has long fled the scene of the crime and wiped all of the prints. So I'm hoping these changes may at least slightly improve the chances of either the user applying the *correct* fix to begin with, or me being able to catch it.

## [Use better error messaging in case of beatmap ID mismatch](https://github.com/ppy/osu/commit/ad586cb5dda8300850baf48b4afb444308b4af9f) 
Should maybe give users a better idea of what's wrong by telling them which difficulty is the problem and what ID is the wrong one.

## [Improve logging around import-as-update flow](https://github.com/ppy/osu/commit/588c1719787fc323d33d8583826c8df68ef7eb2d)

- It was logging success before actually succeeding.
- It appears in practice that this code [can somehow actually nullref](https://discord.com/channels/188630481301012481/1097318920991559880/1368966310909841488). Unfortunately [logs provided in that instance](https://discord.com/channels/188630481301012481/1097318920991559880/1368968694239068270) were not enough to pinpoint what (because of lack of line numbers):

      2025-05-02 19:37:05 [verbose]: Beatmap submission failed on local update: System.NullReferenceException: Object reference not set to an instance of an object.
      2025-05-02 19:37:05 [verbose]: at osu.Game.Beatmaps.BeatmapImporter.<>c__DisplayClass9_0.<ImportAsUpdate>b__1(BeatmapSetInfo updated)
      2025-05-02 19:37:05 [verbose]: at osu.Game.Database.RealmLive`1.<>c__DisplayClass8_0.<PerformWrite>b__0(T t)
      2025-05-02 19:37:05 [verbose]: at osu.Game.Database.RealmLive`1.<>c__DisplayClass6_0.<PerformRead>b__0(Realm r)
      2025-05-02 19:37:05 [verbose]: at osu.Game.Database.RealmAccess.Run(Action`1 action)
      2025-05-02 19:37:05 [verbose]: at osu.Game.Database.RealmLive`1.PerformRead(Action`1 perform)
      2025-05-02 19:37:05 [verbose]: at osu.Game.Database.RealmLive`1.PerformWrite(Action`1 perform)
      2025-05-02 19:37:05 [verbose]: at osu.Game.Beatmaps.BeatmapImporter.ImportAsUpdate(ProgressNotification notification, ImportTask importTask, BeatmapSetInfo original)
      2025-05-02 19:37:05 [verbose]: at osu.Game.Screens.Edit.Submission.BeatmapSubmissionScreen.updateLocalBeatmap()

  I'm hoping that by logging as error, and therefore to sentry, we can actually retrieve this information so that there's no need to work blind.