### PR TITLE
Hack around hold-for-right-click mobile thing not allowing to hold to access song select v2 in main menu

### DIFF
--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -20,6 +20,7 @@ using osu.Game.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Input.StateChanges;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps.ControlPoints;
 
@@ -257,6 +258,15 @@ namespace osu.Game.Screens.Menu
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
+            // HORRIBLE HACK
+            // This is here so that on mobile, the main menu button that progresses to song select can correctly progress to song select v2 when held.
+            // Once the temporary solution of holding the button to access song select v2 is removed, this should be too.
+            // Without this, the long-press-to-right-click flow intercepts the hold and converts it to a right click which would not trigger the button
+            // and therefore not progress to song select.
+            if (e.Button == MouseButton.Right && e.CurrentState.Mouse.LastSource is ISourcedFromTouch)
+                trigger(e);
+            // END OF HORRIBLE HACK
+
             boxHoverLayer.FadeTo(0, 1000, Easing.OutQuint);
             base.OnMouseUp(e);
         }

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
+using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Backgrounds;
@@ -391,12 +392,27 @@ namespace osu.Game.Screens.Menu
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
+            // HORRIBLE HACK
+            // This is here so that on mobile, the logo can correctly progress from main menu to song select v2 when held.
+            // Once the temporary solution of holding the logo to access song select v2 is removed, this should be too.
+            // Without this, the long-press-to-right-click flow intercepts the hold and converts it to a right click which would not trigger the logo
+            // and therefore not progress to song select.
+            if (e.Button == MouseButton.Right && e.CurrentState.Mouse.LastSource is ISourcedFromTouch)
+                triggerClick();
+            // END OF HORRIBLE HACK
+
             if (e.Button != MouseButton.Left) return;
 
             logoBounceContainer.ScaleTo(1f, 500, Easing.OutElastic);
         }
 
         protected override bool OnClick(ClickEvent e)
+        {
+            triggerClick();
+            return true;
+        }
+
+        private void triggerClick()
         {
             flashLayer.ClearTransforms();
             flashLayer.Alpha = 0.4f;
@@ -408,8 +424,6 @@ namespace osu.Game.Screens.Menu
                 sampleClickChannel = sampleClick.GetChannel();
                 sampleClickChannel.Play();
             }
-
-            return true;
         }
 
         protected override bool OnHover(HoverEvent e)


### PR DESCRIPTION
Would close https://github.com/ppy/osu/issues/33427 I guess.

This is terrible but I sincerely believe that anything else trying to do this "properly" would be as terrible if not more.

- You can try to handle touch events in `MainMenu` but then you'd have to awkwardly still manually hand them off to mouse handlers of the logo / menu button in a weird way for them to do what they're supposed to be doing. So any fix here would likely be smeared across `OsuLogo` and `MainMenuButton` anyway.

- The logic in
  https://github.com/ppy/osu/blob/278a372a907c22f04fe28289c305ef47d5bcef45/osu.Game/Screens/Menu/MainMenu.cs#L517-L520
  fundamentally doesn't work with raw touch events because it doesn't check for active touches (easy part) and because drawables do not become "hovered" in the input manager from being touched (hard part)

I'm not willing to spend any more time on this.