### PR TITLE
Increase diff calc processor timeout minutes

### DIFF
--- a/.github/workflows/_diffcalc_processor.yml
+++ b/.github/workflows/_diffcalc_processor.yml
@@ -36,7 +36,7 @@ jobs:
   generator:
     name: Run
     runs-on: self-hosted
-    timeout-minutes: 720
+    timeout-minutes: 1440
 
     outputs:
       target: ${{ steps.run.outputs.target }}


### PR DESCRIPTION
We're having issues with diff calc runs getting cancelled as they're exceeding the 12 hour time and it's getting pretty annoying. I don't really think there is a "correct" number to change this to, so I've just doubled it (to 24 hours). Feel free to change.