### PR TITLE
Implement list virtualisation in multiplayer participants list

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestAddUser()
         {
-            AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 1);
+            AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.Current.Value).Distinct().Count() == 1);
 
             AddStep("add user", () => MultiplayerClient.AddUser(new APIUser
             {
@@ -50,20 +50,20 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 CoverUrl = TestResources.COVER_IMAGE_3,
             }));
 
-            AddAssert("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 2);
+            AddAssert("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.Current.Value).Distinct().Count() == 2);
         }
 
         [Test]
         public void TestAddUnresolvedUser()
         {
-            AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 1);
+            AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.Current.Value).Distinct().Count() == 1);
 
             AddStep("add non-resolvable user", () => MultiplayerClient.TestAddUnresolvedUser());
             AddUntilStep("null user added", () => MultiplayerClient.ClientRoom.AsNonNull().Users.Count(u => u.User == null) == 1);
 
-            AddUntilStep("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 2);
+            AddUntilStep("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.Current.Value).Distinct().Count() == 2);
 
-            AddStep("kick null user", () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.User.User == null)
+            AddStep("kick null user", () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.User == null)
                                                 .ChildrenOfType<ParticipantPanel.KickButton>().Single().TriggerClick());
 
             AddUntilStep("null user kicked", () => MultiplayerClient.ClientRoom.AsNonNull().Users.Count == 1);
@@ -86,7 +86,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("remove host", () => MultiplayerClient.RemoveUser(API.LocalUser.Value));
 
-            AddAssert("single panel is for second user", () => this.ChildrenOfType<ParticipantPanel>().Single().User.UserID == secondUser?.Id);
+            AddAssert("single panel is for second user", () => this.ChildrenOfType<ParticipantPanel>().Single().Current.Value.UserID == secondUser?.Id);
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddRepeatStep("increment progress", () =>
             {
-                float progress = this.ChildrenOfType<ParticipantPanel>().Single().User.BeatmapAvailability.DownloadProgress ?? 0;
+                float progress = this.ChildrenOfType<ParticipantPanel>().Single().Current.Value.BeatmapAvailability.DownloadProgress ?? 0;
                 MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(progress + RNG.NextSingle(0.1f)));
             }, 25);
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -163,13 +163,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 CoverUrl = TestResources.COVER_IMAGE_3,
             }));
 
