### PR TITLE
Fix exception when trying to deserialize generic `Beatmap<T>` from json

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -17,6 +17,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Tests.Resources;
 using osuTK;
 
@@ -219,6 +220,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
             Assert.AreEqual(new Vector2(304, 56), circle.Position);
             Assert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
             Assert.IsTrue(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
+
+            var taikoBeatmap = converted.Serialize().Deserialize<Beatmap<TaikoHitObject>>();
+
+            Assert.IsEmpty(taikoBeatmap.HitObjects);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -15,6 +15,7 @@ using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Resources;
 using osuTK;
@@ -188,6 +189,36 @@ namespace osu.Game.Tests.Beatmaps.Formats
             }
 
             Assert.IsInstanceOf(typeof(JsonBeatmapDecoder), decoder);
+        }
+
+        [Test]
+        public void TestGenericBeatmap()
+        {
+            var converted = new OsuBeatmapConverter(decodeAsJson(normal), new OsuRuleset()).Convert();
+
+            var processor = new OsuBeatmapProcessor(converted);
+
+            processor.PreProcess();
+            foreach (var o in converted.HitObjects)
+                o.ApplyDefaults(converted.ControlPointInfo, converted.Difficulty);
+            processor.PostProcess();
+
+            var beatmap = converted.Serialize().Deserialize<Beatmap<OsuHitObject>>();
+
+            var slider = beatmap.HitObjects[0] as Slider;
+
+            Assert.IsNotNull(slider);
+            Assert.AreEqual(90, slider.Path.Distance);
+            Assert.AreEqual(new Vector2(192, 168), slider.Position);
+            Assert.AreEqual(956, beatmap.HitObjects[0].StartTime);
+            Assert.IsTrue(beatmap.HitObjects[0].Samples.Any(s => s.Name == HitSampleInfo.HIT_NORMAL));
+
+            var circle = beatmap.HitObjects[1] as HitCircle;
+
+            Assert.IsNotNull(circle);
+            Assert.AreEqual(new Vector2(304, 56), circle.Position);
+            Assert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
+            Assert.IsTrue(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Beatmaps
         [JsonIgnore]
         public double TotalBreakTime => Breaks.Sum(b => b.Duration);
 
-        [JsonConverter(typeof(TypedListConverter<HitObject>))]
+        [JsonConverter(typeof(TypedListConverter))]
         public List<T> HitObjects { get; set; } = new List<T>();
 
         IReadOnlyList<T> IBeatmap<T>.HitObjects => HitObjects;

--- a/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
+++ b/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
@@ -43,7 +43,7 @@ namespace osu.Game.IO.Serialization.Converters
         public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (!tryGetListItemType(objectType, out var itemType))
-                throw new JsonSerializationException($"May not use {nameof(TypedListConverter)} on a type that does not implement {typeof(IReadOnlyList<>).Name}");
+                throw new JsonException($"May not use {nameof(TypedListConverter)} on a type that does not implement {typeof(IReadOnlyList<>).Name}");
 
             IList list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(itemType))!;
 

--- a/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
+++ b/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
@@ -74,8 +74,6 @@ namespace osu.Game.IO.Serialization.Converters
                 if (!type.IsAssignableTo(itemType))
                     continue;
 
-                tok.ToObject(type, serializer);
-
                 object instance = Activator.CreateInstance(type)!;
                 serializer.Populate(itemReader, instance);
 

--- a/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
+++ b/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
@@ -133,17 +133,25 @@ namespace osu.Game.IO.Serialization.Converters
 
         private static bool tryGetListItemType(Type objectType, [MaybeNullWhen(false)] out Type itemType)
         {
-            if (objectType.IsInterface && objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+            if (objectType.IsInterface && isListType(objectType))
             {
                 itemType = objectType.GenericTypeArguments[0];
                 return true;
             }
 
-            var listType = objectType.GetInterfaces()
-                                     .FirstOrDefault(it => it.IsGenericType && it.GetGenericTypeDefinition() == typeof(IReadOnlyList<>));
+            var listType = objectType.GetInterfaces().FirstOrDefault(isListType);
 
             itemType = listType?.GenericTypeArguments.FirstOrDefault();
             return itemType != null;
+
+            bool isListType(Type type)
+            {
+                if (!type.IsGenericType)
+                    return false;
+
+                var genericTypeDefinition = type.GetGenericTypeDefinition();
+                return genericTypeDefinition == typeof(IReadOnlyList<>) || genericTypeDefinition == typeof(IList<>);
+            }
         }
     }
 }

--- a/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
+++ b/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
@@ -68,6 +68,9 @@ namespace osu.Game.IO.Serialization.Converters
                 if (typeIndex == null)
                     throw new JsonException("Expected $type token.");
 
+                if (typeIndex < 0 || typeIndex >= lookupTable.Count)
+                    throw new JsonException($"$type index {typeIndex} is out of range.");
+
                 // Prevent instantiation of types that do not inherit the type targetted by this converter
                 Type type = Type.GetType(lookupTable[typeIndex.Value])!;
                 if (!type.IsAssignableTo(itemType))

--- a/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
+++ b/osu.Game/IO/Serialization/Converters/TypedListConverter.cs
@@ -93,10 +93,10 @@ namespace osu.Game.IO.Serialization.Converters
                 return;
             }
 
+            var list = (IEnumerable)value;
+
             var lookupTable = new List<string>();
             var objects = new List<JObject>();
-
-            var list = (IEnumerable)value;
 
             foreach (object item in list)
             {

--- a/osu.Game/Screens/Edit/ClipboardContent.cs
+++ b/osu.Game/Screens/Edit/ClipboardContent.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.Edit
 {
     public class ClipboardContent
     {
-        [JsonConverter(typeof(TypedListConverter<HitObject>))]
+        [JsonConverter(typeof(TypedListConverter))]
         public IList<HitObject> HitObjects;
 
         public ClipboardContent()


### PR DESCRIPTION
I ran into this recently when working on a custom ruleset. Trying to deserialize a `Beatmap<T>` from json where `T` is not `HitObject` will throw the following error because `TypedListConverter<HitObject>` returns a `List<HitObject>` regardless of the property's actual type.
```
Newtonsoft.Json.JsonSerializationException : Error setting value to 'HitObjects' on 'osu.Game.Beatmaps.Beatmap`1[osu.Game.Rulesets.Osu.Objects.OsuHitObject]'.
  ----> System.InvalidCastException : Unable to cast object of type 'System.Collections.Generic.List`1[osu.Game.Rulesets.Objects.HitObject]' to type 'System.Collections.Generic.List`1[osu.Game.Rulesets.Osu.Objects.OsuHitObject]'.
...
```
Changes the `TypedListConverter` to resolve the generic list type from the type provided by the serializer, so it will always deserialize as the exact type specified by the property.