### PR TITLE
Make concurrent object check ruleset specific

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBeatmapVerifier.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Catch.Edit.Checks;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Catch.Edit
@@ -13,7 +14,11 @@ namespace osu.Game.Rulesets.Catch.Edit
     {
         private readonly List<ICheck> checks = new List<ICheck>
         {
+            // Compose
             new CheckBananaShowerGap(),
+            new CheckConcurrentObjects(),
+
+            // Settings
             new CheckCatchAbnormalDifficultySettings(),
         };
 

--- a/osu.Game.Rulesets.Mania.Tests/Editor/Checks/CheckManiaConcurrentObjectsTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/Checks/CheckManiaConcurrentObjectsTest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Rulesets.Mania.Edit.Checks;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Rulesets.Mania.Tests.Editor.Checks
+{
+    [TestFixture]
+    public class CheckManiaConcurrentObjectsTest
+    {
+        private CheckConcurrentObjects check = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckManiaConcurrentObjects();
+        }
+
+        [Test]
+        public void TestHoldNotesSeparateOnSameColumn()
+        {
+            assertOk(new List<HitObject>
+            {
+                createHoldNote(startTime: 100, endTime: 400.75d, column: 1),
+                createHoldNote(startTime: 500, endTime: 900.75d, column: 1)
+            });
+        }
+
+        [Test]
+        public void TestHoldNotesConcurrentOnDifferentColumns()
+        {
+            assertOk(new List<HitObject>
+            {
+                createHoldNote(startTime: 100, endTime: 400.75d, column: 1),
+                createHoldNote(startTime: 300, endTime: 700.75d, column: 2)
+            });
+        }
+
+        [Test]
+        public void TestHoldNotesConcurrentOnSameColumn()
+        {
+            assertConcurrentSame(new List<HitObject>
+            {
+                createHoldNote(startTime: 100, endTime: 400.75d, column: 1),
+                createHoldNote(startTime: 300, endTime: 700.75d, column: 1)
+            });
+        }
+
+        private void assertOk(List<HitObject> hitobjects)
+        {
+            Assert.That(check.Run(getContext(hitobjects)), Is.Empty);
+        }
+
+        private void assertConcurrentSame(List<HitObject> hitobjects, int count = 1)
+        {
+            var issues = check.Run(getContext(hitobjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(count));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentSame));
+        }
+
+        private BeatmapVerifierContext getContext(List<HitObject> hitobjects)
+        {
+            var beatmap = new Beatmap<HitObject> { HitObjects = hitobjects };
+            return new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+        }
+
+        private HoldNote createHoldNote(double startTime, double endTime, int column)
+        {
+            return new HoldNote
+            {
+                StartTime = startTime,
+                EndTime = endTime,
+                Column = column
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Checks
     public class CheckManiaConcurrentObjects : CheckConcurrentObjects
     {
         // Mania hitobjects are only considered concurrent if they also share the same column.
-        protected override bool ConcurrentCondition(HitObject first, HitObject second) => (first as IHasColumn)?.Column == (second as IHasColumn)?.Column;
+        protected override bool ConcurrencyPrecondition(HitObject first, HitObject second)
+            => (first as IHasColumn)?.Column == (second as IHasColumn)?.Column;
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Checks
     public class CheckManiaConcurrentObjects : CheckConcurrentObjects
     {
         // Mania hitobjects are only considered concurrent if they also share the same column.
-        protected override bool ConcurrentCondition(HitObject first, HitObject second) => (first as IHasColumn)?.Column != (second as IHasColumn)?.Column;
+        protected override bool ConcurrentCondition(HitObject first, HitObject second) => (first as IHasColumn)?.Column == (second as IHasColumn)?.Column;
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -1,16 +1,43 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
-using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Rulesets.Mania.Edit.Checks
 {
     public class CheckManiaConcurrentObjects : CheckConcurrentObjects
     {
-        // Mania hitobjects are only considered concurrent if they also share the same column.
-        protected override bool ConcurrencyPrecondition(HitObject first, HitObject second)
-            => (first as IHasColumn)?.Column == (second as IHasColumn)?.Column;
+        public override IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            var hitObjects = context.Beatmap.HitObjects;
+
+            for (int i = 0; i < hitObjects.Count - 1; ++i)
+            {
+                var hitobject = hitObjects[i];
+
+                for (int j = i + 1; j < hitObjects.Count; ++j)
+                {
+                    var nextHitobject = hitObjects[j];
+
+                    // Mania hitobjects are only considered concurrent if they also share the same column.
+                    if ((hitobject as IHasColumn)?.Column != (nextHitobject as IHasColumn)?.Column)
+                        continue;
+
+                    // Two hitobjects cannot be concurrent without also being concurrent with all objects in between.
+                    // So if the next object is not concurrent, then we know no future objects will be either.
+                    if (!AreConcurrent(hitobject, nextHitobject))
+                        break;
+
+                    if (hitobject.GetType() == nextHitobject.GetType())
+                        yield return new IssueTemplateConcurrentSame(this).Create(hitobject, nextHitobject);
+                    else
+                        yield return new IssueTemplateConcurrentDifferent(this).Create(hitobject, nextHitobject);
+                }
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Rulesets.Mania.Edit.Checks
+{
+    public class CheckManiaConcurrentObjects : CheckConcurrentObjects
+    {
+        // Mania hitobjects are only considered concurrent if they also share the same column.
+        protected override bool ConcurrentCondition(HitObject first, HitObject second) => (first as IHasColumn)?.Column != (second as IHasColumn)?.Column;
+    }
+}

--- a/osu.Game.Rulesets.Mania/Edit/ManiaBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaBeatmapVerifier.cs
@@ -13,6 +13,9 @@ namespace osu.Game.Rulesets.Mania.Edit
     {
         private readonly List<ICheck> checks = new List<ICheck>
         {
+            // Compose
+            new CheckManiaConcurrentObjects(),
+
             // Settings
             new CheckKeyCount(),
             new CheckManiaAbnormalDifficultySettings(),

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Osu.Edit.Checks;
 
@@ -16,6 +17,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             // Compose
             new CheckOffscreenObjects(),
             new CheckTooShortSpinners(),
+            new CheckConcurrentObjects(),
 
             // Spread
             new CheckTimeDistanceEquality(),

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoBeatmapVerifier.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Taiko.Edit.Checks;
 
@@ -13,6 +14,10 @@ namespace osu.Game.Rulesets.Taiko.Edit
     {
         private readonly List<ICheck> checks = new List<ICheck>
         {
+            // Compose
+            new CheckConcurrentObjects(),
+
+            // Settings
             new CheckTaikoAbnormalDifficultySettings(),
         };
 

--- a/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
@@ -114,36 +114,6 @@ namespace osu.Game.Tests.Editing.Checks
             Assert.That(issues.Any(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentSame));
         }
 
-        [Test]
-        public void TestHoldNotesSeparateOnSameColumn()
-        {
-            assertOk(new List<HitObject>
-            {
-                getHoldNoteMock(startTime: 100, endTime: 400.75d, column: 1).Object,
-                getHoldNoteMock(startTime: 500, endTime: 900.75d, column: 1).Object
-            });
-        }
-
-        [Test]
-        public void TestHoldNotesConcurrentOnDifferentColumns()
-        {
-            assertOk(new List<HitObject>
-            {
-                getHoldNoteMock(startTime: 100, endTime: 400.75d, column: 1).Object,
-                getHoldNoteMock(startTime: 300, endTime: 700.75d, column: 2).Object
-            });
-        }
-
-        [Test]
-        public void TestHoldNotesConcurrentOnSameColumn()
-        {
-            assertConcurrentSame(new List<HitObject>
-            {
-                getHoldNoteMock(startTime: 100, endTime: 400.75d, column: 1).Object,
-                getHoldNoteMock(startTime: 300, endTime: 700.75d, column: 1).Object
-            });
-        }
-
         private Mock<Slider> getSliderMock(double startTime, double endTime, int repeats = 0)
         {
             var mock = new Mock<Slider>();

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -36,7 +36,6 @@ namespace osu.Game.Rulesets.Edit
 
             // Compose
             new CheckUnsnappedObjects(),
-            new CheckConcurrentObjects(),
             new CheckZeroLengthObjects(),
             new CheckDrainLength(),
             new CheckUnusedAudioAtEnd(),

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -20,13 +20,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateConcurrentDifferent(this)
         };
 
-        /// <summary>
-        /// The conditions that must hold true for any two hitobjects to be considered for the concurrency check.
-        /// </summary>
-        /// <returns>Whether the two hitobjects could be concurrent.</returns>
-        protected virtual bool ConcurrencyPrecondition(HitObject first, HitObject second) => true;
-
-        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        public virtual IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
             var hitObjects = context.Beatmap.HitObjects;
 
@@ -38,13 +32,9 @@ namespace osu.Game.Rulesets.Edit.Checks
                 {
                     var nextHitobject = hitObjects[j];
 
-                    // Some rulesets impose additional preconditions for concurrency, such as Mania only considering hitobjects in the same column.
-                    if (!ConcurrencyPrecondition(hitobject, nextHitobject))
-                        continue;
-
                     // Two hitobjects cannot be concurrent without also being concurrent with all objects in between.
                     // So if the next object is not concurrent, then we know no future objects will be either.
-                    if (!areConcurrent(hitobject, nextHitobject))
+                    if (!AreConcurrent(hitobject, nextHitobject))
                         break;
 
                     if (hitobject.GetType() == nextHitobject.GetType())
@@ -55,7 +45,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             }
         }
 
-        private bool areConcurrent(HitObject hitobject, HitObject nextHitobject) => nextHitobject.StartTime <= hitobject.GetEndTime() + ms_leniency;
+        protected bool AreConcurrent(HitObject hitobject, HitObject nextHitobject) => nextHitobject.StartTime <= hitobject.GetEndTime() + ms_leniency;
 
         public abstract class IssueTemplateConcurrent : IssueTemplate
         {

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Rulesets.Edit.Checks
 {
@@ -21,6 +20,12 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateConcurrentDifferent(this)
         };
 
+        /// <summary>
+        /// Determines whether two hitobjects can be considered concurrent based on ruleset requirements.
+        /// </summary>
+        /// <returns>Whether the two hitobjects can be concurrent.</returns>
+        protected virtual bool ConcurrentCondition(HitObject first, HitObject second) => true;
+
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
             var hitObjects = context.Beatmap.HitObjects;
@@ -33,9 +38,8 @@ namespace osu.Game.Rulesets.Edit.Checks
                 {
                     var nextHitobject = hitObjects[j];
 
-                    // Accounts for rulesets with hitobjects separated by columns, such as Mania.
-                    // In these cases we only care about concurrent objects within the same column.
-                    if ((hitobject as IHasColumn)?.Column != (nextHitobject as IHasColumn)?.Column)
+                    // Some rulesets impose additional requirements for concurrency, such as Mania only considering hitobjects in the same column.
+                    if (!ConcurrentCondition(hitobject, nextHitobject))
                         continue;
 
                     // Two hitobjects cannot be concurrent without also being concurrent with all objects in between.

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -21,10 +21,10 @@ namespace osu.Game.Rulesets.Edit.Checks
         };
 
         /// <summary>
-        /// Determines whether two hitobjects can be considered concurrent based on ruleset requirements.
+        /// The conditions that must hold true for any two hitobjects to be considered for the concurrency check.
         /// </summary>
-        /// <returns>Whether the two hitobjects can be concurrent.</returns>
-        protected virtual bool ConcurrentCondition(HitObject first, HitObject second) => true;
+        /// <returns>Whether the two hitobjects could be concurrent.</returns>
+        protected virtual bool ConcurrencyPrecondition(HitObject first, HitObject second) => true;
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
@@ -38,8 +38,8 @@ namespace osu.Game.Rulesets.Edit.Checks
                 {
                     var nextHitobject = hitObjects[j];
 
-                    // Some rulesets impose additional requirements for concurrency, such as Mania only considering hitobjects in the same column.
-                    if (!ConcurrentCondition(hitobject, nextHitobject))
+                    // Some rulesets impose additional preconditions for concurrency, such as Mania only considering hitobjects in the same column.
+                    if (!ConcurrencyPrecondition(hitobject, nextHitobject))
                         continue;
 
                     // Two hitobjects cannot be concurrent without also being concurrent with all objects in between.


### PR DESCRIPTION
Closes discussion #32904.

The check for concurrent hitobjects worked under the assumption that all rulesets aside from mania cannot have concurrent objects. The check had a hardcoded exception specifically for Mania.

This change makes it so that rulesets can specify additional concurrency conditions by overriding `ConcurrencyCondition`. [(Similar to FailCondition)](https://github.com/ppy/osu/blob/48fe2a672340902d76d96873bdcc9592be2ac126/osu.Game/Rulesets/Mods/ModFailCondition.cs#L48)

In order to allow rulesets to provide their own implementation of the check, this check has been moved out of the ruleset agnostic `BeatmapVerifier`, and moved into each of the ruleset specific `{ruleset}BeatmapVerifier`.

Edit: ~~Aware of failing test's relevancy, will look into.~~ Done. 