### PR TITLE
Ignore case when parsing `OSU_EXTERNAL_UPDATE_STREAM`

### DIFF
--- a/osu.Game/Updater/NoActionUpdateManager.cs
+++ b/osu.Game/Updater/NoActionUpdateManager.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Updater
     /// </summary>
     public partial class NoActionUpdateManager : UpdateManager
     {
-        private static ReleaseStream? externalReleaseStream => Enum.TryParse(Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_STREAM"), out ReleaseStream stream) ? stream : null;
+        private static ReleaseStream? externalReleaseStream => Enum.TryParse(Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_STREAM"), true, out ReleaseStream stream) ? stream : null;
 
         private string version = string.Empty;
 


### PR DESCRIPTION
Noticed when reviewing https://github.com/fufexan/nix-gaming/pull/267, that the package will set a lowercase value, and the default for `Enum.TryParse()` is to _not_ ignore case (i.e. `false`).