### PR TITLE
osu!taiko remove stamina skill component from `strainLengthBonus`

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -120,9 +120,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             // As we don't have pattern integration in osu!taiko, we apply the other two skills relative to rhythm.
             patternMultiplier = Math.Pow(staminaSkill * colourSkill, 0.10);
 
-            strainLengthBonus = 1
-                                + Math.Min(Math.Max((staminaDifficultStrains - 1000) / 3700, 0), 0.15)
-                                + Math.Min(Math.Max((staminaSkill - 7.0) / 1.0, 0), 0.05);
+            strainLengthBonus = 1 + 0.15 * DifficultyCalculationUtils.ReverseLerp(staminaDifficultStrains, 1000, 1555);
 
             double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax, isConvert, out double consistencyFactor);
             double starRating = rescale(combinedRating * 1.4);


### PR DESCRIPTION
This change removes the component of strainLengthBonus that was (accidentally?) causing maps to immediately jump up in difficulty once `staminaSkill` reaches 7. `Blaidd` and `dragonmaxx` are good profiles to look at to see how only maps that cross the 7 stamina threshold are affected. We may make further changes later to bring top-end stamina difficulty back up but this component definitely needs to go. I also gave the other component of strainLengthBonus a slightly prettier formula with no value changes