### PR TITLE
Fix track not looping if specified preview point exceeds duration of track

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -124,18 +124,16 @@ namespace osu.Game.Beatmaps
             Track.Looping = looping;
             Track.RestartPoint = Metadata.PreviewTime;
 
-            if (Track.RestartPoint == -1)
+            if (!Track.IsLoaded)
             {
-                if (!Track.IsLoaded)
-                {
-                    // force length to be populated (https://github.com/ppy/osu-framework/issues/4202)
-                    Track.Seek(Track.CurrentTime);
-                }
-
-                Track.RestartPoint = 0.4f * Track.Length;
+                // force length to be populated (https://github.com/ppy/osu-framework/issues/4202)
+                Track.Seek(Track.CurrentTime);
             }
 
-            Track.RestartPoint += offsetFromPreviewPoint;
+            if (Track.RestartPoint < 0 || Track.RestartPoint > Track.Length)
+                Track.RestartPoint = 0.4f * Track.Length;
+
+            Track.RestartPoint = Math.Clamp(Track.RestartPoint + offsetFromPreviewPoint, 0, Track.Length);
         }
 
         /// <summary>


### PR DESCRIPTION
By falling back to the default of 40% of track duration in such cases.

Also added a safety for the restart point exceeding acceptable bounds in case of a non-zero offset.

Closes https://github.com/ppy/osu/issues/33308.