### PR TITLE
Fix multiple inconsistencies in beatmap carousel animations

### DIFF
--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -801,12 +801,7 @@ namespace osu.Game.Graphics.Carousel
                 base.OffsetScrollPosition(offset);
 
                 foreach (var panel in Panels)
-                {
-                    var c = (ICarouselPanel)panel;
-                    Debug.Assert(c.Item != null);
-
-                    c.DrawYPosition += offset;
-                }
+                    ((ICarouselPanel)panel).DrawYPosition += offset;
             }
 
             public override void Clear(bool disposeChildren)

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -747,10 +747,12 @@ namespace osu.Game.Graphics.Carousel
 
                     if (toDisplay.Contains(panel.Item!))
                     {
-                        if (i == 0)
-                            panel.DrawYPosition = panel.Item!.CarouselYPosition;
-                        else
+                        // Don't apply to the last because animating the tail of the list looks bad.
+                        // It's usually off-screen anyway.
+                        if (i > 0 && i < orderedPanels.Count - 1)
                             panel.DrawYPosition = orderedPanels[i - 1].DrawYPosition;
+                        else
+                            panel.DrawYPosition = panel.Item!.CarouselYPosition;
                     }
                 }
             }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -773,7 +773,7 @@ namespace osu.Game.Graphics.Carousel
             var carouselPanel = (ICarouselPanel)panel;
 
             // expired panels should have a depth behind all other panels to make the transition not look weird.
-            Scroll.Panels.ChangeChildDepth(panel, panel.Depth + 1);
+            Scroll.Panels.ChangeChildDepth(panel, panel.Depth + 1024);
 
             panel.FadeOut(150, Easing.OutQuint);
             panel.MoveToX(panel.X + 100, 200, Easing.Out);

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -710,7 +710,7 @@ namespace osu.Game.Graphics.Carousel
                 }
 
                 // If the new display range doesn't contain the panel, it's no longer required for display.
-                expirePanelImmediately(panel);
+                expirePanel(panel);
             }
 
             // Add any new items which need to be displayed and haven't yet.
@@ -738,12 +738,17 @@ namespace osu.Game.Graphics.Carousel
                 Scroll.SetLayoutHeight(0);
         }
 
-        private static void expirePanelImmediately(Drawable panel)
+        private void expirePanel(Drawable panel)
         {
-            panel.FinishTransforms();
-            panel.Expire();
-
             var carouselPanel = (ICarouselPanel)panel;
+
+            // expired panels should have a depth behind all other panels to make the transition not look weird.
+            Scroll.Panels.ChangeChildDepth(panel, panel.Depth + 1);
+
+            panel.FadeOut(150, Easing.OutQuint);
+            panel.MoveToX(panel.X + 100, 200, Easing.Out);
+
+            panel.Expire();
 
             carouselPanel.Item = null;
             carouselPanel.Selected.Value = false;

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -623,7 +623,7 @@ namespace osu.Game.Graphics.Carousel
                 if (c.Item == null)
                     continue;
 
-                float normalisedDepth = (float)(Math.Abs(selectedYPos - c.DrawYPosition) / DrawHeight);
+                float normalisedDepth = (float)(Math.Abs(selectedYPos - c.Item.CarouselYPosition) / DrawHeight);
                 Scroll.Panels.ChangeChildDepth(panel, c.Item.DepthLayer + normalisedDepth);
 
                 if (c.DrawYPosition != c.Item.CarouselYPosition)


### PR DESCRIPTION
Closes  https://github.com/ppy/osu/issues/33053.

## 7efa724a8ac69ec86fde10a32a451334299354d9

Fixes the visual glitchiness seen here:

https://github.com/user-attachments/assets/b0a9020c-d45d-461a-ba3f-bbeb5bafadfc

## 6a2337dbea348dff90c3953fd388a89462444f33 & 615d4accfb89b54ecf97042682c12be71b948f0a

https://github.com/user-attachments/assets/826e379f-cf5a-4133-80b5-c78e727104ed

https://github.com/user-attachments/assets/a6fcecdd-6708-490b-8173-4f2939bc2fa6


