### PR TITLE
osu!taiko changes to length bonus using consistency factor

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -93,7 +93,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             difficultyValue *= 1 + 0.10 * Math.Max(0, attributes.StarRating - 10);
 
-            double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
+            double totalDifficultHits = totalHits * Math.Pow(attributes.ConsistencyFactor, 0.5);
+            double lengthBonus = 1 + 0.25 * totalDifficultHits / (totalDifficultHits + 4000);
             difficultyValue *= lengthBonus;
 
             difficultyValue *= Math.Pow(0.986, effectiveMissCount);
@@ -121,11 +122,15 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             double accuracyValue = Math.Pow(70 / estimatedUnstableRate.Value, 1.1) * Math.Pow(attributes.StarRating, 0.4) * 100.0;
 
-            double lengthBonus = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
+            double totalDifficultHits = totalHits * Math.Pow(attributes.ConsistencyFactor, 0.5);
+            double lengthBonus = 1 + 0.4 * totalDifficultHits / (totalDifficultHits + 4000);
+            accuracyValue *= lengthBonus;
 
             // Slight HDFL Bonus for accuracy. A clamp is used to prevent against negative values.
+            double lengthBonusHDFL = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
+
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>) && score.Mods.Any(m => m is ModHidden) && !isConvert)
-                accuracyValue *= Math.Max(1.0, 1.05 * lengthBonus);
+                accuracyValue *= Math.Max(1.0, 1.05 * lengthBonusHDFL);
 
             return accuracyValue;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             difficultyValue *= 1 + 0.10 * Math.Max(0, attributes.StarRating - 10);
 
+            // Applies a bonus to maps with more total difficulty, calculating this with a map's total hits and consistency factor.
             double totalDifficultHits = totalHits * Math.Pow(attributes.ConsistencyFactor, 0.5);
             double lengthBonus = 1 + 0.25 * totalDifficultHits / (totalDifficultHits + 4000);
             difficultyValue *= lengthBonus;
@@ -120,6 +121,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (score.Mods.Any(m => m is ModHidden) && !isConvert)
                 accuracyValue *= 1.075;
 
+            // Applies a bonus to maps with more total difficulty, calculating this with a map's total hits and consistency factor.
             double totalDifficultHits = totalHits * Math.Pow(attributes.ConsistencyFactor, 0.5);
             double lengthBonus = 1 + 0.4 * totalDifficultHits / (totalDifficultHits + 4000);
             accuracyValue *= lengthBonus;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -126,11 +126,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double lengthBonus = 1 + 0.4 * totalDifficultHits / (totalDifficultHits + 4000);
             accuracyValue *= lengthBonus;
 
-            // Slight HDFL Bonus for accuracy. A clamp is used to prevent against negative values.
-            double lengthBonusHDFL = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
+            // Applies a bonus to maps with more total memory required with HDFL.
+            double memoryLengthBonus = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
 
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>) && score.Mods.Any(m => m is ModHidden) && !isConvert)
-                accuracyValue *= Math.Max(1.0, 1.05 * lengthBonusHDFL);
+                accuracyValue *= Math.Max(1.0, 1.05 * memoryLengthBonus);
 
             return accuracyValue;
         }


### PR DESCRIPTION
These changes introduce a new formula for difficulty length bonus using a map's `consistency factor` and diminishing slowly rather than capping at a threshold, as well as introducing a similar length bonus for accuracy. As with other recent changes, the values are not extensively balanced and will likely be adjusted in the final balancing pass before deploy. I chose to define `totalDifficultHits` separately for both bonuses as I plan to give accuracy its own formula involving rhythm difficulty in a separate set of changes