### PR TITLE
Fix Show More button may incorrect displayed

### DIFF
--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.Profile.Sections
 
             CurrentPage = CurrentPage?.TakeNext(ItemsPerPage) ?? new PaginationParameters(InitialItemsCount);
 
-            retrievalRequest = CreateRequest(User.Value, new PaginationParameters(CurrentPage.Value.Offset, CurrentPage.Value.Limit + 1));
+            retrievalRequest = CreateRequest(User.Value, new PaginationParameters(CurrentPage.Value.Offset, InitialItemsCount + 1));
             retrievalRequest.Success += items => UpdateItems(items, loadCancellation);
 
             api.Queue(retrievalRequest);

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -46,8 +46,6 @@ namespace osu.Game.Overlays.Profile.Sections
         private OsuSpriteText missing = null!;
         private readonly LocalisableString? missingText;
 
-        private bool hasMore { get; set; }
-
         protected PaginatedProfileSubsection(Bindable<UserProfileData?> user, LocalisableString? headerText = null, LocalisableString? missingText = null)
             : base(user, headerText, CounterVisibilityState.AlwaysVisible)
         {
@@ -101,7 +99,6 @@ namespace osu.Game.Overlays.Profile.Sections
 
             CurrentPage = null;
             ItemsContainer.Clear();
-            hasMore = false;
 
             if (e.NewValue?.User != null)
             {
@@ -131,7 +128,6 @@ namespace osu.Game.Overlays.Profile.Sections
             {
                 moreButton.Hide();
                 moreButton.IsLoading = false;
-                hasMore = false;
 
                 if (missingText.HasValue)
                     missing.Show();
@@ -139,8 +135,7 @@ namespace osu.Game.Overlays.Profile.Sections
                 return;
             }
 
-            // mutates items and returns whether there are more items than expectedCount.
-            hasMore = items.Count > CurrentPage?.Limit;
+            bool hasMore = items.Count > CurrentPage?.Limit;
 
             if (hasMore)
                 items.RemoveAt(items.Count - 1);


### PR DESCRIPTION
Another solution

https://github.com/ppy/osu/blob/045fd474f85b3d0c65bb527caa510332c659c6ad/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs#L129

```diff
// even if the "Show More" button is incorrectly displayed, clicking it will at least make it disappear.
- if (!items.Any() && CurrentPage?.Offset == 0)
+ if (!items.Any())
```

Closes https://github.com/ppy/osu/issues/9203