### PR TITLE
Implement participants sorting for multiplayer lobby

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -265,11 +266,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Id = id,
                 Username = username,
                 CountryCode = country,
-                Statistics = new UserStatistics
+                RulesetsStatistics = new Dictionary<string, UserStatistics>
                 {
-                    GlobalRank = rank,
-                    PP = rank.HasValue ? 10000 - rank.Value : 0,
-                    RankedScore = 1000000
+                    ["osu"] = new UserStatistics
+                    {
+                        GlobalRank = rank,
+                        PP = rank.HasValue ? 10000 - rank.Value : 0,
+                        RankedScore = 1000000
+                    }
                 }
             };
             // Add to room

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -241,10 +241,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 {
                     if (player.UserID != API.LocalUser.Value.Id && player.User != null)
                     {
-                        if (player != null)
-                        {
-                            multiplayerClient.RemoveUser(player.User);
-                        }
+                        multiplayerClient.RemoveUser(player.User);
                     }
                 }
             });
@@ -283,7 +280,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             if (ready)
                 multiplayerClient.ChangeUserState(id, MultiplayerUserState.Ready);
         }
-
 
         [Test]
         public void TestCreateRoomViaKeyboard()
@@ -927,7 +923,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("set other user ready", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Ready));
 
             pressReadyButton(1234);
-            AddUntilStep("wait for gameplay", () => (multiplayerComponents.CurrentScreen as MultiSpectatorScreen)?.IsLoaded == true);
+            AddUntilStep("wait for gameplay", () => multiplayerComponents.CurrentScreen is MultiSpectatorScreen screen && screen.IsLoaded);
 
             AddStep("press back button and exit", () =>
             {
@@ -963,7 +959,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("set other user ready", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Ready));
 
             pressReadyButton(1234);
-            AddUntilStep("wait for gameplay", () => (multiplayerComponents.CurrentScreen as MultiSpectatorScreen)?.IsLoaded == true);
+            AddUntilStep("wait for gameplay", () => multiplayerComponents.CurrentScreen is MultiSpectatorScreen screen && screen.IsLoaded);
             AddStep("set other user loaded", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Loaded));
             AddStep("set other user finished play", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.FinishedPlay));
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -154,13 +154,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             sampleStart = audio.Samples.Get(@"SongSelect/confirm-selection");
 
-            participantsSortControl = new MultiplayerParticipantsSortTabControl
-            {
-                Anchor = Anchor.TopLeft,
-                Origin = Anchor.TopLeft,
-                Margin = new MarginPadding { Bottom = 10 }
-            };
-
             InternalChild = new OsuContextMenuContainer
             {
                 RelativeSizeAxes = Axes.Both,
@@ -246,7 +239,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                                         },
                                                                         new Drawable[]
                                                                         {
-                                                                            participantsSortControl
+                                                                            participantsSortControl = new MultiplayerParticipantsSortTabControl
+                                                                            {
+                                                                                Anchor = Anchor.TopLeft,
+                                                                                Origin = Anchor.TopLeft,
+                                                                                Margin = new MarginPadding { Bottom = 10 }
+                                                                            }
                                                                         },
                                                                         new Drawable[]
                                                                         {
@@ -254,7 +252,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                                             {
                                                                                 RelativeSizeAxes = Axes.Both
                                                                             }
-                                                                        }
+                                                                        },
                                                                     }
                                                                 },
                                                                 null,
@@ -435,8 +433,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             beatmapAvailabilityTracker.Availability.BindValueChanged(onBeatmapAvailabilityChanged, true);
 
-            participantsSortControl.Current.BindValueChanged(_ => updateParticipantsSort(), true);
-            participantsSortControl.SortDirection.BindValueChanged(_ => updateParticipantsSort(), true);
+            participantsList.SortMode.BindTo(participantsSortControl.Current);
+            participantsList.SortDirection.BindTo(participantsSortControl.SortDirection);
 
             onRoomUpdated();
             updateGameplayState();
@@ -916,20 +914,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 client.UserModsChanged -= onUserModsChanged;
                 client.LoadRequested -= onLoadRequested;
             }
