### PR TITLE
osu!taiko simplify pp summing and make performance attributes accurate

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             double accuracyValue = Math.Pow(70 / estimatedUnstableRate.Value, 1.1) * Math.Pow(attributes.StarRating, 0.4) * 100.0;
 
-            if (score.Mods.Any(m => m is ModHidden))
+            if (score.Mods.Any(m => m is ModHidden) && !isConvert)
                 accuracyValue *= 1.075;
 
             double lengthBonus = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             // Converts are detected and omitted from mod-specific bonuses due to the scope of current difficulty calculation.
             bool isConvert = score.BeatmapInfo!.Ruleset.OnlineID != 1;
 
-            double difficultyValue = computeDifficultyValue(score, taikoAttributes) * 1.08;
+            double difficultyValue = computeDifficultyValue(score, taikoAttributes, isConvert) * 1.08;
             double accuracyValue = computeAccuracyValue(score, taikoAttributes, isConvert) * 1.1;
 
             return new TaikoPerformanceAttributes
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             };
         }
 
-        private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
+        private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes, bool isConvert)
         {
             double baseDifficulty = 5 * Math.Max(1.0, attributes.StarRating / 0.110) - 4.0;
             double difficultyValue = Math.Min(Math.Pow(baseDifficulty, 3) / 69052.51, Math.Pow(baseDifficulty, 2.25) / 1250.0);
@@ -89,7 +89,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             difficultyValue *= Math.Pow(0.986, effectiveMissCount);
 
             if (score.Mods.Any(m => m is ModHidden))
-                difficultyValue *= 1.1;
+                difficultyValue *= (isConvert) ? 1.025 : 1.1;
 
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= Math.Max(1, 1.050 - Math.Min(attributes.MonoStaminaFactor / 50, 1) * lengthBonus);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -63,21 +63,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             // Converts are detected and omitted from mod-specific bonuses due to the scope of current difficulty calculation.
             bool isConvert = score.BeatmapInfo!.Ruleset.OnlineID != 1;
 
-            double multiplier = 1.13;
-
-            if (score.Mods.Any(m => m is ModHidden) && !isConvert)
-                multiplier *= 1.075;
-
-            if (score.Mods.Any(m => m is ModEasy))
-                multiplier *= 0.950;
-
-            double difficultyValue = computeDifficultyValue(score, taikoAttributes);
-            double accuracyValue = computeAccuracyValue(score, taikoAttributes, isConvert);
-            double totalValue =
-                Math.Pow(
-                    Math.Pow(difficultyValue, 1.1) +
-                    Math.Pow(accuracyValue, 1.1), 1.0 / 1.1
-                ) * multiplier;
+            double difficultyValue = computeDifficultyValue(score, taikoAttributes) * 1.08;
+            double accuracyValue = computeAccuracyValue(score, taikoAttributes, isConvert) * 1.1;
 
             return new TaikoPerformanceAttributes
             {
@@ -85,7 +72,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 Accuracy = accuracyValue,
                 EffectiveMissCount = effectiveMissCount,
                 EstimatedUnstableRate = estimatedUnstableRate,
-                Total = totalValue
+                Total = difficultyValue + accuracyValue
             };
         }
 
@@ -101,11 +88,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             difficultyValue *= Math.Pow(0.986, effectiveMissCount);
 
-            if (score.Mods.Any(m => m is ModEasy))
-                difficultyValue *= 0.90;
-
             if (score.Mods.Any(m => m is ModHidden))
-                difficultyValue *= 1.025;
+                difficultyValue *= 1.1;
 
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= Math.Max(1, 1.050 - Math.Min(attributes.MonoStaminaFactor / 50, 1) * lengthBonus);
@@ -126,6 +110,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 return 0;
 
             double accuracyValue = Math.Pow(70 / estimatedUnstableRate.Value, 1.1) * Math.Pow(attributes.StarRating, 0.4) * 100.0;
+
+            if (score.Mods.Any(m => m is ModHidden))
+                accuracyValue *= 1.075;
 
             double lengthBonus = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
 


### PR DESCRIPTION
This change replaces the `(diff^1.1 + acc^1.1)^1/1.1` formula applied to pp with simply `diff+acc`, adjusting multipliers for minimal value changes. Taiko's acc values being lower than difficulty on every single play bar a few exceptions means that all this formula did was make acc have even less of an effect on a play's total pp. This is another step towards the larger acc rebalance we have planned for next deploy. Multipliers have also been moved around so that the `Difficulty` and `Accuracy` performance attributes always add up to make `Total`. The approved but not yet merged change to remove multipliers to the Easy mod is also included, hope that doesn't cause trouble merging this