### PR TITLE
Fix general confusion in which combo should be read on which gameplay leaderboard

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlayRulesetLayouts.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlayRulesetLayouts.cs
@@ -136,7 +136,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             IBindableList<GameplayLeaderboardScore> IGameplayLeaderboardProvider.Scores => Scores;
             public BindableList<GameplayLeaderboardScore> Scores { get; } = new BindableList<GameplayLeaderboardScore>();
-            public bool IsPartial { get; } = false;
 
             public TestGameplayLeaderboardProvider()
             {
@@ -147,8 +146,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                         User = new APIUser { Username = $"User {i}" },
                         TotalScore = (20 - i) * 50_000,
                         Accuracy = i * 0.05,
-                        Combo = i * 50
-                    }, i == 19));
+                        MaxCombo = i * 50,
+                    }, i == 19, GameplayLeaderboardScore.ComboDisplayMode.Highest));
                 }
             }
         }

--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -40,6 +40,11 @@ namespace osu.Game.Online.Spectator
         public readonly BindableInt Combo = new BindableInt();
 
         /// <summary>
+        /// The highest combo achieved in the score thus far.
+        /// </summary>
+        public readonly BindableInt HighestCombo = new BindableInt();
+
+        /// <summary>
         /// The <see cref="ScoringMode"/> used to calculate scores.
         /// </summary>
         public readonly Bindable<ScoringMode> Mode = new Bindable<ScoringMode>();
@@ -157,6 +162,7 @@ namespace osu.Game.Online.Spectator
 
             Accuracy.Value = frame.Header.Accuracy;
             Combo.Value = frame.Header.Combo;
+            HighestCombo.Value = frame.Header.MaxCombo;
             TotalScore.Value = frame.Header.TotalScore;
         }
 

--- a/osu.Game/Screens/Select/Leaderboards/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/GameplayLeaderboardScore.cs
@@ -8,6 +8,7 @@ using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
+using osu.Game.Screens.Play;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Select.Leaderboards
@@ -40,7 +41,8 @@ namespace osu.Game.Screens.Select.Leaderboards
         public BindableDouble Accuracy { get; } = new BindableDouble();
 
         /// <summary>
-        /// The current combo of the score.
+        /// The combo of the score to display.
+        /// Can be either highest combo or current combo, depending on constructor parameters.
         /// </summary>
         public BindableInt Combo { get; } = new BindableInt();
 
@@ -87,33 +89,35 @@ namespace osu.Game.Screens.Select.Leaderboards
         /// </summary>
         public Bindable<long> DisplayOrder { get; } = new BindableLong();
 
-        public GameplayLeaderboardScore(IUser user, ScoreProcessor scoreProcessor, bool tracked)
+        public GameplayLeaderboardScore(GameplayState gameplayState, bool tracked, ComboDisplayMode comboMode)
+        {
+            User = gameplayState.Score.ScoreInfo.User;
+            Tracked = tracked;
+
+            var scoreProcessor = gameplayState.ScoreProcessor;
+            TotalScore.BindTarget = scoreProcessor.TotalScore;
+            Accuracy.BindTarget = scoreProcessor.Accuracy;
+            Combo.BindTarget = comboMode == ComboDisplayMode.Current ? scoreProcessor.Combo : scoreProcessor.HighestCombo;
+            GetDisplayScore = scoreProcessor.GetDisplayScore;
+        }
+
+        public GameplayLeaderboardScore(IUser user, SpectatorScoreProcessor scoreProcessor, bool tracked, ComboDisplayMode comboMode)
         {
             User = user;
             Tracked = tracked;
             TotalScore.BindTarget = scoreProcessor.TotalScore;
             Accuracy.BindTarget = scoreProcessor.Accuracy;
-            Combo.BindTarget = scoreProcessor.Combo;
+            Combo.BindTarget = comboMode == ComboDisplayMode.Current ? scoreProcessor.Combo : scoreProcessor.HighestCombo;
             GetDisplayScore = scoreProcessor.GetDisplayScore;
         }
 
