### PR TITLE
Make behaviour of clickable text in song select consistent

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectComponentsTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectComponentsTestScene.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Cached]
         protected readonly OverlayColourProvider ColourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
 
-        protected override Container<Drawable> Content { get; } = new OsuContextMenuContainer
+        protected override Container<Drawable> Content { get; } = new Container
         {
             RelativeSizeAxes = Axes.X,
             AutoSizeAxes = Axes.Y,
@@ -30,17 +30,21 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [BackgroundDependencyLoader]
         private void load()
         {
-            base.Content.Child = new PopoverContainer
+            base.Content.Child = new OsuContextMenuContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = resizeContainer = new Container
+                Child = new PopoverContainer
                 {
-                    Anchor = ComponentAnchor,
-                    Origin = ComponentAnchor,
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Width = InitialRelativeWidth,
-                    Child = Content
+                    RelativeSizeAxes = Axes.Both,
+                    Child = resizeContainer = new Container
+                    {
+                        Anchor = ComponentAnchor,
+                        Origin = ComponentAnchor,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Width = InitialRelativeWidth,
+                        Child = Content
+                    }
                 }
             };
 

--- a/osu.Game/Localisation/ContextMenuStrings.cs
+++ b/osu.Game/Localisation/ContextMenuStrings.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ViewBeatmap => new TranslatableString(getKey(@"view_beatmap"), @"View beatmap");
 
         /// <summary>
+        /// "Search online"
+        /// </summary>
+        public static LocalisableString SearchOnline => new TranslatableString(getKey(@"search_online"), @"Search online");
+
+        /// <summary>
         /// "Invite to room"
         /// </summary>
         public static LocalisableString InvitePlayer => new TranslatableString(getKey(@"invite_player"), @"Invite to room");

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
@@ -141,6 +141,8 @@ namespace osu.Game.Screens.SelectV2
 
                 if (contentContainer.Child is TruncatingSpriteText text)
                     text.MaxWidth = ChildSize.X;
+                else if (contentContainer.Child is UserLinkContainer userLink)
+                    userLink.MaxWidth = ChildSize.X;
                 else if (contentContainer.Child is MetadataLinkContainer link)
                     link.MaxWidth = ChildSize.X;
             }

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
@@ -2,15 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Screens.SelectV2
@@ -20,52 +21,10 @@ namespace osu.Game.Screens.SelectV2
         private partial class MetadataDisplay : FillFlowContainer
         {
             private readonly OsuSpriteText labelText;
-            private readonly OsuSpriteText contentText;
-            private readonly OsuSpriteText contentLinkText;
-            private readonly OsuHoverContainer contentLink;
-            private readonly DrawableDate contentDate;
-            private readonly TagsLine contentTags;
-            private readonly LoadingSpinner contentLoading;
+            private readonly Container contentContainer;
 
-            private (LocalisableString value, Action? linkAction)? data;
-
-            public (LocalisableString value, Action? linkAction)? Data
-            {
-                get => data;
-                set
-                {
-                    data = value;
-
-                    if (value?.linkAction != null)
-                        setLink(value.Value.value, value.Value.linkAction);
-                    else if (value.HasValue)
-                        setText(value.Value.value);
-                    else
-                        setLoading();
-                }
-            }
-
-            public DateTimeOffset? Date
-            {
-                set
-                {
-                    if (value != null)
-                        setDate(value.Value);
-                    else
-                        setText("-");
-                }
-            }
-
-            public (string[] tags, Action<string> linkAction)? Tags
-            {
-                set
-                {
-                    if (value != null)
-                        setTags(value.Value.tags, value.Value.linkAction);
-                    else
-                        setLoading();
-                }
-            }
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
 
             public MetadataDisplay(LocalisableString label)
             {
@@ -81,99 +40,109 @@ namespace osu.Game.Screens.SelectV2
                         Text = label,
                         Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold),
                     },
