### PR TITLE
Disallow placing gameplay leaderboard in skins outside player

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Tests.Gameplay;
 using osuTK.Input;
 
@@ -36,6 +37,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Cached]
         public readonly EditorClipboard Clipboard = new EditorClipboard();
+
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
 
         public TestSceneSkinEditorMultipleSkins()
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
@@ -21,6 +21,7 @@ using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Skinning;
 using osu.Game.Tests.Gameplay;
 
@@ -41,6 +42,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Cached(typeof(IGameplayClock))]
         private readonly IGameplayClock gameplayClock = new GameplayClockContainer(new TrackVirtual(60000), false, false);
+
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
 
         private IEnumerable<HUDOverlay> hudOverlays => CreatedDrawables.OfType<HUDOverlay>();
 

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Edit.GameplayTest
@@ -31,6 +32,9 @@ namespace osu.Game.Screens.Edit.GameplayTest
 
         [Resolved]
         private MusicController musicController { get; set; } = null!;
+
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
 
         public EditorPlayer(Editor editor)
             : base(new PlayerConfiguration { ShowResults = false })

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
@@ -22,6 +23,10 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         public Action? Exited;
 
         protected override UserActivity InitialActivity => new UserActivity.InPlaylistGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
+
+        // TODO: should be replaced with a provider providing scores from the `PlaylistItem`
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
 
         public PlaylistsPlayer(Room room, PlaylistItem playlistItem, PlayerConfiguration? configuration = null)
             : base(room, playlistItem, configuration)

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Play.HUD
         private Player? player { get; set; }
 
         [Resolved]
-        private IGameplayLeaderboardProvider? leaderboardProvider { get; set; }
+        private IGameplayLeaderboardProvider leaderboardProvider { get; set; } = null!;
 
         private readonly IBindableList<GameplayLeaderboardScore> scores = new BindableList<GameplayLeaderboardScore>();
         private readonly Bindable<bool> configVisibility = new Bindable<bool>();
@@ -86,16 +86,13 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            if (leaderboardProvider != null)
+            scores.BindTo(leaderboardProvider.Scores);
+            scores.BindCollectionChanged((_, _) =>
             {
-                scores.BindTo(leaderboardProvider.Scores);
-                scores.BindCollectionChanged((_, _) =>
-                {
-                    Clear();
-                    foreach (var score in scores)
-                        Add(score);
-                }, true);
-            }
+                Clear();
+                foreach (var score in scores)
+                    Add(score);
+            }, true);
 
             configVisibility.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             userPlayingState.BindValueChanged(_ => Scheduler.AddOnce(updateState));

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -13,11 +13,17 @@ using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
+using osu.Game.Screens.Select.Leaderboards;
 
 namespace osu.Game.Screens.Play
 {
     public abstract partial class SpectatorPlayer : Player
     {
+        // TODO: maybe consider giving this proper scores.
+        // `SoloGameplayLeaderboardProvider` doesn't immediately work because there's no guarantee that `LeaderboardManager` global state matches the currently spectated beatmap.
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private readonly EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
+
         [Resolved]
         protected SpectatorClient SpectatorClient { get; private set; } = null!;
 

--- a/osu.Game/Screens/Select/Leaderboards/IGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/IGameplayLeaderboardProvider.cs
@@ -15,4 +15,9 @@ namespace osu.Game.Screens.Select.Leaderboards
         /// </summary>
         IBindableList<GameplayLeaderboardScore> Scores { get; }
     }
+
+    public class EmptyGameplayLeaderboardProvider : IGameplayLeaderboardProvider
+    {
+        public IBindableList<GameplayLeaderboardScore> Scores { get; } = new BindableList<GameplayLeaderboardScore>();
+    }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33542.

For a diff this simple this took much more hemming and hawing because things are a bit annoying here from a few angles:

- The only way that is considered idiomatic right now for a skin component to not be applicable to a screen is to require a dependency from DI that is only provided by applicable screens. `DrawableGameplayLeaderboard` has a few of those dependencies, but the scope of all the usages makes it so that the only really viable one to use here is `IGameplayLeaderboardProvider` itself (see: visual tests, and also the usage of multiplayer spectator, where the leaderboard is *not* under a player instance).

- The smelly part of this is that the `Player` inheritance hierarchy must ensure that *every* non-abstract class has an `IGameplayLeaderboardProvider` cached. It is not trivial - if not straight up impossible - to force this via some `Player` level abstract method, because such a method would need to somehow accommodate all possible leaderboard providers. That however also means that every possible future `Player` implementor *must inherently know* to also cache a leaderboard provider lest it die at runtime. I don't love that, but I also don't see better alternatives.

- Speaking of which, I also noticed that solo spectator and playlists don't have gameplay leaderboards. At all. Which I don't believe to be something that I broke with the leaderboard work - I'm pretty sure that was the pre-existing state - however I don't see any reason why they *couldn't* receive gameplay leaderboards. I'm not doing that here, though, just leaving TODOs for later.