### PR TITLE
Ensure filtering is always waited on after a sort/filter change in tests

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -334,8 +334,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         /// <param name="randomMetadata">Whether to randomise the metadata to make groupings more uniform.</param>
         protected void AddBeatmaps(int count, int? fixedDifficultiesPerSet = null, bool randomMetadata = false) => AddStep($"add {count} beatmaps{(randomMetadata ? " with random data" : "")}", () =>
         {
+            var beatmaps = new List<BeatmapSetInfo>();
+
             for (int i = 0; i < count; i++)
-                BeatmapSets.Add(CreateTestBeatmapSetInfo(fixedDifficultiesPerSet, randomMetadata));
+                beatmaps.Add(CreateTestBeatmapSetInfo(fixedDifficultiesPerSet, randomMetadata));
+
+            BeatmapSets.AddRange(beatmaps);
         });
 
         protected static BeatmapSetInfo CreateTestBeatmapSetInfo(int? fixedDifficultiesPerSet, bool randomMetadata)

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -150,26 +150,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     },
                 };
 
-                Carousel.Filter(new FilterCriteria());
+                // Prefer title sorting so that order of carousel panels match order of BeatmapSets bindable.
+                Carousel.Filter(new FilterCriteria { Sort = SortMode.Title });
             });
-
-            // Prefer title sorting so that order of carousel panels match order of BeatmapSets bindable.
-            SortBy(SortMode.Title);
         }
 
-        protected void SortBy(SortMode mode) => ApplyToFilter($"sort by {mode.GetDescription().ToLowerInvariant()}", c => c.Sort = mode);
-        protected void GroupBy(GroupMode mode) => ApplyToFilter($"group by {mode.GetDescription().ToLowerInvariant()}", c => c.Group = mode);
+        protected void SortBy(SortMode mode) => ApplyToFilterAndWaitForFilter($"sort by {mode.GetDescription().ToLowerInvariant()}", c => c.Sort = mode);
+
+        protected void GroupBy(GroupMode mode) => ApplyToFilterAndWaitForFilter($"group by {mode.GetDescription().ToLowerInvariant()}", c => c.Group = mode);
 
         protected void SortAndGroupBy(SortMode sort, GroupMode group)
         {
-            ApplyToFilter($"sort by {sort.GetDescription().ToLowerInvariant()} & group by {group.GetDescription().ToLowerInvariant()}", c =>
+            ApplyToFilterAndWaitForFilter($"sort by {sort.GetDescription().ToLowerInvariant()} & group by {group.GetDescription().ToLowerInvariant()}", c =>
             {
                 c.Sort = sort;
                 c.Group = group;
             });
         }
 
-        protected void ApplyToFilter(string description, Action<FilterCriteria>? apply)
+        protected void ApplyToFilterAndWaitForFilter(string description, Action<FilterCriteria>? apply)
         {
             AddStep(description, () =>
             {
@@ -177,6 +176,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 apply?.Invoke(criteria);
                 Carousel.Filter(criteria);
             });
+
+            WaitForFiltering();
         }
 
         protected void WaitForDrawablePanels() => AddUntilStep("drawable panels loaded", () => Carousel.ChildrenOfType<ICarouselPanel>().Count(), () => Is.GreaterThan(0));

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -273,16 +273,16 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         protected void WaitForSetSelection(int set, int? diff = null)
         {
-            AddUntilStep($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
+            if (diff != null)
             {
-                if (diff != null)
-                {
-                    return (Carousel.CurrentSelection as BeatmapInfo)?
-                        .Equals(BeatmapSets[set].Beatmaps[diff.Value]) == true;
-                }
-
-                return BeatmapSets[set].Beatmaps.Contains(Carousel.CurrentSelection);
-            });
+                AddUntilStep($"selected is set{set} diff{diff.Value}",
+                    () => (Carousel.CurrentSelection as BeatmapInfo),
+                    () => Is.EqualTo(BeatmapSets[set].Beatmaps[diff.Value]));
+            }
+            else
+            {
+                AddUntilStep($"selected is set{set}", () => BeatmapSets[set].Beatmaps.Contains(Carousel.CurrentSelection));
+            }
         }
 
         protected IEnumerable<T> GetVisiblePanels<T>()

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -217,8 +217,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestBasicFiltering()
         {
-            ApplyToFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
 
             CheckDisplayedGroupsCount(1);
             CheckDisplayedBeatmapSetsCount(1);
@@ -237,8 +236,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForBeatmapSelection(0, 3);
 
-            ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
 
             CheckDisplayedGroupsCount(5);
             CheckDisplayedBeatmapSetsCount(10);

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -196,8 +196,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestBasicFiltering()
         {
-            ApplyToFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
 
             CheckDisplayedGroupsCount(3);
             CheckDisplayedBeatmapsCount(3);
@@ -218,8 +217,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForBeatmapSelection(1, 0);
 
-            ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
 
             CheckDisplayedGroupsCount(3);
             CheckDisplayedBeatmapsCount(30);
@@ -240,7 +238,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("expanded group is first", () => (Carousel.ExpandedGroup as StarDifficultyGroupDefinition)?.Difficulty.Stars, () => Is.EqualTo(0));
 
             // doesn't actually filter anything away, but triggers a filter.
-            ApplyToFilter("filter", c => c.SearchText = "Some");
+            ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = "Some");
 
             AddAssert("expanded group is still first", () => (Carousel.ExpandedGroup as StarDifficultyGroupDefinition)?.Difficulty.Stars, () => Is.EqualTo(0));
         }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -36,8 +36,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddAssert("invocation count correct", () => NewItemsPresentedInvocationCount, () => Is.EqualTo(1));
 
