### PR TITLE
Use stacked position when determining distance snap

### DIFF
--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapProcessor.cs
@@ -15,7 +15,11 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
 {
     public class OsuBeatmapProcessor : BeatmapProcessor
     {
-        private const int stack_distance = 3;
+        /// <summary>
+        /// The maximum distance between the end of one object and the start of another
+        /// which allows the objects to be stacked on top of another.
+        /// </summary>
+        public const int STACK_DISTANCE = 3;
 
         public OsuBeatmapProcessor(IBeatmap beatmap)
             : base(beatmap)
@@ -93,8 +97,8 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                             // We are no longer within stacking range of the next object.
                             break;
 
-                        if (Vector2Extensions.Distance(stackBaseObject.Position, objectN.Position) < stack_distance
-                            || (stackBaseObject is Slider && Vector2Extensions.Distance(stackBaseObject.EndPosition, objectN.Position) < stack_distance))
+                        if (Vector2Extensions.Distance(stackBaseObject.Position, objectN.Position) < STACK_DISTANCE
+                            || (stackBaseObject is Slider && Vector2Extensions.Distance(stackBaseObject.EndPosition, objectN.Position) < STACK_DISTANCE))
                         {
                             stackBaseIndex = n;
 
@@ -163,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                          *        o <- hitCircle has stack of -1
                          *         o <- hitCircle has stack of -2
                          */
-                        if (objectN is Slider && Vector2Extensions.Distance(objectN.EndPosition, objectI.Position) < stack_distance)
+                        if (objectN is Slider && Vector2Extensions.Distance(objectN.EndPosition, objectI.Position) < STACK_DISTANCE)
                         {
                             int offset = objectI.StackHeight - objectN.StackHeight + 1;
 
@@ -171,7 +175,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                             {
                                 // For each object which was declared under this slider, we will offset it to appear *below* the slider end (rather than above).
                                 OsuHitObject objectJ = hitObjects[j];
-                                if (Vector2Extensions.Distance(objectN.EndPosition, objectJ.Position) < stack_distance)
+                                if (Vector2Extensions.Distance(objectN.EndPosition, objectJ.Position) < STACK_DISTANCE)
                                     objectJ.StackHeight -= offset;
                             }
 
@@ -180,7 +184,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                             break;
                         }
 
-                        if (Vector2Extensions.Distance(objectN.Position, objectI.Position) < stack_distance)
+                        if (Vector2Extensions.Distance(objectN.Position, objectI.Position) < STACK_DISTANCE)
                         {
                             // Keep processing as if there are no sliders.  If we come across a slider, this gets cancelled out.
                             //NOTE: Sliders with start positions stacking are a special case that is also handled here.
@@ -204,7 +208,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                             // We are no longer within stacking range of the previous object.
                             break;
 
-                        if (Vector2Extensions.Distance(objectN.EndPosition, objectI.Position) < stack_distance)
+                        if (Vector2Extensions.Distance(objectN.EndPosition, objectI.Position) < STACK_DISTANCE)
                         {
                             objectN.StackHeight = objectI.StackHeight + 1;
                             objectI = objectN;
@@ -245,12 +249,12 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                     // Effects of this can be seen on https://osu.ppy.sh/beatmapsets/243#osu/1146 at sliders around 86647 ms, where
                     // if we use `EndTime` here it would result in unexpected stacking.
 
-                    if (Vector2Extensions.Distance(hitObjects[j].Position, currHitObject.Position) < stack_distance)
+                    if (Vector2Extensions.Distance(hitObjects[j].Position, currHitObject.Position) < STACK_DISTANCE)
                     {
                         currHitObject.StackHeight++;
                         startTime = hitObjects[j].StartTime;
                     }
-                    else if (Vector2Extensions.Distance(hitObjects[j].Position, position2) < stack_distance)
+                    else if (Vector2Extensions.Distance(hitObjects[j].Position, position2) < STACK_DISTANCE)
                     {
                         // Case for sliders - bump notes down and right, rather than up and left.
                         sliderStack++;

--- a/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             var lastObjectWithVelocity = EditorBeatmap.HitObjects.TakeWhile(ho => ho != after).OfType<IHasSliderVelocity>().LastOrDefault();
 
             float expectedDistance = DurationToDistance(after.StartTime - before.GetEndTime(), before.StartTime, lastObjectWithVelocity);
-            float actualDistance = Vector2.Distance(((OsuHitObject)before).EndPosition, ((OsuHitObject)after).StackedPosition);
+            float actualDistance = Vector2.Distance(((OsuHitObject)before).StackedEndPosition, ((OsuHitObject)after).StackedPosition);
 
             return actualDistance / expectedDistance;
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
@@ -7,6 +7,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
@@ -16,8 +17,9 @@ namespace osu.Game.Rulesets.Osu.Edit
     {
         public override double ReadCurrentDistanceSnap(HitObject before, HitObject after)
         {
-            // Check to see if before and after HitObjects exist within the same stack.
-            if (Vector2.Distance(((OsuHitObject)before).EndPosition, ((OsuHitObject)after).Position) < 0.01)
+            // If the pair of hit objects in question here could feasibly be on the same stack, do not provide a distance snap value -
+            // they're likely too close to one another for the distance snap value to be useful anyway even if they somehow are not.
+            if (Vector2.Distance(((OsuHitObject)before).EndPosition, ((OsuHitObject)after).Position) < OsuBeatmapProcessor.STACK_DISTANCE)
                 return 0;
 
             var lastObjectWithVelocity = EditorBeatmap.HitObjects.TakeWhile(ho => ho != after).OfType<IHasSliderVelocity>().LastOrDefault();

--- a/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
@@ -17,13 +17,13 @@ namespace osu.Game.Rulesets.Osu.Edit
         public override double ReadCurrentDistanceSnap(HitObject before, HitObject after)
         {
             // Check to see if before and after HitObjects exist within the same stack.
-            if ((((OsuHitObject)before).EndPosition - ((OsuHitObject)after).Position).Length < 0.01)
+            if (Vector2.Distance(((OsuHitObject)before).EndPosition, ((OsuHitObject)after).Position) < 0.01)
                 return 0;
 
             var lastObjectWithVelocity = EditorBeatmap.HitObjects.TakeWhile(ho => ho != after).OfType<IHasSliderVelocity>().LastOrDefault();
 
             float expectedDistance = DurationToDistance(after.StartTime - before.GetEndTime(), before.StartTime, lastObjectWithVelocity);
-            float actualDistance = (((OsuHitObject)after).StackedPosition - ((OsuHitObject)before).EndPosition).Length;
+            float actualDistance = Vector2.Distance(((OsuHitObject)before).EndPosition, ((OsuHitObject)after).StackedPosition);
 
             return actualDistance / expectedDistance;
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
@@ -16,10 +16,14 @@ namespace osu.Game.Rulesets.Osu.Edit
     {
         public override double ReadCurrentDistanceSnap(HitObject before, HitObject after)
         {
+            // Check to see if before and after HitObjects exist within the same stack.
+            if ((((OsuHitObject)before).EndPosition - ((OsuHitObject)after).Position).Length < 0.01)
+                return 0;
+
             var lastObjectWithVelocity = EditorBeatmap.HitObjects.TakeWhile(ho => ho != after).OfType<IHasSliderVelocity>().LastOrDefault();
 
             float expectedDistance = DurationToDistance(after.StartTime - before.GetEndTime(), before.StartTime, lastObjectWithVelocity);
-            float actualDistance = Vector2.Distance(((OsuHitObject)before).EndPosition, ((OsuHitObject)after).Position);
+            float actualDistance = (((OsuHitObject)after).StackedPosition - ((OsuHitObject)before).EndPosition).Length;
 
             return actualDistance / expectedDistance;
         }


### PR DESCRIPTION
Fixes #32738

OsuDistanceSnapProvider was initially using Position when determining the actual distance between two objects. Since all objects within a stack share the exact same position (which is the position of the "end" object of a stack), when trying to get the distance between a "before" object and an "after" object that's at the start of a stack, it would actually provide the distance snap between the "before" object and the object at the end of the stack (which breaks precedent established in osu!stable.)

I modified it to instead use StackedPosition to remedy this. I also added some logic to check if the two objects exist within the same stack (minor note, I ran into an issue where objects in the same stack may have minute differences in their Position values, which is why I'm checking if the length is really small rather than checking if the two objects have equal positions), in which case we can just do an early return.


## Screenshots
### Before
![Screenshot From 2025-05-23 15-56-27](https://github.com/user-attachments/assets/95a2740c-dbfd-4968-8c75-e39f5099313a)

### After
![Screenshot From 2025-05-23 15-54-57](https://github.com/user-attachments/assets/aa2bc107-3291-4ee3-9a09-c7088783c12d)


