### PR TITLE
Fix clicking beatmap header causing leaderboard to refresh

### DIFF
--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Graphics.Carousel
             get => currentSelection.Model;
             set
             {
-                if (currentSelection.Model != value)
+                if (!CheckModelEquality(currentSelection.Model, value))
                 {
                     HandleItemSelected(value);
 
@@ -210,7 +210,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// Check whether two models are the same for display purposes.
         /// </summary>
-        protected virtual bool CheckModelEquality(object x, object y) => ReferenceEquals(x, y);
+        protected virtual bool CheckModelEquality(object? x, object? y) => ReferenceEquals(x, y);
 
         /// <summary>
         /// Create a drawable for the given carousel item so it can be displayed.

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -553,7 +553,7 @@ namespace osu.Game.Screens.SelectV2
             AddInternal(setPanelPool);
         }
 
-        protected override bool CheckModelEquality(object x, object y)
+        protected override bool CheckModelEquality(object? x, object? y)
         {
             // In the confines of the carousel logic, we assume that CurrentSelection (and all items) are using non-stale
             // BeatmapInfo reference, and that we can match based on beatmap / beatmapset (GU)IDs.

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -447,7 +447,13 @@ namespace osu.Game.Screens.SelectV2
 
             // Debounce consideration is to avoid beatmap churn on key repeat selection.
             selectionDebounce?.Cancel();
-            selectionDebounce = Scheduler.AddDelayed(() => Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap), SELECTION_DEBOUNCE);
+            selectionDebounce = Scheduler.AddDelayed(() =>
+            {
+                if (Beatmap.Value.BeatmapInfo.Equals(beatmap))
+                    return;
+
+                Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap);
+            }, SELECTION_DEBOUNCE);
         }
 
         private bool ensureGlobalBeatmapValid()


### PR DESCRIPTION
This also fixes a double-refresh of leaderboard when returning from gameplay due to incorrect reference equality.