-            AddUntilStep("first user crown visible", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(0).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
-            AddUntilStep("second user crown hidden", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(1).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
+            AddUntilStep("first user crown visible",
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 1001).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
+            AddUntilStep("second user crown hidden",
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 3).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
 
             AddStep("make second user host", () => MultiplayerClient.TransferHost(3));
 
-            AddUntilStep("first user crown hidden", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(0).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
-            AddUntilStep("second user crown visible", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(1).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
+            AddUntilStep("first user crown visible",
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 1001).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
+            AddUntilStep("second user crown hidden",
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 3).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
         }
 
         [Test]
@@ -185,9 +189,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("make second user host", () => MultiplayerClient.TransferHost(3));
             AddAssert("second user above first", () =>
             {
-                var first = this.ChildrenOfType<ParticipantPanel>().ElementAt(0);
-                var second = this.ChildrenOfType<ParticipantPanel>().ElementAt(1);
-                return second.Y < first.Y;
+                var first = this.ChildrenOfType<ParticipantPanel>().Single(u => u.Current.Value.UserID == 1001);
+                var second = this.ChildrenOfType<ParticipantPanel>().Single(u => u.Current.Value.UserID == 3);
+                return second.ScreenSpaceDrawQuad.TopLeft.Y < first.ScreenSpaceDrawQuad.TopLeft.Y;
             });
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -230,7 +230,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestManyUsers()
         {
-            const int users_count = 20;
+            const int users_count = 200;
 
             AddStep("add many users", () =>
             {
@@ -276,6 +276,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddRepeatStep("switch hosts", () => MultiplayerClient.TransferHost(RNG.Next(0, users_count)), 10);
             AddStep("give host back", () => MultiplayerClient.TransferHost(API.LocalUser.Value.Id));
+
+            AddRepeatStep("perform many random state changes at once", () =>
+            {
+                for (int i = 0; i < users_count; ++i)
+                {
+                    MultiplayerClient.ChangeUserBeatmapAvailability(i, BeatmapAvailability.LocallyAvailable());
+                    MultiplayerClient.ChangeUserState(i, RNG.NextBool() ? MultiplayerUserState.Idle : MultiplayerUserState.Ready);
+                }
+            }, 100);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -237,6 +237,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             if (client.IsNotNull())
                 client.RoomUpdated -= onRoomUpdated;
+
+            // this is a safety measure.
+            // `MultiplayerRoomUser` has equality members overridden to compare by `UserID` only.
+            // `MultiplayerClient` only delivers updates of fields values to specific object references.
+            // if this operation is not done here, in a scenario wherein a user quits and rejoins a room,
+            // it is possible for a single poolable panel to be freed and then used for the same user with the same ID,
+            // which at bindable level will lead to `current` not changing (because of the overridden equality member),
+            // which will lead to this instance not showing any updates for the user in question
+            // because it's associated with an object reference that `MultiplayerClient` is no longer updating.
+            current.SetDefault();
         }
 
         private void updateUser()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -106,10 +105,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Colour = Color4Extensions.FromHex("#F7E65D"),
                             Alpha = 0
                         },
-                        new TeamDisplay
-                        {
-                            Current = { BindTarget = Current },
-                        },
+                        new TeamDisplay { Current = Current },
                         new Container
                         {
                             RelativeSizeAxes = Axes.Both,
@@ -161,7 +157,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 18),
-                                            //Text = user?.Username ?? string.Empty
                                         },
                                         userRankText = new OsuSpriteText
                                         {
@@ -215,13 +210,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             };
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            current.BindValueChanged(_ => updateUser());
-        }
-
         protected override void PrepareForUse()
         {
             base.PrepareForUse();
@@ -235,9 +223,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         {
             base.FreeAfterUse();
 
-            if (client.IsNotNull())
-                client.RoomUpdated -= onRoomUpdated;
-
+            client.RoomUpdated -= onRoomUpdated;
             // this is a safety measure.
             // `MultiplayerRoomUser` has equality members overridden to compare by `UserID` only.
             // `MultiplayerClient` only delivers updates of fields values to specific object references.
@@ -251,13 +237,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private void updateUser()
         {
-            userCover.User = current.Value.User;
-            userAvatar.User = current.Value.User;
-            teamFlagContainer.Child = new UpdateableTeamFlag(current.Value.User?.Team)
+            var user = current.Value.User;
+
+            userCover.User = user;
+            userAvatar.User = user;
+            teamFlagContainer.Child = new UpdateableTeamFlag(user?.Team)
             {
                 Size = new Vector2(40, 20)
             };
-            username.Text = current.Value.User?.Username ?? string.Empty;
+            username.Text = user?.Username ?? string.Empty;
 
             updateState();
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -61,7 +61,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private SpriteIcon crown = null!;
 
-        private Container teamDisplayContainer = null!;
         private UserCoverBackground userCover = null!;
         private UpdateableAvatar userAvatar = null!;
         private OsuSpriteText username = null!;
@@ -107,9 +106,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Colour = Color4Extensions.FromHex("#F7E65D"),
                             Alpha = 0
                         },
-                        teamDisplayContainer = new Container
+                        new TeamDisplay
                         {
-                            AutoSizeAxes = Axes.Both,
+                            Current = { BindTarget = Current },
                         },
                         new Container
                         {
@@ -243,7 +242,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private void updateUser()
         {
             userCover.User = current.Value.User;
-            teamDisplayContainer.Child = new TeamDisplay(current.Value);
             userAvatar.User = current.Value.User;
             teamFlagContainer.Child = new UpdateableTeamFlag(current.Value.User?.Team)
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -7,12 +7,14 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -36,9 +38,17 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 {
-    public partial class ParticipantPanel : CompositeDrawable, IHasContextMenu
+    public partial class ParticipantPanel : PoolableDrawable, IHasContextMenu, IHasCurrentValue<MultiplayerRoomUser>
     {
-        public readonly MultiplayerRoomUser User;
+        public const int HEIGHT = 40;
+
+        public Bindable<MultiplayerRoomUser> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        private readonly BindableWithCurrent<MultiplayerRoomUser> current = new BindableWithCurrent<MultiplayerRoomUser>(new MultiplayerRoomUser(-1));
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -51,6 +61,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private SpriteIcon crown = null!;
 
+        private Container teamDisplayContainer = null!;
+        private UserCoverBackground userCover = null!;
+        private UpdateableAvatar userAvatar = null!;
+        private OsuSpriteText username = null!;
+        private Container teamFlagContainer = null!;
         private OsuSpriteText userRankText = null!;
         private StyleDisplayIcon userStyleDisplay = null!;
         private ModDisplay userModsDisplay = null!;
@@ -58,19 +73,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private IconButton kickButton = null!;
 
-        public ParticipantPanel(MultiplayerRoomUser user)
+        public ParticipantPanel()
         {
-            User = user;
-
             RelativeSizeAxes = Axes.X;
-            Height = 40;
+            Height = HEIGHT;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            var user = User.User;
-
             var backgroundColour = Color4Extensions.FromHex("#33413C");
 
             InternalChild = new GridContainer
@@ -96,7 +107,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Colour = Color4Extensions.FromHex("#F7E65D"),
                             Alpha = 0
                         },
-                        new TeamDisplay(User),
+                        teamDisplayContainer = new Container
+                        {
+                            AutoSizeAxes = Axes.Both,
+                        },
                         new Container
                         {
                             RelativeSizeAxes = Axes.Both,
@@ -109,13 +123,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = backgroundColour
                                 },
-                                new UserCoverBackground
+                                userCover = new UserCoverBackground
                                 {
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
                                     RelativeSizeAxes = Axes.Both,
                                     Width = 0.75f,
-                                    User = user,
                                     Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0), Color4.White.Opacity(0.25f))
                                 },
                                 new FillFlowContainer
@@ -125,33 +138,31 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                     Direction = FillDirection.Horizontal,
                                     Children = new Drawable[]
                                     {
-                                        new UpdateableAvatar
+                                        userAvatar = new UpdateableAvatar
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             RelativeSizeAxes = Axes.Both,
                                             FillMode = FillMode.Fit,
-                                            User = user
                                         },
                                         new UpdateableFlag
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             Size = new Vector2(28, 20),
-                                            CountryCode = user?.CountryCode ?? default
                                         },
-                                        new UpdateableTeamFlag(user?.Team)
+                                        teamFlagContainer = new Container
                                         {
+                                            AutoSizeAxes = Axes.Both,
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
-                                            Size = new Vector2(40, 20),
                                         },
-                                        new OsuSpriteText
+                                        username = new OsuSpriteText
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 18),
-                                            Text = user?.Username ?? string.Empty
+                                            //Text = user?.Username ?? string.Empty
                                         },
                                         userRankText = new OsuSpriteText
                                         {
@@ -198,7 +209,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Origin = Anchor.Centre,
                             Alpha = 0,
                             Margin = new MarginPadding(4),
-                            Action = () => client.KickUser(User.UserID).FireAndForget(),
+                            Action = () => client.KickUser(current.Value.UserID).FireAndForget(),
                         },
                     },
                 }
@@ -209,7 +220,37 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         {
             base.LoadComplete();
 
+            current.BindValueChanged(_ => updateUser());
+        }
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+
             client.RoomUpdated += onRoomUpdated;
+            updateUser();
+            FinishTransforms(true);
+        }
+
+        protected override void FreeAfterUse()
+        {
+            base.FreeAfterUse();
+
+            if (client.IsNotNull())
+                client.RoomUpdated -= onRoomUpdated;
+        }
+
+        private void updateUser()
+        {
+            userCover.User = current.Value.User;
+            teamDisplayContainer.Child = new TeamDisplay(current.Value);
+            userAvatar.User = current.Value.User;
+            teamFlagContainer.Child = new UpdateableTeamFlag(current.Value.User?.Team)
+            {
+                Size = new Vector2(40, 20)
+            };
+            username.Text = current.Value.User?.Username ?? string.Empty;
+
             updateState();
         }
 
