### PR TITLE
Reduce difficulty calculation churn overheads when using keyboard to iterate quickly at song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 }
             }
 
-            public override async Task<StarDifficulty?> GetDifficultyAsync(IBeatmapInfo beatmapInfo, IRulesetInfo? rulesetInfo = null, IEnumerable<Mod>? mods = null, CancellationToken cancellationToken = default)
+            public override async Task<StarDifficulty?> GetDifficultyAsync(IBeatmapInfo beatmapInfo, IRulesetInfo? rulesetInfo = null, IEnumerable<Mod>? mods = null, CancellationToken cancellationToken = default, int debounceDelay = 0)
             {
                 if (blockCalculation)
                 {
@@ -149,7 +149,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     await calculationBlocker.Task.ConfigureAwait(false);
                 }
 
-                return await base.GetDifficultyAsync(beatmapInfo, rulesetInfo, mods, cancellationToken).ConfigureAwait(false);
+                return await base.GetDifficultyAsync(beatmapInfo, rulesetInfo, mods, cancellationToken, 0).ConfigureAwait(false);
             }
         }
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModEffectPreviewPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModEffectPreviewPanel.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             public StarDifficulty? Difficulty { get; set; }
 
             public override Task<StarDifficulty?> GetDifficultyAsync(IBeatmapInfo beatmapInfo, IRulesetInfo? rulesetInfo = null, IEnumerable<Mod>? mods = null,
-                                                                     CancellationToken cancellationToken = default)
+                                                                     CancellationToken cancellationToken = default, int computationDelay = 0)
                 => Task.FromResult(Difficulty);
         }
     }

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -102,7 +102,11 @@ namespace osu.Game.Beatmaps
         /// <returns>A bindable that is updated to contain the star difficulty when it becomes available. Will be null while in an initial calculating state (but not during updates to ruleset and mods if a stale value is already propagated).</returns>
         public IBindable<StarDifficulty?> GetBindableDifficulty(IBeatmapInfo beatmapInfo, CancellationToken cancellationToken = default, int computationDelay = 0)
         {
-            var bindable = new BindableStarDifficulty(beatmapInfo, cancellationToken);
+            var bindable = new BindableStarDifficulty(beatmapInfo, cancellationToken)
+            {
+                // Start with an approximate known value instead of zero.
+                Value = new StarDifficulty(beatmapInfo.StarRating, 0)
+            };
 
             updateBindable(bindable, currentRuleset.Value, currentMods.Value, cancellationToken, computationDelay);
 

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -98,12 +98,13 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> to get the difficulty of.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> which stops updating the star difficulty for the given <see cref="BeatmapInfo"/>.</param>
+        /// <param name="computationDelay">A delay in milliseconds before performing the </param>
         /// <returns>A bindable that is updated to contain the star difficulty when it becomes available. Will be null while in an initial calculating state (but not during updates to ruleset and mods if a stale value is already propagated).</returns>
-        public IBindable<StarDifficulty?> GetBindableDifficulty(IBeatmapInfo beatmapInfo, CancellationToken cancellationToken = default)
+        public IBindable<StarDifficulty?> GetBindableDifficulty(IBeatmapInfo beatmapInfo, CancellationToken cancellationToken = default, int computationDelay = 0)
         {
             var bindable = new BindableStarDifficulty(beatmapInfo, cancellationToken);
 
-            updateBindable(bindable, currentRuleset.Value, currentMods.Value, cancellationToken);
+            updateBindable(bindable, currentRuleset.Value, currentMods.Value, cancellationToken, computationDelay);
 
             lock (bindableUpdateLock)
                 trackedBindables.Add(bindable);
@@ -118,13 +119,14 @@ namespace osu.Game.Beatmaps
         /// <param name="rulesetInfo">The <see cref="IRulesetInfo"/> to get the difficulty with.</param>
         /// <param name="mods">The <see cref="Mod"/>s to get the difficulty with.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> which stops computing the star difficulty.</param>
+        /// <param name="computationDelay">In the case a cached lookup was not possible, a value in milliseconds of to wait until performing potentially intensive lookup.</param>
         /// <returns>
         /// The requested <see cref="StarDifficulty"/>, if non-<see langword="null"/>.
         /// A <see langword="null"/> return value indicates that the difficulty process failed or was interrupted early,
         /// and as such there is no usable star difficulty value to be returned.
         /// </returns>
-        public virtual Task<StarDifficulty?> GetDifficultyAsync(IBeatmapInfo beatmapInfo, IRulesetInfo? rulesetInfo = null,
-                                                                IEnumerable<Mod>? mods = null, CancellationToken cancellationToken = default)
+        public virtual Task<StarDifficulty?> GetDifficultyAsync(IBeatmapInfo beatmapInfo, IRulesetInfo? rulesetInfo = null, IEnumerable<Mod>? mods = null,
+                                                                CancellationToken cancellationToken = default, int computationDelay = 0)
         {
             // In the case that the user hasn't given us a ruleset, use the beatmap's default ruleset.
             rulesetInfo ??= beatmapInfo.Ruleset;
@@ -139,7 +141,7 @@ namespace osu.Game.Beatmaps
                 return Task.FromResult<StarDifficulty?>(new StarDifficulty(beatmapInfo.StarRating, (beatmapInfo as IBeatmapOnlineInfo)?.MaxCombo ?? 0));
             }
 
-            return GetAsync(new DifficultyCacheLookup(localBeatmapInfo, localRulesetInfo, mods), cancellationToken);
+            return GetAsync(new DifficultyCacheLookup(localBeatmapInfo, localRulesetInfo, mods), cancellationToken, computationDelay);
         }
 
         protected override Task<StarDifficulty?> ComputeValueAsync(DifficultyCacheLookup lookup, CancellationToken cancellationToken = default)
@@ -206,11 +208,12 @@ namespace osu.Game.Beatmaps
         /// <param name="rulesetInfo">The <see cref="IRulesetInfo"/> to update with.</param>
         /// <param name="mods">The <see cref="Mod"/>s to update with.</param>
         /// <param name="cancellationToken">A token that may be used to cancel this update.</param>
-        private void updateBindable(BindableStarDifficulty bindable, IRulesetInfo? rulesetInfo, IEnumerable<Mod>? mods, CancellationToken cancellationToken = default)
+        /// <param name="computationDelay">In the case a cached lookup was not possible, a value in milliseconds of to wait until performing potentially intensive lookup.</param>
+        private void updateBindable(BindableStarDifficulty bindable, IRulesetInfo? rulesetInfo, IEnumerable<Mod>? mods, CancellationToken cancellationToken = default, int computationDelay = 0)
         {
             // GetDifficultyAsync will fall back to existing data from IBeatmapInfo if not locally available
             // (contrary to GetAsync)
-            GetDifficultyAsync(bindable.BeatmapInfo, rulesetInfo, mods, cancellationToken)
+            GetDifficultyAsync(bindable.BeatmapInfo, rulesetInfo, mods, cancellationToken, computationDelay)
                 .ContinueWith(task =>
                 {
                     // We're on a threadpool thread, but we should exit back to the update thread so consumers can safely handle value-changed events.

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -9,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -23,8 +25,6 @@ namespace osu.Game.Beatmaps.Drawables
     /// </summary>
     public partial class StarRatingDisplay : CompositeDrawable, IHasCurrentValue<StarDifficulty>
     {
-        public const double TRANSFORM_DURATION = 750;
-
         private readonly bool animated;
         private readonly Box background;
         private readonly SpriteIcon starIcon;
@@ -147,7 +147,8 @@ namespace osu.Game.Beatmaps.Drawables
             Current.BindValueChanged(c =>
             {
                 if (animated)
-                    this.TransformBindableTo(displayedStars, c.NewValue.Stars, TRANSFORM_DURATION, Easing.OutQuint);
+                    // Animation roughly matches `StarCounter`'s implementation.
+                    this.TransformBindableTo(displayedStars, c.NewValue.Stars, 100 + 80 * Math.Abs(c.NewValue.Stars - c.OldValue.Stars), Easing.OutQuint);
                 else
                     displayedStars.Value = c.NewValue.Stars;
             });

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;

--- a/osu.Game/Database/MemoryCachingComponent.cs
+++ b/osu.Game/Database/MemoryCachingComponent.cs
@@ -35,8 +35,9 @@ namespace osu.Game.Database
         /// Retrieve the cached value for the given lookup.
         /// </summary>
         /// <param name="lookup">The lookup to retrieve.</param>
-        /// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-        protected async Task<TValue?> GetAsync(TLookup lookup, CancellationToken token = default)
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
+        /// <param name="computationDelay">In the case a cached lookup was not possible, a value in milliseconds of to wait until performing potentially intensive lookup.</param>
+        protected async Task<TValue?> GetAsync(TLookup lookup, CancellationToken cancellationToken = default, int computationDelay = 0)
         {
             if (CheckExists(lookup, out TValue? existing))
             {
@@ -44,7 +45,10 @@ namespace osu.Game.Database
                 return existing;
             }
 
-            var computed = await ComputeValueAsync(lookup, token).ConfigureAwait(false);
+            if (computationDelay > 0)
+                await Task.Delay(computationDelay, cancellationToken).ConfigureAwait(false);
+
+            var computed = await ComputeValueAsync(lookup, cancellationToken).ConfigureAwait(false);
 
             statistics.Value.MissCount++;
 

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Extensions;
 using osu.Game.Graphics;

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -295,7 +295,6 @@ namespace osu.Game.Overlays.BeatmapSet
                     icon = new DifficultyIcon(beatmapInfo, ruleset)
                     {
                         TooltipType = DifficultyIconTooltipType.None,
-                        Current = { Value = new StarDifficulty(beatmapInfo.StarRating, 0) },
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(size - tile_icon_padding * 2),

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -246,7 +246,7 @@ namespace osu.Game.Screens.Select.Carousel
             if (Item?.State.Value != CarouselItemState.Collapsed)
             {
                 // We've potentially cancelled the computation above so a new bindable is required.
-                starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmapInfo, (starDifficultyCancellationSource = new CancellationTokenSource()).Token);
+                starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmapInfo, (starDifficultyCancellationSource = new CancellationTokenSource()).Token, 200);
                 starDifficultyBindable.BindValueChanged(d =>
                 {
                     starCounter.Current = (float)(d.NewValue?.Stars ?? 0);

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmap = (BeatmapInfo)Item.Model;
 
-            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token);
+            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, 200);
             starDifficultyBindable.BindValueChanged(_ => updateDisplay(), true);
         }
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -190,6 +190,8 @@ namespace osu.Game.Screens.SelectV2
 
             localRank.Beatmap = null;
             starDifficultyBindable = null;
+
+            starDifficultyCancellationSource?.Cancel();
         }
 
         private void computeStarRating()
@@ -204,6 +206,17 @@ namespace osu.Game.Screens.SelectV2
 
             starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, 200);
             starDifficultyBindable.BindValueChanged(_ => updateDisplay(), true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (Item?.IsVisible != true)
+            {
+                starDifficultyCancellationSource?.Cancel();
+                starDifficultyCancellationSource = null;
+            }
         }
 
         private void updateKeyCount()

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.SelectV2
                             AutoSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                starRatingDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Small)
+                                starRatingDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Small, animated: true)
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -238,7 +238,7 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmap = (BeatmapInfo)Item.Model;
 
-            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token);
+            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, 200);
             starDifficultyBindable.BindValueChanged(_ => updateDisplay(), true);
         }
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.SelectV2
                                 AutoSizeAxes = Axes.Both,
                                 Children = new Drawable[]
                                 {
-                                    difficultyStarRating = new StarRatingDisplay(default, StarRatingDisplaySize.Small)
+                                    difficultyStarRating = new StarRatingDisplay(default, StarRatingDisplaySize.Small, animated: true)
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -226,6 +226,8 @@ namespace osu.Game.Screens.SelectV2
             updateButton.BeatmapSet = null;
             difficultyRank.Beatmap = null;
             starDifficultyBindable = null;
+
+            starDifficultyCancellationSource?.Cancel();
         }
 
         private void computeStarRating()
