### PR TITLE
Remove button for displaying deleted comments

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneCommentsContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneCommentsContainer.cs
@@ -141,19 +141,20 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestPost()
         {
+            const string written_text = "comm";
+
             setUpCommentsResponse(new CommentBundle { Comments = new List<Comment>() });
             AddStep("show comments", () => commentsContainer.ShowComments(CommentableType.Beatmapset, 123));
             AddAssert("no comments placeholder shown", () => commentsContainer.ChildrenOfType<CommentsContainer.NoCommentsPlaceholder>().Any());
 
             setUpPostResponse();
-            AddStep("enter text", () => editorTextBox.Current.Value = "comm");
+            AddStep("enter text", () => editorTextBox.Current.Value = written_text);
             AddStep("submit", () => commentsContainer.ChildrenOfType<RoundedButton>().First().TriggerClick());
 
             AddUntilStep("comment sent", () =>
             {
-                string writtenText = editorTextBox.Current.Value;
                 var comment = commentsContainer.ChildrenOfType<DrawableComment>().LastOrDefault();
-                return comment != null && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == writtenText);
+                return comment != null && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == written_text);
             });
             AddAssert("no comments placeholder removed", () => !commentsContainer.ChildrenOfType<CommentsContainer.NoCommentsPlaceholder>().Any());
         }
@@ -161,38 +162,40 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestPostWithExistingComments()
         {
+            const string written_text = "comm";
+
             setUpCommentsResponse(getExampleComments());
             AddStep("show comments", () => commentsContainer.ShowComments(CommentableType.Beatmapset, 123));
             AddUntilStep("comments shown", () => commentsContainer.ChildrenOfType<DrawableComment>().Any());
 
             setUpPostResponse();
-            AddStep("enter text", () => editorTextBox.Current.Value = "comm");
+            AddStep("enter text", () => editorTextBox.Current.Value = written_text);
             AddStep("submit", () => commentsContainer.ChildrenOfType<CommentEditor>().Single().ChildrenOfType<RoundedButton>().First().TriggerClick());
 
             AddUntilStep("comment sent", () =>
             {
-                string writtenText = editorTextBox.Current.Value;
                 var comment = commentsContainer.ChildrenOfType<DrawableComment>().LastOrDefault();
-                return comment != null && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == writtenText);
+                return comment != null && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == written_text);
             });
         }
 
         [Test]
         public void TestPostAsOwner()
         {
+            const string written_text = "comm";
+
             setUpCommentsResponse(getExampleComments());
             AddStep("show comments", () => commentsContainer.ShowComments(CommentableType.Beatmapset, 123));
             AddUntilStep("comments shown", () => commentsContainer.ChildrenOfType<DrawableComment>().Any());
 
             setUpPostResponse(true);
-            AddStep("enter text", () => editorTextBox.Current.Value = "comm");
+            AddStep("enter text", () => editorTextBox.Current.Value = written_text);
             AddStep("submit", () => commentsContainer.ChildrenOfType<CommentEditor>().Single().ChildrenOfType<RoundedButton>().First().TriggerClick());
 
             AddUntilStep("comment sent", () =>
             {
-                string writtenText = editorTextBox.Current.Value;
                 var comment = commentsContainer.ChildrenOfType<DrawableComment>().LastOrDefault();
-                return comment != null && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == writtenText) && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == "MAPPER");
+                return comment != null && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == written_text) && comment.ChildrenOfType<SpriteText>().Any(y => y.Text == "MAPPER");
             });
         }
 

--- a/osu.Game/Overlays/Comments/CommentsContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentsContainer.cs
@@ -52,10 +52,12 @@ namespace osu.Game.Overlays.Comments
         private FillFlowContainer pinnedContent;
         private NewCommentEditor newCommentEditor;
         private FillFlowContainer content;
-        private DeletedCommentsCounter deletedCommentsCounter;
+
         private CommentsShowMoreButton moreButton;
         private TotalCommentsCounter commentCounter;
         private UpdateableAvatar avatar;
