### PR TITLE
Fix multiplayer position display looking wrong when player count is low

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPositionDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPositionDisplay.cs
@@ -86,5 +86,39 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("change local user", () => ((DummyAPIAccess)API).LocalUser.Value = new GuestUser());
             AddUntilStep("display hidden", () => display.Alpha, () => Is.EqualTo(0));
         }
+
+        [Test]
+        public void TestTwoPlayers()
+        {
+            AddStep("create content", () =>
+            {
+                Children = new Drawable[]
+                {
+                    new DependencyProvidingContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        CachedDependencies =
+                        [
+                            (typeof(IGameplayLeaderboardProvider), leaderboardProvider = new TestSceneGameplayLeaderboard.TestGameplayLeaderboardProvider()),
+                            (typeof(GameplayState), gameplayState = TestGameplayState.Create(new OsuRuleset()))
+                        ],
+                        Child = display = new MultiplayerPositionDisplay
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        }
+                    }
+                };
+
+                score = leaderboardProvider.CreateLeaderboardScore(new BindableLong(), API.LocalUser.Value, true);
+                score.Position.BindTo(position);
+
+                var r = leaderboardProvider.CreateRandomScore(new APIUser());
+                r.Position.Value = 1;
+            });
+
+            AddStep("first place", () => position.Value = 1);
+            AddStep("second place", () => position.Value = 2);
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
-            float relativePosition = Math.Clamp((float)(position.Value.Value - 1) / (scores.Count - 1), 0, 1);
+            float relativePosition = Math.Clamp((float)(position.Value.Value - 1) / Math.Max(scores.Count - 1, 1), 0, 1);
 
             positionText.Current.Value = position.Value.Value;
             positionText.FadeTo(min_alpha + (max_alpha - min_alpha) * (1 - relativePosition), 1000, Easing.OutPow10);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
@@ -158,13 +158,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
-            float relativePosition = (float)(position.Value.Value - 1) / scores.Count;
+            float relativePosition = Math.Clamp((float)(position.Value.Value - 1) / (scores.Count - 1), 0, 1);
 
             positionText.Current.Value = position.Value.Value;
             positionText.FadeTo(min_alpha + (max_alpha - min_alpha) * (1 - relativePosition), 1000, Easing.OutPow10);
 
             localPlayerMarker.FadeIn();
-            localPlayerMarker.MoveToX(marker_size / 2 + Math.Min(relativePosition * (width - marker_size / 2), width - marker_size / 2), 1000, Easing.OutPow10);
+            float markerWidth = Math.Max(marker_size, width / scores.Count);
+            localPlayerMarker.ResizeWidthTo(markerWidth, 1000, Easing.OutPow10);
+            localPlayerMarker.MoveToX(markerWidth / 2 + (width - markerWidth) * relativePosition, 1000, Easing.OutPow10);
         }
 
         private partial class PositionCounter : RollingCounter<int>


### PR DESCRIPTION
Spotted when watching video in #33173's opening post.

Before:

https://github.com/user-attachments/assets/df5df008-8004-4600-9ffc-2e2aa934bb92

After:

https://github.com/user-attachments/assets/3e993fa5-5d38-40ce-b8d6-f73ea1978a55

