### PR TITLE
Maintain scroll position relative to hovered drawable when editor toolbox expands

### DIFF
--- a/osu.Game/Graphics/Containers/ExpandingContainer.cs
+++ b/osu.Game/Graphics/Containers/ExpandingContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -40,18 +41,24 @@ namespace osu.Game.Graphics.Containers
             RelativeSizeAxes = Axes.Y;
             Width = contractedWidth;
 
-            InternalChild = CreateScrollContainer().With(s =>
-            {
-                s.RelativeSizeAxes = Axes.Both;
-                s.ScrollbarVisible = false;
-            }).WithChild(FillFlow = new FillFlowContainer
+            FillFlow = new FillFlowContainer
             {
                 Origin = Anchor.CentreLeft,
                 Anchor = Anchor.CentreLeft,
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
-            });
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = CreateScrollContainer().With(s =>
+            {
+                s.RelativeSizeAxes = Axes.Both;
+                s.ScrollbarVisible = false;
+            }).WithChild(FillFlow);
         }
 
         protected virtual OsuScrollContainer CreateScrollContainer() => new OsuScrollContainer();

--- a/osu.Game/Graphics/Containers/ExpandingContainer.cs
+++ b/osu.Game/Graphics/Containers/ExpandingContainer.cs
@@ -40,20 +40,21 @@ namespace osu.Game.Graphics.Containers
             RelativeSizeAxes = Axes.Y;
             Width = contractedWidth;
 
-            InternalChild = new OsuScrollContainer
+            InternalChild = CreateScrollContainer().With(s =>
             {
-                RelativeSizeAxes = Axes.Both,
-                ScrollbarVisible = false,
-                Child = FillFlow = new FillFlowContainer
-                {
-                    Origin = Anchor.CentreLeft,
-                    Anchor = Anchor.CentreLeft,
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                },
-            };
+                s.RelativeSizeAxes = Axes.Both;
+                s.ScrollbarVisible = false;
+            }).WithChild(FillFlow = new FillFlowContainer
+            {
+                Origin = Anchor.CentreLeft,
+                Anchor = Anchor.CentreLeft,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+            });
         }
+
+        protected virtual OsuScrollContainer CreateScrollContainer() => new OsuScrollContainer();
 
         private ScheduledDelegate? hoverExpandEvent;
 

--- a/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
+++ b/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
@@ -58,6 +58,8 @@ namespace osu.Game.Rulesets.Edit
             {
                 Expanded.BindValueChanged(_ =>
                 {
+                    // When state changes from expanded -> collapsed the mouse is no longer within the toolbox so there would be no
+                    // hovered children if we used the mouse position directly
                     var position = new Vector2(ScreenSpaceDrawQuad.Centre.X, inputManager.CurrentState.Mouse.Position.Y);
 
                     scrollContainer.TargetDrawable = Children.FirstOrDefault(it => it.Contains(position));

--- a/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
+++ b/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Edit;
@@ -21,6 +24,7 @@ namespace osu.Game.Rulesets.Edit
         private readonly Bindable<bool> contractSidebars = new Bindable<bool>();
 
         private bool expandOnHover;
+        private OffsetMaintainingScrollContainer scrollContainer = null!;
 
         [Resolved]
         private Editor? editor { get; set; }
@@ -42,6 +46,25 @@ namespace osu.Game.Rulesets.Edit
             config.BindWith(OsuSetting.EditorContractSidebars, contractSidebars);
         }
 
+        protected override OsuScrollContainer CreateScrollContainer() => scrollContainer = new OffsetMaintainingScrollContainer();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            var inputManager = GetContainingInputManager();
+
+            if (inputManager != null)
+            {
+                Expanded.BindValueChanged(_ =>
+                {
+                    var position = new Vector2(ScreenSpaceDrawQuad.Centre.X, inputManager.CurrentState.Mouse.Position.Y);
+
+                    scrollContainer.TargetDrawable = Children.FirstOrDefault(it => it.Contains(position));
+                });
+            }
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -53,10 +76,57 @@ namespace osu.Game.Rulesets.Edit
                 expandOnHover = requireContracting;
                 Expanded.Value = !expandOnHover;
             }
+
+            if (scrollContainer.TargetDrawable != null && !TransformsForTargetMember(nameof(Width)).Any())
+                scrollContainer.TargetDrawable = null;
         }
 
         protected override bool OnMouseDown(MouseDownEvent e) => true;
 
         protected override bool OnClick(ClickEvent e) => true;
+
+        private partial class OffsetMaintainingScrollContainer : OsuScrollContainer
+        {
+            private Drawable? targetDrawable;
+            private float targetPosition;
+
+            public Drawable? TargetDrawable
+            {
+                get => targetDrawable;
+                set
+                {
+                    targetDrawable = value;
+
+                    if (value != null)
+                        targetPosition = ToLocalSpace(value.ScreenSpaceDrawQuad.TopLeft).Y;
+                }
+            }
+
+            protected override void UpdateAfterChildren()
+            {
+                if (targetDrawable != null)
+                {
+                    float currentPosition = ToLocalSpace(targetDrawable.ScreenSpaceDrawQuad.TopLeft).Y;
+
+                    if (!Precision.AlmostEquals(targetPosition, currentPosition))
+                    {
+                        double offset = currentPosition - targetPosition;
+
+                        double scrollTarget = Math.Clamp(Current + offset, 0, ScrollableExtent);
+
+                        ScrollTo(scrollTarget, false, double.PositiveInfinity);
+                    }
+                }
+
+                base.UpdateAfterChildren();
+            }
+
+            protected override void OnUserScroll(double value, bool animated = true, double? distanceDecay = null)
+            {
+                targetDrawable = null;
+
+                base.OnUserScroll(value, animated, distanceDecay);
+            }
+        }
     }
 }

--- a/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
+++ b/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
@@ -78,9 +78,6 @@ namespace osu.Game.Rulesets.Edit
                 expandOnHover = requireContracting;
                 Expanded.Value = !expandOnHover;
             }
-
-            if (scrollContainer.TargetDrawable != null && !TransformsForTargetMember(nameof(Width)).Any())
-                scrollContainer.TargetDrawable = null;
         }
 
         protected override bool OnMouseDown(MouseDownEvent e) => true;


### PR DESCRIPTION
Closes #31065

When you hover over the right toolbar in the editor, all it's panels will expand and often your cursor ends up over something completely different then what it was hovering over just a second ago. While I'd prefer the toolbar to do absolutely nothing on hover, at least I want to still be hovering the same thing after the toolbox eventually expands.

This will make the toolbar's ScrollContainer adjust it's scroll position during the expansion so the hovered drawable stays at the same Y position relative to the toolbox.

### Before:

https://github.com/user-attachments/assets/690ac096-1302-4b44-b657-63f937699c7b


### After:


https://github.com/user-attachments/assets/7d9330e3-0101-4207-821d-dfde68039f01

