### PR TITLE
Use `IDisposable` flow for common logo tracking/proxy operations for better robustness

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLogoTrackingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLogoTrackingContainer.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -27,6 +28,9 @@ namespace osu.Game.Tests.Visual.UserInterface
         private Box transferContainerBox;
         private Drawable logoFacade;
         private bool randomPositions;
+
+        [CanBeNull]
+        private IDisposable logoTracking;
 
         private const float visual_box_size = 72;
 
@@ -150,14 +154,15 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("Perform logo movements", () =>
             {
-                trackingContainer.StopTracking();
+                logoTracking?.Dispose();
+
                 logo.MoveTo(new Vector2(0.5f), 500, Easing.InOutExpo);
 
                 visualBox.Colour = Color4.White;
 
                 Scheduler.AddDelayed(() =>
                 {
-                    trackingContainer.StartTracking(logo, 1000, Easing.InOutExpo);
+                    logoTracking = trackingContainer.StartTracking(logo, 1000, Easing.InOutExpo);
                     visualBox.Colour = Color4.Tomato;
                 }, 700);
             });

--- a/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
+++ b/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Graphics.Containers
                 throw new InvalidOperationException($"Cannot track an instance of {typeof(OsuLogo)} to multiple {typeof(LogoTrackingContainer)}s");
 
             if (logo.IsTracking)
-                throw new InvalidOperationException($"A previous tracking operation is still active. Dispose of its return value before starting a new tracking operation.");
+                throw new InvalidOperationException("A previous tracking operation is still active. Dispose of its return value before starting a new tracking operation.");
 
             Logo = logo;
             Logo.IsTracking = true;

--- a/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
+++ b/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
@@ -32,7 +34,7 @@ namespace osu.Game.Graphics.Containers
         /// <param name="logo">The instance of the logo to be used for tracking.</param>
         /// <param name="duration">The duration of the initial transform. Default is instant.</param>
         /// <param name="easing">The easing type of the initial transform.</param>
-        public void StartTracking(OsuLogo logo, double duration = 0, Easing easing = Easing.None)
+        public IDisposable StartTracking(OsuLogo logo, double duration = 0, Easing easing = Easing.None)
         {
             if (Logo != null && Logo != logo)
                 throw new InvalidOperationException("A different logo is already being tracked.");
@@ -50,19 +52,21 @@ namespace osu.Game.Graphics.Containers
 
             startTime = null;
             startPosition = null;
+
+            return new InvokeOnDisposal(stopTracking);
+
+            void stopTracking()
+            {
+                Debug.Assert(Logo != null);
+
+                Logo.IsTracking = false;
+                Logo = null;
+            }
         }
 
         /// <summary>
         /// Stops the logo assigned in <see cref="StartTracking"/> from tracking the facade's position.
         /// </summary>
-        public void StopTracking()
-        {
-            if (Logo == null) return;
-
-            Logo.IsTracking = false;
-            Logo = null;
-        }
-
         /// <summary>
         /// Gets the position that the logo should move to with respect to the <see cref="LogoFacade"/>.
         /// Manually performs a conversion of the Facade's position to the Logo's parent's relative space.

--- a/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
+++ b/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
@@ -65,9 +65,6 @@ namespace osu.Game.Graphics.Containers
         }
 
         /// <summary>
-        /// Stops the logo assigned in <see cref="StartTracking"/> from tracking the facade's position.
-        /// </summary>
-        /// <summary>
         /// Gets the position that the logo should move to with respect to the <see cref="LogoFacade"/>.
         /// Manually performs a conversion of the Facade's position to the Logo's parent's relative space.
         /// </summary>

--- a/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
+++ b/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
@@ -44,6 +44,9 @@ namespace osu.Game.Graphics.Containers
             if (logo.IsTracking && Logo == null)
                 throw new InvalidOperationException($"Cannot track an instance of {typeof(OsuLogo)} to multiple {typeof(LogoTrackingContainer)}s");
 
+            if (logo.IsTracking)
+                throw new InvalidOperationException($"A previous tracking operation is still active. Dispose of its return value before starting a new tracking operation.");
+
             Logo = logo;
             Logo.IsTracking = true;
 

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -48,7 +48,9 @@ namespace osu.Game.Screens.Footer
         private FillFlowContainer<ScreenFooterButton> buttonsFlow = null!;
         private Container footerContentContainer = null!;
         private Container<ScreenFooterButton> hiddenButtonsContainer = null!;
+
         private LogoTrackingContainer logoTrackingContainer = null!;