@@ -222,13 +263,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             const double fade_time = 50;
 
+            var user = current.Value;
+
             if (client.Room.GetCurrentItem() is MultiplayerPlaylistItem currentItem)
             {
-                int userBeatmapId = User.BeatmapId ?? currentItem.BeatmapID;
-                int userRulesetId = User.RulesetId ?? currentItem.RulesetID;
+                int userBeatmapId = user.BeatmapId ?? currentItem.BeatmapID;
+                int userRulesetId = user.RulesetId ?? currentItem.RulesetID;
                 Ruleset? userRuleset = rulesets.GetRuleset(userRulesetId)?.CreateInstance();
 
-                int? currentModeRank = userRuleset == null ? null : User.User?.RulesetsStatistics?.GetValueOrDefault(userRuleset.ShortName)?.GlobalRank;
+                int? currentModeRank = userRuleset == null ? null : user.User?.RulesetsStatistics?.GetValueOrDefault(userRuleset.ShortName)?.GlobalRank;
                 userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
                 if (userBeatmapId == currentItem.BeatmapID && userRulesetId == currentItem.RulesetID)
@@ -238,12 +281,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
                 // If the mods are updated at the end of the frame, the flow container will skip a reflow cycle: https://github.com/ppy/osu-framework/issues/4187
                 // This looks particularly jarring here, so re-schedule the update to that start of our frame as a fix.
-                Schedule(() => userModsDisplay.Current.Value = userRuleset == null ? Array.Empty<Mod>() : User.Mods.Select(m => m.ToMod(userRuleset)).ToList());
+                Schedule(() => userModsDisplay.Current.Value = userRuleset == null ? Array.Empty<Mod>() : user.Mods.Select(m => m.ToMod(userRuleset)).ToList());
             }
 
