### PR TITLE
Add block / unblock options to chat and user profile overlay

### DIFF
--- a/osu.Game/Overlays/Chat/DrawableChatUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableChatUsername.cs
@@ -28,6 +28,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
+using osu.Game.Users;
 using osuTK;
 using osuTK.Graphics;
 using ChatStrings = osu.Game.Localisation.ChatStrings;
@@ -91,6 +92,9 @@ namespace osu.Game.Overlays.Chat
 
         [Resolved]
         private Bindable<Channel?>? currentChannel { get; set; }
+
+        [Resolved]
+        private IDialogOverlay? dialogOverlay { get; set; }
 
         private readonly APIUser user;
         private readonly OsuSpriteText drawableText;
@@ -208,6 +212,9 @@ namespace osu.Game.Overlays.Chat
 
                 items.Add(new OsuMenuItemSpacer());
                 items.Add(new OsuMenuItem(UsersStrings.ReportButtonText, MenuItemType.Destructive, ReportRequested));
+                items.Add(api.Blocks.Any(b => b.TargetID == user.OnlineID)
+                    ? new OsuMenuItem(UsersStrings.BlocksButtonUnblock, MenuItemType.Standard, () => dialogOverlay?.Push(ConfirmBlockActionDialog.Unblock(user)))
+                    : new OsuMenuItem(UsersStrings.BlocksButtonBlock, MenuItemType.Destructive, () => dialogOverlay?.Push(ConfirmBlockActionDialog.Block(user))));
 
                 return items.ToArray();
             }

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -55,6 +55,10 @@ namespace osu.Game.Overlays.Profile.Header
                         {
                             User = { BindTarget = User }
                         },
+                        new UserActionsButton
+                        {
+                            User = { BindTarget = User }
+                        }
                     }
                 },
                 new Container

