### PR TITLE
Discard distance snapping result if it results in objects being placed out of playfield bounds

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -259,6 +259,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             var playfield = PlayfieldAtScreenSpacePosition(screenSpacePosition);
             (Vector2 pos, double time) = distanceSnapGrid.GetSnappedPosition(distanceSnapGrid.ToLocalSpace(screenSpacePosition), fixedTime);
+
+            if (pos.X < 0 || pos.X > OsuPlayfield.BASE_SIZE.X || pos.Y < 0 || pos.Y > OsuPlayfield.BASE_SIZE.Y)
+                return null;
+
             return new SnapResult(distanceSnapGrid.ToScreenSpace(pos), time, playfield);
         }
 


### PR DESCRIPTION
Mainly an issue with "limit distance snap to current time". Reported in https://discord.com/channels/90072389919997952/1259818301517725707/1369037235797753999.

This slightly changes behaviour of distance snap when the mouse is near the edges of the screen (will turn off snap rather than clamp to edge as previously), but I think that's probably fine.