### PR TITLE
SongSelectV2: Fix triangles being sheared on leaderboard panels

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -370,6 +370,7 @@ namespace osu.Game.Screens.SelectV2
                                             },
                                             new TrianglesV2
                                             {
+                                                Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                                 RelativeSizeAxes = Axes.Both,
                                                 Anchor = Anchor.TopRight,
                                                 Origin = Anchor.TopRight,


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/fd781846-9cb4-425a-81b3-0be59f126c06

After:

https://github.com/user-attachments/assets/3f73e221-8b9e-481f-952b-95c22118dd70

