### PR TITLE
SongSelectV2: Allow switching between details and rankings page via keyboard

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapDetailsArea_Header.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapDetailsArea_Header.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Screens.SelectV2
                                 Width = 200,
                                 Height = 22,
                                 Margin = new MarginPadding { Top = 2f },
+                                IsSwitchable = true,
                             },
                             leaderboardControls = new FillFlowContainer
                             {


### PR DESCRIPTION
Doesn't completely replicate behaviour of old song select because we don't place leaderboard scope in the tab control anymore. I guess this will do for now anyway.

No test coverage added because the change is a very explicit one liner.