### PR TITLE
SongSelectV2: Add back basic random selection support

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -1,0 +1,118 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    [TestFixture]
+    public partial class TestSceneBeatmapCarouselRandom : BeatmapCarouselTestScene
+    {
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            RemoveAllBeatmaps();
+            CreateCarousel();
+
+            SortAndGroupBy(SortMode.Artist, GroupMode.Artist);
+        }
+
+        /// <summary>
+        /// Test random non-repeating algorithm
+        /// </summary>
+        [Test]
+        public void TestRandom()
+        {
+            AddBeatmaps(10, 3, true);
+            WaitForDrawablePanels();
+
+            nextRandom();
+            ensureRandomDidNotRepeat();
+            nextRandom();
+            ensureRandomDidNotRepeat();
+            nextRandom();
+            ensureRandomDidNotRepeat();
+
+            prevRandom();
+            checkRewindCorrectSet();
+            prevRandom();
+            checkRewindCorrectSet();
+
+            nextRandom();
+            ensureRandomDidNotRepeat();
+            nextRandom();
+            ensureRandomDidNotRepeat();
+
+            nextRandom();
+            AddAssert("ensure repeat", () => BeatmapSetRequestedSelections.Contains(Carousel.SelectedBeatmapSet!));
+        }
+
+        [Test]
+        public void TestRewindOverMultipleIterations()
+        {
+            const int local_set_count = 3;
+            const int random_select_count = local_set_count * 3;
+
+            AddBeatmaps(local_set_count, 3, true);
+            WaitForDrawablePanels();
+
+            SelectNextGroup();
+
+            for (int i = 0; i < random_select_count; i++)
+                nextRandom();
+
+            for (int i = 0; i < random_select_count; i++)
+            {
+                prevRandom();
+                checkRewindCorrectSet();
+            }
+        }
+
+        [Test]
+        public void TestRewindToDeletedBeatmap()
+        {
+            AddBeatmaps(10, 3, true);
+            WaitForDrawablePanels();
+
+            BeatmapInfo? originalSelected = null;
+            BeatmapInfo? postRandomSelection = null;
+
+            nextRandom();
+
+            CheckHasSelection();
+            AddStep("store selection", () => originalSelected = (BeatmapInfo)Carousel.CurrentSelection!);
+
+            nextRandom();
+            AddStep("store selection", () => postRandomSelection = (BeatmapInfo)Carousel.CurrentSelection!);
+
+            AddAssert("selection changed", () => originalSelected, () => Is.Not.SameAs(postRandomSelection));
+
+            AddStep("delete previous selection beatmaps", () => BeatmapSets.Remove(originalSelected!.BeatmapSet!));
+            WaitForFiltering();
+
+            AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(postRandomSelection));
+
+            prevRandom();
+            AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(postRandomSelection));
+        }
+
+        private void nextRandom() =>
+            AddStep("select random next", () => Carousel.NextRandom());
+
+        private void ensureRandomDidNotRepeat() =>
+            AddAssert("no repeats", () => BeatmapSetRequestedSelections.Distinct().Count(), () => Is.EqualTo(BeatmapSetRequestedSelections.Count));
+
+        private void checkRewindCorrectSet() =>
+            AddAssert("rewind matched expected set", () => BeatmapSetRequestedSelections.Peek(), () => Is.EqualTo(Carousel.SelectedBeatmapSet));
+
+        private void prevRandom() => AddStep("select random last", () =>
+        {
+            Carousel.PreviousRandom();
+            BeatmapSetRequestedSelections.Pop();
+        });
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -17,16 +17,48 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             RemoveAllBeatmaps();
             CreateCarousel();
-
-            SortAndGroupBy(SortMode.Artist, GroupMode.Artist);
         }
 
         /// <summary>
         /// Test random non-repeating algorithm
         /// </summary>
         [Test]
