### PR TITLE
osu!taiko new reading penalty for repetitive patterns

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -35,12 +35,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             }
 
             var taikoObject = (TaikoDifficultyHitObject)current;
-            int index = taikoObject.ColourData.MonoStreak?.HitObjects.IndexOf(taikoObject) ?? 0;
 
-            currentStrain *= DifficultyCalculationUtils.Logistic(index, 4, -1 / 25.0, 0.5) + 0.5;
+            // Penalise repetitive patterns by decaying notes based on their index in the alternating mono pattern.
+            int index = taikoObject.NoteIndex - taikoObject.ColourData.AlternatingMonoPattern.FirstHitObject.NoteIndex;
+            double simplePatternPenalty = DifficultyCalculationUtils.Logistic(index, 5, -1);
 
             currentStrain *= StrainDecayBase;
-            currentStrain += ReadingEvaluator.EvaluateDifficultyOf(taikoObject) * SkillMultiplier;
+            currentStrain += ReadingEvaluator.EvaluateDifficultyOf(taikoObject) * SkillMultiplier * simplePatternPenalty;
 
             return currentStrain;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             var taikoObject = (TaikoDifficultyHitObject)current;
 
             // Penalise repetitive patterns by decaying notes based on their index in the alternating mono pattern.
-            int index = taikoObject.NoteIndex - taikoObject.ColourData.AlternatingMonoPattern.FirstHitObject.NoteIndex;
+            int index = taikoObject.NoteIndex - (taikoObject.ColourData.AlternatingMonoPattern?.FirstHitObject.NoteIndex ?? taikoObject.NoteIndex);
             double simplePatternPenalty = DifficultyCalculationUtils.Logistic(index, 5, -1);
 
             currentStrain *= StrainDecayBase;


### PR DESCRIPTION
This change replaces the penalty to reading based on notes' `MonoStreak` index with a new one based on their index in the `AlternatingMonoPattern`. The new penalty applies to the reading difficulty **added** rather than the strain decay to make more of a difference. The effect can be seen easily on maps like 3913621 and 1695591 with HR and DT, and especially on converts like 28065 and 3939912 (which we can bring back up in the final balancing pass if necessary)