### PR TITLE
osu!taiko remove interval difficulty from doublets

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -62,6 +62,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 }
             }
 
+            // If the pattern is a doublet, return no difficulty as the interval of doublets can be ignored while playing.
+            if (sameRhythmGroupedHitObjects?.HitObjects.Count == 2 && sameRhythmGroupedHitObjects?.HitObjects[0] == sameRhythmGroupedHitObjects?.FirstHitObject)
+                return 0;
+
             // Penalise patterns that can be hit within a single hit window.
             intervalDifficulty *= DifficultyCalculationUtils.Logistic(
                 sameRhythmGroupedHitObjects.Duration / hitWindow,

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double staminaDifficultStrains = stamina.CountTopWeightedStrains();
 
             // As we don't have pattern integration in osu!taiko, we apply the other two skills relative to rhythm.
-            patternMultiplier = Math.Pow(staminaSkill * colourSkill, 0.12);
+            patternMultiplier = Math.Pow(staminaSkill * colourSkill, 0.10);
 
             strainLengthBonus = 1 + 0.15 * DifficultyCalculationUtils.ReverseLerp(staminaDifficultStrains, 1000, 1555);
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double staminaDifficultStrains = stamina.CountTopWeightedStrains();
 
             // As we don't have pattern integration in osu!taiko, we apply the other two skills relative to rhythm.
-            patternMultiplier = Math.Pow(staminaSkill * colourSkill, 0.10);
+            patternMultiplier = Math.Pow(staminaSkill * colourSkill, 0.12);
 
             strainLengthBonus = 1 + 0.15 * DifficultyCalculationUtils.ReverseLerp(staminaDifficultStrains, 1000, 1555);
 


### PR DESCRIPTION
This change prevents rhythm groupings that are two notes long (called doublets) from awarding difficulty for the interval between them. The exact time between the two notes of a doublet has basically no effect on how it plays, and mappers have been abusing this using doublets of varying lengths to blow up star rating.

Some notable SR changes:
5033325: 8.41 -> 7.60
5060035: 8.03 -> 7.34
5019666: 7.26 -> 5.79

Other doublet and rhythm heavy maps like 3969098 and 4543374 lose tiny amounts, with the worst loss I could find other than the abuse maps being 2912740 going 7.34 -> 7.13. A smoogisheet would still be good to have