### PR TITLE
Add "Tachyon" (unstable) release stream

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -17,6 +17,7 @@ using osu.Framework.Logging;
 using osu.Game.Updater;
 using osu.Desktop.Windows;
 using osu.Framework.Allocation;
+using osu.Game.Configuration;
 using osu.Game.IO;
 using osu.Game.IPC;
 using osu.Game.Online.Multiplayer;
@@ -32,6 +33,8 @@ namespace osu.Desktop
 
         [Cached(typeof(IHighPerformanceSessionManager))]
         private readonly HighPerformanceSessionManager highPerformanceSessionManager = new HighPerformanceSessionManager();
+
+        public bool IsFirstRun { get; init; }
 
         public OsuGameDesktop(string[]? args = null)
             : base(args)
@@ -104,6 +107,14 @@ namespace osu.Desktop
 
         protected override UpdateManager CreateUpdateManager()
         {
+            // If this is the first time we've run the game, ie it is being installed,
+            // reset the user's release stream to "lazer".
+            //
+            // This ensures that if a user is trying to recover from a failed startup on an unstable release stream,
+            // the game doesn't immediately try and update them back to the release stream after starting up.
+            if (IsFirstRun)
+                LocalConfig.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
+
             if (IsPackageManaged)
                 return new NoActionUpdateManager();
 

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -28,6 +28,8 @@ namespace osu.Desktop
 
         private static LegacyTcpIpcProvider? legacyIpc;
 
+        private static bool isFirstRun;
+
         [STAThread]
         public static void Main(string[] args)
         {
@@ -135,7 +137,12 @@ namespace osu.Desktop
                 if (tournamentClient)
                     host.Run(new TournamentGame());
                 else
-                    host.Run(new OsuGameDesktop(args));
+                {
+                    host.Run(new OsuGameDesktop(args)
+                    {
+                        IsFirstRun = isFirstRun
+                    });
+                }
             }
         }
 
@@ -186,7 +193,11 @@ namespace osu.Desktop
         [SupportedOSPlatform("windows")]
         private static void configureWindows(VelopackApp app)
         {
-            app.WithFirstRun(_ => WindowsAssociationManager.InstallAssociations());
+            app.WithFirstRun(_ =>
+            {
+                isFirstRun = true;
+                WindowsAssociationManager.InstallAssociations();
+            });
             app.WithAfterUpdateFastCallback(_ => WindowsAssociationManager.UpdateAssociations());
             app.WithBeforeUninstallFastCallback(_ => WindowsAssociationManager.UninstallAssociations());
         }

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -184,6 +184,8 @@ namespace osu.Desktop
 
             var app = VelopackApp.Build();
 
+            app.WithFirstRun(_ => isFirstRun = true);
+
             if (OperatingSystem.IsWindows())
                 configureWindows(app);
 
@@ -193,11 +195,7 @@ namespace osu.Desktop
         [SupportedOSPlatform("windows")]
         private static void configureWindows(VelopackApp app)
         {
-            app.WithFirstRun(_ =>
-            {
-                isFirstRun = true;
-                WindowsAssociationManager.InstallAssociations();
-            });
+            app.WithFirstRun(_ => WindowsAssociationManager.InstallAssociations());
             app.WithAfterUpdateFastCallback(_ => WindowsAssociationManager.UpdateAssociations());
             app.WithBeforeUninstallFastCallback(_ => WindowsAssociationManager.UninstallAssociations());
         }

--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Game;
+using osu.Game.Configuration;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Play;
@@ -16,8 +18,8 @@ namespace osu.Desktop.Updater
 {
     public partial class VelopackUpdateManager : Game.Updater.UpdateManager
     {
-        private readonly UpdateManager updateManager;
-        private INotificationOverlay notificationOverlay = null!;
+        [Resolved]
+        private INotificationOverlay notificationOverlay { get; set; } = null!;
 
         [Resolved]
         private OsuGameBase game { get; set; } = null!;
@@ -25,22 +27,32 @@ namespace osu.Desktop.Updater
         [Resolved]
         private ILocalUserPlayInfo? localUserInfo { get; set; }
 
+        [Resolved]
+        private OsuConfigManager osuConfigManager { get; set; } = null!;
+
         private bool isInGameplay => localUserInfo?.PlayingState.Value != LocalUserPlayingState.NotPlaying;
 
+        private readonly Bindable<ReleaseStream> releaseStream = new Bindable<ReleaseStream>();
+        private UpdateManager? updateManager;
         private UpdateInfo? pendingUpdate;
 
-        public VelopackUpdateManager()
+        protected override void LoadComplete()
         {
-            updateManager = new UpdateManager(new GithubSource(@"https://github.com/ppy/osu", null, false), new UpdateOptions
+            // Used by the base implementation.
+            osuConfigManager.BindWith(OsuSetting.ReleaseStream, releaseStream);
+            releaseStream.BindValueChanged(_ => onReleaseStreamChanged(), true);
+
+            base.LoadComplete();
+        }
+
+        private void onReleaseStreamChanged()
+        {
+            updateManager = new UpdateManager(new GithubSource(@"https://github.com/ppy/osu", null, releaseStream.Value == ReleaseStream.Photon), new UpdateOptions
             {
                 AllowVersionDowngrade = true,
             });
-        }
 
-        [BackgroundDependencyLoader]
-        private void load(INotificationOverlay notifications)
-        {
-            notificationOverlay = notifications;
+            Schedule(() => Task.Run(CheckForUpdateAsync));
         }
 
         protected override async Task<bool> PerformUpdateCheck() => await checkForUpdateAsync().ConfigureAwait(false);
@@ -74,6 +86,12 @@ namespace osu.Desktop.Updater
                     });
 
                     return true;
+                }
+
+                if (updateManager == null)
+                {
+                    scheduleRecheck = true;
+                    return false;
                 }
 
                 pendingUpdate = await updateManager.CheckForUpdatesAsync().ConfigureAwait(false);
