### PR TITLE
Remove fade from footer display transition

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -308,7 +308,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for join", () => RoomJoined);
 
             ClickButtonWhenEnabled<UserModSelectButton>();
-            AddAssert("mod select shows unranked", () => this.ChildrenOfType<RankingInformationDisplay>().Single().Ranked.Value == false);
+            AddUntilStep("mod select shows unranked", () => this.ChildrenOfType<RankingInformationDisplay>().Single().Ranked.Value == false);
             AddAssert("score multiplier = 1.20", () => this.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value, () => Is.EqualTo(1.2).Within(0.01));
 
             AddStep("select flashlight", () => this.ChildrenOfType<MultiplayerUserModSelectOverlay>().Single().ChildrenOfType<ModPanel>().Single(m => m.Mod is ModFlashlight).TriggerClick());

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneScreenFooter.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneScreenFooter.cs
@@ -114,11 +114,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddWaitStep("wait for transition", 3);
 
             AddStep("show overlay", () => externalOverlay.Show());
-            AddAssert("content displayed in footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().Single().IsPresent);
+            contentDisplayed();
             AddUntilStep("other buttons hidden", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.Child.Parent!.Y > 0));
 
             AddStep("hide overlay", () => externalOverlay.Hide());
-            AddUntilStep("content hidden from footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().SingleOrDefault()?.IsPresent != true);
+            contentHidden();
             AddUntilStep("other buttons returned", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.ChildrenOfType<Container>().First().Y == 0));
         }
 
@@ -133,11 +133,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("add external overlay", () => contentContainer.Add(externalOverlay = new TestShearedOverlayContainer()));
             AddStep("show external overlay", () => externalOverlay.Show());
             AddAssert("footer shown", () => screenFooter.State.Value == Visibility.Visible);