-                    new Container
+                    contentContainer = new Container
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = OsuFont.Style.Caption1.Size,
-                        Children = new Drawable[]
-                        {
-                            contentText = new TruncatingSpriteText
-                            {
-                                RelativeSizeAxes = Axes.X,
-                                Font = OsuFont.Style.Caption1,
-                            },
-                            contentLink = new OsuHoverContainer
-                            {
-                                AutoSizeAxes = Axes.Both,
-                                Child = contentLinkText = new TruncatingSpriteText
-                                {
-                                    Font = OsuFont.Style.Caption1,
-                                },
-                            },
-                            contentDate = new DrawableDate(default, OsuFont.Style.Caption1.Size, false),
-                            contentTags = new TagsLine(),
-                            contentLoading = new LoadingSpinner
-                            {
-                                Anchor = Anchor.TopLeft,
-                                Origin = Anchor.TopLeft,
-                                Size = new Vector2(10),
-                                Margin = new MarginPadding { Top = 3f },
-                                State = { Value = Visibility.Visible },
-                            }
-                        },
                     },
                 };
             }
 
             [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
+            private void load()
             {
                 labelText.Colour = colourProvider.Content1;
-                contentText.Colour = colourProvider.Content2;
-                contentLink.IdleColour = colourProvider.Light2;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                SetHyphen();
+            }
+
+            public void SetHyphen()
+            {
+                contentContainer.Child = new TruncatingSpriteText
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Font = OsuFont.Style.Caption1,
+                    Text = "-",
+                    Colour = colourProvider.Content1,
+                };
+            }
+
+            public void SetText(string? text)
+            {
+                if (string.IsNullOrEmpty(text))
+                {
+                    SetHyphen();
+                    return;
+                }
+
+                contentContainer.Child = new MetadataLinkContainer
+                {
+                    Font = OsuFont.Style.Caption1,
+                    Text = text,
+                };
+            }
+
+            public void SetUser(IUser? user)
+            {
+                if (string.IsNullOrEmpty(user?.Username))
+                {
+                    SetHyphen();
+                    return;
+                }
+
+                contentContainer.Child = new UserLinkContainer
+                {
+                    Font = OsuFont.Style.Caption1,
+                    User = user,
+                };
+            }
+
+            public void SetDate(DateTimeOffset? date)
+            {
+                if (!date.HasValue)
+                {
+                    SetHyphen();
+                    return;
+                }
+
+                contentContainer.Child = new DrawableDate(date.Value, OsuFont.Style.Caption1.Size, false);
+            }
+
+            public void SetTags(string[] tags)
+            {
+                if (!tags.Any())
+                {
+                    SetHyphen();
+                    return;
+                }
+
+                contentContainer.Child = new TagsLine { Tags = tags };
+            }
+
+            public void SetLoading()
+            {
+                contentContainer.Child = new LoadingSpinner
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Size = new Vector2(10),
+                    Margin = new MarginPadding { Top = 3f },
+                    State = { Value = Visibility.Visible },
+                };
             }
 
             protected override void Update()
             {
                 base.Update();
-                contentLinkText.MaxWidth = ChildSize.X;
-            }
 
-            private void clear()
-            {
-                contentText.Text = string.Empty;
-                contentLinkText.Text = string.Empty;
-                contentDate.Hide();
-                contentTags.Tags = Array.Empty<string>();
-                contentLoading.Hide();
-            }
-
-            private void setText(LocalisableString text)
-            {
-                clear();
-
-                contentText.Text = text;
-            }
-
-            private void setLink(LocalisableString text, Action action) => Schedule(() =>
-            {
-                clear();
-
-                contentLinkText.Text = text;
-                contentLink.Action = action;
-            });
-
-            private void setDate(DateTimeOffset date)
-            {
-                clear();
-
-                contentDate.Show();
-                contentDate.Date = date;
-            }
-
-            private void setTags(string[] tags, Action<string> link)
-            {
-                clear();
-
-                contentTags.Tags = tags;
-                contentTags.Action = link;
-            }
-
-            private void setLoading()
-            {
-                clear();
-
-                contentLoading.Show();
+                if (contentContainer.Child is TruncatingSpriteText text)
+                    text.MaxWidth = ChildSize.X;
+                else if (contentContainer.Child is MetadataLinkContainer link)
+                    link.MaxWidth = ChildSize.X;
             }
         }
     }

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -18,7 +18,6 @@ using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -27,6 +26,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Utils;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -49,25 +49,17 @@ namespace osu.Game.Screens.SelectV2
 
         private BeatmapSetOnlineStatusPill statusPill = null!;
         private Container titleContainer = null!;
