### PR TITLE
SongSelectV2: Fix incorrect selection change when filtered down to one set

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
 using FilterControl = osu.Game.Screens.SelectV2.FilterControl;
 using NoResultsPlaceholder = osu.Game.Screens.SelectV2.NoResultsPlaceholder;
 
@@ -63,6 +64,28 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("return", () => SongSelect.MakeCurrent());
             AddUntilStep("wait for current", () => SongSelect.IsCurrentScreen());
             AddAssert("filter count is 0", () => filterOperationsCount, () => Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestFilterSingleResult_RetainsSelectedDifficulty()
+        {
+            LoadSongSelect();
+
+            ImportBeatmapForRuleset(0);
+
+            AddUntilStep("wait for single set", () => Carousel.ChildrenOfType<PanelBeatmapSet>().Count(), () => Is.EqualTo(1));
+
+            AddStep("select last difficulty", () =>
+            {
+                Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmaps.GetAllUsableBeatmapSets().First().Beatmaps.Last());
+            });
+
+            AddStep("set filter text", () => filterTextBox.Current.Value = " ");
+
+            AddWaitStep("wait for debounce", 5);
+            AddUntilStep("wait for filter", () => !Carousel.IsFiltering);
+
+            AddAssert("selection unchanged", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(Beatmaps.GetAllUsableBeatmapSets().First().Beatmaps.Last()));
         }
 
         [Test]

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -318,7 +318,12 @@ namespace osu.Game.Screens.SelectV2
                 }
             }
 
-            RequestRecommendedSelection(items.Select(i => i.Model).OfType<BeatmapInfo>());
+            var beatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
+
+            if (beatmaps.Any(b => b.Equals(CurrentSelection as BeatmapInfo)))
+                return;
+
+            RequestRecommendedSelection(beatmaps);
         }
 
         protected override bool CheckValidForGroupSelection(CarouselItem item)


### PR DESCRIPTION
This fixes incorrect selection on returning from gameplay if only one set was displayed and you were playing the non-recommended difficulty.

I have full "navigation" test coverage in a WIP branch, but the test here is more direct and covers the same fail case, so hopefully is enough for now.