### PR TITLE
SongSelectV2: Animate placeholder ghost

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneGhostIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneGhostIcon.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public partial class TestSceneGhostIcon : OsuTestScene
+    {
+        public TestSceneGhostIcon()
+        {
+            Add(new GhostIcon
+            {
+                Size = new Vector2(64),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            });
+        }
+    }
+}

--- a/osu.Game/Graphics/GhostIcon.cs
+++ b/osu.Game/Graphics/GhostIcon.cs
@@ -129,6 +129,14 @@ namespace osu.Game.Graphics
                 public UniformFloat Time;
                 private UniformPadding12 pad;
             }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                ghostParametersBuffer?.Dispose();
+                quadBatch?.Dispose();
+            }
         }
     }
 }

--- a/osu.Game/Graphics/GhostIcon.cs
+++ b/osu.Game/Graphics/GhostIcon.cs
@@ -22,6 +22,11 @@ namespace osu.Game.Graphics
     {
         private IShader ghostShader = null!;
 
+        /// <summary>
+        /// How long one complete loop of the ghost's animation takes, in milliseconds
+        /// </summary>
+        public float AnimationDuration = 2000;
+
         [BackgroundDependencyLoader]
         private void load(ShaderManager shaders)
         {
@@ -60,7 +65,7 @@ namespace osu.Game.Graphics
                 drawRectangle = new Vector4(0, 0, Source.DrawWidth, Source.DrawHeight);
                 shader = Source.ghostShader;
                 blend = new Vector2(Math.Min(Source.DrawWidth, Source.DrawHeight) / Math.Min(screenSpaceDrawQuad.Width, screenSpaceDrawQuad.Height));
-                time = (float)(Source.Time.Current % 1000f) * 0.0005f;
+                time = (float)(Source.Time.Current % 1000f) / Source.AnimationDuration;
             }
 
             private IUniformBuffer<GhostParameters>? ghostParametersBuffer;

--- a/osu.Game/Graphics/GhostIcon.cs
+++ b/osu.Game/Graphics/GhostIcon.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Graphics
                 drawRectangle = new Vector4(0, 0, Source.DrawWidth, Source.DrawHeight);
                 shader = Source.ghostShader;
                 blend = new Vector2(Math.Min(Source.DrawWidth, Source.DrawHeight) / Math.Min(screenSpaceDrawQuad.Width, screenSpaceDrawQuad.Height));
-                time = (float)(Source.Time.Current % 1000f) / Source.AnimationDuration;
+                time = (float)(Source.Time.Current / Source.AnimationDuration) % 1f;
             }
 
             private IUniformBuffer<GhostParameters>? ghostParametersBuffer;