+        private IDisposable? logoTracking;
 
         // TODO: This has some weird update logic local in this class, but it only works for overlay containers.
         // This is not what we want. The footer is to be displayed on *screens* with different colour schemes.
@@ -145,13 +147,14 @@ namespace osu.Game.Screens.Footer
             changeLogoDepthDelegate?.Cancel();
             changeLogoDepthDelegate = null;
 
-            logoTrackingContainer.StartTracking(logo, duration, easing);
+            logoTracking = logoTrackingContainer.StartTracking(logo, duration, easing);
             RequestLogoInFront?.Invoke(true);
         }
 
         public void StopTrackingLogo()
         {
-            logoTrackingContainer.StopTracking();
+            logoTracking?.Dispose();
+            logoTracking = null;
 
             changeLogoDepthDelegate = Scheduler.AddDelayed(() => RequestLogoInFront?.Invoke(false), transition_duration);
         }

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -432,6 +432,7 @@ namespace osu.Game.Screens.Menu
 
                             logo.ScaleTo(0.5f, 200, Easing.In);
 
+                            logoTracking?.Dispose();
                             logoTracking = logoTrackingContainer.StartTracking(logo, 200, Easing.In);
 
                             logoDelayedAction?.Cancel();
@@ -446,7 +447,10 @@ namespace osu.Game.Screens.Menu
 
                         default:
                             logo.ClearTransforms(targetMember: nameof(Position));
-                            logoTrackingContainer.StartTracking(logo, 0, Easing.In);
+
+                            logoTracking?.Dispose();
+                            logoTracking = logoTrackingContainer.StartTracking(logo, 0, Easing.In);
+
                             logo.ScaleTo(0.5f, 200, Easing.OutQuint);
                             break;
                     }
@@ -454,6 +458,7 @@ namespace osu.Game.Screens.Menu
                     break;
 
                 case ButtonSystemState.EnteringMode:
+                    logoTracking?.Dispose();
                     logoTracking = logoTrackingContainer.StartTracking(logo, lastState == ButtonSystemState.Initial ? MainMenu.FADE_OUT_DURATION : 0, Easing.InSine);
                     break;
             }

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -73,7 +73,8 @@ namespace osu.Game.Screens.Menu
             else
             {
                 // We should stop tracking as the facade is now out of scope.
-                logoTrackingContainer.StopTracking();
+                logoTracking?.Dispose();
+                logoTracking = null;
             }
         }
 
@@ -390,6 +391,7 @@ namespace osu.Game.Screens.Menu
         }
 
         private ScheduledDelegate? logoDelayedAction;