-            ApplyToFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);
 
             AddAssert("invocation count correct", () => NewItemsPresentedInvocationCount, () => Is.EqualTo(2));
 
@@ -52,8 +51,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             Select();
             WaitForSetSelection(2, 1);
 
-            ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
 
             AddAssert("invocation count correct", () => NewItemsPresentedInvocationCount, () => Is.EqualTo(3));
 
@@ -84,46 +82,39 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForDrawablePanels();
 
-            ApplyToFilter("filter [5..]", c =>
+            ApplyToFilterAndWaitForFilter("filter [5..]", c =>
             {
                 c.UserStarDifficulty.Min = 5;
                 c.UserStarDifficulty.Max = null;
             });
-            WaitForFiltering();
             CheckDisplayedBeatmapsCount(11);
 
-            ApplyToFilter("filter to [0..7]", c =>
+            ApplyToFilterAndWaitForFilter("filter to [0..7]", c =>
             {
                 c.UserStarDifficulty.Min = null;
                 c.UserStarDifficulty.Max = 7;
             });
-            WaitForFiltering();
             CheckDisplayedBeatmapsCount(7);
 
-            ApplyToFilter("filter to [5..7]", c =>
+            ApplyToFilterAndWaitForFilter("filter to [5..7]", c =>
             {
                 c.UserStarDifficulty.Min = 5;
                 c.UserStarDifficulty.Max = 7;
             });
-
-            WaitForFiltering();
             CheckDisplayedBeatmapsCount(3);
 
-            ApplyToFilter("filter to [2..2]", c =>
+            ApplyToFilterAndWaitForFilter("filter to [2..2]", c =>
             {
                 c.UserStarDifficulty.Min = 2;
                 c.UserStarDifficulty.Max = 2;
             });
-
-            WaitForFiltering();
             CheckDisplayedBeatmapsCount(1);
 
-            ApplyToFilter("filter to [0..]", c =>
+            ApplyToFilterAndWaitForFilter("filter to [0..]", c =>
             {
                 c.UserStarDifficulty.Min = 0;
                 c.UserStarDifficulty.Max = null;
             });
-            WaitForFiltering();
             CheckDisplayedBeatmapsCount(15);
         }
 
@@ -143,9 +134,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             for (int i = 0; i < 5; i++)
             {
-                ApplyToFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
+                ApplyToFilterAndWaitForFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
                 AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
-                ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
+                ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
                 AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
             }
         }
@@ -159,7 +150,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectPrevSet();
             WaitForSetSelection(49, 0);
 
-            ApplyToFilter("filter all but one", c => c.SearchText = BeatmapSets.First().Metadata.Title);
+            ApplyToFilterAndWaitForFilter("filter all but one", c => c.SearchText = BeatmapSets.First().Metadata.Title);
             WaitForSetSelection(0, 0);
         }
 
@@ -170,7 +161,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForDrawablePanels();
 
             CheckNoSelection();
-            ApplyToFilter("filter all but one", c => c.SearchText = BeatmapSets.First().Metadata.Title);
+            ApplyToFilterAndWaitForFilter("filter all but one", c => c.SearchText = BeatmapSets.First().Metadata.Title);
             WaitForSetSelection(0, 0);
         }
 
@@ -190,9 +181,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             for (int i = 0; i < 5; i++)
             {
-                ApplyToFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
+                ApplyToFilterAndWaitForFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
                 AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
-                ApplyToFilter("remove filter", c => c.SearchText = string.Empty);
+                ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
                 AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
             }
         }
