### PR TITLE
Slider Rhythm Correction

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -89,19 +89,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     else
                     {
                         // bpm change is into slider, this is easy acc window
-                        if (currObj.BaseObject is Slider)
-                        {
-                            if (isClassic)
-                                effectiveRatio *= 0.125;
-                            else
-                                effectiveRatio *= 1;
-                        }
+                        if (currObj.BaseObject is Slider && isClassic)
+                            effectiveRatio *= 0.125;
 
                         // bpm change was from a slider, this is easier typically than circle -> circle
                         // unintentional side effect is that bursts with kicksliders at the ends might have lower difficulty than bursts without sliders
-                        if (prevObj.BaseObject is Slider)
-                            if (prevObj.TravelTime > (currDelta - deltaDifferenceEpsilon) / 6)
-                                effectiveRatio *= 0.3;
+                        if (prevObj.BaseObject is Slider && prevObj.TravelTime > (currDelta - deltaDifferenceEpsilon) / 6)
+                            effectiveRatio *= 0.3;
 
                         // repeated island polarity (2 -> 4, 3 -> 5)
                         if (island.IsSimilarPolarity(previousIsland))

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -42,7 +42,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             currentStrain *= strainDecay(((OsuDifficultyHitObject)current).StrainTime);
             currentStrain += SpeedEvaluator.EvaluateDifficultyOf(current, Mods) * skillMultiplier;
 
-            currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
+
+
+            currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current, Mods.Any(m => m is ModClassic));
 
             double totalStrain = currentStrain * currentRhythm;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -42,8 +42,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             currentStrain *= strainDecay(((OsuDifficultyHitObject)current).StrainTime);
             currentStrain += SpeedEvaluator.EvaluateDifficultyOf(current, Mods) * skillMultiplier;
 
-
-
             currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current, Mods.Any(m => m is ModClassic));
 
             double totalStrain = currentStrain * currentRhythm;


### PR DESCRIPTION
**This branch aims to fix the incorrect rhythm calculation for sliders. Currently, it is assumed that any slider is rhythmically easier by default.**

### *Rhythm circle into slider*
  On stable, the slider is indeed easier. However, on lazer, with this correction it is treated with the same difficulty as a circle-to-circle transition.

### *Rhythm slider into circle*
  This pattern is generally easier unless the slider is short enough not to interfere rhythmically with the following circle.
  A check has been added to determine whether the slider rhythmically interferes with the next object. If it does not, the slider is treated like a circle; otherwise, the usual nerf is applied.

_Additionally, other values have been adjusted to rebalance the overall difficulty._