--- a/osu.Game/Graphics/GhostIcon.cs
+++ b/osu.Game/Graphics/GhostIcon.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Shaders.Types;
+using osuTK;
+
+namespace osu.Game.Graphics
+{
+    public partial class GhostIcon : Drawable
+    {
+        private IShader ghostShader = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders)
+        {
+            ghostShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, "Ghost");
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            Invalidate(Invalidation.DrawNode);
+        }
+
+        protected override DrawNode CreateDrawNode() => new GhostIconDrawNode(this);
+
+        private class GhostIconDrawNode : DrawNode
+        {
+            protected new GhostIcon Source => (GhostIcon)base.Source;
+
+            public GhostIconDrawNode(IDrawable source)
+                : base(source)
+            {
+            }
+
+            private Quad screenSpaceDrawQuad;
+            private Vector4 drawRectangle;
+            private Vector2 blend;
+            private IShader shader = null!;
+            private float time;
+
+            public override void ApplyState()
+            {
+                base.ApplyState();
+
+                screenSpaceDrawQuad = Source.ScreenSpaceDrawQuad;
+                drawRectangle = new Vector4(0, 0, Source.DrawWidth, Source.DrawHeight);
+                shader = Source.ghostShader;
+                blend = new Vector2(Math.Min(Source.DrawWidth, Source.DrawHeight) / Math.Min(screenSpaceDrawQuad.Width, screenSpaceDrawQuad.Height));
+                time = (float)(Source.Time.Current % 1000f) * 0.0005f;
+            }
+
+            private IUniformBuffer<GhostParameters>? ghostParametersBuffer;
+
+            private IVertexBatch<TexturedVertex2D>? quadBatch;
+
+            protected override void Draw(IRenderer renderer)
+            {
+                base.Draw(renderer);
+
+                if (!renderer.BindTexture(renderer.WhitePixel))
+                    return;
+
+                quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(1, 2);
+                ghostParametersBuffer ??= renderer.CreateUniformBuffer<GhostParameters>();
+
+                ghostParametersBuffer.Data = new GhostParameters
+                {
+                    Time = time
+                };
+
+                shader.Bind();
+                shader.BindUniformBlock("m_GhostParameters", ghostParametersBuffer);
+
+                var vertexAction = quadBatch.AddAction;
+
+                vertexAction(new TexturedVertex2D(renderer)
+                {
+                    Position = screenSpaceDrawQuad.BottomLeft,
+                    TexturePosition = new Vector2(0, 1),
+                    TextureRect = drawRectangle,
+                    BlendRange = blend,
+                    Colour = DrawColourInfo.Colour.BottomLeft.SRGB,
+                });
+                vertexAction(new TexturedVertex2D(renderer)
+                {
+                    Position = screenSpaceDrawQuad.BottomRight,
+                    TexturePosition = new Vector2(1, 1),
+                    TextureRect = drawRectangle,
+                    BlendRange = blend,
+                    Colour = DrawColourInfo.Colour.BottomRight.SRGB,
+                });
+                vertexAction(new TexturedVertex2D(renderer)
+                {
+                    Position = screenSpaceDrawQuad.TopRight,
+                    TexturePosition = new Vector2(1, 0),
+                    TextureRect = drawRectangle,
+                    BlendRange = blend,
+                    Colour = DrawColourInfo.Colour.TopRight.SRGB,
+                });
+                vertexAction(new TexturedVertex2D(renderer)
+                {
+                    Position = screenSpaceDrawQuad.TopLeft,
+                    TexturePosition = Vector2.Zero,
+                    TextureRect = drawRectangle,
+                    BlendRange = blend,
+                    Colour = DrawColourInfo.Colour.TopLeft.SRGB,
+                });
+
+                shader.Unbind();
+            }
+
+            [StructLayout(LayoutKind.Sequential, Pack = 1)]
+            private record struct GhostParameters
+            {
+                public UniformFloat Time;
+                private UniformPadding12 pad;
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/GhostIcon.cs
+++ b/osu.Game/Graphics/GhostIcon.cs
@@ -10,10 +10,14 @@ using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shaders.Types;
+using osu.Framework.Graphics.Sprites;
 using osuTK;
 
 namespace osu.Game.Graphics
 {
+    /// <summary>
+    /// A (very cute) animated version of the <see cref="FontAwesome.Solid.Ghost"/> icon.
+    /// </summary>
     public partial class GhostIcon : Drawable
     {
         private IShader ghostShader = null!;

--- a/osu.Game/Screens/SelectV2/NoResultsPlaceholder.cs
+++ b/osu.Game/Screens/SelectV2/NoResultsPlaceholder.cs
@@ -71,9 +71,16 @@ namespace osu.Game.Screens.SelectV2
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        icon = new GhostIcon
+                        new Container
                         {
-                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Margin = new MarginPadding(10),
+                            Size = new Vector2(50),
+                            Child = icon = new GhostIcon
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                            },
                         },
                         new OsuSpriteText
                         {
@@ -97,6 +104,17 @@ namespace osu.Game.Screens.SelectV2
             };
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            icon.Loop(t =>
+                t.MoveToY(-10, 2000, Easing.InOutSine)
+                 .Then()
+                 .MoveToY(0, 2000, Easing.InOutSine)
+            );
+        }
+
         protected override void PopIn()
         {
             this.FadeIn(600, Easing.OutQuint);
@@ -116,9 +134,6 @@ namespace osu.Game.Screens.SelectV2
             // Bounce should play every time the filter criteria is updated.
             this.ScaleTo(0.9f)
                 .ScaleTo(1f, 1000, Easing.OutQuint);
-
-            icon.ScaleTo(new Vector2(-1, 1))
-                .ScaleTo(new Vector2(1, 1), 500, Easing.InOutSine);
 
             textFlow.FadeInFromZero(800, Easing.OutQuint);
 

--- a/osu.Game/Screens/SelectV2/NoResultsPlaceholder.cs
+++ b/osu.Game/Screens/SelectV2/NoResultsPlaceholder.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.SelectV2
 
         private LinkFlowContainer textFlow = null!;
 
-        private SpriteIcon icon = null!;
+        private GhostIcon icon = null!;
 
         [Resolved]
         private BeatmapManager beatmaps { get; set; } = null!;
@@ -71,13 +71,9 @@ namespace osu.Game.Screens.SelectV2
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        icon = new SpriteIcon
+                        icon = new GhostIcon
                         {
-                            Icon = FontAwesome.Solid.Ghost,
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            Margin = new MarginPadding(10),
-                            Size = new Vector2(50),
+                            RelativeSizeAxes = Axes.Both,
                         },
                         new OsuSpriteText
                         {

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -703,14 +703,14 @@ namespace osu.Game.Screens.SelectV2
                 noResultsPlaceholder.Filter = carousel.Criteria!;
 
                 attachTrackDuckingIfShould();
-                rightGradientBackground.ResizeWidthTo(3, 1000, Easing.OutQuint);
+                rightGradientBackground.ResizeWidthTo(3, 1000, Easing.OutPow10);
             }
             else
             {
                 noResultsPlaceholder.Hide();
 
                 detachTrackDucking();
-                rightGradientBackground.ResizeWidthTo(1, 500, Easing.OutQuint);
+                rightGradientBackground.ResizeWidthTo(1, 400, Easing.OutPow10);
             }
         }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.604.1" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.530.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.605.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
Depends on ppy/osu-resources#367

Saw a screenshot of the no-results message in a random pull request and thought that animating the ghost icon like this would fit quite well here.
The icon should match the fontawesome version exactly apart from the bottom zigzag which is a sine wave instead of a rounded triangle wave to keep the shader simple.

Implementation is largely based on `FastCircle` class, with the shader using signed distance fields to construct the shapes.

https://github.com/user-attachments/assets/03907bf3-5b54-4809-81f3-89b900df6567

https://github.com/user-attachments/assets/1ff14f93-a274-42d2-b2e6-d447e5165823
