### PR TITLE
SongSelectV2: Improve scrolling area and behaviour

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -22,6 +22,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
+using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
@@ -52,11 +53,16 @@ using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Screens.Select.Options;
+using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Beatmaps.IO;
 using osu.Game.Tests.Resources;
 using osu.Game.Utils;
 using osuTK;
 using osuTK.Input;
+using BeatmapCarousel = osu.Game.Screens.Select.BeatmapCarousel;
+using CollectionDropdown = osu.Game.Collections.CollectionDropdown;
+using FilterControl = osu.Game.Screens.Select.FilterControl;
+using FooterButtonRandom = osu.Game.Screens.Select.FooterButtonRandom;
 
 namespace osu.Game.Tests.Visual.Navigation
 {
@@ -272,6 +278,60 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("carousel moved", getCarouselScrollPosition, () => Is.Not.EqualTo(scrollPosition));
 
             double getCarouselScrollPosition() => Game.ChildrenOfType<UserTrackingScrollContainer<DrawableCarouselItem>>().Single().Current;
+        }
+
+        [Test]
+        public void TestNewSongSelectScrollHandling()
+        {
+            SoloSongSelect songSelect = null;
+            double scrollPosition = 0;
+
+            AddStep("set game volume to max", () => Game.Dependencies.Get<FrameworkConfigManager>().SetValue(FrameworkSetting.VolumeUniversal, 1d));
+            AddUntilStep("wait for volume overlay to hide", () => Game.ChildrenOfType<VolumeOverlay>().SingleOrDefault()?.State.Value, () => Is.EqualTo(Visibility.Hidden));
+            PushAndConfirm(() => songSelect = new SoloSongSelect());
+            AddUntilStep("wait for song select", () => songSelect.IsLoaded);
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for beatmap", () => Game.ChildrenOfType<PanelBeatmapSet>().Any());
+
+            // todo: remove when selection is automatically performed.
+            AddStep("select", () => Game.ChildrenOfType<PanelBeatmapSet>().Single().TriggerClick());
+            AddWaitStep("wait for scroll", 10);
+
+            AddStep("store scroll position", () => scrollPosition = getCarouselScrollPosition());
+
+            AddStep("move to title wedge", () => InputManager.MoveMouseTo(
+                songSelect.ChildrenOfType<BeatmapTitleWedge>().Single()));
+            AddStep("scroll down", () => InputManager.ScrollVerticalBy(-1));
+            AddAssert("carousel didn't move", getCarouselScrollPosition, () => Is.EqualTo(scrollPosition));
+
+            AddRepeatStep("alt-scroll down", () =>
+            {
+                InputManager.PressKey(Key.AltLeft);
+                InputManager.ScrollVerticalBy(-1);
+                InputManager.ReleaseKey(Key.AltLeft);
+            }, 5);
+            AddAssert("game volume decreased", () => Game.Dependencies.Get<FrameworkConfigManager>().Get<double>(FrameworkSetting.VolumeUniversal), () => Is.LessThan(1));
+
+            AddStep("set game volume to max", () => Game.Dependencies.Get<FrameworkConfigManager>().SetValue(FrameworkSetting.VolumeUniversal, 1d));
+
+            AddStep("move to metadata wedge", () => InputManager.MoveMouseTo(
+                songSelect.ChildrenOfType<BeatmapMetadataWedge>().Single()));
+            AddStep("scroll down", () => InputManager.ScrollVerticalBy(-1));
+            AddAssert("carousel didn't move", getCarouselScrollPosition, () => Is.EqualTo(scrollPosition));
+
+            AddRepeatStep("alt-scroll down", () =>
+            {
+                InputManager.PressKey(Key.AltLeft);
+                InputManager.ScrollVerticalBy(-1);
+                InputManager.ReleaseKey(Key.AltLeft);
+            }, 5);
+            AddAssert("game volume decreased", () => Game.Dependencies.Get<FrameworkConfigManager>().Get<double>(FrameworkSetting.VolumeUniversal), () => Is.LessThan(1));
+
+            AddStep("move to carousel", () => InputManager.MoveMouseTo(songSelect.ChildrenOfType<Screens.SelectV2.BeatmapCarousel>().Single()));
+            AddStep("scroll down", () => InputManager.ScrollVerticalBy(-1));
+            AddAssert("carousel moved", getCarouselScrollPosition, () => Is.Not.EqualTo(scrollPosition));
+
+            double getCarouselScrollPosition() => Game.ChildrenOfType<Carousel<BeatmapInfo>>().Single().ChildrenOfType<UserTrackingScrollContainer>().Single().Current;
         }
 
         /// <summary>

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -823,6 +823,9 @@ namespace osu.Game.Graphics.Carousel
 
             public void SetLayoutHeight(float height) => Panels.Height = height;
 
