### PR TITLE
SongSelectV2: Hook up screen to carousel and move selection logic up one level

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -108,7 +108,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                 Carousel = new TestBeatmapCarousel
                                 {
                                     NewItemsPresented = () => NewItemsPresentedInvocationCount++,
-                                    ChooseRecommendedBeatmap = beatmaps => BeatmapRecommendationFunction?.Invoke(beatmaps) ?? beatmaps.First(),
+                                    RequestSelection = b => Carousel.CurrentSelection = b,
+                                    RequestRecommendedSelection = beatmaps => Carousel.CurrentSelection = BeatmapRecommendationFunction?.Invoke(beatmaps) ?? beatmaps.First(),
                                     BleedTop = 50,
                                     BleedBottom = 50,
                                     Anchor = Anchor.Centre,

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                             {
                                 Carousel = new TestBeatmapCarousel
                                 {
-                                    NewItemsPresented = () => NewItemsPresentedInvocationCount++,
+                                    NewItemsPresented = _ => NewItemsPresentedInvocationCount++,
                                     RequestSelection = b => Carousel.CurrentSelection = b,
                                     RequestRecommendedSelection = beatmaps => Carousel.CurrentSelection = BeatmapRecommendationFunction?.Invoke(beatmaps) ?? beatmaps.First(),
                                     BleedTop = 50,

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -37,10 +37,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddAssert("beatmap imported", () => Beatmaps.GetAllUsableBeatmapSets().Any(), () => Is.True);
 
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
             AddAssert("beatmap selected", () => !Beatmap.IsDefault);
 
             AddStep("import score", () =>
@@ -91,11 +87,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             ImportBeatmapForRuleset(0);
 
             AddAssert("beatmap imported", () => Beatmaps.GetAllUsableBeatmapSets().Any(), () => Is.True);
-
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
             AddAssert("beatmap selected", () => !Beatmap.IsDefault);
 
             AddStep("press shift-delete", () =>
@@ -254,11 +245,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             ImportBeatmapForRuleset(0);
 
             LoadSongSelect();
-
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
             AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
             AddAssert("beatmap selected", () => !Beatmap.IsDefault);
 
@@ -284,11 +270,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             ImportBeatmapForRuleset(0);
 
             LoadSongSelect();
-
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
             AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
             AddAssert("beatmap selected", () => !Beatmap.IsDefault);
 
@@ -316,11 +297,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             ImportBeatmapForRuleset(0);
 
             LoadSongSelect();
-
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
             AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
             AddAssert("beatmap selected", () => !Beatmap.IsDefault);
 
@@ -461,11 +437,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             LoadSongSelect();
 
             ImportBeatmapForRuleset(0);
-
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
             AddAssert("options enabled", () => this.ChildrenOfType<FooterButtonOptions>().Single().Enabled.Value);
 
             AddStep("click", () => this.ChildrenOfType<FooterButtonOptions>().Single().TriggerClick());
@@ -523,16 +494,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             ImportBeatmapForRuleset(0);
 
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
-
             AddAssert("options enabled", () => this.ChildrenOfType<FooterButtonOptions>().Single().Enabled.Value);
             AddStep("delete all beatmaps", () => Beatmaps.Delete());
 
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
             AddAssert("beatmap selected", () => !Beatmap.IsDefault);
             AddStep("select no beatmap", () => Beatmap.SetDefault());
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -254,11 +254,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             checkMatchedBeatmaps(3);
 
-            // song select should automatically select the beatmap for us but this is not implemented yet.
-            // todo: remove when that's the case.
-            AddAssert("no beatmap selected", () => Beatmap.IsDefault);
-            AddStep("select beatmap", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().Single().Beatmaps.First()));
-
             AddStep("hide", () => Beatmaps.Hide(Beatmap.Value.BeatmapInfo));
 
             checkMatchedBeatmaps(2);

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -90,6 +90,12 @@ namespace osu.Game.Beatmaps
             return ID == other.ID;
         }
 
+        public override int GetHashCode()
+        {
+            // ReSharper disable once NonReadonlyMemberInGetHashCode
+            return ID.GetHashCode();
+        }
+
         public override string ToString() => Metadata.GetDisplayString();
 
         public bool Equals(IBeatmapSetInfo? other) => other is BeatmapSetInfo b && Equals(b);

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// Called after a filter operation or change in items results in the visible carousel items changing.
         /// </summary>
-        public Action? NewItemsPresented { private get; init; }
+        public Action<IEnumerable<CarouselItem>>? NewItemsPresented { private get; init; }
 
         /// <summary>
         /// Height of the area above the carousel that should be treated as visible due to transparency of elements in front of it.
@@ -318,7 +318,7 @@ namespace osu.Game.Graphics.Carousel
                 if (!Scroll.UserScrolling)
                     scrollToSelection();
 
-                NewItemsPresented?.Invoke();
+                NewItemsPresented?.Invoke(carouselItems);
             });
 
             return items;

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -27,9 +27,14 @@ namespace osu.Game.Screens.SelectV2
         public Action<BeatmapInfo>? RequestPresentBeatmap { private get; init; }
 
         /// <summary>
-        /// From the provided beatmaps, return the most appropriate one for the user's skill.
+        /// From the provided beatmaps, select the most appropriate one for the user's skill.
         /// </summary>
-        public Func<IEnumerable<BeatmapInfo>, BeatmapInfo>? ChooseRecommendedBeatmap { private get; init; }
+        public required Action<IEnumerable<BeatmapInfo>> RequestRecommendedSelection { private get; init; }
+
+        /// <summary>
+        /// Selection requested for the provided beatmap.
+        /// </summary>
+        public required Action<BeatmapInfo> RequestSelection { private get; init; }
 
         public const float SPACING = 3f;
 
@@ -139,7 +144,7 @@ namespace osu.Game.Screens.SelectV2
                             // TODO: should this exist in song select instead of here?
                             // we need to ensure the global beatmap is also updated alongside changes.
                             if (CurrentSelection != null && CheckModelEquality(beatmap, CurrentSelection))
-                                CurrentSelection = matchingNewBeatmap;
+                                RequestSelection(matchingNewBeatmap);
 
                             Items.ReplaceRange(previousIndex, 1, [matchingNewBeatmap]);
                             newSetBeatmaps.Remove(matchingNewBeatmap);
@@ -190,7 +195,7 @@ namespace osu.Game.Screens.SelectV2
                     if (grouping.SetItems.TryGetValue(setInfo, out var items))
                     {
                         var beatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
-                        CurrentSelection = ChooseRecommendedBeatmap?.Invoke(beatmaps) ?? beatmaps.First();
+                        RequestRecommendedSelection(beatmaps);
                     }
 
                     return;
@@ -202,7 +207,7 @@ namespace osu.Game.Screens.SelectV2
                         return;
                     }
 
