### PR TITLE
SongSelectV2: Fix pressing multiple traversal keys in same frame causing weirdness

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -156,6 +156,38 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestMultipleKeyboardOperationsPerFrame()
+        {
+            AddBeatmaps(10, 3);
+            WaitForDrawablePanels();
+
+            SelectNextSet();
+            WaitForSetSelection(0, 0);
+
+            SelectNextPanel();
+            SelectNextPanel();
+            SelectNextPanel();
+
+            AddStep("Press two keys at once", () =>
+            {
+                InputManager.Key(Key.Down);
+                InputManager.Key(Key.Right);
+            });
+
+            // Second key is respected, so only set selection changes.
+            WaitForSetSelection(1, 0);
+
+            AddStep("Press two keys at once", () =>
+            {
+                InputManager.Key(Key.Left);
+                InputManager.Key(Key.Up);
+            });
+
+            // Second key is respected, so only keyboard selection changes.
+            WaitForSetSelection(1, 0);
+        }
+
+        [Test]
         public void TestKeyboardSelection()
         {
             AddBeatmaps(10, 3);

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -453,24 +453,45 @@ namespace osu.Game.Graphics.Carousel
                 // `refreshAfterSelection()` is the method responsible for updating the index of the selected item here which runs once per frame.
 
                 case GlobalAction.SelectNext:
-                    Scheduler.AddOnce(traverseKeyboardSelection, 1);
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Keyboard, 1));
                     return true;
 
                 case GlobalAction.SelectPrevious:
-                    Scheduler.AddOnce(traverseKeyboardSelection, -1);
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Keyboard, -1));
                     return true;
 
                 case GlobalAction.ActivateNextSet:
-                    Scheduler.AddOnce(traverseSetSelection, 1);
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Set, 1));
                     return true;
 
                 case GlobalAction.ActivatePreviousSet:
-                    Scheduler.AddOnce(traverseSetSelection, -1);
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Set, -1));
                     return true;
             }
 
             return false;
+
+            void traverseFromKey(TraversalOperation traversal)
+            {
+                switch (traversal.Type)
+                {
+                    case TraversalType.Keyboard:
+                        traverseKeyboardSelection(traversal.Direction);
+                        break;
+
+                    case TraversalType.Set:
+                        traverseSetSelection(traversal.Direction);
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
         }
+
+        private enum TraversalType { Keyboard, Set }
+
+        private record TraversalOperation(TraversalType Type, int Direction);
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -458,29 +458,28 @@ namespace osu.Game.Graphics.Carousel
                 // if the selection is changed more than once during an update frame,
                 // which can happen if repeat inputs are enqueued for processing at a rate faster than the update refresh rate.
                 // `refreshAfterSelection()` is the method responsible for updating the index of the selected item here which runs once per frame.
-
-                case GlobalAction.SelectNext:
-                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Keyboard, 1));
-                    return true;
-
                 case GlobalAction.SelectPrevious:
                     Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Keyboard, -1));
                     return true;
 
-                case GlobalAction.ActivateNextSet:
-                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Set, 1));
+                case GlobalAction.SelectNext:
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Keyboard, 1));
                     return true;
 
                 case GlobalAction.ActivatePreviousSet:
                     Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Set, -1));
                     return true;
 
+                case GlobalAction.ActivateNextSet:
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Set, 1));
+                    return true;
+
                 case GlobalAction.ExpandPreviousGroup:
-                    Scheduler.AddOnce(traverseGroupSelection, -1);
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Group, -1));
                     return true;
 
                 case GlobalAction.ExpandNextGroup:
-                    Scheduler.AddOnce(traverseGroupSelection, 1);
+                    Scheduler.AddOnce(traverseFromKey, new TraversalOperation(TraversalType.Group, 1));
                     return true;
 
                 case GlobalAction.ToggleCurrentGroup:
@@ -527,13 +526,17 @@ namespace osu.Game.Graphics.Carousel
                         traverseSetSelection(traversal.Direction);
                         break;
 
+                    case TraversalType.Group:
+                        traverseGroupSelection(traversal.Direction);
+                        break;
+
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
             }
         }
 
-        private enum TraversalType { Keyboard, Set }
+        private enum TraversalType { Keyboard, Set, Group }
 
         private record TraversalOperation(TraversalType Type, int Direction);
 


### PR DESCRIPTION
Closes #33453.

I wonder if the next case will be a user clicking and using keys at the same time. Maybe the traversal operations should just fail if the selection objects are not yet populated. Thought for next time this comes up I guess, I prefer this solution for now.