### PR TITLE
Fix partially displayed leaderboard scores looking wrong when resizing game

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -103,6 +103,7 @@ namespace osu.Game.Screens.SelectV2
 
         private ClickableAvatar innerAvatar = null!;
 
+        private Container centreContent = null!;
         private Container rightContent = null!;
 
         private FillFlowContainer<Drawable> modsContainer = null!;
@@ -157,318 +158,309 @@ namespace osu.Game.Screens.SelectV2
                         RelativeSizeAxes = Axes.Both,
                         Colour = backgroundColour
                     },
-                    new GridContainer
+                    rankLabelStandalone = new Container
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        ColumnDimensions = new[]
+                        Width = rank_label_width,
+                        RelativeSizeAxes = Axes.Y,
+                        Children = new Drawable[]
                         {
-                            new Dimension(GridSizeMode.AutoSize),
-                            new Dimension(),
-                            new Dimension(GridSizeMode.AutoSize),
-                        },
-                        Content = new[]
-                        {
-                            new Drawable[]
+                            highlightGradient = new Container
                             {
-                                rankLabelStandalone = new Container
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding { Right = -10f },
+                                Alpha = Highlight != null ? 1 : 0,
+                                Colour = getHighlightColour(Highlight),
+                                Child = new Box { RelativeSizeAxes = Axes.Both },
+                            },
+                            new RankLabel(Rank, sheared, darkText: Highlight == HighlightType.Own)
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                            }
+                        },
+                    },
+                    centreContent = new Container
+                    {
+                        Name = @"Centre container",
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new Container
+                        {
+                            Masking = true,
+                            CornerRadius = corner_radius,
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                foreground = new Box
                                 {
-                                    Width = rank_label_width,
-                                    RelativeSizeAxes = Axes.Y,
-                                    Children = new Drawable[]
+                                    Alpha = 0.4f,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = foregroundColour
+                                },
+                                new UserCoverBackground
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    User = score.User,
+                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Colour = ColourInfo.GradientHorizontal(Colour4.White.Opacity(0.5f), Colour4.FromHex(@"222A27").Opacity(1)),
+                                },
+                                new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    ColumnDimensions = new[]
                                     {
-                                        highlightGradient = new Container
+                                        new Dimension(GridSizeMode.AutoSize),
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize),
+                                    },
+                                    Content = new[]
+                                    {
+                                        new Drawable[]
                                         {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Padding = new MarginPadding { Right = -10f },
-                                            Alpha = Highlight != null ? 1 : 0,
-                                            Colour = getHighlightColour(Highlight),
-                                            Child = new Box { RelativeSizeAxes = Axes.Both },
-                                        },
-                                        new RankLabel(Rank, sheared, darkText: Highlight == HighlightType.Own)
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
+                                            new Container
+                                            {
+                                                AutoSizeAxes = Axes.Both,
+                                                CornerRadius = corner_radius,
+                                                Masking = true,
+                                                Children = new Drawable[]
+                                                {
+                                                    new DelayedLoadWrapper(innerAvatar = new ClickableAvatar(score.User)
+                                                    {
+                                                        Anchor = Anchor.Centre,
+                                                        Origin = Anchor.Centre,
+                                                        Scale = new Vector2(1.1f),
+                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                                        RelativeSizeAxes = Axes.Both,
+                                                    })
+                                                    {
+                                                        RelativeSizeAxes = Axes.None,
+                                                        Size = new Vector2(HEIGHT)
+                                                    },
+                                                    rankLabelOverlay = new Container
+                                                    {
+                                                        RelativeSizeAxes = Axes.Both,
+                                                        Alpha = 0,
+                                                        Children = new Drawable[]
+                                                        {
+                                                            new Box
+                                                            {
+                                                                RelativeSizeAxes = Axes.Both,
+                                                                Colour = Colour4.Black.Opacity(0.5f),
+                                                            },
+                                                            new RankLabel(Rank, sheared, false)
+                                                            {
+                                                                AutoSizeAxes = Axes.Both,
+                                                                Anchor = Anchor.Centre,
+                                                                Origin = Anchor.Centre,
+                                                            },
+                                                        }
+                                                    }
+                                                },
+                                            },
+                                            new FillFlowContainer
+                                            {
+                                                Anchor = Anchor.CentreLeft,
+                                                Origin = Anchor.CentreLeft,
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Direction = FillDirection.Vertical,
+                                                Padding = new MarginPadding { Horizontal = corner_radius },
+                                                Children = new Drawable[]
+                                                {
+                                                    new FillFlowContainer
+                                                    {
+                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                                        Direction = FillDirection.Horizontal,
+                                                        Spacing = new Vector2(5),
+                                                        AutoSizeAxes = Axes.Both,
+                                                        Masking = true,
+                                                        Children = new Drawable[]
+                                                        {
+                                                            new UpdateableFlag(score.User.CountryCode)
+                                                            {
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Origin = Anchor.CentreLeft,
+                                                                Size = new Vector2(20, 14),
+                                                            },
+                                                            new UpdateableTeamFlag(score.User.Team)
+                                                            {
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Origin = Anchor.CentreLeft,
+                                                                Size = new Vector2(30, 15),
+                                                            },
+                                                            new DateLabel(score.Date)
+                                                            {
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Origin = Anchor.CentreLeft,
+                                                                Colour = colourProvider.Content2,
+                                                                UseFullGlyphHeight = false,
+                                                            }
+                                                        }
+                                                    },
+                                                    new TruncatingSpriteText
+                                                    {
+                                                        RelativeSizeAxes = Axes.X,
+                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                                        Text = score.User.Username,
+                                                        Font = OsuFont.Style.Heading2,
+                                                    }
+                                                }
+                                            },
+                                            new Container
+                                            {
+                                                AutoSizeAxes = Axes.Both,
+                                                Anchor = Anchor.CentreRight,
+                                                Origin = Anchor.CentreRight,
+                                                Child = statisticsContainer = new FillFlowContainer
+                                                {
+                                                    Name = @"Statistics container",
+                                                    Padding = new MarginPadding { Right = 10 },
+                                                    Spacing = new Vector2(20, 0),
+                                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                                    Anchor = Anchor.CentreRight,
+                                                    Origin = Anchor.CentreRight,
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Direction = FillDirection.Horizontal,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        new ScoreComponentLabel(BeatmapsetsStrings.ShowScoreboardHeadersCombo.ToUpper(), $"{score.MaxCombo.ToString()}x",
+                                                            score.MaxCombo == score.GetMaximumAchievableCombo(), 60),
+                                                        new ScoreComponentLabel(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy.ToUpper(), score.DisplayAccuracy, score.Accuracy == 1,
+                                                            55),
+                                                    },
+                                                    Alpha = 0,
+                                                }
+                                            }
                                         }