@@ -223,10 +214,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestExternalRulesetChange()
         {
-            ApplyToFilter("allow converted beatmaps", c => c.AllowConvertedBeatmaps = true);
-            ApplyToFilter("filter to osu", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(0));
-
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("allow converted beatmaps, filter to osu", c =>
+            {
+                c.AllowConvertedBeatmaps = true;
+                c.Ruleset = rulesets.AvailableRulesets.ElementAt(0);
+            });
 
             AddStep("add mixed ruleset beatmapset", () =>
             {
@@ -250,9 +242,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                        && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 0) == 1;
             });
 
-            ApplyToFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
-
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
 
             AddUntilStep("wait for filtered difficulties", () =>
             {
@@ -263,9 +253,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                        && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 1) == 1;
             });
 
-            ApplyToFilter("filter to catch", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(2));
-
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter to catch", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(2));
 
             AddUntilStep("wait for filtered difficulties", () =>
             {
@@ -297,17 +285,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
 
             SortBy(SortMode.Difficulty);
-            WaitForFiltering();
 
             CheckDisplayedBeatmapsCount(local_set_count * diffs_per_set);
 
-            ApplyToFilter("filter to normal", c => c.SearchText = "Normal");
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter to normal", c => c.SearchText = "Normal");
 
             CheckDisplayedBeatmapsCount(local_set_count);
 
-            ApplyToFilter("filter to insane", c => c.SearchText = "Insane");
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter to insane", c => c.SearchText = "Insane");
 
             CheckDisplayedBeatmapsCount(local_set_count);
         }
@@ -323,8 +308,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckDisplayedBeatmapsCount(6);
 
-            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
 
             CheckDisplayedBeatmapsCount(4);
 
@@ -345,8 +329,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             WaitForSetSelection(2, 0);
 
-            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
 
             SelectNextSet();
             WaitForSetSelection(0, 1);
@@ -363,8 +346,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             WaitForSetSelection(2, 0);
 
-            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
 
             SelectPrevSet();
             WaitForSetSelection(4, 1);
@@ -379,8 +361,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectPrevSet();
             WaitForSetSelection(1, 0);
 
-            ApplyToFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
 
             SelectPrevSet();
             WaitForSetSelection(0, 0);
@@ -395,8 +376,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             WaitForSetSelection(0, 0);
 
-            ApplyToFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
 
             SelectNextSet();
             WaitForSetSelection(1, 0);
@@ -413,8 +393,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             WaitForSetSelection(2, 0);
 
-            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
 
             SelectNextPanel();
             AddAssert("keyboard selected is first set", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(BeatmapSets.First()));
@@ -431,8 +410,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             WaitForSetSelection(2, 0);
 
-            ApplyToFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter first away", c => c.UserStarDifficulty.Min = 3);
 
             SelectPrevPanel();
             AddAssert("keyboard selected is last set", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(BeatmapSets.Last()));
@@ -447,8 +425,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectPrevSet();
             WaitForSetSelection(1, 0);
 
-            ApplyToFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter last set away", c => c.SearchText = BeatmapSets.First().Metadata.Title);
 
             SelectPrevPanel();
             AddAssert("keyboard selected is first set", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(BeatmapSets.First()));
@@ -463,8 +440,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             WaitForSetSelection(0, 0);
 
-            ApplyToFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter first set away", c => c.SearchText = BeatmapSets.Last().Metadata.Title);
 
             // Single result is automatically selected for us, so we iterate once backwards to the set header.
             SelectPrevPanel();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -290,7 +290,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForDrawablePanels();
 
             SortAndGroupBy(SortMode.Difficulty, GroupMode.None);
-            WaitForFiltering();
 
             AddUntilStep("standalone panels displayed", () => GetVisiblePanels<PanelBeatmapStandalone>().Any());
 
@@ -314,7 +313,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForDrawablePanels();
 
             SortBy(SortMode.Difficulty);
-            WaitForFiltering();
 
             AddUntilStep("standalone panels displayed", () => GetVisiblePanels<PanelBeatmapStandalone>().Count(), () => Is.EqualTo(3));
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -24,8 +24,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             AddBeatmaps(2, 10, true);
 
-            ApplyToFilter("filter", c => c.SearchText = BeatmapSets[0].Beatmaps.Last().DifficultyName);
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = BeatmapSets[0].Beatmaps.Last().DifficultyName);
 
             CheckDisplayedBeatmapSetsCount(1);
             CheckDisplayedBeatmapsCount(1);

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
@@ -97,8 +97,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("scroll to end", () => Scroll.ScrollToEnd());
             WaitForScrolling();
 
