### PR TITLE
Add support for traversing and toggling expanded state of song select groups

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -184,6 +184,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         protected void WaitForFiltering() => AddUntilStep("filtering finished", () => Carousel.IsFiltering, () => Is.False);
         protected void WaitForScrolling() => AddUntilStep("scroll finished", () => Scroll.Current, () => Is.EqualTo(Scroll.Target));
 
+        protected void ToggleGroupCollapse() => AddStep("toggle group collapse", () =>
+        {
+            InputManager.PressKey(Key.ShiftLeft);
+            InputManager.Key(Key.Enter);
+            InputManager.ReleaseKey(Key.ShiftLeft);
+        });
+
         protected void SelectNextGroup() => AddStep("select next group", () =>
         {
             InputManager.PressKey(Key.ShiftLeft);

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -114,17 +114,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectPrevPanel();
             SelectPrevPanel();
 
+            ICarouselPanel? groupPanel = null;
+
+            AddStep("get group panel", () => groupPanel = GetKeyboardSelectedPanel());
+
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
+            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, () => Is.EqualTo(groupPanel));
 
             SelectPrevSet();
 
             WaitForBeatmapSelection(0, 1);
             AddAssert("keyboard selected panel is contracted", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.False);
+            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, () => Is.EqualTo(groupPanel));
 
             SelectPrevSet();
 
             WaitForBeatmapSelection(0, 1);
-            AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
+            // Expanding a group will move keyboard selection to the selected beatmap if contained.
+            AddAssert("keyboard selected panel is expanded", () => groupPanel?.Expanded.Value, () => Is.True);
+            AddAssert("keyboard selected panel is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, Is.TypeOf<BeatmapInfo>);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -125,6 +125,37 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestKeyboardGroupToggleCollapse_SelectionContained()
+        {
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 0);
+            checkBeatmapIsKeyboardSelected();
+
+            ToggleGroupCollapse();
+            checkGroupKeyboardSelected(0);
+
+            ToggleGroupCollapse();
+            checkBeatmapIsKeyboardSelected();
+        }
+
+        [Test]
+        public void TestKeyboardGroupToggleCollapse_SelectionNotContained()
+        {
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 0);
+            checkBeatmapIsKeyboardSelected();
+
+            SelectNextGroup();
+            checkGroupKeyboardSelected(1);
+
+            ToggleGroupCollapse();
+            checkGroupKeyboardSelected(1);
+
+            ToggleGroupCollapse();
+            checkGroupKeyboardSelected(1);
+        }
+
+        [Test]
         public void TestKeyboardGroupTraversal()
         {
             SelectNextSet();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -156,6 +156,21 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestKeyboardGroupTraversalSingleGroup()
+        {
+            RemoveAllBeatmaps();
+            AddBeatmaps(1, 1);
+
+            WaitForBeatmapSelection(0, 0);
+
+            SelectNextGroup();
+            checkBeatmapIsKeyboardSelected();
+
+            SelectPrevGroup();
+            checkBeatmapIsKeyboardSelected();
+        }
+
+        [Test]
         public void TestKeyboardGroupTraversal()
         {
             SelectNextSet();

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -102,18 +102,69 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForBeatmapSelection(0, 0);
 
             SelectPrevPanel();
+
+            ICarouselPanel? groupPanel = null;
+
+            AddStep("get group panel", () => groupPanel = GetKeyboardSelectedPanel());
+
             AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
+            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, () => Is.EqualTo(groupPanel));
 
             SelectPrevSet();
 
             WaitForBeatmapSelection(0, 0);
             AddAssert("keyboard selected panel is contracted", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.False);
+            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, () => Is.EqualTo(groupPanel));
 
             SelectPrevSet();
 
             WaitForBeatmapSelection(0, 0);
-            AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
+            // Expanding a group will move keyboard selection to the selected beatmap if contained.
+            AddAssert("keyboard selected panel is expanded", () => groupPanel?.Expanded.Value, () => Is.True);
+            AddAssert("keyboard selected panel is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, Is.TypeOf<BeatmapInfo>);
         }
