### PR TITLE
Fix `HitWindows.WindowFor()` returning values for invalid results

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 foreach (BreakPeriod b in drawableRuleset.Beatmap.Breaks)
                     periods.Add(new Period(b.StartTime, getValidJudgementTime(ruleset.Objects.First(h => h.StartTime >= b.EndTime)) - 1));
 
-                static double getValidJudgementTime(HitObject hitObject) => hitObject.StartTime - hitObject.HitWindows.WindowFor(HitResult.Meh);
+                static double getValidJudgementTime(HitObject hitObject) => hitObject.StartTime - hitObject.HitWindows.WindowFor(HitResult.Ok);
             }
 
             nonGameplayPeriods = new PeriodTracker(periods);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -204,12 +204,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Origin = Anchor.Centre,
                 Direction = FillDirection.Vertical,
                 AutoSizeAxes = Axes.Both,
-                Children = new[]
-                {
-                    new OsuSpriteText { Text = $@"Great: {hitWindows?.WindowFor(HitResult.Great)}" },
-                    new OsuSpriteText { Text = $@"Good: {hitWindows?.WindowFor(HitResult.Ok)}" },
-                    new OsuSpriteText { Text = $@"Meh: {hitWindows?.WindowFor(HitResult.Meh)}" },
-                }
+                ChildrenEnumerable = hitWindows?.GetAllAvailableWindows().Select(w => new OsuSpriteText { Text = $@"{w.result}: {w.length}" }) ?? []
             });
 
             Add(new BarHitErrorMeter

--- a/osu.Game/Rulesets/Scoring/HitWindows.cs
+++ b/osu.Game/Rulesets/Scoring/HitWindows.cs
@@ -193,17 +193,7 @@ namespace osu.Game.Rulesets.Scoring
                 new DifficultyRange(HitResult.Miss, 0, 0, 0),
             };
 
-            public override bool IsHitResultAllowed(HitResult result)
-            {
-                switch (result)
-                {
-                    case HitResult.Perfect:
-                    case HitResult.Miss:
-                        return true;
-                }
-
-                return false;
-            }
+            public override bool IsHitResultAllowed(HitResult result) => true;
 
             protected override DifficultyRange[] GetRanges() => ranges;
         }

--- a/osu.Game/Rulesets/Scoring/HitWindows.cs
+++ b/osu.Game/Rulesets/Scoring/HitWindows.cs
@@ -143,6 +143,9 @@ namespace osu.Game.Rulesets.Scoring
         /// <returns>One half of the hit window for <paramref name="result"/>.</returns>
         public double WindowFor(HitResult result)
         {
+            if (!IsHitResultAllowed(result))
+                throw new ArgumentOutOfRangeException(nameof(result), result, $@"{result} is not an allowed result.");
+
             switch (result)
             {
                 case HitResult.Perfect:
@@ -164,7 +167,7 @@ namespace osu.Game.Rulesets.Scoring
                     return miss;
 
                 default:
-                    throw new ArgumentException("Unknown enum member", nameof(result));
+                    throw new ArgumentOutOfRangeException(nameof(result), result, null);
             }
         }
 


### PR DESCRIPTION
This fell out of my work on hit window-related replay issues. In my WIP branch (that is probably going to get PR'd as draft soon) I refactored `HitWindows` and found a few straggling test failures due to some places reading hit windows for results that were not actually supported by the underlying `HitWindows` implementations, leading to returning garbage (mostly zeroes), which after my refactor started throwing.

Importantly, there is one actual usage in game code with impact here - `TaikoModSingleTap` was attempting to read the hit window for MEH, when MEH was never actually a valid hit result in taiko (OK is). This was a result of a copy-paste oversight from osu!, specifically from

https://github.com/ppy/osu/blob/51cf835fb6300aca53b5b98143d606f64d7a4d49/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs#L58