### PR TITLE
Partial support for windowed/borderless resolution modes (issue #17999)

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Drawing;
 using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
@@ -129,6 +130,9 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.CursorRotation, true);
 
             SetDefault(OsuSetting.MenuParallax, true);
+
+            SetDefault(OsuSetting.VirtualResolution, new Size(1366, 768));
+
 
             // See https://stackoverflow.com/a/63307411 for default sourcing.
             SetDefault(OsuSetting.Prefer24HourTime, !CultureInfoHelper.SystemCulture.DateTimeFormat.ShortTimePattern.Contains(@"tt"));
@@ -380,6 +384,7 @@ namespace osu.Game.Configuration
         MenuTips,
         CursorRotation,
         MenuParallax,
+        VirtualResolution,
         Prefer24HourTime,
         BeatmapDetailTab,
         BeatmapDetailModsFilter,


### PR DESCRIPTION
## Summary

This PR addresses [#17999]  which concerns adding resolution changes for windowed and borderless modes. 

## Changes

- Adds a **virtual resolution** setting for custom scaling in windowed and borderless modes.
- Integrates the setting into the settings UI with a dropdown.
- Hides the dropdown when in fullscreen mode.
- Dynamically applies the resolution change on selection.
- Resets the virtual resolution when switching to fullscreen.

## Implementation Notes

- The virtual resolution is stored as a 'System.Drawing.Size' in the configuration.
- No changes are made to osu-framework config to minimize the scope of this PR.
- **This is a small step** toward full resolution control, not a final solution.

## Known Limitations
- The main menu and settings screen are not fully confined within the virtual container and may overflow the defined resolution area.
-  No aspect-ratio enforcement is implemented, allowing users to select resolutions that may distort the layout.
- Mouse cursor confinement within the virtual bounds is not currently handled.

![menu](https://github.com/user-attachments/assets/246b4bdb-b7b5-412e-a677-337217dbfd4d)
![ingame_cursor](https://github.com/user-attachments/assets/08243783-3ad7-4d38-b745-056cf070b8a9)
![settings](https://github.com/user-attachments/assets/068ae444-6dcc-4f5e-8fbd-b5d0ff832893)