-            userStateDisplay.UpdateStatus(User.State, User.BeatmapAvailability);
+            userStateDisplay.UpdateStatus(user.State, user.BeatmapAvailability);
 
-            if (User.BeatmapAvailability.State == DownloadState.LocallyAvailable && User.State != MultiplayerUserState.Spectating)
+            if (user.BeatmapAvailability.State == DownloadState.LocallyAvailable && user.State != MultiplayerUserState.Spectating)
             {
                 userModsDisplay.FadeIn(fade_time);
                 userStyleDisplay.FadeIn(fade_time);
@@ -254,8 +297,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 userStyleDisplay.FadeOut(fade_time);
             }
 
-            kickButton.Alpha = client.IsHost && !User.Equals(client.LocalUser) ? 1 : 0;
-            crown.Alpha = client.Room.Host?.Equals(User) == true ? 1 : 0;
+            kickButton.Alpha = client.IsHost && !user.Equals(client.LocalUser) ? 1 : 0;
+            crown.Alpha = client.Room.Host?.Equals(user) == true ? 1 : 0;
         }
 
         public MenuItem[]? ContextMenuItems
@@ -265,15 +308,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 if (client.Room == null)
                     return null;
 
+                var user = current.Value;
+
                 // If the local user is targetted.
-                if (User.UserID == api.LocalUser.Value.Id)
+                if (user.UserID == api.LocalUser.Value.Id)
                     return null;
 
                 // If the local user is not the host of the room.
                 if (client.Room.Host?.UserID != api.LocalUser.Value.Id)
                     return null;
 
-                int targetUser = User.UserID;
+                int targetUser = user.UserID;
 
                 return new MenuItem[]
                 {
@@ -295,14 +340,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     })
                 };
             }
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (client.IsNotNull())
-                client.RoomUpdated -= onRoomUpdated;
         }
 
         public partial class KickButton : IconButton


### PR DESCRIPTION
Yesterday's "let's break lazer" stream has mostly resulted in no particularly bad breakage to the best of my knowledge, aside from things we mostly know which is that aspire is still broken and that spectator server is still somewhat bandwidth-inefficient. However people were also reporting lag spikes from people toggling ready state as well as ["memory leaks"](https://discord.com/channels/188630481301012481/1097318920991559880/1375151614045982781).

I believe that both track down to the fact that if the participants list is long enough to start being scrollable, panels offscreen start accumulating transforms. List virtualisation & pooling addresses this because in such cases the panels are no longer in the drawable hierarchy and updating, therefore not accumulating transforms.

In profiling, using https://github.com/ppy/osu/commit/40a412977637b5dbccef433df308497e34e50648:

| before | after |
| :-: | :-: |
| ![Screenshot 2025-05-23 at 10 42 28](https://github.com/user-attachments/assets/d240cd6c-ac18-4f98-beea-312af76e7f83) | ![Screenshot 2025-05-23 at 10 44 20](https://github.com/user-attachments/assets/607dadc8-f48c-477e-960e-e570d752bcd2) |