### PR TITLE
Fix #31142: Right-clicking between 2 beatmaps absolute scrolls.

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -1159,6 +1159,14 @@ namespace osu.Game.Screens.Select
 
         public partial class CarouselScrollContainer : UserTrackingScrollContainer<DrawableCarouselItem>, IKeyBindingHandler<GlobalAction>
         {
+
+            private bool isMouseOnLeftSide(MouseEvent e)
+            {
+                var mousePos = e.CurrentState.Mouse.Position;
+                var localPos = ToLocalSpace(mousePos);
+                return localPos.X < DrawWidth * 0.2f;
+            }
+
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
             public CarouselScrollContainer()
@@ -1203,7 +1211,7 @@ namespace osu.Game.Screens.Select
                 if (e.Button == MouseButton.Right)
                 {
                     // To avoid conflicts with context menus, disallow absolute scroll if it looks like things will fall over.
-                    if (GetContainingInputManager()!.HoveredDrawables.OfType<IHasContextMenu>().Any())
+                    if (!isMouseOnLeftSide(e) || GetContainingInputManager()!.HoveredDrawables.OfType<IHasContextMenu>().Any())
                         return false;
 
                     beginAbsoluteScrolling(e);
@@ -1214,8 +1222,9 @@ namespace osu.Game.Screens.Select
 
             protected override void OnMouseUp(MouseUpEvent e)
             {
-                if (e.Button == MouseButton.Right)
+                if (e.Button == MouseButton.Right && absoluteScrolling)
                     endAbsoluteScrolling();
+
                 base.OnMouseUp(e);
             }
 


### PR DESCRIPTION
Between the beatmaps in the carousel,
in song selection, there is a small space.
When trying to open the editing menu for the beatmaps, if you misclick and right-click on that space,
it will start the absolute scroll
and move you to another place on the carousel.
In this fix, it is only possible to absolute scroll by right-clicking to the left of the carousel.