### PR TITLE
osu!taiko new miss penalty using consistency factor

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             estimatedUnstableRate = computeDeviationUpperBound() * 10;
 
-            // Effective miss count is calculated by raising the fraction of hits missed to a power based on the map's consistency factor
-            // This is because in less consistently difficult maps, each miss removes more of the map's total difficulty
+            // Effective miss count is calculated by raising the fraction of hits missed to a power based on the map's consistency factor.
+            // This is because in less consistently difficult maps, each miss removes more of the map's total difficulty.
             effectiveMissCount = totalHits * Math.Pow(
                 (double)countMiss / totalHits,
                 Math.Pow(taikoAttributes.ConsistencyFactor, 0.2)
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
             difficultyValue *= lengthBonus;
 
-            // The penalty applied for each miss scales with the number of total hits, making misses more punishing on shorter maps than longer ones
+            // Scales miss penalty by the total hits of a map, making misses more punishing on maps with fewer objects.
             double missPenalty = Math.Pow(0.5, 30.0 / totalHits);
             difficultyValue *= Math.Pow(missPenalty, effectiveMissCount);
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -56,7 +56,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             estimatedUnstableRate = computeDeviationUpperBound() * 10;
 
-            // Effective miss count punishes misses more on less consistently difficult maps
+            // Effective miss count is calculated by raising the fraction of hits missed to a power based on the map's consistency factor
+            // This is because in less consistently difficult maps, each miss removes more of the map's total difficulty
             effectiveMissCount = totalHits * Math.Pow(
                 (double)countMiss / totalHits,
                 Math.Pow(taikoAttributes.ConsistencyFactor, 0.2)
@@ -101,7 +102,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
             difficultyValue *= lengthBonus;
 
-            // Misses are punished more on maps with less total hits
+            // The penalty applied for each miss scales with the number of total hits, making misses more punishing on shorter maps than longer ones
             double missPenalty = Math.Pow(0.5, 30.0 / totalHits);
             difficultyValue *= Math.Pow(missPenalty, effectiveMissCount);
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -56,9 +56,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             estimatedUnstableRate = computeDeviationUpperBound() * 10;
 
-            // The effectiveMissCount is calculated by gaining a ratio for totalSuccessfulHits and increasing the miss penalty for shorter object counts lower than 1000.
-            if (totalSuccessfulHits > 0)
-                effectiveMissCount = Math.Max(1.0, 1000.0 / totalSuccessfulHits) * countMiss;
+            // Effective miss count punishes misses more on less consistently difficult maps
+            effectiveMissCount = totalHits * Math.Pow(
+                (double)countMiss / totalHits,
+                Math.Pow(taikoAttributes.ConsistencyFactor, 0.2)
+            );
 
             // Converts are detected and omitted from mod-specific bonuses due to the scope of current difficulty calculation.
             bool isConvert = score.BeatmapInfo!.Ruleset.OnlineID != 1;
@@ -99,7 +101,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
             difficultyValue *= lengthBonus;
 
-            difficultyValue *= Math.Pow(0.986, effectiveMissCount);
+            // Misses are punished more on maps with less total hits
+            double missPenalty = Math.Pow(0.5, 30.0 / totalHits);
+            difficultyValue *= Math.Pow(missPenalty, effectiveMissCount);
 
             if (score.Mods.Any(m => m is ModEasy))
                 difficultyValue *= 0.90;


### PR DESCRIPTION
These changes rework `effectiveMissCount` to be based on a map's total hits and consistency factor, as well as punishing said effective misses more on maps with less total hits and vice versa. Not a huge amount of effort has been put into balancing the numbers, as we plan on doing a full balancing pass once everything we want before next deploy is implemented