-        private OsuHoverContainer titleLink = null!;
-        private OsuSpriteText titleLabel = null!;
+        private MetadataLinkContainer titleLink = null!;
         private Container artistContainer = null!;
-        private OsuHoverContainer artistLink = null!;
-        private OsuSpriteText artistLabel = null!;
+        private MetadataLinkContainer artistLink = null!;
 
-        internal string DisplayedTitle => titleLabel.Text.ToString();
-        internal string DisplayedArtist => artistLabel.Text.ToString();
+        internal string DisplayedTitle => titleLink.Text.ToString();
+        internal string DisplayedArtist => artistLink.Text.ToString();
 
         private StatisticPlayCount playCount = null!;
         private Statistic favouritesStatistic = null!;
         private Statistic lengthStatistic = null!;
         private Statistic bpmStatistic = null!;
-
-        [Resolved]
-        private ISongSelect? songSelect { get; set; }
-
-        [Resolved]
-        private LocalisationManager localisation { get; set; } = null!;
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -118,15 +110,11 @@ namespace osu.Game.Screens.SelectV2
                             RelativeSizeAxes = Axes.X,
                             Height = OsuFont.Style.Title.Size,
                             Margin = new MarginPadding { Bottom = -4f },
-                            Child = titleLink = new OsuHoverContainer
+                            Child = titleLink = new MetadataLinkContainer
                             {
-                                AutoSizeAxes = Axes.Both,
-                                Child = titleLabel = new TruncatingSpriteText
-                                {
-                                    Shadow = true,
-                                    Font = OsuFont.Style.Title,
-                                },
-                            }
+                                Font = OsuFont.Style.Title,
+                                IdleColour = Color4.White,
+                            },
                         }),
                         new ShearAligningWrapper(artistContainer = new Container
                         {
@@ -134,15 +122,11 @@ namespace osu.Game.Screens.SelectV2
                             RelativeSizeAxes = Axes.X,
                             Height = OsuFont.Style.Heading2.Size,
                             Margin = new MarginPadding { Left = 1f },
-                            Child = artistLink = new OsuHoverContainer
+                            Child = artistLink = new MetadataLinkContainer
                             {
-                                AutoSizeAxes = Axes.Both,
-                                Child = artistLabel = new TruncatingSpriteText
-                                {
-                                    Shadow = true,
-                                    Font = OsuFont.Style.Heading2,
-                                },
-                            }
+                                Font = OsuFont.Style.Heading2,
+                                IdleColour = Color4.White,
+                            },
                         }),
                         new ShearAligningWrapper(statisticsFlow = new FillFlowContainer
                         {
@@ -221,8 +205,8 @@ namespace osu.Game.Screens.SelectV2
         protected override void Update()
         {
             base.Update();
-            titleLabel.MaxWidth = titleContainer.DrawWidth - 20;
-            artistLabel.MaxWidth = artistContainer.DrawWidth - 20;
+            titleLink.MaxWidth = titleContainer.DrawWidth - 20;
+            artistLink.MaxWidth = artistContainer.DrawWidth - 20;
         }
 
         private void updateDisplay()
@@ -233,13 +217,8 @@ namespace osu.Game.Screens.SelectV2
 
             statusPill.Status = beatmapInfo.Status;
 
-            var titleText = new RomanisableString(metadata.TitleUnicode, metadata.Title);
-            titleLabel.Text = titleText;
-            titleLink.Action = () => songSelect?.Search(titleText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript));
-
-            var artistText = new RomanisableString(metadata.ArtistUnicode, metadata.Artist);
-            artistLabel.Text = artistText;
-            artistLink.Action = () => songSelect?.Search(artistText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript));
+            titleLink.Text = new RomanisableString(metadata.TitleUnicode, metadata.Title);
+            artistLink.Text = new RomanisableString(metadata.ArtistUnicode, metadata.Artist);
 
             updateLengthAndBpmStatistics();
 

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.SelectV2
             private FillFlowContainer nameLine = null!;
             private OsuSpriteText difficultyText = null!;
             private OsuSpriteText mappedByText = null!;
