### PR TITLE
SongSelectV2: Refine random selection to currently open group (and support difficulty split panels better)

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
     public abstract partial class BeatmapCarouselTestScene : OsuManualInputManagerTestScene
     {
         protected readonly Stack<BeatmapSetInfo> BeatmapSetRequestedSelections = new Stack<BeatmapSetInfo>();
+        protected readonly Stack<BeatmapInfo> BeatmapRequestedSelections = new Stack<BeatmapInfo>();
 
         protected readonly BindableList<BeatmapSetInfo> BeatmapSets = new BindableList<BeatmapSetInfo>();
 
@@ -73,6 +74,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             AddStep("create components", () =>
             {
+                BeatmapRequestedSelections.Clear();
                 BeatmapSetRequestedSelections.Clear();
                 BeatmapRecommendationFunction = null;
                 NewItemsPresentedInvocationCount = 0;
@@ -113,6 +115,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                     NewItemsPresented = _ => NewItemsPresentedInvocationCount++,
                                     RequestSelection = b =>
                                     {
+                                        BeatmapRequestedSelections.Push(b);
                                         Carousel.CurrentSelection = b;
                                     },
                                     RequestRecommendedSelection = beatmaps =>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -40,6 +40,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestGroupingModeChangeStillWorks()
         {
+            BeatmapInfo originalSelected = null!;
+            GroupDefinition? expanded = null;
+
             SortAndGroupBy(SortMode.Artist, GroupMode.Artist);
             AddBeatmaps(10, 3, true);
             WaitForDrawablePanels();
@@ -47,11 +50,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             nextRandom();
             ensureRandomDidNotRepeat();
 
-            SortAndGroupBy(SortMode.Artist, GroupMode.None);
+            AddStep("store selection", () => originalSelected = (BeatmapInfo)Carousel.CurrentSelection!);
+
+            SortAndGroupBy(SortMode.Artist, GroupMode.Difficulty);
             WaitForFiltering();
 
-            nextRandom();
-            ensureRandomDidNotRepeat();
+            AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(originalSelected));
+
+            storeExpandedGroup();
+
+            for (int i = 0; i < 5; i++)
+            {
+                nextRandom();
+                ensureRandomDidNotRepeat();
+                checkExpandedGroupUnchanged();
+            }
+
+            void storeExpandedGroup() => AddStep("store open group", () => expanded = Carousel.ExpandedGroup);
+
+            void checkExpandedGroupUnchanged() => AddAssert("expanded did not change", () => Carousel.ExpandedGroup, () => Is.EqualTo(expanded));
         }
 
         /// <summary>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -37,6 +37,23 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             }
         }
 
+        [Test]
+        public void TestGroupingModeChangeStillWorks()
+        {
+            SortAndGroupBy(SortMode.Artist, GroupMode.Artist);
+            AddBeatmaps(10, 3, true);
+            WaitForDrawablePanels();
+
+            nextRandom();
+            ensureRandomDidNotRepeat();
+
+            SortAndGroupBy(SortMode.Artist, GroupMode.None);
+            WaitForFiltering();
+
+            nextRandom();
+            ensureRandomDidNotRepeat();
+        }
+
         /// <summary>
         /// Test random non-repeating algorithm
         /// </summary>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -66,6 +66,15 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 checkExpandedGroupUnchanged();
             }
 
+            SortAndGroupBy(SortMode.Artist, GroupMode.None);
+            WaitForFiltering();
+
+            for (int i = 0; i < 5; i++)
+            {
+                nextRandom();
+                ensureRandomDidNotRepeat();
+            }
+
             void storeExpandedGroup() => AddStep("store open group", () => expanded = Carousel.ExpandedGroup);
 
             void checkExpandedGroupUnchanged() => AddAssert("expanded did not change", () => Carousel.ExpandedGroup, () => Is.EqualTo(expanded));

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
 
 namespace osu.Game.Tests.Visual.SongSelectV2
 {
@@ -47,25 +48,42 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(10, 3, true);
             WaitForDrawablePanels();
 
+            GroupDefinition? expanded = null;
+
+            for (int i = 0; i < 2; i++)
+            {
+                nextRandom();
+                expanded ??= storeExpandedGroup();
+
+                ensureRandomDidNotRepeat();
+                checkExpandedGroupUnchanged();
+            }
+
             nextRandom();
-            ensureRandomDidNotRepeat();
-            nextRandom();
-            ensureRandomDidNotRepeat();
-            nextRandom();
-            ensureRandomDidNotRepeat();
+            ensureRandomDidRepeat();
+            checkExpandedGroupUnchanged();
 
             prevRandom();
             checkRewindCorrectSet();
+            checkExpandedGroupUnchanged();
             prevRandom();
             checkRewindCorrectSet();
+            checkExpandedGroupUnchanged();
 
             nextRandom();
             ensureRandomDidNotRepeat();
+            checkExpandedGroupUnchanged();
             nextRandom();
-            ensureRandomDidNotRepeat();
+            ensureRandomDidRepeat();
+            checkExpandedGroupUnchanged();
 
-            nextRandom();
-            AddAssert("ensure repeat", () => BeatmapSetRequestedSelections.Contains(Carousel.SelectedBeatmapSet!));
+            GroupDefinition? storeExpandedGroup()
+            {
+                AddStep("store open group", () => expanded = Carousel.ExpandedGroup);
+                return null;
+            }
+
+            void checkExpandedGroupUnchanged() => AddAssert("expanded did not change", () => Carousel.ExpandedGroup, () => Is.EqualTo(expanded));
         }
 
         /// <summary>
