### PR TITLE
Disable status pill animation on carousel panels

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
     public partial class TestSceneBeatmapSetOnlineStatusPill : ThemeComparisonTestScene
     {
         private bool showUnknownStatus;
+        private bool animated = true;
 
         protected override Drawable CreateContent() => new FillFlowContainer
         {
@@ -37,10 +38,11 @@ namespace osu.Game.Tests.Visual.Beatmaps
                     new BeatmapSetOnlineStatusPill
                     {
                         ShowUnknownStatus = showUnknownStatus,
+                        Animated = animated,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Status = status
-                    }
+                    },
                 }
             })
         };
@@ -61,6 +63,12 @@ namespace osu.Game.Tests.Visual.Beatmaps
             AddStep("toggle show unknown", () =>
             {
                 showUnknownStatus = !showUnknownStatus;
+                CreateThemedContent(OverlayColourScheme.Red);
+            });
+
+            AddStep("toggle animate", () =>
+            {
+                animated = !animated;
                 CreateThemedContent(OverlayColourScheme.Red);
             });
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Utils;
@@ -60,6 +62,26 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             AddStep("disable masking", () => Scroll.Masking = false);
             AddStep("enable masking", () => Scroll.Masking = true);
+        }
+
+        [Test]
+        [Explicit]
+        public void TestRandomStatus()
+        {
+            SortBy(SortMode.Title);
+            AddStep("add beatmaps", () =>
+            {
+                for (int i = 0; i < 50; i++)
+                {
+                    var set = TestResources.CreateTestBeatmapSetInfo();
+                    set.Status = Enum.GetValues<BeatmapOnlineStatus>().MinBy(_ => RNG.Next());
+
+                    if (i % 2 == 0)
+                        set.Status = BeatmapOnlineStatus.None;
+
+                    BeatmapSets.Add(set);
+                }
+            });
         }
 
         [Test]

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
@@ -24,6 +24,11 @@ namespace osu.Game.Beatmaps.Drawables
         /// </summary>
         public bool ShowUnknownStatus { get; init; }
 
+        /// <summary>
+        /// Whether changing status performs transition transforms.
+        /// </summary>
+        public bool Animated { get; init; } = true;
+
         public BeatmapOnlineStatus Status
         {
             get => status;
@@ -98,9 +103,11 @@ namespace osu.Game.Beatmaps.Drawables
 
         private void updateState()
         {
+            double duration = Animated ? animation_duration : 0;
+
             if (Status == BeatmapOnlineStatus.None && !ShowUnknownStatus)
             {
-                this.FadeOut(animation_duration, Easing.OutQuint);
+                this.FadeOut(duration, Easing.OutQuint);
                 return;
             }
 
@@ -109,15 +116,16 @@ namespace osu.Game.Beatmaps.Drawables
             // after we have a valid size.
             if (Height > 0)
             {
-                AutoSizeDuration = (float)animation_duration;
+                AutoSizeDuration = (float)duration;
                 AutoSizeEasing = Easing.OutQuint;
             }
 
-            this.FadeIn(animation_duration, Easing.OutQuint);
+            this.FadeIn(duration, Easing.OutQuint);
 
             // Handle the case where transition from hidden to non-hidden may cause
             // a fade from a colour that doesn't make sense (due to not being able to see the previous colour).
-            double duration = Alpha > 0 ? animation_duration : 0;
+            if (Alpha == 0)
+                duration = 0;
 
             Color4 statusTextColour;
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -102,6 +102,7 @@ namespace osu.Game.Screens.SelectV2
                                     Anchor = Anchor.CentreLeft,
                                     TextSize = OsuFont.Style.Caption2.Size,
                                     Margin = new MarginPadding { Right = 5f },
+                                    Animated = false,
                                 },
                                 difficultiesDisplay = new DifficultySpectrumDisplay
                                 {


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/issues/32736#issuecomment-2883631395. We might also want to consider skipping any transforms pending from previous usage of a panel, but this is not simple to do as there are potentially certain transforms we want to keep (such as initial X offset and alpha transform for beatmaps that are just added to the carousel). Going with this solution for now.