### PR TITLE
Emit important replay frames on every judgement

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRecording.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRecording.cs
@@ -46,8 +46,10 @@ namespace osu.Game.Rulesets.Mania.Tests
         public void TestRecording()
         {
             seekTo(0);
-            AddStep("press space", () => InputManager.Key(Key.Space));
-            AddAssert("button press recorded to replay", () => Player.Score.Replay.Frames.OfType<ManiaReplayFrame>().Any(f => f.Actions.SequenceEqual([ManiaAction.Key1])));
+            AddStep("press space", () => InputManager.PressKey(Key.Space));
+            seekTo(15);
+            AddStep("release space", () => InputManager.ReleaseKey(Key.Space));
+            AddUntilStep("button press recorded to replay", () => Player.Score.Replay.Frames.OfType<ManiaReplayFrame>().Any(f => f.Actions.SequenceEqual([ManiaAction.Key1])));
         }
 
         private void seekTo(double time)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneReplayRecording.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneReplayRecording.cs
@@ -58,17 +58,23 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             seekTo(0);
             AddStep("move cursor to circle", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.Single()));
-            AddStep("press X", () => InputManager.Key(Key.X));
+            AddStep("press X", () => InputManager.PressKey(Key.X));
+            seekTo(15);
+            AddStep("release X", () => InputManager.ReleaseKey(Key.X));
             AddAssert("right button press recorded to replay", () => Player.Score.Replay.Frames.OfType<OsuReplayFrame>().Any(f => f.Actions.SequenceEqual([OsuAction.RightButton])));
 
             seekTo(5000);
             AddStep("move cursor to circle", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.Single()));
-            AddStep("press Z", () => InputManager.Key(Key.Z));
+            AddStep("press Z", () => InputManager.PressKey(Key.Z));
+            seekTo(5015);
+            AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
             AddAssert("left button press recorded to replay", () => Player.Score.Replay.Frames.OfType<OsuReplayFrame>().Any(f => f.Actions.SequenceEqual([OsuAction.LeftButton])));
 
             seekTo(10000);
             AddStep("move cursor to circle", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.Single()));
