### PR TITLE
Fix combo accounting when rewinding mania replays

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRewinding.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayRewinding.cs
@@ -65,5 +65,61 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep(@"exit player", () => currentPlayer.Exit());
         }
+
+        [Test]
+        public void TestCorrectComboAccountingForConcurrentObjects()
+        {
+            Score score = null!;
+
+            var beatmap = new ManiaBeatmap(new StageDefinition(4))
+            {
+                HitObjects =
+                {
+                    new Note
+                    {
+                        StartTime = 500,
+                        Column = 0,
+                    },
+                    new Note
+                    {
+                        StartTime = 500,
+                        Column = 2,
+                    },
+                    new HoldNote
+                    {
+                        StartTime = 1000,
+                        EndTime = 1500,
+                        Column = 1,
+                    }
+                }
+            };
+
+            AddStep(@"create replay", () => score = new Score
+            {
+                Replay = new Replay
+                {
+                    Frames =
+                    {
+                        new ManiaReplayFrame(500, ManiaAction.Key1, ManiaAction.Key3),
+                        new ManiaReplayFrame(520),
+                        new ManiaReplayFrame(1000, ManiaAction.Key2),
+                        new ManiaReplayFrame(1500),
+                    }
+                },
+                ScoreInfo = new ScoreInfo()
+            });
+
+            AddStep(@"set beatmap", () => Beatmap.Value = CreateWorkingBeatmap(beatmap));
+            AddStep(@"set ruleset", () => Ruleset.Value = beatmap.BeatmapInfo.Ruleset);
+            AddStep(@"push player", () => LoadScreen(currentPlayer = new ReplayPlayer(score)));
+
+            AddUntilStep(@"wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep(@"wait for objects to be judged", () => currentPlayer.ChildrenOfType<IFrameStableClock>().Single().CurrentTime, () => Is.GreaterThan(1600));
+            AddStep(@"stop gameplay", () => currentPlayer.ChildrenOfType<GameplayClockContainer>().Single().Stop());
+            AddStep(@"seek to start", () => currentPlayer.Seek(0));
+            AddAssert(@"combo is 0", () => currentPlayer.GameplayState.ScoreProcessor.Combo.Value, () => Is.Zero);
+
+            AddStep(@"exit player", () => currentPlayer.Exit());
+        }
     }
 }

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -422,7 +422,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         }
 
         [Test]
-        public void TestComboAccounting()
+        public void TestComboAccounting([Values] bool shuffleResults)
         {
             var testBeatmap = new Beatmap
             {
@@ -467,7 +467,13 @@ namespace osu.Game.Tests.Rulesets.Scoring
             Assert.That(scoreProcessor.Combo.Value, Is.EqualTo(14));
             Assert.That(scoreProcessor.HighestCombo.Value, Is.EqualTo(25));
 
-            foreach (var result in Enumerable.Reverse(results))
+            // random shuffle is VERY extreme and overkill.
+            // it might not work correctly for any other `ScoreProcessor` property, and the intermediate results likely make no sense.
+            // the goal is only to demonstrate idempotency to zero when reverting all results.
+            var random = new Random(20250519);
+            var toRevert = shuffleResults ? results.OrderBy(_ => random.Next()).ToList() : Enumerable.Reverse(results);
+
+            foreach (var result in toRevert)
                 scoreProcessor.RevertResult(result);
 
             Assert.That(scoreProcessor.Combo.Value, Is.Zero);

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -75,6 +75,11 @@ namespace osu.Game.Rulesets.Judgements
         public int HighestComboAtJudgement { get; internal set; }
 
         /// <summary>
+        /// The highest combo achieved after this <see cref="JudgementResult"/> occurred.
+        /// </summary>
+        public int HighestComboAfterJudgement { get; internal set; }
+
+        /// <summary>
         /// The health prior to this <see cref="JudgementResult"/> occurring.
         /// </summary>
         public double HealthAtJudgement { get; internal set; }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -202,7 +202,6 @@ namespace osu.Game.Rulesets.Scoring
         {
             Ruleset = ruleset;
 
-            Combo.ValueChanged += combo => HighestCombo.Value = Math.Max(HighestCombo.Value, combo.NewValue);
             Accuracy.ValueChanged += _ => updateRank();
 
             Mods.ValueChanged += mods =>
@@ -238,7 +237,10 @@ namespace osu.Game.Rulesets.Scoring
             else if (result.Type.BreaksCombo())
                 Combo.Value = 0;
 
+            HighestCombo.Value = Math.Max(HighestCombo.Value, Combo.Value);
+
             result.ComboAfterJudgement = Combo.Value;
+            result.HighestComboAfterJudgement = HighestCombo.Value;
 
             if (result.Judgement.MaxResult.AffectsAccuracy())
             {
@@ -281,8 +283,11 @@ namespace osu.Game.Rulesets.Scoring
             if (!TrackHitEvents)
                 throw new InvalidOperationException(@$"Rewind is not supported when {nameof(TrackHitEvents)} is disabled.");
 
-            Combo.Value = result.ComboAtJudgement;
-            HighestCombo.Value = result.HighestComboAtJudgement;
+            // the reason this is written so funnily rather than just using `ComboAtJudgement`
+            // is to nullify impact of ordering when reverting concurrent judgement results
+            // (think mania and multiple judgements within a frame).
+            Combo.Value -= (result.ComboAfterJudgement - result.ComboAtJudgement);
+            HighestCombo.Value -= (result.HighestComboAfterJudgement - result.HighestComboAtJudgement);
 
             if (result.FailedAtJudgement && !ApplyNewJudgementsWhenFailed)
                 return;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21732.

This is a RFC and a left-field "clever" fix, so I can accept an immediate refusal of the idea here. That said hear me out.

While the problem of multiple judgements in one frame and ordering of `RevertResult()` calls [as described in the issue](https://github.com/ppy/osu/issues/21732#issuecomment-1408374309) is a real one, this commit is a bit of a sidestep of the entire issue.

The idea here is that while *snapshots* of instantaneous combo values are susceptible to such ordering foibles on revert, *deltas* are not - and such, when deltas are used to update the combo counts on revert, ordering stops mattering so much. The intermediate values may be nonsense briefly, but as long as all judgements on a single time frame are reverted in a group, this *should* result in correct behaviour?

I'm basically trying to see if we can all consider this acceptable or if I have to do a major refactor of judgement processing to make sure the ordering of result revert *is* exactly the reverse of ordering of result application, which is going to be probably pretty painful to do.