### PR TITLE
Move and rename next/previous "group" selection keybindings to make way for group-specific bindings

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -183,10 +183,24 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         protected void WaitForFiltering() => AddUntilStep("filtering finished", () => Carousel.IsFiltering, () => Is.False);
         protected void WaitForScrolling() => AddUntilStep("scroll finished", () => Scroll.Current, () => Is.EqualTo(Scroll.Target));
 
+        protected void SelectNextGroup() => AddStep("select next group", () =>
+        {
+            InputManager.PressKey(Key.ShiftLeft);
+            InputManager.Key(Key.Right);
+            InputManager.ReleaseKey(Key.ShiftLeft);
+        });
+
+        protected void SelectPrevGroup() => AddStep("select prev group", () =>
+        {
+            InputManager.PressKey(Key.ShiftLeft);
+            InputManager.Key(Key.Left);
+            InputManager.ReleaseKey(Key.ShiftLeft);
+        });
+
         protected void SelectNextPanel() => AddStep("select next panel", () => InputManager.Key(Key.Down));
         protected void SelectPrevPanel() => AddStep("select prev panel", () => InputManager.Key(Key.Up));
-        protected void SelectNextGroup() => AddStep("select next group", () => InputManager.Key(Key.Right));
-        protected void SelectPrevGroup() => AddStep("select prev group", () => InputManager.Key(Key.Left));
+        protected void SelectNextSet() => AddStep("select next set", () => InputManager.Key(Key.Right));
+        protected void SelectPrevSet() => AddStep("select prev set", () => InputManager.Key(Key.Left));
 
         protected void Select() => AddStep("select", () => InputManager.Key(Key.Enter));
 
@@ -228,7 +242,21 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         protected ICarouselPanel? GetSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.Selected.Value);
         protected ICarouselPanel? GetKeyboardSelectedPanel() => Carousel.ChildrenOfType<ICarouselPanel>().SingleOrDefault(p => p.KeyboardSelected.Value);
 