-        }
-        private void updateParticipantsSort()
-        {
-            if (client.Room == null)
-                return;
-
-            if (participantsList == null)
-                return;
-
-            // Pass the current sort mode and direction to the participants list
-            participantsList.UpdateParticipants(
-                participantsSortControl.Current.Value,
-                participantsSortControl.SortDirection.Value
-            );
         }
 
         public partial class AddItemButton : PurpleRoundedButton

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -139,6 +139,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private MultiplayerParticipantsSortTabControl participantsSortControl = null!;
 
         private ParticipantsList participantsList = null!;
+
         public MultiplayerMatchSubScreen(Room room)
         {
             this.room = room;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -136,6 +136,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private long lastPlaylistItemId;
         private bool isRoomJoined;
 
+        private MultiplayerParticipantsSortTabControl participantsSortControl = null!;
+
+        private ParticipantsList participantsList = null!;
         public MultiplayerMatchSubScreen(Room room)
         {
             this.room = room;
@@ -150,6 +153,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private void load()
         {
             sampleStart = audio.Samples.Get(@"SongSelect/confirm-selection");
+
+            participantsSortControl = new MultiplayerParticipantsSortTabControl
+            {
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopLeft,
+                Margin = new MarginPadding { Bottom = 10 }
+            };
 
             InternalChild = new OsuContextMenuContainer
             {
@@ -224,7 +234,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                                     RelativeSizeAxes = Axes.Both,
                                                                     RowDimensions = new[]
                                                                     {
-                                                                        new Dimension(GridSizeMode.AutoSize)
+                                                                        new Dimension(GridSizeMode.AutoSize),
+                                                                        new Dimension(GridSizeMode.AutoSize),
+                                                                        new Dimension(),
                                                                     },
                                                                     Content = new[]
                                                                     {
@@ -234,10 +246,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                                         },
                                                                         new Drawable[]
                                                                         {
-                                                                            new ParticipantsList
+                                                                            participantsSortControl
+                                                                        },
+                                                                        new Drawable[]
+                                                                        {
+                                                                            participantsList = new ParticipantsList
                                                                             {
                                                                                 RelativeSizeAxes = Axes.Both
-                                                                            },
+                                                                            }
                                                                         }
                                                                     }
                                                                 },
@@ -418,6 +434,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             client.LoadRequested += onLoadRequested;
 
             beatmapAvailabilityTracker.Availability.BindValueChanged(onBeatmapAvailabilityChanged, true);
+
+            participantsSortControl.Current.BindValueChanged(_ => updateParticipantsSort(), true);
+            participantsSortControl.SortDirection.BindValueChanged(_ => updateParticipantsSort(), true);
 
             onRoomUpdated();
             updateGameplayState();
@@ -897,6 +916,20 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 client.UserModsChanged -= onUserModsChanged;
                 client.LoadRequested -= onLoadRequested;
             }