-            private UserLinkContainer userLink = null!;
+            private UserLinkContainer mapperLink = null!;
 
             private GridContainer ratingAndNameContainer = null!;
             private DifficultyStatisticsDisplay countStatisticsDisplay = null!;
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.SelectV2
                                                     Text = " mapped by ",
                                                     Font = OsuFont.Style.Body,
                                                 },
-                                                userLink = new UserLinkContainer
+                                                mapperLink = new UserLinkContainer
                                                 {
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
@@ -237,7 +237,7 @@ namespace osu.Game.Screens.SelectV2
                 {
                     ratingAndNameContainer.FadeIn(300, Easing.OutQuint);
                     difficultyText.Text = beatmap.Value.BeatmapInfo.DifficultyName;
-                    userLink.User = beatmap.Value.Metadata.Author;
+                    mapperLink.User = beatmap.Value.Metadata.Author;
                 }
 
                 starRatingDisplay.Current = (Bindable<StarDifficulty>)difficultyCache.GetBindableDifficulty(beatmap.Value.BeatmapInfo, cancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
@@ -330,7 +330,7 @@ namespace osu.Game.Screens.SelectV2
             {
                 base.Update();
 
-                difficultyText.MaxWidth = Math.Max(nameLine.DrawWidth - mappedByText.DrawWidth - userLink.DrawWidth - 20, 0);
+                difficultyText.MaxWidth = Math.Max(nameLine.DrawWidth - mappedByText.DrawWidth - mapperLink.DrawWidth - 20, 0);
 
                 // Use difficulty colour until it gets too dark to be visible against dark backgrounds.
                 Color4 col = starRatingDisplay.DisplayedStars.Value >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : starRatingDisplay.DisplayedDifficultyColour;

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -19,9 +19,6 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Localisation;
-using osu.Game.Online;
-using osu.Game.Online.Chat;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Resources.Localisation.Web;
@@ -59,8 +56,7 @@ namespace osu.Game.Screens.SelectV2
             private FillFlowContainer nameLine = null!;
             private OsuSpriteText difficultyText = null!;
             private OsuSpriteText mappedByText = null!;
-            private OsuHoverContainer mapperLink = null!;
-            private OsuSpriteText mapperText = null!;
+            private UserLinkContainer userLink = null!;
 
             private GridContainer ratingAndNameContainer = null!;
             private DifficultyStatisticsDisplay countStatisticsDisplay = null!;
@@ -139,16 +135,11 @@ namespace osu.Game.Screens.SelectV2
                                                     Text = " mapped by ",
                                                     Font = OsuFont.Style.Body,
                                                 },
-                                                mapperLink = new MapperLinkContainer
+                                                userLink = new UserLinkContainer
                                                 {
-                                                    AutoSizeAxes = Axes.Both,
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
-                                                    Child = mapperText = new TruncatingSpriteText
-                                                    {
-                                                        Shadow = true,
-                                                        Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
-                                                    },
+                                                    Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                                                 },
                                             },
                                         },
@@ -232,9 +223,6 @@ namespace osu.Game.Screens.SelectV2
                 updateDisplay();
             }
 
