### PR TITLE
Allow using previous valid score for offset calibration when subsequent retries are too short

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         /// <summary>
-        /// When a beatmap offset was already set, the calibration should take it into account.
+        /// If we already have an old score with enough hit events and the new score doesn't have enough, continue displaying the old one rather than showing the user "play too short" message.
         /// </summary>
         [Test]
         public void TestTooShortToDisplay_HasPreviousValidScore()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -163,10 +163,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("Has calibration button", () => offsetControl.ChildrenOfType<SettingsButton>().Any());
             AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
             AddAssert("Offset is adjusted", () => offsetControl.Current.Value == -average_error);
-
             AddUntilStep("Button is disabled", () => !offsetControl.ChildrenOfType<SettingsButton>().Single().Enabled.Value);
-            AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
-            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
 
             recreateControl();
             AddStep("Set same reference score", () => offsetControl.ReferenceScore.Value = referenceScore);
@@ -179,6 +176,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestCalibrationFromNonZero()
         {
+            ScoreInfo referenceScore = null!;
             const double average_error = -4.5;
             const double initial_offset = -2;
 
@@ -186,7 +184,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
             AddStep("Set reference score", () =>
             {
-                offsetControl.ReferenceScore.Value = new ScoreInfo
+                offsetControl.ReferenceScore.Value = referenceScore = new ScoreInfo
                 {
                     HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents(average_error),
                     BeatmapInfo = Beatmap.Value.BeatmapInfo,
@@ -196,9 +194,10 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("Has calibration button", () => offsetControl.ChildrenOfType<SettingsButton>().Any());
             AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
             AddAssert("Offset is adjusted", () => offsetControl.Current.Value == initial_offset - average_error);
-
             AddUntilStep("Button is disabled", () => !offsetControl.ChildrenOfType<SettingsButton>().Single().Enabled.Value);
-            AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
+
+            recreateControl();
+            AddStep("Set same reference score", () => offsetControl.ReferenceScore.Value = referenceScore);
             AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
         }
 
@@ -247,10 +246,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("Has calibration button", () => offsetControl.ChildrenOfType<SettingsButton>().Any());
             AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
             AddAssert("Offset is adjusted", () => offsetControl.Current.Value, () => Is.EqualTo(initial_offset - average_error));
-
             AddUntilStep("Button is disabled", () => !offsetControl.ChildrenOfType<SettingsButton>().Single().Enabled.Value);
-            AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
-            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
 
             AddStep("Clean up beatmap", () => Realm.Write(r => r.RemoveAll<BeatmapInfo>()));
         }
@@ -274,10 +270,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("Has calibration button", () => offsetControl.ChildrenOfType<SettingsButton>().Any());
             AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
             AddAssert("Offset is adjusted", () => offsetControl.Current.Value == -average_error);
-
             AddUntilStep("Button is disabled", () => !offsetControl.ChildrenOfType<SettingsButton>().Single().Enabled.Value);
-            AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
-            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
         }
 
         private void recreateControl()

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             // i.e. one that it *makes sense to use* when doing anything with timing and offsets.
             bool hasEnoughUsableEvents = hitEvents.Count(HitEventExtensions.AffectsUnstableRate) >= 50;
 
-            // If we are already displaying a score, continue displaying it rather than showing the user "play too short" message.
+            // If we already have an old score with enough hit events and the new score doesn't have enough, continue displaying the old one rather than showing the user "play too short" message.
             if (lastValidScore != null && !hasEnoughUsableEvents)
                 return;
 

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -69,6 +69,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private IDisposable? beatmapOffsetSubscription;
 
         private Task? realmWriteTask;
+        private ScoreInfo? lastValidScore;
 
         public BeatmapOffsetControl()
         {
@@ -177,8 +178,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         private void scoreChanged(ValueChangedEvent<ScoreInfo?> score)
         {
-            referenceScoreContainer.Clear();
-
             if (score.NewValue == null)
                 return;
 
@@ -196,6 +195,15 @@ namespace osu.Game.Screens.Play.PlayerSettings
             if (!(hitEvents.CalculateMedianHitError() is double median))
                 return;
 
+            // affecting unstable rate here is used as a substitute of determining if a hit event represents a *timed* hit event,
+            // i.e. an user input that the user had to *time to the track*,
+            // i.e. one that it *makes sense to use* when doing anything with timing and offsets.
+            bool hasEnoughUsableEvents = hitEvents.Count(HitEventExtensions.AffectsUnstableRate) >= 50;
+
+            // If we are already displaying a score, continue displaying it rather than showing the user "play too short" message.
+            if (lastValidScore != null && !hasEnoughUsableEvents)
+                return;
+
             referenceScoreContainer.Children = new Drawable[]
             {
                 new OsuSpriteText
@@ -204,10 +212,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
             };
 
-            // affecting unstable rate here is used as a substitute of determining if a hit event represents a *timed* hit event,
-            // i.e. an user input that the user had to *time to the track*,
-            // i.e. one that it *makes sense to use* when doing anything with timing and offsets.
-            if (hitEvents.Count(HitEventExtensions.AffectsUnstableRate) < 50)
+            if (!hasEnoughUsableEvents)
             {
                 referenceScoreContainer.AddRange(new Drawable[]
                 {
@@ -223,6 +228,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 return;
             }
 
+            lastValidScore = score.NewValue!;
             lastPlayMedian = median;
             lastPlayBeatmapOffset = Current.Value;
 
@@ -245,7 +251,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                             return;
 
                         Current.Value = lastPlayBeatmapOffset - lastPlayMedian;
-                        lastAppliedScore.Value = ReferenceScore.Value;
+                        lastAppliedScore.Value = lastValidScore;
                     },
                 },
                 globalOffsetText = new LinkFlowContainer


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu/discussions/33572.

Note that this won't work if you leave to song select. We could make that work but it would require further global faffing and I don't think it's worth the effort.
