### PR TITLE
Fix editor player sometimes crashing because of instantiating wrong judgement result type for object

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -781,7 +781,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// Creates the <see cref="JudgementResult"/> that represents the scoring result for this <see cref="DrawableHitObject"/>.
         /// </summary>
         /// <param name="judgement">The <see cref="Judgement"/> that provides the scoring information.</param>
-        protected virtual JudgementResult CreateResult(Judgement judgement) => new JudgementResult(HitObject, judgement);
+        protected internal virtual JudgementResult CreateResult(Judgement judgement) => new JudgementResult(HitObject, judgement);
 
         private void ensureEntryHasResult()
         {

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -14,6 +14,7 @@ using osu.Game.Overlays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
@@ -75,6 +76,11 @@ namespace osu.Game.Screens.Edit.GameplayTest
             foreach (var hitObject in enumerateHitObjects(DrawableRuleset.Objects, editorState.Time))
             {
                 var judgement = hitObject.Judgement;
+                // this is very dodgy because there's no guarantee that `JudgementResult` is the correct result type for the object.
+                // however, instantiating the correct one is difficult here, because `JudgementResult`s are constructed by DHOs
+                // and because of pooling we don't *have* a DHO to use here.
+                // this basically mostly attempts to fill holes in `ScoreProcessor` tallies
+                // so that gameplay can actually complete at the end of the map when entering gameplay test midway through it, and not much else.
                 var result = new JudgementResult(hitObject, judgement)
                 {
                     Type = judgement.MaxResult,
@@ -109,30 +115,28 @@ namespace osu.Game.Screens.Edit.GameplayTest
                 return;
             }
 
-            foreach (var drawableObjectEntry in enumerateDrawableEntries(
-                         DrawableRuleset.Playfield.AllHitObjects
-                                        .Select(ho => ho.Entry)
-                                        .Where(e => e != null)
-                                        .Cast<HitObjectLifetimeEntry>(), editorState.Time))
+            foreach (var drawableObject in enumerateDrawableObjects(DrawableRuleset.Playfield.AllHitObjects, editorState.Time))
             {
-                drawableObjectEntry.Result = new JudgementResult(drawableObjectEntry.HitObject, drawableObjectEntry.HitObject.Judgement)
-                {
-                    Type = drawableObjectEntry.HitObject.Judgement.MaxResult
-                };
+                if (drawableObject.Entry == null)
+                    continue;
+
+                var result = drawableObject.CreateResult(drawableObject.HitObject.Judgement);
+                result.Type = result.Judgement.MaxResult;
+                drawableObject.Entry.Result = result;
             }
 
-            static IEnumerable<HitObjectLifetimeEntry> enumerateDrawableEntries(IEnumerable<HitObjectLifetimeEntry> entries, double cutoffTime)
+            static IEnumerable<DrawableHitObject> enumerateDrawableObjects(IEnumerable<DrawableHitObject> drawableObjects, double cutoffTime)
             {
-                foreach (var entry in entries)
+                foreach (var drawableObject in drawableObjects)
                 {
-                    foreach (var nested in enumerateDrawableEntries(entry.NestedEntries, cutoffTime))
+                    foreach (var nested in enumerateDrawableObjects(drawableObject.NestedHitObjects, cutoffTime))
                     {
                         if (nested.HitObject.GetEndTime() < cutoffTime)
                             yield return nested;
                     }
 
-                    if (entry.HitObject.GetEndTime() < cutoffTime)
-                        yield return entry;
+                    if (drawableObject.HitObject.GetEndTime() < cutoffTime)
+                        yield return drawableObject;
                 }
             }
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33231.

I'm not sure how to reproduce the instances of this reported to sentry with `Drawable{Slider,Spinner}`, but this bug is about to be made worse by `DrawableHoldNote` in mania getting its own `JudgementResult` subtype in https://github.com/ppy/osu/pull/33194 - for that one to reproduce just start gameplay test while editor is seeked to a time instant where a hold note is mid-hold.

There's possibly an argument here that `CreateResult()` should live on `HitObject` and not `DrawableHitObject`, and I'd even be partial to such an argument, but doing that would be a rather hard ruleset API break (albeit trivial one to resolve), and also may dredge up past conversations about `Judgement` and `JudgementResult` (cf. https://github.com/ppy/osu/pull/26563) that I would rather not get into again.

Notably this is not source-breaking for rulesets. It may be binary-breaking, I haven't tested.