### PR TITLE
Fix leaderboard wedge transition looking bad when user is scrolled down

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.PolygonExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -310,7 +311,10 @@ namespace osu.Game.Screens.SelectV2
                  .FadeOut(120, Easing.Out)
                  .Expire();
 
-                delay += 20;
+                // If the user is scrolled down in the list, start delaying only from the current visible range to
+                // avoid the perceived transition from taking longer than expected.
+                if (d.ScreenSpaceDrawQuad.Intersects(scoresScroll.ScreenSpaceDrawQuad))
+                    delay += 20;
             }
 
             personalBestDisplay.MoveToX(-100, 300, Easing.OutQuint);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33227.

Can be manually tested by using

```diff
diff --git a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardWedge.cs b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardWedge.cs
index 992651d73c..770dda5875 100644
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardWedge.cs
@@ -118,7 +118,11 @@ public void TestGlobalScoresDisplay()
         {
             setScope(BeatmapLeaderboardScope.Global);
 
-            AddStep(@"New Scores", () => leaderboard.SetScores(TestSceneBeatmapLeaderboard.GenerateSampleScores(new BeatmapInfo())));
+            AddStep(@"New Scores", () =>
+            {
+                var generateSampleScores = TestSceneBeatmapLeaderboard.GenerateSampleScores(new BeatmapInfo());
+                leaderboard.SetScores(generateSampleScores.Concat(generateSampleScores).Concat(generateSampleScores));
+            });
             AddStep(@"New Scores with teams", () => leaderboard.SetScores(TestSceneBeatmapLeaderboard.GenerateSampleScores(new BeatmapInfo()).Select(s =>
             {
                 s.User.Team = new APITeam();

```

and scrolling down between presses of the button.