### PR TITLE
Attempt to fix flaky tests by removing finaliser

### DIFF
--- a/osu.Game.Tests/WaveformTestBeatmap.cs
+++ b/osu.Game.Tests/WaveformTestBeatmap.cs
@@ -39,12 +39,6 @@ namespace osu.Game.Tests
             trackStore = audioManager.GetTrackStore(getZipReader());
         }
 
-        ~WaveformTestBeatmap()
-        {
-            // Remove the track store from the audio manager
-            trackStore?.Dispose();
-        }
-
         private static Stream getStream() => TestResources.GetTestBeatmapStream();
 
         private static ZipArchiveReader getZipReader() => new ZipArchiveReader(getStream());

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -341,8 +341,6 @@ namespace osu.Game.Tests.Visual
         {
             private readonly Track track;
 
-            private readonly TrackVirtualStore store;
-
             /// <summary>
             /// Create an instance which creates a <see cref="TestBeatmap"/> for the provided ruleset when requested.
             /// </summary>
@@ -372,7 +370,7 @@ namespace osu.Game.Tests.Visual
 
                 if (referenceClock != null)
                 {
-                    store = new TrackVirtualStore(referenceClock);
+                    var store = new TrackVirtualStore(referenceClock);
                     audio.AddItem(store);
                     track = store.GetVirtual(trackLength);
                 }
@@ -383,12 +381,6 @@ namespace osu.Game.Tests.Visual
                 // To ease testability, ensure the track is available from point of construction.
                 // (Usually this would be done by MusicController for us).
                 LoadTrack();
-            }
-
-            ~ClockBackedTestWorkingBeatmap()
-            {
-                // Remove the track store from the audio manager
-                store?.Dispose();
             }
 
             protected override Track GetBeatmapTrack() => track;


### PR DESCRIPTION
I'm attempting to fix the SkipOverlay related failure in https://github.com/ppy/osu/runs/43365481507#r0s0, which I've managed to reproduce by early-disposing the `WorkingBeatmap` to emulate the finaliser because we look to not be storing the `WorkingBeatmap` anywhere.

```diff
diff --git a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
index 276a0c3410..a35ba478e7 100644
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -32,7 +32,7 @@ public partial class TestSceneSkipOverlay : OsuManualInputManagerTestScene
             requestCount = 0;
             increment = skip_time;
 
-            var working = CreateWorkingBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
+            var working = (ClockBackedTestWorkingBeatmap)CreateWorkingBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
 
             Child = gameplayClockContainer = new MasterGameplayClockContainer(working, 0)
             {
@@ -50,6 +50,8 @@ public partial class TestSceneSkipOverlay : OsuManualInputManagerTestScene
                 },
             };
 
+            working.RemoveStore();
+
             gameplayClockContainer.Start();
             gameplayClock = gameplayClockContainer;
         });
diff --git a/osu.Game/Tests/Visual/OsuTestScene.cs b/osu.Game/Tests/Visual/OsuTestScene.cs
index 09cfe5ecad..92343e3b40 100644
--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -385,6 +385,11 @@ public ClockBackedTestWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard, IF
                 LoadTrack();
             }
 
+            public void RemoveStore()
+            {
+                store?.Dispose();
+            }
+
             ~ClockBackedTestWorkingBeatmap()
             {
                 // Remove the track store from the audio manager

```

I believe this finaliser is mostly a good-faith attempt to clean up and not relevant to ensuring correct execution, but since we instantiate a new host (thus new `AudioManager`) per-`TestScene` it shouldn't be too bad to _not_ do this janky/potentially unsafe cleanup.

Let's see how this goes in a few CI runs, and go with it if it passes a few times?