-            AddStep("press C", () => InputManager.Key(Key.C));
+            AddStep("press C", () => InputManager.PressKey(Key.C));
+            seekTo(10015);
+            AddStep("release C", () => InputManager.ReleaseKey(Key.C));
             AddAssert("smoke button press recorded to replay", () => Player.Score.Replay.Frames.OfType<OsuReplayFrame>().Any(f => f.Actions.SequenceEqual([OsuAction.Smoke])));
         }
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayRecording.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayRecording.cs
@@ -40,19 +40,27 @@ namespace osu.Game.Rulesets.Taiko.Tests
         public void TestRecording()
         {
             seekTo(0);
-            AddStep("press D", () => InputManager.Key(Key.D));
+            AddStep("press D", () => InputManager.PressKey(Key.D));
+            seekTo(15);
+            AddStep("release D", () => InputManager.ReleaseKey(Key.D));
             AddAssert("left rim press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.LeftRim])));
 
             seekTo(5000);
-            AddStep("press F", () => InputManager.Key(Key.F));
+            AddStep("press F", () => InputManager.PressKey(Key.F));
+            seekTo(5015);
+            AddStep("release F", () => InputManager.ReleaseKey(Key.F));
             AddAssert("left centre press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.LeftCentre])));
 
             seekTo(10000);
-            AddStep("press J", () => InputManager.Key(Key.J));
+            AddStep("press J", () => InputManager.PressKey(Key.J));
+            seekTo(10015);
+            AddStep("release J", () => InputManager.ReleaseKey(Key.J));
             AddAssert("right centre press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.RightCentre])));
 
-            seekTo(10000);
-            AddStep("press K", () => InputManager.Key(Key.K));
+            seekTo(15000);
+            AddStep("press K", () => InputManager.PressKey(Key.K));
+            seekTo(15015);
+            AddStep("release K", () => InputManager.ReleaseKey(Key.K));
             AddAssert("right rim press recorded to replay", () => Player.Score.Replay.Frames.OfType<TaikoReplayFrame>().Any(f => f.Actions.SequenceEqual([TaikoAction.RightRim])));
         }
 

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -247,6 +247,11 @@ namespace osu.Game.Online.Spectator
 
                 var convertedFrame = convertible.ToLegacy(currentBeatmap);
 
+                // only keep the last recorded frame for a given timestamp.
+                // this reduces redundancy of frames in the resulting replay.
+                //
+                // this is also done at `ReplayRecorded`, but needs to be done here as well
+                // due to the flow being handled differently.
                 if (pendingFrames.LastOrDefault()?.Time == convertedFrame.Time)
                     pendingFrames[^1] = convertedFrame;
                 else

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Online.Spectator
 
         private readonly Queue<FrameDataBundle> pendingFrameBundles = new Queue<FrameDataBundle>();
 
-        private readonly Queue<LegacyReplayFrame> pendingFrames = new Queue<LegacyReplayFrame>();
+        private readonly List<LegacyReplayFrame> pendingFrames = new List<LegacyReplayFrame>();
 
         private double lastPurgeTime;
 
@@ -244,7 +244,13 @@ namespace osu.Game.Online.Spectator
             if (frame is IConvertibleReplayFrame convertible)
             {
                 Debug.Assert(currentBeatmap != null);
-                pendingFrames.Enqueue(convertible.ToLegacy(currentBeatmap));
+
+                var convertedFrame = convertible.ToLegacy(currentBeatmap);
+
+                if (pendingFrames.LastOrDefault()?.Time == convertedFrame.Time)
+                    pendingFrames[^1] = convertedFrame;
+                else
+                    pendingFrames.Add(convertedFrame);
             }
 
             if (pendingFrames.Count > max_pending_frames)

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -300,6 +300,7 @@ namespace osu.Game.Rulesets.UI
 
             if (score == null)
             {
+                NewResult -= emitImportantFrame;
                 recordingInputManager.Recorder = null;
                 return;
             }
@@ -311,7 +312,10 @@ namespace osu.Game.Rulesets.UI
 
             recorder.ScreenSpaceToGamefield = Playfield.ScreenSpaceToGamefield;
 
+            NewResult += emitImportantFrame;
             recordingInputManager.Recorder = recorder;
+
+            void emitImportantFrame(JudgementResult judgementResult) => recordingInputManager.Recorder?.RecordFrame(true);
         }
 
         public override void SetReplayScore(Score replayScore)

--- a/osu.Game/Rulesets/UI/IHasRecordingHandler.cs
+++ b/osu.Game/Rulesets/UI/IHasRecordingHandler.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.UI
     /// </summary>
     public interface IHasRecordingHandler
     {
-        public ReplayRecorder? Recorder { set; }
+        public ReplayRecorder? Recorder { get; set; }
     }
 }

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -93,10 +93,8 @@ namespace osu.Game.Rulesets.UI
                 else
                     target.Replay.Frames.Add(frame);
 
-                // the above de-duplication is not done for spectator client because it's more complicated to do
-                // (not possible to "un-send" a sent frame).
-                // a similar solution to the above could be applied at `FrameDataBundle` buffering level in `SpectatorClient` if deemed necessary,
-                // but it'd still not be completely matching (consider situation where buffer happens to be flushed between frames with the same timestamp).
+                // the above de-duplication is done at `FrameDataBundle` level in `SpectatorClient`.
+                // it's not 100% matching because of the possibility of duplicated frames crossing a bundle boundary, but it's close and simple enough.
                 spectatorClient?.HandleFrame(frame);
             }
         }

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -51,29 +51,29 @@ namespace osu.Game.Rulesets.UI
         protected override void Update()
         {
             base.Update();
-            recordFrame(false);
+            RecordFrame(false);
         }
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            recordFrame(false);
+            RecordFrame(false);
             return base.OnMouseMove(e);
         }
 
         public bool OnPressed(KeyBindingPressEvent<T> e)
         {
             pressedActions.Add(e.Action);
-            recordFrame(true);
+            RecordFrame(true);
             return false;
         }
 
         public void OnReleased(KeyBindingReleaseEvent<T> e)
         {
             pressedActions.Remove(e.Action);
-            recordFrame(true);
+            RecordFrame(true);
         }
 
