### PR TITLE
Allow changing difficulties using up and down arrows when sets are grouped

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -163,13 +163,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextGroup();
             WaitForGroupSelection(0, 1);
 
+            // Difficulties should get immediate selection even when using up and down traversal.
             SelectNextPanel();
+            WaitForGroupSelection(0, 2);
             SelectNextPanel();
+            WaitForGroupSelection(0, 3);
+
             SelectNextPanel();
-            SelectNextPanel();
+            WaitForGroupSelection(0, 3);
 
             SelectNextGroup();
-            WaitForGroupSelection(0, 1);
+            WaitForGroupSelection(0, 5);
 
             SelectNextPanel();
             SelectNextGroup();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -171,15 +171,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForSelection(3, 0);
 
             SelectNextPanel();
-            WaitForSelection(3, 0);
-
-            Select();
             WaitForSelection(3, 1);
 
             SelectNextPanel();
-            WaitForSelection(3, 1);
-
-            Select();
             WaitForSelection(3, 2);
 
             SelectNextPanel();

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -506,7 +506,7 @@ namespace osu.Game.Graphics.Carousel
 
                 if (newItem.IsVisible)
                 {
-                    if (currentSelection.Model != newItem.Model && ShouldActivateOnKeyboardSelection(newItem))
+                    if (!CheckModelEquality(currentSelection.Model, newItem.Model) && ShouldActivateOnKeyboardSelection(newItem))
                         Activate(newItem);
                     else
                     {

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -241,6 +241,12 @@ namespace osu.Game.Graphics.Carousel
         protected virtual bool CheckValidForGroupSelection(CarouselItem item) => true;
 
         /// <summary>
+        /// Keyboard selection usually does not automatically activate an item. There may be exceptions to this rule.
+        /// Returning <c>true</c> here will make keyboard traversal act like group traversal for the target item.
+        /// </summary>
+        protected virtual bool ShouldActivateOnKeyboardSelection(CarouselItem item) => false;
+
+        /// <summary>
         /// Called after an item becomes the <see cref="CurrentSelection"/>.
         /// Should be used to handle any group expansion, item visibility changes, etc.
         /// </summary>
@@ -500,8 +506,14 @@ namespace osu.Game.Graphics.Carousel
 
                 if (newItem.IsVisible)
                 {
-                    playTraversalSound();
-                    setKeyboardSelection(newItem.Model);
+                    if (currentSelection.Model != newItem.Model && ShouldActivateOnKeyboardSelection(newItem))
+                        Activate(newItem);
+                    else
+                    {
+                        playTraversalSound();
+                        setKeyboardSelection(newItem.Model);
+                    }
+
                     return;
                 }
             } while (newIndex != originalIndex);

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -208,6 +208,9 @@ namespace osu.Game.Screens.SelectV2
 
         protected BeatmapSetInfo? ExpandedBeatmapSet { get; private set; }
 
+        protected override bool ShouldActivateOnKeyboardSelection(CarouselItem item) =>
+            grouping.BeatmapSetsGroupedTogether && item.Model is BeatmapInfo;
+
         protected override void HandleItemActivated(CarouselItem item)
         {
             try

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
@@ -201,19 +201,19 @@ namespace osu.Game.Screens.SelectV2
 
         private void refetchScores()
         {
+            SetScores(Array.Empty<ScoreInfo>());
+
+            if (beatmap.IsDefault)
+            {
+                SetState(LeaderboardState.NoneSelected);
+                return;
+            }
+
+            SetState(LeaderboardState.Retrieving);
+
             refetchOperation?.Cancel();
             refetchOperation = Scheduler.AddDelayed(() =>
             {
-                SetScores(Array.Empty<ScoreInfo>());
-
-                if (beatmap.IsDefault)
-                {
-                    SetState(LeaderboardState.NoneSelected);
-                    return;
-                }
-
-                SetState(LeaderboardState.Retrieving);
-
                 var fetchBeatmapInfo = beatmap.Value.BeatmapInfo;
                 var fetchRuleset = ruleset.Value ?? fetchBeatmapInfo.Ruleset;
 
@@ -230,7 +230,7 @@ namespace osu.Game.Screens.SelectV2
                     fetchedScores.BindValueChanged(_ => updateScores(), true);
                     initialFetchComplete = true;
                 }
-            }, initialFetchComplete ? 200 : 0);
+            }, initialFetchComplete ? 300 : 0);
         }
 
         private void updateScores()


### PR DESCRIPTION
This matches stable. Restored this behaviour due to popular demand.

Closes https://github.com/ppy/osu/issues/33474.
