### PR TITLE
Fix results screen not showing local scores on results screen for some beatmap statuses

### DIFF
--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -74,6 +74,12 @@ namespace osu.Game.Screens.Ranking
                 // this simplifies handling later.
                 if (clonedScore.Equals(Score) || clonedScore.MatchesOnlineID(Score))
                 {
+                    // this is a precautionary guard that prevents `Score` from appearing multiple times in the list.
+                    // that can occur in rare cases wherein two local scores have the same online ID but different replay contents
+                    // (this is possible e.g. in cases of client-side vs server-side recorded replays, see https://github.com/ppy/osu-server-spectator/issues/193)
+                    if (sortedScores.Contains(Score))
+                        continue;
+
                     Score.Position = clonedScore.Position;
                     sortedScores.Add(Score);
                 }

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
-using osu.Game.Beatmaps;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Online.Leaderboards;
@@ -41,9 +40,6 @@ namespace osu.Game.Screens.Ranking
         protected override async Task<ScoreInfo[]> FetchScores()
         {
             Debug.Assert(Score != null);
-
-            if (Score.BeatmapInfo!.OnlineID <= 0 || Score.BeatmapInfo.Status <= BeatmapOnlineStatus.Pending)
-                return [];
 
             var criteria = new LeaderboardCriteria(
                 Score.BeatmapInfo!,


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33609.

Case of leftover code that should have been removed.

This condition is still active in the online leaderboards path via

https://github.com/ppy/osu/blob/4dcc928c7e46e020c62f4d60e7b859ba18c9142f/osu.Game/Online/Leaderboards/LeaderboardManager.cs#L91-L95

Not sure trying to add test coverage is a productive use of time? Will do on request though.