### PR TITLE
Fix extreme Drawable thrashing on initial leaderboard population

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -34,10 +35,12 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             isPartial = leaderboardManager?.CurrentCriteria?.Scope != BeatmapLeaderboardScope.Local && globalScores?.TopScores.Count >= 50;
 
+            List<GameplayLeaderboardScore> newScores = new List<GameplayLeaderboardScore>();
+
             if (globalScores != null)
             {
                 foreach (var topScore in globalScores.AllScores.OrderByTotalScore())
-                    scores.Add(new GameplayLeaderboardScore(topScore, false));
+                    newScores.Add(new GameplayLeaderboardScore(topScore, false));
             }
 
             if (gameplayState != null)
@@ -48,8 +51,10 @@ namespace osu.Game.Screens.Select.Leaderboards
                     TotalScoreTiebreaker = long.MaxValue
                 };
                 localScore.TotalScore.BindValueChanged(_ => sorting.Invalidate());
-                scores.Add(localScore);
+                newScores.Add(localScore);
             }
+
+            scores.AddRange(newScores);
 
             Scheduler.AddDelayed(sort, 1000, true);
         }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/issues/33448. Not going to mark as a fix because there's still an initial stutter on the first update frame, but it's a lot less noticeable than on master.

Should be able to be reproed immediately on https://osu.ppy.sh/beatmapsets/1388906#osu/2868387 (storyboards disabled).

The cause here is this event handler, which clears and re-adds _all_ scores on every change:

https://github.com/ppy/osu/blob/278a372a907c22f04fe28289c305ef47d5bcef45/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs#L92-L97

... And scores that were previously added one-at-a-time inside `SoloGameplayLeaderboardProvider`. This PR now batches them into one bundle.

Master:

https://github.com/user-attachments/assets/32971aa8-bc57-4140-a968-175b7f6ff49c

This PR:

https://github.com/user-attachments/assets/98b1de7f-6278-4c79-9e72-a6b19dcf3b8f

Logged out:

https://github.com/user-attachments/assets/b9904938-e7c9-4361-8024-753a407cefb9

