### PR TITLE
Fix intermittent online play mod select tests

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -59,9 +59,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             importedSet = beatmaps.GetAllUsableBeatmapSets().First();
         }
 
-        [SetUpSteps]
-        public void SetupSteps()
+        public override void SetUpSteps()
         {
+            base.SetUpSteps();
+
+            AddUntilStep("wait for mod select removed", () => this.ChildrenOfType<MultiplayerUserModSelectOverlay>().Count(), () => Is.Zero);
+
             AddStep("load match", () =>
             {
                 room = new Room { Name = "Test Room" };

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             base.SetUpSteps();
 
+            AddUntilStep("wait for mod select removed", () => this.ChildrenOfType<FreeModSelectOverlay>().Count(), () => Is.Zero);
+
             AddStep("reset", () =>
             {
                 room = new Room();


### PR DESCRIPTION
I previously tried to formally fix these in https://github.com/ppy/osu/pull/33412, but ran into issues with the `ScreenTestScene` structure. So this is the sledgehammer method.

See: [[1]](https://github.com/ppy/osu/actions/runs/15416542079/job/43431573630?pr=33391) [[2]](https://github.com/ppy/osu/actions/runs/15536100593/job/43735378811)

Test failures can be reproed with:

```diff
diff --git a/osu.Game/Overlays/Mods/ModSelectOverlay.cs b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
index 9ba3b3774f..00084848dd 100644
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -738,6 +739,12 @@ protected override void Update()
             }
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            Thread.Sleep(1000);
+            base.Dispose(isDisposing);
+        }
+
         /// <summary>
         /// Manages layout of mod columns.
         /// </summary>

```