### PR TITLE
Add Tachyon support for package managed installations

### DIFF
--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -101,7 +101,7 @@ namespace osu.Desktop.Updater
                     progressNotification.StartDownload();
                     runOutsideOfGameplay(() => notificationOverlay.Post(progressNotification), cts.Token);
 
-                    await updateManager.DownloadUpdatesAsync(update, p => progressNotification.Progress = p / 100f, false, cts.Token).ConfigureAwait(false);
+                    await updateManager.DownloadUpdatesAsync(update, p => progressNotification.Progress = p / 100f, cts.Token).ConfigureAwait(false);
                     runOutsideOfGameplay(() => progressNotification.State = ProgressNotificationState.Completed, cts.Token);
                 }
             }

--- a/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
+++ b/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
@@ -59,10 +59,17 @@ namespace osu.Game.Tests.NonVisual
             AddStep("complete check", () => manager.Complete());
             AddUntilStep("2 checks completed", () => manager.Completions, () => Is.EqualTo(2));
             AddUntilStep("no check pending", () => !manager.IsPending);
+
+            AddStep("change release stream", () => config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Lazer));
+
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("3 checks completed", () => manager.Completions, () => Is.EqualTo(3));
+            AddUntilStep("no check pending", () => !manager.IsPending);
         }
 
         /// <summary>
-        /// Updates should be checked once more if the release stream is changed during an going check
+        /// Updates should be checked once more if the release stream is changed during an going check.
         /// </summary>
         [Test]
         public void TestReleaseStreamChangedDuringCheck()
@@ -92,8 +99,18 @@ namespace osu.Game.Tests.NonVisual
             AddStep("complete check", () => manager.Complete());
             AddUntilStep("2 checks completed", () => manager.Completions, () => Is.EqualTo(2));
             AddUntilStep("no check pending", () => !manager.IsPending);
+
+            AddStep("request check", () => manager.CheckForUpdateAsync());
+
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("3 checks completed", () => manager.Completions, () => Is.EqualTo(3));
+            AddUntilStep("no check pending", () => !manager.IsPending);
         }
 
