### PR TITLE
Fix directory breadcrumb buttons playing clicking sounds twice

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FileSelection/OsuDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelection/OsuDirectorySelectorBreadcrumbDisplay.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -78,13 +77,9 @@ namespace osu.Game.Graphics.UserInterfaceV2.FileSelection
                 Flow.Height = 25;
                 Flow.Margin = new MarginPadding { Horizontal = 10, };
 
-                AddRangeInternal(new Drawable[]
+                AddInternal(new BackgroundLayer(0.5f)
                 {
-                    new BackgroundLayer(0.5f)
-                    {
-                        Depth = 1
-                    },
-                    new HoverClickSounds(),
+                    Depth = 1
                 });
 
                 Flow.Add(new SpriteIcon


### PR DESCRIPTION
`BackgroundLayer` already has `HoverClickSounds`.

Before:

https://github.com/user-attachments/assets/e391cc34-2d88-4219-b8c4-c461320d8759

After:

https://github.com/user-attachments/assets/46192a53-85cc-41d2-87fa-dea211f639c8