### PR TITLE
Add back scrollbar padding in new beatmap carousel

### DIFF
--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -1009,6 +1009,29 @@ namespace osu.Game.Graphics.Carousel
                     d.Y = (float)(((ICarouselPanel)d).DrawYPosition + scrollableExtent);
             }
 
+            #region Scrollbar padding
+
+            public float ScrollbarPaddingTop { get; set; } = 5;
+            public float ScrollbarPaddingBottom { get; set; } = 5;
+
+            protected override float ToScrollbarPosition(double scrollPosition)
+            {
+                if (Precision.AlmostEquals(0, ScrollableExtent))
+                    return 0;
+
+                return (float)(ScrollbarPaddingTop + (ScrollbarMovementExtent - (ScrollbarPaddingTop + ScrollbarPaddingBottom)) * (scrollPosition / ScrollableExtent));
+            }
+
+            protected override float FromScrollbarPosition(float scrollbarPosition)
+            {
+                if (Precision.AlmostEquals(0, ScrollbarMovementExtent))
+                    return 0;
+
+                return (float)(ScrollableExtent * ((scrollbarPosition - ScrollbarPaddingTop) / (ScrollbarMovementExtent - (ScrollbarPaddingTop + ScrollbarPaddingBottom))));
+            }
+
+            #endregion
+
             #region Absolute scrolling
 
             private bool absoluteScrolling;

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -91,6 +91,9 @@ namespace osu.Game.Screens.SelectV2
             DebounceDelay = 100;
             DistanceOffscreenToPreload = 100;
 
+            // Account for the osu! logo being in the way.
+            Scroll.ScrollbarPaddingBottom = 70;
+
             Filters = new ICarouselFilter[]
             {
                 matching = new BeatmapCarouselFilterMatching(() => Criteria!),


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33447. Implementation copied from previous carousel.
