### PR TITLE
osu!taiko remove multipliers nerfing Easy mod

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -68,9 +68,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (score.Mods.Any(m => m is ModHidden) && !isConvert)
                 multiplier *= 1.075;
 
-            if (score.Mods.Any(m => m is ModEasy))
-                multiplier *= 0.950;
-
             double difficultyValue = computeDifficultyValue(score, taikoAttributes);
             double accuracyValue = computeAccuracyValue(score, taikoAttributes, isConvert);
             double totalValue =
@@ -100,9 +97,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             difficultyValue *= lengthBonus;
 
             difficultyValue *= Math.Pow(0.986, effectiveMissCount);
-
-            if (score.Mods.Any(m => m is ModEasy))
-                difficultyValue *= 0.90;
 
             if (score.Mods.Any(m => m is ModHidden))
                 difficultyValue *= 1.025;


### PR DESCRIPTION
This change removes the flat multipliers to pp applied to plays with the Easy mod. With the `Reading` skill rewarding maps at higher scroll speeds and plans existing to rebalance accuracy, these arbitrary nerfs don't need to exist anymore