### PR TITLE
Adds SFX for rank changes to the in-game rank display

### DIFF
--- a/osu.Game/Skinning/LegacyRankDisplay.cs
+++ b/osu.Game/Skinning/LegacyRankDisplay.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
 using osuTK;
 
 namespace osu.Game.Skinning
@@ -20,13 +22,15 @@ namespace osu.Game.Skinning
         [Resolved]
         private ISkinSource source { get; set; } = null!;
 
-        private readonly Sprite rank;
+        private readonly Sprite rankDisplay;
+
+        private IBindable<ScoreRank> rank = null!;
 
         public LegacyRankDisplay()
         {
             AutoSizeAxes = Axes.Both;
 
-            AddInternal(rank = new Sprite
+            AddInternal(rankDisplay = new Sprite
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -35,11 +39,12 @@ namespace osu.Game.Skinning
 
         protected override void LoadComplete()
         {
-            scoreProcessor.Rank.BindValueChanged(v =>
+            rank = scoreProcessor.Rank.GetBoundCopy();
+            rank.BindValueChanged(r =>
             {
-                var texture = source.GetTexture($"ranking-{v.NewValue}-small");
+                var texture = source.GetTexture($"ranking-{r.NewValue}-small");
 
-                rank.Texture = texture;
+                rankDisplay.Texture = texture;
 
                 if (texture != null)
                 {
@@ -57,6 +62,7 @@ namespace osu.Game.Skinning
                                  .Expire();
                 }
             }, true);
+
             FinishTransforms(true);
         }
     }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.512.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.425.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.530.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
Component isn't visible by default, but can be added via the skin layout editor. Skinnable via `rank-up` and `rank-down`.

https://github.com/user-attachments/assets/92fdcf21-8e0a-4402-9d34-809899cfe837


---

- [x] depends on ppy/osu-resources#365
- resolves #32449