### PR TITLE
Fix timeline not updating ticks correctly after arbitrary timing control point changes (again)

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -32,9 +33,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private BindableBeatDivisor beatDivisor { get; set; } = null!;
 
         [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
-
-        [Resolved]
         private OsuColour colours { get; set; } = null!;
 
         public TimelineTickDisplay()
@@ -51,9 +49,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             beatDivisor.BindValueChanged(_ => invalidateTicks());
 
-            if (changeHandler != null)
-                // currently this is the best way to handle any kind of timing changes.
-                changeHandler.OnStateChange += invalidateTicks;
+            beatmap.ControlPointInfo.ControlPointsChanged += invalidateTicks;
 
             configManager.BindWith(OsuSetting.EditorTimelineShowTimingChanges, showTimingChanges);
             showTimingChanges.BindValueChanged(_ => invalidateTicks());
@@ -194,8 +190,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.Dispose(isDisposing);
 
-            if (changeHandler != null)
-                changeHandler.OnStateChange -= invalidateTicks;
+            if (beatmap.IsNotNull())
+                beatmap.ControlPointInfo.ControlPointsChanged -= invalidateTicks;
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33393.

This is admittedly a half-assed diff. This was apparently "fixed" once before, eons ago, in https://github.com/ppy/osu/pull/11032, but I'm not sure whether it regressed, or where, because I don't want to bisect four years back. (At that time `ControlPointInfo.ControlPointsChanged` did not exist yet.)

Also there's the part where changes to control points do not undo or redo (see https://github.com/ppy/osu/issues/31942), but I'm not touching that *either*, because if I start touching that, then I will get yelled at for not reviewing the 2.5k line PR that rewrites the entirety of change handling in editor instead (https://github.com/ppy/osu/pull/30314). I will attempt to get through that mental block sometime within the year. Please do not rush me.

The cheap cop-out argument is that hooking this up to `ControlPointInfo` specifically is probably "more efficient" anyway.