### PR TITLE
SongSelectV2: Fix carousel not displaying anything if there is only one panel to display

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarousel.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.SongSelectV2
@@ -115,6 +117,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddUntilStep("maybe they are done now", () => generated.Count, () => Is.EqualTo(count));
 
             AddStep("add all beatmaps", () => BeatmapSets.AddRange(generated));
+        }
+
+        [Test]
+        public void TestSingleItemDisplayed()
+        {
+            CreateCarousel();
+            RemoveAllBeatmaps();
+
+            SortAndGroupBy(SortMode.Difficulty, GroupMode.NoGrouping);
+            AddBeatmaps(1, fixedDifficultiesPerSet: 1);
+            AddUntilStep("single item is shown", () => this.ChildrenOfType<PanelBeatmapStandalone>().Count(), () => Is.EqualTo(1));
         }
     }
 }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -743,6 +743,9 @@ namespace osu.Game.Graphics.Carousel
         {
             Debug.Assert(carouselItems != null);
 
+            if (carouselItems.Count == 0)
+                return DisplayRange.EMPTY;
+
             // Find index range of all items that should be on-screen
             carouselBoundsItem.CarouselYPosition = visibleUpperBound - DistanceOffscreenToPreload;
             int firstIndex = carouselItems.BinarySearch(carouselBoundsItem);
@@ -762,7 +765,7 @@ namespace osu.Game.Graphics.Carousel
         {
             Debug.Assert(carouselItems != null);
 
-            List<CarouselItem> toDisplay = range.Last - range.First == 0
+            List<CarouselItem> toDisplay = range == DisplayRange.EMPTY
                 ? new List<CarouselItem>()
                 : carouselItems.GetRange(range.First, range.Last - range.First + 1);
 
@@ -881,7 +884,10 @@ namespace osu.Game.Graphics.Carousel
         /// <param name="Index">The index of the selection as of the last run of <see cref="Carousel{T}.refreshAfterSelection"/>. May be null if selection is not present as an item, or if <see cref="Carousel{T}.refreshAfterSelection"/> has not been run yet.</param>
         private record Selection(object? Model = null, CarouselItem? CarouselItem = null, double? YPosition = null, int? Index = null);
 
-        private record DisplayRange(int First, int Last);
+        private record DisplayRange(int First, int Last)
+        {
+            public static readonly DisplayRange EMPTY = new DisplayRange(-1, -1);
+        }
 
         /// <summary>
         /// Implementation of scroll container which handles very large vertical lists by internally using <c>double</c> precision


### PR DESCRIPTION
If there is only one panel to display, a `DisplayRange` of (0, 0) is *very much* valid.