### PR TITLE
Prevent rank display shown in skin editor toolbox from playing samples

### DIFF
--- a/osu.Game/Localisation/DefaultRankDisplayStrings.cs
+++ b/osu.Game/Localisation/DefaultRankDisplayStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class DefaultRankDisplayStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.DefaultRankDisplay";
+
+        /// <summary>
+        /// "Play samples on rank change"
+        /// </summary>
+        public static LocalisableString PlaySamplesOnRankChange => new TranslatableString(getKey(@"play_samples_on_rank_change"), @"Play samples on rank change");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Overlays.SkinEditor
             }
         }
 
-        public partial class DependencyBorrowingContainer : Container
+        private partial class DependencyBorrowingContainer : Container
         {
             protected override bool ShouldBeConsideredForInput(Drawable child) => false;
 
@@ -232,8 +232,19 @@ namespace osu.Game.Overlays.SkinEditor
                 this.donor = donor;
             }
 
-            protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>
-                new DependencyContainer(donor?.Dependencies ?? base.CreateChildDependencies(parent));
+            protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+            {
+                var baseDependencies = base.CreateChildDependencies(parent);
+                if (donor == null)
+                    return baseDependencies;
+
+                var dependencies = new DependencyContainer(donor.Dependencies);
+                // inject `SkinEditor` again *on top* of the borrowed dependencies.
+                // this is designed to let components know when they are being displayed in the context of the skin editor
+                // via attempting to resolve `SkinEditor`.
+                dependencies.CacheAs(baseDependencies.Get<SkinEditor>());
+                return dependencies;
+            }
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
 using osu.Game.Configuration;
 using osu.Game.Online.Leaderboards;
+using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
@@ -39,7 +40,7 @@ namespace osu.Game.Screens.Play.HUD
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(SkinEditor? skinEditor)
         {
             InternalChildren = new Drawable[]
             {
@@ -50,6 +51,9 @@ namespace osu.Game.Screens.Play.HUD
                     RelativeSizeAxes = Axes.Both
                 },
             };
+
+            if (skinEditor != null)
+                PlaySamples.Value = false;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -6,11 +6,13 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
+using osu.Game.Configuration;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osuTK;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Play.HUD
 {
@@ -18,6 +20,9 @@ namespace osu.Game.Screens.Play.HUD
     {
         [Resolved]
         private ScoreProcessor scoreProcessor { get; set; } = null!;
+
+        [SettingSource(typeof(DefaultRankDisplayStrings), nameof(DefaultRankDisplayStrings.PlaySamplesOnRankChange))]
+        public BindableBool PlaySamples { get; set; } = new BindableBool(true);
 
         public bool UsesFixedAnchor { get; set; }
 
@@ -55,7 +60,7 @@ namespace osu.Game.Screens.Play.HUD
             rank.BindValueChanged(r =>
             {
                 // Don't play rank-down sfx on quit/retry
-                if (r.NewValue != r.OldValue && r.NewValue > ScoreRank.F)
+                if (r.NewValue != r.OldValue && r.NewValue > ScoreRank.F && PlaySamples.Value)
                 {
                     if (r.NewValue > rankDisplay.Rank)
                         rankUpSample.Play();


### PR DESCRIPTION
## [Add toggle for rank change sound playback to default rank display](https://github.com/ppy/osu/commit/6835d7659d4f15c0f73c495fd36e57b794b0d885)

Because some people don't seem to like it. Defaults to on still.

## [Prevent rank display shown in skin editor toolbox from playing samples](https://github.com/ppy/osu/commit/fd3514c062729edb01257388e1402b4d06de6f6e)

Closes https://github.com/ppy/osu/issues/33456.

Not sure how to feel about that change but I don't see many other alternatives. Trying basically any solution with DI runs against the problem that the dependencies are borrowed wholesale from the screen that the component is supposed to *work in*, so trying things like implementing `ISamplePlaybackDisabler` on `SkinEditor` just straight up fails because resolving via that interface from toolbox buttons returns *`Player`* and not `SkinEditor`.