-            [Resolved]
-            private ILinkHandler? linkHandler { get; set; }
-
             private void updateDisplay()
             {
                 cancellationSource?.Cancel();
@@ -249,8 +237,7 @@ namespace osu.Game.Screens.SelectV2
                 {
                     ratingAndNameContainer.FadeIn(300, Easing.OutQuint);
                     difficultyText.Text = beatmap.Value.BeatmapInfo.DifficultyName;
-                    mapperLink.Action = () => linkHandler?.HandleLink(new LinkDetails(LinkAction.OpenUserProfile, beatmap.Value.Metadata.Author));
-                    mapperText.Text = beatmap.Value.Metadata.Author.Username;
+                    userLink.User = beatmap.Value.Metadata.Author;
                 }
 
                 starRatingDisplay.Current = (Bindable<StarDifficulty>)difficultyCache.GetBindableDifficulty(beatmap.Value.BeatmapInfo, cancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
@@ -343,7 +330,7 @@ namespace osu.Game.Screens.SelectV2
             {
                 base.Update();
 
-                difficultyText.MaxWidth = Math.Max(nameLine.DrawWidth - mappedByText.DrawWidth - mapperText.DrawWidth - 20, 0);
+                difficultyText.MaxWidth = Math.Max(nameLine.DrawWidth - mappedByText.DrawWidth - userLink.DrawWidth - 20, 0);
 
                 // Use difficulty colour until it gets too dark to be visible against dark backgrounds.
                 Color4 col = starRatingDisplay.DisplayedStars.Value >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : starRatingDisplay.DisplayedDifficultyColour;
@@ -352,16 +339,6 @@ namespace osu.Game.Screens.SelectV2
                 mappedByText.Colour = col;
                 countStatisticsDisplay.AccentColour = col;
                 difficultyStatisticsDisplay.AccentColour = col;
-            }
-
-            private partial class MapperLinkContainer : OsuHoverContainer
-            {
-                [BackgroundDependencyLoader]
-                private void load(OverlayColourProvider? overlayColourProvider, OsuColour colours)
-                {
-                    TooltipText = ContextMenuStrings.ViewProfile;
-                    IdleColour = overlayColourProvider?.Light2 ?? colours.Blue;
-                }
             }
 
             private partial class AdjustableDifficultyStatisticsDisplay : DifficultyStatisticsDisplay, IHasCustomTooltip<AdjustedAttributesTooltip.Data>

--- a/osu.Game/Screens/SelectV2/MetadataLinkContainer.cs
+++ b/osu.Game/Screens/SelectV2/MetadataLinkContainer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
+using osu.Game.Online;
+using osu.Game.Online.Chat;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class MetadataLinkContainer : OsuHoverContainer, IHasContextMenu
+    {
+        private readonly TruncatingSpriteText text;
+
+        public float MaxWidth
+        {
+            set => text.MaxWidth = value;
+        }
+
+        public LocalisableString Text
+        {
+            get => text.Text;
+            set => text.Text = value;
+        }
+
+        public FontUsage Font
+        {
+            set => text.Font = value;
+        }
+
+        public MetadataLinkContainer()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            Child = text = new TruncatingSpriteText();
+        }
+
+        [Resolved]
+        private ILinkHandler? linkHandler { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider, ISongSelect? songSelect, LocalisationManager localisations)
+        {
+            IdleColour ??= colourProvider.Light2;
+            Action = () => songSelect?.Search(localisations.GetLocalisedString(text.Text));
+        }
+
+        public MenuItem[] ContextMenuItems => new MenuItem[]
+        {
+            new OsuMenuItem(ContextMenuStrings.SearchOnline, MenuItemType.Standard, () => linkHandler?.HandleLink(new LinkDetails(LinkAction.SearchBeatmapSet, text.Text)))
+        };
+    }
+}

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -190,16 +190,27 @@ namespace osu.Game.Screens.SelectV2
                                                             RelativeSizeAxes = Axes.Both,
                                                         },
                                                     },