+                                    }
+                                },
+                            },
+                        },
+                    },
+                    rightContent = new Container
+                    {
+                        Anchor = Anchor.TopRight,
+                        Origin = Anchor.TopRight,
+                        Name = @"Right content",
+                        RelativeSizeAxes = Axes.Y,
+                        Child = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Children = new Drawable[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Padding = new MarginPadding { Right = grade_width },
+                                    Child = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0), OsuColour.ForRank(score.Rank)),
+                                    },
+                                },
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Y,
+                                    Width = grade_width,
+                                    Anchor = Anchor.TopRight,
+                                    Origin = Anchor.TopRight,
+                                    Colour = OsuColour.ForRank(score.Rank),
+                                },
+                                new TrianglesV2
+                                {
+                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Anchor = Anchor.TopRight,
+                                    Origin = Anchor.TopRight,
+                                    SpawnRatio = 2,
+                                    Velocity = 0.7f,
+                                    Colour = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0), OsuColour.ForRank(score.Rank).Darken(0.2f)),
+                                },
+                                new Container
+                                {
+                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    RelativeSizeAxes = Axes.Y,
+                                    Width = grade_width,
+                                    Child = new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Spacing = new Vector2(-2),
+                                        Colour = DrawableRank.GetRankNameColour(score.Rank),
+                                        Font = OsuFont.Numeric.With(size: 14),
+                                        Text = DrawableRank.GetRankName(score.Rank),
+                                        ShadowColour = Color4.Black.Opacity(0.3f),
+                                        ShadowOffset = new Vector2(0, 0.08f),
+                                        Shadow = true,
+                                        UseFullGlyphHeight = false,
                                     },
                                 },
                                 new Container
                                 {
-                                    Name = @"Centre container",
-                                    Masking = true,
-                                    CornerRadius = corner_radius,
                                     RelativeSizeAxes = Axes.Both,
-                                    Children = new Drawable[]
-                                    {
-                                        foreground = new Box
-                                        {
-                                            Alpha = 0.4f,
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = foregroundColour
-                                        },
-                                        new UserCoverBackground
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            User = score.User,
-                                            Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                            Anchor = Anchor.BottomLeft,
-                                            Origin = Anchor.BottomLeft,
-                                            Colour = ColourInfo.GradientHorizontal(Colour4.White.Opacity(0.5f), Colour4.FromHex(@"222A27").Opacity(1)),
-                                        },
-                                        new GridContainer
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            ColumnDimensions = new[]
-                                            {
-                                                new Dimension(GridSizeMode.AutoSize),
-                                                new Dimension(),
-                                                new Dimension(GridSizeMode.AutoSize),
-                                            },
-                                            Content = new[]
-                                            {
-                                                new Drawable[]
-                                                {
-                                                    new Container
-                                                    {
-                                                        AutoSizeAxes = Axes.Both,
-                                                        CornerRadius = corner_radius,
-                                                        Masking = true,
-                                                        Children = new Drawable[]
-                                                        {
-                                                            new DelayedLoadWrapper(innerAvatar = new ClickableAvatar(score.User)
-                                                            {
-                                                                Anchor = Anchor.Centre,
-                                                                Origin = Anchor.Centre,
-                                                                Scale = new Vector2(1.1f),
-                                                                Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                                RelativeSizeAxes = Axes.Both,
-                                                            })
-                                                            {
-                                                                RelativeSizeAxes = Axes.None,
-                                                                Size = new Vector2(HEIGHT)
-                                                            },
-                                                            rankLabelOverlay = new Container
-                                                            {
-                                                                RelativeSizeAxes = Axes.Both,
-                                                                Alpha = 0,
-                                                                Children = new Drawable[]
-                                                                {
-                                                                    new Box
-                                                                    {
-                                                                        RelativeSizeAxes = Axes.Both,
-                                                                        Colour = Colour4.Black.Opacity(0.5f),
-                                                                    },
-                                                                    new RankLabel(Rank, sheared, false)
-                                                                    {
-                                                                        AutoSizeAxes = Axes.Both,
-                                                                        Anchor = Anchor.Centre,
-                                                                        Origin = Anchor.Centre,
-                                                                    },
-                                                                }
-                                                            }
-                                                        },
-                                                    },
-                                                    new FillFlowContainer
-                                                    {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft,
-                                                        RelativeSizeAxes = Axes.X,
-                                                        AutoSizeAxes = Axes.Y,
-                                                        Direction = FillDirection.Vertical,
-                                                        Padding = new MarginPadding { Horizontal = corner_radius },
-                                                        Children = new Drawable[]
-                                                        {
-                                                            new FillFlowContainer
-                                                            {
-                                                                Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                                Direction = FillDirection.Horizontal,
-                                                                Spacing = new Vector2(5),
-                                                                AutoSizeAxes = Axes.Both,
-                                                                Masking = true,
-                                                                Children = new Drawable[]
-                                                                {
-                                                                    new UpdateableFlag(score.User.CountryCode)
-                                                                    {
-                                                                        Anchor = Anchor.CentreLeft,
-                                                                        Origin = Anchor.CentreLeft,
-                                                                        Size = new Vector2(20, 14),
-                                                                    },
-                                                                    new UpdateableTeamFlag(score.User.Team)
-                                                                    {
-                                                                        Anchor = Anchor.CentreLeft,
-                                                                        Origin = Anchor.CentreLeft,
-                                                                        Size = new Vector2(30, 15),
-                                                                    },
-                                                                    new DateLabel(score.Date)
-                                                                    {
-                                                                        Anchor = Anchor.CentreLeft,
-                                                                        Origin = Anchor.CentreLeft,
-                                                                        Colour = colourProvider.Content2,
-                                                                        UseFullGlyphHeight = false,
-                                                                    }
-                                                                }
-                                                            },
-                                                            new TruncatingSpriteText
-                                                            {
-                                                                RelativeSizeAxes = Axes.X,
-                                                                Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                                Text = score.User.Username,
-                                                                Font = OsuFont.Style.Heading2,
-                                                            }
-                                                        }
-                                                    },
-                                                    new Container
-                                                    {
-                                                        AutoSizeAxes = Axes.Both,
-                                                        Anchor = Anchor.CentreRight,
-                                                        Origin = Anchor.CentreRight,
-                                                        Child = statisticsContainer = new FillFlowContainer
-                                                        {
-                                                            Name = @"Statistics container",
-                                                            Padding = new MarginPadding { Right = 10 },
-                                                            Spacing = new Vector2(20, 0),
-                                                            Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                            Anchor = Anchor.CentreRight,
-                                                            Origin = Anchor.CentreRight,
-                                                            AutoSizeAxes = Axes.Both,
-                                                            Direction = FillDirection.Horizontal,
-                                                            Children = new Drawable[]
-                                                            {
-                                                                new ScoreComponentLabel(BeatmapsetsStrings.ShowScoreboardHeadersCombo.ToUpper(), $"{score.MaxCombo.ToString()}x", score.MaxCombo == score.GetMaximumAchievableCombo(), 60),
-                                                                new ScoreComponentLabel(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy.ToUpper(), score.DisplayAccuracy, score.Accuracy == 1, 55),
-                                                            },
-                                                            Alpha = 0,
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                        },
-                                    },
-                                },
-                                rightContent = new Container
-                                {
-                                    Name = @"Right content",
-                                    RelativeSizeAxes = Axes.Y,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Padding = new MarginPadding { Right = grade_width },
                                     Child = new Container
                                     {
                                         RelativeSizeAxes = Axes.Both,
-                                        Anchor = Anchor.TopRight,
-                                        Origin = Anchor.TopRight,
+                                        Masking = true,
+                                        CornerRadius = corner_radius,
                                         Children = new Drawable[]
                                         {
-                                            new Container
+                                            totalScoreBackground = new Box
                                             {
                                                 RelativeSizeAxes = Axes.Both,
-                                                Padding = new MarginPadding { Right = grade_width },
-                                                Child = new Box
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0), OsuColour.ForRank(score.Rank)),
-                                                },
+                                                Colour = totalScoreBackgroundGradient,
                                             },
                                             new Box
                                             {
-                                                RelativeSizeAxes = Axes.Y,
-                                                Width = grade_width,
-                                                Anchor = Anchor.TopRight,
-                                                Origin = Anchor.TopRight,
-                                                Colour = OsuColour.ForRank(score.Rank),
-                                            },
-                                            new TrianglesV2
-                                            {
-                                                Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                                 RelativeSizeAxes = Axes.Both,
-                                                Anchor = Anchor.TopRight,
-                                                Origin = Anchor.TopRight,
-                                                SpawnRatio = 2,
-                                                Velocity = 0.7f,
-                                                Colour = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0), OsuColour.ForRank(score.Rank).Darken(0.2f)),
+                                                Colour = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0), OsuColour.ForRank(score.Rank).Opacity(0.5f)),
                                             },
