### PR TITLE
Remove replay recorder depth hack

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneReplayRecording.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneReplayRecording.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Replays;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public partial class TestSceneReplayRecording : PlayerTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
+        {
+            HitObjects =
+            {
+                new Fruit { StartTime = 0, },
+                new Fruit { StartTime = 5000, },
+                new Fruit { StartTime = 10000, },
+                new Fruit { StartTime = 15000, }
+            }
+        };
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null) =>
+            new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+
+        [Test]
+        public void TestRecording()
+        {
+            seekTo(0);
+            AddStep("start moving left", () => InputManager.PressKey(Key.Left));
+            seekTo(5000);
+            AddStep("end moving left", () => InputManager.ReleaseKey(Key.Left));
+            AddAssert("catcher max left", () => this.ChildrenOfType<CatcherArea>().Single().X, () => Is.EqualTo(0));
+            AddAssert("movement to left recorded to replay", () => Player.Score.Replay.Frames.OfType<CatchReplayFrame>().Any(f => f.Actions.SequenceEqual([CatchAction.MoveLeft])));
+            AddAssert("replay reached left edge", () => Player.Score.Replay.Frames.OfType<CatchReplayFrame>().Any(f => Precision.AlmostEquals(f.Position, 0)));
+
+            AddStep("start dashing right", () =>
+            {
+                InputManager.PressKey(Key.LShift);
+                InputManager.PressKey(Key.Right);
+            });
+            seekTo(10000);
+            AddStep("end dashing right", () =>
+            {
+                InputManager.ReleaseKey(Key.LShift);
+                InputManager.ReleaseKey(Key.Right);
+            });
+            AddAssert("catcher max right", () => this.ChildrenOfType<CatcherArea>().Single().X, () => Is.EqualTo(0));
+            AddAssert("dash to right recorded to replay", () => Player.Score.Replay.Frames.OfType<CatchReplayFrame>().Any(f => f.Actions.SequenceEqual([CatchAction.Dash, CatchAction.MoveRight])));
+            AddAssert("replay reached right edge", () => Player.Score.Replay.Frames.OfType<CatchReplayFrame>().Any(f => Precision.AlmostEquals(f.Position, CatchPlayfield.WIDTH)));
+        }
+
+        private void seekTo(double time)
+        {
+            AddStep($"seek to {time}ms", () => Player.GameplayClockContainer.Seek(time));
+            AddUntilStep("wait for seek to finish", () => Player.DrawableRuleset.FrameStableClock.CurrentTime, () => Is.EqualTo(time).Within(500));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRecording.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRecording.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Replays;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Mania.Tests
+{
+    public partial class TestSceneReplayRecording : PlayerTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new ManiaBeatmap(new StageDefinition(1))
+        {
+            HitObjects =
+            {
+                new Note { StartTime = 0, },
+                new Note { StartTime = 5000, },
+                new Note { StartTime = 10000, },
+                new Note { StartTime = 15000, }
+            },
+            Difficulty = { CircleSize = 1 },
+            BeatmapInfo =
+            {
+                Ruleset = ruleset,
+            }
+        };
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null) =>
+            new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+
+        [Test]
+        public void TestRecording()
+        {
+            seekTo(0);
+            AddStep("press space", () => InputManager.Key(Key.Space));
+            AddAssert("button press recorded to replay", () => Player.Score.Replay.Frames.OfType<ManiaReplayFrame>().Any(f => f.Actions.SequenceEqual([ManiaAction.Key1])));
+        }
+
+        private void seekTo(double time)
+        {
+            AddStep($"seek to {time}ms", () => Player.GameplayClockContainer.Seek(time));
+            AddUntilStep("wait for seek to finish", () => Player.DrawableRuleset.FrameStableClock.CurrentTime, () => Is.EqualTo(time).Within(500));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneReplayRecording.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneReplayRecording.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public partial class TestSceneReplayRecording : PlayerTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
+        {
+            HitObjects =
+            {
+                new HitCircle
+                {
+                    Position = OsuPlayfield.BASE_SIZE / 2,
+                    StartTime = 0,
+                },
+                new HitCircle
+                {
+                    Position = OsuPlayfield.BASE_SIZE / 2,
+                    StartTime = 5000,
+                },
+                new HitCircle
+                {
+                    Position = OsuPlayfield.BASE_SIZE / 2,
+                    StartTime = 10000,
+                },
+                new HitCircle
+                {
+                    Position = OsuPlayfield.BASE_SIZE / 2,
+                    StartTime = 15000,
+                }
+            }
+        };
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null) =>
+            new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+
+        [Test]
+        public void TestRecording()
+        {
+            seekTo(0);
+            AddStep("move cursor to circle", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.Single()));
+            AddStep("press X", () => InputManager.Key(Key.X));
+            AddAssert("right button press recorded to replay", () => Player.Score.Replay.Frames.OfType<OsuReplayFrame>().Any(f => f.Actions.SequenceEqual([OsuAction.RightButton])));
+
+            seekTo(5000);
+            AddStep("move cursor to circle", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.Single()));
+            AddStep("press Z", () => InputManager.Key(Key.Z));
+            AddAssert("left button press recorded to replay", () => Player.Score.Replay.Frames.OfType<OsuReplayFrame>().Any(f => f.Actions.SequenceEqual([OsuAction.LeftButton])));
+
+            seekTo(10000);
+            AddStep("move cursor to circle", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.Single()));
+            AddStep("press C", () => InputManager.Key(Key.C));
+            AddAssert("smoke button press recorded to replay", () => Player.Score.Replay.Frames.OfType<OsuReplayFrame>().Any(f => f.Actions.SequenceEqual([OsuAction.Smoke])));
+        }
+
+        private void seekTo(double time)
+        {
+            AddStep($"seek to {time}ms", () => Player.GameplayClockContainer.Seek(time));
+            AddUntilStep("wait for seek to finish", () => Player.DrawableRuleset.FrameStableClock.CurrentTime, () => Is.EqualTo(time).Within(500));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayRecording.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayRecording.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Replays;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public partial class TestSceneReplayRecording : PlayerTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new TaikoRuleset();
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
+        {
+            HitObjects =
+            {
+                new Hit { StartTime = 0, },
+                new Hit { StartTime = 5000, },
+                new Hit { StartTime = 10000, },
+                new Hit { StartTime = 15000, }
+            }
+        };
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null) =>
+            new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+
+        [Test]
+        public void TestRecording()
+        {
+            seekTo(0);
+            AddStep("press D", () => InputManager.Key(Key.D));
+            AddAssert("left rim press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.LeftRim])));
+
+            seekTo(5000);
+            AddStep("press F", () => InputManager.Key(Key.F));
+            AddAssert("left centre press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.LeftCentre])));
+
+            seekTo(10000);
+            AddStep("press J", () => InputManager.Key(Key.J));
+            AddAssert("right centre press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.RightCentre])));
+
+            seekTo(10000);
+            AddStep("press K", () => InputManager.Key(Key.K));
+            AddAssert("right rim press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.RightRim])));
+        }
+
+        private void seekTo(double time)
+        {
+            AddStep($"seek to {time}ms", () => Player.GameplayClockContainer.Seek(time));
+            AddUntilStep("wait for seek to finish", () => Player.DrawableRuleset.FrameStableClock.CurrentTime, () => Is.EqualTo(time).Within(500));
+        }
+    }
+}

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -40,8 +40,6 @@ namespace osu.Game.Rulesets.UI
             this.target = target;
 
             RelativeSizeAxes = Axes.Both;
-
-            Depth = float.MinValue;
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/pull/33102#discussion_r2087963889.

Split off separately for the sake of the test coverage (and to give this change enough gravity I guess?)

To see why I bothered to add tests for this, apply

```diff
diff --git a/osu.Game/Rulesets/UI/ReplayRecorder.cs b/osu.Game/Rulesets/UI/ReplayRecorder.cs
index d723c31434..3e47f229f0 100644
--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -40,6 +40,8 @@ protected ReplayRecorder(Score target)
             this.target = target;
 
             RelativeSizeAxes = Axes.Both;
+
+            Depth = float.MaxValue;
         }
 
         protected override void LoadComplete()

```

to see them fail.