### PR TITLE
Allow using "mirror" mod to gain PP

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModMirror : ModMirror, IApplicableToBeatmap
     {
         public override LocalisableString Description => "Notes are flipped horizontally.";
-        public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -9,5 +9,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "MR";
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1;
+        public override bool Ranked => true;
     }
 }


### PR DESCRIPTION
Has been coming up more often in discussion. The community seems to have a unanimously positive reception to this happening.

See https://github.com/ppy/osu/discussions/33076 / https://discord.com/channels/188630481301012481/188630652340404224/1370295710293037077

Of note, https://github.com/ppy/osu/discussions/29327 was brought up as a blocker but I don't see it this way, and I think it's fine to let stacking work how it currently does (normal stack direction) as part of the mod's mechanics.

Will require some server-side considerations for existing scores.

- [ ] Blocked by https://github.com/ppy/osu/issues/30532