### PR TITLE
Uncap the BPM multiplier curve for acute angle bonus

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
                                     (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) > 350 ?
-                                    0.015 * (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) - 350) + 0.5 :
+                                    (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) - 350) * 0.015 + 0.5 :
                                     DifficultyCalculationUtils.Smoothstep(DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2), 300, 400)) *
                                     DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -92,8 +92,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
-                                       DifficultyCalculationUtils.Smootherstep(DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2), 300, 400) *
-                                       DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
+                                    (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) > 350 ?
+                                    0.015 * (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) - 350) + 0.5 :
+                                    DifficultyCalculationUtils.Smoothstep(DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2), 300, 400)) *
+                                    DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
 
                     // Apply wiggle bonus for jumps that are [radius, 3*diameter] in distance, with < 110 angle
                     // https://www.desmos.com/calculator/dp0v0nvowc

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -92,9 +92,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
-                                    (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) > 350 ?
-                                    (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) - 350) * 0.015 + 0.5 :
-                                    DifficultyCalculationUtils.Smoothstep(DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2), 300, 400)) *
+                                    (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) < 350 ?
+                                    DifficultyCalculationUtils.Smoothstep(DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2), 300, 400) :
+                                    (DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.StrainTime, 2) - 350) * 0.015 + 0.5) *
                                     DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
 
                     // Apply wiggle bonus for jumps that are [radius, 3*diameter] in distance, with < 110 angle


### PR DESCRIPTION
There are maps that with DT end up having jumps near or above 400 BPM (not to mention rate change), and data collection has suggested that the difficulty of an acute jump ramps up aggressively as its BPM increases. The current BPM curve for the acute bonus (a smootherstep between 300 and 400) doesn't align with this and the maps with 400+ BPM jumps are often underweighted or far less viable than the maps with 300-400BPM jumps. The new curve is a smoothstep between 300BPM and 400BPM, but it smoothly transitions into a line at 350BPM. It's a smoothstep instead of a smootherstep to make the curve above 350BPM not too steep.

[https://www.desmos.com/calculator/x0enpjmovt](https://www.desmos.com/calculator/x0enpjmovt)