### PR TITLE
Adjust rank formatting logic to avoid getting cut in score

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardScore.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardScore.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     {
                         fillFlow = new FillFlowContainer
                         {
+                            X = 100,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             RelativeSizeAxes = Axes.X,
@@ -281,7 +282,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 },
                 new ScoreInfo
                 {
-                    Position = 110000,
+                    Position = 2233,
                     Rank = ScoreRank.D,
                     Accuracy = 1,
                     MaxCombo = 244,

--- a/osu.Game/Utils/FormatUtils.cs
+++ b/osu.Game/Utils/FormatUtils.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Utils
         /// Formats the supplied rank/leaderboard position in a consistent, simplified way.
         /// </summary>
         /// <param name="rank">The rank/position to be formatted.</param>
-        public static string FormatRank(this int rank) => rank.ToMetric(decimals: rank < 100_000 ? 1 : 0);
+        public static string FormatRank(this int rank) => rank.ToMetric(decimals: rank < 10_000 ? 1 : 0);
 
         /// <summary>
         /// Formats the supplied star rating in a consistent, simplified way.


### PR DESCRIPTION
- Closes #33705

I think it's too much to try displaying one decimal place on 10k-99k rank range in scores. This change also affects gameplay leaderboard scores and old song select scores, but I don't think that's a problem.

Before (notice second score):

![CleanShot 2025-06-18 at 01 53 57](https://github.com/user-attachments/assets/f27b4be6-bfb4-4c8f-aeb6-002f82784ed0)

After:

![CleanShot 2025-06-18 at 01 52 55](https://github.com/user-attachments/assets/a1d508d0-fe8d-46eb-abfd-706931e50c9d)