--- a/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
@@ -1,0 +1,210 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Game.Overlays.Profile.Header.Components
+{
+    public partial class UserActionsButton : OsuHoverContainer, IHasPopover
+    {
+        public readonly Bindable<UserProfileData?> User = new Bindable<UserProfileData?>();
+
+        private Box background = null!;
+
+        protected override IEnumerable<Drawable> EffectTargets => [background];
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            IdleColour = colourProvider.Background2;
+            HoverColour = colourProvider.Background1;
+
+            Size = new Vector2(40);
+            Masking = true;
+            CornerRadius = 20;
+
+            Child = new CircularContainer
+            {
+                Masking = true,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new SpriteIcon
+                    {
+                        Size = new Vector2(12),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Icon = FontAwesome.Solid.EllipsisV,
+                    },
+                }
+            };
+
+            Action = this.ShowPopover;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            User.BindValueChanged(_ => Alpha = User.Value?.User.OnlineID == api.LocalUser.Value.OnlineID ? 0 : 1, true);
+        }
+
+        public Popover GetPopover() => new UserActionPopover(User.Value!.User);
+
+        private partial class UserActionPopover : OsuPopover
+        {
+            private readonly APIUser user;
+
+            public UserActionPopover(APIUser user)
+                : base(false)
+            {
+                this.user = user;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider, IAPIProvider api, IDialogOverlay? dialogOverlay)
+            {
+                Background.Colour = colourProvider.Background6;
+
+                bool userBlocked = api.Blocks.Any(b => b.TargetID == user.Id);
+
+                AllowableAnchors = [Anchor.BottomCentre, Anchor.TopCentre];
+
+                Child = new FillFlowContainer
+                {
+                    Width = 160,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding { Horizontal = 5, Vertical = 10 },
+                    Children = new Drawable[]
+                    {
+                        new UserAction(FontAwesome.Solid.Ban, userBlocked ? UsersStrings.BlocksButtonUnblock : UsersStrings.BlocksButtonBlock)
+                        {
+                            Action = () =>
+                            {
+                                dialogOverlay?.Push(userBlocked ? ConfirmBlockActionDialog.Unblock(user) : ConfirmBlockActionDialog.Block(user));
+                                this.HidePopover();
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        private partial class UserAction : OsuClickableContainer
+        {
+            private readonly IconUsage icon;
+            private readonly LocalisableString caption;
+
+            private Box background = null!;
+            private CircularContainer indicator = null!;
+
+            public UserAction(IconUsage icon, LocalisableString caption)
+            {
+                this.icon = icon;
+                this.caption = caption;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                RelativeSizeAxes = Content.RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Content.AutoSizeAxes = Axes.Y;
+
+                Masking = true;
+                CornerRadius = 4;
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background5,
+                        Alpha = 0,
+                    },
+                    indicator = new Circle
+                    {
+                        Width = 4,
+                        Height = 14,
+                        X = 10,
+                        Colour = colourProvider.Highlight1,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.Centre,
+                        Alpha = 0,
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Y,
+                        RelativeSizeAxes = Axes.X,
+                        Padding = new MarginPadding { Horizontal = 25, Vertical = 5 },
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(3, 0),
+                        Children = new Drawable[]
+                        {
+                            new SpriteIcon
+                            {
+                                Icon = icon,
+                                Size = new Vector2(14),
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = caption,
+                                Font = OsuFont.Style.Caption1,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                            }
+                        }
+                    }
+                };
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                updateState();
+                return true;
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                updateState();
+                base.OnHoverLost(e);
+            }
+
+            private void updateState()
+            {
+                background.Alpha = indicator.Alpha = IsHovered ? 1 : 0;
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
@@ -167,22 +167,23 @@ namespace osu.Game.Overlays.Profile.Header.Components
                         RelativeSizeAxes = Axes.X,
                         Padding = new MarginPadding { Horizontal = 25, Vertical = 5 },
                         Direction = FillDirection.Horizontal,
-                        Spacing = new Vector2(3, 0),
+                        Spacing = new Vector2(5, 0),
                         Children = new Drawable[]
                         {
                             new SpriteIcon
                             {
                                 Icon = icon,
-                                Size = new Vector2(14),
+                                Size = new Vector2(11),
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                             },
                             new OsuSpriteText
                             {
                                 Text = caption,
-                                Font = OsuFont.Style.Caption1,
+                                Font = OsuFont.Style.Body,
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
+                                UseFullGlyphHeight = false,
                             }
                         }
                     }

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
@@ -55,13 +56,17 @@ namespace osu.Game.Overlays
         public UserProfileOverlay()
             : base(OverlayColourScheme.Pink)
         {
-            base.Content.AddRange(new Drawable[]
+            base.Content.Add(new PopoverContainer
             {
-                onlineViewContainer = new OnlineViewContainer($"Sign in to view the {Header.Title.Title}")
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both
-                },
-                loadingLayer = new LoadingLayer(true)
+                    onlineViewContainer = new OnlineViewContainer($"Sign in to view the {Header.Title.Title}")
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    loadingLayer = new LoadingLayer(true)
+                }
             });
         }
 

--- a/osu.Game/Users/ConfirmBlockActionDialog.cs
+++ b/osu.Game/Users/ConfirmBlockActionDialog.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Dialog;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Users
+{
+    public partial class ConfirmBlockActionDialog : DangerousActionDialog
+    {
+        private readonly APIUser user;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private NotificationOverlay? notifications { get; set; }
+
+        private ConfirmBlockActionDialog(APIUser user, LocalisableString text, Action<ConfirmBlockActionDialog> action)
+        {
+            this.user = user;
+            BodyText = text;
+            DangerousAction = () => action(this);
+        }
+
+        public static ConfirmBlockActionDialog Block(APIUser user) => new ConfirmBlockActionDialog(user, ContextMenuStrings.ConfirmBlockUser(user.Username), d => d.toggleBlock(true));
+        public static ConfirmBlockActionDialog Unblock(APIUser user) => new ConfirmBlockActionDialog(user, ContextMenuStrings.ConfirmUnblockUser(user.Username), d => d.toggleBlock(false));
+
+        private void toggleBlock(bool block)
+        {
+            APIRequest req = block ? new BlockUserRequest(user.OnlineID) : new UnblockUserRequest(user.OnlineID);
+
+            req.Success += () =>
+            {
+                api.UpdateLocalBlocks();
+            };
+
+            req.Failure += e =>
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = e.Message,
+                    Icon = FontAwesome.Solid.Times,
+                });
+            };
+
+            api.Queue(req);
+        }
+    }
+}

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -14,7 +14,6 @@ using osu.Game.Overlays;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
@@ -23,11 +22,8 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Localisation;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
-using osu.Game.Overlays.Dialog;
-using osu.Game.Overlays.Notifications;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
 using osu.Game.Users.Drawables;
@@ -168,14 +164,8 @@ namespace osu.Game.Users
                 }));
 
                 items.Add(!isUserBlocked()
-                    ? new OsuMenuItem(UsersStrings.BlocksButtonBlock, MenuItemType.Destructive, () =>
-                    {
-                        dialogOverlay?.Push(new ConfirmBlockActionDialog(ContextMenuStrings.ConfirmBlockUser(User.Username), () => toggleBlock(true)));
-                    })
-                    : new OsuMenuItem(UsersStrings.BlocksButtonUnblock, MenuItemType.Standard, () =>
-                    {
-                        dialogOverlay?.Push(new ConfirmBlockActionDialog(ContextMenuStrings.ConfirmUnblockUser(User.Username), () => toggleBlock(false)));
-                    }));
+                    ? new OsuMenuItem(UsersStrings.BlocksButtonBlock, MenuItemType.Destructive, () => dialogOverlay?.Push(ConfirmBlockActionDialog.Block(User)))
+                    : new OsuMenuItem(UsersStrings.BlocksButtonUnblock, MenuItemType.Standard, () => dialogOverlay?.Push(ConfirmBlockActionDialog.Unblock(User))));
 
                 if (isUserOnline())
                 {
@@ -203,27 +193,6 @@ namespace osu.Game.Users
             }
         }
 
