### PR TITLE
Use localised strings for SSV2

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmap.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Game.Localisation;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Objects;
 
@@ -23,21 +24,21 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = @"Fruits",
+                    Name = BeatmapStatisticStrings.Fruits,
                     Content = fruits.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     BarDisplayLength = fruits / (float)sum,
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Juice Streams",
+                    Name = BeatmapStatisticStrings.JuiceStreams,
                     Content = juiceStreams.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     BarDisplayLength = juiceStreams / (float)sum,
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Banana Showers",
+                    Name = BeatmapStatisticStrings.BananaShowers,
                     Content = bananaShowers.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                     BarDisplayLength = Math.Min(bananaShowers / 10f, 1),

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Game.Localisation;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
 
@@ -42,14 +43,14 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = @"Notes",
+                    Name = BeatmapStatisticStrings.Notes,
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = notes.ToString(),
                     BarDisplayLength = notes / (float)sum,
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Hold Notes",
+                    Name = BeatmapStatisticStrings.HoldNotes,
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = holdNotes.ToString(),
                     BarDisplayLength = holdNotes / (float)sum,

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Game.Localisation;
 using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Beatmaps
@@ -22,21 +23,21 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = "Circles",
+                    Name = BeatmapStatisticStrings.Circles,
                     Content = circles.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     BarDisplayLength = circles / (float)sum,
                 },
                 new BeatmapStatistic
                 {
-                    Name = "Sliders",
+                    Name = BeatmapStatisticStrings.Sliders,
                     Content = sliders.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     BarDisplayLength = sliders / (float)sum,
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Spinners",
+                    Name = BeatmapStatisticStrings.Spinners,
                     Content = spinners.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                     BarDisplayLength = Math.Min(spinners / 10f, 1),

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Game.Localisation;
 using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Beatmaps
@@ -22,21 +23,21 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = @"Hits",
+                    Name = BeatmapStatisticStrings.Hits,
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                     Content = hits.ToString(),
                     BarDisplayLength = hits / (float)sum,
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Drumrolls",
+                    Name = BeatmapStatisticStrings.Drumrolls,
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                     Content = drumRolls.ToString(),
                     BarDisplayLength = drumRolls / (float)sum,
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Swells",
+                    Name = BeatmapStatisticStrings.Swells,
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners),
                     Content = swells.ToString(),
                     BarDisplayLength = Math.Min(swells / 10f, 1),

--- a/osu.Game/Localisation/BeatmapStatisticStrings.cs
+++ b/osu.Game/Localisation/BeatmapStatisticStrings.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public class BeatmapStatisticStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.BeatmapStatisticStrings";
+
+        /// <summary>
+        /// "Circles"
+        /// </summary>
+        public static LocalisableString Circles => new TranslatableString(getKey(@"circles"), @"Circles");
+
+        /// <summary>
+        /// "Sliders"
+        /// </summary>
+        public static LocalisableString Sliders => new TranslatableString(getKey(@"sliders"), @"Sliders");
+
+        /// <summary>
+        /// "Spinners"
+        /// </summary>
+        public static LocalisableString Spinners => new TranslatableString(getKey(@"spinners"), @"Spinners");
+
+        /// <summary>
+        /// "Hits"
+        /// </summary>
+        public static LocalisableString Hits => new TranslatableString(getKey(@"hits"), @"Hits");
+
+        /// <summary>
+        /// "Drumrolls"
+        /// </summary>
+        public static LocalisableString Drumrolls => new TranslatableString(getKey(@"drumrolls"), @"Drumrolls");
+
+        /// <summary>
+        /// "Swells"
+        /// </summary>
+        public static LocalisableString Swells => new TranslatableString(getKey(@"swells"), @"Swells");
+
+        /// <summary>
+        /// "Fruits"
+        /// </summary>
+        public static LocalisableString Fruits => new TranslatableString(getKey(@"fruits"), @"Fruits");
+
+        /// <summary>
+        /// "Juice Streams"
+        /// </summary>
+        public static LocalisableString JuiceStreams => new TranslatableString(getKey(@"juice_streams"), @"Juice Streams");
+
+        /// <summary>
+        /// "Banana Showers"
+        /// </summary>
+        public static LocalisableString BananaShowers => new TranslatableString(getKey(@"banana_showers"), @"Banana Showers");
+
+        /// <summary>
+        /// "Notes"
+        /// </summary>
+        public static LocalisableString Notes => new TranslatableString(getKey(@"notes"), @"Notes");
+
+        /// <summary>
+        /// "Hold Notes"
+        /// </summary>
+        public static LocalisableString HoldNotes => new TranslatableString(getKey(@"hold_notes"), @"Hold Notes");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -59,6 +59,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Stars(LocalisableString value) => new TranslatableString(getKey(@"stars"), @"{0} stars", value);
 
