### PR TITLE
SongSelectV2: Add support for deselecting all mods by right clicking mod button

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -53,6 +53,21 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestClearModsViaModButtonRightClick()
+        {
+            LoadSongSelect();
+
+            AddStep("select NC", () => SelectedMods.Value = new[] { new OsuModNightcore() });
+            AddAssert("mods selected", () => SelectedMods.Value, () => Has.Count.EqualTo(1));
+            AddStep("right click mod button", () =>
+            {
+                InputManager.MoveMouseTo(Footer.ChildrenOfType<FooterButtonMods>().Single());
+                InputManager.Click(MouseButton.Right);
+            });
+            AddAssert("not mods selected", () => SelectedMods.Value, () => Has.Count.EqualTo(0));
+        }
+
+        [Test]
         public void TestSpeedChange()
         {
             LoadSongSelect();

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -27,11 +28,14 @@ using osu.Game.Screens.Play.HUD;
 using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Screens.SelectV2
 {
     public partial class FooterButtonMods : ScreenFooterButton, IHasCurrentValue<IReadOnlyList<Mod>>
     {
+        public Action? RequestDeselectAllMods { get; init; }
+
         private const float bar_height = 30f;
         private const float mod_display_portion = 0.65f;
 
@@ -170,6 +174,18 @@ namespace osu.Game.Screens.SelectV2
             }, true);
 
             FinishTransforms(true);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            // should probably be OnClick but right mouse button clicks isn't setup well.
+            if (e.Button == MouseButton.Right)
+            {
+                RequestDeselectAllMods?.Invoke();
+                return true;
+            }
+
+            return base.OnMouseDown(e);
         }
 
         private const double duration = 240;

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -21,6 +22,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Volume;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Menu;
@@ -194,7 +196,11 @@ namespace osu.Game.Screens.SelectV2
 
         public override IReadOnlyList<ScreenFooterButton> CreateFooterButtons() => new ScreenFooterButton[]
         {
-            new FooterButtonMods(modSelectOverlay) { Current = Mods },
+            new FooterButtonMods(modSelectOverlay)
+            {
+                Current = Mods,
+                RequestDeselectAllMods = () => Mods.Value = Array.Empty<Mod>()
+            },
             new FooterButtonRandom(),
             new FooterButtonOptions(),
         };


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/28301.

No sound effects on click because right click handling is weird. I would have liked to call `DeselectAll` on the mod select overlay, but this doesn't work unless it's displayed due to queued operation.

I added the final commit because I wanted to be sure this behaviour doesn't accidentally get included in other song select modes when support for them is added, but it's likely unnecessary at this point – if a subclassed version of song select isn't allowing mod selection, the button code shouldn't be there in the first place. I'll leave it up to the reviewer to decide whether to drop the commit and save for later, or whether it's fine to exist.