### PR TITLE
SongSelectV2: Show loading spinner underneath user tags during transitions

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Models;
 using osu.Game.Online.API;
@@ -30,26 +31,29 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             };
         }
 
-        [SetUp]
-        public void SetUp()
+        [SetUpSteps]
+        public override void SetUpSteps()
         {
-            ((DummyAPIAccess)API).HandleRequest = request =>
+            AddStep("register request handling", () =>
             {
-                switch (request)
+                ((DummyAPIAccess)API).HandleRequest = request =>
                 {
-                    case GetBeatmapSetRequest set:
-                        if (set.ID == currentOnlineSet?.OnlineID)
-                        {
-                            set.TriggerSuccess(currentOnlineSet);
-                            return true;
-                        }
+                    switch (request)
+                    {
+                        case GetBeatmapSetRequest set:
+                            if (set.ID == currentOnlineSet?.OnlineID)
+                            {
+                                set.TriggerSuccess(currentOnlineSet);
+                                return true;
+                            }
 
-                        return false;
+                            return false;
 
-                    default:
-                        return false;
-                }
-            };
+                        default:
+                            return false;
+                    }
+                };
+            });
         }
 
         [Test]
@@ -214,7 +218,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Action proceed = null!;
 
-            AddStep("setup", () =>
+            AddStep("override request handling", () =>
             {
                 currentOnlineSet = null;
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
@@ -216,8 +216,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestLoading()
         {
-            Action proceed = null!;
-
             AddStep("override request handling", () =>
             {
                 currentOnlineSet = null;
@@ -227,7 +225,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     switch (request)
                     {
                         case GetBeatmapSetRequest set:
-                            proceed = () => set.TriggerSuccess(currentOnlineSet!);
+                            Scheduler.AddDelayed(() => set.TriggerSuccess(currentOnlineSet!), 500);
                             return true;
 
                         default:
@@ -243,7 +241,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
             });
-            AddStep("finish load", () => proceed());
+            AddWaitStep("wait", 5);
 
             AddStep("set beatmap", () =>
             {
@@ -256,7 +254,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
             });
-            AddStep("finish load", () => proceed());
+            AddWaitStep("wait", 5);
 
             AddStep("no user tags", () =>
             {
@@ -268,7 +266,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
             });
-            AddStep("finish load", () => proceed());
+            AddWaitStep("wait", 5);
 
             AddStep("no user tags", () =>
             {
@@ -280,7 +278,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
             });
-            AddStep("finish load", () => proceed());
+            AddWaitStep("wait", 5);
         }
 
         private (WorkingBeatmap, APIBeatmapSet) createTestBeatmap()

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -338,6 +338,7 @@ namespace osu.Game.Screens.SelectV2
             {
                 genre.Data = null;
                 language.Data = null;
+                userTags.Tags = null;
                 return;
             }
 

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
@@ -56,9 +56,15 @@ namespace osu.Game.Screens.SelectV2
                 }
             }
 
-            public (string[] tags, Action<string> linkAction) Tags
+            public (string[] tags, Action<string> linkAction)? Tags
             {
-                set => setTags(value.tags, value.linkAction);
+                set
+                {
+                    if (value != null)
+                        setTags(value.Value.tags, value.Value.linkAction);
+                    else
+                        setLoading();
+                }
             }
 
             public MetadataDisplay(LocalisableString label)


### PR DESCRIPTION
Noticed for some time while playing around with song select. Now should feel more consistent with the rest of the components.

Before:

https://github.com/user-attachments/assets/0fa1efaf-a903-4be7-9979-441c143ae2f3

After:

https://github.com/user-attachments/assets/ac00ca70-899e-443b-9401-88e87f842783