+
+        // private DeletedCommentsCounter deletedCommentsCounter;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -149,15 +151,16 @@ namespace osu.Game.Overlays.Comments
                                     Margin = new MarginPadding { Bottom = 20 },
                                     Children = new Drawable[]
                                     {
-                                        deletedCommentsCounter = new DeletedCommentsCounter
-                                        {
-                                            ShowDeleted = { BindTarget = ShowDeleted },
-                                            Margin = new MarginPadding
-                                            {
-                                                Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING,
-                                                Vertical = 10
-                                            }
-                                        },
+                                        // TODO: This should eventually be visible for moderators.
+                                        // deletedCommentsCounter = new DeletedCommentsCounter
+                                        // {
+                                        //     ShowDeleted = { BindTarget = ShowDeleted },
+                                        //     Margin = new MarginPadding
+                                        //     {
+                                        //         Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING,
+                                        //         Vertical = 10
+                                        //     }
+                                        // },
                                         new Container
                                         {
                                             AutoSizeAxes = Axes.Y,
@@ -231,7 +234,7 @@ namespace osu.Game.Overlays.Comments
         protected void ClearComments()
         {
             currentPage = 1;
-            deletedCommentsCounter.Count.Value = 0;
+            // deletedCommentsCounter.Count.Value = 0;
             moreButton.Show();
             moreButton.IsLoading = true;
             pinnedContent.Clear();
@@ -244,7 +247,8 @@ namespace osu.Game.Overlays.Comments
         protected void OnSuccess(CommentBundle response)
         {
             commentCounter.Current.Value = response.Total;
-            newCommentEditor.CommentableMeta.Value = response.CommentableMeta.SingleOrDefault(m => m.Id == id.Value && string.Equals(m.Type, type.Value.ToString().ToSnakeCase(), StringComparison.OrdinalIgnoreCase));
+            newCommentEditor.CommentableMeta.Value =
+                response.CommentableMeta.SingleOrDefault(m => m.Id == id.Value && string.Equals(m.Type, type.Value.ToString().ToSnakeCase(), StringComparison.OrdinalIgnoreCase));
 
             if (!response.Comments.Any())
             {
@@ -284,7 +288,7 @@ namespace osu.Game.Overlays.Comments
                 {
                     pinnedContent.AddRange(loaded.Where(d => d.Comment.Pinned));
                     content.AddRange(loaded.Where(d => !d.Comment.Pinned));
-                    deletedCommentsCounter.Count.Value += topLevelComments.Select(d => d.Comment).Count(c => c.IsDeleted && c.IsTopLevel);
+                    // deletedCommentsCounter.Count.Value += topLevelComments.Select(d => d.Comment).Count(c => c.IsDeleted && c.IsTopLevel);
 
                     if (bundle.HasMore)
                     {

--- a/osu.Game/Overlays/Comments/CommentsHeader.cs
+++ b/osu.Game/Overlays/Comments/CommentsHeader.cs
@@ -50,12 +50,13 @@ namespace osu.Game.Overlays.Comments
                             Origin = Anchor.CentreLeft,
                             Current = Sort
                         },
-                        new ShowDeletedButton
-                        {
-                            Anchor = Anchor.CentreRight,
-                            Origin = Anchor.CentreRight,
-                            Checked = { BindTarget = ShowDeleted }
-                        }
+                        // TODO: This should eventually be visible for moderators.
+                        // new ShowDeletedButton
+                        // {
+                        //     Anchor = Anchor.CentreRight,
+                        //     Origin = Anchor.CentreRight,
+                        //     Checked = { BindTarget = ShowDeleted }
+                        // }
                     }
                 }
             });

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -69,12 +69,13 @@ namespace osu.Game.Overlays.Comments
         private ChevronButton chevronButton = null!;
         private LinkFlowContainer actionsContainer = null!;
         private LoadingSpinner actionsLoading = null!;
-        private DeletedCommentsCounter deletedCommentsCounter = null!;
         private CommentAuthorLine author = null!;
         private GridContainer content = null!;
         private VotePill votePill = null!;
         private Container<CommentEditor> replyEditorContainer = null!;
         private Container repliesButtonContainer = null!;
+
+        // private DeletedCommentsCounter deletedCommentsCounter = null!;
 
         [Resolved]
         private IDialogOverlay? dialogOverlay { get; set; }
@@ -258,14 +259,15 @@ namespace osu.Game.Overlays.Comments
                                         AutoSizeAxes = Axes.Y,
                                         Direction = FillDirection.Vertical
                                     },
-                                    deletedCommentsCounter = new DeletedCommentsCounter
-                                    {
-                                        ShowDeleted = { BindTarget = ShowDeleted },
-                                        Margin = new MarginPadding
-                                        {
-                                            Top = 10
-                                        }
-                                    },
+                                    // TODO: This should eventually be visible for moderators.
+                                    // deletedCommentsCounter = new DeletedCommentsCounter
+                                    // {
+                                    //     ShowDeleted = { BindTarget = ShowDeleted },
+                                    //     Margin = new MarginPadding
+                                    //     {
+                                    //         Top = 10
+                                    //     }
+                                    // },
                                     showMoreButton = new ShowMoreRepliesButton
                                     {
                                         Action = () => RepliesRequested(this, ++currentPage)
@@ -477,7 +479,7 @@ namespace osu.Game.Overlays.Comments
 
             var newReplies = replies.Select(reply => reply.Comment);
             newReplies.ForEach(reply => loadedReplies.Add(reply.Id, reply));
-            deletedCommentsCounter.Count.Value += newReplies.Count(reply => reply.IsDeleted);
+            // deletedCommentsCounter.Count.Value += newReplies.Count(reply => reply.IsDeleted);
             updateButtonsState();
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33068

I was initially going to limit this to moderators in a similar manner to web, but we don't have any existing moderator-only features yet, and only having this wouldn't be of much point.

If desired, I can go the other way around and at least accompany this toggle with the ability to delete other comments.