-        protected void WaitForGroupSelection(int group, int panel)
+        protected void WaitForExpandedGroup(int group)
+        {
+            AddUntilStep($"group {group} is expanded", () =>
+            {
+                var groupingFilter = Carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single();
+
+                GroupDefinition g = groupingFilter.GroupItems.Keys.ElementAt(group);
+                // offset by one because the group itself is included in the items list.
+                CarouselItem item = groupingFilter.GroupItems[g].ElementAt(0);
+
+                return item.Model is GroupDefinition def && def == Carousel.ExpandedGroup;
+            });
+        }
+
+        protected void WaitForBeatmapSelection(int group, int panel)
         {
             AddUntilStep($"selected is group{group} panel{panel}", () =>
             {
@@ -243,7 +271,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
         }
 
-        protected void WaitForSelection(int set, int? diff = null)
+        protected void WaitForSetSelection(int set, int? diff = null)
         {
             AddUntilStep($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
             {

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestCarouselRemembersSelection()
         {
-            SelectNextGroup();
+            SelectNextSet();
 
             object? selection = null;
 
@@ -108,22 +108,22 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestGroupSelectionOnHeader()
         {
-            SelectNextGroup();
-            WaitForGroupSelection(0, 1);
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 1);
 
             SelectPrevPanel();
             SelectPrevPanel();
 
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
 
-            SelectPrevGroup();
+            SelectPrevSet();
 
-            WaitForGroupSelection(0, 1);
+            WaitForBeatmapSelection(0, 1);
             AddAssert("keyboard selected panel is contracted", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.False);
 
-            SelectPrevGroup();
+            SelectPrevSet();
 
-            WaitForGroupSelection(0, 1);
+            WaitForBeatmapSelection(0, 1);
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
         }
 
@@ -143,41 +143,41 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             SelectNextPanel();
             Select();
-            WaitForGroupSelection(3, 1);
+            WaitForBeatmapSelection(3, 1);
 
-            SelectNextGroup();
-            WaitForGroupSelection(3, 5);
+            SelectNextSet();
+            WaitForBeatmapSelection(3, 5);
 
-            SelectNextGroup();
-            WaitForGroupSelection(4, 1);
+            SelectNextSet();
+            WaitForBeatmapSelection(4, 1);
 
-            SelectPrevGroup();
-            WaitForGroupSelection(3, 5);
+            SelectPrevSet();
+            WaitForBeatmapSelection(3, 5);
 
-            SelectNextGroup();
-            WaitForGroupSelection(4, 1);
+            SelectNextSet();
+            WaitForBeatmapSelection(4, 1);
 
-            SelectNextGroup();
-            WaitForGroupSelection(4, 5);
+            SelectNextSet();
+            WaitForBeatmapSelection(4, 5);
 
-            SelectNextGroup();
-            WaitForGroupSelection(0, 1);
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 1);
 
             // Difficulties should get immediate selection even when using up and down traversal.
             SelectNextPanel();
-            WaitForGroupSelection(0, 2);
+            WaitForBeatmapSelection(0, 2);
             SelectNextPanel();
-            WaitForGroupSelection(0, 3);
+            WaitForBeatmapSelection(0, 3);
 
             SelectNextPanel();
-            WaitForGroupSelection(0, 3);
+            WaitForBeatmapSelection(0, 3);
 
-            SelectNextGroup();
-            WaitForGroupSelection(0, 5);
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 5);
 
             SelectNextPanel();
-            SelectNextGroup();
-            WaitForGroupSelection(1, 1);
+            SelectNextSet();
+            WaitForBeatmapSelection(1, 1);
         }
 
         [Test]
@@ -199,19 +199,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("no beatmaps visible", () => !GetVisiblePanels<PanelBeatmap>().Any());
 
             ClickVisiblePanelWithOffset<PanelBeatmapSet>(0, new Vector2(0, -(CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
-            WaitForGroupSelection(0, 1);
+            WaitForBeatmapSelection(0, 1);
 
             AddUntilStep("wait for beatmaps visible", () => GetVisiblePanels<PanelBeatmap>().Any());
 
             // Beatmap panels expand their selection area to cover holes from spacing.
             ClickVisiblePanelWithOffset<PanelBeatmap>(0, new Vector2(0, -(CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
-            WaitForGroupSelection(0, 1);
+            WaitForBeatmapSelection(0, 1);
 
             ClickVisiblePanelWithOffset<PanelBeatmap>(1, new Vector2(0, CarouselItem.DEFAULT_HEIGHT / 2 + 1));
-            WaitForGroupSelection(0, 2);
+            WaitForBeatmapSelection(0, 2);
 
             ClickVisiblePanelWithOffset<PanelBeatmapSet>(1, new Vector2(0, CarouselItem.DEFAULT_HEIGHT / 2 + 1));
-            WaitForGroupSelection(0, 5);
+            WaitForBeatmapSelection(0, 5);
         }
 
         [Test]
@@ -228,14 +228,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             SelectNextPanel();
             Select();
-            WaitForGroupSelection(0, 2);
+            WaitForBeatmapSelection(0, 2);
 
             for (int i = 0; i < 6; i++)
                 SelectNextPanel();
 
             Select();
 
-            WaitForGroupSelection(0, 3);
+            WaitForBeatmapSelection(0, 3);
 
             ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
             WaitForFiltering();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestCarouselRemembersSelection()
         {
-            SelectNextGroup();
+            SelectNextSet();
 
             object? selection = null;
 
@@ -98,28 +98,28 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestGroupSelectionOnHeaderKeyboard()
         {
-            SelectNextGroup();
-            WaitForGroupSelection(0, 0);
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 0);
 
             SelectPrevPanel();
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
 
-            SelectPrevGroup();
+            SelectPrevSet();
 
-            WaitForGroupSelection(0, 0);
+            WaitForBeatmapSelection(0, 0);
             AddAssert("keyboard selected panel is contracted", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.False);
 
-            SelectPrevGroup();
+            SelectPrevSet();
 
-            WaitForGroupSelection(0, 0);
+            WaitForBeatmapSelection(0, 0);
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
         }
 
         [Test]
         public void TestGroupSelectionOnHeaderMouse()
         {
-            SelectNextGroup();
-            WaitForGroupSelection(0, 0);
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 0);
 
             AddAssert("keyboard selected panel is beatmap", GetKeyboardSelectedPanel, Is.TypeOf<PanelBeatmapStandalone>);
             AddAssert("selected panel is beatmap", GetSelectedPanel, Is.TypeOf<PanelBeatmapStandalone>);
@@ -151,22 +151,22 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             SelectNextPanel();
             Select();
-            WaitForGroupSelection(0, 0);
+            WaitForBeatmapSelection(0, 0);
 
-            SelectNextGroup();
-            WaitForGroupSelection(0, 1);
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 1);
 
-            SelectNextGroup();
-            WaitForGroupSelection(0, 2);
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 2);
 
-            SelectPrevGroup();
-            WaitForGroupSelection(0, 1);
+            SelectPrevSet();
+            WaitForBeatmapSelection(0, 1);
 
-            SelectPrevGroup();
-            WaitForGroupSelection(0, 0);
+            SelectPrevSet();
+            WaitForBeatmapSelection(0, 0);
 
-            SelectPrevGroup();
-            WaitForGroupSelection(2, 9);
+            SelectPrevSet();
+            WaitForBeatmapSelection(2, 9);
         }
 
         [Test]
@@ -187,10 +187,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             // Beatmap panels expand their selection area to cover holes from spacing.
             ClickVisiblePanelWithOffset<PanelBeatmapStandalone>(0, new Vector2(0, -(CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
-            WaitForGroupSelection(0, 0);
+            WaitForBeatmapSelection(0, 0);
 
             ClickVisiblePanelWithOffset<PanelBeatmapStandalone>(1, new Vector2(0, (CarouselItem.DEFAULT_HEIGHT / 2 + 1)));
-            WaitForGroupSelection(0, 1);
+            WaitForBeatmapSelection(0, 1);
         }
 
         [Test]
@@ -203,11 +203,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckDisplayedBeatmapsCount(3);
 
             // Single result gets selected automatically
-            WaitForGroupSelection(0, 0);
+            WaitForBeatmapSelection(0, 0);
 
             SelectNextPanel();
             Select();
-            WaitForGroupSelection(0, 0);
+            WaitForBeatmapSelection(0, 0);
 
             for (int i = 0; i < 5; i++)
                 SelectNextPanel();
@@ -216,7 +216,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextPanel();
             Select();
 
-            WaitForGroupSelection(1, 0);
+            WaitForBeatmapSelection(1, 0);
 
             ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
             WaitForFiltering();
@@ -228,15 +228,15 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestExpandedGroupStillExpandedAfterFilter()
         {
-            SelectPrevGroup();
+            SelectPrevSet();
 
-            WaitForGroupSelection(2, 9);
+            WaitForBeatmapSelection(2, 9);
             AddAssert("expanded group is last", () => (Carousel.ExpandedGroup as StarDifficultyGroupDefinition)?.Difficulty.Stars, () => Is.EqualTo(6));
 
             SelectNextPanel();
             Select();
 
-            WaitForGroupSelection(2, 9);
+            WaitForBeatmapSelection(2, 9);
             AddAssert("expanded group is first", () => (Carousel.ExpandedGroup as StarDifficultyGroupDefinition)?.Difficulty.Stars, () => Is.EqualTo(0));
 
             // doesn't actually filter anything away, but triggers a filter.

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -44,13 +44,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckDisplayedBeatmapSetsCount(1);
             CheckDisplayedBeatmapsCount(3);
 
-            WaitForSelection(2, 0);
+            WaitForSetSelection(2, 0);
 
             for (int i = 0; i < 5; i++)
                 SelectNextPanel();
 
             Select();
-            WaitForSelection(2, 1);
+            WaitForSetSelection(2, 1);
 
             ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
             WaitForFiltering();
@@ -135,7 +135,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(50, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
+            SelectNextSet();
             SelectNextPanel();
             Select();
 
@@ -156,11 +156,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(50, 3);
             WaitForDrawablePanels();
 
-            SelectPrevGroup();
-            WaitForSelection(49, 0);
+            SelectPrevSet();
+            WaitForSetSelection(49, 0);
 
             ApplyToFilter("filter all but one", c => c.SearchText = BeatmapSets.First().Metadata.Title);
-            WaitForSelection(0, 0);
+            WaitForSetSelection(0, 0);
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckNoSelection();
             ApplyToFilter("filter all but one", c => c.SearchText = BeatmapSets.First().Metadata.Title);
-            WaitForSelection(0, 0);
+            WaitForSetSelection(0, 0);
         }
 
         [Test]
@@ -184,7 +184,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             SortBy(SortMode.Difficulty);
 
-            SelectNextGroup();
+            SelectNextSet();
 
             AddStep("record selection", () => selectedID = ((BeatmapInfo)Carousel.CurrentSelection!).ID);
 
@@ -318,8 +318,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(2, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            WaitForSelection(0, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
 
             CheckDisplayedBeatmapsCount(6);
 
@@ -328,10 +328,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckDisplayedBeatmapsCount(4);
 
-            SelectNextGroup();
-            WaitForSelection(0, 1);
-            SelectPrevGroup();
-            WaitForSelection(1, 1);
+            SelectNextSet();
+            WaitForSetSelection(0, 1);
+            SelectPrevSet();
+            WaitForSetSelection(1, 1);
         }
 
         [Test]
@@ -340,16 +340,16 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(5, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            SelectNextGroup();
-            SelectNextGroup();
-            WaitForSelection(2, 0);
+            SelectNextSet();
+            SelectNextSet();
+            SelectNextSet();
+            WaitForSetSelection(2, 0);
 
             ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
             WaitForFiltering();
 
-            SelectNextGroup();
-            WaitForSelection(0, 1);
+            SelectNextSet();
+            WaitForSetSelection(0, 1);
         }
 
         [Test]
@@ -358,16 +358,16 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(5, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            SelectNextGroup();
-            SelectNextGroup();
-            WaitForSelection(2, 0);
+            SelectNextSet();
+            SelectNextSet();
+            SelectNextSet();
+            WaitForSetSelection(2, 0);
 
             ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
             WaitForFiltering();
 
-            SelectPrevGroup();
-            WaitForSelection(4, 1);
+            SelectPrevSet();
+            WaitForSetSelection(4, 1);
         }
 
         [Test]
@@ -376,14 +376,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(2, 3);
             WaitForDrawablePanels();
 
-            SelectPrevGroup();
-            WaitForSelection(1, 0);
+            SelectPrevSet();
+            WaitForSetSelection(1, 0);
 
             ApplyToFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
             WaitForFiltering();
 
-            SelectPrevGroup();
-            WaitForSelection(0, 0);
+            SelectPrevSet();
+            WaitForSetSelection(0, 0);
         }
 
         [Test]
@@ -392,14 +392,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(2, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            WaitForSelection(0, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
 
             ApplyToFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
             WaitForFiltering();
 
-            SelectNextGroup();
-            WaitForSelection(1, 0);
+            SelectNextSet();
+            WaitForSetSelection(1, 0);
         }
 
         [Test]
@@ -408,10 +408,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(5, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            SelectNextGroup();
-            SelectNextGroup();
-            WaitForSelection(2, 0);
+            SelectNextSet();
+            SelectNextSet();
+            SelectNextSet();
+            WaitForSetSelection(2, 0);
 
             ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
             WaitForFiltering();
@@ -426,10 +426,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(5, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            SelectNextGroup();
-            SelectNextGroup();
-            WaitForSelection(2, 0);
+            SelectNextSet();
+            SelectNextSet();
+            SelectNextSet();
+            WaitForSetSelection(2, 0);
 
             ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
             WaitForFiltering();
@@ -444,8 +444,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(2, 3);
             WaitForDrawablePanels();
 
-            SelectPrevGroup();
-            WaitForSelection(1, 0);
+            SelectPrevSet();
+            WaitForSetSelection(1, 0);
 
             ApplyToFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
             WaitForFiltering();
@@ -460,8 +460,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(2, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            WaitForSelection(0, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
 
             ApplyToFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
             WaitForFiltering();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(10);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
+            SelectNextSet();
 
             object? selection = null;
 
@@ -116,10 +116,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(total_set_count);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            WaitForSelection(0, 0);
-            SelectPrevGroup();
-            WaitForSelection(total_set_count - 1, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
+            SelectPrevSet();
+            WaitForSetSelection(total_set_count - 1, 0);
         }
 
         [Test]
@@ -130,10 +130,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(total_set_count);
             WaitForDrawablePanels();
 
-            SelectPrevGroup();
-            WaitForSelection(total_set_count - 1, 0);
-            SelectNextGroup();
-            WaitForSelection(0, 0);
+            SelectPrevSet();
+            WaitForSetSelection(total_set_count - 1, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
         }
 
         [Test]
@@ -142,17 +142,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(10, 3);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
-            SelectNextGroup();
-            WaitForSelection(1, 0);
+            SelectNextSet();
+            SelectNextSet();
+            WaitForSetSelection(1, 0);
 
             SelectPrevPanel();
-            SelectPrevGroup();
-            WaitForSelection(1, 0);
+            SelectPrevSet();
+            WaitForSetSelection(1, 0);
 
             SelectPrevPanel();
-            SelectNextGroup();
-            WaitForSelection(1, 0);
+            SelectNextSet();
+            WaitForSetSelection(1, 0);
         }
 
         [Test]
@@ -168,19 +168,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckNoSelection();
 
             Select();
-            WaitForSelection(3, 0);
+            WaitForSetSelection(3, 0);
 
             SelectNextPanel();
-            WaitForSelection(3, 1);
+            WaitForSetSelection(3, 1);
 
             SelectNextPanel();
-            WaitForSelection(3, 2);
+            WaitForSetSelection(3, 2);
 
             SelectNextPanel();
-            WaitForSelection(3, 2);
+            WaitForSetSelection(3, 2);
 
             Select();
-            WaitForSelection(4, 0);
+            WaitForSetSelection(4, 0);
         }
 
         [Test]
@@ -189,11 +189,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckNoSelection();
             AddBeatmaps(1, 3);
 
-            WaitForSelection(0, 0);
+            WaitForSetSelection(0, 0);
             CheckActivationCount(0);
 
-            SelectNextGroup();
-            WaitForSelection(0, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
 
             // In the case of a grouped beatmap set, the header gets activated and re-selects the recommended difficulty.
             // This is probably fine.
@@ -201,8 +201,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             // We don't want it to request present though, which would start gameplay.
             CheckRequestPresentCount(0);
 
-            SelectPrevGroup();
-            WaitForSelection(0, 0);
+            SelectPrevSet();
+            WaitForSetSelection(0, 0);
 
             CheckActivationCount(1);
             CheckRequestPresentCount(0);
@@ -216,11 +216,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckNoSelection();
             AddBeatmaps(1, 1);
 
-            WaitForSelection(0, 0);
+            WaitForSetSelection(0, 0);
             CheckActivationCount(0);
 
-            SelectNextGroup();
-            WaitForSelection(0, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
 
             // In the case of a grouped beatmap set, the header gets activated and re-selects the recommended difficulty.
             // This is probably fine.
@@ -228,8 +228,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             // We don't want it to request present though, which would start gameplay.
             CheckRequestPresentCount(0);
 
-            SelectPrevGroup();
-            WaitForSelection(0, 0);
+            SelectPrevSet();
+            WaitForSetSelection(0, 0);
 
             CheckActivationCount(0);
             CheckRequestPresentCount(0);
@@ -241,13 +241,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextPanel();
             CheckNoSelection();
 
-            SelectNextGroup();
+            SelectNextSet();
             CheckNoSelection();
 
             SelectPrevPanel();
             CheckNoSelection();
 
-            SelectPrevGroup();
+            SelectPrevSet();
             CheckNoSelection();
         }
 
@@ -267,20 +267,20 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             ClickVisiblePanelWithOffset<PanelBeatmapSet>(0, new Vector2(0, -(PanelBeatmapSet.HEIGHT / 2 - 1)));
 
             AddUntilStep("wait for beatmaps visible", () => GetVisiblePanels<PanelBeatmap>().Any());
-            WaitForSelection(0, 0);
+            WaitForSetSelection(0, 0);
 
             // Beatmap panels expand their selection area to cover holes from spacing.
             ClickVisiblePanelWithOffset<PanelBeatmap>(0, new Vector2(0, -(PanelBeatmap.HEIGHT / 2 + 1)));
-            WaitForSelection(0, 0);
+            WaitForSetSelection(0, 0);
 
             ClickVisiblePanelWithOffset<PanelBeatmap>(2, new Vector2(0, (PanelBeatmap.HEIGHT / 2 + 1)));
-            WaitForSelection(0, 2);
+            WaitForSetSelection(0, 2);
 
             ClickVisiblePanelWithOffset<PanelBeatmap>(2, new Vector2(0, -(PanelBeatmap.HEIGHT / 2 + 1)));
-            WaitForSelection(0, 2);
+            WaitForSetSelection(0, 2);
 
             ClickVisiblePanelWithOffset<PanelBeatmap>(3, new Vector2(0, (PanelBeatmap.HEIGHT / 2 + 1)));
-            WaitForSelection(0, 3);
+            WaitForSetSelection(0, 3);
         }
 
         [Test]
@@ -294,17 +294,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddUntilStep("standalone panels displayed", () => GetVisiblePanels<PanelBeatmapStandalone>().Any());
 
-            SelectNextGroup();
+            SelectNextSet();
             // both sets have a difficulty with 0.00* star rating.
             // in the case of a tie when sorting, the first tie-breaker is `DateAdded` descending, which will pick the last set added (see `TestResources.CreateTestBeatmapSetInfo()`).
-            WaitForSelection(1, 0);
+            WaitForSetSelection(1, 0);
 
-            SelectNextGroup();
-            WaitForSelection(0, 0);
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
 
             SelectNextPanel();
             Select();
-            WaitForSelection(1, 1);
+            WaitForSetSelection(1, 1);
         }
 
         [Test]
@@ -318,7 +318,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddUntilStep("standalone panels displayed", () => GetVisiblePanels<PanelBeatmapStandalone>().Count(), () => Is.EqualTo(3));
 
-            WaitForSelection(0, 0);
+            WaitForSetSelection(0, 0);
 
             SortBy(SortMode.Title);
 
@@ -335,30 +335,30 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("set recommendation algorithm", () => BeatmapRecommendationFunction = beatmaps => beatmaps.Last());
 
-            SelectPrevGroup();
+            SelectPrevSet();
 
             // check recommended was selected
-            SelectNextGroup();
-            WaitForSelection(0, 2);
+            SelectNextSet();
+            WaitForSetSelection(0, 2);
 
             // change away from recommended
             SelectPrevPanel();
             Select();
-            WaitForSelection(0, 1);
+            WaitForSetSelection(0, 1);
 
             // next set, check recommended
-            SelectNextGroup();
-            WaitForSelection(1, 2);
+            SelectNextSet();
+            WaitForSetSelection(1, 2);
 
             // next set, check recommended
-            SelectNextGroup();
-            WaitForSelection(2, 2);
+            SelectNextSet();
+            WaitForSetSelection(2, 2);
 
             // go back to first set and ensure user selection was retained
             // todo: we don't do that yet. not sure if we will continue to have this.
-            // SelectPrevGroup();
-            // SelectPrevGroup();
-            // WaitForSelection(0, 1);
+            // SelectPrevSet();
+            // SelectPrevSet();
+            // WaitForSetSelection(0, 1);
         }
 
         private void checkSelectionIterating(bool isIterating)

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             for (int i = 0; i < 10; i++)
             {
                 nextRandom();
-                WaitForSelection(0, 9);
+                WaitForSetSelection(0, 9);
             }
         }
 
@@ -110,7 +110,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(local_set_count, 3, true);
             WaitForDrawablePanels();
 
-            SelectNextGroup();
+            SelectNextSet();
 
             for (int i = 0; i < random_select_count; i++)
                 nextRandom();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -94,9 +94,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestSelectionHeld()
         {
-            SelectNextGroup();
+            SelectNextSet();
 
-            WaitForSelection(1, 0);
+            WaitForSetSelection(1, 0);
             AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
@@ -110,9 +110,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test] // Checks that we keep selection based on online ID where possible.
         public void TestSelectionHeldDifficultyNameChanged()
         {
-            SelectNextGroup();
+            SelectNextSet();
 
-            WaitForSelection(1, 0);
+            WaitForSetSelection(1, 0);
             AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
@@ -126,9 +126,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test] // Checks that we fallback to keeping selection based on difficulty name.
         public void TestSelectionHeldDifficultyOnlineIDChanged()
         {
-            SelectNextGroup();
+            SelectNextSet();
 
-            WaitForSelection(1, 0);
+            WaitForSetSelection(1, 0);
             AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -234,27 +234,27 @@ namespace osu.Game.Graphics.Carousel
             Scroll.Panels.SingleOrDefault(p => ((ICarouselPanel)p).Item == item);
 
         /// <summary>
-        /// When a user is traversing the carousel via group selection keys, assert whether the item provided is a valid target.
+        /// When a user is traversing the carousel via set selection keys, assert whether the item provided is a valid target.
         /// </summary>
         /// <param name="item">The candidate item.</param>
-        /// <returns>Whether the provided item is a valid group target. If <c>false</c>, more panels will be checked in the user's requested direction until a valid target is found.</returns>
-        protected virtual bool CheckValidForGroupSelection(CarouselItem item) => true;
+        /// <returns>Whether the provided item is a valid set target. If <c>false</c>, more panels will be checked in the user's requested direction until a valid target is found.</returns>
+        protected virtual bool CheckValidForSetSelection(CarouselItem item) => true;
 
         /// <summary>
         /// Keyboard selection usually does not automatically activate an item. There may be exceptions to this rule.
-        /// Returning <c>true</c> here will make keyboard traversal act like group traversal for the target item.
+        /// Returning <c>true</c> here will make keyboard traversal act like set traversal for the target item.
         /// </summary>
         protected virtual bool ShouldActivateOnKeyboardSelection(CarouselItem item) => false;
 
         /// <summary>
         /// Called after an item becomes the <see cref="CurrentSelection"/>.
-        /// Should be used to handle any group expansion, item visibility changes, etc.
+        /// Should be used to handle any set expansion, item visibility changes, etc.
         /// </summary>
         protected virtual void HandleItemSelected(object? model) { }
 
         /// <summary>
         /// Called when the <see cref="CurrentSelection"/> changes to a new selection.
-        /// Should be used to handle any group expansion, item visibility changes, etc.
+        /// Should be used to handle any set expansion, item visibility changes, etc.
         /// </summary>
         protected virtual void HandleItemDeselected(object? model) { }
 
@@ -460,12 +460,12 @@ namespace osu.Game.Graphics.Carousel
                     Scheduler.AddOnce(traverseKeyboardSelection, -1);
                     return true;
 
-                case GlobalAction.SelectNextGroup:
-                    Scheduler.AddOnce(traverseGroupSelection, 1);
+                case GlobalAction.ActivateNextSet:
+                    Scheduler.AddOnce(traverseSetSelection, 1);
                     return true;
 
-                case GlobalAction.SelectPreviousGroup:
-                    Scheduler.AddOnce(traverseGroupSelection, -1);
+                case GlobalAction.ActivatePreviousSet:
+                    Scheduler.AddOnce(traverseSetSelection, -1);
                     return true;
             }
 
@@ -525,12 +525,12 @@ namespace osu.Game.Graphics.Carousel
         /// </summary>
         /// <param name="direction">Positive for downwards, negative for upwards.</param>
         /// <returns>Whether selection was possible.</returns>
-        private void traverseGroupSelection(int direction)
+        private void traverseSetSelection(int direction)
         {
             if (carouselItems == null || carouselItems.Count == 0) return;
 
             // If the user has a different keyboard selection and requests
-            // group selection, first transfer the keyboard selection to actual selection.
+            // set selection, first transfer the keyboard selection to actual selection.
             if (currentKeyboardSelection.CarouselItem != null && currentSelection.CarouselItem != currentKeyboardSelection.CarouselItem)
             {
                 Activate(currentKeyboardSelection.CarouselItem);
@@ -549,11 +549,11 @@ namespace osu.Game.Graphics.Carousel
             {
                 newIndex = originalIndex = currentKeyboardSelection.Index.Value;
 
-                // As a second special case, if we're group selecting backwards and the current selection isn't a group,
-                // make sure to go back to the group header this item belongs to, so that the block below doesn't find it and stop too early.
+                // As a second special case, if we're set selecting backwards and the current selection isn't a set,
+                // make sure to go back to the set header this item belongs to, so that the block below doesn't find it and stop too early.
                 if (direction < 0)
                 {
-                    while (newIndex > 0 && !CheckValidForGroupSelection(carouselItems[newIndex]))
+                    while (newIndex > 0 && !CheckValidForSetSelection(carouselItems[newIndex]))
                         newIndex--;
                 }
             }
@@ -569,7 +569,7 @@ namespace osu.Game.Graphics.Carousel
 
                 var newItem = carouselItems[newIndex];
 
-                if (CheckValidForGroupSelection(newItem))
+                if (CheckValidForSetSelection(newItem))
                 {
                     HandleItemActivated(newItem);
                     return;

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -89,9 +89,6 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Up, GlobalAction.SelectPrevious),
             new KeyBinding(InputKey.Down, GlobalAction.SelectNext),
 
-            new KeyBinding(InputKey.Left, GlobalAction.SelectPreviousGroup),
-            new KeyBinding(InputKey.Right, GlobalAction.SelectNextGroup),
-
             new KeyBinding(InputKey.Space, GlobalAction.Select),
             new KeyBinding(InputKey.Enter, GlobalAction.Select),
             new KeyBinding(InputKey.KeypadEnter, GlobalAction.Select),
@@ -199,6 +196,9 @@ namespace osu.Game.Input.Bindings
 
         private static IEnumerable<KeyBinding> songSelectKeyBindings => new[]
         {
+            new KeyBinding(InputKey.Left, GlobalAction.ActivatePreviousSet),
+            new KeyBinding(InputKey.Right, GlobalAction.ActivateNextSet),
+
             new KeyBinding(InputKey.F1, GlobalAction.ToggleModSelection),
             new KeyBinding(InputKey.F2, GlobalAction.SelectNextRandom),
             new KeyBinding(new[] { InputKey.Shift, InputKey.F2 }, GlobalAction.SelectPreviousRandom),
@@ -396,11 +396,11 @@ namespace osu.Game.Input.Bindings
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDecreaseDistanceSpacing))]
         EditorDecreaseDistanceSpacing,
 
-        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectPreviousGroup))]
-        SelectPreviousGroup,
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ActivatePreviousSet))]
+        ActivatePreviousSet,
 
-        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectNextGroup))]
-        SelectNextGroup,
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ActivateNextSet))]
+        ActivateNextSet,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.DeselectAllMods))]
         DeselectAllMods,

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -130,14 +130,14 @@ namespace osu.Game.Localisation
         public static LocalisableString SelectNext => new TranslatableString(getKey(@"select_next"), @"Next selection");
 
         /// <summary>
