### PR TITLE
SongSelectV2: Fix `TagsOverflowPopover` not applying tag search to song select

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.SelectV2
                 private OverlayColourProvider colourProvider { get; set; } = null!;
 
                 [Resolved]
-                private SongSelect? songSelect { get; set; }
+                private ISongSelect? songSelect { get; set; }
 
                 public float LineBaseHeight => text.LineBaseHeight;
 
@@ -196,7 +196,7 @@ namespace osu.Game.Screens.SelectV2
                 private readonly string[] tags;
                 private readonly ISongSelect? songSelect;
 
-                public TagsOverflowPopover(string[] tags, SongSelect? songSelect)
+                public TagsOverflowPopover(string[] tags, ISongSelect? songSelect)
                 {
                     this.tags = tags;
                     this.songSelect = songSelect;


### PR DESCRIPTION
Spotted this one in passing.

Before:
https://github.com/user-attachments/assets/1eceabb1-9865-47d1-8a2e-f0fe63fcee2d

After:
https://github.com/user-attachments/assets/5b4b5e11-92ca-4776-8883-e4598a3e125e

