### PR TITLE
Adjust max sizing at song select slightly

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -153,9 +153,9 @@ namespace osu.Game.Screens.SelectV2
                                     RelativeSizeAxes = Axes.Both,
                                     ColumnDimensions = new[]
                                     {
-                                        new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 660),
+                                        new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 700),
                                         new Dimension(),
-                                        new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 620),
+                                        new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 660),
                                     },
                                     Content = new[]
                                     {


### PR DESCRIPTION
Based on general feedback I've seen (widescreen users; people preferring slightly larger panels)

| Before | After |
| :---: | :---: |
| ![Safari 2025-06-09 at 08 35 46](https://github.com/user-attachments/assets/52a96a2a-0874-48e9-b2e7-502bd14521c0) | ![osu! 2025-06-09 at 08 33 53](https://github.com/user-attachments/assets/28689f73-92b0-4478-9686-09d9dcf80ad0) |

v1 for comparison:

![Safari 2025-06-09 at 08 37 14](https://github.com/user-attachments/assets/1776fa20-1cd4-4ea4-b9e9-c791ab6e4d3d)

There's no pleasing everyone here, but the hope is that we can expose a setting for fine-tuning this sizing in the layout editor in the future.