### PR TITLE
Fix gameplay leaderboard score reading off wrong combo property

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/GameplayLeaderboardScore.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             Tracked = tracked;
             TotalScore.Value = scoreInfo.TotalScore;
             Accuracy.Value = scoreInfo.Accuracy;
-            Combo.Value = scoreInfo.Combo;
+            Combo.Value = scoreInfo.MaxCombo;
             TotalScoreTiebreaker = scoreInfo.OnlineID > 0 ? scoreInfo.OnlineID : scoreInfo.Date.ToUnixTimeSeconds();
             GetDisplayScore = scoreInfo.GetDisplayScore;
             InitialPosition = scoreInfo.Position;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33006.

Broke in c231571f06167b4445148bf29ac70c4facb3f8e3.

The fact that this mistake can be made at all is... something, but it was made.