@@ -240,6 +242,17 @@ namespace osu.Game.Screens.SelectV2
 
             starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, 200);
             starDifficultyBindable.BindValueChanged(_ => updateDisplay(), true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (Item?.IsVisible != true)
+            {
+                starDifficultyCancellationSource?.Cancel();
+                starDifficultyCancellationSource = null;
+            }
         }
 
         private void updateKeyCount()


### PR DESCRIPTION
I had this on my backlist, but it becomes a very apparent issue with song select v2 due to less debounce considerations than v1 so I took a shot at fixing things. This a solution along the lines of what @smoogipoo mentioned in the issue thread. I think it works fine and doesn't feel too bad.

no mod (unaffected; now uses realm `StarRating` as a sane starting point as per 01edee123f5f26add8723016e76cccee856aef68):

https://github.com/user-attachments/assets/c5117543-eb8a-4aa1-abd9-10be0e353609

with DT:

https://github.com/user-attachments/assets/2b304ff7-7808-4df4-80b4-bef678a9684b

Old song select is unaffected as you can't see the SR number and the stars are already animating anyway:

https://github.com/user-attachments/assets/58bd7912-a483-41c2-8f7b-3015a1721524

You could argue that in the case a user *isn't* performing rapid key repeat iteration, this is a slight visual regression when playing with mods that adjust difficulty due to the brief incorrect display, but again, I feel it's fine and if anything we'll fix this with more persistent caching of difficulties to the point it's an edge case rather than the norm.

The value of 200 ms for the debounce is intentionally larger than [key repeat](https://github.com/ppy/osu-framework/blob/0ee307ed781391e26d90199c6be6ad8b15a4fd9c/osu.Framework/Input/InputManager.cs#L40-L43).

Closes https://github.com/ppy/osu/issues/33140.
