### PR TITLE
SongSelectV2: Fix carousel never displaying if too many beatmap updates are arriving in background

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -409,10 +409,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             protected override async Task<IEnumerable<CarouselItem>> FilterAsync(bool clearExistingPanels = false)
             {
-                var items = await base.FilterAsync(clearExistingPanels);
+                var items = await base.FilterAsync(clearExistingPanels).ConfigureAwait(true);
 
                 if (FilterDelay != 0)
-                    await Task.Delay(FilterDelay);
+                    await Task.Delay(FilterDelay).ConfigureAwait(true);
 
                 PostFilterBeatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
                 return items;

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
@@ -92,6 +93,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     BeatmapSets.Add(set);
                 }
             });
+        }
+
+        [Test]
+        public void TestHighChurnUpdatesStillShowsPanels()
+        {
+            ScheduledDelegate updateTask = null!;
+
+            AddBeatmaps(1, 1);
+
+            AddStep("start constantly updating beatmap in background", () =>
+            {
+                updateTask = Scheduler.AddDelayed(() => { BeatmapSets.ReplaceRange(0, 1, [BeatmapSets.First()]); }, 1, true);
+            });
+
+            CreateCarousel();
+
+            AddUntilStep("panels loaded", () => Carousel.ChildrenOfType<Panel>(), () => Is.Not.Empty);
+
+            AddStep("end task", () => updateTask.Cancel());
         }
 
         [Test]

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -12,6 +12,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
+using osu.Framework.Development;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -309,16 +310,17 @@ namespace osu.Game.Graphics.Carousel
             var cts = new CancellationTokenSource();
 
             var previousCancellationSource = Interlocked.Exchange(ref cancellationSource, cts);
-            await previousCancellationSource.CancelAsync().ConfigureAwait(false);
+            await previousCancellationSource.CancelAsync().ConfigureAwait(true);
 
             if (DebounceDelay > 0)
             {
                 log($"Filter operation queued, waiting for {DebounceDelay} ms debounce");
-                await Task.Delay(DebounceDelay, cts.Token).ConfigureAwait(false);
+                await Task.Delay(DebounceDelay, cts.Token).ConfigureAwait(true);
             }
 
             // Copy must be performed on update thread for now (see ConfigureAwait above).
             // Could potentially be optimised in the future if it becomes an issue.
+            Debug.Assert(ThreadSafety.IsUpdateThread);
             List<CarouselItem> items = new List<CarouselItem>(Items.Select(m => new CarouselItem(m)));
 
             await Task.Run(async () =>

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -103,19 +103,19 @@ namespace osu.Game.Screens.SelectV2
         private void load(BeatmapStore beatmapStore, AudioManager audio, OsuConfigManager config, CancellationToken? cancellationToken)
         {
             setupPools();
-            setupBeatmaps(beatmapStore, cancellationToken);
+            detachedBeatmaps = beatmapStore.GetBeatmapSets(cancellationToken);
             loadSamples(audio);
 
             config.BindWith(OsuSetting.RandomSelectAlgorithm, randomAlgorithm);
         }
 
-        #region Beatmap source hookup
-
-        private void setupBeatmaps(BeatmapStore beatmapStore, CancellationToken? cancellationToken)
+        protected override void LoadComplete()
         {
-            detachedBeatmaps = beatmapStore.GetBeatmapSets(cancellationToken);
+            base.LoadComplete();
             detachedBeatmaps.BindCollectionChanged(beatmapSetsChanged, true);
         }
+
+        #region Beatmap source hookup
 
         private void beatmapSetsChanged(object? beatmaps, NotifyCollectionChangedEventArgs changed)
         {


### PR DESCRIPTION
First round of performance testing with >100k beatmaps was quite successful... as long as difficulty calculation was not running in the background. If it was, the carousel would remain in a filtering loop where it never displayed.

This fixes that issues, along with a few threading concerns that also popped up along the way.

- [x] Depends on https://github.com/ppy/osu/pull/33332