### PR TITLE
allow changing rulesets through CLI: osu set-ruleset shortname

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -30,6 +30,7 @@ namespace osu.Desktop
     {
         private OsuSchemeLinkIPCChannel? osuSchemeLinkIPCChannel;
         private ArchiveImportIPCChannel? archiveImportIPCChannel;
+        private CommandIPCChannel? commandIPCChannel;
 
         [Cached(typeof(IHighPerformanceSessionManager))]
         private readonly HighPerformanceSessionManager highPerformanceSessionManager = new HighPerformanceSessionManager();
@@ -140,6 +141,7 @@ namespace osu.Desktop
 
             osuSchemeLinkIPCChannel = new OsuSchemeLinkIPCChannel(Host, this);
             archiveImportIPCChannel = new ArchiveImportIPCChannel(Host, this);
+            commandIPCChannel = new CommandIPCChannel(Host, this);
         }
 
         public override void SetHost(GameHost host)
@@ -160,6 +162,7 @@ namespace osu.Desktop
             base.Dispose(isDisposing);
             osuSchemeLinkIPCChannel?.Dispose();
             archiveImportIPCChannel?.Dispose();
+            commandIPCChannel?.Dispose();
         }
     }
 }

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -157,6 +157,15 @@ namespace osu.Desktop
                 return true;
             }
 
+            if (args.Length == 2 && args[0] == "set-ruleset")
+            {
+                var commandHandler = new CommandIPCChannel(host);
+                if (!commandHandler.RunCommand(args[0], args[1..]).Wait(3000))
+                    throw new IPCTimeoutException(commandHandler.GetType());
+
+                return true;
+            }
+
             if (args.Length > 0 && args[0].Contains('.')) // easy way to check for a file import in args
             {
                 var importer = new ArchiveImportIPCChannel(host);

--- a/osu.Game/IPC/CommandIPCChannel.cs
+++ b/osu.Game/IPC/CommandIPCChannel.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System.Diagnostics;
+using System.Threading.Tasks;
+using osu.Framework.Platform;
+
+namespace osu.Game.IPC
+{
+    public class CommandIPCChannel : IpcChannel<CommandMessage>
+    {
+        private readonly OsuGame game;
+
+        public CommandIPCChannel(IIpcHost host, OsuGame game = null)
+            : base(host)
+        {
+            this.game = game;
+
+            MessageReceived += msg =>
+            {
+                Debug.Assert(game != null);
+                RunCommand(msg.Command, msg.Arguments).ContinueWith(t =>
+                {
+                    if (t.Exception != null) throw t.Exception;
+                }, TaskContinuationOptions.OnlyOnFaulted);
+
+                return null;
+            };
+        }
+
+        public async Task RunCommand(string command, string[] arguments)
+        {
+            if (game == null)
+            {
+                // we want to contact a remote osu! to handle the import.
+                await SendMessageAsync(new CommandMessage { Command = command, Arguments = arguments }).ConfigureAwait(false);
+                return;
+            }
+
+            switch (command)
+            {
+                case @"set-ruleset":
+                    game.TrySetRuleset(arguments[0]);
+                    break;
+            }
+        }
+    }
+
+    public class CommandMessage
+    {
+        public string Command;
+        public string[] Arguments;
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -587,6 +587,18 @@ namespace osu.Game
         public void FilterBeatmapSetLanguage(SearchLanguage language) => waitForReady(() => beatmapListing, _ => beatmapListing.ShowWithLanguageFilter(language));
 
         /// <summary>
+        /// Sets the currently selected ruleset to the given other ruleset by looking it up using its short name.
+        /// Does nothing if currently playing a map or otherwise unable to change ruleset.
+        /// </summary>
+        /// <param name="shortName">The new ruleset's shortname.</param>
+        public void TrySetRuleset(string shortName) => Schedule(() =>
+        {
+            var ruleset = RulesetStore.GetRuleset(shortName);
+            if (ruleset is not null && !Ruleset.Disabled)
+                Ruleset.Value = ruleset;
+        });
+
+        /// <summary>
         /// Show a wiki's page as an overlay
         /// </summary>
         /// <param name="path">The wiki page to show</param>


### PR DESCRIPTION
e.g.:
osu://ruleset/osu
osu://ruleset/taiko
osu://ruleset/mania
osu://ruleset/fruits
osu://ruleset/pippidon

I just personally want this for my arcade cab, which allows switching games or gamemodes by plugging in/out controllers via USB, where I want to switch to my custom ruleset (https://github.com/WebFreak001/katsudon) when 2 taiko controllers are plugged in and switch to regular taiko when just a single controller is plugged in.