@@ -76,28 +94,47 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             SortAndGroupBy(SortMode.Difficulty, GroupMode.Difficulty);
 
-            AddBeatmaps(10, 3, true);
+            AddBeatmaps(3, 3, true);
             WaitForDrawablePanels();
 
+            GroupDefinition? expanded = null;
+
+            for (int i = 0; i < 3; i++)
+            {
+                nextRandom();
+                expanded ??= storeExpandedGroup();
+
+                ensureRandomDidNotRepeat();
+                checkExpandedGroupUnchanged();
+            }
+
             nextRandom();
-            ensureRandomDidNotRepeat();
-            nextRandom();
-            ensureRandomDidNotRepeat();
-            nextRandom();
-            ensureRandomDidNotRepeat();
+            ensureRandomDidRepeat();
+            checkExpandedGroupUnchanged();
 
             prevRandom();
             checkRewindCorrectSet();
+            checkExpandedGroupUnchanged();
+
             prevRandom();
             checkRewindCorrectSet();
+            checkExpandedGroupUnchanged();
 
             nextRandom();
             ensureRandomDidNotRepeat();
-            nextRandom();
-            ensureRandomDidNotRepeat();
+            checkExpandedGroupUnchanged();
 
             nextRandom();
-            AddAssert("ensure repeat", () => BeatmapSetRequestedSelections.Contains(Carousel.SelectedBeatmapSet!));
+            ensureRandomDidRepeat();
+            checkExpandedGroupUnchanged();
+
+            GroupDefinition? storeExpandedGroup()
+            {
+                AddStep("store open group", () => expanded = Carousel.ExpandedGroup);
+                return null;
+            }
+
+            void checkExpandedGroupUnchanged() => AddAssert("expanded did not change", () => Carousel.ExpandedGroup, () => Is.EqualTo(expanded));
         }
 
         [Test]
@@ -173,6 +210,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         private void nextRandom() =>
             AddStep("select random next", () => Carousel.NextRandom());
+
+        private void ensureRandomDidRepeat() =>
+            AddAssert("did repeat", () => BeatmapSetRequestedSelections.Distinct().Count(), () => Is.LessThan(BeatmapSetRequestedSelections.Count));
 
         private void ensureRandomDidNotRepeat() =>
             AddAssert("no repeats", () => BeatmapSetRequestedSelections.Distinct().Count(), () => Is.EqualTo(BeatmapSetRequestedSelections.Count));

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -267,8 +267,7 @@ namespace osu.Game.Screens.SelectV2
                     // Find any containing group. There should never be too many groups so iterating is efficient enough.
                     GroupDefinition? containingGroup = grouping.GroupItems.SingleOrDefault(kvp => kvp.Value.Any(i => CheckModelEquality(i.Model, beatmapInfo))).Key;
 
-                    if (containingGroup != null)
-                        setExpandedGroup(containingGroup);
+                    setExpandedGroup(containingGroup);
 
                     if (grouping.BeatmapSetsGroupedTogether)
                         setExpandedSet(beatmapInfo);
@@ -362,8 +361,11 @@ namespace osu.Game.Screens.SelectV2
         {
             if (ExpandedGroup != null)
                 setExpansionStateOfGroup(ExpandedGroup, false);
+
             ExpandedGroup = group;
-            setExpansionStateOfGroup(group, true);
+
+            if (ExpandedGroup != null)
+                setExpansionStateOfGroup(group, true);
         }
 
         private void setExpansionStateOfGroup(GroupDefinition group, bool expanded)

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -290,13 +290,9 @@ namespace osu.Game.Screens.SelectV2
             HandleItemSelected(CurrentSelection);
 
             // If a group was selected that is not the one containing the selection, attempt to reselect it.
