### PR TITLE
Hide the beatmap background if there is a video in the storyboard

### DIFF
--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -84,6 +84,10 @@ namespace osu.Game.Storyboards
         {
             get
             {
+                // Hide if there is a video
+                if (GetLayer("Video").Elements.Count != 0)
+                    return true;
+
                 string backgroundPath = BeatmapInfo.Metadata.BackgroundFile;
 
                 if (string.IsNullOrEmpty(backgroundPath))


### PR DESCRIPTION
Fix #28990. 
(Sorry for videos low fps)

Tested on https://osu.ppy.sh/beatmapsets/15920#osu/58062

## Before PR

https://github.com/user-attachments/assets/215efebe-74bd-4667-b449-1de1162d7b13

## After PR

https://github.com/user-attachments/assets/ea8aab99-b788-4be2-9458-8cd0a5274a4e

