### PR TITLE
Fix beatmap offset control potentially reporting negative zero

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -242,6 +242,12 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
         }
 
+        [Test]
+        public void TestNegativeZero()
+        {
+            AddAssert("assert", () => BeatmapOffsetControl.GetOffsetExplanatoryText(-0.0001).ToString(), () => Is.EqualTo("0 ms"));
+        }
+
         private void recreateControl()
         {
             AddStep("Create control", () =>

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -17,6 +17,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -315,9 +316,11 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         public static LocalisableString GetOffsetExplanatoryText(double offset)
         {
-            return offset == 0
-                ? LocalisableString.Interpolate($@"{offset:0.0} ms")
-                : LocalisableString.Interpolate($@"{offset:0.0} ms {getEarlyLateText(offset)}");
+            string formatOffset = offset.ToStandardFormattedString(1);
+
+            return formatOffset == "0"
+                ? LocalisableString.Interpolate($@"{formatOffset} ms")
+                : LocalisableString.Interpolate($@"{formatOffset} ms {getEarlyLateText(offset)}");
 
             LocalisableString getEarlyLateText(double value)
             {


### PR DESCRIPTION
Fix for issue: https://github.com/ppy/osu/issues/33511

When clicking the "Calibrate using last play" button the audio offset value can sometimes go to -0.0 instead of 0. It seems like functionally this is working as intended, just a cosmetic change to the UI so the user sees it as 0.0.