### PR TITLE
Add support for rank change SFX to `LegacyRankDisplay`

### DIFF
--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -8,6 +8,8 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Scoring;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Skinning;
 using osu.Game.Users;
 
 namespace osu.Game.Configuration
@@ -25,6 +27,7 @@ namespace osu.Game.Configuration
             SetDefault(Static.FeaturedArtistDisclaimerShownOnce, false);
             SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null);
             SetDefault(Static.LastModSelectPanelSamplePlaybackTime, (double?)null);
+            SetDefault(Static.LastRankChangeSamplePlaybackTime, (double?)null);
             SetDefault<APISeasonalBackgrounds?>(Static.SeasonalBackgrounds, null);
             SetDefault(Static.TouchInputActive, RuntimeInfo.IsMobile);
             SetDefault<ScoreInfo?>(Static.LastLocalUserScore, null);
@@ -71,6 +74,12 @@ namespace osu.Game.Configuration
         /// Used to debounce <see cref="ModSelectPanel"/> on/off sounds game-wide to avoid volume saturation, especially in activating mod presets with many mods.
         /// </summary>
         LastModSelectPanelSamplePlaybackTime,
+
+        /// <summary>
+        /// The last playback time in milliseconds of a rank up/down sample (in <see cref="DefaultRankDisplay"/> and <see cref="LegacyRankDisplay"/>).
+        /// Used to debounce rank change sounds game-wide to avoid potential volume saturation from multiple simultaneous playback.
+        /// </summary>
+        LastRankChangeSamplePlaybackTime,
 
         /// <summary>
         /// Whether the last positional input received was a touch input.

--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -76,6 +76,8 @@ namespace osu.Game.Screens.Play.HUD
                         rankUpSample.Play();
                     else
                         rankDownSample.Play();
+
+                    lastSamplePlaybackTime.Value = Time.Current;
                 }
 
                 rankDisplay.Rank = r.NewValue;

--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Screens.Play.HUD
         private SkinnableSound rankDownSample = null!;
         private SkinnableSound rankUpSample = null!;
 
+        private Bindable<double?> lastSamplePlaybackTime = null!;
+
         private IBindable<ScoreRank> rank = null!;
 
         public DefaultRankDisplay()
@@ -40,7 +42,7 @@ namespace osu.Game.Screens.Play.HUD
         }
 
         [BackgroundDependencyLoader]
-        private void load(SkinEditor? skinEditor)
+        private void load(SkinEditor? skinEditor, SessionStatics statics)
         {
             InternalChildren = new Drawable[]
             {
@@ -54,6 +56,8 @@ namespace osu.Game.Screens.Play.HUD
 
             if (skinEditor != null)
                 PlaySamples.Value = false;
+
+            lastSamplePlaybackTime = statics.GetBindable<double?>(Static.LastRankChangeSamplePlaybackTime);
         }
 
         protected override void LoadComplete()
@@ -63,8 +67,10 @@ namespace osu.Game.Screens.Play.HUD
             rank = scoreProcessor.Rank.GetBoundCopy();
             rank.BindValueChanged(r =>
             {
+                bool enoughTimeElapsed = !lastSamplePlaybackTime.Value.HasValue || Time.Current - lastSamplePlaybackTime.Value >= OsuGameBase.SAMPLE_DEBOUNCE_TIME;
+
                 // Don't play rank-down sfx on quit/retry
-                if (r.NewValue != r.OldValue && r.NewValue > ScoreRank.F && PlaySamples.Value)
+                if (r.NewValue != r.OldValue && r.NewValue > ScoreRank.F && PlaySamples.Value && enoughTimeElapsed)
                 {
                     if (r.NewValue > rankDisplay.Rank)
                         rankUpSample.Play();


### PR DESCRIPTION
Closes #33359.

- Adds support for rank up/down sample playback in `LegacyRankDisplay`.
- Adds debouncing to fix multiple rank display components all triggering sounds simultaneously, resulting in a summed volume increase.