+            /// <summary>
+            /// Allow handling right click scroll outside of the carousel's display area.
+            /// </summary>
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
             public CarouselScrollContainer()

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -137,6 +137,15 @@ namespace osu.Game.Graphics.Carousel
         }
 
         /// <summary>
+        /// Scroll carousel to the selected item if available.
+        /// </summary>
+        public void ScrollToSelection()
+        {
+            if (currentKeyboardSelection.CarouselItem != null)
+                Scroll.ScrollTo(currentKeyboardSelection.CarouselItem.CarouselYPosition - visibleHalfHeight + BleedTop);
+        }
+
+        /// <summary>
         /// Returns the vertical spacing between two given carousel items. Negative value can be used to create an overlapping effect.
         /// </summary>
         protected virtual float GetSpacingBetweenPanels(CarouselItem top, CarouselItem bottom) => 0f;
@@ -316,7 +325,7 @@ namespace osu.Game.Graphics.Carousel
 
                 refreshAfterSelection();
                 if (!Scroll.UserScrolling)
-                    scrollToSelection();
+                    ScrollToSelection();
 
                 NewItemsPresented?.Invoke();
             });
@@ -553,12 +562,6 @@ namespace osu.Game.Graphics.Carousel
                 Scroll.OffsetScrollPosition((float)(currentKeyboardSelection.YPosition!.Value - prevKeyboard.YPosition.Value));
         }
 
-        private void scrollToSelection()
-        {
-            if (currentKeyboardSelection.CarouselItem != null)
-                Scroll.ScrollTo(currentKeyboardSelection.CarouselItem.CarouselYPosition - visibleHalfHeight + BleedTop);
-        }
-
         #endregion
 
         #region Display handling
@@ -598,7 +601,7 @@ namespace osu.Game.Graphics.Carousel
                 refreshAfterSelection();
 
                 // Always scroll to selection in this case (regardless of `UserScrolling` state), centering the selection.
-                scrollToSelection();
+                ScrollToSelection();
 
                 selectionValid.Validate();
             }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -823,6 +823,8 @@ namespace osu.Game.Graphics.Carousel
 
             public void SetLayoutHeight(float height) => Panels.Height = height;
 
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+
             public CarouselScrollContainer()
             {
                 // Managing our own custom layout within ScrollContent causes feedback with public ScrollContainer calculations,

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -65,7 +65,11 @@ namespace osu.Game.Screens.SelectV2
 
             Width = 0.9f;
 
-            InternalChild = new FillFlowContainer
+            AddInternal(new WedgeScrollBlockerComponent
+            {
+                Shear = OsuGame.SHEAR,
+            });
+            AddInternal(new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
@@ -226,7 +230,7 @@ namespace osu.Game.Screens.SelectV2
                         },
                     }),
                 }
-            };
+            });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -92,6 +92,7 @@ namespace osu.Game.Screens.SelectV2
             InternalChildren = new Drawable[]
             {
                 new WedgeBackground(),
+                new WedgeScrollBlockerComponent(),
                 new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -116,7 +116,6 @@ namespace osu.Game.Screens.SelectV2
                                 RelativeSizeAxes = Axes.Both,
                                 ColumnDimensions = new[]
                                 {
-                                    new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 850),
                                     new Dimension(),
                                     new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 750),
                                 },
