### PR TITLE
Fix argon & triangles skins reading legacy slider colour overrides from beatmap skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -44,10 +44,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             SnakingOut.BindTo(configSnakingOut);
 
-            BorderColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value ?? Color4.White;
+            BorderColour = GetBorderColour(skin);
         }
 
-        protected virtual Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour) =>
-            skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderTrackOverride)?.Value ?? hitObjectAccentColour;
+        protected virtual Color4 GetBorderColour(ISkinSource skin) => Color4.White;
+
+        protected virtual Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour) => hitObjectAccentColour;
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -15,11 +15,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
     {
         protected override DrawableSliderPath CreateSliderPath() => new LegacyDrawableSliderPath();
 
+        protected override Color4 GetBorderColour(ISkinSource skin)
+            => skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value ?? Color4.White;
+
         protected override Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour)
-        {
             // legacy skins use a constant value for slider track alpha, regardless of the source colour.
-            return base.GetBodyAccentColour(skin, hitObjectAccentColour).Opacity(0.7f);
-        }
+            => (skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderTrackOverride)?.Value ?? hitObjectAccentColour).Opacity(0.7f);
 
         private partial class LegacyDrawableSliderPath : DrawableSliderPath
         {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33383.

| | master | this PR |
| :-: | :-: | :-: |
| argon | ![osu_2025-06-03_12-54-13](https://github.com/user-attachments/assets/012e92dd-7f9b-457a-94fc-51d9f69d8bd9) | ![osu_2025-06-03_12-55-05](https://github.com/user-attachments/assets/2aa72cd2-a078-4f97-ba31-13409d8d6a1e) |
| triangles | ![osu_2025-06-03_12-54-20](https://github.com/user-attachments/assets/8f763226-cf00-46c4-8745-9c05c520633a) | ![osu_2025-06-03_12-55-14](https://github.com/user-attachments/assets/9d60f0cd-9fa4-42b7-954a-0e8750a85514) |
| legacy | ![osu_2025-06-03_12-54-26](https://github.com/user-attachments/assets/dd8bd489-df7b-4820-8b97-5e44066aac67) | ![osu_2025-06-03_12-55-19](https://github.com/user-attachments/assets/81f117aa-25ce-4eb3-8a9a-49a75d6a1c6a) |

Screenshots taken from https://osu.ppy.sh/beatmapsets/2209401#osu/4720349, timestamp `01:14:477 (1) -`.

Issue OP claims that the issue "seems to have occurred sometime within the past two major releases" but that's patently false. I checked 2025.101.0 on a whim and the issue was still there. Probably been there for years, just requires specific beatmaps with these colours overridden.