### PR TITLE
Fix incompatible mods not retaining settings after selecting autoplay via ctrl+enter

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -19,7 +19,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModMagnetised : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
+    public class OsuModMagnetised : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
     {
         public override string Name => "Magnetised";
         public override string Acronym => "MG";

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
@@ -10,6 +10,7 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens;
@@ -124,6 +125,47 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddUntilStep("wait for track playing", () => Game.MusicController.IsPlaying);
             AddAssert("Ensure time wasn't reset to preview point", () => Game.MusicController.CurrentTrack.CurrentTime < beatmap().BeatmapInfo.Metadata.PreviewTime);
+        }
+
+        [Test]
+        public void TestAutoplayShortcutReturnsInitialModsOnExit()
+        {
+            PushAndConfirm(() => new SoloSongSelect());
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadOszIntoOsu(Game, virtualTrack: true).WaitSafely());
+
+            AddUntilStep("wait for selection", () => !Game.Beatmap.IsDefault);
+
+            AddStep("open mod select", () => InputManager.Key(Key.F1));
+            AddStep("search magnetised", () => this.ChildrenOfType<ModSelectOverlay>().Single().SearchTerm = "MG");
+            AddStep("select", () => InputManager.Key(Key.Enter));
+
+            AddAssert("magnetised selected", () => Game.SelectedMods.Value.Single(), Is.TypeOf<OsuModMagnetised>);
+            AddStep("configure mod", () => ((OsuModMagnetised)Game.SelectedMods.Value.Single()).AttractionStrength.Value = 1.0f);
+
+            pushEscape();
+            pushEscape();
+
+            AddStep("press ctrl+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () =>
+            {
+                DismissAnyNotifications();
+                return Game.ScreenStack.CurrentScreen is Player;
+            });
+
+            AddAssert("only autoplay selected", () => Game.SelectedMods.Value.Single(), Is.TypeOf<OsuModAutoplay>);
+
+            pushEscape();
+            waitForScreen<SoloSongSelect>();
+
+            AddAssert("magnetised selected", () => Game.SelectedMods.Value.Single(), Is.TypeOf<OsuModMagnetised>);
+            AddAssert("mod configured", () => ((OsuModMagnetised)Game.SelectedMods.Value.Single()).AttractionStrength.Value, () => Is.EqualTo(1.0f));
         }
 
         private Func<Player> playToResults()

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.Select
         {
             if (playerLoader != null) return false;
 
-            modsAtGameplayStart = Mods.Value;
+            modsAtGameplayStart = Mods.Value.Select(m => m.DeepClone()).ToArray();
 
             // Ctrl+Enter should start map with autoplay enabled.
             if (GetContainingInputManager()?.CurrentState?.Keyboard.ControlPressed == true)

--- a/osu.Game/Screens/SelectV2/SoloSongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SoloSongSelect.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.SelectV2
         {
             if (playerLoader != null) return;
 
-            modsAtGameplayStart = Mods.Value;
+            modsAtGameplayStart = Mods.Value.Select(m => m.DeepClone()).ToArray();
 
             // Ctrl+Enter should start map with autoplay enabled.
             if (GetContainingInputManager()?.CurrentState?.Keyboard.ControlPressed == true)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33762

Holding a reference to the mods directly is not safe, they're originated from the mod select overlay and the overlay resets their settings when they're deselected.