### PR TITLE
SongSelectV2: Fix "no results" placeholder having weird transitions

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -346,7 +346,6 @@ namespace osu.Game.Screens.SelectV2
             filterDebounce?.Cancel();
             filterDebounce = Scheduler.AddDelayed(() =>
             {
-                noResultsPlaceholder.Filter = criteria;
                 carousel.Filter(criteria);
             }, filter_delay);
         }
@@ -355,7 +354,13 @@ namespace osu.Game.Screens.SelectV2
         {
             int count = carousel.MatchedBeatmapsCount;
 
-            noResultsPlaceholder.State.Value = count == 0 ? Visibility.Visible : Visibility.Hidden;
+            if (count == 0)
+            {
+                noResultsPlaceholder.Show();
+                noResultsPlaceholder.Filter = carousel.Criteria;
+            }
+            else
+                noResultsPlaceholder.Hide();
 
             // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
             // but also in this case we want support for formatting a number within a string).


### PR DESCRIPTION
This PR consists of two changes:
 - Update filter criteria after the new items are presented, otherwise a false "no beatmaps match your filter" will be displayed as the new items are being loaded.
 - Update filter criteria only if the placeholder will be / is visible, otherwise the placeholder will awkwardly update its text as it is fading out.

Before:

https://github.com/user-attachments/assets/0790f572-b620-436a-9da8-8af633be94eb

After:

https://github.com/user-attachments/assets/8dc2dbdf-5f17-402b-802a-60551a508cb6

