### PR TITLE
Song Select V2: Fix GPU overhead on carousel scroll

### DIFF
--- a/osu.Game/Screens/SelectV2/Panel.cs
+++ b/osu.Game/Screens/SelectV2/Panel.cs
@@ -120,35 +120,28 @@ namespace osu.Game.Screens.SelectV2
                 },
                 Children = new[]
                 {
-                    new BufferedContainer
+                    backgroundBorder = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Children = new Drawable[]
+                        Colour = Color4.Black,
+                    },
+                    backgroundLayerHorizontalPadding = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new Container
                         {
-                            backgroundBorder = new Box
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            CornerRadius = corner_radius,
+                            Children = new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = Color4.Black,
-                            },
-                            backgroundLayerHorizontalPadding = new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Child = new Container
+                                backgroundGradient = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Masking = true,
-                                    CornerRadius = corner_radius,
-                                    Children = new Drawable[]
-                                    {
-                                        backgroundGradient = new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                        },
-                                        backgroundContainer = new Container
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                        },
-                                    }
+                                },
+                                backgroundContainer = new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
                                 },
                             }
                         },

--- a/osu.Game/Screens/SelectV2/PanelSetBackground.cs
+++ b/osu.Game/Screens/SelectV2/PanelSetBackground.cs
@@ -18,7 +18,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.SelectV2
 {
-    public partial class PanelSetBackground : BufferedContainer
+    public partial class PanelSetBackground : Container
     {
         [Resolved]
         private BeatmapCarousel? beatmapCarousel { get; set; }
@@ -52,10 +52,6 @@ namespace osu.Game.Screens.SelectV2
         }
 
         public PanelSetBackground()
-            // TODO: for performance reasons we may want this to be true.
-            // Setting to true will require that the buffered portion is moved to a child such that `FadeIn`/`FadeOut` transforms
-            // still work.
-            : base(cachedFrameBuffer: false)
         {
             RelativeSizeAxes = Axes.Both;
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33517, closes https://github.com/ppy/osu/issues/33462

Making a pr since this change is basically 0 effort.

Constant updates of `BufferedContainer`s were a reason of a huge gpu overhead, so I tried to just remove them and see what breaks. Surprisingly - nothing? As far as I can tell of course.
Here's a visual comparison
|master|pr|
|---|---|
|![buffer](https://github.com/user-attachments/assets/57a1468e-817c-4299-a2c1-9f2d7a4edbc2)|![nobuffer](https://github.com/user-attachments/assets/2acc904c-e4b3-42c5-8ac2-5b3076e46c3e)|

I personally wouldn't be able to tell which one is which. May be a few pixels are different here or there (and no smoothing for bg previews), but I'd rather take these over bad performance.

Here's a video showing performance improvements:
master: https://streamable.com/dvd9bq
pr: https://streamable.com/t1skt9