### PR TITLE
Fix letterbox overlay potentially fading incorrectly during seeks

### DIFF
--- a/osu.Game/Screens/Play/LetterboxOverlay.cs
+++ b/osu.Game/Screens/Play/LetterboxOverlay.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Screens.Play
 
         private readonly IBindable<Period?> currentPeriod = new Bindable<Period?>();
 
-        private static readonly Color4 transparent_black = new Color4(0, 0, 0, 0);
-
         public LetterboxOverlay()
         {
             RelativeSizeAxes = Axes.Both;
@@ -59,10 +57,11 @@ namespace osu.Game.Screens.Play
             currentPeriod.BindValueChanged(updateDisplay, true);
         }
 
+        public override bool RemoveCompletedTransforms => false;
+
         private void updateDisplay(ValueChangedEvent<Period?> period)
         {
             FinishTransforms(true);
-            Scheduler.CancelDelayedTasks();
 
             if (period.NewValue == null)
                 return;
@@ -71,7 +70,7 @@ namespace osu.Game.Screens.Play
 
             using (BeginAbsoluteSequence(b.Start))
             {
-                fadeContainer.FadeIn(BreakOverlay.BREAK_FADE_DURATION);
+                fadeContainer.FadeInFromZero(BreakOverlay.BREAK_FADE_DURATION);
                 using (BeginDelayedSequence(b.Duration - BreakOverlay.BREAK_FADE_DURATION))
                     fadeContainer.FadeOut(BreakOverlay.BREAK_FADE_DURATION);
             }


### PR DESCRIPTION
Pushing this out with zero testing as a "probably fixes" https://github.com/ppy/osu/issues/33108.

Previous logic would mean that the start value of the fade-in may not be zero depending on current state, leaving the final alpha state incorrect after a rewind beyond the start time.

Hope for an immediate merge with no further testing based on "yeah that's probably correct".