### PR TITLE
Fix user profile overlay performing API requests on off-screen sections

### DIFF
--- a/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
@@ -12,29 +12,29 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetUserScoresRequest : PaginatedAPIRequest<List<SoloScoreInfo>>
     {
-        private readonly long userId;
-        private readonly ScoreType type;
-        private readonly RulesetInfo ruleset;
+        public readonly long UserId;
+        public readonly ScoreType Type;
+        public readonly RulesetInfo Ruleset;
 
         public GetUserScoresRequest(long userId, ScoreType type, PaginationParameters pagination, RulesetInfo ruleset = null)
             : base(pagination)
         {
-            this.userId = userId;
-            this.type = type;
-            this.ruleset = ruleset;
+            UserId = userId;
+            Type = type;
+            Ruleset = ruleset;
         }
 
         protected override WebRequest CreateWebRequest()
         {
             var req = base.CreateWebRequest();
 
-            if (ruleset != null)
-                req.AddParameter("mode", ruleset.ShortName);
+            if (Ruleset != null)
+                req.AddParameter("mode", Ruleset.ShortName);
 
             return req;
         }
 
-        protected override string Target => $@"users/{userId}/scores/{type.ToString().ToLowerInvariant()}";
+        protected override string Target => $@"users/{UserId}/scores/{Type.ToString().ToLowerInvariant()}";
     }
 
     public enum ScoreType


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33636

I considered wrapping the entire section/subsection with `DelayedLoadUnloadWrapper`, but one major problem is that it will reset the number of extra panels the user may have displayed via the `Show More` button, as the entire subsection will be reconstructed when scrolling away then back into position.

Alternatively, since the only desire here is to delay API requests until the section is on screen, I've went with having an "indicator" component which signals when the section is on-screen, and delay initial API requests until that signal is triggered.

https://github.com/user-attachments/assets/0bd3b5bd-273c-475f-8f79-7cd582163f12


