### PR TITLE
Reduce combo scaling for osu!catch

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             // Combo scaling
             if (catchAttributes.MaxCombo > 0)
-                value *= Math.Min(Math.Pow(score.MaxCombo, 0.45) / Math.Pow(catchAttributes.MaxCombo, 0.45), 1.0);
+                value *= Math.Min(Math.Pow(score.MaxCombo, 0.35) / Math.Pow(catchAttributes.MaxCombo, 0.35), 1.0);
 
             var difficulty = score.BeatmapInfo!.Difficulty.Clone();
 

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             // Combo scaling
             if (catchAttributes.MaxCombo > 0)
-                value *= Math.Min(Math.Pow(score.MaxCombo, 0.8) / Math.Pow(catchAttributes.MaxCombo, 0.8), 1.0);
+                value *= Math.Min(Math.Pow(score.MaxCombo, 0.45) / Math.Pow(catchAttributes.MaxCombo, 0.45), 1.0);
 
             var difficulty = score.BeatmapInfo!.Difficulty.Clone();
 


### PR DESCRIPTION
The current combo scaling is very harsh, making most of non-FC scores have insignificant pp values.
As a first step, let's reduce the scaling a bit.
Before and after: https://www.desmos.com/calculator/q0ljxequi9