@@ -124,23 +123,6 @@ namespace osu.Game.Screens.SelectV2
                                 {
                                     new[]
                                     {
-                                        wedgesContainer = new FillFlowContainer
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Margin = new MarginPadding
-                                            {
-                                                Top = -CORNER_RADIUS_HIDE_OFFSET,
-                                                Left = -CORNER_RADIUS_HIDE_OFFSET
-                                            },
-                                            Spacing = new Vector2(0f, 4f),
-                                            Direction = FillDirection.Vertical,
-                                            Shear = OsuGame.SHEAR,
-                                            Children = new Drawable[]
-                                            {
-                                                new ShearAligningWrapper(titleWedge = new BeatmapTitleWedge()),
-                                                new ShearAligningWrapper(detailsArea = new BeatmapDetailsArea()),
-                                            },
-                                        },
                                         Empty(),
                                         new Container
                                         {
@@ -179,6 +161,41 @@ namespace osu.Game.Screens.SelectV2
                                     },
                                 }
                             },
+                            new GridContainer // used for max width implementation
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                ColumnDimensions = new[]
+                                {
+                                    new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 850),
+                                },
+                                Content = new[]
+                                {
+                                    new Drawable[]
+                                    {
+                                        new ResetScrollOnHoverContainer(carousel)
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Child = wedgesContainer = new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Margin = new MarginPadding
+                                                {
+                                                    Top = -CORNER_RADIUS_HIDE_OFFSET,
+                                                    Left = -CORNER_RADIUS_HIDE_OFFSET
+                                                },
+                                                Spacing = new Vector2(0f, 4f),
+                                                Direction = FillDirection.Vertical,
+                                                Shear = OsuGame.SHEAR,
+                                                Children = new Drawable[]
+                                                {
+                                                    new ShearAligningWrapper(titleWedge = new BeatmapTitleWedge()),
+                                                    new ShearAligningWrapper(detailsArea = new BeatmapDetailsArea()),
+                                                },
+                                            },
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                 },
@@ -444,5 +461,21 @@ namespace osu.Game.Screens.SelectV2
         public void ClearScores(BeatmapInfo beatmap) => dialogOverlay?.Push(new BeatmapClearScoresDialog(beatmap));
 
         #endregion
+
+        private partial class ResetScrollOnHoverContainer : Container
+        {
+            private readonly BeatmapCarousel carousel;
+
+            public ResetScrollOnHoverContainer(BeatmapCarousel carousel)
+            {
+                this.carousel = carousel;
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                carousel.ScrollToSelection();
+                return base.OnHover(e);
+            }
+        }
     }
 }

--- a/osu.Game/Screens/SelectV2/WedgeScrollBlockerComponent.cs
+++ b/osu.Game/Screens/SelectV2/WedgeScrollBlockerComponent.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+
+namespace osu.Game.Screens.SelectV2
+{
+    /// <summary>
+    /// A component inserted in the wedge hierarchy to block scroll components from reaching the carousel.
+    /// </summary>
+    public partial class WedgeScrollBlockerComponent : Component
+    {
+        public WedgeScrollBlockerComponent()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        // we want to block plain scrolls on the left side so that they don't scroll the carousel,
+        // but also we *don't* want to handle scrolls when they're combined with keyboard modifiers
+        // as those will usually correspond to other interactions like adjusting volume.
+        protected override bool OnScroll(ScrollEvent e) => !e.ControlPressed && !e.AltPressed && !e.ShiftPressed && !e.SuperPressed;
+    }
+}


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/pull/32854#issuecomment-2820632611

This partially matches old song select with further tweaks to work with the new design, behaving as such:
 - Scrolling in the carousel or in any empty area in the screen will scroll the carousel.
 - Scrolling in the title wedge or the metadata wedges will not scroll the carousel.
 - If the carousel is scrolled away and you hover over the wedges, the carousel will scroll back to selection (unless it's filtered away, at which point /shrug).

![CleanShot 2025-05-21 at 18 24 47](https://github.com/user-attachments/assets/aed6488a-9adf-45af-9c55-4bbcec4001ab)

For comparison with old song select on same UI scale:

![CleanShot 2025-05-21 at 18 50 23](https://github.com/user-attachments/assets/40488f4d-6e39-4a0b-b740-ffe019c73ff9)

The filter control also blocks scroll but that's due to being an `OverlayContainer` instead. Not sure if I need to apply any changes for that.

When rankings mode is selected, the entire left side area gets taken by the leaderboard scroll container. This matches old song select, and I don't have any clever idea to change this if deemed bad.