+        }
+        private void updateParticipantsSort()
+        {
+            if (client.Room == null)
+                return;
+
+            if (participantsList == null)
+                return;
+
+            // Pass the current sort mode and direction to the participants list
+            participantsList.UpdateParticipants(
+                participantsSortControl.Current.Value,
+                participantsSortControl.SortDirection.Value
+            );
         }
 
         public partial class AddItemButton : PurpleRoundedButton

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerParticipantsSortTabControl.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerParticipantsSortTabControl.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Graphics;
+using osuTK.Graphics;
+using osuTK;
+using osu.Framework.Input.Events;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Participants;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer
+{
+    public partial class MultiplayerParticipantsSortTabControl : OverlaySortTabControl<ParticipantsSortMode>
+    {
+        public readonly Bindable<SortDirection> SortDirection = new Bindable<SortDirection>(Overlays.SortDirection.Descending);
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Current.BindValueChanged(_ => SortDirection.Value = Overlays.SortDirection.Descending);
+        }
+
+        protected override SortTabControl CreateControl() => new ParticipantsSortTabControlInternal
+        {
+            SortDirection = { BindTarget = SortDirection },
+        };
+
+        private partial class ParticipantsSortTabControlInternal : SortTabControl
+        {
+            protected override bool AddEnumEntriesAutomatically => true;
+
+            public readonly Bindable<SortDirection> SortDirection = new Bindable<SortDirection>();
+
+            protected override TabItem<ParticipantsSortMode> CreateTabItem(ParticipantsSortMode value) => new ParticipantsSortTabItem(value)
+            {
+                SortDirection = { BindTarget = SortDirection }
+            };
+        }
+
+        private partial class ParticipantsSortTabItem : SortTabItem
+        {
+            public readonly Bindable<SortDirection> SortDirection = new Bindable<SortDirection>();
+
+            public ParticipantsSortTabItem(ParticipantsSortMode value)
+                : base(value)
+            {
+            }
+
+            protected override TabButton CreateTabButton(ParticipantsSortMode value) => new ParticipantsTabButton(value)
+            {
+                Active = { BindTarget = Active },
+                SortDirection = { BindTarget = SortDirection }
+            };
+        }
+
+        public partial class ParticipantsTabButton : TabButton
+        {
+            public readonly Bindable<SortDirection> SortDirection = new Bindable<SortDirection>();
+
+            protected override Color4 ContentColour
+            {
+                set
+                {
+                    base.ContentColour = value;
+                    icon.Colour = value;
+                }
+            }
+
+            private readonly SpriteIcon icon;
+
+            public ParticipantsTabButton(ParticipantsSortMode value)
+                : base(value)
+            {
+                Add(icon = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AlwaysPresent = true,
+                    Alpha = 0,
+                    Size = new Vector2(6),
+                    Icon = FontAwesome.Solid.CaretDown,
+                });
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                SortDirection.BindValueChanged(direction =>
+                {
+                    icon.ScaleTo(direction.NewValue == Overlays.SortDirection.Ascending && Active.Value ? new Vector2(1f, -1f) : Vector2.One, 300, Easing.OutQuint);
+                }, true);
+            }
+
+            protected override void UpdateState()
+            {
+                base.UpdateState();
+                icon.FadeTo(Active.Value || IsHovered ? 1 : 0, 200, Easing.OutQuint);
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                if (Active.Value)
+                    SortDirection.Value = SortDirection.Value == Overlays.SortDirection.Ascending ? Overlays.SortDirection.Descending : Overlays.SortDirection.Ascending;
+
+                return base.OnClick(e);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -153,18 +153,18 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             if (SortDirection.Value == Overlays.SortDirection.Ascending)
             {
                 return users
-                            .GroupBy(u => u.User!.CountryCode.ToString())
-                            .OrderBy(g => g.Key)
-                            .SelectMany(g => g.OrderBy(getCurrentRulesetRank))
-                            .ToList();
+                .GroupBy(u => u.User!.CountryCode.ToString())
+                .OrderBy(g => g.Key)
+                .SelectMany(g => g.OrderBy(getCurrentRulesetRank))
+                .ToList();
             }
             else
             {
                 return users
-                            .GroupBy(u => u.User!.CountryCode.ToString())
-                            .OrderByDescending(g => g.Key)
-                            .SelectMany(g => g.OrderBy(getCurrentRulesetRank))
-                            .ToList();
+                .GroupBy(u => u.User!.CountryCode.ToString())
+                .OrderByDescending(g => g.Key)
+                .SelectMany(g => g.OrderBy(getCurrentRulesetRank))
+                .ToList();
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -52,6 +52,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         }
 
         private void onRoomUpdated() => Scheduler.AddOnce(updateState);
+
         private void updateState()
         {
             if (client.Room == null)
@@ -120,11 +121,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     sortedUsers = sortByRankForCurrentRuleset(sortedUsers);
                     break;
             }
+
             // Reorder existing participants to match the sorted user list
             for (int i = 0; i < sortedUsers.Count; i++)
             {
                 var user = sortedUsers[i];
-                var existingIndex = participants.IndexOf(user);
+                int existingIndex = participants.IndexOf(user);
 
                 if (existingIndex != -1 && existingIndex != i)
                     participants.Move(existingIndex, i);
@@ -133,7 +135,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             // Ensure host is still positioned at the top (override sort for host)
             if (client.Room?.Host != null)
             {
-                var hostIndex = participants.IndexOf(client.Room.Host);
+                int hostIndex = participants.IndexOf(client.Room.Host);
+
                 if (hostIndex > 0)
                 {
                     participants.Move(hostIndex, 0);
@@ -150,18 +153,18 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             if (SortDirection.Value == Overlays.SortDirection.Ascending)
             {
                 return users
-                    .GroupBy(u => u.User!.CountryCode.ToString())
-                    .OrderBy(g => g.Key)
-                    .SelectMany(g => g.OrderBy(u => getCurrentRulesetRank(u)))
-                    .ToList();
+                            .GroupBy(u => u.User!.CountryCode.ToString())
+                            .OrderBy(g => g.Key)
+                            .SelectMany(g => g.OrderBy(getCurrentRulesetRank))
+                            .ToList();
             }
             else
             {
                 return users
-                    .GroupBy(u => u.User!.CountryCode.ToString())
-                    .OrderByDescending(g => g.Key)
-                    .SelectMany(g => g.OrderBy(u => getCurrentRulesetRank(u)))
-                    .ToList();
+                            .GroupBy(u => u.User!.CountryCode.ToString())
+                            .OrderByDescending(g => g.Key)
+                            .SelectMany(g => g.OrderBy(getCurrentRulesetRank))
+                            .ToList();
             }
         }
 
@@ -172,11 +175,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         {
             if (SortDirection.Value == Overlays.SortDirection.Ascending)
             {
-                return users.OrderBy(u => getCurrentRulesetRank(u)).ToList();
+                return users.OrderBy(getCurrentRulesetRank).ToList();
             }
             else
             {
-                return users.OrderByDescending(u => getCurrentRulesetRank(u)).ToList();
+                return users.OrderByDescending(getCurrentRulesetRank).ToList();
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -9,14 +10,17 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Overlays;
+using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 {
     public partial class ParticipantsList : VirtualisedListContainer<MultiplayerRoomUser, ParticipantPanel>
     {
         private BindableList<MultiplayerRoomUser> participants => RowData;
-
         private MultiplayerRoomUser? currentHost;
+        private ParticipantsSortMode? currentSortMode;
+        private SortDirection? currentSortDirection;
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
@@ -40,7 +44,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         }
 
         private void onRoomUpdated() => Scheduler.AddOnce(updateState);
-
         private void updateState()
         {
             if (client.Room == null)
@@ -60,15 +63,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 // Add panels for all users new to the room.
                 foreach (var user in client.Room.Users.Except(participants))
                     participants.Add(user);
-
-                if (currentHost == null || !currentHost.Equals(client.Room.Host))
+                    if (currentHost == null || !ReferenceEquals(currentHost, client.Room.Host))
                 {
                     currentHost = null;
 
                     // Change position of new host to display above all participants.
                     if (client.Room.Host != null)
                     {
-                        currentHost = participants.SingleOrDefault(u => u.Equals(client.Room.Host));
+                        currentHost = participants.SingleOrDefault(u => ReferenceEquals(u, client.Room.Host));
                         int currentHostIndex = participants.IndexOf(client.Room.Host);
 
                         if (currentHostIndex > 0)
@@ -78,6 +80,91 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                         }
                     }
                 }
+
+                UpdateParticipants();
+            }
+        }
+        /// <summary>
+        /// Reorders existing panels based on sort criteria.
+        /// </summary>
+        /// <param name="sortMode">Optional sort mode to apply and store for future updates</param>
+        /// <param name="sortDirection">Optional sort direction to apply and store for future updates</param>
+        public void UpdateParticipants(ParticipantsSortMode? sortMode = null, SortDirection? sortDirection = null)
+        {
+            if (client.Room == null)
+                return;
+
+            // Update stored sort settings if provided
+            if (sortMode.HasValue)
+                currentSortMode = sortMode.Value;
+            if (sortDirection.HasValue)
+                currentSortDirection = sortDirection.Value;
+
+            // Only reorder if we have sort settings
+            if (!currentSortMode.HasValue || !currentSortDirection.HasValue)
+                return;
+
+            IList<MultiplayerRoomUser> sortedUsers = client.Room.Users.ToList();
+
+            switch (currentSortMode.Value)
+            {
+                case ParticipantsSortMode.Alphabetical:
+                    sortedUsers = currentSortDirection.Value == SortDirection.Ascending
+                        ? sortedUsers.OrderBy(u => u.User!.Username).ToList()
+                        : sortedUsers.OrderByDescending(u => u.User!.Username).ToList();
+                    break;
+
+                case ParticipantsSortMode.Country:
+                    sortedUsers = sortByCountryWithRankSecondary(sortedUsers);
+                    break;
+
+                case ParticipantsSortMode.Rank:
+                    sortedUsers = currentSortDirection.Value == SortDirection.Ascending
+                        ? sortedUsers.OrderBy(u => u.User!.Statistics?.GlobalRank ?? int.MaxValue).ToList()
+                        : sortedUsers.OrderByDescending(u => u.User!.Statistics?.GlobalRank ?? int.MaxValue).ToList();
+                    break;
+            }
+            // Reorder existing participants to match the sorted user list
+            for (int i = 0; i < sortedUsers.Count; i++)
+            {
+                var user = sortedUsers[i];
+                var existingIndex = participants.IndexOf(user);
+
+                if (existingIndex != -1 && existingIndex != i)
+                    participants.Move(existingIndex, i);
+            }
+
+            // Ensure host is still positioned at the top (override sort for host)
+            if (client.Room?.Host != null)
+            {
+                var hostIndex = participants.IndexOf(client.Room.Host);
+                if (hostIndex > 0)
+                {
+                    participants.Move(hostIndex, 0);
+                    currentHost = participants[0];
+                }
+            }
+        }
+        /// <summary>
+        /// Sorts users by country first, then by rank within each country (best rank first).
+        /// </summary>
+        private IList<MultiplayerRoomUser> sortByCountryWithRankSecondary(IList<MultiplayerRoomUser> users)
+        {
+            if (currentSortDirection!.Value == SortDirection.Ascending)
+            {
+                return users
+                    .GroupBy(u => u.User!.CountryCode.ToString())
+                    .OrderBy(g => g.Key)
+                    .SelectMany(g => g.OrderBy(u => u.User!.Statistics?.GlobalRank ?? int.MaxValue))
+                    .ToList();
+            }
+            else
+            {
+                return users
+                    .GroupBy(u => u.User!.CountryCode.ToString())
+                    .OrderByDescending(g => g.Key)
+                    .SelectMany(g => g.OrderBy(u => u.User!.Statistics?.GlobalRank ?? int.MaxValue))
+                    .ToList();
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -13,7 +13,6 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
-using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 {
@@ -72,7 +71,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 // Add panels for all users new to the room.
                 foreach (var user in client.Room.Users.Except(participants))
                     participants.Add(user);
-                    if (currentHost == null || !ReferenceEquals(currentHost, client.Room.Host))
+
+                if (currentHost == null || !ReferenceEquals(currentHost, client.Room.Host))
                 {
                     currentHost = null;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsSortMode.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsSortMode.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
+{
+    public enum ParticipantsSortMode
+    {
+        [Description("Rank")]
+        Rank,
+
+        [Description("Alphabetical")]
+        Alphabetical,
+
+        [Description("Country")]
+        Country
+    }
+}

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -85,7 +85,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void Disconnect() => isConnected.Value = false;
 
         public MultiplayerRoomUser AddUser(APIUser user, bool markAsPlaying = false)
-            => AddUser(new MultiplayerRoomUser(user.Id) { User = user }, markAsPlaying);
+        {
+            apiRequestHandler.RegisterUser(user); // registers test user
+            return AddUser(new MultiplayerRoomUser(user.Id) { User = user }, markAsPlaying);
+        }
 
         public MultiplayerRoomUser AddUser(MultiplayerRoomUser roomUser, bool markAsPlaying = false)
         {

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -224,7 +224,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                     getUsersRequest.TriggerSuccess(new GetUsersResponse
                     {
                         Users = getUsersRequest.UserIds.Select(id => id == TestUserLookupCache.UNRESOLVED_USER_ID
-                                                   ? null
+                                                    ? null
                                                         : knownUsers.TryGetValue(id, out var user)
                                                         ? user
                                                             : new APIUser
@@ -240,7 +240,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                                                                     }
                                                                     : null,
                                                             })
-                                                       .Where(u => u != null).ToList(),
+                                                        .Where(u => u != null).ToList(),
                     });
                     return true;
                 }

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -39,8 +39,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         // method to register users
         public void RegisterUser(APIUser user)
         {
-            if (!knownUsers.ContainsKey(user.Id))
-                knownUsers[user.Id] = user;
+            knownUsers.TryAdd(user.Id, user);
         }
 
         /// <summary>
@@ -228,19 +227,19 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                                                    ? null
                                                         : knownUsers.TryGetValue(id, out var user)
                                                         ? user
-                                                           : new APIUser
-                                                           {
-                                                               Id = id,
-                                                               Username = $"User {id}",
-                                                               Team = RNG.NextBool()
-                                                                   ? new APITeam
-                                                                   {
-                                                                       Name = "Collective Wangs",
-                                                                       ShortName = "WANG",
-                                                                       FlagUrl = "https://assets.ppy.sh/teams/flag/1/wanglogo.jpg",
-                                                                   }
-                                                                   : null,
-                                                           })
+                                                            : new APIUser
+                                                            {
+                                                                Id = id,
+                                                                Username = $"User {id}",
+                                                                Team = RNG.NextBool()
+                                                                    ? new APITeam
+                                                                    {
+                                                                        Name = "Collective Wangs",
+                                                                        ShortName = "WANG",
+                                                                        FlagUrl = "https://assets.ppy.sh/teams/flag/1/wanglogo.jpg",
+                                                                    }
+                                                                    : null,
+                                                            })
                                                        .Where(u => u != null).ToList(),
                     });
                     return true;

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -34,6 +34,15 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         private int currentPlaylistItemId = 1;
         private int currentScoreId = 1;
 
+        private readonly Dictionary<int, APIUser> knownUsers = new Dictionary<int, APIUser>();
+
+        // method to register users
+        public void RegisterUser(APIUser user)
+        {
+            if (!knownUsers.ContainsKey(user.Id))
+                knownUsers[user.Id] = user;
+        }
+
         /// <summary>
         /// Handles an API request, while also updating the local state to match how the server would eventually respond.
         /// </summary>
@@ -217,20 +226,22 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                     {
                         Users = getUsersRequest.UserIds.Select(id => id == TestUserLookupCache.UNRESOLVED_USER_ID
                                                    ? null
-                                                   : new APIUser
-                                                   {
-                                                       Id = id,
-                                                       Username = $"User {id}",
-                                                       Team = RNG.NextBool()
-                                                           ? new APITeam
+                                                        : knownUsers.TryGetValue(id, out var user)
+                                                        ? user
+                                                           : new APIUser
                                                            {
-                                                               Name = "Collective Wangs",
-                                                               ShortName = "WANG",
-                                                               FlagUrl = "https://assets.ppy.sh/teams/flag/1/wanglogo.jpg",
-                                                           }
-                                                           : null,
-                                                   })
-                                               .Where(u => u != null).ToList(),
+                                                               Id = id,
+                                                               Username = $"User {id}",
+                                                               Team = RNG.NextBool()
+                                                                   ? new APITeam
+                                                                   {
+                                                                       Name = "Collective Wangs",
+                                                                       ShortName = "WANG",
+                                                                       FlagUrl = "https://assets.ppy.sh/teams/flag/1/wanglogo.jpg",
+                                                                   }
+                                                                   : null,
+                                                           })
+                                                       .Where(u => u != null).ToList(),
                     });
                     return true;
                 }


### PR DESCRIPTION
Co-authored-by: @RodrigoMFC

Implements: #32958

We added the three sorting options described in the discussion. We reused the sorting UI for the beatmaps and tried to follow similar logic.
For testing, we couldnt add custom players (with custom names, countries and rank) so we had to add a small workaround for registering players (there is probably a better way to do this)