### PR TITLE
Slider Path Calculation Rework

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 1.35;
+        private const double slider_multiplier = 5.35;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 1.35;
+        private const double slider_multiplier = 16.15;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 16.15;
+        private const double slider_multiplier = 1.35;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 4.25;
+        private const double slider_multiplier = 4.35;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 currVelocity = (osuCurrObj.LazyJumpDistance + osuLastObj.TravelDistance) / osuCurrObj.StrainTime;
 
                 // Scale with ratio of difference compared to 0.5 * max dist.
-                double distRatio = Math.Pow(Math.Sin(Math.PI / 2 * Math.Abs(prevVelocity - currVelocity) / Math.Max(prevVelocity, currVelocity)), 2);
+                double distRatio = Math.Pow(Math.Sin(Math.PI / 2 * Math.Abs(prevVelocity - currVelocity) / (1 + Math.Max(prevVelocity, currVelocity))), 2);
 
                 // Reward for % distance up to 125 / strainTime for overlaps where velocity is still changing.
                 double overlapVelocityBuff = Math.Min(diameter * 1.25 / Math.Min(osuCurrObj.StrainTime, osuLastObj.StrainTime), Math.Abs(prevVelocity - currVelocity));

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -44,13 +44,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             // But if the last object is a slider, then we extend the travel velocity through the slider into the current object.
             if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
-                currVelocity = Math.Max(currVelocity, osuCurrObj.MinimumJumpDistance / osuCurrObj.MinimumJumpTime + osuLastObj.SliderTailVelocityVelocity); // calculate the slider velocity from slider head to slider end.
+                currVelocity = Math.Max(currVelocity, osuCurrObj.MinimumJumpDistance / osuCurrObj.MinimumJumpTime + osuLastObj.SliderTailVelocity); // calculate the slider velocity from slider head to slider end.
 
             // As above, do the same for the previous hitobject.
             double prevVelocity = osuLastObj.LazyJumpDistance / osuLastObj.StrainTime;
 
             if (osuLastLastObj.BaseObject is Slider && withSliderTravelDistance)
-                prevVelocity = Math.Max(prevVelocity, osuLastObj.MinimumJumpDistance / osuLastObj.MinimumJumpTime + osuLastLastObj.SliderTailVelocityVelocity);
+                prevVelocity = Math.Max(prevVelocity, osuLastObj.MinimumJumpDistance / osuLastObj.MinimumJumpTime + osuLastLastObj.SliderTailVelocity);
 
             double wideAngleBonus = 0;
             double acuteAngleBonus = 0;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 5.35;
+        private const double slider_multiplier = 2.95;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 2.95;
+        private const double slider_multiplier = 3.95;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 
@@ -44,23 +44,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             // But if the last object is a slider, then we extend the travel velocity through the slider into the current object.
             if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
-            {
-                double travelVelocity = osuLastObj.TravelDistance / osuLastObj.TravelTime; // calculate the slider velocity from slider head to slider end.
-                double movementVelocity = osuCurrObj.MinimumJumpDistance / osuCurrObj.MinimumJumpTime; // calculate the movement velocity from slider end to current object
-
-                currVelocity = Math.Max(currVelocity, movementVelocity + travelVelocity); // take the larger total combined velocity.
-            }
+                currVelocity = Math.Max(currVelocity, osuCurrObj.MinimumJumpDistance / osuCurrObj.MinimumJumpTime + osuLastObj.SliderTailVelocityVelocity); // calculate the slider velocity from slider head to slider end.
 
             // As above, do the same for the previous hitobject.
             double prevVelocity = osuLastObj.LazyJumpDistance / osuLastObj.StrainTime;
 
             if (osuLastLastObj.BaseObject is Slider && withSliderTravelDistance)
-            {
-                double travelVelocity = osuLastLastObj.TravelDistance / osuLastLastObj.TravelTime;
-                double movementVelocity = osuLastObj.MinimumJumpDistance / osuLastObj.MinimumJumpTime;
-
-                prevVelocity = Math.Max(prevVelocity, movementVelocity + travelVelocity);
-            }
+                prevVelocity = Math.Max(prevVelocity, osuLastObj.MinimumJumpDistance / osuLastObj.MinimumJumpTime + osuLastLastObj.SliderTailVelocityVelocity);
 
             double wideAngleBonus = 0;
             double acuteAngleBonus = 0;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -130,10 +130,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 velocityChangeBonus *= Math.Pow(Math.Min(osuCurrObj.StrainTime, osuLastObj.StrainTime) / Math.Max(osuCurrObj.StrainTime, osuLastObj.StrainTime), 2);
             }
 
-            if (osuLastObj.BaseObject is Slider)
+            if (osuCurrObj.BaseObject is Slider)
             {
                 // Reward sliders based on velocity.
-                sliderBonus = osuLastObj.TravelDistance / osuLastObj.TravelTime;
+                sliderBonus = osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
             }
 
             aimStrain += wiggleBonus * wiggle_multiplier;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 4.35;
+        private const double slider_multiplier = 3.25;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.6;
-        private const double slider_multiplier = 3.95;
+        private const double slider_multiplier = 4.25;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double hidden_bonus = 0.2;
 
         private const double min_velocity = 0.5;
