### PR TITLE
Use fast invert helper in hot path

### DIFF
--- a/osu.Game/Graphics/Containers/UprightAspectMaintainingContainer.cs
+++ b/osu.Game/Graphics/Containers/UprightAspectMaintainingContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Extensions.MatrixExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
@@ -54,7 +55,8 @@ namespace osu.Game.Graphics.Containers
             parentMatrix.M31 = 0.0f;
             parentMatrix.M32 = 0.0f;
 
-            Matrix3 reversedParent = parentMatrix.Inverted();
+            Matrix3 reversedParent = parentMatrix;
+            MatrixExtensions.FastInvert(ref reversedParent);
 
             // Extract the rotation.
             float angle = MathF.Atan2(reversedParent.M12, reversedParent.M11);


### PR DESCRIPTION
Removes the `int[]` and `float[]` allocations:

Before:
<img width="604" alt="Screenshot 2025-05-11 at 13 08 00" src="https://github.com/user-attachments/assets/61d0bf20-696c-4db3-8793-0092e1b72428" />

After:
<img width="605" alt="Screenshot 2025-05-11 at 13 08 07" src="https://github.com/user-attachments/assets/1aacc213-49dc-459c-8b7c-7929e3c49d56" />