-                                            new Container
+                                            new FillFlowContainer
                                             {
-                                                Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                                AutoSizeAxes = Axes.Both,
                                                 Anchor = Anchor.CentreRight,
                                                 Origin = Anchor.CentreRight,
-                                                RelativeSizeAxes = Axes.Y,
-                                                Width = grade_width,
-                                                Child = new OsuSpriteText
+                                                Direction = FillDirection.Vertical,
+                                                Padding = new MarginPadding { Horizontal = corner_radius },
+                                                Spacing = new Vector2(0f, -2f),
+                                                Children = new Drawable[]
                                                 {
-                                                    Anchor = Anchor.Centre,
-                                                    Origin = Anchor.Centre,
-                                                    Spacing = new Vector2(-2),
-                                                    Colour = DrawableRank.GetRankNameColour(score.Rank),
-                                                    Font = OsuFont.Numeric.With(size: 14),
-                                                    Text = DrawableRank.GetRankName(score.Rank),
-                                                    ShadowColour = Color4.Black.Opacity(0.3f),
-                                                    ShadowOffset = new Vector2(0, 0.08f),
-                                                    Shadow = true,
-                                                    UseFullGlyphHeight = false,
-                                                },
-                                            },
-                                            new Container
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Anchor = Anchor.CentreLeft,
-                                                Origin = Anchor.CentreLeft,
-                                                Padding = new MarginPadding { Right = grade_width },
-                                                Child = new Container
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Masking = true,
-                                                    CornerRadius = corner_radius,
-                                                    Children = new Drawable[]
+                                                    new OsuSpriteText
                                                     {
-                                                        totalScoreBackground = new Box
-                                                        {
-                                                            RelativeSizeAxes = Axes.Both,
-                                                            Colour = totalScoreBackgroundGradient,
-                                                        },
-                                                        new Box
-                                                        {
-                                                            RelativeSizeAxes = Axes.Both,
-                                                            Colour = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0), OsuColour.ForRank(score.Rank).Opacity(0.5f)),
-                                                        },
-                                                        new FillFlowContainer
-                                                        {
-                                                            AutoSizeAxes = Axes.Both,
-                                                            Anchor = Anchor.CentreRight,
-                                                            Origin = Anchor.CentreRight,
-                                                            Direction = FillDirection.Vertical,
-                                                            Padding = new MarginPadding { Horizontal = corner_radius },
-                                                            Spacing = new Vector2(0f, -2f),
-                                                            Children = new Drawable[]
-                                                            {
-                                                                new OsuSpriteText
-                                                                {
-                                                                    Anchor = Anchor.TopRight,
-                                                                    Origin = Anchor.TopRight,
-                                                                    UseFullGlyphHeight = false,
-                                                                    Current = scoreManager.GetBindableTotalScoreString(score),
-                                                                    Spacing = new Vector2(-1.5f),
-                                                                    Font = OsuFont.Style.Subtitle.With(weight: FontWeight.Light, fixedWidth: true),
-                                                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                                },
-                                                                modsContainer = new FillFlowContainer<Drawable>
-                                                                {
-                                                                    Anchor = Anchor.TopRight,
-                                                                    Origin = Anchor.TopRight,
-                                                                    AutoSizeAxes = Axes.Both,
-                                                                    Direction = FillDirection.Horizontal,
-                                                                    Spacing = new Vector2(-10, 0),
-                                                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                                },
-                                                            }
-                                                        }
-                                                    }
+                                                        Anchor = Anchor.TopRight,
+                                                        Origin = Anchor.TopRight,
+                                                        UseFullGlyphHeight = false,
+                                                        Current = scoreManager.GetBindableTotalScoreString(score),
+                                                        Spacing = new Vector2(-1.5f),
+                                                        Font = OsuFont.Style.Subtitle.With(weight: FontWeight.Light, fixedWidth: true),
+                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                                    },
+                                                    modsContainer = new FillFlowContainer<Drawable>
+                                                    {
+                                                        Anchor = Anchor.TopRight,
+                                                        Origin = Anchor.TopRight,
+                                                        AutoSizeAxes = Axes.Both,
+                                                        Direction = FillDirection.Horizontal,
+                                                        Spacing = new Vector2(-10, 0),
+                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                                    },
                                                 }
                                             }
                                         }