+        /// <summary>
+        /// "Submitted"
+        /// </summary>
+        public static LocalisableString Submitted => new TranslatableString(getKey(@"submitted"), @"Submitted");
+
+        /// <summary>
+        /// "Ranked"
+        /// </summary>
+        public static LocalisableString Ranked => new TranslatableString(getKey(@"ranked"), @"Ranked");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore_Tooltip.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore_Tooltip.cs
@@ -22,6 +22,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
@@ -126,7 +127,7 @@ namespace osu.Game.Screens.SelectV2
                         var generalStatistics = new[]
                         {
                             new PerformanceStatisticRow(BeatmapsetsStrings.ShowScoreboardHeaderspp.ToUpper(), colourProvider.Content2, score),
-                            new StatisticRow("Score Multiplier", colourProvider.Content2, ModUtils.FormatScoreMultiplier(multiplier)),
+                            new StatisticRow(ModSelectOverlayStrings.ScoreMultiplier, colourProvider.Content2, ModUtils.FormatScoreMultiplier(multiplier)),
                             new StatisticRow(BeatmapsetsStrings.ShowScoreboardHeadersCombo, colourProvider.Content2, value.MaxCombo.ToLocalisableString(@"0\x")),
                             new StatisticRow(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, colourProvider.Content2, value.Accuracy.FormatAccuracy()),
                         };

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -151,8 +151,8 @@ namespace osu.Game.Screens.SelectV2
                                                             Spacing = new Vector2(0f, 10f),
                                                             Children = new[]
                                                             {
-                                                                submitted = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateSubmitted("").ToSentence()),
-                                                                ranked = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateRanked("").ToSentence()),
+                                                                submitted = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateSubmitted(string.Empty).ToSentence()),
+                                                                ranked = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateRanked(string.Empty).ToSentence()),
                                                             },
                                                         },
                                                     },

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
@@ -151,8 +150,8 @@ namespace osu.Game.Screens.SelectV2
                                                             Spacing = new Vector2(0f, 10f),
                                                             Children = new[]
                                                             {
-                                                                submitted = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateSubmitted(string.Empty).ToSentence()),
-                                                                ranked = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateRanked(string.Empty).ToSentence()),
+                                                                submitted = new MetadataDisplay(SongSelectStrings.Submitted),
+                                                                ranked = new MetadataDisplay(SongSelectStrings.Ranked),
                                                             },
                                                         },
                                                     },

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -5,15 +5,18 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
+using osu.Game.Localisation;
 using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
 namespace osu.Game.Screens.SelectV2
@@ -124,8 +127,8 @@ namespace osu.Game.Screens.SelectV2
                                                             Spacing = new Vector2(0f, 10f),
                                                             Children = new[]
                                                             {
-                                                                creator = new MetadataDisplay("Creator"),
-                                                                genre = new MetadataDisplay("Genre"),
+                                                                creator = new MetadataDisplay(EditorSetupStrings.Creator),
+                                                                genre = new MetadataDisplay(BeatmapsetsStrings.ShowInfoGenre),
                                                             },
                                                         },
                                                         new FillFlowContainer
@@ -136,8 +139,8 @@ namespace osu.Game.Screens.SelectV2
                                                             Spacing = new Vector2(0f, 10f),
                                                             Children = new[]
                                                             {
-                                                                source = new MetadataDisplay("Source"),
-                                                                language = new MetadataDisplay("Language"),
+                                                                source = new MetadataDisplay(BeatmapsetsStrings.ShowInfoSource),
+                                                                language = new MetadataDisplay(BeatmapsetsStrings.ShowInfoLanguage),
                                                             },
                                                         },
                                                         new FillFlowContainer
@@ -148,18 +151,18 @@ namespace osu.Game.Screens.SelectV2
                                                             Spacing = new Vector2(0f, 10f),
                                                             Children = new[]
                                                             {
-                                                                submitted = new MetadataDisplay("Submitted"),
-                                                                ranked = new MetadataDisplay("Ranked"),
+                                                                submitted = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateSubmitted("").ToSentence()),
+                                                                ranked = new MetadataDisplay(BeatmapsetsStrings.ShowDetailsDateRanked("").ToSentence()),
                                                             },
                                                         },
                                                     },
                                                 },
                                             },
-                                            userTags = new MetadataDisplay("User Tags")
+                                            userTags = new MetadataDisplay(BeatmapsetsStrings.ShowInfoUserTags)
                                             {
                                                 Alpha = 0,
                                             },