-        private void recordFrame(bool important)
+        public override void RecordFrame(bool important)
         {
             var last = target.Replay.Frames.LastOrDefault();
 
@@ -98,5 +98,7 @@ namespace osu.Game.Rulesets.UI
     public abstract partial class ReplayRecorder : Component
     {
         public Func<Vector2, Vector2> ScreenSpaceToGamefield;
+
+        public abstract void RecordFrame(bool important);
     }
 }

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -86,8 +86,17 @@ namespace osu.Game.Rulesets.UI
 
             if (frame != null)
             {
-                target.Replay.Frames.Add(frame);
+                // only keep the last recorded frame for a given timestamp.
+                // this reduces redundancy of frames in the resulting replay.
+                if (last?.Time == frame.Time)
+                    target.Replay.Frames[^1] = frame;
+                else
+                    target.Replay.Frames.Add(frame);
 
+                // the above de-duplication is not done for spectator client because it's more complicated to do
+                // (not possible to "un-send" a sent frame).
+                // a similar solution to the above could be applied at `FrameDataBundle` buffering level in `SpectatorClient` if deemed necessary,
+                // but it'd still not be completely matching (consider situation where buffer happens to be flushed between frames with the same timestamp).
                 spectatorClient?.HandleFrame(frame);
             }
         }

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Rulesets.UI
 
         public ReplayRecorder? Recorder
         {
+            get => recorder;
             set
             {
                 if (value == recorder)


### PR DESCRIPTION
## [Emit important replay frames on every judgement](https://github.com/ppy/osu/commit/9f91c2e25ce76255dc39b90f5b1bfef3cfbfba99) 
- Closes https://github.com/ppy/osu/issues/4287
- Probably closes https://github.com/ppy/osu/issues/25405 (but not retroactively)
- Closes https://github.com/ppy/osu/issues/28677 (but not retroactively)

Up until now, whether or not a replay frame is emitted depended solely on the user's input, i.e. mouse movement or key presses/releases. This, intersected with the replay playback system which is given allowance to perform interpolation between replay frames, leads to potential situations wherein a replay can play inaccurately when a judgement takes place without user input meaningfully changing. One such case is slider ends with their 36ms of judgement leniency, see
https://github.com/ppy/osu/issues/25405#issuecomment-2879031106 for details on that; https://github.com/ppy/osu/issues/28677#issuecomment-2883534680 is another.

To that end, this commit aims to counteract that issue by *forcing* an important replay frame to be emitted on every new judgement recorded during gameplay. This will only benefit rulesets wherein judgements can occur that are not inherently tied to user input changing, which are going to be osu! as mentioned above, and ~~maybe possibly~~ catch. I don't foresee this doing anything relevant for taiko or mania.

## [Do not emit multiple consequent replay frames with the exact same data](https://github.com/ppy/osu/commit/cd4ab9307c5ed7d160919aa265392ecbad29a138)

With judgements occurring forcing emission of important frames, there's the question of emitting redundant frames. In a majority of cases still, a judgement *will* be tied to a specific user input, which means that there's a high likelihood of duplicate frames, as one will be emitted by the input change, and another by the judgement.

To a degree this is a pre-existing issue. The replay recording code responds to both mouse movement and key presses by recording frames, so depending on the intrinsic (basically undefined) ordering between handling mouse move and key presses, it was possible for multiple frames to be emitted with the same timestamp to the replay, each containing
partial input state changes (e.g. first frame with mouse position changed, and the second with a key pressed).

The extent to which this increases the frame count will obviously depend on the beatmap, but in my ballpark testing across all rulesets on a single "relatively standard" beatmap (think no aspire chicanery), around 4-10% of frames can end up being duplicates / not meaningful. This has implications both on replay size and on playback performance.

This commit therefore performs de-duplication of the frames based on timestamp - only the last frame with a given timestamp ends up in the final replay.

The CPU cost of this is negligible to the point of not being useful to profile - it's a single condition gated behind a single float comparison.