### PR TITLE
SongSelectV2: Choose recommended difficulty on beatmap selection

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -47,6 +47,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
 
+        public Func<IEnumerable<BeatmapInfo>, BeatmapInfo>? BeatmapRecommendationFunction { get; set; }
+
         private OsuTextFlowContainer stats = null!;
 
         private int beatmapCount;
@@ -69,6 +71,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             AddStep("create components", () =>
             {
+                BeatmapRecommendationFunction = null;
                 NewItemsPresentedInvocationCount = 0;
 
                 Box topBox;
@@ -105,6 +108,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                 Carousel = new TestBeatmapCarousel
                                 {
                                     NewItemsPresented = () => NewItemsPresentedInvocationCount++,
+                                    ChooseRecommendedBeatmap = beatmaps => BeatmapRecommendationFunction?.Invoke(beatmaps) ?? beatmaps.First(),
                                     BleedTop = 50,
                                     BleedBottom = 50,
                                     Anchor = Anchor.Centre,

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -261,6 +261,40 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForSelection(1, 1);
         }
 
+        [Test]
+        public void TestRecommendedSelection()
+        {
+            AddBeatmaps(5, 3);
+            WaitForDrawablePanels();
+
+            AddStep("set recommendation algorithm", () => Carousel.GetRecommendedBeatmap = beatmaps => beatmaps.Last());
+
+            SelectPrevGroup();
+
+            // check recommended was selected
+            SelectNextGroup();
+            WaitForSelection(0, 2);
+
+            // change away from recommended
+            SelectPrevPanel();
+            Select();
+            WaitForSelection(0, 1);
+
+            // next set, check recommended
+            SelectNextGroup();
+            WaitForSelection(1, 2);
+
+            // next set, check recommended
+            SelectNextGroup();
+            WaitForSelection(2, 2);
+
+            // go back to first set and ensure user selection was retained
+            // todo: we don't do that yet. not sure if we will continue to have this.
+            // SelectPrevGroup();
+            // SelectPrevGroup();
+            // WaitForSelection(0, 1);
+        }
+
         private void checkSelectionIterating(bool isIterating)
         {
             object? selection = null;

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(5, 3);
             WaitForDrawablePanels();
 
-            AddStep("set recommendation algorithm", () => Carousel.GetRecommendedBeatmap = beatmaps => beatmaps.Last());
+            AddStep("set recommendation algorithm", () => BeatmapRecommendationFunction = beatmaps => beatmaps.Last());
 
             SelectPrevGroup();
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Screens.SelectV2
         public Action<BeatmapInfo>? RequestPresentBeatmap { private get; init; }
 
         /// <summary>
-        /// Accepts a list of beatmaps and returns the beatmap recommended for the user.
+        /// From the provided beatmaps, return the most appropriate one for the user's skill.
         /// </summary>
-        public Func<IEnumerable<BeatmapInfo>, BeatmapInfo>? GetRecommendedBeatmap { private get; set; }
+        public Func<IEnumerable<BeatmapInfo>, BeatmapInfo>? ChooseRecommendedBeatmap { private get; init; }
 
         public const float SPACING = 3f;
 
@@ -190,7 +190,7 @@ namespace osu.Game.Screens.SelectV2
                     if (grouping.SetItems.TryGetValue(setInfo, out var items))
                     {
                         var beatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
-                        CurrentSelection = GetRecommendedBeatmap?.Invoke(beatmaps) ?? beatmaps.First();
+                        CurrentSelection = ChooseRecommendedBeatmap?.Invoke(beatmaps) ?? beatmaps.First();
                     }
 
                     return;

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -26,6 +26,11 @@ namespace osu.Game.Screens.SelectV2
     {
         public Action<BeatmapInfo>? RequestPresentBeatmap { private get; init; }
 
+        /// <summary>
+        /// Accepts a list of beatmaps and returns the beatmap recommended for the user.
+        /// </summary>
+        public Func<IEnumerable<BeatmapInfo>, BeatmapInfo>? GetRecommendedBeatmap { private get; set; }
+
         public const float SPACING = 3f;
 
         private IBindableList<BeatmapSetInfo> detachedBeatmaps = null!;
@@ -183,7 +188,10 @@ namespace osu.Game.Screens.SelectV2
                 case BeatmapSetInfo setInfo:
                     // Selecting a set isn't valid – let's re-select the first visible difficulty.
                     if (grouping.SetItems.TryGetValue(setInfo, out var items))
-                        CurrentSelection = items.Select(i => i.Model).OfType<BeatmapInfo>().First();
+                    {
+                        var beatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
+                        CurrentSelection = GetRecommendedBeatmap?.Invoke(beatmaps) ?? beatmaps.First();
+                    }
 
                     return;
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -90,6 +90,9 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private ManageCollectionsDialog? collectionsDialog { get; set; }
 
+        [Resolved]
+        private DifficultyRecommender? difficultyRecommender { get; set; }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -162,6 +165,7 @@ namespace osu.Game.Screens.SelectV2
                                                             BleedTop = FilterControl.HEIGHT_FROM_SCREEN_TOP + 5,
                                                             BleedBottom = ScreenFooter.HEIGHT + 5,
                                                             RequestPresentBeatmap = _ => OnStart(),
+                                                            GetRecommendedBeatmap = getRecommendedBeatmap,
                                                             NewItemsPresented = newItemsPresented,
                                                             RelativeSizeAxes = Axes.Both,
                                                         },
@@ -227,6 +231,13 @@ namespace osu.Game.Screens.SelectV2
 
             detailsArea.Height = wedgesContainer.DrawHeight - titleWedge.LayoutSize.Y - 4;
         }
+
+        #region Selection handling
+
+        private BeatmapInfo getRecommendedBeatmap(IEnumerable<BeatmapInfo> beatmaps)
+            => difficultyRecommender?.GetRecommendedBeatmap(beatmaps) ?? beatmaps.First();
+
+        #endregion
 
         #region Transitions
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.SelectV2
                                                             BleedTop = FilterControl.HEIGHT_FROM_SCREEN_TOP + 5,
                                                             BleedBottom = ScreenFooter.HEIGHT + 5,
                                                             RequestPresentBeatmap = _ => OnStart(),
-                                                            GetRecommendedBeatmap = getRecommendedBeatmap,
+                                                            ChooseRecommendedBeatmap = getRecommendedBeatmap,
                                                             NewItemsPresented = newItemsPresented,
                                                             RelativeSizeAxes = Axes.Both,
                                                         },


### PR DESCRIPTION
One part from old song select that hasn't been added here is preserving user selection when they select a difficulty different from recommendation then navigate a few sets away and then back to the original set. I'm not entirely sure how we can have this with the new carousel structure.

This came up from the recommendation test case in old carousel test, so I've copied that part and commented it out and left a TODO on top of it.