-        private void toggleBlock(bool block)
-        {
-            APIRequest req = block ? new BlockUserRequest(User.OnlineID) : new UnblockUserRequest(User.OnlineID);
-
-            req.Success += () =>
-            {
-                api.UpdateLocalBlocks();
-            };
-
-            req.Failure += e =>
-            {
-                notifications?.Post(new SimpleNotification
-                {
-                    Text = e.Message,
-                    Icon = FontAwesome.Solid.Times,
-                });
-            };
-
-            api.Queue(req);
-        }
-
         public IEnumerable<LocalisableString> FilterTerms => [User.Username];
 
         public bool MatchingFilter
@@ -238,14 +207,5 @@ namespace osu.Game.Users
         }
 
         public bool FilteringActive { get; set; }
-
-        private partial class ConfirmBlockActionDialog : DangerousActionDialog
-        {
-            public ConfirmBlockActionDialog(LocalisableString text, Action? action = null)
-            {
-                BodyText = text;
-                DangerousAction = action;
-            }
-        }
     }
 }

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -83,9 +83,6 @@ namespace osu.Game.Users
         [Resolved]
         private MetadataClient? metadataClient { get; set; }
 
-        [Resolved]
-        private INotificationOverlay? notifications { get; set; }
-
         [BackgroundDependencyLoader]
         private void load()
         {


### PR DESCRIPTION
Because the current implementation is a wet fart as the option is only available from the user card...? (https://github.com/ppy/osu/pull/33606#pullrequestreview-2912248570)

This is not doing the thing that the website does wherein the entire user profile is replaced by the message that the user is blocked if they're blocked. Someone else can try doing that.

I'm also not adding report button to user profile because it's going to be annoying to make happen because currently reporting is only available as a popover and not as a dialog. Someone else can pick that up as well.