+        /// <summary>
+        /// Any ongoing request should be returned when the user requests a new one.
+        /// </summary>
         [Test]
         public void TestUserRequestReturnsExistingCheck()
         {

--- a/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
+++ b/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
@@ -91,14 +91,14 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void TestUserRequest()
         {
-            AddStep("request check", () => manager.CheckForUpdateAsync());
+            AddStep("request check", () => manager.CheckForUpdate());
 
             AddUntilStep("check pending", () => manager.IsPending);
             AddStep("complete check", () => manager.Complete());
             AddUntilStep("2 checks completed", () => manager.Completions, () => Is.EqualTo(2));
             AddUntilStep("no check pending", () => !manager.IsPending);
 
-            AddStep("request check", () => manager.CheckForUpdateAsync());
+            AddStep("request check", () => manager.CheckForUpdate());
 
             AddUntilStep("check pending", () => manager.IsPending);
             AddStep("complete check", () => manager.Complete());
@@ -115,9 +115,9 @@ namespace osu.Game.Tests.NonVisual
             // This part covering double user input is not really possible because the settings button is disabled during the check,
             // but it's kept here for sanity in-case the update manager is used as a standalone object elsewhere.
 
-            AddStep("request check", () => manager.CheckForUpdateAsync());
+            AddStep("request check", () => manager.CheckForUpdate());
             AddUntilStep("check pending", () => manager.IsPending);
-            AddStep("request check", () => manager.CheckForUpdateAsync());
+            AddStep("request check", () => manager.CheckForUpdate());
             AddUntilStep("3 invocations", () => manager.Invocations, () => Is.EqualTo(3));
 
             AddStep("complete check", () => manager.Complete());
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.NonVisual
 
             AddStep("change release stream", () => config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Tachyon));
             AddUntilStep("check pending", () => manager.IsPending);
-            AddStep("request check", () => manager.CheckForUpdateAsync());
+            AddStep("request check", () => manager.CheckForUpdate());
             AddUntilStep("5 invocations", () => manager.Invocations, () => Is.EqualTo(5));
 
             AddStep("complete check", () => manager.Complete());

--- a/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
+++ b/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
@@ -17,7 +17,7 @@ using osu.Game.Updater;
 namespace osu.Game.Tests.NonVisual
 {
     [HeadlessTest]
-    public class TestSceneUpdateManager : OsuTestScene
+    public partial class TestSceneUpdateManager : OsuTestScene
     {
         [Cached(typeof(INotificationOverlay))]
         private readonly INotificationOverlay notifications = new TestNotificationOverlay();
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.NonVisual
             AddUntilStep("no check pending", () => !manager.IsPending);
         }
 
-        private class TestUpdateManager : UpdateManager
+        private partial class TestUpdateManager : UpdateManager
         {
             public bool IsPending { get; private set; }
             public int Completions { get; private set; }
@@ -161,7 +161,7 @@ namespace osu.Game.Tests.NonVisual
             }
         }
 
-        private class TestNotificationOverlay : INotificationOverlay
+        private partial class TestNotificationOverlay : INotificationOverlay
         {
             public void Post(Notification notification)
             {

--- a/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
+++ b/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
@@ -1,0 +1,179 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Testing;
+using osu.Game.Configuration;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Tests.Visual;
+using osu.Game.Updater;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [HeadlessTest]
+    public class TestSceneUpdateManager : OsuTestScene
+    {
+        [Cached(typeof(INotificationOverlay))]
+        private readonly INotificationOverlay notifications = new TestNotificationOverlay();
+
+        private TestUpdateManager manager = null!;
+        private OsuConfigManager config = null!;
+
+        [SetUpSteps]
+        public void SetupSteps()
+        {
+            AddStep("add manager", () =>
+            {
+                config = new OsuConfigManager(LocalStorage);
+                config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
+
+                Child = new DependencyProvidingContainer
+                {
+                    CachedDependencies = [(typeof(OsuConfigManager), config)],
+                    Child = manager = new TestUpdateManager()
+                };
+            });
+
+            // Updates should be checked when the object is loaded for the first time.
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("1 check completed", () => manager.Completions, () => Is.EqualTo(1));
+            AddUntilStep("no check pending", () => !manager.IsPending);
+        }
+
+        /// <summary>
+        /// Updates should be checked when the release stream is changed.
+        /// </summary>
+        [Test]
+        public void TestReleaseStreamChanged()
+        {
+            AddStep("change release stream", () => config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Tachyon));
+
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("2 checks completed", () => manager.Completions, () => Is.EqualTo(2));
+            AddUntilStep("no check pending", () => !manager.IsPending);
+        }
+
+        /// <summary>
+        /// Updates should be checked once more if the release stream is changed during an going check
+        /// </summary>
+        [Test]
+        public void TestReleaseStreamChangedDuringCheck()
+        {
+            AddStep("change release stream", () => config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Tachyon));
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("change release stream", () => config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Lazer));
+
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("2 checks completed", () => manager.Completions, () => Is.EqualTo(2));
+
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("complete one check", () => manager.Complete());
+            AddUntilStep("3 checks completed", () => manager.Completions, () => Is.EqualTo(3));
+            AddUntilStep("no check pending", () => !manager.IsPending);
+        }
+
+        /// <summary>
+        /// Updates should be checked when the user requests them to.
+        /// </summary>
+        [Test]
+        public void TestUserRequest()
+        {
+            AddStep("request check", () => manager.CheckForUpdateAsync());
+
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("2 checks completed", () => manager.Completions, () => Is.EqualTo(2));
+            AddUntilStep("no check pending", () => !manager.IsPending);
+        }
+
+        [Test]
+        public void TestUserRequestReturnsExistingCheck()
+        {
+            Task task1 = null!;
+            Task task2 = null!;
+
+            // This part covering double user input is not really possible because the settings button is disabled during the check,
+            // but it's kept here for sanity in-case the update manager is used as a standalone object elsewhere.
+
+            AddStep("request check", () => task1 = manager.CheckForUpdateAsync());
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("request check", () => task2 = manager.CheckForUpdateAsync());
+            AddAssert("second request returned original task", () => task2 == task1);
+
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("2 checks completed", () => manager.Completions, () => Is.EqualTo(2));
+            AddUntilStep("no check pending", () => !manager.IsPending);
+
+            // This next part tests for the user requesting an update during a background check, and is possible to occur in practice.
+
+            AddStep("change release stream", () => config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Tachyon));
+            AddUntilStep("check pending", () => manager.IsPending);
+            AddStep("request check", () =>
+            {
+                task1 = manager.CurrentTask;
+                task2 = manager.CheckForUpdateAsync();
+            });
+            AddAssert("second request returned original task", () => task2 == task1);
+
+            AddStep("complete check", () => manager.Complete());
+            AddUntilStep("3 checks completed", () => manager.Completions, () => Is.EqualTo(3));
+            AddUntilStep("no check pending", () => !manager.IsPending);
+        }
+
+        private class TestUpdateManager : UpdateManager
+        {
+            public bool IsPending { get; private set; }
+            public int Completions { get; private set; }
+
+            public Task CurrentTask { get; private set; } = Task.CompletedTask;
+
+            private TaskCompletionSource<bool>? pendingCheck;
+
+            protected override Task<bool> PerformUpdateCheck()
+            {
+                var task = Task.Run(async () =>
+                {
+                    var check = pendingCheck = new TaskCompletionSource<bool>();
+                    IsPending = true;
+
+                    bool result = await check.Task.ConfigureAwait(false);
+                    IsPending = false;
+                    Completions++;
+
+                    return result;
+                });
+
+                CurrentTask = task;
+                return task;
+            }
+
+            public void Complete()
+            {
+                pendingCheck?.SetResult(true);
+            }
+        }
+
+        private class TestNotificationOverlay : INotificationOverlay
+        {
+            public void Post(Notification notification)
+            {
+            }
+
+            public void Hide()
+            {
+            }
+
+            public IBindable<int> UnreadCount { get; } = new Bindable<int>();
+
+            public IEnumerable<Notification> AllNotifications { get; } = Enumerable.Empty<Notification>();
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
@@ -456,7 +457,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             {
                 applyUpdate = false;
 
-                var updateNotification = new UpdateManager.UpdateProgressNotification
+                var updateNotification = new UpdateManager.UpdateDownloadProgressNotification(CancellationToken.None)
                 {
                     CompletionClickAction = () => applyUpdate = true
                 };
@@ -468,9 +469,9 @@ namespace osu.Game.Tests.Visual.UserInterface
             checkProgressingCount(1);
             waitForCompletion();
 
-            UpdateManager.UpdateApplicationCompleteNotification? completionNotification = null;
+            UpdateManager.UpdateReadyNotification? completionNotification = null;
             AddUntilStep("wait for completion notification",
-                () => (completionNotification = notificationOverlay.ChildrenOfType<UpdateManager.UpdateApplicationCompleteNotification>().SingleOrDefault()) != null);
+                () => (completionNotification = notificationOverlay.ChildrenOfType<UpdateManager.UpdateReadyNotification>().SingleOrDefault()) != null);
             AddStep("click notification", () => completionNotification?.TriggerClick());
 
             AddUntilStep("wait for update applied", () => applyUpdate);

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
 
             try
             {
-                bool foundUpdate = await updateManager.CheckForUpdateAsync().ConfigureAwait(true);
+                bool foundUpdate = await updateManager.CheckForUpdateAsync(checkingNotification.CancellationToken).ConfigureAwait(true);
 
                 if (!foundUpdate)
                 {
@@ -142,8 +142,9 @@ namespace osu.Game.Overlays.Settings.Sections.General
             }
             finally
             {
-                // This sequence allows the notification to be immediately dismissed.
-                checkingNotification.State = ProgressNotificationState.Cancelled;
+                // This sequence allows the notification to be immediately dismissed without posting a continuation message.
+                checkingNotification.CompletionTarget = null;
+                checkingNotification.State = ProgressNotificationState.Completed;
                 checkingNotification.Close(false);
                 checkForUpdatesButton.Enabled.Value = true;
             }

--- a/osu.Game/Updater/GitHubRelease.cs
+++ b/osu.Game/Updater/GitHubRelease.cs
@@ -3,7 +3,9 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace osu.Game.Updater
@@ -18,5 +20,11 @@ namespace osu.Game.Updater
 
         [JsonProperty("assets")]
         public List<GitHubAsset> Assets { get; set; }
+
+        [JsonProperty("prerelease")]
+        public bool Prerelease { get; set; }
+
+        [JsonPropertyName("published_at")]
+        public DateTime? PublishedAt { get; set; }
     }
 }

