### PR TITLE
Pick better initial beatmap status when submitting

### DIFF
--- a/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
+++ b/osu.Game/Screens/Edit/Submission/BeatmapSubmissionScreen.cs
@@ -191,6 +191,13 @@ namespace osu.Game.Screens.Edit.Submission
             });
 
             completedSample = audio.Samples.Get(@"UI/bss-complete");
+
+            if (Beatmap.Value.BeatmapSetInfo.OnlineID > 0)
+            {
+                var req = new GetBeatmapSetRequest(Beatmap.Value.BeatmapSetInfo.OnlineID);
+                api.Queue(req);
+                settings.LatestOnlineStateRequest = req;
+            }
         }
 
         private void createBeatmapSet()

--- a/osu.Game/Screens/Edit/Submission/BeatmapSubmissionSettings.cs
+++ b/osu.Game/Screens/Edit/Submission/BeatmapSubmissionSettings.cs
@@ -8,6 +8,8 @@ namespace osu.Game.Screens.Edit.Submission
 {
     public class BeatmapSubmissionSettings
     {
+        public GetBeatmapSetRequest? LatestOnlineStateRequest { get; set; }
+
         public Bindable<BeatmapSubmissionTarget> Target { get; } = new Bindable<BeatmapSubmissionTarget>();
 
         public Bindable<bool> NotifyOnDiscussionReplies { get; } = new Bindable<bool>();


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/33291

This is a half-baked RFC because things are awkward.

For this to work correctly the submission flow has to do an API request, because one, the local beatmap status has been overwritten with "locally modified", and secondly, even if it *was* there, there's no guarantee that it was actually *up to date*.

And if we have to do an API request then there are two choices:

- Hard block on the API request and don't show anything until it completes which possibly means waiting at a spinner for several seconds if someone's on bad internet.

- Don't block on the API request --- but then there's no guarantee what timing the API request completes at, which means that possibly the user could change the dropdown before the API request completes, and the API request will overwrite their choice, so to prevent that block the dropdown until the request completes. This is what this commit does.