### PR TITLE
Prevent random button action from being affected by shift when triggered by key binding

### DIFF
--- a/osu.Game/Screens/Select/FooterButtonRandom.cs
+++ b/osu.Game/Screens/Select/FooterButtonRandom.cs
@@ -119,6 +119,7 @@ namespace osu.Game.Screens.Select
                 {
                     rewindSearch |= e.ShiftPressed;
                 }
+
                 fromKeyBinding = false;
                 return base.OnClick(e);
             }

--- a/osu.Game/Screens/Select/FooterButtonRandom.cs
+++ b/osu.Game/Screens/Select/FooterButtonRandom.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Screens.Select
         private OsuSpriteText randomSpriteText;
         private OsuSpriteText rewindSpriteText;
         private bool rewindSearch;
+        private bool fromKeyBinding;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -114,7 +115,11 @@ namespace osu.Game.Screens.Select
             try
             {
                 // this uses OR to handle rewinding when clicks are triggered by other sources (i.e. right button in OnMouseUp).
-                rewindSearch |= e.ShiftPressed;
+                if (!fromKeyBinding)
+                {
+                    rewindSearch |= e.ShiftPressed;
+                }
+                fromKeyBinding = false;
                 return base.OnClick(e);
             }
             finally
@@ -145,6 +150,7 @@ namespace osu.Game.Screens.Select
                 return false;
             }
 
+            fromKeyBinding = true;
             if (!e.Repeat)
                 TriggerClick();
             return true;

--- a/osu.Game/Screens/SelectV2/FooterButtonRandom.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonRandom.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Screens.SelectV2
         private OsuSpriteText randomSpriteText = null!;
         private OsuSpriteText rewindSpriteText = null!;
         private bool rewindSearch;
+        private bool fromKeyBinding;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colour)
@@ -110,7 +111,11 @@ namespace osu.Game.Screens.SelectV2
             try
             {
                 // this uses OR to handle rewinding when clicks are triggered by other sources (i.e. right button in OnMouseUp).
-                rewindSearch |= e.ShiftPressed;
+                if (!fromKeyBinding)
+                {
+                    rewindSearch |= e.ShiftPressed;
+                }
+                fromKeyBinding = false;
                 return base.OnClick(e);
             }
             finally
@@ -140,6 +145,7 @@ namespace osu.Game.Screens.SelectV2
                 return false;
             }
 
+            fromKeyBinding = true;
             if (!e.Repeat)
                 TriggerClick();
             return true;

--- a/osu.Game/Screens/SelectV2/FooterButtonRandom.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonRandom.cs
@@ -115,6 +115,7 @@ namespace osu.Game.Screens.SelectV2
                 {
                     rewindSearch |= e.ShiftPressed;
                 }
+
                 fromKeyBinding = false;
                 return base.OnClick(e);
             }


### PR DESCRIPTION
Should resolve #33527.
