### PR TITLE
Exclude extended limits setting in `ModDifficultyAdjust.UserAdjustedSettingsCount`

### DIFF
--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -123,6 +123,9 @@ namespace osu.Game.Rulesets.Mods
 
                 foreach (var (_, property) in this.GetSettingsSourceProperties())
                 {
+                    if (property.Name == nameof(ExtendedLimits))
+                        continue;
+
                     var bindable = (IBindable)property.GetValue(this)!;
 
                     if (!bindable.IsDefault)


### PR DESCRIPTION
Resolves #33522.

There's no point including it in the adjusted settings count since enabling it without changing any other properties does nothing.

![image](https://github.com/user-attachments/assets/2b4e3b51-6ada-468a-aa9f-c4ab7de664d5)
![image](https://github.com/user-attachments/assets/059a661b-2f13-4a20-99cd-029d68e65a9a)
