### PR TITLE
Fix simplified rhythm mod not working on some beatmaps

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSimplifiedRhythm.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSimplifiedRhythm.cs
@@ -148,5 +148,96 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
             },
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 8 && Player.ScoreProcessor.Accuracy.Value == 1
         });
+
+        /// <summary>
+        /// Regression tests a case of 1/3rd conversion where there are exactly div-3 number of hitobjects.
+        /// </summary>
+        [Test]
+        public void TestOnlyOneThirdConversion()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new TaikoModSimplifiedRhythm
+                {
+                    OneThirdConversion = { Value = true },
+                },
+                Autoplay = false,
+                CreateBeatmap = () => new Beatmap
+                {
+                    HitObjects = new List<HitObject>
+                    {
+                        new Hit { StartTime = 1000, Type = HitType.Centre },
+                        new Hit { StartTime = 1333, Type = HitType.Centre }, // mod removes this
+                        new Hit { StartTime = 1666, Type = HitType.Centre }, // mod moves this to 1500
+                        new Hit { StartTime = 2000, Type = HitType.Centre },
+                        new Hit { StartTime = 2333, Type = HitType.Centre }, // mod removes this
+                        new Hit { StartTime = 2666, Type = HitType.Centre }, // mod moves this to 2500
+                    },
+                },
+                ReplayFrames = new List<ReplayFrame>
+                {
+                    new TaikoReplayFrame(1000, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(1200),
+                    new TaikoReplayFrame(1500, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(1700),
+                    new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(2200),
+                    new TaikoReplayFrame(2500, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(2700),
+                },
+                PassCondition = () => Player.ScoreProcessor.Combo.Value == 4 && Player.ScoreProcessor.Accuracy.Value == 1
+            });
+        }
+
+        /// <summary>
+        /// Regression tests a case of 1/6th conversion where there are exactly div-6 number of hitobjects.
+        /// </summary>
+        [Test]
+        public void TestOnlyOneSixthConversion() => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModSimplifiedRhythm
+            {
+                OneSixthConversion = { Value = true }
+            },
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit { StartTime = 1000, Type = HitType.Centre },
+                    new Hit { StartTime = 1166, Type = HitType.Centre }, // mod removes this
+                    new Hit { StartTime = 1333, Type = HitType.Centre }, // mod moves this to 1250
+                    new Hit { StartTime = 1500, Type = HitType.Centre },
+                    new Hit { StartTime = 1666, Type = HitType.Centre }, // mod removes this
+                    new Hit { StartTime = 1833, Type = HitType.Centre }, // mod moves this to 1750
+                    new Hit { StartTime = 2000, Type = HitType.Centre },
+                    new Hit { StartTime = 2166, Type = HitType.Centre }, // mod removes this
+                    new Hit { StartTime = 2333, Type = HitType.Centre }, // mod moves this to 2250
+                    new Hit { StartTime = 2500, Type = HitType.Centre },
+                    new Hit { StartTime = 2666, Type = HitType.Centre }, // mod removes this
+                    new Hit { StartTime = 2833, Type = HitType.Centre }, // mod moves this to 2750
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(1000, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1200),
+                new TaikoReplayFrame(1250, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1450),
+                new TaikoReplayFrame(1500, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1600),
+                new TaikoReplayFrame(1750, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1800),
+                new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(2200),
+                new TaikoReplayFrame(2250, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(2450),
+                new TaikoReplayFrame(2500, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(2600),
+                new TaikoReplayFrame(2750, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(2800),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 8 && Player.ScoreProcessor.Accuracy.Value == 1
+        });
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                                 if (indexInPattern % 3 == 1)
                                     taikoBeatmap.HitObjects.Remove(hits[j]);
                                 else if (indexInPattern % 3 == 2)
-                                    hits[j].StartTime = hits[j + 1].StartTime - controlPointInfo.TimingPointAt(hits[j].StartTime).BeatLength / adjustedRhythm;
+                                    hits[j].StartTime = hits[j - 2].StartTime + controlPointInfo.TimingPointAt(hits[j].StartTime).BeatLength / adjustedRhythm;
 
                                 break;
                             }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
             var taikoBeatmap = (TaikoBeatmap)beatmap;
             var controlPointInfo = taikoBeatmap.ControlPointInfo;
 
-            Hit[] hits = taikoBeatmap.HitObjects.Where(obj => obj is Hit).Cast<Hit>().ToArray();
+            Hit[] hits = taikoBeatmap.HitObjects.OfType<Hit>().ToArray();
 
             if (hits.Length == 0)
                 return;
@@ -61,10 +61,10 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     if (inPattern)
                     {
                         // pattern continues
-                        if (snapValue == baseRhythm) continue;
+                        if (snapValue == baseRhythm)
+                            continue;
 
                         inPattern = false;
-
                         processPattern(i);
                     }
                     else


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/33467

Rather than adjusting every third object's position based on the next object (that may not exist), adjust it based on the second-last object. I'm not sure the original code was correct in the first place because we'd adjust based on the next pattern rather than the current pattern?

I don't know what to call the tests, so hopefully the xmldoc is good enough.