### PR TITLE
Fix corner clicks not activating back button at new song select

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
@@ -39,6 +39,23 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestPushSongSelectAndClickBottomLeftCorner()
+        {
+            AddStep("push song select", () => Game.ScreenStack.Push(new SoloSongSelect()));
+
+            // TODO: without this step, a critical bug will be hit, see inline comment in `OsuGame.handleBackButton`.
+            AddUntilStep("Wait for song select", () => Game.ScreenStack.CurrentScreen is SoloSongSelect select && select.IsLoaded);
+
+            AddStep("click in corner", () =>
+            {
+                InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.BottomLeft);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            ConfirmAtMainMenu();
+        }
+
+        [Test]
         public void TestPushSongSelectAndPressBackButtonImmediately()
         {
             AddStep("push song select", () => Game.ScreenStack.Push(new SoloSongSelect()));

--- a/osu.Game/Screens/Footer/ScreenBackButton.cs
+++ b/osu.Game/Screens/Footer/ScreenBackButton.cs
@@ -19,6 +19,19 @@ namespace osu.Game.Screens.Footer
     {
         public const float BUTTON_WIDTH = 240;
 
+        public sealed override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            // Ensure clicks in the corner of the screen still trigger the back button.
+            // Need to apply more than 1x inflation due to shear.
+            var inputRectangle = DrawRectangle.Inflate(new MarginPadding
+            {
+                Left = OsuGame.SCREEN_EDGE_MARGIN * 2,
+                Bottom = OsuGame.SCREEN_EDGE_MARGIN * 2,
+            });
+
+            return inputRectangle.Contains(ToLocalSpace(screenSpacePos));
+        }
+
         public ScreenBackButton()
             : base(BUTTON_WIDTH)
         {


### PR DESCRIPTION
Based on countless feedback of users wanting to be able to throw their mouse into the corner of the screen to go back. It makes sense.

Addresses https://github.com/ppy/osu/discussions/33344.