### PR TITLE
Simple menu navigation with arrow keys

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -286,7 +286,6 @@ namespace osu.Game.Screens.Menu
 
         private void NavButtonManager(bool foward)
         {
-
             if(selectedButton != -1) currButtonsLevel[selectedButton].NavUnhover();
             Logger.Log($"selectedButton: {selectedButton}");
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -21,14 +20,12 @@ using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface.PageSelector;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
-using osu.Game.Screens.Edit;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -284,9 +281,10 @@ namespace osu.Game.Screens.Menu
             return base.OnMidiDown(e);
         }
 
-        private void NavButtonManager(bool foward)
+        private void navButtonManager(bool foward)
         {
-            if(selectedButton != -1) currButtonsLevel[selectedButton].NavUnhover();
+            if(selectedButton != -1)
+                currButtonsLevel[selectedButton].NavUnhover();
             Logger.Log($"selectedButton: {selectedButton}");
 
             selectedButton += foward ? 1 : -1;
@@ -323,12 +321,12 @@ namespace osu.Game.Screens.Menu
                     return true;
 
                 case GlobalAction.SelectNextGroup:
-                    NavButtonManager(true);
+                    navButtonManager(true);
                     Logger.Log($"next pressed in menu");
                     return true;
 
                 case GlobalAction.SelectPreviousGroup:
-                    NavButtonManager(false);
+                    navButtonManager(false);
                     Logger.Log("prev pressed in menu");
                     return true;
 
@@ -363,8 +361,6 @@ namespace osu.Game.Screens.Menu
                 default:
                     return false;
             }
-
-            return false; // Ensure all code paths return a value.
         }
 
         public void StopSamplePlayback()
@@ -504,16 +500,19 @@ namespace osu.Game.Screens.Menu
             {
                 case ButtonSystemState.TopLevel:
                     currButtonsLevel = buttonsTopLevel;
-                    if (currButtonsLevel.Count == 4) currButtonsLevel.Add(settingsButton);
+                    if (currButtonsLevel.Count == 4)
+                        currButtonsLevel.Add(settingsButton);
                     break;
                 case ButtonSystemState.Play:
                     currButtonsLevel = buttonsPlay;
                     currButtonsLevel.RemoveAt(currButtonsLevel.Count - 1);
-                    if (currButtonsLevel.Count == 3) currButtonsLevel.Add(backButton);
+                    if (currButtonsLevel.Count == 3)
+                        currButtonsLevel.Add(backButton);
                     break;
                 case ButtonSystemState.Edit:
                     currButtonsLevel = buttonsEdit;
-                    if(currButtonsLevel.Count == 2) currButtonsLevel.Add(backButton);
+                    if(currButtonsLevel.Count == 2)
+                        currButtonsLevel.Add(backButton);
                     break;
                 default:
                     return;

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -22,6 +22,8 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps.ControlPoints;
+using NUnit.Framework.Internal;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Screens.Menu
 {
@@ -213,6 +215,33 @@ namespace osu.Game.Screens.Menu
             );
 
             rightward = !rightward;
+        }
+
+        public string NavHover()
+        {
+            if (State != ButtonState.Expanded) return this.sampleName;
+
+            double duration = TimeUntilNextBeat;
+
+            icon.ClearTransforms();
+            icon.RotateTo(rightward ? -BOUNCE_ROTATION : BOUNCE_ROTATION, duration, Easing.InOutSine);
+            icon.ScaleTo(new Vector2(HOVER_SCALE, HOVER_SCALE * BOUNCE_COMPRESSION), duration, Easing.Out);
+
+            //sampleHover?.Play();
+            background.ResizeTo(Vector2.Multiply(initialSize, new Vector2(1.5f, 1)), 500, Easing.OutElastic);
+
+            return this.sampleName;
+        }
+
+        public void NavUnhover()
+        {
+            icon.ClearTransforms();
+            icon.RotateTo(0, 500, Easing.Out);
+            icon.MoveTo(Vector2.Zero, 500, Easing.Out);
+            icon.ScaleTo(Vector2.One, 200, Easing.Out);
+
+            if (State == ButtonState.Expanded)
+                background.ResizeTo(initialSize, 500, Easing.OutElastic);
         }
 
         protected override bool OnHover(HoverEvent e)


### PR DESCRIPTION
This PR adds keyboard navigation support using the ← and → arrow keys for the Top-Level Menu, Edit Menu, and Play Menu.
The Enter key selects the currently highlighted (hovered) button, mimicking mouse click behavior.

Known issues:

Hover animation working as intended.
The osu! logo may become visually misaligned when switching between buttons that are positioned around it.
Notes:
This is a prototype and I’d appreciate feedback on:

The navigation logic across menus
Whether this behavior fits the intended UI flow
Help with understanding how the animations on the menu work