### PR TITLE
SongSelectV2: Fix carousel loading state looking out of place

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -365,17 +365,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         public partial class TestBeatmapCarousel : BeatmapCarousel
         {
+            public int FilterDelay = 0;
+
             public IEnumerable<BeatmapInfo> PostFilterBeatmaps = null!;
 
-            protected override Task<IEnumerable<CarouselItem>> FilterAsync(bool clearExistingPanels = false)
+            protected override async Task<IEnumerable<CarouselItem>> FilterAsync(bool clearExistingPanels = false)
             {
-                var filterAsync = base.FilterAsync(clearExistingPanels);
-                filterAsync.ContinueWith(result =>
-                {
-                    if (result.IsCompletedSuccessfully)
-                        PostFilterBeatmaps = result.GetResultSafely().Select(i => i.Model).OfType<BeatmapInfo>();
-                });
-                return filterAsync;
+                var items = await base.FilterAsync(clearExistingPanels);
+
+                if (FilterDelay != 0)
+                    await Task.Delay(FilterDelay);
+
+                PostFilterBeatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
+                return items;
             }
         }
     }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
@@ -46,6 +47,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             RemoveFirstBeatmap();
             RemoveAllBeatmaps();
+        }
+
+        [Test]
+        [Explicit]
+        public void TestLoadingDisplay()
+        {
+            AddStep("induce slow filtering", () => Carousel.FilterDelay = 2000);
+            SortAndGroupBy(SortMode.Artist, GroupMode.NoGrouping);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -17,6 +17,7 @@ using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Select;
@@ -77,7 +78,7 @@ namespace osu.Game.Screens.SelectV2
                 grouping = new BeatmapCarouselFilterGrouping(() => Criteria),
             };
 
-            AddInternal(loading = new LoadingLayer(dimBackground: true));
+            AddInternal(loading = new LoadingLayer());
         }
 
         [BackgroundDependencyLoader]
@@ -428,13 +429,18 @@ namespace osu.Game.Screens.SelectV2
 
             Criteria = criteria;
 
-            loadingDebounce ??= Scheduler.AddDelayed(() => loading.Show(), 250);
+            loadingDebounce ??= Scheduler.AddDelayed(() =>
+            {
+                Scroll.FadeColour(OsuColour.Gray(0.5f), 1000, Easing.OutQuint);
+                loading.Show();
+            }, 250);
 
             FilterAsync(resetDisplay).ContinueWith(_ => Schedule(() =>
             {
                 loadingDebounce?.Cancel();
                 loadingDebounce = null;
 
+                Scroll.FadeColour(OsuColour.Gray(1f), 500, Easing.OutQuint);
                 loading.Hide();
             }));
         }


### PR DESCRIPTION
Previously a huge black box was placed over half of the song select screen. Now just the panels are dimmed.


https://github.com/user-attachments/assets/197ddde6-2d02-45eb-9545-a59448739b64

