### PR TITLE
Fix mod adjustment marker not masking correctly

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneFooterButtonMods.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneFooterButtonMods.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("modified", () => changeMods(new List<Mod> { new OsuModDoubleTime { SpeedChange = { Value = 1.2 } } }));
             AddStep("modified + one", () => changeMods(new List<Mod> { new OsuModHidden(), new OsuModDoubleTime { SpeedChange = { Value = 1.2 } } }));
             AddStep("modified + two", () => changeMods(new List<Mod> { new OsuModHidden(), new OsuModHardRock(), new OsuModDoubleTime { SpeedChange = { Value = 1.2 } } }));
+            AddStep("modified + five", () => changeMods(new List<Mod> { new OsuModHidden(), new OsuModHardRock(), new OsuModDoubleTime { SpeedChange = { Value = 1.2 } }, new OsuModClassic(), new OsuModDifficultyAdjust(), new OsuModRandom() }));
+            AddStep("modified + six", () => changeMods(new List<Mod> { new OsuModHidden(), new OsuModHardRock(), new OsuModDoubleTime { SpeedChange = { Value = 1.2 } }, new OsuModClassic(), new OsuModDifficultyAdjust(), new OsuModRandom(), new OsuModAlternate() }));
 
             AddStep("clear mods", () => changeMods(Array.Empty<Mod>()));
             AddWaitStep("wait", 3);

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -8,7 +8,6 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
@@ -84,7 +83,7 @@ namespace osu.Game.Rulesets.UI
 
         private Drawable adjustmentMarker = null!;
 
-        private Circle cogBackground = null!;
+        private SpriteIcon cogBackground = null!;
         private SpriteIcon cog = null!;
 
         private ModSettingChangeTracker? modSettingsChangeTracker;
@@ -178,11 +177,12 @@ namespace osu.Game.Rulesets.UI
                             Position = new Vector2(64, 14),
                             Children = new Drawable[]
                             {
-                                cogBackground = new Circle
+                                cogBackground = new SpriteIcon
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
                                     RelativeSizeAxes = Axes.Both,
+                                    Icon = FontAwesome.Solid.Circle,
                                 },
                                 cog = new SpriteIcon
                                 {


### PR DESCRIPTION
Changes `Circle` to `SpriteIcon` with fontawesome circle.

| Before | After |
| --- | --- |
| ![Screenshot 2025-06-16 at 10 40 25 PM](https://github.com/user-attachments/assets/e17bb966-0107-43d5-8ad2-e811099625e2) | ![Screenshot 2025-06-16 at 10 41 04 PM](https://github.com/user-attachments/assets/ef3a2d82-fe51-451a-bc80-000699972cc5) |
| ![Screenshot 2025-06-16 at 10 36 49 PM](https://github.com/user-attachments/assets/6b622d9a-b868-4966-a365-b25840cdac5f) | ![Screenshot 2025-06-16 at 10 35 42 PM](https://github.com/user-attachments/assets/4665d3a4-512c-476b-b215-0a9763b65ff9) |
| ![Screenshot 2025-06-16 at 10 37 06 PM](https://github.com/user-attachments/assets/5d582ecc-834f-4488-802c-8f98d661fecf) | ![Screenshot 2025-06-16 at 10 35 50 PM](https://github.com/user-attachments/assets/2d7f15bf-d1cf-4b0a-b7bc-3b06e7a615c8) |