-                                    },
+                                    }
                                 }
                             }
-                        }
+                        },
                     }
                 }
             };
-
             innerAvatar.OnLoadComplete += d => d.FadeInFromZero(200);
         }
 
@@ -565,30 +557,39 @@ namespace osu.Game.Screens.SelectV2
             DisplayMode mode = getCurrentDisplayMode();
 
             if (currentMode != mode)
+                updateDisplayMode(mode);
+
+            centreContent.Padding = new MarginPadding
             {
-                double duration = currentMode == null ? 0 : transition_duration;
-                if (mode >= DisplayMode.Full)
-                    rankLabelStandalone.FadeIn(duration, Easing.OutQuint).ResizeWidthTo(rank_label_width, duration, Easing.OutQuint);
-                else
-                    rankLabelStandalone.FadeOut(duration, Easing.OutQuint).ResizeWidthTo(0, duration, Easing.OutQuint);
+                Left = rankLabelStandalone.DrawWidth,
+                Right = rightContent.DrawWidth,
+            };
+        }
 
-                if (mode >= DisplayMode.Regular)
-                {
-                    statisticsContainer.FadeIn(duration, Easing.OutQuint).MoveToX(0, duration, Easing.OutQuint);
-                    statisticsContainer.Direction = FillDirection.Horizontal;
-                    statisticsContainer.ScaleTo(1, duration, Easing.OutQuint);
-                }
-                else if (mode >= DisplayMode.Compact)
-                {
-                    statisticsContainer.FadeIn(duration, Easing.OutQuint).MoveToX(0, duration, Easing.OutQuint);
-                    statisticsContainer.Direction = FillDirection.Vertical;
-                    statisticsContainer.ScaleTo(0.8f, duration, Easing.OutQuint);
-                }
-                else
-                    statisticsContainer.FadeOut(duration, Easing.OutQuint).MoveToX(statisticsContainer.DrawWidth, duration, Easing.OutQuint);
+        private void updateDisplayMode(DisplayMode mode)
+        {
+            double duration = currentMode == null ? 0 : transition_duration;
+            if (mode >= DisplayMode.Full)
+                rankLabelStandalone.FadeIn(duration, Easing.OutQuint).ResizeWidthTo(rank_label_width, duration, Easing.OutQuint);
+            else
+                rankLabelStandalone.FadeOut(duration, Easing.OutQuint).ResizeWidthTo(0, duration, Easing.OutQuint);
 
-                currentMode = mode;
+            if (mode >= DisplayMode.Regular)
+            {
+                statisticsContainer.FadeIn(duration, Easing.OutQuint).MoveToX(0, duration, Easing.OutQuint);
+                statisticsContainer.Direction = FillDirection.Horizontal;
+                statisticsContainer.ScaleTo(1, duration, Easing.OutQuint);
             }
+            else if (mode >= DisplayMode.Compact)
+            {
+                statisticsContainer.FadeIn(duration, Easing.OutQuint).MoveToX(0, duration, Easing.OutQuint);
+                statisticsContainer.Direction = FillDirection.Vertical;
+                statisticsContainer.ScaleTo(0.8f, duration, Easing.OutQuint);
+            }
+            else
+                statisticsContainer.FadeOut(duration, Easing.OutQuint).MoveToX(statisticsContainer.DrawWidth, duration, Easing.OutQuint);
+
+            currentMode = mode;
         }
 
         private DisplayMode getCurrentDisplayMode()


### PR DESCRIPTION
- Closes #33365 

When display mode changes, `rankLabelStandalone` is applied a resize transform. But since `rankLabelStandalone` is wrapped inside an auto-sized grid container cell, and the score itself is partially displayed on the screen, then the cell is placed offscreen and `IsMaskedAway` is set to true on the cell container. Therefore, the rank container's resize transform never gets processed because the rank container never gets updated.

The solution here is to get rid of the grid container altogether and place the rank container directly as a child of the entire score container, therefore it will always be updated unless the entire score is offscreen.

Before:

https://github.com/user-attachments/assets/77d18ed1-ef47-48d7-abed-3f20eea8011d

After:

https://github.com/user-attachments/assets/3fa89b33-a8b7-422e-9a98-9ff2f192018f