-            AddAssert("content displayed in footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().Single().IsPresent);
+            contentDisplayed();
 
             AddStep("hide external overlay", () => externalOverlay.Hide());
             AddAssert("footer hidden", () => screenFooter.State.Value == Visibility.Hidden);
-            AddUntilStep("content hidden from footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().SingleOrDefault()?.IsPresent != true);
+            contentHidden();
 
             AddStep("show footer", () => screenFooter.Show());
             AddAssert("content still hidden from footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().SingleOrDefault()?.IsPresent != true);
@@ -216,15 +216,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddWaitStep("wait for transition", 3);
 
             AddStep("show overlay", () => externalOverlay.Show());
-            AddAssert("content displayed in footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().Single().IsPresent);
+            contentDisplayed();
             AddUntilStep("other buttons hidden", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.Child.Parent!.Y > 0));
 
             AddStep("resize active button", () => this.ChildrenOfType<ScreenFooterButton>().First().ResizeWidthTo(240, 300, Easing.OutQuint));
             AddStep("resize active button back", () => this.ChildrenOfType<ScreenFooterButton>().First().ResizeWidthTo(116, 300, Easing.OutQuint));
 
             AddStep("hide overlay", () => externalOverlay.Hide());
-            AddUntilStep("content hidden from footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().SingleOrDefault()?.IsPresent != true);
+            contentHidden();
             AddUntilStep("other buttons returned", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.ChildrenOfType<Container>().First().Y == 0));
+        }
+
+        private void contentHidden()
+        {
+            AddUntilStep("content hidden from footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().SingleOrDefault()?.IsPresent != true);
+        }
+
+        private void contentDisplayed()
+        {
+            AddUntilStep("content displayed in footer", () => screenFooter.ChildrenOfType<TestShearedOverlayContainer.TestFooterContent>().Single().IsPresent);
         }
 
         private partial class TestShearedOverlayContainer : ShearedOverlayContainer
@@ -261,7 +271,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 [BackgroundDependencyLoader]
                 private void load()
                 {
-                    RelativeSizeAxes = Axes.Both;
+                    AutoSizeAxes = Axes.Both;
 
                     InternalChild = new FillFlowContainer
                     {

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -40,7 +40,11 @@ namespace osu.Game.Screens.Footer
 
         private const int padding = 60;
         private const float delay_per_button = 30;
-        private const double transition_duration = 400;
+        private const double transition_duration = 500;
+
+        // Disable masking because it breaks due to the height of this container being less than the displayed content.
+        // The height being set as it is is required for transition purposes.
+        public override bool UpdateSubTreeMasking() => false;
 
         private readonly List<OverlayContainer> overlays = new List<OverlayContainer>();
 
@@ -162,13 +166,14 @@ namespace osu.Game.Screens.Footer
         protected override void PopIn()
         {
             this.MoveToY(0, transition_duration, Easing.OutQuint)
-                .FadeIn(transition_duration, Easing.OutQuint);
+                .FadeIn();
         }
 
         protected override void PopOut()
         {
-            this.MoveToY(HEIGHT, transition_duration, Easing.OutQuint)
-                .FadeOut(transition_duration, Easing.OutQuint);
+            this.MoveToY(ScreenFooterButton.HEIGHT, transition_duration, Easing.OutQuint)
+                .Then()
+                .FadeOut();
         }
 
         public void SetButtons(IReadOnlyList<ScreenFooterButton> buttons)

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Footer
                             {
                                 Anchor = Anchor.BottomLeft,
                                 Origin = Anchor.BottomLeft,
-                                Y = ScreenFooterButton.Y_OFFSET,
+                                Y = ScreenFooterButton.CORNER_RADIUS,
                                 Direction = FillDirection.Horizontal,
                                 Spacing = new Vector2(7, 0),
                                 AutoSizeAxes = Axes.Both,
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Footer
                 hiddenButtonsContainer = new Container<ScreenFooterButton>
                 {
                     Margin = new MarginPadding { Left = OsuGame.SCREEN_EDGE_MARGIN + ScreenBackButton.BUTTON_WIDTH + padding },
-                    Y = ScreenFooterButton.Y_OFFSET,
+                    Y = ScreenFooterButton.CORNER_RADIUS,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     AutoSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Footer/ScreenFooterButton.cs
+++ b/osu.Game/Screens/Footer/ScreenFooterButton.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Footer
     {
         public const int CORNER_RADIUS = 10;
 
-        protected const int BUTTON_HEIGHT = 75;
+        public const int HEIGHT = 75;
         protected const int BUTTON_WIDTH = 116;
 
         public Bindable<Visibility> OverlayState = new Bindable<Visibility>();
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Footer
         {
             Overlay = overlay;
 
-            Size = new Vector2(BUTTON_WIDTH, BUTTON_HEIGHT);
+            Size = new Vector2(BUTTON_WIDTH, HEIGHT);
 
             Children = new Drawable[]
             {

--- a/osu.Game/Screens/Footer/ScreenFooterButton.cs
+++ b/osu.Game/Screens/Footer/ScreenFooterButton.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Footer
 {
     public partial class ScreenFooterButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>
     {
-        public const int Y_OFFSET = 10;
+        public const int CORNER_RADIUS = 10;
 
         protected const int BUTTON_HEIGHT = 75;
         protected const int BUTTON_WIDTH = 116;
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.Footer
                     },
                     Shear = OsuGame.SHEAR,
                     Masking = true,
-                    CornerRadius = 10,
+                    CornerRadius = CORNER_RADIUS,
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
@@ -138,7 +138,7 @@ namespace osu.Game.Screens.Footer
                             Shear = -OsuGame.SHEAR,
                             Anchor = Anchor.BottomCentre,
                             Origin = Anchor.Centre,
-                            Y = -Y_OFFSET,
+                            Y = -CORNER_RADIUS,
                             Size = new Vector2(100, 5),
                             Masking = true,
                             CornerRadius = 3,

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Screens.SelectV2
                     Depth = float.MaxValue,
                     Origin = Anchor.BottomLeft,
                     Shear = OsuGame.SHEAR,
-                    CornerRadius = Y_OFFSET,
+                    CornerRadius = CORNER_RADIUS,
                     Size = new Vector2(BUTTON_WIDTH, bar_height),
                     Masking = true,
                     EdgeEffect = new EdgeEffectParameters
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.SelectV2
                         },
                         modContainer = new Container
                         {
-                            CornerRadius = Y_OFFSET,
+                            CornerRadius = CORNER_RADIUS,
                             RelativeSizeAxes = Axes.Both,
                             Width = mod_display_portion,
                             Masking = true,
@@ -304,7 +304,7 @@ namespace osu.Game.Screens.SelectV2
                 private void load()
                 {
                     AutoSizeAxes = Axes.Both;
-                    CornerRadius = Y_OFFSET;
+                    CornerRadius = CORNER_RADIUS;
                     Masking = true;
 
                     InternalChildren = new Drawable[]
@@ -346,7 +346,7 @@ namespace osu.Game.Screens.SelectV2
                 Depth = float.MaxValue;
                 Origin = Anchor.BottomLeft;
                 Shear = OsuGame.SHEAR;
-                CornerRadius = Y_OFFSET;
+                CornerRadius = CORNER_RADIUS;
                 AutoSizeAxes = Axes.X;
                 Height = bar_height;
                 Masking = true;


### PR DESCRIPTION
Fades should not be used for these kinds of elements. The opacity changes of multiple elements looks shocking. It's unnecessary.

Before:

https://github.com/user-attachments/assets/943a189d-a1e5-414e-9190-223f77965525

After:

https://github.com/user-attachments/assets/35a373cd-5368-4ecb-9b6d-63273010b9ea