-            if (groupForReselection != null)
-            {
-                if (!grouping.GroupItems.TryGetValue(groupForReselection, out _))
-                    ExpandedGroup = null;
-                else
-                    setExpandedGroup(groupForReselection);
-            }
+            // If the original group was not found, ExpandedGroup will already have been updated to a valid value in `HandleItemSelected` above.
+            if (groupForReselection != null && grouping.GroupItems.TryGetValue(groupForReselection, out _))
+                setExpandedGroup(groupForReselection);
         }
 
         private void selectRecommendedDifficultyForBeatmapSet(BeatmapSetInfo beatmapSet)

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -289,9 +289,14 @@ namespace osu.Game.Screens.SelectV2
             // This will update the visual state of the selected item.
             HandleItemSelected(CurrentSelection);
 
-            // If a group was selected that is not the one containing the selection, reselect it.
+            // If a group was selected that is not the one containing the selection, attempt to reselect it.
             if (groupForReselection != null)
-                setExpandedGroup(groupForReselection);
+            {
+                if (!grouping.GroupItems.TryGetValue(groupForReselection, out _))
+                    ExpandedGroup = null;
+                else
+                    setExpandedGroup(groupForReselection);
+            }
         }
 
         private void selectRecommendedDifficultyForBeatmapSet(BeatmapSetInfo beatmapSet)

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -634,6 +634,26 @@ namespace osu.Game.Screens.SelectV2
             // This is the fastest way to retrieve sets for randomisation.
             ICollection<BeatmapSetInfo> visibleSets = grouping.SetItems.Keys;
 
+            if (ExpandedGroup != null)
+            {
+                // In the case of grouping, users expect random to only operate on the expanded group.
+                // This is going to incur some overhead as we don't have a group-beatmapset mapping currently.
+                //
+                // If this becomes an issue, we could either store a mapping, or run the random algorithm many times
+                // using the `SetItems` method until we get a group HIT.
+                if (grouping.BeatmapSetsGroupedTogether)
+                    visibleSets = grouping.GroupItems[ExpandedGroup].Select(i => i.Model).OfType<BeatmapSetInfo>().ToArray();
+                else
+                {
+                    // Note that this is probably not correct in all cases.
+                    // When we aren't grouping sets together, we might want to randomise by beatmaps, not sets.
+                    //
+                    // Imagine the scenario where a single beatmap set has multiple difficulties in the same difficulty grouping, where this
+                    // would always choose the set's user recommended difficulty rather than the visible ones.
+                    visibleSets = grouping.GroupItems[ExpandedGroup].Select(i => i.Model).OfType<BeatmapInfo>().Select(b => b.BeatmapSet!).Distinct().ToArray();
+                }
+            }
+
             if (CurrentSelection is BeatmapInfo beatmapInfo)
             {
                 randomSelectedBeatmaps.Add(beatmapInfo);

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -467,6 +467,9 @@ namespace osu.Game.Screens.SelectV2
             if (!this.IsCurrentScreen())
                 return false;
 
+            if (selectionDebounce?.State == ScheduledDelegate.RunState.Waiting)
+                selectionDebounce?.RunTask();
+
             // While filtering, let's not ever attempt to change selection.
             // This will be resolved after the filter completes, see `newItemsPresented`.
             bool carouselStateIsValid = filterDebounce?.State != ScheduledDelegate.RunState.Waiting && !carousel.IsFiltering;


### PR DESCRIPTION
The goal of this pull request was to fix the random button not respecting groups. But in the process of adding test coverage I noticed that I'd also need to fix a larger issue with random selection. The group fix change doesn't work well on its own so I've bundled these together.

## Fix random button not respecting open group

Closes https://github.com/ppy/osu/issues/33569.

## Fix random selection not working as expected when displaying individual difficulties

Previously, random selection would always be done at a *set* level. The final operation of a random action would be "select the user's recommended difficulty from this randomly selected set".

This makes no sense when sets are not grouped together at song select. In fact, it is completely broken with the previous commit which adds group-isolated random support – if we're grouping by difficulty and the user's recommendation is not in the current group it would throw the user into another group unexpectedly.

This fixes the issue by splitting out the random implementation into two separate pathways depending on the carousel display mode.
