### PR TITLE
Fix hold notes getting incorrectly missed after rewinding gameplay

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHoldNote.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHoldNote.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
             {
                 foreach (var holdNote in CreatedDrawables.SelectMany(d => d.ChildrenOfType<DrawableHoldNote>()))
                 {
-                    ((Bindable<bool>)holdNote.IsHitting).Value = v;
+                    ((Bindable<bool>)holdNote.IsHolding).Value = v;
                 }
             });
         }

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRewinding.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRewinding.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Mania.Tests
+{
+    public partial class TestSceneReplayRewinding : RateAdjustedBeatmapTestScene
+    {
+        private ReplayPlayer currentPlayer = null!;
+
+        [Test]
+        public void TestRewindingToMiddleOfHoldNote()
+        {
+            Score score = null!;
+
+            var beatmap = new ManiaBeatmap(new StageDefinition(4))
+            {
+                HitObjects =
+                {
+                    new HoldNote
+                    {
+                        StartTime = 500,
+                        EndTime = 1500,
+                        Column = 2
+                    }
+                }
+            };
+
+            AddStep(@"create replay", () => score = new Score
+            {
+                Replay = new Replay
+                {
+                    Frames =
+                    {
+                        new ManiaReplayFrame(500, ManiaAction.Key3),
+                        new ManiaReplayFrame(1500),
+                    }
+                },
+                ScoreInfo = new ScoreInfo()
+            });
+
+            AddStep(@"set beatmap", () => Beatmap.Value = CreateWorkingBeatmap(beatmap));
+            AddStep(@"set ruleset", () => Ruleset.Value = beatmap.BeatmapInfo.Ruleset);
+            AddStep(@"push player", () => LoadScreen(currentPlayer = new ReplayPlayer(score)));
+
+            AddUntilStep(@"wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep(@"wait for hold to be judged", () => currentPlayer.ChildrenOfType<IFrameStableClock>().Single().CurrentTime, () => Is.GreaterThan(1600));
+            AddStep(@"seek to middle of hold note", () => currentPlayer.Seek(1000));
+            AddUntilStep(@"wait for gameplay to complete", () => currentPlayer.GameplayState.HasCompleted);
+            AddAssert(@"no misses registered", () => currentPlayer.GameplayState.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss), () => Is.Zero);
+
+            AddStep(@"exit player", () => currentPlayer.Exit());
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteJudgementResult.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteJudgementResult.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania.Objects;
+
+namespace osu.Game.Rulesets.Mania.Judgements
+{
+    public class HoldNoteJudgementResult : JudgementResult
+    {
+        private Stack<(double time, bool holding)> holdingState { get; } = new Stack<(double, bool)>();
+
+        public HoldNoteJudgementResult(HoldNote hitObject, Judgement judgement)
+            : base(hitObject, judgement)
+        {
+            holdingState.Push((double.NegativeInfinity, false));
+        }
+
+        private (double time, bool holding) getLastReport(double currentTime)
+        {
+            while (holdingState.Peek().time > currentTime)
+                holdingState.Pop();
+
+            return holdingState.Peek();
+        }
+
+        public bool IsHolding(double currentTime) => getLastReport(currentTime).holding;
+
+        public void ReportHoldState(double currentTime, bool holding)
+        {
+            var lastReport = getLastReport(currentTime);
+            if (holding != lastReport.holding)
+                holdingState.Push((currentTime, holding));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteJudgementResult.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteJudgementResult.cs
@@ -27,6 +27,17 @@ namespace osu.Game.Rulesets.Mania.Judgements
 
         public bool IsHolding(double currentTime) => getLastReport(currentTime).holding;
 
+        public bool DroppedHoldAfter(double time)
+        {
+            foreach (var state in holdingState)
+            {
+                if (state.time >= time && !state.holding)
+                    return true;
+            }
+
+            return false;
+        }
+
         public void ReportHoldState(double currentTime, bool holding)
         {
             var lastReport = getLastReport(currentTime);

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             protected override void CheckForResult(bool userTriggered, double timeOffset)
             {
                 // apply perfect once the tail is reached
-                if (HoldNote.HoldStartTime != null && timeOffset >= 0)
+                if (HoldNote.IsHolding.Value && timeOffset >= 0)
                     ApplyResult(GetCappedResult(HitResult.Perfect));
                 else
                     base.CheckForResult(userTriggered, timeOffset);

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -235,7 +235,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 //
                 // As per stable, this should not apply for early hits, waiting until the object starts to touch the
                 // judgement area first.
-                if (Head.IsHit && isHolding.Value && DrawHeight > 0)
+                if (Head.IsHit && !Result.DroppedHoldAfter(HitObject.StartTime) && DrawHeight > 0)
                 {
                     // How far past the hit target this hold note is.
                     float yOffset = Direction.Value == ScrollingDirection.Up ? -Y : Y;

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -11,6 +11,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -29,9 +31,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     {
         public override bool DisplayResult => false;
 
-        public IBindable<bool> IsHitting => isHitting;
+        public IBindable<bool> IsHolding => isHolding;
 
-        private readonly Bindable<bool> isHitting = new Bindable<bool>();
+        private readonly Bindable<bool> isHolding = new Bindable<bool>();
 
         public DrawableHoldNoteHead Head => headContainer.Child;
         public DrawableHoldNoteTail Tail => tailContainer.Child;
@@ -54,16 +56,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         private Container maskingContainer;
 
         private SkinnableDrawable bodyPiece;
-
-        /// <summary>
-        /// Time at which the user started holding this hold note. Null if the user is not holding this hold note.
-        /// </summary>
-        public double? HoldStartTime { get; private set; }
-
-        /// <summary>
-        /// Used to decide whether to visually clamp the hold note to the judgement line.
-        /// </summary>
-        private double? releaseTime;
 
         public DrawableHoldNote()
             : this(null)
@@ -126,7 +118,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             base.LoadComplete();
 
-            isHitting.BindValueChanged(updateSlidingSample, true);
+            isHolding.BindValueChanged(updateSlidingSample, true);
         }
 
         protected override void OnApply()
@@ -134,8 +126,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             base.OnApply();
 
             sizingContainer.Size = Vector2.One;
-            HoldStartTime = null;
-            releaseTime = null;
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
@@ -214,11 +204,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             base.Update();
 
-            if (Time.Current < releaseTime)
-                releaseTime = null;
-
-            if (Time.Current < HoldStartTime)
-                endHold();
+            isHolding.Value = Result.IsHolding(Time.Current);
 
             // Pad the full size container so its contents (i.e. the masking container) reach under the tail.
             // This is required for the tail to not be masked away, since it lies outside the bounds of the hold note.
@@ -249,7 +235,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 //
                 // As per stable, this should not apply for early hits, waiting until the object starts to touch the
                 // judgement area first.
-                if (Head.IsHit && releaseTime == null && DrawHeight > 0)
+                if (Head.IsHit && isHolding.Value && DrawHeight > 0)
                 {
                     // How far past the hit target this hold note is.
                     float yOffset = Direction.Value == ScrollingDirection.Up ? -Y : Y;
@@ -259,6 +245,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             else
                 sizingContainer.Height = 1;
         }
+
+        protected override JudgementResult CreateResult(Judgement judgement) => new HoldNoteJudgementResult(HitObject, judgement);
+
+        public new HoldNoteJudgementResult Result => (HoldNoteJudgementResult)base.Result;
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
@@ -274,7 +264,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     Body.TriggerResult(Tail.IsHit);
 
                 // Important that this is always called when a result is applied.
-                endHold();
+                Result.ReportHoldState(Time.Current, false);
             }
         }
 
@@ -283,7 +273,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             base.MissForcefully();
 
             // Important that this is always called when a result is applied.
-            endHold();
+            Result.ReportHoldState(Time.Current, false);
         }
 
         public bool OnPressed(KeyBindingPressEvent<ManiaAction> e)
@@ -317,8 +307,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (timeOffset < -Head.HitObject.HitWindows.WindowFor(HitResult.Miss))
                 return;
 
-            HoldStartTime = Time.Current;
-            isHitting.Value = true;
+            Result.ReportHoldState(Time.Current, true);
         }
 
         public void OnReleased(KeyBindingReleaseEvent<ManiaAction> e)
@@ -337,20 +326,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             // the user has released too early (before the tail).
             //
             // In such a case, we want to record this against the DrawableHoldNoteBody.
-            if (HoldStartTime != null)
+            if (isHolding.Value)
             {
                 Tail.UpdateResult();
                 Body.TriggerResult(Tail.IsHit);
 
-                endHold();
-                releaseTime = Time.Current;
+                Result.ReportHoldState(Time.Current, false);
             }
-        }
-
-        private void endHold()
-        {
-            HoldStartTime = null;
-            isHitting.Value = false;
         }
 
         protected override void LoadSamples()

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
                 AccentColour.BindTo(holdNote.AccentColour);
                 hittingLayer.AccentColour.BindTo(holdNote.AccentColour);
-                ((IBindable<bool>)hittingLayer.IsHitting).BindTo(holdNote.IsHitting);
+                ((IBindable<bool>)hittingLayer.IsHitting).BindTo(holdNote.IsHolding);
             }
 
             AccentColour.BindValueChanged(colour =>

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             hittingLayer.AccentColour.BindTo(holdNoteTail.HoldNote.AccentColour);
 
             hittingLayer.IsHitting.UnbindBindings();
-            ((IBindable<bool>)hittingLayer.IsHitting).BindTo(holdNoteTail.HoldNote.IsHitting);
+            ((IBindable<bool>)hittingLayer.IsHitting).BindTo(holdNoteTail.HoldNote.IsHolding);
         }
 
         private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)

--- a/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBodyPiece.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
                 var holdNote = (DrawableHoldNote)drawableObject;
 
                 AccentColour.BindTo(drawableObject.AccentColour);
-                IsHitting.BindTo(holdNote.IsHitting);
+                IsHitting.BindTo(holdNote.IsHolding);
             }
 
             AccentColour.BindValueChanged(onAccentChanged, true);

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
             var wrapMode = bodyStyle == LegacyNoteBodyStyle.Stretch ? WrapMode.ClampToEdge : WrapMode.Repeat;
 
             direction.BindTo(scrollingInfo.Direction);
-            isHitting.BindTo(holdNote.IsHitting);
+            isHitting.BindTo(holdNote.IsHolding);
 
             bodySprite = skin.GetAnimation(imageName, wrapMode, wrapMode, true, true, frameLength: 30)?.With(d =>
             {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27589.

Follows osu! spinner precedent in storing the holding state to the judgement result rather than attempting to keep it in the DHO (where it is prone to getting dropped on pool re-use).

I'm not super sure about this diff - the ordering between `HoldNoteJudgementResult.IsHolding(double time)` and `HoldNoteJudgementResult.ReportHoldState(double time)` is a bit dicey, but that's kind of what it was all along anyway. Tests appear to pass locally and I'm heavily relying on that. We'll see how review goes I guess.

I can still reproduce misses on rewind even on this branch, but they go from occurring almost every seek on `master` to maybe one every minute spamming rewind back and forth. Which is to say this isn't the end-all-be-all of mania replay issues and I still need to stare at it more but I'd rather take it piece by piece if possible.