### PR TITLE
SongSelectV2: Fix carousel not correctly handling traversal when current selection is filtered away

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -220,7 +220,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 // offset by one because the group itself is included in the items list.
                 CarouselItem item = groupingFilter.GroupItems[g].ElementAt(panel + 1);
 
-                return ReferenceEquals(Carousel.CurrentSelection, item.Model);
+                return (Carousel.CurrentSelection as BeatmapInfo)?
+                    .Equals(item.Model as BeatmapInfo) == true;
             });
         }
 
@@ -229,7 +230,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddUntilStep($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
             {
                 if (diff != null)
-                    return ReferenceEquals(Carousel.CurrentSelection, BeatmapSets[set].Beatmaps[diff.Value]);
+                {
+                    return (Carousel.CurrentSelection as BeatmapInfo)?
+                        .Equals(BeatmapSets[set].Beatmaps[diff.Value]) == true;
+                }
 
                 return BeatmapSets[set].Beatmaps.Contains(Carousel.CurrentSelection);
             });

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -308,8 +308,145 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckDisplayedBeatmapsCount(4);
 
             SelectNextGroup();
-            SelectPrevGroup();
             WaitForSelection(0, 1);
+            SelectPrevGroup();
+            WaitForSelection(1, 1);
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectNextGroup()
+        {
+            AddBeatmaps(5, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            SelectNextGroup();
+            SelectNextGroup();
+            WaitForSelection(2, 0);
+
+            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
+            WaitForFiltering();
+
+            SelectNextGroup();
+            WaitForSelection(0, 1);
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectPrevGroup()
+        {
+            AddBeatmaps(5, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            SelectNextGroup();
+            SelectNextGroup();
+            WaitForSelection(2, 0);
+
+            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
+            WaitForFiltering();
+
+            SelectPrevGroup();
+            WaitForSelection(4, 1);
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectPrevGroup_OnlyOnePanelAvailable()
+        {
+            AddBeatmaps(2, 3);
+            WaitForDrawablePanels();
+
+            SelectPrevGroup();
+            WaitForSelection(1, 0);
+
+            ApplyToFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
+            WaitForFiltering();
+
+            SelectPrevGroup();
+            WaitForSelection(0, 0);
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectNextGroup_OnlyOnePanelAvailable()
+        {
+            AddBeatmaps(2, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            WaitForSelection(0, 0);
+
+            ApplyToFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
+            WaitForFiltering();
+
+            SelectNextGroup();
+            WaitForSelection(1, 0);
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectNextPanel()
+        {
+            AddBeatmaps(5, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            SelectNextGroup();
+            SelectNextGroup();
+            WaitForSelection(2, 0);
+
+            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
+            WaitForFiltering();
+
+            SelectNextPanel();
+            AddAssert("keyboard selected is first set", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(BeatmapSets.First()));
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectPrevPanel()
+        {
+            AddBeatmaps(5, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            SelectNextGroup();
+            SelectNextGroup();
+            WaitForSelection(2, 0);
+
+            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
+            WaitForFiltering();
+
+            SelectPrevPanel();
+            AddAssert("keyboard selected is last set", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(BeatmapSets.Last()));
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectPrevPanel_OnlyOnePanelAvailable()
+        {
+            AddBeatmaps(2, 3);
+            WaitForDrawablePanels();
+
+            SelectPrevGroup();
+            WaitForSelection(1, 0);
+
+            ApplyToFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
+            WaitForFiltering();
+
+            SelectPrevPanel();
+            AddAssert("keyboard selected is first set", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(BeatmapSets.First()));
+        }
+
+        [Test]
+        public void TestNavigateFromFilteredItem_SelectNextPanel_OnlyOnePanelAvailable()
+        {
+            AddBeatmaps(2, 3);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+            WaitForSelection(0, 0);
+
+            ApplyToFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
+            WaitForFiltering();
+
+            SelectNextPanel();
+            AddAssert("keyboard selected is second set", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(BeatmapSets.Last()));
         }
     }
 }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -518,18 +518,19 @@ namespace osu.Game.Graphics.Carousel
             // Position transfer won't happen unless we invalidate this.
             displayedRange = null;
 
-            // The case where no items are available for display yet.
+            Selection prevKeyboard = currentKeyboardSelection;
+
+            // Importantly, we also reset the `Selection` to the most basic state.
+            // Removing the index and carousel item here is important to ensure we are aware of if a selection has been filtered away.
+            // If it hasn't been filtered, the full details will be re-populated just below in the loop.
+            currentKeyboardSelection = new Selection(currentKeyboardSelection.Model);
+            currentSelection = new Selection(currentSelection.Model);
+
             if (carouselItems == null)
-            {
-                currentKeyboardSelection = new Selection();
-                currentSelection = new Selection();
                 return;
-            }
 
             CarouselItem? lastVisible = null;
             int count = carouselItems.Count;
-
-            Selection prevKeyboard = currentKeyboardSelection;
 
             // We are performing two important operations here:
             // - Update all Y positions. After a selection occurs, panels may have changed visibility state and therefore Y positions.
@@ -549,7 +550,7 @@ namespace osu.Game.Graphics.Carousel
 
             // If a keyboard selection is currently made, we want to keep the view stable around the selection.
             // That means that we should offset the immediate scroll position by any change in Y position for the selection.
-            if (prevKeyboard.YPosition != null && currentKeyboardSelection.YPosition != prevKeyboard.YPosition)
+            if (prevKeyboard.YPosition != null && currentKeyboardSelection.YPosition != null && currentKeyboardSelection.YPosition != prevKeyboard.YPosition)
                 Scroll.OffsetScrollPosition((float)(currentKeyboardSelection.YPosition!.Value - prevKeyboard.YPosition.Value));
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33215.

- If the selection is unfiltered, it will be restored as expected.
- If traversing while filtered, either end of the carousel will be used for traversal (matches stable).