### PR TITLE
Add slider velocity slider to slider toolbox

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                                                      .HitObjects
                                                      .LastOrDefault(h => h is Slider && h.GetEndTime() < HitObject.StartTime) as Slider)?.SliderVelocityMultiplier;
 
-                    HitObject.SliderVelocityMultiplier = nearestSliderVelocity ?? 1;
+                    HitObject.SliderVelocityMultiplier = freehandToolboxGroup?.SliderVelocity.Value ?? 1;
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
 
                     // Replacing the DifficultyControlPoint above doesn't trigger any kind of invalidation.

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -111,9 +111,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             }
         }
 
-        [Resolved]
-        private EditorBeatmap editorBeatmap { get; set; } = null!;
-
         public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double fallbackTime)
         {
             var result = composer?.TrySnapToNearbyObjects(screenSpacePosition, fallbackTime);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private IDistanceSnapProvider? distanceSnapProvider { get; set; }
 
         [Resolved]
-        private FreehandSliderToolboxGroup? freehandToolboxGroup { get; set; }
+        private SliderToolboxGroup? sliderToolboxGroup { get; set; }
 
         [Resolved]
         private EditorClock? editorClock { get; set; }
@@ -90,21 +90,21 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             inputManager = GetContainingInputManager()!;
 
-            if (freehandToolboxGroup != null)
+            if (sliderToolboxGroup != null)
             {
-                freehandToolboxGroup.Tolerance.BindValueChanged(e =>
+                sliderToolboxGroup.Tolerance.BindValueChanged(e =>
                 {
                     bSplineBuilder.Tolerance = e.NewValue;
                     Scheduler.AddOnce(updateSliderPathFromBSplineBuilder);
                 }, true);
 
-                freehandToolboxGroup.CornerThreshold.BindValueChanged(e =>
+                sliderToolboxGroup.CornerThreshold.BindValueChanged(e =>
                 {
                     bSplineBuilder.CornerThreshold = e.NewValue;
                     Scheduler.AddOnce(updateSliderPathFromBSplineBuilder);
                 }, true);
 
-                freehandToolboxGroup.CircleThreshold.BindValueChanged(e =>
+                sliderToolboxGroup.CircleThreshold.BindValueChanged(e =>
                 {
                     Scheduler.AddOnce(updateSliderPathFromBSplineBuilder);
                 }, true);
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 case SliderPlacementState.Initial:
                     BeginPlacement();
 
-                    HitObject.SliderVelocityMultiplier = freehandToolboxGroup?.SliderVelocity.Value ?? 1;
+                    HitObject.SliderVelocityMultiplier = sliderToolboxGroup?.SliderVelocity.Value ?? 1;
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
                     break;
 
@@ -470,7 +470,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private Vector2[]? tryCircleArc(List<Vector2> segment)
         {
-            if (segment.Count < 3 || freehandToolboxGroup?.CircleThreshold.Value == 0) return null;
+            if (segment.Count < 3 || sliderToolboxGroup?.CircleThreshold.Value == 0) return null;
 
             // Assume the segment creates a reasonable circular arc and then check if it reasonable
             var points = PathApproximator.BSplineToPiecewiseLinear(segment.ToArray(), bSplineBuilder.Degree);
@@ -543,7 +543,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             loss /= points.Count;
 
-            return loss > freehandToolboxGroup?.CircleThreshold.Value || totalWinding > MathHelper.TwoPi ? null : circleArcControlPoints;
+            return loss > sliderToolboxGroup?.CircleThreshold.Value || totalWinding > MathHelper.TwoPi ? null : circleArcControlPoints;
         }
 
         private enum SliderPlacementState

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -128,6 +128,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
                     HitObject.SliderVelocityMultiplier = sliderToolboxGroup?.SliderVelocity.Value ?? 1;
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
+
+                    // If defaults aren't re-applied, the slider may display an incorrect length in the timeline
+                    // while being placed in certain scenarios (e.g., if the slider placement tool is selected,
+                    // and then slider velocity is changed through the slider toolbox).
+                    ApplyDefaultsToHitObject();
                     break;
 
                 case SliderPlacementState.ControlPoints:

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -129,16 +129,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 case SliderPlacementState.Initial:
                     BeginPlacement();
 
-                    double? nearestSliderVelocity = (editorBeatmap
-                                                     .HitObjects
-                                                     .LastOrDefault(h => h is Slider && h.GetEndTime() < HitObject.StartTime) as Slider)?.SliderVelocityMultiplier;
-
                     HitObject.SliderVelocityMultiplier = freehandToolboxGroup?.SliderVelocity.Value ?? 1;
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
-
-                    // Replacing the DifficultyControlPoint above doesn't trigger any kind of invalidation.
-                    // Without re-applying defaults, velocity won't be updated.
-                    ApplyDefaultsToHitObject();
                     break;
 
                 case SliderPlacementState.ControlPoints:

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -38,6 +38,13 @@ namespace osu.Game.Rulesets.Osu.Edit
             Precision = 0.0001f
         };
 
+        public BindableDouble SliderVelocity { get; } = new BindableDouble(1.00)
+        {
+            MinValue = 0.1,
+            MaxValue = 10,
+            Precision = 0.01,
+        };
+
         // We map internal ranges to a more standard range of values for display to the user.
         private readonly BindableInt displayTolerance = new BindableInt(90)
         {
@@ -57,6 +64,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             MaxValue = 100
         };
 
+        private ExpandableSlider<double> sliderVelocitySlider = null!;
         private ExpandableSlider<int> toleranceSlider = null!;
         private ExpandableSlider<int> cornerThresholdSlider = null!;
         private ExpandableSlider<int> circleThresholdSlider = null!;
@@ -66,6 +74,10 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             Children = new Drawable[]
             {
+                sliderVelocitySlider = new ExpandableSlider<double>
+                {
+                    Current = SliderVelocity
+                },
                 toleranceSlider = new ExpandableSlider<int>
                 {
                     Current = displayTolerance
@@ -84,6 +96,14 @@ namespace osu.Game.Rulesets.Osu.Edit
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            SliderVelocity.BindValueChanged(velocity =>
+            {
+                sliderVelocitySlider.ContractedLabelText = $"S. V.: {velocity.NewValue:N2}";
+                sliderVelocitySlider.ExpandedLabelText = $"Slider Velocity: {velocity.NewValue:N2}";
+
+                SliderVelocity.Value = velocity.NewValue;
+            }, true);
 
             displayTolerance.BindValueChanged(tolerance =>
             {

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         protected readonly OsuGridToolboxGroup OsuGridToolboxGroup = new OsuGridToolboxGroup();
 
         [Cached]
-        protected readonly FreehandSliderToolboxGroup FreehandSliderToolboxGroup = new FreehandSliderToolboxGroup();
+        protected readonly SliderToolboxGroup SliderToolboxGroup = new SliderToolboxGroup();
 
         [BackgroundDependencyLoader]
         private void load()
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                         GridToolbox = OsuGridToolboxGroup,
                     },
                     new GenerateToolboxGroup(),
-                    FreehandSliderToolboxGroup
+                    SliderToolboxGroup
                 }
             );
         }

--- a/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             Precision = 0.01,
         };
 
-        private double? previousSliderVelocity = null;
+        private double? previousSliderVelocity;
 
         // We map internal ranges to a more standard range of values for display to the user.
         private readonly BindableInt displayTolerance = new BindableInt(90)
@@ -172,13 +172,13 @@ namespace osu.Game.Rulesets.Osu.Edit
         protected override void Update()
         {
             previousSliderVelocity = (editorBeatmap
-                                     .HitObjects
-                                     .LastOrDefault(h => h is Slider && h.StartTime <= editorClock.CurrentTime) as Slider)?.SliderVelocityMultiplier;
+                                    .HitObjects
+                                    .LastOrDefault(h => h is Slider && h.StartTime <= editorClock.CurrentTime) as Slider)?.SliderVelocityMultiplier;
 
             if (previousSliderVelocity != null)
             {
                 // If the previous slider's velocity is the same as the s.v. slider's current value, there's no point in having the button enabled.
-                previousSliderVelocityButton.Enabled.Value = !(previousSliderVelocity == SliderVelocity.Value);
+                previousSliderVelocityButton.Enabled.Value = previousSliderVelocity != SliderVelocity.Value;
                 previousSliderVelocityButton.ExpandedLabelText = $"Use previous: ({previousSliderVelocity:0.##x})";
                 previousSliderVelocityButton.ContractedLabelText = $"Previous: ({previousSliderVelocity:0.##x})";
             }

--- a/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Rulesets.Edit;
 
 namespace osu.Game.Rulesets.Osu.Edit
@@ -64,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             MaxValue = 100
         };
 
-        private ExpandableSlider<double> sliderVelocitySlider = null!;
+        private ExpandableSlider<double, SizeSlider<double>> sliderVelocitySlider = null!;
         private ExpandableSlider<int> toleranceSlider = null!;
         private ExpandableSlider<int> cornerThresholdSlider = null!;
         private ExpandableSlider<int> circleThresholdSlider = null!;
@@ -74,9 +75,10 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             Children = new Drawable[]
             {
-                sliderVelocitySlider = new ExpandableSlider<double>
+                sliderVelocitySlider = new ExpandableSlider<double, SizeSlider<double>>
                 {
-                    Current = SliderVelocity
+                    Current = SliderVelocity,
+                    KeyboardStep = 0.1f,
                 },
                 toleranceSlider = new ExpandableSlider<int>
                 {
@@ -99,8 +101,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             SliderVelocity.BindValueChanged(velocity =>
             {
-                sliderVelocitySlider.ContractedLabelText = $"S. V.: {velocity.NewValue:N2}";
-                sliderVelocitySlider.ExpandedLabelText = $"Slider Velocity: {velocity.NewValue:N2}";
+                sliderVelocitySlider.ContractedLabelText = $"S. V.: {velocity.NewValue:0.##x}";
+                sliderVelocitySlider.ExpandedLabelText = $"Slider Velocity: {velocity.NewValue:0.##x}";
             }, true);
 
             displayTolerance.BindValueChanged(tolerance =>

--- a/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
@@ -172,8 +172,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         protected override void Update()
         {
             previousSliderVelocity = (editorBeatmap
-                                    .HitObjects
-                                    .LastOrDefault(h => h is Slider && h.StartTime <= editorClock.CurrentTime) as Slider)?.SliderVelocityMultiplier;
+                                      .HitObjects
+                                      .LastOrDefault(h => h is Slider && h.StartTime <= editorClock.CurrentTime) as Slider)?.SliderVelocityMultiplier;
 
             if (previousSliderVelocity != null)
             {

--- a/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
@@ -10,9 +10,9 @@ using osu.Game.Rulesets.Edit;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
-    public partial class FreehandSliderToolboxGroup : EditorToolboxGroup
+    public partial class SliderToolboxGroup : EditorToolboxGroup
     {
-        public FreehandSliderToolboxGroup()
+        public SliderToolboxGroup()
             : base("slider")
         {
         }
@@ -102,7 +102,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                 sliderVelocitySlider.ContractedLabelText = $"S. V.: {velocity.NewValue:N2}";
                 sliderVelocitySlider.ExpandedLabelText = $"Slider Velocity: {velocity.NewValue:N2}";
 
-                SliderVelocity.Value = velocity.NewValue;
             }, true);
 
             displayTolerance.BindValueChanged(tolerance =>

--- a/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Rulesets.Osu.Edit
             Precision = 0.01,
         };
 
+        private double? previousSliderVelocity = null;
+
         // We map internal ranges to a more standard range of values for display to the user.
         private readonly BindableInt displayTolerance = new BindableInt(90)
         {
@@ -94,9 +96,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     Action = () =>
                     {
-                        double? previousSliderVelocity = getPreviousSliderVelocityMultiplier();
-
-                        SliderVelocity.Value = previousSliderVelocity ?? 1;
+                        SliderVelocity.Value = previousSliderVelocity!.Value;
                     },
                     RelativeSizeAxes = Axes.X,
                 },
@@ -171,11 +171,13 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         protected override void Update()
         {
-            double? previousSliderVelocity = getPreviousSliderVelocityMultiplier();
+            previousSliderVelocity = (editorBeatmap
+                                     .HitObjects
+                                     .LastOrDefault(h => h is Slider && h.StartTime <= editorClock.CurrentTime) as Slider)?.SliderVelocityMultiplier;
 
             if (previousSliderVelocity != null)
             {
-                // If the previous slider's velocity is the same the s.v. slider's current value, there's no point in having the button enabled.
+                // If the previous slider's velocity is the same as the s.v. slider's current value, there's no point in having the button enabled.
                 previousSliderVelocityButton.Enabled.Value = !(previousSliderVelocity == SliderVelocity.Value);
                 previousSliderVelocityButton.ExpandedLabelText = $"Use previous: ({previousSliderVelocity:0.##x})";
                 previousSliderVelocityButton.ContractedLabelText = $"Previous: ({previousSliderVelocity:0.##x})";
@@ -186,13 +188,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                 previousSliderVelocityButton.ExpandedLabelText = "Use previous (unavailable)";
                 previousSliderVelocityButton.ContractedLabelText = string.Empty;
             }
-        }
-
-        private double? getPreviousSliderVelocityMultiplier()
-        {
-            return (editorBeatmap
-                    .HitObjects
-                    .LastOrDefault(h => h is Slider && h.StartTime < editorClock.CurrentTime) as Slider)?.SliderVelocityMultiplier;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SliderToolboxGroup.cs
@@ -101,7 +101,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 sliderVelocitySlider.ContractedLabelText = $"S. V.: {velocity.NewValue:N2}";
                 sliderVelocitySlider.ExpandedLabelText = $"Slider Velocity: {velocity.NewValue:N2}";
-
             }, true);
 
             displayTolerance.BindValueChanged(tolerance =>


### PR DESCRIPTION
(a.k.a., how many times can I use the word "slider" in one PR?)

Closes #29309
Closes https://github.com/ppy/osu/pull/33707

This PR adds a slider to control slider velocity to the freehand slider toolbox group. Even though this toolbox group currently contains controls solely for freehand drawing of sliders, I think adding the control for slider velocity in here makes the most sense. It would feel kind of weird to have one group labelled "Slider", and then another section solely for slider velocity.

I considered adding a toggle to couple the value from this slider to distance snapping (like mentioned [here](https://github.com/ppy/osu/issues/29309#issuecomment-2747068625)) in this PR, but a) I would like to get confirmation on whether such a toggle is necessary before doing so and b) I would rather split that into a separate PR, anyways.

## Quick Demo

https://github.com/user-attachments/assets/2dacc4d5-c5c0-4594-bcaf-4195df547739