+
+        [Test]
+        public void TestKeyboardGroupTraversal()
+        {
+            SelectNextSet();
+            WaitForBeatmapSelection(0, 0);
+            checkBeatmapIsKeyboardSelected();
+
+            SelectNextGroup();
+            WaitForBeatmapSelection(0, 0);
+            WaitForExpandedGroup(1);
+            checkGroupKeyboardSelected(1);
+
+            SelectNextGroup();
+            WaitForBeatmapSelection(0, 0);
+            WaitForExpandedGroup(2);
+            checkGroupKeyboardSelected(2);
+
+            SelectNextGroup();
+            WaitForBeatmapSelection(0, 0);
+            WaitForExpandedGroup(0);
+            checkBeatmapIsKeyboardSelected();
+
+            SelectPrevGroup();
+            WaitForBeatmapSelection(0, 0);
+            WaitForExpandedGroup(2);
+            checkGroupKeyboardSelected(2);
+        }
+
+        private void checkBeatmapIsKeyboardSelected() =>
+            AddUntilStep("check keyboard selected group is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(Carousel.CurrentSelection));
+
+        private void checkGroupKeyboardSelected(int index) => AddUntilStep($"check keyboard selected group is {index}", () => GetKeyboardSelectedPanel()?.Item?.Model, () =>
+        {
+            var groupingFilter = Carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single();
+
+            GroupDefinition g = groupingFilter.GroupItems.Keys.ElementAt(index);
+            // offset by one because the group itself is included in the items list.
+            CarouselItem item = groupingFilter.GroupItems[g].ElementAt(0);
+
+            return Is.EqualTo(item.Model);
+        });
 
         [Test]
         public void TestGroupSelectionOnHeaderMouse()
@@ -129,9 +180,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("keyboard selected panel is contracted", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.False);
 
             ClickVisiblePanel<PanelGroupStarDifficulty>(0);
-            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, Is.TypeOf<PanelGroupStarDifficulty>);
-            AddAssert("keyboard selected panel is expanded", () => GetKeyboardSelectedPanel()?.Expanded.Value, () => Is.True);
-
+            // Expanding a group will move keyboard selection to the selected beatmap if contained.
+            AddAssert("keyboard selected panel is group", GetKeyboardSelectedPanel, Is.TypeOf<PanelBeatmapStandalone>);
             AddAssert("selected panel is still beatmap", GetSelectedPanel, Is.TypeOf<PanelBeatmapStandalone>);
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -313,9 +313,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckDisplayedBeatmapsCount(4);
 
             SelectNextSet();
-            WaitForSetSelection(0, 1);
-            SelectPrevSet();
             WaitForSetSelection(1, 1);
+            SelectPrevSet();
+            WaitForSetSelection(0, 1);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -195,16 +195,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             WaitForSetSelection(0, 0);
 
-            // In the case of a grouped beatmap set, the header gets activated and re-selects the recommended difficulty.
-            // This is probably fine.
-            CheckActivationCount(1);
-            // We don't want it to request present though, which would start gameplay.
+            CheckActivationCount(0);
             CheckRequestPresentCount(0);
 
             SelectPrevSet();
             WaitForSetSelection(0, 0);
 
-            CheckActivationCount(1);
+            CheckActivationCount(0);
             CheckRequestPresentCount(0);
         }
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -482,6 +482,20 @@ namespace osu.Game.Graphics.Carousel
                 case GlobalAction.ExpandNextGroup:
                     Scheduler.AddOnce(traverseGroupSelection, 1);
                     return true;
+
+                case GlobalAction.ToggleCurrentGroup:
+                    if (currentKeyboardSelection.CarouselItem != null && CheckValidForGroupSelection(currentKeyboardSelection.CarouselItem))
+                    {
+                        // If keyboard selection is a group, toggle group and then change keyboard selection to actual selection.
+                        Activate(currentKeyboardSelection.CarouselItem);
+                    }
+                    else
+                    {
+                        // If current keyboard selection is not a group, toggle closest group and move keyboard selection to that group.
+                        traverseSelection(-1, CheckValidForGroupSelection, false);
+                    }
+
+                    return true;
             }
 
             return false;
@@ -563,7 +577,7 @@ namespace osu.Game.Graphics.Carousel
             traverseSelection(direction, CheckValidForSetSelection);
         }
 
-        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate)
+        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate, bool skipFirst = true)
         {
             if (carouselItems == null || carouselItems.Count == 0) return;
 
@@ -579,12 +593,15 @@ namespace osu.Game.Graphics.Carousel
             {
                 newIndex = originalIndex = currentKeyboardSelection.Index.Value;
 
-                // As a second special case, if we're set selecting backwards and the current selection isn't a set,
-                // make sure to go back to the set header this item belongs to, so that the block below doesn't find it and stop too early.
-                if (direction < 0)
+                if (skipFirst)
                 {
-                    while (newIndex > 0 && !predicate(carouselItems[newIndex]))
-                        newIndex--;
+                    // As a second special case, if we're set selecting backwards and the current selection isn't a set,
+                    // make sure to go back to the set header this item belongs to, so that the block below doesn't find it and stop too early.
+                    if (direction < 0)
+                    {
+                        while (newIndex > 0 && !predicate(carouselItems[newIndex]))
+                            newIndex--;
+                    }
                 }
             }
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -592,7 +592,7 @@ namespace osu.Game.Graphics.Carousel
             traverseSelection(direction, CheckValidForSetSelection);
         }
 
