### PR TITLE
SongSelectV2: Add delete hotkey functionality

### DIFF
--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -9,6 +9,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
@@ -21,6 +23,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -274,6 +277,15 @@ namespace osu.Game.Screens.SelectV2
             private partial class InnerTextBox : InnerFilterTextBox
             {
                 public override bool HandleLeftRightArrows => false;
+
+                public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+                {
+                    // the "cut" platform key binding (shift-delete) conflicts with the beatmap deletion action.
+                    if (e.Action == PlatformAction.Cut && e.ShiftPressed && e.CurrentState.Keyboard.Keys.IsPressed(Key.Delete))
+                        return false;
+
+                    return base.OnPressed(e);
+                }
             }
         }
     }

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -9,8 +9,10 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
@@ -19,6 +21,7 @@ using osu.Game.Screens.Menu;
 using osu.Game.Screens.Select;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -56,6 +59,9 @@ namespace osu.Game.Screens.SelectV2
 
         [Resolved]
         private OsuLogo? logo { get; set; }
+
+        [Resolved]
+        private IDialogOverlay? dialogs { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -313,6 +319,42 @@ namespace osu.Game.Screens.SelectV2
             // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
             // but also in this case we want support for formatting a number within a string).
             filterControl.StatusText = count != 1 ? $"{count:#,0} matches" : $"{count:#,0} match";
+        }
+
+        #endregion
+
+        #region Beatmap management
+
+        /// <summary>
+        /// Opens up <see cref="BeatmapDeleteDialog"/> with the given beatmap set.
+        /// </summary>
+        public void RequestDeleteBeatmap(BeatmapSetInfo set)
+        {
+            dialogs?.Push(new BeatmapDeleteDialog(set));
+        }
+
+        #endregion
+
+        #region Hotkeys
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Repeat) return false;
+
+            switch (e.Key)
+            {
+                case Key.Delete:
+                    if (e.ShiftPressed)
+                    {
+                        if (!Beatmap.IsDefault)
+                            RequestDeleteBeatmap(Beatmap.Value.BeatmapSetInfo);
+                        return true;
+                    }
+
+                    break;
+            }
+
+            return base.OnKeyDown(e);
         }
 
         #endregion


### PR DESCRIPTION
There's no realistic method of testing this yet as we don't update the global beatmap bindable with current selection, but a sufficient test case backs this up enough that it doesn't have to be postponed.