### PR TITLE
Add a `consistency` factor to osu!taiko diffcalc

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         public double StaminaTopStrains { get; set; }
 
         /// <summary>
-        /// The factor corresponding to the consistency ratio of a map.
+        /// The factor corresponding to the consistency of a map.
         /// </summary>
         [JsonProperty("consistency_factor")]
         public double ConsistencyFactor { get; set; }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -13,21 +13,25 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// <summary>
         /// The difficulty corresponding to the rhythm skill.
         /// </summary>
+        [JsonProperty("rhythm_difficulty")]
         public double RhythmDifficulty { get; set; }
 
         /// <summary>
         /// The difficulty corresponding to the reading skill.
         /// </summary>
+        [JsonProperty("reading_difficulty")]
         public double ReadingDifficulty { get; set; }
 
         /// <summary>
         /// The difficulty corresponding to the colour skill.
         /// </summary>
+        [JsonProperty("colour_difficulty")]
         public double ColourDifficulty { get; set; }
 
         /// <summary>
         /// The difficulty corresponding to the stamina skill.
         /// </summary>
+        [JsonProperty("stamina_difficulty")]
         public double StaminaDifficulty { get; set; }
 
         /// <summary>
@@ -36,11 +40,20 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("mono_stamina_factor")]
         public double MonoStaminaFactor { get; set; }
 
+        [JsonProperty("rhythm_peak_strains")]
         public double RhythmTopStrains { get; set; }
 
+        [JsonProperty("colour_peak_strains")]
         public double ColourTopStrains { get; set; }
 
+        [JsonProperty("stamina_peak_strains")]
         public double StaminaTopStrains { get; set; }
+
+        /// <summary>
+        /// The factor corresponding to the consistency ratio of a map.
+        /// </summary>
+        [JsonProperty("consistency_factor")]
+        public double ConsistencyFactor { get; set; }
 
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -11,6 +11,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
     public class TaikoDifficultyAttributes : DifficultyAttributes
     {
         /// <summary>
+        /// The difficulty corresponding to the mechanical skills in osu!taiko.
+        /// This includes colour and stamina combined.
+        /// </summary>
+        [JsonProperty("mechanical_difficulty")]
+        public double MechanicalDifficulty { get; set; }
+
+        /// <summary>
         /// The difficulty corresponding to the rhythm skill.
         /// </summary>
         [JsonProperty("rhythm_difficulty")]
@@ -25,13 +32,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// <summary>
         /// The difficulty corresponding to the colour skill.
         /// </summary>
-        [JsonProperty("colour_difficulty")]
         public double ColourDifficulty { get; set; }
 
         /// <summary>
         /// The difficulty corresponding to the stamina skill.
         /// </summary>
-        [JsonProperty("stamina_difficulty")]
         public double StaminaDifficulty { get; set; }
 
         /// <summary>
@@ -40,20 +45,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("mono_stamina_factor")]
         public double MonoStaminaFactor { get; set; }
 
-        [JsonProperty("rhythm_peak_strains")]
-        public double RhythmTopStrains { get; set; }
-
-        [JsonProperty("colour_peak_strains")]
-        public double ColourTopStrains { get; set; }
-
-        [JsonProperty("stamina_peak_strains")]
-        public double StaminaTopStrains { get; set; }
-
         /// <summary>
         /// The factor corresponding to the consistency of a map.
         /// </summary>
         [JsonProperty("consistency_factor")]
         public double ConsistencyFactor { get; set; }
