### PR TITLE
Fix carousel tests failing randomly depending on order run

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Resources
             {
                 // Create random metadata, then we can check if sorting works based on these
                 Artist = "Some Artist " + RNG.Next(0, 9),
-                Title = $"Some Song (set id {setId:000}) {Guid.NewGuid()}",
+                Title = $"Some Song (set id {setId:000000}) {Guid.NewGuid()}",
                 Author = { Username = "Some Guy " + RNG.Next(0, 9) },
             };
 


### PR DESCRIPTION
`TestTraversalBeyondStart` could fail if run headless via rider with a certain order of tests. I'm sure you can guess why 🤦‍♂️🤦🤦‍♀️.


https://github.com/user-attachments/assets/461de1e5-666b-4cbd-996c-19459cbe6af1

