### PR TITLE
Fix flaky collections test

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
@@ -139,6 +139,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                 });
             });
 
+            assertCollectionCount(2);
+
             AddStep("remove first collection", () => Realm.Write(r => r.Remove(first)));
             assertCollectionCount(1);
             assertCollectionName(0, "2");


### PR DESCRIPTION
Has been happening for a while now, see for example https://github.com/ppy/osu/actions/runs/15531059433?pr=33578

This change only targets the tests, but there's a very real possibility this could happen in practice. We should, at some point, reconsider whether [this](https://github.com/ppy/osu/blob/fd5dc01220257f30af0978fadea78f1e50659d91/osu.Game/Database/RealmLive.cs#L87) use of null forgiving is really valid.

Repro:

```diff
diff --git a/osu.Game/Collections/DrawableCollectionListItem.cs b/osu.Game/Collections/DrawableCollectionListItem.cs
index b0dd70227c..02b020e4f4 100644
--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -140,6 +141,8 @@ public ItemTextBox(Live<BeatmapCollection> collection)
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
+                Thread.Sleep(1000);
+
                 BackgroundUnfocused = colours.GreySeaFoamDarker.Darken(0.5f);
                 BackgroundFocused = colours.GreySeaFoam;
 

```