### PR TITLE
Fix flaky playlists song select / overlay tests

### DIFF
--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -44,11 +44,8 @@ namespace osu.Game.Tests.Visual
                     RelativeSizeAxes = Axes.Both
                 },
                 content = new Container { RelativeSizeAxes = Axes.Both },
-                overlayContent = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = DialogOverlay = new DialogOverlay()
-                },
+                DialogOverlay = new DialogOverlay(),
+                overlayContent = new Container { RelativeSizeAxes = Axes.Both },
                 footer = new ScreenFooter(),
             });
 
@@ -72,7 +69,11 @@ namespace osu.Game.Tests.Visual
         {
             AddUntilStep("exit all screens", () =>
             {
-                if (Stack.CurrentScreen == null) return true;
+                // Immediately remove any overlays, because these are usually removed in async disposal.
+                overlayContent.Clear();
+
+                if (Stack.CurrentScreen == null)
+                    return true;
 
                 Stack.Exit();
                 return false;


### PR DESCRIPTION
See: https://github.com/ppy/osu/actions/runs/15416542079/job/43431573630?pr=33391

Repro (run entire test scene):

```diff
diff --git a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
index bb6d75fa3b..8aaf48f067 100644
--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -267,6 +268,7 @@ private bool isValidAllowedMod(Mod mod) => ModUtils.IsValidModForMatch(mod, fals
 
         protected override void Dispose(bool isDisposing)
         {
+            Thread.Sleep(1000);
             base.Dispose(isDisposing);
             freeModSelectOverlayRegistration?.Dispose();
         }

```
