### PR TITLE
Disallow selected mods from being valid for freestyle as required mods due to them not being consistently compatible with other mods across rulesets

### DIFF
--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -259,9 +259,6 @@ namespace osu.Game.Tests.Mods
             new MultiplayerTestScenario(true, true, [new OsuModPerfect()], []),
             new MultiplayerTestScenario(true, true, [new OsuModDoubleTime()], []),
             new MultiplayerTestScenario(true, true, [new OsuModNightcore()], []),
-            new MultiplayerTestScenario(true, true, [new OsuModHidden()], []),
-            new MultiplayerTestScenario(true, true, [new OsuModFlashlight()], []),
-            new MultiplayerTestScenario(true, true, [new OsuModAccuracyChallenge()], []),
             new MultiplayerTestScenario(true, true, [new OsuModDifficultyAdjust()], []),
             new MultiplayerTestScenario(true, true, [new ModWindUp()], []),
             new MultiplayerTestScenario(true, true, [new ModWindDown()], []),
@@ -347,8 +344,11 @@ namespace osu.Game.Tests.Mods
                     {
                         if (mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && !commonAcronyms.Contains(mod.Acronym))
                             Assert.Fail($"{mod.GetType().ReadableName()} declares {nameof(Mod.ValidForFreestyleAsRequiredMod)} but does not exist in all four basic rulesets!");
+
+                        // downgraded to warning, because there are valid reasons why they may still not be specified to be valid for freestyle as required
+                        // (see `TestModsValidForRequiredFreestyleAreConsistentlyCompatibleAcrossRulesets()` test case below).
                         if (!mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && commonAcronyms.Contains(mod.Acronym))
-                            Assert.Fail($"{mod.GetType().ReadableName()} does not declare {nameof(Mod.ValidForFreestyleAsRequiredMod)} but exists in all four basic rulesets!");
+                            Assert.Warn($"{mod.GetType().ReadableName()} does not declare {nameof(Mod.ValidForFreestyleAsRequiredMod)} but exists in all four basic rulesets.");
                     }
                 }
             });

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool Ranked => true;
 
-        public override bool ValidForFreestyleAsRequiredMod => true;
-
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
         {
             get

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Restricted view area.";
         public override bool Ranked => UsesDefaultConfiguration;
-        public override bool ValidForFreestyleAsRequiredMod => true;
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
         public abstract BindableFloat SizeMultiplier { get; }

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModHidden;
         public override ModType Type => ModType.DifficultyIncrease;
         public override bool Ranked => UsesDefaultConfiguration;
-        public override bool ValidForFreestyleAsRequiredMod => true;
 
         public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33444.

The issue here is that for a set of required mods to make sense in the context of a freestyle playlist item, it must be consistently either valid or invalid *as a combination* across all four default rulesets, because freestyle also permits changing ruleset. There are two pertinent cases here:

- Flashlight and Hidden are compatible in osu!, taiko, and catch, but not compatible in mania. In this case I've disallowed both mods because of symmetry, basically - I don't see one "better mod" to disallow here.
- Accuracy Challenge and Easy are incompatible in osu!, catch, and mania because Easy gives extra lives there, but *compatible* in taiko, where it does not. In this case I've disallowed Accuracy Challenge only, because I find its value in being forced on a freestyle room to be much smaller than Easy's.

In the large scale of things I don't see this being very important because my view is that 99% of the use case of required mods in freestyle is going to be changing the track speed. So I don't think anyone is going to care about this going away - but we can reassess if I'm proven wrong.