-        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate, bool skipFirst = true)
+        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate)
         {
             if (carouselItems == null || carouselItems.Count == 0) return;
 
@@ -608,15 +608,12 @@ namespace osu.Game.Graphics.Carousel
             {
                 newIndex = originalIndex = currentKeyboardSelection.Index.Value;
 
-                if (skipFirst)
+                // As a second special case, if we're set selecting backwards and the current selection isn't a set,
+                // make sure to go back to the set header this item belongs to, so that the block below doesn't find it and stop too early.
+                if (direction < 0)
                 {
-                    // As a second special case, if we're set selecting backwards and the current selection isn't a set,
-                    // make sure to go back to the set header this item belongs to, so that the block below doesn't find it and stop too early.
-                    if (direction < 0)
-                    {
-                        while (newIndex > 0 && !predicate(carouselItems[newIndex]))
-                            newIndex--;
-                    }
+                    while (newIndex > 0 && !predicate(carouselItems[newIndex]))
+                        newIndex--;
                 }
             }
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -484,7 +484,13 @@ namespace osu.Game.Graphics.Carousel
                     return true;
 
                 case GlobalAction.ToggleCurrentGroup:
-                    if (currentKeyboardSelection.CarouselItem != null && CheckValidForGroupSelection(currentKeyboardSelection.CarouselItem))
+                    if (carouselItems == null || carouselItems.Count == 0)
+                        return true;
+
+                    if (currentKeyboardSelection.CarouselItem == null || currentKeyboardSelection.Index == null)
+                        return true;
+
+                    if (CheckValidForGroupSelection(currentKeyboardSelection.CarouselItem))
                     {
                         // If keyboard selection is a group, toggle group and then change keyboard selection to actual selection.
                         Activate(currentKeyboardSelection.CarouselItem);
@@ -492,7 +498,16 @@ namespace osu.Game.Graphics.Carousel
                     else
                     {
                         // If current keyboard selection is not a group, toggle the closest group and move keyboard selection to that group.
-                        traverseSelection(-1, CheckValidForGroupSelection, skipFirst: false, activateExpandedItems: true);
+                        for (int i = currentKeyboardSelection.Index.Value; i >= 0; i--)
+                        {
+                            var newItem = carouselItems[i];
+
+                            if (CheckValidForGroupSelection(newItem))
+                            {
+                                Activate(newItem);
+                                return true;
+                            }
+                        }
                     }
 
                     return true;
@@ -577,7 +592,7 @@ namespace osu.Game.Graphics.Carousel
             traverseSelection(direction, CheckValidForSetSelection);
         }
 
-        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate, bool skipFirst = true, bool activateExpandedItems = false)
+        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate, bool skipFirst = true)
         {
             if (carouselItems == null || carouselItems.Count == 0) return;
 
@@ -616,7 +631,7 @@ namespace osu.Game.Graphics.Carousel
 
                 var newItem = carouselItems[newIndex];
 
-                if ((activateExpandedItems || !newItem.IsExpanded) && predicate(newItem))
+                if (!newItem.IsExpanded && predicate(newItem))
                 {
                     Activate(newItem);
                     return;

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -491,8 +491,8 @@ namespace osu.Game.Graphics.Carousel
                     }
                     else
                     {
-                        // If current keyboard selection is not a group, toggle closest group and move keyboard selection to that group.
-                        traverseSelection(-1, CheckValidForGroupSelection, false);
+                        // If current keyboard selection is not a group, toggle the closest group and move keyboard selection to that group.
+                        traverseSelection(-1, CheckValidForGroupSelection, skipFirst: false, activateExpandedItems: true);
                     }
 
                     return true;
@@ -577,7 +577,7 @@ namespace osu.Game.Graphics.Carousel
             traverseSelection(direction, CheckValidForSetSelection);
         }
 
