### PR TITLE
Fix alignment issue of beatmap background for non-widescreen storyboard

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -319,6 +319,8 @@ namespace osu.Game.Beatmaps
 
                 storyboard.BeatmapInfo = BeatmapInfo;
 
+                storyboard.AddBeatmapBackgroundIfNeeded();
+
                 return storyboard;
             }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardBeatmapBackground.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardBeatmapBackground.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Game.Storyboards.Drawables
+{
+    public partial class DrawableStoryboardBeatmapBackground : Sprite
+    {
+        public StoryboardBeatmapBackground BeatmapBackground { get; }
+
+        public override bool RemoveWhenNotAlive => false;
+
+        [Resolved]
+        private TextureStore textureStore { get; set; } = null!;
+
+        public DrawableStoryboardBeatmapBackground(StoryboardBeatmapBackground beatmapBackground)
+        {
+            BeatmapBackground = beatmapBackground;
+            Name = beatmapBackground.Path;
+            Anchor = beatmapBackground.Anchor;
+            Origin = beatmapBackground.Origin;
+            RelativeSizeAxes = Axes.Both;
+            FillMode = FillMode.Fill;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Texture = textureStore.Get(BeatmapBackground.Path);
+        }
+    }
+}

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -80,12 +80,12 @@ namespace osu.Game.Storyboards
         /// <summary>
         /// Whether the beatmap's background should be hidden while this storyboard is being displayed.
         /// </summary>
-        public bool ReplacesBackground => AlreadyBackgroundInStoryboard;
+        public bool ReplacesBackground => HasBeatmapBackground;
 
         /// <summary>
         /// Whether the beatmap's background is already displayed as an element in the storyboard.
         /// </summary>
-        public bool AlreadyBackgroundInStoryboard
+        public bool HasBeatmapBackground
         {
             get
             {
@@ -111,7 +111,7 @@ namespace osu.Game.Storyboards
         /// </summary>
         public void AddBeatmapBackgroundIfNeeded()
         {
-            if (!AlreadyBackgroundInStoryboard && !Beatmap.WidescreenStoryboard && !HasVideo)
+            if (!HasBeatmapBackground && !Beatmap.WidescreenStoryboard && !HasVideo)
             {
                 var backgroundLayer = GetLayer("Background");
                 backgroundLayer.Elements.Insert(0, new StoryboardBeatmapBackground(BeatmapInfo.Metadata.BackgroundFile));

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -107,16 +107,11 @@ namespace osu.Game.Storyboards
         public bool HasVideo => GetLayer("Video").Elements.Count != 0;
 
         /// <summary>
-        /// Whether the beatmap background needs to be set as a storyboard element to fix alignment issues with storyboard that rely on the beatmap background.
-        /// </summary>
-        public bool NeedSetBackgroundInStoryboard => !AlreadyBackgroundInStoryboard && !Beatmap.WidescreenStoryboard && !HasVideo;
-
-        /// <summary>
         /// Add the beatmap background as an element of the storyboard if conditions are met.
         /// </summary>
         public void AddBeatmapBackgroundIfNeeded()
         {
-            if (NeedSetBackgroundInStoryboard)
+            if (!AlreadyBackgroundInStoryboard && !Beatmap.WidescreenStoryboard && !HasVideo)
             {
                 var backgroundLayer = GetLayer("Background");
                 backgroundLayer.Elements.Insert(0, new StoryboardBeatmapBackground(BeatmapInfo.Metadata.BackgroundFile));

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Storyboards
         /// <summary>
         /// Whether the beatmap's background should be hidden while this storyboard is being displayed.
         /// </summary>
-        public bool ReplacesBackground => AlreadyBackgroundInStoryboard || NeedSetBackgroundInStoryboard;
+        public bool ReplacesBackground => AlreadyBackgroundInStoryboard;
 
         /// <summary>
         /// Whether the beatmap's background is already displayed as an element in the storyboard.

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -80,7 +80,12 @@ namespace osu.Game.Storyboards
         /// <summary>
         /// Whether the beatmap's background should be hidden while this storyboard is being displayed.
         /// </summary>
-        public bool ReplacesBackground
+        public bool ReplacesBackground => AlreadyBackgroundInStoryboard || NeedSetBackgroundInStoryboard;
+
+        /// <summary>
+        /// Whether the beatmap's background is already displayed as an element in the storyboard.
+        /// </summary>
+        public bool AlreadyBackgroundInStoryboard
         {
             get
             {
@@ -93,6 +98,28 @@ namespace osu.Game.Storyboards
                 backgroundPath = backgroundPath.ToLowerInvariant();
 
                 return GetLayer("Background").Elements.Any(e => string.Equals(e.Path, backgroundPath, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        /// <summary>
+        /// Whether there is a video in the beatmap.
+        /// </summary>
+        public bool HasVideo => GetLayer("Video").Elements.Count != 0;
+
+        /// <summary>
+        /// Whether the beatmap background needs to be set as a storyboard element to fix alignment issues with storyboard that rely on the beatmap background.
+        /// </summary>
+        public bool NeedSetBackgroundInStoryboard => !AlreadyBackgroundInStoryboard && !Beatmap.WidescreenStoryboard && !HasVideo;
+
+        /// <summary>
+        /// Add the beatmap background as an element of the storyboard if conditions are met.
+        /// </summary>
+        public void AddBeatmapBackgroundIfNeeded()
+        {
+            if (NeedSetBackgroundInStoryboard)
+            {
+                var backgroundLayer = GetLayer("Background");
+                backgroundLayer.Elements.Insert(0, new StoryboardBeatmapBackground(BeatmapInfo.Metadata.BackgroundFile));
             }
         }
 

--- a/osu.Game/Storyboards/StoryboardBeatmapBackground.cs
+++ b/osu.Game/Storyboards/StoryboardBeatmapBackground.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Storyboards.Drawables;
+
+namespace osu.Game.Storyboards
+{
+    public class StoryboardBeatmapBackground : IStoryboardElement
+    {
+        public string Path { get; }
+        public bool IsDrawable { get; } = true;
+        public double StartTime { get; } = 0;
+
+        public Anchor Anchor = Anchor.Centre;
+        public Anchor Origin = Anchor.Centre;
+
+        public Drawable CreateDrawable() => new DrawableStoryboardBeatmapBackground(this);
+
+        public StoryboardBeatmapBackground(string path)
+        {
+            Path = path;
+        }
+    }
+}


### PR DESCRIPTION
- Similar to closed PR #14001
- Fix #2086
- Fix #28928

To fix the issue, this PR adds the beatmap background as a storyboard element in the "Background" layer to resolve the alignment issue IF the storyboard is non-widescreen (and other conditions see `NeedSetBackgroundInStoryboard` in `Storyboard.cs`)

I chose this approach based on [peppy's recommendation](https://github.com/ppy/osu/pull/14001#issuecomment-887157884) on closed PR #14001 that tried to fix the same issue.


### Before PR:

https://github.com/user-attachments/assets/ba20dba7-1882-436b-a9d3-8507d7b02757


### After PR:

https://github.com/user-attachments/assets/71a427e6-fd3c-44e8-abab-f70f7ab50d48


Beatmap used in video : https://osu.ppy.sh/beatmapsets/58246