### PR TITLE
SongSelectV2: Add padding to avoid overlap between mods button and personal best

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.SelectV2
 
         private readonly IBindable<LeaderboardScores?> fetchedScores = new Bindable<LeaderboardScores?>();
 
-        private const float personal_best_height = 100;
+        private const float personal_best_height = 112;
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
I've added the minimum padding to avoid information being hidden. There's still a small amount of overlap, intentionally, to avoid the padding looking weird when the mod button isn't showing the extra line.