-        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate, bool skipFirst = true)
+        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate, bool skipFirst = true, bool activateExpandedItems = false)
         {
             if (carouselItems == null || carouselItems.Count == 0) return;
 
@@ -616,7 +616,7 @@ namespace osu.Game.Graphics.Carousel
 
                 var newItem = carouselItems[newIndex];
 
-                if (!newItem.IsExpanded && predicate(newItem))
+                if ((activateExpandedItems || !newItem.IsExpanded) && predicate(newItem))
                 {
                     Activate(newItem);
                     return;

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -616,7 +616,7 @@ namespace osu.Game.Graphics.Carousel
 
                 var newItem = carouselItems[newIndex];
 
-                if (predicate(newItem))
+                if (!newItem.IsExpanded && predicate(newItem))
                 {
                     Activate(newItem);
                     return;

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -234,6 +234,13 @@ namespace osu.Game.Graphics.Carousel
             Scroll.Panels.SingleOrDefault(p => ((ICarouselPanel)p).Item == item);
 
         /// <summary>
+        /// When a user is traversing the carousel via group selection keys, assert whether the item provided is a valid target.
+        /// </summary>
+        /// <param name="item">The candidate item.</param>
+        /// <returns>Whether the provided item is a valid group target. If <c>false</c>, more panels will be checked in the user's requested direction until a valid target is found.</returns>
+        protected virtual bool CheckValidForGroupSelection(CarouselItem item) => false;
+
+        /// <summary>
         /// When a user is traversing the carousel via set selection keys, assert whether the item provided is a valid target.
         /// </summary>
         /// <param name="item">The candidate item.</param>
@@ -467,6 +474,14 @@ namespace osu.Game.Graphics.Carousel
                 case GlobalAction.ActivatePreviousSet:
                     Scheduler.AddOnce(traverseSetSelection, -1);
                     return true;
+
+                case GlobalAction.ExpandPreviousGroup:
+                    Scheduler.AddOnce(traverseGroupSelection, -1);
+                    return true;
+
+                case GlobalAction.ExpandNextGroup:
+                    Scheduler.AddOnce(traverseGroupSelection, 1);
+                    return true;
             }
 
             return false;
@@ -520,22 +535,37 @@ namespace osu.Game.Graphics.Carousel
         }
 
         /// <summary>
-        /// Select the next valid selection relative to a current selection.
+        /// Select the next valid group selection relative to a current selection.
+        /// This is generally for keyboard based traversal.
+        /// </summary>
+        /// <param name="direction">Positive for downwards, negative for upwards.</param>
+        /// <returns>Whether selection was possible.</returns>
+        private void traverseGroupSelection(int direction) => traverseSelection(direction, CheckValidForGroupSelection);
+
+        /// <summary>
+        /// Select the next valid set selection relative to a current selection.
         /// This is generally for keyboard based traversal.
         /// </summary>
         /// <param name="direction">Positive for downwards, negative for upwards.</param>
         /// <returns>Whether selection was possible.</returns>
         private void traverseSetSelection(int direction)
         {
-            if (carouselItems == null || carouselItems.Count == 0) return;
-
             // If the user has a different keyboard selection and requests
             // set selection, first transfer the keyboard selection to actual selection.
+            //
+            // It is assumed that selecting a set will immediately change selection to one of its children.
             if (currentKeyboardSelection.CarouselItem != null && currentSelection.CarouselItem != currentKeyboardSelection.CarouselItem)
             {
                 Activate(currentKeyboardSelection.CarouselItem);
                 return;
             }
+
+            traverseSelection(direction, CheckValidForSetSelection);
+        }
+
+        private void traverseSelection(int direction, Func<CarouselItem, bool> predicate)
+        {
+            if (carouselItems == null || carouselItems.Count == 0) return;
 
             int originalIndex;
             int newIndex;
@@ -553,7 +583,7 @@ namespace osu.Game.Graphics.Carousel
                 // make sure to go back to the set header this item belongs to, so that the block below doesn't find it and stop too early.
                 if (direction < 0)
                 {
-                    while (newIndex > 0 && !CheckValidForSetSelection(carouselItems[newIndex]))
+                    while (newIndex > 0 && !predicate(carouselItems[newIndex]))
                         newIndex--;
                 }
             }
@@ -569,9 +599,9 @@ namespace osu.Game.Graphics.Carousel
 
                 var newItem = carouselItems[newIndex];
 
-                if (CheckValidForSetSelection(newItem))
+                if (predicate(newItem))
                 {
-                    HandleItemActivated(newItem);
+                    Activate(newItem);
                     return;
                 }
             } while (true);

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -199,6 +199,9 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Left, GlobalAction.ActivatePreviousSet),
             new KeyBinding(InputKey.Right, GlobalAction.ActivateNextSet),
 
+            new KeyBinding(new[] { InputKey.Shift, InputKey.Left }, GlobalAction.ExpandPreviousGroup),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.Right }, GlobalAction.ExpandNextGroup),
+
             new KeyBinding(InputKey.F1, GlobalAction.ToggleModSelection),
             new KeyBinding(InputKey.F2, GlobalAction.SelectNextRandom),
             new KeyBinding(new[] { InputKey.Shift, InputKey.F2 }, GlobalAction.SelectPreviousRandom),