+        private IDisposable? logoTracking;
 
         private void updateLogoState(ButtonSystemState lastState = ButtonSystemState.Initial)
         {
@@ -402,7 +404,8 @@ namespace osu.Game.Screens.Menu
                     logoDelayedAction?.Cancel();
                     logoDelayedAction = Scheduler.AddDelayed(() =>
                     {
-                        logoTrackingContainer.StopTracking();
+                        logoTracking?.Dispose();
+                        logoTracking = null;
 
                         game?.Toolbar.Hide();
 
@@ -429,7 +432,7 @@ namespace osu.Game.Screens.Menu
 
                             logo.ScaleTo(0.5f, 200, Easing.In);
 
-                            logoTrackingContainer.StartTracking(logo, 200, Easing.In);
+                            logoTracking = logoTrackingContainer.StartTracking(logo, 200, Easing.In);
 
                             logoDelayedAction?.Cancel();
                             logoDelayedAction = Scheduler.AddDelayed(() =>
@@ -451,7 +454,7 @@ namespace osu.Game.Screens.Menu
                     break;
 
                 case ButtonSystemState.EnteringMode:
-                    logoTrackingContainer.StartTracking(logo, lastState == ButtonSystemState.Initial ? MainMenu.FADE_OUT_DURATION : 0, Easing.InSine);
+                    logoTracking = logoTrackingContainer.StartTracking(logo, lastState == ButtonSystemState.Initial ? MainMenu.FADE_OUT_DURATION : 0, Easing.InSine);
                     break;
             }
         }

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Screens.Menu
             logo.FadeColour(Color4.White, 100, Easing.OutQuint);
             logo.FadeIn(100, Easing.OutQuint);
 
-            logo.ProxyToContainer(logoTarget);
+            logoProxy = logo.ProxyToContainer(logoTarget);
 
             if (resuming)
             {
@@ -350,7 +350,8 @@ namespace osu.Game.Screens.Menu
             var seq = logo.FadeOut(300, Easing.InSine)
                           .ScaleTo(0.2f, 300, Easing.InSine);
 
-            logo.ReturnProxy();
+            logoProxy?.Dispose();
+            logoProxy = null;
 
             seq.OnComplete(_ => Buttons.SetOsuLogo(null));
             seq.OnAbort(_ => Buttons.SetOsuLogo(null));
@@ -360,7 +361,8 @@ namespace osu.Game.Screens.Menu
         {
             base.LogoExiting(logo);
 
-            logo.ReturnProxy();
+            logoProxy?.Dispose();
+            logoProxy = null;
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)
@@ -495,6 +497,9 @@ namespace osu.Game.Screens.Menu
         private bool ssv2Expanded;
         private IDisposable ssv2Duck;
         private Sample ssv2Sample;
+
+        [CanBeNull]
+        private IDisposable logoProxy;
 
         private void loadPreferredSongSelect()
         {

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -472,7 +473,7 @@ namespace osu.Game.Screens.Menu
 
         public void StopSamplePlayback() => sampleClickChannel?.Stop();
 
-        public Drawable ProxyToContainer(Container c)
+        public IDisposable ProxyToContainer(Container c)
         {
             if (currentProxyTarget != null)
                 throw new InvalidOperationException("Previous proxy usage was not returned");
@@ -484,21 +485,19 @@ namespace osu.Game.Screens.Menu
 
             defaultProxyTarget.Remove(proxy, false);
             currentProxyTarget.Add(proxy);
-            return proxy;
-        }
 
-        public void ReturnProxy()
-        {
-            if (currentProxyTarget == null)
-                throw new InvalidOperationException("No usage to return");
+            return new InvokeOnDisposal(returnProxy);
 
-            if (defaultProxyTarget == null)
-                throw new InvalidOperationException($"{nameof(SetupDefaultContainer)} must be called first");
+            void returnProxy()
+            {
+                Debug.Assert(currentProxyTarget != null);
+                Debug.Assert(defaultProxyTarget != null);
 
-            currentProxyTarget.Remove(proxy, false);
-            currentProxyTarget = null;
+                currentProxyTarget.Remove(proxy, false);
+                currentProxyTarget = null;
 
-            defaultProxyTarget.Add(proxy);
+                defaultProxyTarget.Add(proxy);
+            }
         }
 
         public void SetupDefaultContainer(Container container)

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -144,6 +144,7 @@ namespace osu.Game.Screens.Play
         private bool playerConsumed;
 
         private LogoTrackingContainer content = null!;
+        private IDisposable? logoTracking;
 
         private bool hideOverlays;
 
@@ -379,21 +380,26 @@ namespace osu.Game.Screens.Play
             Scheduler.AddDelayed(() =>
             {
                 if (this.IsCurrentScreen())
-                    content.StartTracking(logo, resuming ? 0 : 500, Easing.InOutExpo);
+                    logoTracking = content.StartTracking(logo, resuming ? 0 : 500, Easing.InOutExpo);
             }, resuming ? 0 : 250);
         }
 
         protected override void LogoExiting(OsuLogo logo)
         {
             base.LogoExiting(logo);
-            content.StopTracking();
+
+            logoTracking?.Dispose();
+            logoTracking = null;
+
             osuLogo = null;
         }
 
         protected override void LogoSuspending(OsuLogo logo)
         {
             base.LogoSuspending(logo);
-            content.StopTracking();
+
+            logoTracking?.Dispose();
+            logoTracking = null;
 
             logo
                 .FadeOut(CONTENT_OUT_DURATION / 2, Easing.OutQuint)
@@ -538,7 +544,8 @@ namespace osu.Game.Screens.Play
         protected virtual void ContentOut()
         {
             // Ensure the logo is no longer tracking before we scale the content
-            content.StopTracking();
+            logoTracking?.Dispose();
+            logoTracking = null;
 
             content.ScaleTo(0.7f, CONTENT_OUT_DURATION * 2, Easing.OutQuint);
             content.FadeOut(CONTENT_OUT_DURATION, Easing.OutQuint)


### PR DESCRIPTION
The root cause of the linked issue is probably related to a screen being skipped completely in the chain, as far as I recall it can bypass calling the arriving method completely and this is expected from `ScreenStack`. I'm not focusing on that here, just refactoring two methods to use the `IDisposable` flow we have come to adopt for operations like this in recent times. This has bugged me while working through song select v2 work as well.

Closes https://github.com/ppy/osu/issues/33637.