-        private const double slider_multiplier = 1.3;
+        private const double slider_multiplier = 0.3;
 
         private const double min_angle_multiplier = 0.2;
 
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             for (int i = 0; i < Math.Min(current.Index, 10); i++)
             {
                 var currentObj = (OsuDifficultyHitObject)current.Previous(i);
-                var currentHitObject = (OsuHitObject)(currentObj.BaseObject);
+                var currentHitObject = (OsuHitObject)currentObj.BaseObject;
 
                 cumulativeStrainTime += lastObj.StrainTime;
 
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                 // Nerf sliders with repeats, as less memorisation is required.
                 if (osuSlider.RepeatCount > 0)
-                    sliderBonus /= (osuSlider.RepeatCount + 1);
+                    sliderBonus /= osuSlider.RepeatCount + 1;
             }
 
             result += sliderBonus * slider_multiplier;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double hidden_bonus = 0.2;
 
         private const double min_velocity = 0.5;
-        private const double slider_multiplier = 0.3;
+        private const double slider_multiplier = 0.5;
 
         private const double min_angle_multiplier = 0.2;
 
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 return 0;
 
             var osuCurrent = (OsuDifficultyHitObject)current;
-            var osuHitObject = (OsuHitObject)(osuCurrent.BaseObject);
+            var osuHitObject = (OsuHitObject)osuCurrent.BaseObject;
 
             double scalingFactor = 52.0 / osuHitObject.Radius;
             double smallDistNerf = 1.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -198,7 +198,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             if (BaseObject is Slider)
             {
                 // Bonus for repeat sliders until a better per nested object strain system can be achieved.
-                TravelDistance = LazyTravelDistance;
+                bool lastIsSlider = LastObject is Slider;
+                bool lastLastIsSlider = lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is Slider;
+
+                double lastMultiplier = lastIsSlider ? 0.1 : 0;
+                double lastLastMultiplier = lastLastIsSlider ? 0.1 : 0;
+                double totalMultiplier = 1 + lastMultiplier + lastLastMultiplier;
+
+                TravelDistance = LazyTravelDistance * totalMultiplier;
                 TravelTime = Math.Max(LazyTravelTime / clockRate, MIN_DELTA_TIME);
             }
 
@@ -215,17 +222,17 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             MinimumJumpTime = StrainTime;
             MinimumJumpDistance = LazyJumpDistance;
 
-            Vector2 lastObjStackedPosition = LastObject is Slider lastslider ? lastslider.TailCircle.StackedPosition : LastObject.StackedPosition;
+            Vector2 lastObjStackedPosition = LastObject.StackedPosition;
+
+            if (lastDifficultyObject is not null && lastDifficultyObject.BaseObject is Slider lastslider && lastDifficultyObject.TravelDistance > 0)
+                lastObjStackedPosition = lastslider.TailCircle.StackedPosition;
 
             if (lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is not Spinner)
             {
-                bool sliderValidation = lastLastDifficultyObject.BaseObject is Slider &&
-                                        TravelDistance > 0;
+                bool sliderValidation = lastLastDifficultyObject.BaseObject is Slider && TravelDistance > 0;
                 Vector2 lastLastCursorPosition = sliderValidation ? lastCursorSliderPosition : getEndCursorPosition(lastLastDifficultyObject);
 
-                Angle = Math.Abs(calculateAngle(lastLastCursorPosition,
-                                                lastObjStackedPosition,
-                                                BaseObject.StackedPosition));
+                Angle = Math.Abs(calculateAngle(lastLastCursorPosition, lastObjStackedPosition, BaseObject.StackedPosition));
             }
 
             if (LastObject is Slider lastSlider && lastDifficultyObject != null)

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -233,9 +233,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 //
 
                 const double slider_radius = NORMALISED_RADIUS * SLIDER_RADIUS_MULTIPLIER;
+                const double jump_slider_radius = NORMALISED_RADIUS * 1.62711864447; // magic number to match the previous calculation of jump distance.
 
                 float tailJumpDistance = Vector2.Subtract(lastSlider.TailCircle.StackedPosition, BaseObject.StackedPosition).Length * scalingFactor;
-                MinimumJumpDistance = Math.Max(0, Math.Min(LazyJumpDistance - slider_radius, tailJumpDistance - slider_radius));
+                MinimumJumpDistance = Math.Max(0, Math.Min(LazyJumpDistance - (slider_radius - jump_slider_radius), tailJumpDistance - slider_radius));
             }
 
             if (lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is not Spinner)

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -296,7 +296,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 double middleStrainValue = (currMovementObj.StartTime + lastStartTime) / 2 - lastStartTime;
 
                 Vector2 currMovement = Vector2.Subtract(slider.StackedPositionAt(currentStrainValue / slider.SpanDuration), currCursorPosition);
-                double currMovementLength = scalingFactor * currMovement.Length;
+                double currMovementLength;
 
                 Vector2 additionalSliderPath = slider.StackedPositionAt(middleStrainValue / slider.SpanDuration);
 


### PR DESCRIPTION
## Changes and features in this rework
### Changes
- Implemented logic that follow more how a player follow sliders. And not assuming players always move in a perfectly straight line to the next slider element.
### New features:
- If a slider angle makes cheesing very easy, significantly less bonus is given.
- If the angle makes cheesing not viable, the full bonus is retained.
### Impact
- Maps with genuinely difficult sliders will receive a buff in star rating. (e.g. https://osu.ppy.sh/beatmapsets/1851103#osu/3802734 or https://osu.ppy.sh/beatmapsets/1137778#osu/2376713)
- Maps containing sliders with high cheese potential can be a little nerfed or buffed. (e.g. https://osu.ppy.sh/beatmapsets/1455997#osu/2992705 or https://osu.ppy.sh/beatmapsets/1376308#osu/2844649)
- Maps with little to no slider difficulty are not impacted by this change.