@@ -506,6 +509,12 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDiscardUnsavedChanges))]
         EditorDiscardUnsavedChanges,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ExpandPreviousGroup))]
+        ExpandPreviousGroup,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ExpandNextGroup))]
+        ExpandNextGroup,
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -202,6 +202,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Shift, InputKey.Left }, GlobalAction.ExpandPreviousGroup),
             new KeyBinding(new[] { InputKey.Shift, InputKey.Right }, GlobalAction.ExpandNextGroup),
 
+            new KeyBinding(new[] { InputKey.Shift, InputKey.Enter }, GlobalAction.ToggleCurrentGroup),
+
             new KeyBinding(InputKey.F1, GlobalAction.ToggleModSelection),
             new KeyBinding(InputKey.F2, GlobalAction.SelectNextRandom),
             new KeyBinding(new[] { InputKey.Shift, InputKey.F2 }, GlobalAction.SelectPreviousRandom),
@@ -515,6 +517,9 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ExpandNextGroup))]
         ExpandNextGroup,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleCurrentGroup))]
+        ToggleCurrentGroup,
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -150,6 +150,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ExpandNextGroup => new TranslatableString(getKey(@"expand_next_group"), @"Expand next group");
 
         /// <summary>
+        /// "Toggle expansion of current group"
+        /// </summary>
+        public static LocalisableString ToggleCurrentGroup => new TranslatableString(getKey(@"toggle_current_group"), @"Toggle expansion of current group");
+
+        /// <summary>
         /// "Home"
         /// </summary>
         public static LocalisableString Home => new TranslatableString(getKey(@"home"), @"Home");

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -140,6 +140,16 @@ namespace osu.Game.Localisation
         public static LocalisableString ActivateNextSet => new TranslatableString(getKey(@"activate_next_set"), @"Activate next set");
 
         /// <summary>
+        /// "Expand previous group"
+        /// </summary>
+        public static LocalisableString ExpandPreviousGroup => new TranslatableString(getKey(@"expand_previous_group"), @"Expand previous group");
+
+        /// <summary>
+        /// "Expand next group"
+        /// </summary>
+        public static LocalisableString ExpandNextGroup => new TranslatableString(getKey(@"expand_next_group"), @"Expand next group");
+
+        /// <summary>
         /// "Home"
         /// </summary>
         public static LocalisableString Home => new TranslatableString(getKey(@"home"), @"Home");

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -230,6 +230,11 @@ namespace osu.Game.Screens.SelectV2
                         }
 
                         setExpandedGroup(group);
+
+                        // If the active selection is within this group, it should get keyboard focus immediately.
+                        if (CurrentSelectionItem?.IsVisible == true && CurrentSelection is BeatmapInfo info)
+                            RequestSelection(info);
+
                         return;
 
                     case BeatmapSetInfo setInfo:

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -339,6 +339,8 @@ namespace osu.Game.Screens.SelectV2
             RequestRecommendedSelection(beatmaps);
         }
 
+        protected override bool CheckValidForGroupSelection(CarouselItem item) => item.Model is GroupDefinition;
+
         protected override bool CheckValidForSetSelection(CarouselItem item)
         {
             switch (item.Model)

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -279,6 +279,10 @@ namespace osu.Game.Screens.SelectV2
 
                 public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
                 {
+                    // Conflicts with default group navigation keys (shift-left shift-right).
+                    if (e.Action == PlatformAction.SelectBackwardChar || e.Action == PlatformAction.SelectForwardChar)
+                        return false;
+
                     // the "cut" platform key binding (shift-delete) conflicts with the beatmap deletion action.
                     if (e.Action == PlatformAction.Cut && e.ShiftPressed && e.CurrentState.Keyboard.Keys.IsPressed(Key.Delete))
                         return false;


### PR DESCRIPTION
This adds back some keys which users have learned to depend on (and I have forgotten ever existed).

- <kbd>Shift</kbd> + <kbd>Left</kbd> / <kbd>Right</kbd> now allows traversing between groups
- <kbd>Shift</kbd> + <kbd>Enter</kbd> now toggles the expanded state for the current group

This also changes the behaviour such that when you open a group which contains the currently selected beatmap, keyboard selection (and scroll target) will be transferred to it.

https://github.com/user-attachments/assets/6d337beb-1d93-46e1-82fc-36dfecfc0246

---

Closes #33599. 
Closes #33617.
