### PR TITLE
Allow profile and beatmap overlays to coexist

### DIFF
--- a/osu.Game/Graphics/Containers/WaveContainer.cs
+++ b/osu.Game/Graphics/Containers/WaveContainer.cs
@@ -120,6 +120,17 @@ namespace osu.Game.Graphics.Containers
             });
         }
 
+        public void ReplayPopInAnimation()
+        {
+            foreach (var w in wavesContainer)
+                w.ReplayPopInAnimation();
+
+            contentContainer.MoveToY(2);
+            contentContainer.MoveToY(0, APPEAR_DURATION, Easing.OutQuint);
+            samplePopIn?.Play();
+            wasShown = true;
+        }
+
         protected override void PopIn()
         {
             foreach (var w in wavesContainer)
@@ -179,6 +190,12 @@ namespace osu.Game.Graphics.Containers
                 // We can not use RelativeSizeAxes for Height, because the height
                 // of our parent diminishes as the content moves up.
                 Height = Parent!.Parent!.DrawSize.Y * 1.5f;
+            }
+
+            public void ReplayPopInAnimation()
+            {
+                this.MoveToY(Parent!.Parent!.DrawSize.Y);
+                this.MoveToY(FinalPosition, APPEAR_DURATION, easing_show);
             }
 
             protected override void PopIn() => Schedule(() => this.MoveToY(FinalPosition, APPEAR_DURATION, easing_show));

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1263,7 +1263,7 @@ namespace osu.Game
                 };
             }
 
-            // eventually informational overlays should be displayed in a stack, but for now let's only allow one to stay open at a time.
+            // eventually informational overlays should be displayed in a stack, but for now each overlay only has one instance.
             var informationalOverlays = new OverlayContainer[] { beatmapSetOverlay, userProfile };
 
             foreach (var overlay in informationalOverlays)
@@ -1271,7 +1271,7 @@ namespace osu.Game
                 overlay.State.ValueChanged += state =>
                 {
                     if (state.NewValue != Visibility.Hidden)
-                        showOverlayAboveOthers(overlay, informationalOverlays);
+                        showOverlayAboveOthers(overlay, Array.Empty<OverlayContainer>(), true);
                 };
             }
 
@@ -1339,7 +1339,7 @@ namespace osu.Game
             }
         }
 
-        private void showOverlayAboveOthers(OverlayContainer overlay, OverlayContainer[] otherOverlays)
+        private void showOverlayAboveOthers(OverlayContainer overlay, OverlayContainer[] otherOverlays, bool bringToFront = false)
         {
             otherOverlays.Where(o => o != overlay).ForEach(o => o.Hide());
 
@@ -1347,7 +1347,7 @@ namespace osu.Game
             Notifications.Hide();
 
             // Partially visible so leave it at the current depth.
-            if (overlay.IsPresent)
+            if (overlay.IsPresent && !bringToFront)
                 return;
 
             // Show above all other overlays.

--- a/osu.Game/Overlays/BeatmapSetOverlay.cs
+++ b/osu.Game/Overlays/BeatmapSetOverlay.cs
@@ -89,21 +89,31 @@ namespace osu.Game.Overlays
 
         public void FetchAndShowBeatmap(int beatmapId)
         {
+            var previousState = State.Value;
+
             lastLookup = (BeatmapSetLookupType.BeatmapId, beatmapId);
             beatmapSet.Value = null;
 
             performFetch();
             Show();
+            // If the overlay was previously visible, we need to replay the popIn animation.
+            if (previousState == Visibility.Visible)
+                ReplayPopInAnimation();
         }
 
         public void FetchAndShowBeatmapSet(int beatmapSetId)
         {
+            var previousState = State.Value;
+
             lastLookup = (BeatmapSetLookupType.SetId, beatmapSetId);
 
             beatmapSet.Value = null;
 
             performFetch();
             Show();
+            // If the overlay was previously visible, we need to replay the popIn animation.
+            if (previousState == Visibility.Visible)
+                ReplayPopInAnimation();
         }
 
         /// <summary>

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -90,10 +90,16 @@ namespace osu.Game.Overlays
             if (userToShow.OnlineID == APIUser.SYSTEM_USER_ID)
                 return;
 
+            var previousState = State.Value;
+
             user = userToShow;
             ruleset = userRuleset;
 
             Show();
+            // If the overlay was previously visible, we need to replay the popIn animation.
+            if (previousState == Visibility.Visible)
+                ReplayPopInAnimation();
+
             Scheduler.AddOnce(fetchAndSetContent);
         }
 

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -32,6 +32,11 @@ namespace osu.Game.Overlays
             });
         }
 
+        public void ReplayPopInAnimation()
+        {
+            Waves.ReplayPopInAnimation();
+        }
+
         protected override void PopIn()
         {
             Waves.Show();


### PR DESCRIPTION
Apologies for submitting this PR without prior discussion. The changes are relatively minor, so please feel free to close it if it doesn't align with the project's direction.

I noticed the long-standing issue at https://github.com/ppy/osu/issues/5063, and I've personally experienced this inconvenience while playing.

I reviewed the code, and found

https://github.com/ppy/osu/blob/4ec526874b33f9c35f564757a93fc563d7649a15/osu.Game/OsuGame.cs#L1266

the comments suggest that informational overlays are intended to be implemented as a stack. However, they currently they are singletons, allowing only one overlay to be displayed at a time. Refactoring these overlays from singletons to multiple instances to achieve a true stack would involve significant development effort.

In this PR, my approach is to allow informational overlays to coexist. When a user navigates to a specific overlay, it's brought to the foreground with the popIn animation.

While this doesn't implement a stacked overlay system, but the user can open the userProfile and beatmap and return to the previous. I believe this is a relatively low-cost solution for now.

screen recording:

https://github.com/user-attachments/assets/d8d79ccf-7f37-45ad-8990-f46bc1a9a2a9



If you find this approach suitable, I can add tests for this.