### PR TITLE
Add localisation support to difficulty range slider

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneDifficultyRangeSlider.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneDifficultyRangeSlider.cs
@@ -59,7 +59,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     Scale = new Vector2(1),
                     LowerBound = customStart,
                     UpperBound = customEnd,
-                    TooltipSuffix = "suffix",
                     NubWidth = 32,
                     MinRange = 0.1f,
                 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneShearedRangeSlider.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneShearedRangeSlider.cs
@@ -64,7 +64,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Scale = new Vector2(1),
                     LowerBound = customStart,
                     UpperBound = customEnd,
-                    TooltipSuffix = "suffix",
                     NubWidth = 32,
                     DefaultStringLowerBound = "0.0",
                     DefaultStringUpperBound = "∞",

--- a/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedRangeSlider.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -54,20 +55,14 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Lower bound display for when it is set to its default value.
+        /// Lower bound display for when it is set to its default value, or null to display the value directly.
         /// </summary>
-        public string DefaultStringLowerBound { get; init; } = string.Empty;
+        public LocalisableString? DefaultStringLowerBound { get; init; }
 
         /// <summary>
-        /// Upper bound display for when it is set to its default value.
+        /// Upper bound display for when it is set to its default value, or null to display the value directly.
         /// </summary>
-        public string DefaultStringUpperBound { get; init; } = string.Empty;
-
-        public LocalisableString DefaultTooltipLowerBound { get; init; } = string.Empty;
-
-        public LocalisableString DefaultTooltipUpperBound { get; init; } = string.Empty;
-
-        public string TooltipSuffix { get; init; } = string.Empty;
+        public LocalisableString? DefaultStringUpperBound { get; init; }
 
         private float minRange = 0.1f;
 
@@ -144,9 +139,7 @@ namespace osu.Game.Graphics.UserInterface
                                 {
                                     d.KeyboardStep = 0.1f;
                                     d.RelativeSizeAxes = Axes.X;
-                                    d.TooltipSuffix = TooltipSuffix;
                                     d.DefaultString = DefaultStringUpperBound;
-                                    d.DefaultTooltip = DefaultTooltipUpperBound;
                                     d.NubWidth = NubWidth;
                                     d.Current = upperBound;
                                 }),
@@ -154,9 +147,7 @@ namespace osu.Game.Graphics.UserInterface
                                 {
                                     d.KeyboardStep = 0.1f;
                                     d.RelativeSizeAxes = Axes.X;
-                                    d.TooltipSuffix = TooltipSuffix;
                                     d.DefaultString = DefaultStringLowerBound;
-                                    d.DefaultTooltip = DefaultTooltipLowerBound;
                                     d.NubWidth = NubWidth;
                                     d.Current = lowerBound;
                                 }),
@@ -188,14 +179,20 @@ namespace osu.Game.Graphics.UserInterface
 
             public new ShearedNub Nub => base.Nub;
 
-            public string? DefaultString;
-            public LocalisableString? DefaultTooltip;
-            public string? TooltipSuffix;
+            public LocalisableString? DefaultString;
 
             public float NubWidth { get; set; } = ShearedNub.HEIGHT;
 
-            public override LocalisableString TooltipText =>
-                (Current.IsDefault ? DefaultTooltip : Current.Value.ToString($@"0.## {TooltipSuffix}")) ?? Current.Value.ToString($@"0.## {TooltipSuffix}");
+            public override LocalisableString TooltipText
+            {
+                get
+                {
+                    if (Current.IsDefault)
+                        return string.Empty;
+
+                    return Current.Value.ToLocalisableString(@"N1");
+                }
+            }
 
             protected OsuSpriteText NubText { get; private set; } = null!;
 
@@ -245,8 +242,10 @@ namespace osu.Game.Graphics.UserInterface
 
             protected virtual void UpdateDisplay(double value)
             {
-                string defaultString = DefaultString ?? value.ToString("N1");
-                NubText.Text = Current.IsDefault ? defaultString : value.ToString("N1");
+                if (Current.IsDefault && DefaultString != null)
+                    NubText.Text = DefaultString.Value;
+                else
+                    NubText.Text = value.ToLocalisableString(@"N1");
             }
 
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -54,6 +54,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditBeatmap => new TranslatableString(getKey(@"edit_beatmap"), @"Edit beatmap");
 
+        /// <summary>
+        /// "{0} stars"
+        /// </summary>
+        public static LocalisableString Stars(LocalisableString value) => new TranslatableString(getKey(@"stars"), @"{0} stars", value);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/SelectV2/FilterControl_DifficultyRangeSlider.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl_DifficultyRangeSlider.cs
@@ -5,11 +5,13 @@ using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
@@ -35,10 +37,7 @@ namespace osu.Game.Screens.SelectV2
                 : base("Star Rating")
             {
                 NubWidth = ShearedNub.HEIGHT * 1.16f;
-                TooltipSuffix = "stars";
-                DefaultStringLowerBound = "0.0";
                 DefaultStringUpperBound = "∞";
-                DefaultTooltipUpperBound = UserInterfaceStrings.NoLimit;
 
                 AddLayout(drawSizeLayout);
             }
@@ -124,6 +123,17 @@ namespace osu.Game.Screens.SelectV2
                 private readonly bool isUpper;
 
                 protected override bool FocusIndicator => false;
+
+                public override LocalisableString TooltipText
+                {
+                    get
+                    {
+                        if (Current.IsDefault && isUpper)
+                            return UserInterfaceStrings.NoLimit;
+
+                        return SongSelectStrings.Stars(Current.Value.ToLocalisableString(@"0.##"));
+                    }
+                }
 
                 public DifficultyBoundSliderBar(ShearedRangeSlider slider, bool isUpper)
                     : base(slider, isUpper)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33696

I've removed some of the properties for tooltip / default string customization as they don't fit well with localisation or are unnecessary. I've replaced them with direct overrides in the slider pieces instead.