### PR TITLE
Add support for reading and displaying the release stream suffix

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Version = "2018.712.0",
                 DisplayVersion = "2018.712.0",
-                UpdateStream = streams[OsuGameBase.CLIENT_STREAM_NAME],
+                UpdateStream = streams["lazer"],
                 CreatedAt = new DateTime(2018, 7, 12),
                 ChangelogEntries = new List<APIChangelogEntry>
                 {

--- a/osu.Game/Online/API/Requests/Responses/APIUpdateStream.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUpdateStream.cs
@@ -39,7 +39,8 @@ namespace osu.Game.Online.API.Requests.Responses
             ["stable"] = new Color4(34, 153, 187, 255),
             ["beta40"] = new Color4(255, 221, 85, 255),
             ["cuttingedge"] = new Color4(238, 170, 0, 255),
-            [OsuGameBase.CLIENT_STREAM_NAME] = new Color4(237, 18, 33, 255),
+            ["lazer"] = new Color4(237, 18, 33, 255),
+            ["tachyon"] = new Color4(206, 0, 255, 255),
             ["web"] = new Color4(136, 102, 238, 255)
         };
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1024,6 +1024,10 @@ namespace osu.Game
             if (RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>() == null)
                 Logger.Log(NotificationsStrings.NotOfficialBuild.ToString());
 
+            // Make sure the release stream setting matches the build which was just run.
+            if (Enum.TryParse<ReleaseStream>(Version.Split('-').Last(), true, out var releaseStream))
+                LocalConfig.SetValue(OsuSetting.ReleaseStream, releaseStream);
+
             var languages = Enum.GetValues<Language>();
 
             var mappings = languages.Select(language =>

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -519,7 +519,7 @@ namespace osu.Game
                     else
                     {
                         string[] changelogArgs = argString.Split("/");
-                        ShowChangelogBuild(changelogArgs[0], changelogArgs[1]);
+                        ShowChangelogBuild($"{changelogArgs[1]}-{changelogArgs[0]}");
                     }
 
                     break;
@@ -600,9 +600,8 @@ namespace osu.Game
         /// <summary>
         /// Show changelog's build as an overlay
         /// </summary>
-        /// <param name="updateStream">The update stream name</param>
-        /// <param name="version">The build version of the update stream</param>
-        public void ShowChangelogBuild(string updateStream, string version) => waitForReady(() => changelogOverlay, _ => changelogOverlay.ShowBuild(updateStream, version));
+        /// <param name="version">The build version, including stream suffix.</param>
+        public void ShowChangelogBuild(string version) => waitForReady(() => changelogOverlay, _ => changelogOverlay.ShowBuild(version));
 
         /// <summary>
         /// Joins a multiplayer or playlists room with the given <paramref name="id"/>.

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -83,8 +83,6 @@ namespace osu.Game
 
         public const string OSU_PROTOCOL = "osu://";
 
-        public const string CLIENT_STREAM_NAME = @"lazer";
-
         /// <summary>
         /// The filename of the main client database.
         /// </summary>
@@ -120,8 +118,6 @@ namespace osu.Game
 
         public bool IsDeployedBuild => AssemblyVersion.Major > 0;
 
-        internal const string BUILD_SUFFIX = "lazer";
-
         public virtual string Version
         {
             get
@@ -129,8 +125,16 @@ namespace osu.Game
                 if (!IsDeployedBuild)
                     return @"local " + (DebugUtils.IsDebugBuild ? @"debug" : @"release");
 
-                var version = AssemblyVersion;
-                return $@"{version.Major}.{version.Minor}.{version.Build}-{BUILD_SUFFIX}";
+                string informationalVersion = Assembly.GetEntryAssembly()?
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                    .InformationalVersion;
+
+                // Example: [assembly: AssemblyInformationalVersion("2025.613.0-tachyon+d934e574b2539e8787956c3c9ecce9dadebb10ee")]
+                if (!string.IsNullOrEmpty(informationalVersion))
+                    return informationalVersion.Split('+').First();
+
+                Version version = AssemblyVersion;
+                return $@"{version.Major}.{version.Minor}.{version.Build}-lazer";
             }
         }
 

--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -76,16 +76,18 @@ namespace osu.Game.Overlays
             Show();
         }
 
-        public void ShowBuild([NotNull] string updateStream, [NotNull] string version)
+        public void ShowBuild([NotNull] string version)
         {
-            ArgumentNullException.ThrowIfNull(updateStream);
             ArgumentNullException.ThrowIfNull(version);
 
             Show();
 
             performAfterFetch(() =>
             {
-                var build = builds.Find(b => b.Version == version && b.UpdateStream.Name == updateStream)
+                string versionPart = version.Split('-')[0];
+                string updateStream = version.Split('-')[1];
+
+                var build = builds.Find(b => b.Version == versionPart && b.UpdateStream.Name == updateStream)
                             ?? Streams.Find(s => s.Name == updateStream)?.LatestBuild;
 
                 if (build != null)

--- a/osu.Game/Overlays/Settings/SettingsFooter.cs
+++ b/osu.Game/Overlays/Settings/SettingsFooter.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Overlays.Settings
             [BackgroundDependencyLoader]
             private void load(ChangelogOverlay? changelog)
             {
-                Action = () => changelog?.ShowBuild(OsuGameBase.CLIENT_STREAM_NAME, version);
+                Action = () => changelog?.ShowBuild(version);
 
                 Add(new OsuSpriteText
                 {

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Updater
                 Activated = delegate
                 {
                     notificationOverlay.Hide();
-                    changelog.ShowBuild(OsuGameBase.CLIENT_STREAM_NAME, version);
+                    changelog.ShowBuild(version);
                     return true;
                 };
             }

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Utils
                 options.IsGlobalModeEnabled = true;
                 options.CacheDirectoryPath = storage?.GetFullPath(string.Empty);
                 // The reported release needs to match version as reported to Sentry in .github/workflows/sentry-release.yml
-                options.Release = $"osu@{game.Version.Replace($@"-{OsuGameBase.BUILD_SUFFIX}", string.Empty)}";
+                options.Release = $"osu@{game.Version.Split('-').First()}";
             });
 
             Logger.NewEntry += processLogEntry;


### PR DESCRIPTION
Next step in making tachyon a permanent (and more regularly updated) fixture.

Tested locally to some extent. Maybe we want more safeties in the string parsing, not sure.

This also means that if you install a different release stream, the client update setting will update to the new stream.