-        /// "Select previous group"
+        /// "Activate previous set"
         /// </summary>
-        public static LocalisableString SelectPreviousGroup => new TranslatableString(getKey(@"select_previous_group"), @"Select previous group");
+        public static LocalisableString ActivatePreviousSet => new TranslatableString(getKey(@"activate_previous_set"), @"Activate previous set");
 
         /// <summary>
-        /// "Select next group"
+        /// "Activate next set"
         /// </summary>
-        public static LocalisableString SelectNextGroup => new TranslatableString(getKey(@"select_next_group"), @"Select next group");
+        public static LocalisableString ActivateNextSet => new TranslatableString(getKey(@"activate_next_set"), @"Activate next set");
 
         /// <summary>
         /// "Home"

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -701,13 +701,13 @@ namespace osu.Game.Screens.Select
             switch (e.Action)
             {
                 case GlobalAction.SelectNext:
-                case GlobalAction.SelectNextGroup:
-                    SelectNext(1, e.Action == GlobalAction.SelectNextGroup);
+                case GlobalAction.ActivateNextSet:
+                    SelectNext(1, e.Action == GlobalAction.ActivateNextSet);
                     return true;
 
                 case GlobalAction.SelectPrevious:
-                case GlobalAction.SelectPreviousGroup:
-                    SelectNext(-1, e.Action == GlobalAction.SelectPreviousGroup);
+                case GlobalAction.ActivatePreviousSet:
+                    SelectNext(-1, e.Action == GlobalAction.ActivatePreviousSet);
                     return true;
             }
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -339,7 +339,7 @@ namespace osu.Game.Screens.SelectV2
             RequestRecommendedSelection(beatmaps);
         }
 
-        protected override bool CheckValidForGroupSelection(CarouselItem item)
+        protected override bool CheckValidForSetSelection(CarouselItem item)
         {
             switch (item.Model)
             {


### PR DESCRIPTION
Prerequisite for adding new hotkeys for (actual) group traversal.

PRing this initially to get the headache portion out of the way (can check upcoming changes on https://github.com/ppy/osu/compare/master...peppy:osu:ssv2-group-key-bindings?expand=1)

There are no functional changes here, just renaming.