### PR TITLE
Song Select - Add 'background dim' setting slider

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ToolbarClockDisplayMode, ToolbarClockDisplayMode.Full);
 
             SetDefault(OsuSetting.SongSelectBackgroundBlur, true);
-            SetDefault(OsuSetting.SongSelectBackgroundDim, 0f, 0.1f, 0.8f, 0.01f);
+            SetDefault(OsuSetting.SongSelectBackgroundDim, 0.1f, 0.1f, 0.8f, 0.01f);
 
             // Online settings
             SetDefault(OsuSetting.Username, string.Empty);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ToolbarClockDisplayMode, ToolbarClockDisplayMode.Full);
 
             SetDefault(OsuSetting.SongSelectBackgroundBlur, true);
-            SetDefault(OsuSetting.SongSelectBackgroundDim, 0.1f, 0.1f, 0.8f, 0.01f);
+            SetDefault(OsuSetting.SongSelectBackgroundDim, 0.1f, 0.1f, 0.5f, 0.01f);
 
             // Online settings
             SetDefault(OsuSetting.Username, string.Empty);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ToolbarClockDisplayMode, ToolbarClockDisplayMode.Full);
 
             SetDefault(OsuSetting.SongSelectBackgroundBlur, true);
+            SetDefault(OsuSetting.SongSelectBackgroundDim, 0f, 0.1f, 0.8f, 0.01f);
 
             // Online settings
             SetDefault(OsuSetting.Username, string.Empty);
@@ -398,6 +399,7 @@ namespace osu.Game.Configuration
         BeatmapListingCardSize,
         ToolbarClockDisplayMode,
         SongSelectBackgroundBlur,
+        SongSelectBackgroundDim,
         Version,
         ShowFirstRunSetup,
         ShowConvertedBeatmaps,

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -47,7 +47,14 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     LabelText = GameplaySettingsStrings.BackgroundBlur,
                     Current = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur),
                     ClassicDefault = false,
-                }
+                },
+                new SettingsSlider<float>
+                {
+                    LabelText = GameplaySettingsStrings.BackgroundDim,
+                    Current = config.GetBindable<float>(OsuSetting.SongSelectBackgroundDim),
+                    KeyboardStep = 0.01f,
+                    DisplayAsPercentage = true
+                },
             };
         }
     }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -157,12 +157,22 @@ namespace osu.Game.Screens.Select
         internal IOverlayManager? OverlayManager { get; private set; }
 
         private Bindable<bool> configBackgroundBlur = null!;
+        private Bindable<float> configBackgroundDim = null!;
 
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, OsuColour colours, ManageCollectionsDialog? manageCollectionsDialog, DifficultyRecommender? recommender, OsuConfigManager config)
         {
             configBackgroundBlur = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur);
             configBackgroundBlur.BindValueChanged(e =>
+            {
+                if (!this.IsCurrentScreen())
+                    return;
+
+                ApplyToBackground(applyBlurToBackground);
+            });
+
+            configBackgroundDim = config.GetBindable<float>(OsuSetting.SongSelectBackgroundDim);
+            configBackgroundDim.BindValueChanged(e =>
             {
                 if (!this.IsCurrentScreen())
                     return;
@@ -908,7 +918,7 @@ namespace osu.Game.Screens.Select
         private void applyBlurToBackground(BackgroundScreenBeatmap backgroundModeBeatmap)
         {
             backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value ? BACKGROUND_BLUR : 0f;
-            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundBlur.Value ? 0 : 0.4f;
+            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundDim.Value;
 
             wedgeBackground.FadeTo(configBackgroundBlur.Value ? 0.5f : 0.2f, UserDimContainer.BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -918,7 +918,7 @@ namespace osu.Game.Screens.Select
         private void applyBlurToBackground(BackgroundScreenBeatmap backgroundModeBeatmap)
         {
             backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value ? BACKGROUND_BLUR : 0f;
-            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundDim.Value;
+            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundBlur.Value ? 0f : configBackgroundDim.Value;
 
             wedgeBackground.FadeTo(configBackgroundBlur.Value ? 0.5f : 0.2f, UserDimContainer.BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -21,6 +22,7 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
+using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Containers;
@@ -123,6 +125,11 @@ namespace osu.Game.Screens.SelectV2
 
         [Resolved]
         private IDialogOverlay? dialogOverlay { get; set; }
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
+
+        private Bindable<float> configBackgroundDim = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -311,8 +318,17 @@ namespace osu.Game.Screens.SelectV2
                 ensureGlobalBeatmapValid();
 
                 ensurePlayingSelected(true);
-                updateBackgroundDim();
+                updateBackground();
                 updateWedgeVisibility();
+            });
+
+            configBackgroundDim = config.GetBindable<float>(OsuSetting.SongSelectBackgroundDim);
+            configBackgroundDim.BindValueChanged(e =>
+            {
+                if (!this.IsCurrentScreen())
+                    return;
+
+                updateBackground();
             });
         }
 
@@ -571,7 +587,7 @@ namespace osu.Game.Screens.SelectV2
             ensureGlobalBeatmapValid();
 
             ensurePlayingSelected(false);
-            updateBackgroundDim();
+            updateBackground();
         }
 
         private void onLeavingScreen()
@@ -647,15 +663,15 @@ namespace osu.Game.Screens.SelectV2
             }
         }
 
-        private void updateBackgroundDim() => ApplyToBackground(backgroundModeBeatmap =>
+        private void updateBackground() => ApplyToBackground(backgroundModeBeatmap =>
         {
             backgroundModeBeatmap.BlurAmount.Value = 0;
             backgroundModeBeatmap.Beatmap = Beatmap.Value;
             backgroundModeBeatmap.IgnoreUserSettings.Value = true;
-            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = 0.1f;
+            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundDim.Value;
 
             // Required to undo results screen dimming the background.
-            // Probably needs more thought because this needs to be in every `ApplyToBackground` currently to restore sane defaults.
+            // Probably needs more thought because this needs to be in every `ApplyToBackgrongound` currently to restore sane defaults.
             backgroundModeBeatmap.FadeColour(Color4.White, 250);
         });
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -671,7 +671,7 @@ namespace osu.Game.Screens.SelectV2
             backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundDim.Value;
 
             // Required to undo results screen dimming the background.
-            // Probably needs more thought because this needs to be in every `ApplyToBackgrongound` currently to restore sane defaults.
+            // Probably needs more thought because this needs to be in every `ApplyToBackground` currently to restore sane defaults.
             backgroundModeBeatmap.FadeColour(Color4.White, 250);
         });
 


### PR DESCRIPTION
related to @rrex971 's suggestion in #33385

## what's inside
- adds a background dim slider in the song select section of settings:
	<img width="419" alt="Screenshot 2025-06-05 at 14 21 12" src="https://github.com/user-attachments/assets/497c51e5-f196-4898-870c-b34782c57856" />

- the setting currently applies to both SSV1 & SSV2, as i felt having a slider which does nothing in SSV1 would cause more trouble and confusion than it should, but i made this with SSV2 in mind
- defaults to 0.1f, following what's currently in SSV2
- forcing a [0.1; 0.8] range as i felt it's the best looking values (i don't think a black background would be a good idea for a ss screen)

i feel this should in the future be a skin setting, but it could temporarily give a tiny bit more control over the look in the meantime
