### PR TITLE
Fix fetching too few items per page in profile subsections

### DIFF
--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.Profile.Sections
 
             CurrentPage = CurrentPage?.TakeNext(ItemsPerPage) ?? new PaginationParameters(InitialItemsCount);
 
-            retrievalRequest = CreateRequest(User.Value, new PaginationParameters(CurrentPage.Value.Offset, InitialItemsCount + 1));
+            retrievalRequest = CreateRequest(User.Value, new PaginationParameters(CurrentPage.Value.Offset, CurrentPage.Value.Limit + 1));
             retrievalRequest.Success += items => UpdateItems(items, loadCancellation);
 
             api.Queue(retrievalRequest);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/33d453c2-ed95-4c59-9f17-5fc7cca7b96c)

![image](https://github.com/user-attachments/assets/77b6ad7f-ac90-48ec-81e3-54a1ed27ad32)

**This error was caused by directly changing to `InitialItemsCount + 1`. My bad for not checking before committing the changes :(**

Respond https://github.com/ppy/osu/pull/33070#discussion_r2080986545

```
 First request: offset = 0,  limit = InitialItemsCount + 1 (e.g. 6)
Second request: offset = 5,  limit = ItemsPerPage + 1      (e.g. 51)
 Third request: offset = 55, limit = ItemsPerPage + 1      (e.g. 51)
```

The "+1" is applied within each individual request to check for more data, not accumulated between requests.

But to be honest, I'm not entirely clear on the logic behind this either :(

This reverts commit 10cb038f1230b89a1c07964cd25ae69ff7417c70.