### PR TITLE
Attempt to stabilise hot-reload

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <!-- Stabilises hot reload, see: https://platform.uno/docs/articles/studio/Hot%20Reload/hot-reload-overview.html?tabs=vswin%2Cwindows%2Cskia-desktop%2Ccommon-issues -->
     <GenerateAssemblyInfo Condition="'$(Configuration)'=='Debug'">false</GenerateAssemblyInfo>
+    <!-- Required due to the above  -->
+    <NoWarn Condition="'$(Configuration)'=='Debug'">$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>$(MSBuildThisFileDirectory)app.manifest</ApplicationManifest>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
   <PropertyGroup Label="C#">
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
+    <!-- Stabilises hot reload, see: https://platform.uno/docs/articles/studio/Hot%20Reload/hot-reload-overview.html?tabs=vswin%2Cwindows%2Cskia-desktop%2Ccommon-issues -->
+    <GenerateAssemblyInfo Condition="'$(Configuration)'=='Debug'">false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>$(MSBuildThisFileDirectory)app.manifest</ApplicationManifest>


### PR DESCRIPTION
Don't know why this happens - we no longer reference the sourcelink package which should've fixed this. I believe it's related to the background dotnet build server, but it's hard to investigate with such a component.

`osu.Game.Tests.AssemblyInfo.cs(17, 12): [ENC0003] Updating 'attribute' requires restarting the application.`

Looking around, I've come across https://platform.uno/docs/articles/studio/Hot%20Reload/hot-reload-overview.html?tabs=vswin%2Cwindows%2Cskia-desktop%2Ccommon-issues, listing the workaround here. Crossing fingers?

- We'll have to test if this is still required in .NET 9/10, because it's a bit of an ugly hack.
- If this works, it should also be applied to osu-framework.