-            ApplyToFilter("search", f => f.SearchText = "Some");
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("search", f => f.SearchText = "Some");
 
             AddUntilStep("select screen position returned to selection", () => Carousel.ChildrenOfType<PanelBeatmap>().Single(p => p.Selected.Value).ScreenSpaceDrawQuad,
                 () => Is.EqualTo(positionBefore));
@@ -121,8 +120,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("save selected screen position", () => positionBefore = Carousel.ChildrenOfType<PanelBeatmap>().FirstOrDefault(p => p.Selected.Value)!.ScreenSpaceDrawQuad);
 
-            ApplyToFilter("search", f => f.SearchText = "Some");
-            WaitForFiltering();
+            ApplyToFilterAndWaitForFilter("search", f => f.SearchText = "Some");
 
             AddUntilStep("select screen position returned to selection", () => Carousel.ChildrenOfType<PanelBeatmap>().Single(p => p.Selected.Value).ScreenSpaceDrawQuad,
                 () => Is.EqualTo(positionBefore));

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -172,7 +172,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             Guid[] originalOrder = null!;
 
             SortBy(SortMode.Artist);
-            WaitForFiltering();
 
             AddAssert("Items in descending added order", () => Carousel.PostFilterBeatmaps.Select(b => b.BeatmapSet!.DateAdded), () => Is.Ordered.Descending);
             AddStep("Save order", () => originalOrder = Carousel.PostFilterBeatmaps.Select(b => b.ID).ToArray());
@@ -188,7 +187,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("Order didn't change", () => Carousel.PostFilterBeatmaps.Select(b => b.ID), () => Is.EqualTo(originalOrder));
 
             SortBy(SortMode.Title);
-            WaitForFiltering();
 
             AddAssert("Order didn't change", () => Carousel.PostFilterBeatmaps.Select(b => b.ID), () => Is.EqualTo(originalOrder));
         }
@@ -225,7 +223,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             Guid[] originalOrder = null!;
 
             SortBy(SortMode.Artist);
-            WaitForFiltering();
 
             AddAssert("Items in descending added order", () => Carousel.PostFilterBeatmaps.Select(b => b.BeatmapSet!.DateAdded), () => Is.Ordered.Descending);
             AddStep("Save order", () => originalOrder = Carousel.PostFilterBeatmaps.Select(b => b.ID).ToArray());
@@ -252,7 +249,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("Order didn't change", () => Carousel.PostFilterBeatmaps.Select(b => b.ID), () => Is.EqualTo(originalOrder));
 
             SortBy(SortMode.Title);
-            WaitForFiltering();
 
             AddAssert("Order didn't change", () => Carousel.PostFilterBeatmaps.Select(b => b.ID), () => Is.EqualTo(originalOrder));
         }


### PR DESCRIPTION
There were some cases where this wasn't handled correctly, which led to test failures under certain criteria.

Also contains a couple of other test related improvements, mostly for my sanity. See individual commits.