### PR TITLE
Fix carousel potentially selecting filtered difficulty

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -290,5 +290,26 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckDisplayedBeatmapsCount(local_set_count);
         }
+
+        [Test]
+        public void TestFirstDifficultyFiltered()
+        {
+            AddBeatmaps(2, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            WaitForSelection(0, 0);
+
+            CheckDisplayedBeatmapsCount(6);
+
+            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
+            WaitForFiltering();
+
+            CheckDisplayedBeatmapsCount(4);
+
+            SelectNextGroup();
+            SelectPrevGroup();
+            WaitForSelection(0, 1);
+        }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -181,8 +181,9 @@ namespace osu.Game.Screens.SelectV2
                     return;
 
                 case BeatmapSetInfo setInfo:
-                    // Selecting a set isn't valid – let's re-select the first difficulty.
-                    CurrentSelection = setInfo.Beatmaps.First();
+                    // Selecting a set isn't valid – let's re-select the first visible difficulty.
+                    if (grouping.SetItems.TryGetValue(setInfo, out var items))
+                        CurrentSelection = items.ElementAt(1).Model;
                     return;
 
                 case BeatmapInfo beatmapInfo:

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -183,7 +183,8 @@ namespace osu.Game.Screens.SelectV2
                 case BeatmapSetInfo setInfo:
                     // Selecting a set isn't valid – let's re-select the first visible difficulty.
                     if (grouping.SetItems.TryGetValue(setInfo, out var items))
-                        CurrentSelection = items.ElementAt(1).Model;
+                        CurrentSelection = items.Select(i => i.Model).OfType<BeatmapInfo>().First();
+
                     return;
 
                 case BeatmapInfo beatmapInfo:


### PR DESCRIPTION
When the first difficulty in the beatmapset in database records is hidden due to being in another ruleset, filtered away, or hidden by the user, then we don't want to select it.