### PR TITLE
Remove logo scale when mod select appears

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -299,8 +299,7 @@ namespace osu.Game.Screens.SelectV2
                 if (!this.IsCurrentScreen())
                     return;
 
-                logo?.ScaleTo(v.NewValue == Visibility.Visible ? 0f : logo_scale, 400, Easing.OutQuint)
-                    .FadeTo(v.NewValue == Visibility.Visible ? 0f : 1f, 200, Easing.OutQuint);
+                logo?.FadeTo(v.NewValue == Visibility.Visible ? 0f : 1f, 200, Easing.OutQuint);
             });
 
             Beatmap.BindValueChanged(_ =>


### PR DESCRIPTION
This was causing the logo to not be clickable immediately after closing the overlay, which was reported as frustrating by some user.

I hoped to fix this by unfuckulating the logo logic but it's a multi-day excursion that I'd rather avoid for now.