### PR TITLE
Add a skin-level setting to leaderboard to allow disabling automatic collapsing

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("toggle expanded", () =>
             {
                 if (leaderboard.IsNotNull())
-                    leaderboard.ForceExpand.Value = !leaderboard.ForceExpand.Value;
+                    leaderboard.CollapseDuringGameplay.Value = !leaderboard.CollapseDuringGameplay.Value;
             });
 
             AddSliderStep("set player score", 50, 5000000, 1222333, v => playerScore.Value = v);

--- a/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestScoreUpdates()
         {
             AddRepeatStep("update state", UpdateUserStatesRandomly, 100);
-            AddToggleStep("switch compact mode", expanded => Leaderboard!.ForceExpand.Value = expanded);
+            AddToggleStep("switch compact mode", collapsed => Leaderboard!.CollapseDuringGameplay.Value = collapsed);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        ForceExpand = { Value = true }
+                        CollapseDuringGameplay = { Value = false }
                     }
                 });
             });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
@@ -44,14 +44,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Team2Score = { BindTarget = LeaderboardProvider.TeamScores[1] }
                 }, Add);
 
-                LoadComponentAsync(new GameplayMatchScoreDisplay
+                GameplayMatchScoreDisplay matchScoreDisplay;
+                LoadComponentAsync(matchScoreDisplay = new GameplayMatchScoreDisplay
                 {
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.BottomCentre,
                     Team1Score = { BindTarget = LeaderboardProvider.TeamScores[0] },
                     Team2Score = { BindTarget = LeaderboardProvider.TeamScores[1] },
-                    Expanded = { BindTarget = Leaderboard!.ForceExpand },
                 }, Add);
+
+                Leaderboard!.CollapseDuringGameplay.BindValueChanged(_ => matchScoreDisplay.Expanded.Value = !Leaderboard.CollapseDuringGameplay.Value);
             });
         }
     }

--- a/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
@@ -84,6 +84,17 @@ namespace osu.Game.Localisation.SkinComponents
         /// </summary>
         public static LocalisableString UseRelativeSize => new TranslatableString(getKey(@"use_relative_size"), @"Use relative size");
 
+        /// <summary>
+        /// "Collapse during gameplay"
+        /// </summary>
+        public static LocalisableString CollapseDuringGameplay => new TranslatableString(getKey(@"collapse_during_gameplay"), @"Collapse during gameplay");
+
+        /// <summary>
+        /// "If enabled, the leaderboard will become more compact during active gameplay."
+        /// </summary>
+        public static LocalisableString CollapseDuringGameplayDescription =>
+            new TranslatableString(getKey(@"if_enabled_the_leaderboard_will"), @"If enabled, the leaderboard will become more compact during active gameplay.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             });
             leaderboardFlow.Insert(0, Leaderboard = new DrawableGameplayLeaderboard
             {
-                ForceExpand = { Value = true }
+                CollapseDuringGameplay = { Value = false }
             });
 
             LoadComponentAsync(new GameplayChatDisplay(room)

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -20,8 +20,6 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class DrawableGameplayLeaderboard : CompositeDrawable, ISerialisableDrawable
     {
-        public readonly Bindable<bool> ForceExpand = new Bindable<bool>();
-
         protected readonly FillFlowContainer<DrawableGameplayLeaderboardScore> Flow;
 
         private bool requiresScroll;
@@ -100,7 +98,6 @@ namespace osu.Game.Screens.Play.HUD
             configVisibility.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             userPlayingState.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             holdingForHUD.BindValueChanged(_ => Scheduler.AddOnce(updateState));
-            ForceExpand.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             CollapseDuringGameplay.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             updateState();
         }
@@ -112,7 +109,7 @@ namespace osu.Game.Screens.Play.HUD
                 scroll.ScrollToStart(false);
 
             Flow.FadeTo(player?.Configuration.ShowLeaderboard != false && configVisibility.Value ? 1 : 0, 100, Easing.OutQuint);
-            expanded.Value = !CollapseDuringGameplay.Value || ForceExpand.Value || userPlayingState.Value != LocalUserPlayingState.Playing || holdingForHUD.Value;
+            expanded.Value = !CollapseDuringGameplay.Value || userPlayingState.Value != LocalUserPlayingState.Playing || holdingForHUD.Value;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
+using osu.Game.Localisation.SkinComponents;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Skinning;
 using osuTK;
@@ -27,7 +28,7 @@ namespace osu.Game.Screens.Play.HUD
 
         public DrawableGameplayLeaderboardScore? TrackedScore { get; private set; }
 
-        [SettingSource("Collapse during gameplay", "If enabled, the leaderboard will become more compact during active gameplay.")]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.CollapseDuringGameplay), nameof(SkinnableComponentStrings.CollapseDuringGameplayDescription))]
         public Bindable<bool> CollapseDuringGameplay { get; } = new BindableBool(true);
 
         [Resolved]

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -29,6 +29,9 @@ namespace osu.Game.Screens.Play.HUD
 
         public DrawableGameplayLeaderboardScore? TrackedScore { get; private set; }
 
+        [SettingSource("Collapse during gameplay", "If enabled, the leaderboard will become more compact during active gameplay.")]
+        public Bindable<bool> CollapseDuringGameplay { get; } = new BindableBool(true);
+
         [Resolved]
         private Player? player { get; set; }
 
@@ -98,6 +101,7 @@ namespace osu.Game.Screens.Play.HUD
             userPlayingState.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             holdingForHUD.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             ForceExpand.BindValueChanged(_ => Scheduler.AddOnce(updateState));
+            CollapseDuringGameplay.BindValueChanged(_ => Scheduler.AddOnce(updateState));
             updateState();
         }
 
@@ -108,7 +112,7 @@ namespace osu.Game.Screens.Play.HUD
                 scroll.ScrollToStart(false);
 
             Flow.FadeTo(player?.Configuration.ShowLeaderboard != false && configVisibility.Value ? 1 : 0, 100, Easing.OutQuint);
-            expanded.Value = ForceExpand.Value || userPlayingState.Value != LocalUserPlayingState.Playing || holdingForHUD.Value;
+            expanded.Value = !CollapseDuringGameplay.Value || ForceExpand.Value || userPlayingState.Value != LocalUserPlayingState.Playing || holdingForHUD.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
Was a 2 minute implementation, so why not?

Addresses https://github.com/ppy/osu/discussions/33523, https://github.com/ppy/osu/discussions/22040.