-                                            mapperTags = new MetadataDisplay("Mapper Tags"),
+                                            mapperTags = new MetadataDisplay(BeatmapsetsStrings.ShowInfoMapperTags),
                                         },
                                     },
                                 },

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -130,8 +130,6 @@ namespace osu.Game.Screens.SelectV2
                                                 {
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
-                                                    // margin to replicate the missing leading space in `ShowDetailsMappedBy` string
-                                                    Padding = new MarginPadding { Right = 3f },
                                                     Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                                                 },
                                                 mappedByText = new OsuSpriteText

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Screens.SelectV2
                                                 {
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
-                                                    Text = BeatmapsetsStrings.ShowDetailsMappedBy(string.Empty),
+                                                    Text = " mapped by ",
                                                     Font = OsuFont.Style.Body,
                                                 },
                                                 mapperLink = new MapperLinkContainer

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Screens.SelectV2
                                                 {
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
-                                                    Text = " mapped by ",
+                                                    Text = BeatmapsStrings.DiscussionsShowTitle("", ""),
                                                     Font = OsuFont.Style.Body,
                                                 },
                                                 mapperLink = new MapperLinkContainer

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -130,6 +130,7 @@ namespace osu.Game.Screens.SelectV2
                                                 {
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
+                                                    // margin to replicate the missing leading space in `ShowDetailsMappedBy` string
                                                     Padding = new MarginPadding { Right = 3f },
                                                     Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                                                 },

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -130,13 +130,14 @@ namespace osu.Game.Screens.SelectV2
                                                 {
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
+                                                    Padding = new MarginPadding { Right = 3f },
                                                     Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                                                 },
                                                 mappedByText = new OsuSpriteText
                                                 {
                                                     Anchor = Anchor.BottomLeft,
                                                     Origin = Anchor.BottomLeft,
-                                                    Text = BeatmapsStrings.DiscussionsShowTitle("", ""),
+                                                    Text = BeatmapsetsStrings.ShowDetailsMappedBy(string.Empty),
                                                     Font = OsuFont.Style.Body,
                                                 },
                                                 mapperLink = new MapperLinkContainer

--- a/osu.Game/Screens/SelectV2/FilterControl_DifficultyRangeSlider.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl_DifficultyRangeSlider.cs
@@ -16,6 +16,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Utils;
 using osuTK.Graphics;
 
@@ -34,7 +35,7 @@ namespace osu.Game.Screens.SelectV2
                                                                           .Prepend((0.0f, OsuColour.STAR_DIFFICULTY_SPECTRUM.ElementAt(1).Item2)).ToArray();
 
             public DifficultyRangeSlider()
-                : base("Star Rating")
+                : base(BeatmapsetsStrings.ShowStatsStars)
             {
                 NubWidth = ShearedNub.HEIGHT * 1.16f;
                 DefaultStringUpperBound = "∞";

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -232,7 +232,7 @@ namespace osu.Game.Screens.SelectV2
                 if (manageCollectionsDialog != null)
                     collectionItems.Add(new OsuMenuItem("Manage...", MenuItemType.Standard, manageCollectionsDialog.Show));
 
-                items.Add(new OsuMenuItem("Collections") { Items = collectionItems });
+                items.Add(new OsuMenuItem(CommonStrings.Collections) { Items = collectionItems });
 
                 if (beatmapSet.Beatmaps.Any(b => b.Hidden))
                     items.Add(new OsuMenuItem("Restore all hidden", MenuItemType.Standard, () => songSelect?.RestoreAllHidden(beatmapSet)));

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -904,7 +904,7 @@ namespace osu.Game.Screens.SelectV2
 
             collectionItems.Add(new OsuMenuItem("Manage...", MenuItemType.Standard, () => manageCollectionsDialog?.Show()));
 
-            yield return new OsuMenuItem("Collections") { Items = collectionItems };
+            yield return new OsuMenuItem(CommonStrings.Collections) { Items = collectionItems };
         }
 
         public void ManageCollections() => collectionsDialog?.Show();


### PR DESCRIPTION
I added some localized strings from osu!web on SSV2

| master | pr |
|--------|--------|
| ![details-lazer](https://github.com/user-attachments/assets/f893f220-4591-46b6-843d-00fc3d47d9d8) | ![details-pr](https://github.com/user-attachments/assets/e3b25f7e-5ebc-4dbf-b2d8-e1b2e8218767) |

| master | pr |
|--------|--------|
| ![score-lazer](https://github.com/user-attachments/assets/b7ee68ce-9462-4f45-9a60-7e6e8f8b3c49) | ![score-pr](https://github.com/user-attachments/assets/c8287701-6a31-4124-8978-1fcf5996a453) |

this is my first pr for osu!lazer, so point out all my mistakes so that I don't repeat them in the future, please =)

it seems to me that I have already made a couple of crutches, so I would like to know if it is acceptable in the case of `LocalisableStrings`, if not, I will add new ones for both those that I have translated now, and for `Circles`, `Spinners` and `Sliders`