+
+        public double StaminaTopStrains { get; set; }
 
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {
@@ -61,7 +59,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 yield return v;
 
             yield return (ATTRIB_ID_DIFFICULTY, StarRating);
+            yield return (ATTRIB_ID_MECHANICAL_DIFFICULTY, MechanicalDifficulty);
+            yield return (ATTRIB_ID_RHYTHM_DIFFICULTY, RhythmDifficulty);
+            yield return (ATTRIB_ID_READING_DIFFICULTY, ReadingDifficulty);
             yield return (ATTRIB_ID_MONO_STAMINA_FACTOR, MonoStaminaFactor);
+            yield return (ATTRIB_ID_CONSISTENCY_FACTOR, ConsistencyFactor);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
@@ -69,7 +71,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             base.FromDatabaseAttributes(values, onlineInfo);
 
             StarRating = values[ATTRIB_ID_DIFFICULTY];
+            MechanicalDifficulty = values[ATTRIB_ID_MECHANICAL_DIFFICULTY];
+            RhythmDifficulty = values[ATTRIB_ID_RHYTHM_DIFFICULTY];
+            ReadingDifficulty = values[ATTRIB_ID_READING_DIFFICULTY];
             MonoStaminaFactor = values[ATTRIB_ID_MONO_STAMINA_FACTOR];
+            ConsistencyFactor = values[ATTRIB_ID_CONSISTENCY_FACTOR];
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -115,8 +115,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double monoStaminaSkill = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaFactor = staminaSkill == 0 ? 1 : Math.Pow(monoStaminaSkill / staminaSkill, 5);
 
-            double colourDifficultStrains = colour.CountTopWeightedStrains();
-            double rhythmDifficultStrains = rhythm.CountTopWeightedStrains();
             double staminaDifficultStrains = stamina.CountTopWeightedStrains();
 
             // As we don't have pattern integration in osu!taiko, we apply the other two skills relative to rhythm.
@@ -136,18 +134,18 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double readingDifficulty = readingSkill * skillRating;
             double colourDifficulty = colourSkill * skillRating;
             double staminaDifficulty = staminaSkill * skillRating;
+            double mechanicalDifficulty = colourDifficulty + staminaDifficulty; // Mechanical difficulty is the sum of colour and stamina difficulties.
 
             TaikoDifficultyAttributes attributes = new TaikoDifficultyAttributes
             {
                 StarRating = starRating,
                 Mods = mods,
+                MechanicalDifficulty = mechanicalDifficulty,
                 RhythmDifficulty = rhythmDifficulty,
                 ReadingDifficulty = readingDifficulty,
                 ColourDifficulty = colourDifficulty,
                 StaminaDifficulty = staminaDifficulty,
                 MonoStaminaFactor = monoStaminaFactor,
-                RhythmTopStrains = rhythmDifficultStrains,
-                ColourTopStrains = colourDifficultStrains,
                 StaminaTopStrains = staminaDifficultStrains,
                 ConsistencyFactor = consistencyFactor,
                 MaxCombo = beatmap.GetMaxCombo(),

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                                 + Math.Min(Math.Max((staminaDifficultStrains - 1000) / 3700, 0), 0.15)
                                 + Math.Min(Math.Max((staminaSkill - 7.0) / 1.0, 0), 0.05);
 
-            double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax, isConvert);
+            double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax, isConvert, out double consistencyFactor);
             double starRating = rescale(combinedRating * 1.4);
 
             // Calculate proportional contribution of each skill to the combinedRating.
@@ -149,6 +149,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 RhythmTopStrains = rhythmDifficultStrains,
                 ColourTopStrains = colourDifficultStrains,
                 StaminaTopStrains = staminaDifficultStrains,
+                ConsistencyFactor = consistencyFactor,
                 MaxCombo = beatmap.GetMaxCombo(),
             };
 
@@ -162,7 +163,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// For each section, the peak strains of all separate skills are combined into a single peak strain for the section.
         /// The resulting partial rating of the beatmap is a weighted sum of the combined peaks (higher peaks are weighted more).
         /// </remarks>
-        private double combinedDifficultyValue(Rhythm rhythm, Reading reading, Colour colour, Stamina stamina, bool isRelax, bool isConvert)
+        private double combinedDifficultyValue(Rhythm rhythm, Reading reading, Colour colour, Stamina stamina, bool isRelax, bool isConvert, out double consistencyFactor)
         {
             List<double> peaks = new List<double>();
 
@@ -196,7 +197,33 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 weight *= 0.9;
             }
 
+            consistencyFactor = calculateConsistencyFactor(peaks);
+
             return difficulty;
+        }
+
+        /// <summary>
+        /// Calculates a consistency factor based on how 'spiked' the strain peaks are.
+        /// Higher values indicate more consistent difficulty, lower values indicate diff-spike heavy maps.
+        /// </summary>
+        private double calculateConsistencyFactor(List<double> peaks)
+        {
+            // If there are too few sections in a map, assume it is consistent.
+            if (peaks.Count < 3)
+                return 1.0;
+
+            List<double> sorted = peaks.OrderDescending().ToList();
+
+            double topPeak = sorted[0];
+            double secondTopPeak = sorted.Count > 1 ? sorted[1] : topPeak;
+
+            // Compute the average of the middle 50% of strain values.
+            double midAvg = sorted.Skip(sorted.Count / 4).Take(sorted.Count / 2).Average();
+
+            // A higher ratio means the top sections are much harder than the average, indicating inconsistency.
+            double spikeSeverity = (topPeak + secondTopPeak) / 2.0 / midAvg;
+
+            return 1.0 / spikeSeverity;
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -31,6 +31,10 @@ namespace osu.Game.Rulesets.Difficulty
         protected const int ATTRIB_ID_SLIDER_NESTED_SCORE_PER_OBJECT = 37;
         protected const int ATTRIB_ID_LEGACY_SCORE_BASE_MULTIPLIER = 39;
         protected const int ATTRIB_ID_MAXIMUM_LEGACY_COMBO_SCORE = 41;
+        protected const int ATTRIB_ID_MECHANICAL_DIFFICULTY = 43;
+        protected const int ATTRIB_ID_RHYTHM_DIFFICULTY = 45;
+        protected const int ATTRIB_ID_READING_DIFFICULTY = 47;
+        protected const int ATTRIB_ID_CONSISTENCY_FACTOR = 49;
 
         /// <summary>
         /// The mods which were applied to the beatmap.


### PR DESCRIPTION

- Added properties to all diffcalc attributes in osu!taiko in order for them to display in perfcalcgui, in line with other gamemodes.

Comments are self explanatory, will be used within the skill split happening soon in order to better scale reading values from maps that are consistently difficult, or inconsistent. As peaks is precalculated and this only grabs a descending list, its very minimal on performance.

Currently purely an attribute, and will need to be written to db when its respective feature pr comes out.