### PR TITLE
SongSelectV2: Fix mod changes not updating displayed star rating, and add debounce to avoid stutter

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -225,10 +225,10 @@ namespace osu.Game.Screens.SelectV2
                 {
                     settingChangeTracker?.Dispose();
 
-                    updateDifficultyStatistics();
+                    updateDisplay();
 
                     settingChangeTracker = new ModSettingChangeTracker(m.NewValue);
-                    settingChangeTracker.SettingChanged += _ => updateDifficultyStatistics();
+                    settingChangeTracker.SettingChanged += _ => updateDisplay();
                 });
 
                 updateDisplay();

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -287,7 +287,7 @@ namespace osu.Game.Screens.SelectV2
                 {
                     // This can take time as it is a synchronous task.
                     // TODO: We're calling `GetPlayableBeatmap` multiple times every map load at song select.
-                    var playableBeatmap = beatmap.Value.GetPlayableBeatmap(ruleset.Value);
+                    var playableBeatmap = beatmap.Value.GetPlayableBeatmap(ruleset.Value, mods.Value);
                     var statistics = playableBeatmap.GetStatistics()
                                                     .Select(s => new StatisticDifficulty.Data(s.Name, s.BarDisplayLength ?? 0, s.BarDisplayLength ?? 0, 1, s.Content))
                                                     .ToList();


### PR DESCRIPTION
Since mod settings signal change events on every single drag of a slider, I've added a local debounce for that to not cause stutter.

This also features a tiny change to fix count statistics not respecting selected mods.