### PR TITLE
Fix distance snap grid being used before it's ready for use

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -254,7 +254,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         [CanBeNull]
         public SnapResult TrySnapToDistanceGrid(Vector2 screenSpacePosition, double? fixedTime = null)
         {
-            if (DistanceSnapProvider.DistanceSnapToggle.Value != TernaryState.True || distanceSnapGrid == null)
+            if (DistanceSnapProvider.DistanceSnapToggle.Value != TernaryState.True || distanceSnapGrid?.IsLoaded != true)
                 return null;
 
             var playfield = PlayfieldAtScreenSpacePosition(screenSpacePosition);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32136.

`DistanceSnapGrid.MaxIntervals` is written to in
	https://github.com/ppy/osu/blob/a360f153f73255d6f78148da17edf2c348af4e94/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs#L107-L110

which gets run the first time on `LoadComplete()`:
	https://github.com/ppy/osu/blob/a360f153f73255d6f78148da17edf2c348af4e94/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs#L96-L97

meaning it is not valid to attempt to use the grid to snap before it's loaded, which does actually appear to occur sometimes before this change.