-                                                    wedgesContainer = new FillFlowContainer
+                                                    // Add another context menu container dedicated to the wedges area,
+                                                    // since the LeftSideInteractionContainer layer that's directly behind us
+                                                    // blocks right clicks from reaching the outer context menu container.
+                                                    new OsuContextMenuContainer
                                                     {
                                                         RelativeSizeAxes = Axes.Both,
-                                                        Spacing = new Vector2(0f, 4f),
-                                                        Direction = FillDirection.Vertical,
-                                                        Children = new Drawable[]
+                                                        // Temporarily un-shear here so that context menus don't appear sheared.
+                                                        Shear = -OsuGame.SHEAR,
+                                                        Child = wedgesContainer = new FillFlowContainer
                                                         {
-                                                            new ShearAligningWrapper(titleWedge = new BeatmapTitleWedge()),
-                                                            new ShearAligningWrapper(detailsArea = new BeatmapDetailsArea()),
-                                                        },
+                                                            RelativeSizeAxes = Axes.Both,
+                                                            Spacing = new Vector2(0f, 4f),
+                                                            Direction = FillDirection.Vertical,
+                                                            // Shear again after un-shearing in parent.
+                                                            Shear = OsuGame.SHEAR,
+                                                            Children = new Drawable[]
+                                                            {
+                                                                new ShearAligningWrapper(titleWedge = new BeatmapTitleWedge()),
+                                                                new ShearAligningWrapper(detailsArea = new BeatmapDetailsArea()),
+                                                            },
+                                                        }
                                                     },
                                                 }
                                             },

--- a/osu.Game/Screens/SelectV2/UserLinkContainer.cs
+++ b/osu.Game/Screens/SelectV2/UserLinkContainer.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.SelectV2
         public MenuItem[] ContextMenuItems => new MenuItem[]
         {
             new OsuMenuItem(ContextMenuStrings.ViewProfile, MenuItemType.Standard, () => linkHandler?.HandleLink(new LinkDetails(LinkAction.OpenUserProfile, user!))),
-            new OsuMenuItem(ContextMenuStrings.SearchOnline, MenuItemType.Standard, () => linkHandler?.HandleLink(new LinkDetails(LinkAction.OpenUserProfile, user!))),
+            new OsuMenuItem(ContextMenuStrings.SearchOnline, MenuItemType.Standard, () => linkHandler?.HandleLink(new LinkDetails(LinkAction.SearchBeatmapSet, user!.Username))),
         };
     }
 }

--- a/osu.Game/Screens/SelectV2/UserLinkContainer.cs
+++ b/osu.Game/Screens/SelectV2/UserLinkContainer.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
+using osu.Game.Online;
+using osu.Game.Online.Chat;
+using osu.Game.Overlays;
+using osu.Game.Users;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class UserLinkContainer : OsuHoverContainer, IHasContextMenu
+    {
+        private readonly TruncatingSpriteText text;
+
+        public float MaxWidth
+        {
+            set => text.MaxWidth = value;
+        }
+
+        public FontUsage Font
+        {
+            set => text.Font = value;
+        }
+
+        [Resolved]
+        private ILinkHandler? linkHandler { get; set; }
+
+        private IUser? user;
+
+        public IUser? User
+        {
+            get => user;
+            set
+            {
+                user = value;
+                text.Text = user?.Username ?? string.Empty;
+            }
+        }
+
+        public UserLinkContainer()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            Child = text = new TruncatingSpriteText
+            {
+                Shadow = true,
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider? overlayColourProvider, OsuColour colours, ISongSelect? songSelect)
+        {
+            IdleColour = overlayColourProvider?.Light2 ?? colours.Blue;
+            Action = () => songSelect?.Search(user!.Username);
+        }
+
+        public MenuItem[] ContextMenuItems => new MenuItem[]
+        {
+            new OsuMenuItem(ContextMenuStrings.ViewProfile, MenuItemType.Standard, () => linkHandler?.HandleLink(new LinkDetails(LinkAction.OpenUserProfile, user!))),
+            new OsuMenuItem(ContextMenuStrings.SearchOnline, MenuItemType.Standard, () => linkHandler?.HandleLink(new LinkDetails(LinkAction.OpenUserProfile, user!))),
+        };
+    }
+}


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/32777

Now that the structure has long since persisted in the code base, I think now is a good time to address this.

I've took the time to refactor `MetadataDisplay` completely and make it more explicit than it usually was written (where `null` values was arbitrarily interpreted as sometimes loading and sometimes n/a). The new structure should read better, and as a result, simplify all external usages of the component.