### PR TITLE
Fix back button not displaying when transitioning to non-footer screen

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenFooterNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenFooterNavigation.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Screens;
+using osu.Game.Screens.Footer;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    public partial class TestSceneScreenFooterNavigation : OsuGameTestScene
+    {
+        private ScreenFooter screenFooter => this.ChildrenOfType<ScreenFooter>().Single();
+
+        [Test]
+        public void TestFooterHidesOldBackButton()
+        {
+            PushAndConfirm(() => new TestScreen(false));
+            AddAssert("footer hidden", () => screenFooter.State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("old back button shown", () => Game.BackButton.State.Value, () => Is.EqualTo(Visibility.Visible));
+
+            PushAndConfirm(() => new TestScreen(true));
+            AddAssert("footer shown", () => screenFooter.State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddAssert("old back button hidden", () => Game.BackButton.State.Value, () => Is.EqualTo(Visibility.Hidden));
+
+            PushAndConfirm(() => new TestScreen(false));
+            AddAssert("footer hidden", () => screenFooter.State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("back button shown", () => Game.BackButton.State.Value, () => Is.EqualTo(Visibility.Visible));
+
+            AddStep("exit screen", () => Game.ScreenStack.Exit());
+            AddAssert("footer shown", () => screenFooter.State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddAssert("old back button hidden", () => Game.BackButton.State.Value, () => Is.EqualTo(Visibility.Hidden));
+
+            AddStep("exit screen", () => Game.ScreenStack.Exit());
+            AddAssert("footer hidden", () => screenFooter.State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("old back button shown", () => Game.BackButton.State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+
+        private partial class TestScreen : OsuScreen
+        {
+            public override bool ShowFooter { get; }
+
+            public TestScreen(bool footer)
+            {
+                ShowFooter = footer;
+            }
+        }
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1732,7 +1732,10 @@ namespace osu.Game
 
                 if (newScreen.ShowFooter)
                 {
-                    BackButton.Hide();
+                    // force the back button to be hidden when footer is visible
+                    backButtonVisibility.UnbindFrom(newScreen.BackButtonVisibility);
+                    backButtonVisibility.BindTo(new BindableBool());
+
                     ScreenFooter.SetButtons(newScreen.CreateFooterButtons());
                     ScreenFooter.Show();
                 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -188,7 +188,7 @@ namespace osu.Game
         /// <summary>
         /// Whether the back button is currently displayed.
         /// </summary>
-        private readonly IBindable<bool> backButtonVisibility = new Bindable<bool>();
+        private readonly IBindable<bool> backButtonVisibility = new BindableBool();
 
         IBindable<LocalUserPlayingState> ILocalUserPlayInfo.PlayingState => UserPlayingState;
 
@@ -1718,7 +1718,6 @@ namespace osu.Game
             // Bind to new screen.
             if (newScreen != null)
             {
-                backButtonVisibility.BindTo(newScreen.BackButtonVisibility);
                 OverlayActivationMode.BindTo(newScreen.OverlayActivationMode);
                 configUserActivity.BindTo(newScreen.Activity);
 
@@ -1732,15 +1731,17 @@ namespace osu.Game
 
                 if (newScreen.ShowFooter)
                 {
-                    // force the back button to be hidden when footer is visible
-                    backButtonVisibility.UnbindFrom(newScreen.BackButtonVisibility);
-                    backButtonVisibility.BindTo(new BindableBool());
+                    // the legacy back button should never display while the new footer is in use, as it
+                    // contains its own local back button.
+                    ((BindableBool)backButtonVisibility).Value = false;
 
                     ScreenFooter.SetButtons(newScreen.CreateFooterButtons());
                     ScreenFooter.Show();
                 }
                 else
                 {
+                    backButtonVisibility.BindTo(newScreen.BackButtonVisibility);
+
                     ScreenFooter.SetButtons(Array.Empty<ScreenFooterButton>());
                     ScreenFooter.Hide();
                 }

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -79,7 +79,9 @@ namespace osu.Game.Screens
 
         /// <summary>
         /// Whether the back button should be displayed in this screen.
+        /// Note that this property is ignored when <see cref="ShowFooter"/> is <c>true</c>.
         /// </summary>
+        // todo: make this work with footer.
         IBindable<bool> BackButtonVisibility { get; }
 
         /// <summary>


### PR DESCRIPTION
Noticed while attempting to push results screen from new song select.