-        public GameplayLeaderboardScore(IUser user, SpectatorScoreProcessor scoreProcessor, bool tracked)
-        {
-            User = user;
-            Tracked = tracked;
-            TotalScore.BindTarget = scoreProcessor.TotalScore;
-            Accuracy.BindTarget = scoreProcessor.Accuracy;
-            Combo.BindTarget = scoreProcessor.Combo;
-            GetDisplayScore = scoreProcessor.GetDisplayScore;
-        }
-
-        public GameplayLeaderboardScore(ScoreInfo scoreInfo, bool tracked)
+        public GameplayLeaderboardScore(ScoreInfo scoreInfo, bool tracked, ComboDisplayMode comboMode)
         {
             User = scoreInfo.User;
             Tracked = tracked;
             TotalScore.Value = scoreInfo.TotalScore;
             Accuracy.Value = scoreInfo.Accuracy;
-            Combo.Value = scoreInfo.MaxCombo;
+            Combo.Value = comboMode == ComboDisplayMode.Current ? scoreInfo.Combo : scoreInfo.MaxCombo;
             TotalScoreTiebreaker = scoreInfo.OnlineID > 0 ? scoreInfo.OnlineID : scoreInfo.Date.ToUnixTimeSeconds();
             GetDisplayScore = scoreInfo.GetDisplayScore;
             InitialPosition = scoreInfo.Position;
@@ -128,6 +132,12 @@ namespace osu.Game.Screens.Select.Leaderboards
             Tracked = tracked;
             TotalScore.BindTarget = displayScore;
             GetDisplayScore = _ => displayScore.Value;
+        }
+
+        public enum ComboDisplayMode
+        {
+            Current,
+            Highest,
         }
     }
 }

--- a/osu.Game/Screens/Select/Leaderboards/MultiplayerLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/MultiplayerLeaderboardProvider.cs
@@ -99,7 +99,11 @@ namespace osu.Game.Screens.Select.Leaderboards
 
                                        var trackedUser = UserScores[user.Id];
 
-                                       var leaderboardScore = new GameplayLeaderboardScore(user, trackedUser.ScoreProcessor, user.Id == api.LocalUser.Value.Id)
+                                       var leaderboardScore = new GameplayLeaderboardScore(
+                                           user,
+                                           trackedUser.ScoreProcessor,
+                                           user.Id == api.LocalUser.Value.Id,
+                                           GameplayLeaderboardScore.ComboDisplayMode.Current)
                                        {
                                            HasQuit = { BindTarget = trackedUser.UserQuit },
                                            TeamColour = UserScores[user.OnlineID].Team is int team ? getTeamColour(team) : null,

--- a/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
@@ -40,12 +40,14 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (globalScores != null)
             {
                 foreach (var topScore in globalScores.AllScores.OrderByTotalScore())
-                    newScores.Add(new GameplayLeaderboardScore(topScore, false));
+                {
+                    newScores.Add(new GameplayLeaderboardScore(topScore, false, GameplayLeaderboardScore.ComboDisplayMode.Highest));
+                }
             }
 
             if (gameplayState != null)
             {
-                var localScore = new GameplayLeaderboardScore(gameplayState.Score.ScoreInfo.User, gameplayState.ScoreProcessor, true)
+                var localScore = new GameplayLeaderboardScore(gameplayState, tracked: true, GameplayLeaderboardScore.ComboDisplayMode.Highest)
                 {
                     // Local score should always show lower than any existing scores in cases of ties.
                     TotalScoreTiebreaker = long.MaxValue


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33455.

The fundamental misunderstanding and source of confusion in https://github.com/ppy/osu/pull/33062 is that solo wants to show *maximum combo*, and multiplayer wants to show *current combo*, for their own, valid reasons. Which is spelled out explicitly in this change.