-                    CurrentSelection = beatmapInfo;
+                    RequestSelection(beatmapInfo);
                     return;
             }
         }

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmap = (BeatmapInfo)Item.Model;
 
-            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, 200);
+            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(_ => updateDisplay(), true);
         }
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -245,7 +245,7 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmap = (BeatmapInfo)Item.Model;
 
-            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, 200);
+            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(_ => updateDisplay(), true);
         }
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -341,6 +341,9 @@ namespace osu.Game.Screens.SelectV2
 
         private void selectBeatmap(WorkingBeatmap beatmap)
         {
+            if (beatmap.BeatmapInfo.BeatmapSet!.Protected)
+                return;
+
             carousel.CurrentSelection = beatmap.BeatmapInfo;
 
             Beatmap.Value = beatmap;
@@ -377,9 +380,13 @@ namespace osu.Game.Screens.SelectV2
             modSelectOverlay.Beatmap.BindTo(Beatmap);
             modSelectOverlay.SelectedMods.BindTo(Mods);
 
-            selectBeatmap(Beatmap.Value);
-
             beginLooping();
+
+            // force reselection if entering song select with a protected beatmap
+            if (Beatmap.Value.BeatmapInfo.BeatmapSet!.Protected)
+                Beatmap.SetDefault();
+            else
+                selectBeatmap(Beatmap.Value);
         }
 
         public override void OnResuming(ScreenTransitionEvent e)
@@ -401,6 +408,11 @@ namespace osu.Game.Screens.SelectV2
             modSelectOverlay.SelectedMods.BindTo(Mods);
 
             beginLooping();
+
+            if (Beatmap.Value.BeatmapInfo.BeatmapSet!.Protected)
+                Beatmap.SetDefault();
+            else
+                selectBeatmap(Beatmap.Value);
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.SelectV2
     [Cached(typeof(ISongSelect))]
     public abstract partial class SongSelect : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, ISongSelect
     {
-        // this is intentionally slightly higher than key repeat, but low enough to not impeded user experience.
+        // this is intentionally slightly higher than key repeat, but low enough to not impede user experience.
         // this avoids rapid churn loading when iterating the carousel using keyboard.
         public const int SELECTION_DEBOUNCE = 100;
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -35,6 +35,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Menu;
+using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
 using osu.Game.Skinning;
@@ -50,7 +51,7 @@ namespace osu.Game.Screens.SelectV2
     /// This will be gradually built upon and ultimately replace <see cref="Select.SongSelect"/> once everything is in place.
     /// </summary>
     [Cached(typeof(ISongSelect))]
-    public abstract partial class SongSelect : OsuScreen, IKeyBindingHandler<GlobalAction>, ISongSelect
+    public abstract partial class SongSelect : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, ISongSelect
     {
         // this is intentionally slightly higher than key repeat, but low enough to not impeded user experience.
         // this avoids rapid churn loading when iterating the carousel using keyboard.
@@ -346,6 +347,17 @@ namespace osu.Game.Screens.SelectV2
 
             if (this.IsCurrentScreen())
                 ensurePlayingSelected();
+
+            // If not the current screen, this will be applied in OnResuming.
+            if (this.IsCurrentScreen())
+            {
+                ApplyToBackground(backgroundModeBeatmap =>
+                {
+                    backgroundModeBeatmap.Beatmap = beatmap;
+                    backgroundModeBeatmap.IgnoreUserSettings.Value = true;
+                    backgroundModeBeatmap.FadeColour(Color4.White, 250);
+                });
+            }
         }
 
         #endregion


### PR DESCRIPTION
This should make song select v2 "usable" from the main menu. There's a lot of visual issues still, but it's a start.

- Hooks up global beatmap
- Copies over audio handling logic from old song select
- Copies over basic beatmap background support across (blur intentionally missing)

I'm struggling to ensure all cases are covered here, but just trying to move towards a working solution piece by piece.