### PR TITLE
SongSelectV2: Fix more crashes resulting from users deliberately trying to break things

### DIFF
--- a/osu.Game/Screens/SelectV2/SoloSongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SoloSongSelect.cs
@@ -143,6 +143,9 @@ namespace osu.Game.Screens.SelectV2
 
         private void edit(BeatmapInfo beatmap)
         {
+            if (!this.IsCurrentScreen())
+                return;
+
             FinaliseSelection();
 
             // Forced refetch is important here to guarantee correct invalidation across all difficulties.

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -390,6 +390,9 @@ namespace osu.Game.Screens.SelectV2
 
         private void selectBeatmap(BeatmapInfo beatmap)
         {
+            if (!this.IsCurrentScreen())
+                return;
+
             if (beatmap.BeatmapSet!.Protected)
                 return;
 
@@ -674,6 +677,9 @@ namespace osu.Game.Screens.SelectV2
         /// </summary>
         public void SelectAndStart(BeatmapInfo beatmap)
         {
+            if (!this.IsCurrentScreen())
+                return;
+
             Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap);
             OnStart();
         }


### PR DESCRIPTION
See https://github.com/ppy/osu/issues/33336#issuecomment-2922443444.

Can't wait for even more human fuzzing to come later.

I've only guarded the ones that hard-die. User also reported being able to delete beatmap the same way but It doesn't die so I decided I don't care that much. Up for discussion whether we should.