### PR TITLE
Add Option To Toggle Hit Circle Animations In Legacy Skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -8,6 +8,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -37,6 +38,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private SkinnableSpriteText hitCircleText = null!;
 
+        private Bindable<bool> configHitAnimations = null!;
+
         private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
         private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
 
@@ -55,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuConfigManager config)
         {
             const string base_lookup = @"hitcircle";
 
@@ -124,6 +127,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 accentColour.BindTo(drawableOsuObject.AccentColour);
                 indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
             }
+
+            configHitAnimations = config.GetBindable<bool>(OsuSetting.HitAnimations);
         }
 
         protected override void LoadComplete()
@@ -164,11 +169,22 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 switch (state)
                 {
                     case ArmedState.Hit:
-                        CircleSprite.FadeOut(legacy_fade_duration);
-                        CircleSprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
+                        if (configHitAnimations.Value)
+                        {
+                            CircleSprite.FadeOut(legacy_fade_duration);
+                            CircleSprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 
-                        OverlaySprite.FadeOut(legacy_fade_duration);
-                        OverlaySprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
+                            OverlaySprite.FadeOut(legacy_fade_duration);
+                            OverlaySprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
+                        }
+                        else
+                        {
+                            CircleSprite.FadeOut(0);
+                            CircleSprite.ScaleTo(1f, 0, Easing.Out);
+
+                            OverlaySprite.FadeOut(0);
+                            OverlaySprite.ScaleTo(1f, 0, Easing.Out);
+                        }
 
                         if (hasNumber)
                         {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -179,11 +179,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         }
                         else
                         {
-                            CircleSprite.FadeOut(0);
-                            CircleSprite.ScaleTo(1f, 0, Easing.Out);
-
-                            OverlaySprite.FadeOut(0);
-                            OverlaySprite.ScaleTo(1f, 0, Easing.Out);
+                            CircleSprite.FadeOut();
+                            OverlaySprite.FadeOut();
                         }
 
                         if (hasNumber)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.LightenDuringBreaks, true);
 
             SetDefault(OsuSetting.HitLighting, true);
+            SetDefault(OsuSetting.HitAnimations, true);
             SetDefault(OsuSetting.StarFountains, true);
 
             SetDefault(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always);
@@ -424,6 +425,7 @@ namespace osu.Game.Configuration
         NotifyOnFriendPresenceChange,
         UIHoldActivationDelay,
         HitLighting,
+        HitAnimations,
         StarFountains,
         MenuBackgroundSource,
         GameplayDisableWinKey,

--- a/osu.Game/Localisation/GraphicsSettingsStrings.cs
+++ b/osu.Game/Localisation/GraphicsSettingsStrings.cs
@@ -115,6 +115,11 @@ namespace osu.Game.Localisation
         public static LocalisableString HitLighting => new TranslatableString(getKey(@"hit_lighting"), @"Hit lighting");
 
         /// <summary>
+        /// "Hit animations"
+        /// </summary>
+        public static LocalisableString HitAnimations => new TranslatableString(getKey(@"hit_animations"), @"Hit animations");
+
+        /// <summary>
         /// "Screenshots"
         /// </summary>
         public static LocalisableString Screenshots => new TranslatableString(getKey(@"screenshots"), @"Screenshots");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -33,6 +33,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = GraphicsSettingsStrings.HitAnimations,
+                    Current = config.GetBindable<bool>(OsuSetting.HitAnimations)
+                },
+                new SettingsCheckbox
+                {
                     LabelText = GameplaySettingsStrings.StarFountains,
                     Current = config.GetBindable<bool>(OsuSetting.StarFountains)
                 },


### PR DESCRIPTION
### Hit Animations Are Important But...
There is a (growing)subset of the community which wants this feature badly, me included for years. Seeing as the last comment Peppy gave on the subject was a leading question along the lines of "Are you going to develop it yourself?" I decided it's time to actually do that. 

No disrespect intended. I'm not trying to be a smart-ass, I just have wanted to see this feature for years.

### Why this is better than the current implementation of bypassing hit animations:
- Old method relies on a unintended broken skinning mechanic, this will allow for simplification that no longer needs to make sure to support this old unintended feature.
- "Hit Animations" in my opinion falls under the same umbrella as "Hit Lighting", giving it a fitting place in the options menu.
- "The game looks bad without hit animations" \\ There are countless examples of players in every rhythm game(including osu) disabling animations and removing unnecessary elements to achieve an advantage in readability.
- The original implementation does not allow for certain skinning features such as working combo numbers > 9 and proper support of combo colors. Which are both very important when it comes to playing the game at a higher level.
- The Argon skin has a different hit animation which is less intrusive than the legacy hit animation.
- This feature **does clearly help with reading**, which means it will more than likely become a setting that most people recommend disabling for higher level gameplay.
- If custom skin animations are planned in the future, the necessity for this setting is even more apparent. As some players may like a skin but not want to play with it's animations.
- This feature has been asked for many times in discussions with little to no progress in years. This is a simple solution that may push higher skill level players into trying Lazer for a feature they have wanted for a long time.

### How Does This Make Reading Easier?
Essentially when the fade-out & expand is happening when a note is clicked it can obscure nearby circles & combo numbers, making it take slightly longer to read them properly.

Without hit animations you have more time to read the other notes on the screen with less clutter.

### "We are not going to support this in a hacky way (aka adding a new setting just for it)."
There have been many statements made about animations being configurable "in the future" but with the focus having been in other places for years now it feels like this feature will never properly get added. All this PR aims to do is give people the option to use something that is originally behind a hacky skinning method, I think anyone would agree that an actual toggle in the settings for something like hit animations is less "hacky" than having to modify and remove core elements of a skin. Alongside this if necessary it can be removed at a later time when skinning is expanded upon further.


### Closing Thoughts
I understand that no official discussions have been decided on when it comes to instafade/hit animations but I feel this is a feature that a lot of people want.

## Related
https://github.com/ppy/osu/discussions/24018 https://github.com/ppy/osu/discussions/27514 https://github.com/ppy/osu/discussions/25473 https://github.com/ppy/osu/discussions/20027 https://github.com/ppy/osu/discussions/18789 https://github.com/ppy/osu/discussions/15123

## Video

https://github.com/user-attachments/assets/002c431a-bbc6-46cd-b860-7d451ba66eb4

