### PR TITLE
Add HitAnimations skin.ini Command

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -164,27 +164,35 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 switch (state)
                 {
                     case ArmedState.Hit:
+                        decimal? legacyVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
+
+                        bool hitAnimations = skin.GetConfig<SkinConfiguration.LegacySetting, bool>(SkinConfiguration.LegacySetting.HitAnimations)?.Value ?? true;
+
+                        if (legacyVersion > 2.7m && !hitAnimations)
+                        {
+                            // legacy skins of version 2.8 and newer on lazer have an option to only apply very short fade out to the circle.
+                            this.FadeOut(legacy_fade_duration / 4);
+                            break;
+                        }
+
                         CircleSprite.FadeOut(legacy_fade_duration);
                         CircleSprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 
                         OverlaySprite.FadeOut(legacy_fade_duration);
                         OverlaySprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 
-                        if (hasNumber)
-                        {
-                            decimal? legacyVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
+                        if (!hasNumber) break;
 
-                            if (legacyVersion > 1.0m)
-                                // legacy skins of version 2.0 and newer only apply very short fade out to the number piece.
-                                hitCircleText.FadeOut(legacy_fade_duration / 4);
-                            else
-                            {
-                                // old skins scale and fade it normally along other pieces.
-                                hitCircleText.FadeOut(legacy_fade_duration);
-                                hitCircleText.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
-                            }
+                        if (legacyVersion > 1.0m)
+                        {
+                            // legacy skins of version 2.0 and newer only apply very short fade out to the number piece.
+                            hitCircleText.FadeOut(legacy_fade_duration / 4);
+                            break;
                         }
 
+                        // old skins scale and fade it normally along other pieces.
+                        hitCircleText.FadeOut(legacy_fade_duration);
+                        hitCircleText.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -158,6 +158,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
             const double legacy_fade_duration = 240;
+            const double legacy_short_fade_duration = 60;
 
             using (BeginAbsoluteSequence(drawableObject.AsNonNull().HitStateUpdateTime))
             {
@@ -171,7 +172,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         if (legacyVersion > 2.7m && !hitAnimations)
                         {
                             // legacy skins of version 2.8 and newer on lazer have an option to only apply very short fade out to the circle.
-                            this.FadeOut(legacy_fade_duration / 4);
+                            this.FadeOut(legacy_short_fade_duration);
                             break;
                         }
 
@@ -186,7 +187,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         if (legacyVersion > 1.0m)
                         {
                             // legacy skins of version 2.0 and newer only apply very short fade out to the number piece.
-                            hitCircleText.FadeOut(legacy_fade_duration / 4);
+                            hitCircleText.FadeOut(legacy_short_fade_duration);
                             break;
                         }
 

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Skinning
     {
         public readonly SkinInfo SkinInfo = new SkinInfo();
 
-        public const decimal LATEST_VERSION = 2.7m;
+        public const decimal LATEST_VERSION = 2.8m;
 
         /// <summary>
         /// Whether to allow <see cref="DefaultComboColours"/> as a fallback list for when no combo colours are provided.

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Skinning
             LayeredHitSounds,
             AllowSliderBallTint,
             InputOverlayText,
+            HitAnimations,
         }
 
         public static List<Color4> DefaultComboColours { get; } = new List<Color4>


### PR DESCRIPTION
Final attempt at an implementation on this.

Key Differences:
- No longer in settings, is now a skin.ini command in legacy skin versions 2.8 and greater.
- Refactored legacy hit case for readability & fast breaks.
- Matches originally accepted implementation of instafade within Lazer. (legacy_fade_duration / 4)
- Pairing Wiki branch: https://github.com/Toasterly/osu-wiki/tree/skin-ini-hit-toggle

Why This Should Be Considered:
- This has potential to bring new players into Lazer who have been wanting this feature for a long time.
- I hope you reconsider your opinion on hit animations, It's been widely accepted by most of the community for years that disabling certain parts of osu! for readability is acceptable.
- Clearly people want instafade/hit animation toggle support to be expanded upon within Lazer. I understand that skinning is going to be looked at in a whole new light but at least temporarily this might be a nice medium. The main reason why my original PR was made is because it's a feature I myself had wanted for years but didn't see any discussion or progress towards it.

Thank you for the detailed responses in my last PR, feel free to close if not interested still whatsoever.

https://github.com/user-attachments/assets/264b4175-ab6c-4095-8057-861757237f44

