### PR TITLE
Fix song select tests not loading footer buttons with dependencies

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -189,10 +189,24 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         private void updateFooter(IScreen? _, IScreen? newScreen)
         {
-            if (newScreen is IOsuScreen osuScreen && osuScreen.ShowFooter)
+            if (newScreen is OsuScreen osuScreen && osuScreen.ShowFooter)
             {
                 Footer.Show();
-                Footer.SetButtons(osuScreen.CreateFooterButtons());
+
+                if (osuScreen.IsLoaded)
+                    updateFooterButtons();
+                else
+                    osuScreen.OnLoadComplete += _ => updateFooterButtons();
+
+                void updateFooterButtons()
+                {
+                    var buttons = osuScreen.CreateFooterButtons();
+
+                    osuScreen.LoadComponentsAgainstScreenDependencies(buttons);
+
+                    Footer.SetButtons(buttons);
+                    Footer.Show();
+                }
             }
             else
             {


### PR DESCRIPTION
I've tried to fix this first by loading the footer alongside the screen and use `DependencyProvidingContainer` to cache the screen, but the resulting code alongside everything else felt too hard to swallow.

I've went ahead with a local solution by copying exactly how `OsuGame` loads screen dependencies and called it a day.