@@ -141,6 +159,9 @@ namespace osu.Desktop.Updater
 
         private async Task restartToApplyUpdate()
         {
+            if (updateManager == null)
+                return;
+
             await updateManager.WaitExitThenApplyUpdatesAsync(pendingUpdate?.TargetFullRelease).ConfigureAwait(false);
             Schedule(() => game.AttemptExit());
         }

--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -47,7 +47,7 @@ namespace osu.Desktop.Updater
 
         private void onReleaseStreamChanged()
         {
-            updateManager = new UpdateManager(new GithubSource(@"https://github.com/ppy/osu", null, releaseStream.Value == ReleaseStream.Photon), new UpdateOptions
+            updateManager = new UpdateManager(new GithubSource(@"https://github.com/ppy/osu", null, releaseStream.Value == ReleaseStream.Tachyon), new UpdateOptions
             {
                 AllowVersionDowngrade = true,
             });

--- a/osu.Game/Configuration/ReleaseStream.cs
+++ b/osu.Game/Configuration/ReleaseStream.cs
@@ -6,8 +6,6 @@ namespace osu.Game.Configuration
     public enum ReleaseStream
     {
         Lazer,
-        //Stable40,
-        //Beta40,
-        //Stable
+        Photon
     }
 }

--- a/osu.Game/Configuration/ReleaseStream.cs
+++ b/osu.Game/Configuration/ReleaseStream.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.ComponentModel;
+
 namespace osu.Game.Configuration
 {
     public enum ReleaseStream
     {
         Lazer,
-        Photon
+
+        [Description("Tachyon (Unstable)")]
+        Tachyon
     }
 }

--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -80,6 +80,18 @@ namespace osu.Game.Localisation
         public static LocalisableString LearnMoreAboutLazerTooltip => new TranslatableString(getKey(@"check_out_the_feature_comparison"), @"Check out the feature comparison and FAQ");
 
         /// <summary>
+        /// "Are you sure you want to run a potentially unstable version of the game?"
+        /// </summary>
+        public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release stream_confirmation"),
+            @"Are you sure you want to run a potentially unstable version of the game?");
+
+        /// <summary>
+        /// "If you run into issues starting the game, you can usually run the installer from the official site to recover."
+        /// </summary>
+        public static LocalisableString ChangeReleaseStreamConfirmationInfo => new TranslatableString(getKey(@"change_release stream_confirmation_info"),
+            @"If you run into issues starting the game, you can usually run the installer from the official site to recover.");
+
+        /// <summary>
         /// "You are running the latest release ({0})"
         /// </summary>
         public static LocalisableString RunningLatestRelease(string version) => new TranslatableString(getKey(@"running_latest_release"), @"You are running the latest release ({0})", version);


### PR DESCRIPTION
Supersedes/closes https://github.com/ppy/osu-deploy/pull/183
Supersedes/closes https://github.com/ppy/osu/pull/30706

Inspired by https://github.com/ppy/osu-deploy/pull/183#issuecomment-2487367697, this is my take at adding a "Photon" (beta) release stream. Unlike the implementation above, this one only relies on the pre-release flag which I believe to be advantageous:
- We don't have to upkeep multiple concurrent release streams. All existing tooling continues to work without change as this is only a flag on the releases page itself. This also includes osu!web and the README, both of which link to [`releases/latest`](https://github.com/ppy/osu-web/blob/745ebed3c983bd0624ac5888112b0998eb27e926/.env.example#L306-L311) and will continue to link to the latest **non**-pre-release version.
    ![image](https://github.com/user-attachments/assets/941e4fec-bf1f-49b6-ba69-4e1b520ddac5)
- We're not locked into this. If we decide this isn't working for us we can also revert the change and delete the pre-release versions without worrying about people being stuck on streams and having to [rename streams](https://docs.velopack.io/packaging/channels#renaming-a-channel). If later down the track we want to add a second beta stream (i.e. `stable/beta/ce`), we can decide how to handle it at that point in time. If we want to use the old-style stream naming, then we can also do that.

https://github.com/user-attachments/assets/6ac77f8c-a12d-459b-91b9-baf7076e7973

Notably, we should do one release prior to deploying any super experimental stuff (Satori GC) so that people have the `Photon` setting in the dropdown.