--- a/osu.Game/Updater/MobileUpdateNotifier.cs
+++ b/osu.Game/Updater/MobileUpdateNotifier.cs
@@ -4,13 +4,13 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
 using osu.Game.Online.API;
-using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Updater
 {
@@ -31,13 +31,13 @@ namespace osu.Game.Updater
             version = game.Version;
         }
 
-        protected override async Task<bool> PerformUpdateCheck()
+        protected override async Task<bool> PerformUpdateCheck(CancellationToken cancellationToken)
         {
             try
             {
                 var releases = new OsuJsonWebRequest<GitHubRelease>("https://api.github.com/repos/ppy/osu/releases/latest");
 
-                await releases.PerformAsync().ConfigureAwait(false);
+                await releases.PerformAsync(cancellationToken).ConfigureAwait(false);
 
                 var latest = releases.ResponseObject;
 
@@ -48,7 +48,7 @@ namespace osu.Game.Updater
 
                 if (latestTagName != version && tryGetBestUrl(latest, out string? url))
                 {
-                    Notifications.Post(new SimpleNotification
+                    Notifications.Post(new UpdateAvailableNotification(cancellationToken)
                     {
                         Text = $"A newer release of osu! has been found ({version} → {latestTagName}).\n\n"
                                + "Click here to download the new version, which can be installed over the top of your existing installation",

--- a/osu.Game/Updater/NoActionUpdateManager.cs
+++ b/osu.Game/Updater/NoActionUpdateManager.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Notifications;
 
@@ -16,6 +18,8 @@ namespace osu.Game.Updater
     /// </summary>
     public partial class NoActionUpdateManager : UpdateManager
     {
+        private static ReleaseStream? externalReleaseStream => Enum.TryParse(Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_STREAM"), out ReleaseStream stream) ? stream : null;
+
         private string version = string.Empty;
 
         [BackgroundDependencyLoader]
@@ -28,7 +32,8 @@ namespace osu.Game.Updater
         {
             try
             {
-                bool includePrerelease = ReleaseStream.Value == Configuration.ReleaseStream.Tachyon;
+                ReleaseStream stream = externalReleaseStream ?? ReleaseStream.Value;
+                bool includePrerelease = stream == Configuration.ReleaseStream.Tachyon;
 
                 OsuJsonWebRequest<GitHubRelease[]> releasesRequest = new OsuJsonWebRequest<GitHubRelease[]>("https://api.github.com/repos/ppy/osu/releases?per_page=10&page=1");
                 await releasesRequest.PerformAsync().ConfigureAwait(false);

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -105,6 +105,14 @@ namespace osu.Game.Updater
         /// <returns>Whether any update is waiting. May return true if an error occured (there is potentially an update available).</returns>
         protected virtual Task<bool> PerformUpdateCheck(CancellationToken cancellationToken) => Task.FromResult(false);
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            updateCancellation.Cancel();
+            updateCancellation.Dispose();
+        }
+
         private partial class UpdateCompleteNotification : SimpleNotification
         {
             private readonly string version;

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Updater
 
         private readonly Bindable<ReleaseStream> releaseStream = new Bindable<ReleaseStream>();
         private bool updateCheckRequested;
-        private Task<bool>? updateCheckTask;
+        private Task<bool> updateCheckTask = Task.FromResult(false);
 
         protected override void LoadComplete()
         {
@@ -95,7 +95,7 @@ namespace osu.Game.Updater
             if (!updateCheckRequested)
                 return;
 
-            if (updateCheckTask?.IsCompleted == false)
+            if (!updateCheckTask.IsCompleted)
                 return;
 
             if (CanCheckForUpdate)
@@ -110,13 +110,13 @@ namespace osu.Game.Updater
         /// <returns><c>true</c> if any updates are available, <c>false</c> otherwise.</returns>
         public Task<bool> CheckForUpdateAsync()
         {
-            if (updateCheckTask?.IsCompleted == false)
+            if (!updateCheckTask.IsCompleted)
                 return updateCheckTask;
 
             scheduleUpdateCheck();
             processScheduledUpdateCheck();
 
-            return updateCheckTask ?? Task.FromResult(false);
+            return updateCheckTask;
         }
 
         /// <summary>

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -87,6 +87,9 @@ namespace osu.Game.Updater
         /// <returns><c>true</c> if any updates are available, <c>false</c> otherwise.</returns>
         public async Task<bool> CheckForUpdateAsync(CancellationToken cancellationToken = default)
         {
+            if (!CanCheckForUpdate)
+                return false;
+
             var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var lastCancellation = Interlocked.Exchange(ref updateCancellation, cancellation);
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/33565
Supersedes / closes https://github.com/ppy/osu/pull/33645

- Considers up to 10 items from the first page. This is also what [`velopack`](https://github.com/velopack/velopack/blob/10c80a835e8b8ceef42f546b3ed5506d35d7428d/src/lib-csharp/Sources/GithubSource.cs#L98-L109) does.
- Adds `OSU_EXTERNAL_UPDATE_STREAM`. Packaged builds will use this to set their release flavour, for example [`osu-lazer-tachyon-bin`](https://aur.archlinux.org/packages/osu-lazer-tachyon-bin) would set it to `Tachyon`, and [`osu-lazer-bin`](https://aur.archlinux.org/packages/osu-lazer-bin) would set it to `Lazer`.
- Basically rewrote `UpdateManager` to better handle notifications and cancellations and all that.