-        public void TestRandom()
+        public void TestRandomArtistGrouping()
         {
+            SortAndGroupBy(SortMode.Artist, GroupMode.Artist);
+
+            AddBeatmaps(10, 3, true);
+            WaitForDrawablePanels();
+
+            nextRandom();
+            ensureRandomDidNotRepeat();
+            nextRandom();
+            ensureRandomDidNotRepeat();
+            nextRandom();
+            ensureRandomDidNotRepeat();
+
+            prevRandom();
+            checkRewindCorrectSet();
+            prevRandom();
+            checkRewindCorrectSet();
+
+            nextRandom();
+            ensureRandomDidNotRepeat();
+            nextRandom();
+            ensureRandomDidNotRepeat();
+
+            nextRandom();
+            AddAssert("ensure repeat", () => BeatmapSetRequestedSelections.Contains(Carousel.SelectedBeatmapSet!));
+        }
+
+        /// <summary>
+        /// Test random non-repeating algorithm
+        /// </summary>
+        [Test]
+        public void TestRandomDifficultyGrouping()
+        {
+            SortAndGroupBy(SortMode.Difficulty, GroupMode.Difficulty);
+
             AddBeatmaps(10, 3, true);
             WaitForDrawablePanels();
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -279,6 +279,11 @@ namespace osu.Game.Graphics.Carousel
 
         #region Filtering and display preparation
 
+        /// <summary>
+        /// Retrieve a list of all <see cref="CarouselItem"/>s currently displayed.
+        /// </summary>
+        protected IList<CarouselItem>? GetCarouselItems() => carouselItems;
+
         private List<CarouselItem>? carouselItems;
 
         private Task<IEnumerable<CarouselItem>> filterTask = Task.FromResult(Enumerable.Empty<CarouselItem>());
@@ -547,6 +552,11 @@ namespace osu.Game.Graphics.Carousel
         #endregion
 
         #region Selection handling
+
+        /// <summary>
+        /// The currently selected <see cref="CarouselItem"/>, if any is selected.
+        /// </summary>
+        protected CarouselItem? CurrentSelectionItem => currentSelection.CarouselItem;
 
         /// <summary>
         /// Becomes invalid when the current selection has changed and needs to be updated visually.

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -282,7 +282,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// Retrieve a list of all <see cref="CarouselItem"/>s currently displayed.
         /// </summary>
-        protected IList<CarouselItem>? GetCarouselItems() => carouselItems;
+        protected IReadOnlyCollection<CarouselItem>? GetCarouselItems() => carouselItems;
 
         private List<CarouselItem>? carouselItems;
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -523,7 +523,15 @@ namespace osu.Game.Screens.SelectV2
             if (carouselItems?.Any() != true)
                 return false;
 
+            // If set grouping is available, this is the fastest way to retrieve sets for randomisation.
             ICollection<BeatmapSetInfo> visibleSets = grouping.SetItems.Keys;
+
+            // If not, we need to do an expensive copy.
+            //
+            // There's probably a more efficient way to handle this. Maybe the grouping filter should always expose grouped sets regardless
+            // as that process is done asynchronously.
+            if (!visibleSets.Any())
+                visibleSets = carouselItems.Select(i => i.Model).OfType<BeatmapInfo>().Select(b => b.BeatmapSet!).Distinct().ToList();
 
             if (CurrentSelection is BeatmapInfo beatmapInfo)
             {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -564,7 +564,7 @@ namespace osu.Game.Screens.SelectV2
             if (CurrentSelectionItem != null)
                 playSpinSample(distanceBetween(carouselItems.First(i => !ReferenceEquals(i.Model, set)), CurrentSelectionItem), visibleSets.Count);
 
-            RequestRecommendedSelection(set.Beatmaps);
+            RequestRecommendedSelection(set.Beatmaps.Where(b => !b.Hidden));
             return true;
         }
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -259,7 +259,11 @@ namespace osu.Game.Screens.SelectV2
                 Current = Mods,
                 RequestDeselectAllMods = () => Mods.Value = Array.Empty<Mod>()
             },
-            new FooterButtonRandom(),
+            new FooterButtonRandom
+            {
+                NextRandom = () => carousel.NextRandom(),
+                PreviousRandom = () => carousel.PreviousRandom()
+            },
             new FooterButtonOptions
             {
                 Hotkey = GlobalAction.ToggleBeatmapOptions,

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -425,7 +425,10 @@ namespace osu.Game.Screens.SelectV2
 
             // force reselection if entering song select with a protected beatmap
             if (Beatmap.Value.BeatmapInfo.BeatmapSet!.Protected)
-                Beatmap.SetDefault();
+            {
+                if (!carousel.NextRandom())
+                    Beatmap.SetDefault();
+            }
             else
                 updateSelection();
         }


### PR DESCRIPTION
This is a minimal implementation in order to keep moving forward.

For simplicity I've copied over the old implementation verbatim. Note that this is beatmap*set* based randomisation, which means that when panels are split up by difficulty, it is still randomising by set (with the difficulty choice being left up to the user recommendation system). I think this is what we want, but if it isn't, any changes can come later.