### PR TITLE
SongSelectV2: Fix input gap between last beatmap panel in set and next set panel

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -266,8 +266,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddAssert("no beatmaps visible", () => !GetVisiblePanels<PanelBeatmap>().Any());
 
-            // Clicks just above the first group panel should not actuate any action.
-            ClickVisiblePanelWithOffset<PanelBeatmapSet>(0, new Vector2(0, -(PanelBeatmapSet.HEIGHT / 2 + 1)));
+            ClickVisiblePanelWithOffset<PanelBeatmapSet>(0, new Vector2(0, -(PanelBeatmapSet.HEIGHT / 2 + BeatmapCarousel.SPACING + 1)));
 
             AddAssert("no beatmaps visible", () => !GetVisiblePanels<PanelBeatmap>().Any());
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -67,6 +67,19 @@ namespace osu.Game.Screens.SelectV2
             PanelXOffset = 20f;
         }
 
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            var inputRectangle = TopLevelContent.DrawRectangle;
+
+            // Cover the gaps introduced by the spacing between BeatmapPanels so that clicks will not fall through the carousel.
+            //
+            // Caveat is that for simplicity, we are covering the full spacing, so panels with frontmost depth will have a slightly
+            // larger hit target.
+            inputRectangle = inputRectangle.Inflate(new MarginPadding { Vertical = BeatmapCarousel.SPACING });
+
+            return inputRectangle.Contains(TopLevelContent.ToLocalSpace(screenSpacePos));
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {


### PR DESCRIPTION
Still doesn't seem to fix the flaky tests, but does seem to fix the actual gap that is now there after https://github.com/ppy/osu/pull/33329/commits/017cef42553cf9b8800e1e8793bf0fc91602fd68.

Maybe the spacing should be doubled. Not sure.