### PR TITLE
Add "Alternate" mod to osu!taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModAlternate.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModAlternate.cs
@@ -16,9 +16,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
     public partial class TestSceneTaikoModAlternate : TaikoModTestScene
     {
         [Test]
-        public void TestInputAlternate() => CreateModTest(new ModTestData
+        public void TestInputAlternateHands() => CreateModTest(new ModTestData
         {
-            Mod = new TaikoModAlternate(),
+            Mod = new TaikoModAlternate { Style = { Value = TaikoModAlternate.Playstyle.AlternateHands } },
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
@@ -61,9 +61,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         });
 
         [Test]
-        public void TestInputSameKey([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        public void TestInputSameKey([Values] TaikoModAlternate.Playstyle playstyle) => CreateModTest(new ModTestData
         {
-            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Mod = new TaikoModAlternate { Style = { Value = playstyle } },
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
@@ -106,9 +106,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         });
 
         [Test]
-        public void TestInputIntro([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        public void TestInputIntro([Values] TaikoModAlternate.Playstyle playstyle) => CreateModTest(new ModTestData
         {
-            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Mod = new TaikoModAlternate { Style = { Value = playstyle } },
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
@@ -132,9 +132,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         });
 
         [Test]
-        public void TestInputStrong([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        public void TestInputStrong([Values] TaikoModAlternate.Playstyle playstyle) => CreateModTest(new ModTestData
         {
-            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Mod = new TaikoModAlternate { Style = { Value = playstyle } },
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
@@ -166,9 +166,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         });
 
         [Test]
-        public void TestInputSpecialObjects([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        public void TestInputSpecialObjects([Values] TaikoModAlternate.Playstyle playstyle) => CreateModTest(new ModTestData
         {
-            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Mod = new TaikoModAlternate { Style = { Value = playstyle } },
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
@@ -242,9 +242,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         });
 
         [Test]
-        public void TestInputBreaks([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        public void TestInputBreaks([Values] TaikoModAlternate.Playstyle playstyle) => CreateModTest(new ModTestData
         {
-            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Mod = new TaikoModAlternate { Style = { Value = playstyle } },
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
@@ -285,7 +285,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             CreateModTest(new ModTestData
             {
-                Mod = new TaikoModAlternate { AlternateFingers = { Value = true } },
+                Mod = new TaikoModAlternate { Style = { Value = TaikoModAlternate.Playstyle.AlternateFingers } },
                 Autoplay = false,
                 CreateBeatmap = () => new Beatmap
                 {

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModAlternate.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModAlternate.cs
@@ -188,7 +188,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
                     },
 
                     // Swell
-                    new Swell()
+                    new Swell
                     {
                         StartTime = 700,
                         EndTime = 900,
@@ -201,7 +201,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
                     },
 
                     // Drumroll
-                    new DrumRoll()
+                    new DrumRoll
                     {
                         StartTime = 1100,
                         EndTime = 1400,

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModAlternate.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModAlternate.cs
@@ -1,0 +1,331 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Taiko.Mods;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Replays;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Mods
+{
+    public partial class TestSceneTaikoModAlternate : TaikoModTestScene
+    {
+        [Test]
+        public void TestInputAlternate() => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModAlternate(),
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit
+                    {
+                        StartTime = 100,
+                        Type = HitType.Rim
+                    },
+                    new Hit
+                    {
+                        StartTime = 300,
+                        Type = HitType.Rim
+                    },
+                    new Hit
+                    {
+                        StartTime = 500,
+                        Type = HitType.Rim
+                    },
+                    new Hit
+                    {
+                        StartTime = 700,
+                        Type = HitType.Rim
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(100, TaikoAction.RightRim),
+                new TaikoReplayFrame(120),
+                new TaikoReplayFrame(300, TaikoAction.LeftRim),
+                new TaikoReplayFrame(320),
+                new TaikoReplayFrame(500, TaikoAction.RightRim),
+                new TaikoReplayFrame(520),
+                new TaikoReplayFrame(700, TaikoAction.LeftRim),
+                new TaikoReplayFrame(720),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 4
+        });
+
+        [Test]
+        public void TestInputSameKey([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit
+                    {
+                        StartTime = 100,
+                        Type = HitType.Rim
+                    },
+                    new Hit
+                    {
+                        StartTime = 300,
+                        Type = HitType.Rim
+                    },
+                    new Hit
+                    {
+                        StartTime = 500,
+                        Type = HitType.Rim
+                    },
+                    new Hit
+                    {
+                        StartTime = 700,
+                        Type = HitType.Rim
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(100, TaikoAction.RightRim),
+                new TaikoReplayFrame(120),
+                new TaikoReplayFrame(300, TaikoAction.RightRim),
+                new TaikoReplayFrame(320),
+                new TaikoReplayFrame(500, TaikoAction.RightRim),
+                new TaikoReplayFrame(520),
+                new TaikoReplayFrame(700, TaikoAction.RightRim),
+                new TaikoReplayFrame(720),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 1
+        });
+
+        [Test]
+        public void TestInputIntro([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit
+                    {
+                        StartTime = 100,
+                        Type = HitType.Rim
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(0, TaikoAction.RightRim),
+                new TaikoReplayFrame(20),
+                new TaikoReplayFrame(100, TaikoAction.RightRim),
+                new TaikoReplayFrame(120),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 1
+        });
+
+        [Test]
+        public void TestInputStrong([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit
+                    {
+                        StartTime = 100,
+                        Type = HitType.Centre
+                    },
+                    new Hit
+                    {
+                        StartTime = 300,
+                        Type = HitType.Rim,
+                        IsStrong = true
+                    }
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(100, TaikoAction.RightCentre),
+                new TaikoReplayFrame(120),
+                // Ensure you can hit strong hits starting with the same hand.
+                new TaikoReplayFrame(300, TaikoAction.RightRim),
+                new TaikoReplayFrame(310, TaikoAction.LeftRim),
+                new TaikoReplayFrame(320),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 2
+        });
+
+        [Test]
+        public void TestInputSpecialObjects([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    // Strong
+                    new Hit
+                    {
+                        StartTime = 300,
+                        Type = HitType.Rim,
+                        IsStrong = true
+                    },
+                    new Hit
+                    {
+                        StartTime = 500,
+                        Type = HitType.Rim,
+                    },
+
+                    // Swell
+                    new Swell()
+                    {
+                        StartTime = 700,
+                        EndTime = 900,
+                        RequiredHits = 2
+                    },
+                    new Hit
+                    {
+                        StartTime = 1000,
+                        Type = HitType.Rim,
+                    },
+
+                    // Drumroll
+                    new DrumRoll()
+                    {
+                        StartTime = 1100,
+                        EndTime = 1400,
+                    },
+                    new Hit
+                    {
+                        StartTime = 1500,
+                        Type = HitType.Rim,
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                // Ensure strongs reset handedness.
+                new TaikoReplayFrame(300, TaikoAction.LeftRim),
+                new TaikoReplayFrame(310, TaikoAction.RightRim),
+                new TaikoReplayFrame(320),
+                new TaikoReplayFrame(500, TaikoAction.RightRim),
+                new TaikoReplayFrame(520),
+
+                // Ensure swells reset handedness.
+                new TaikoReplayFrame(700, TaikoAction.RightCentre),
+                new TaikoReplayFrame(710),
+                new TaikoReplayFrame(800, TaikoAction.RightRim),
+                new TaikoReplayFrame(810),
+                new TaikoReplayFrame(1000, TaikoAction.RightRim),
+                new TaikoReplayFrame(1010),
+
+                // Ensure drumrolls reset handedness.
+                new TaikoReplayFrame(1100, TaikoAction.RightCentre),
+                new TaikoReplayFrame(1110),
+                new TaikoReplayFrame(1300, TaikoAction.RightRim),
+                new TaikoReplayFrame(1310),
+                new TaikoReplayFrame(1500, TaikoAction.RightRim),
+                new TaikoReplayFrame(1510),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 4
+        });
+
+        [Test]
+        public void TestInputBreaks([Values] bool alternateFingers) => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModAlternate { AlternateFingers = { Value = alternateFingers } },
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                Breaks =
+                {
+                    new BreakPeriod(100, 1300),
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new Hit
+                    {
+                        StartTime = 100,
+                        Type = HitType.Rim
+                    },
+                    new Hit
+                    {
+                        StartTime = 1500,
+                        Type = HitType.Rim,
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(100, TaikoAction.RightRim),
+                new TaikoReplayFrame(120),
+                // Press same key after break but before hit object.
+                new TaikoReplayFrame(1400, TaikoAction.RightRim),
+                new TaikoReplayFrame(1420),
+                // Press same key again at second hitobject and ensure the break has reset handedness.
+                new TaikoReplayFrame(1500, TaikoAction.RightRim),
+                new TaikoReplayFrame(1520),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 2
+        });
+
+        [Test]
+        public void TestInputAlternateFingers()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new TaikoModAlternate { AlternateFingers = { Value = true } },
+                Autoplay = false,
+                CreateBeatmap = () => new Beatmap
+                {
+                    HitObjects = new List<HitObject>
+                    {
+                        new Hit
+                        {
+                            StartTime = 100,
+                            Type = HitType.Centre
+                        },
+                        new Hit
+                        {
+                            StartTime = 300,
+                            Type = HitType.Rim
+                        },
+                        new Hit
+                        {
+                            StartTime = 500,
+                            Type = HitType.Centre
+                        },
+                        new Hit
+                        {
+                            StartTime = 700,
+                            Type = HitType.Rim
+                        },
+                    },
+                },
+                ReplayFrames = new List<ReplayFrame>
+                {
+                    new TaikoReplayFrame(100, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(120),
+                    new TaikoReplayFrame(300, TaikoAction.LeftRim),
+                    new TaikoReplayFrame(320),
+                    new TaikoReplayFrame(500, TaikoAction.RightCentre),
+                    new TaikoReplayFrame(520),
+                    new TaikoReplayFrame(700, TaikoAction.RightRim),
+                    new TaikoReplayFrame(720),
+                },
+                PassCondition = () => Player.ScoreProcessor.Combo.Value == 4
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 Reset();
             }
         }
-
+        
         protected DrawableTaikoHitObject? GetNextHitObject()
         {
             DrawableHitObject? hitObject = Playfield.HitObjectContainer.AliveObjects.FirstOrDefault(h => h.Result?.HasResult != true);

--- a/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
@@ -21,6 +22,9 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public abstract partial class InputBlockingMod : Mod, IApplicableToDrawableRuleset<TaikoHitObject>, IUpdatableByPlayfield
     {
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(ModCinema) };
+        public override ModType Type => ModType.Conversion;
+
         private DrawableTaikoRuleset ruleset = null!;
 
         protected TaikoPlayfield Playfield => (TaikoPlayfield)ruleset.Playfield;

--- a/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
@@ -1,10 +1,103 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.UI;
+using osu.Game.Rulesets.UI;
+using osu.Game.Utils;
+
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class InputBlockingMod
+    public abstract partial class InputBlockingMod : Mod, IApplicableToDrawableRuleset<TaikoHitObject>, IUpdatableByPlayfield
     {
-        
+        private DrawableTaikoRuleset ruleset = null!;
+
+        protected TaikoPlayfield Playfield => (TaikoPlayfield)ruleset.Playfield;
+
+        /// <summary>
+        /// A tracker for periods where alternation should not be enforced (i.e. non-gameplay periods).
+        /// </summary>
+        /// <remarks>
+        /// This is different from <see cref="Player.IsBreakTime"/> in that the periods here end strictly at the first object after the break, rather than the break's end time.
+        /// </remarks>
+        private PeriodTracker nonGameplayPeriods = null!;
+
+        private IFrameStableClock gameplayClock = null!;
+
+        public abstract void Reset();
+        protected abstract bool CheckCorrectAction(TaikoAction action);
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
+        {
+            ruleset = (DrawableTaikoRuleset)drawableRuleset;
+            ruleset.KeyBindingInputManager.Add(new InputInterceptor(this));
+
+            var periods = new List<Period>();
+
+            if (drawableRuleset.Objects.Any())
+            {
+                periods.Add(new Period(int.MinValue, getValidJudgementTime(ruleset.Objects.First()) - 1));
+
+                foreach (BreakPeriod b in drawableRuleset.Beatmap.Breaks)
+                    periods.Add(new Period(b.StartTime, getValidJudgementTime(ruleset.Objects.First(h => h.StartTime >= b.EndTime)) - 1));
+
+                static double getValidJudgementTime(HitObject hitObject) => hitObject.StartTime - hitObject.HitWindows.WindowFor(HitResult.Ok);
+            }
+
+            nonGameplayPeriods = new PeriodTracker(periods);
+
+            gameplayClock = drawableRuleset.FrameStableClock;
+        }
+
+        public void Update(Playfield playfield)
+        {
+            if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
+            {
+                Reset();
+            }
+        }
+
+        protected DrawableTaikoHitObject? GetNextHitObject()
+        {
+            DrawableHitObject? hitObject = Playfield.HitObjectContainer.AliveObjects.FirstOrDefault(h => h.Result?.HasResult != true);
+            return (DrawableTaikoHitObject?)hitObject;
+        }
+
+        private bool checkCorrectAction(TaikoAction action)
+        {
+            if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
+                return true;
+
+            return CheckCorrectAction(action);
+        }
+
+        private partial class InputInterceptor : Component, IKeyBindingHandler<TaikoAction>
+        {
+            private readonly InputBlockingMod mod;
+
+            public InputInterceptor(InputBlockingMod mod)
+            {
+                this.mod = mod;
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
+                // if the pressed action is incorrect, block it from reaching gameplay.
+                => !mod.checkCorrectAction(e.Action);
+
+            public void OnReleased(KeyBindingReleaseEvent<TaikoAction> e)
+            {
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
 using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Taiko.Mods
@@ -71,7 +72,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 Reset();
             }
         }
-        
+
         protected DrawableTaikoHitObject? GetNextHitObject()
         {
             DrawableHitObject? hitObject = Playfield.HitObjectContainer.AliveObjects.FirstOrDefault(h => h.Result?.HasResult != true);

--- a/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/InputBlockingMod.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Taiko.Mods
+{
+    public class InputBlockingMod
+    {
+        
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
@@ -6,25 +6,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
-using osu.Game.Beatmaps.Timing;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
-using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Play;
-using osu.Game.Utils;
-using osu.Game.Rulesets.Taiko.UI;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public partial class TaikoModAlternate : Mod, IApplicableToDrawableRuleset<TaikoHitObject>, IUpdatableByPlayfield
+    public partial class TaikoModAlternate : InputBlockingMod
     {
         public override string Name => @"Alternate";
         public override string Acronym => @"AL";
@@ -37,43 +27,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         [SettingSource("Alternate Fingers", "For ddkk or kkdd players who alternate fingers instead of hands.")]
         public Bindable<bool> AlternateFingers { get; } = new BindableBool();
 
-        private DrawableTaikoRuleset ruleset = null!;
-
-        private TaikoPlayfield playfield { get; set; } = null!;
-
-        /// <summary>
-        /// A tracker for periods where alternation should not be enforced (i.e. non-gameplay periods).
-        /// </summary>
-        /// <remarks>
-        /// This is different from <see cref="Player.IsBreakTime"/> in that the periods here end strictly at the first object after the break, rather than the break's end time.
-        /// </remarks>
-        private PeriodTracker nonGameplayPeriods = null!;
-
-        private IFrameStableClock gameplayClock = null!;
-
-        public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
-        {
-            ruleset = (DrawableTaikoRuleset)drawableRuleset;
-            ruleset.KeyBindingInputManager.Add(new InputInterceptor(this));
-            playfield = (TaikoPlayfield)ruleset.Playfield;
-
-            var periods = new List<Period>();
-
-            if (drawableRuleset.Objects.Any())
-            {
-                periods.Add(new Period(int.MinValue, getValidJudgementTime(ruleset.Objects.First()) - 1));
-
-                foreach (BreakPeriod b in drawableRuleset.Beatmap.Breaks)
-                    periods.Add(new Period(b.StartTime, getValidJudgementTime(ruleset.Objects.First(h => h.StartTime >= b.EndTime)) - 1));
-
-                static double getValidJudgementTime(HitObject hitObject) => hitObject.StartTime - hitObject.HitWindows.WindowFor(HitResult.Ok);
-            }
-
-            nonGameplayPeriods = new PeriodTracker(periods);
-
-            gameplayClock = drawableRuleset.FrameStableClock;
-        }
-
         private Side? lastAcceptedSide;
         private TaikoAction? lastAcceptedAction;
 
@@ -83,23 +36,17 @@ namespace osu.Game.Rulesets.Taiko.Mods
             [Side.Right] = [TaikoAction.RightCentre, TaikoAction.RightRim],
         };
 
-        public void Update(Playfield playfield)
+        public override void Reset()
         {
-            if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
-            {
-                lastAcceptedSide = null;
-                lastAcceptedAction = null;
-            }
+            lastAcceptedSide = null;
+            lastAcceptedAction = null;
         }
 
-        private bool checkCorrectAction(TaikoAction action)
+        protected override bool CheckCorrectAction(TaikoAction action)
         {
-            if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
-                return true;
-
             // Some objects are traditionally ignore for alternating and thus allows you to reset your alternation pattern.
             bool altReset = false;
-            TaikoHitObject? nextHitObject = getNextHitObject()?.HitObject;
+            TaikoHitObject? nextHitObject = GetNextHitObject()?.HitObject;
             TaikoHitObject? lastHitObject = getLastHitObject()?.HitObject;
 
             // The most significant example being strong hits, which requires both sides to hit.
@@ -149,15 +96,9 @@ namespace osu.Game.Rulesets.Taiko.Mods
             return false;
         }
 
-        private DrawableTaikoHitObject? getNextHitObject()
-        {
-            DrawableHitObject? hitObject = playfield.HitObjectContainer.AliveObjects.FirstOrDefault(h => h.Result?.HasResult != true);
-            return (DrawableTaikoHitObject?)hitObject;
-        }
-
         private DrawableTaikoHitObject? getLastHitObject()
         {
-            DrawableHitObject? hitObject = playfield.HitObjectContainer.AliveObjects.LastOrDefault(h => h.Result?.HasResult == true);
+            DrawableHitObject? hitObject = Playfield.HitObjectContainer.AliveObjects.LastOrDefault(h => h.Result?.HasResult == true);
             return (DrawableTaikoHitObject?)hitObject;
         }
 
@@ -169,23 +110,5 @@ namespace osu.Game.Rulesets.Taiko.Mods
         }
 
         private Side getOppositeSide(Side side) => side == Side.Left ? Side.Right : Side.Left;
-
-        private partial class InputInterceptor : Component, IKeyBindingHandler<TaikoAction>
-        {
-            private readonly TaikoModAlternate mod;
-
-            public InputInterceptor(TaikoModAlternate mod)
-            {
-                this.mod = mod;
-            }
-
-            public bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
-                // if the pressed action is incorrect, block it from reaching gameplay.
-                => !mod.checkCorrectAction(e.Action);
-
-            public void OnReleased(KeyBindingReleaseEvent<TaikoAction> e)
-            {
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
@@ -1,0 +1,190 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
+using osu.Game.Utils;
+using osu.Game.Rulesets.Taiko.UI;
+
+namespace osu.Game.Rulesets.Taiko.Mods
+{
+    public partial class TaikoModAlternate : Mod, IApplicableToDrawableRuleset<TaikoHitObject>, IUpdatableByPlayfield
+    {
+        public override string Name => @"Alternate";
+        public override string Acronym => @"AL";
+        public override LocalisableString Description => @"Don't use the same side twice in a row!";
+
+        public override double ScoreMultiplier => 1.0;
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema), typeof(TaikoModSingleTap) };
+        public override ModType Type => ModType.Conversion;
+
+        [SettingSource("Alternate Fingers", "For ddkk or kkdd players who alternate fingers instead of hands.")]
+        public Bindable<bool> AlternateFingers { get; } = new BindableBool();
+
+        private DrawableTaikoRuleset ruleset = null!;
+
+        private TaikoPlayfield playfield { get; set; } = null!;
+
+        /// <summary>
+        /// A tracker for periods where alternation should not be enforced (i.e. non-gameplay periods).
+        /// </summary>
+        /// <remarks>
+        /// This is different from <see cref="Player.IsBreakTime"/> in that the periods here end strictly at the first object after the break, rather than the break's end time.
+        /// </remarks>
+        private PeriodTracker nonGameplayPeriods = null!;
+
+        private IFrameStableClock gameplayClock = null!;
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
+        {
+            ruleset = (DrawableTaikoRuleset)drawableRuleset;
+            ruleset.KeyBindingInputManager.Add(new InputInterceptor(this));
+            playfield = (TaikoPlayfield)ruleset.Playfield;
+
+            var periods = new List<Period>();
+
+            if (drawableRuleset.Objects.Any())
+            {
+                periods.Add(new Period(int.MinValue, getValidJudgementTime(ruleset.Objects.First()) - 1));
+
+                foreach (BreakPeriod b in drawableRuleset.Beatmap.Breaks)
+                    periods.Add(new Period(b.StartTime, getValidJudgementTime(ruleset.Objects.First(h => h.StartTime >= b.EndTime)) - 1));
+
+                static double getValidJudgementTime(HitObject hitObject) => hitObject.StartTime - hitObject.HitWindows.WindowFor(HitResult.Ok);
+            }
+
+            nonGameplayPeriods = new PeriodTracker(periods);
+
+            gameplayClock = drawableRuleset.FrameStableClock;
+        }
+
+        private Side? lastAcceptedSide;
+        private TaikoAction? lastAcceptedAction;
+
+        private readonly Dictionary<Side, TaikoAction[]> sideActions = new Dictionary<Side, TaikoAction[]>()
+        {
+            [Side.Left] = [TaikoAction.LeftCentre, TaikoAction.LeftRim],
+            [Side.Right] = [TaikoAction.RightCentre, TaikoAction.RightRim],
+        };
+
+        public void Update(Playfield playfield)
+        {
+            if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
+            {
+                lastAcceptedSide = null;
+            }
+        }
+
+        private bool checkCorrectAction(TaikoAction action)
+        {
+            if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
+                return true;
+
+            // Some objects are traditionally ignore for alternating and thus allows you to reset your alternation pattern.
+            bool altReset = false;
+            TaikoHitObject? nextHitObject = getNextHitObject()?.HitObject;
+            TaikoHitObject? lastHitObject = getLastHitObject()?.HitObject;
+
+            // The most significant example being strong hits, which requires both sides to hit.
+            altReset |= nextHitObject is TaikoStrongableHitObject nextStrongHitObject && nextStrongHitObject.IsStrong;
+            altReset |= lastHitObject is TaikoStrongableHitObject lastStrongHitObject && lastStrongHitObject.IsStrong;
+
+            // Swells are often played by tapping dk on one hand, and then dk on the other, in a fast "rolling" fashion.
+            // Drumrolls are rarer but the same idea applies.
+            altReset |= nextHitObject is Swell or DrumRoll;
+            altReset |= lastHitObject is Swell or DrumRoll;
+
+            if (altReset)
+            {
+                lastAcceptedSide = null;
+                lastAcceptedAction = null;
+                return true;
+            }
+
+            // If there's no previous side, accept everything.
+            if (lastAcceptedSide == null)
+            {
+                lastAcceptedSide = getSideForAction(action);
+                lastAcceptedAction = action;
+                return true;
+            }
+
+            if (AlternateFingers.Value)
+            {
+                if (action != lastAcceptedAction)
+                {
+                    lastAcceptedAction = action;
+                    return true;
+                }
+            }
+            else
+            {
+                Side targetSide = getOppositeSide(lastAcceptedSide.Value);
+                TaikoAction[] acceptableActions = sideActions[targetSide];
+
+                if (acceptableActions.Contains(action))
+                {
+                    lastAcceptedSide = targetSide;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private DrawableTaikoHitObject? getNextHitObject()
+        {
+            DrawableHitObject? hitObject = playfield.HitObjectContainer.AliveObjects.FirstOrDefault(h => h.Result?.HasResult != true);
+            return (DrawableTaikoHitObject?)hitObject;
+        }
+
+        private DrawableTaikoHitObject? getLastHitObject()
+        {
+            DrawableHitObject? hitObject = playfield.HitObjectContainer.AliveObjects.LastOrDefault(h => h.Result?.HasResult == true);
+            return (DrawableTaikoHitObject?)hitObject;
+        }
+
+        private Side getSideForAction(TaikoAction action) => sideActions[Side.Left].Contains(action) ? Side.Left : Side.Right;
+
+        private enum Side
+        {
+            Left, Right
+        }
+
+        private Side getOppositeSide(Side side) => side == Side.Left ? Side.Right : Side.Left;
+
+        private partial class InputInterceptor : Component, IKeyBindingHandler<TaikoAction>
+        {
+            private readonly TaikoModAlternate mod;
+
+            public InputInterceptor(TaikoModAlternate mod)
+            {
+                this.mod = mod;
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
+                // if the pressed action is incorrect, block it from reaching gameplay.
+                => !mod.checkCorrectAction(e.Action);
+
+            public void OnReleased(KeyBindingReleaseEvent<TaikoAction> e)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
@@ -88,6 +88,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
             if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
             {
                 lastAcceptedSide = null;
+                lastAcceptedAction = null;
             }
         }
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAlternate.cs
@@ -21,8 +21,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override LocalisableString Description => @"Don't use the same side twice in a row!";
 
         public override double ScoreMultiplier => 1.0;
-        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema), typeof(TaikoModSingleTap) };
-        public override ModType Type => ModType.Conversion;
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap) }).ToArray();
 
         [SettingSource("Alternate Fingers", "For ddkk or kkdd players who alternate fingers instead of hands.")]
         public Bindable<bool> AlternateFingers { get; } = new BindableBool();

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
@@ -15,6 +15,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "mekkadosu!" });
 
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap), typeof(TaikoModAlternate) }).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "mekkadosu!" });
 
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap), typeof(TaikoModAlternate) }).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModRelax.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModRelax.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override LocalisableString Description => @"No need to remember which key is correct anymore!";
 
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap), typeof(TaikoModAlternate) }).ToArray();
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -3,7 +3,7 @@
 
 using osu.Framework.Localisation;
 using System;
-using osu.Game.Rulesets.Mods;
+using System.Linq;
 using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Mods
@@ -15,8 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override LocalisableString Description => @"One key for dons, one key for kats.";
 
         public override double ScoreMultiplier => 1.0;
-        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema), typeof(TaikoModAlternate) };
-        public override ModType Type => ModType.Conversion;
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModAlternate) }).ToArray();
 
         private TaikoAction? lastAcceptedCentreAction { get; set; }
         private TaikoAction? lastAcceptedRimAction { get; set; }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override LocalisableString Description => @"One key for dons, one key for kats.";
 
         public override double ScoreMultiplier => 1.0;
-        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema) };
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema), typeof(TaikoModAlternate) };
         public override ModType Type => ModType.Conversion;
 
         private DrawableTaikoRuleset ruleset = null!;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -3,24 +3,12 @@
 
 using osu.Framework.Localisation;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
-using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Objects;
-using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Play;
-using osu.Game.Utils;
-using osu.Game.Rulesets.Taiko.UI;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public partial class TaikoModSingleTap : Mod, IApplicableToDrawableRuleset<TaikoHitObject>, IUpdatableByPlayfield
+    public partial class TaikoModSingleTap : InputBlockingMod
     {
         public override string Name => @"Single Tap";
         public override string Acronym => @"SG";
@@ -30,61 +18,19 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema), typeof(TaikoModAlternate) };
         public override ModType Type => ModType.Conversion;
 
-        private DrawableTaikoRuleset ruleset = null!;
-
-        private TaikoPlayfield playfield { get; set; } = null!;
-
         private TaikoAction? lastAcceptedCentreAction { get; set; }
         private TaikoAction? lastAcceptedRimAction { get; set; }
 
-        /// <summary>
-        /// A tracker for periods where single tap should not be enforced (i.e. non-gameplay periods).
-        /// </summary>
-        /// <remarks>
-        /// This is different from <see cref="Player.IsBreakTime"/> in that the periods here end strictly at the first object after the break, rather than the break's end time.
-        /// </remarks>
-        private PeriodTracker nonGameplayPeriods = null!;
-
-        private IFrameStableClock gameplayClock = null!;
-
-        public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
+        public override void Reset()
         {
-            ruleset = (DrawableTaikoRuleset)drawableRuleset;
-            ruleset.KeyBindingInputManager.Add(new InputInterceptor(this));
-            playfield = (TaikoPlayfield)ruleset.Playfield;
-
-            var periods = new List<Period>();
-
-            if (drawableRuleset.Objects.Any())
-            {
-                periods.Add(new Period(int.MinValue, getValidJudgementTime(ruleset.Objects.First()) - 1));
-
-                foreach (BreakPeriod b in drawableRuleset.Beatmap.Breaks)
-                    periods.Add(new Period(b.StartTime, getValidJudgementTime(ruleset.Objects.First(h => h.StartTime >= b.EndTime)) - 1));
-
-                static double getValidJudgementTime(HitObject hitObject) => hitObject.StartTime - hitObject.HitWindows.WindowFor(HitResult.Ok);
-            }
-
-            nonGameplayPeriods = new PeriodTracker(periods);
-
-            gameplayClock = drawableRuleset.FrameStableClock;
-        }
-
-        public void Update(Playfield playfield)
-        {
-            if (!nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime)) return;
-
             lastAcceptedCentreAction = null;
             lastAcceptedRimAction = null;
         }
 
-        private bool checkCorrectAction(TaikoAction action)
+        protected override bool CheckCorrectAction(TaikoAction action)
         {
-            if (nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
-                return true;
-
             // If next hit object is strong, allow usage of all actions. Strong drumrolls are ignored in this check.
-            if (playfield.HitObjectContainer.AliveObjects.FirstOrDefault(h => h.Result?.HasResult != true)?.HitObject is TaikoStrongableHitObject hitObject
+            if (GetNextHitObject()?.HitObject is TaikoStrongableHitObject hitObject
                 && hitObject.IsStrong
                 && hitObject is not DrumRoll)
                 return true;
@@ -104,24 +50,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
             }
 
             return false;
-        }
-
-        private partial class InputInterceptor : Component, IKeyBindingHandler<TaikoAction>
-        {
-            private readonly TaikoModSingleTap mod;
-
-            public InputInterceptor(TaikoModSingleTap mod)
-            {
-                this.mod = mod;
-            }
-
-            public bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
-                // if the pressed action is incorrect, block it from reaching gameplay.
-                => !mod.checkCorrectAction(e.Action);
-
-            public void OnReleased(KeyBindingReleaseEvent<TaikoAction> e)
-            {
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Rulesets.Taiko
                         new TaikoModDifficultyAdjust(),
                         new TaikoModClassic(),
                         new TaikoModSwap(),
-                        new TaikoModSingleTap(),
+                        new MultiMod(new TaikoModAlternate(), new TaikoModSingleTap()),
                         new TaikoModConstantSpeed(),
                     };
 


### PR DESCRIPTION
This PR adds an "Alternate" mod similar to the osu ruleset and complements taiko's singletap mod.

I've seen the old PR, I'm not exactly sure what code quality concerns there were there but I tried to make this cleaner.

Also, `osu.Game.Rulesets.Osu.Mods.InputBlockingMod` and the new `osu.Game.Rulesets.Taiko.Mods.InputBlockingMod` classes are *very* similar, I believe they could lifted up to `osu.Game.Rulesets.Mods` easily. I didn't wanna touch osu ruleset and engine code unnecessarily, but if it's ok I can add it to this PR.