### PR TITLE
SongSelectV2: Fix `SongSelect` not cached for subcomponents

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Screens.SelectV2
     /// This screen is intended to house all components introduced in the new song select design to add transitions and examine the overall look.
     /// This will be gradually built upon and ultimately replace <see cref="Select.SongSelect"/> once everything is in place.
     /// </summary>
+    [Cached(typeof(SongSelect))]
     public abstract partial class SongSelect : OsuScreen, IKeyBindingHandler<GlobalAction>
     {
         private const float logo_scale = 0.4f;


### PR DESCRIPTION
Fixes clicking title/artist text in wedge or source/genre/language/tags in metadata not putting it into filter control search bar. `SongSelect` is attempted to be DI'd for that purpose.