### PR TITLE
Fix leaderboard wedge updating scores in non-update thread

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardManager.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardManager.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
@@ -24,7 +25,11 @@ namespace osu.Game.Online.Leaderboards
 {
     public partial class LeaderboardManager : Component
     {
+        /// <summary>
+        /// The latest leaderboard scores fetched by the criteria in <see cref="CurrentCriteria"/>.
+        /// </summary>
         public IBindable<LeaderboardScores?> Scores => scores;
+
         private readonly Bindable<LeaderboardScores?> scores = new Bindable<LeaderboardScores?>();
 
         public LeaderboardCriteria? CurrentCriteria { get; private set; }
@@ -47,6 +52,9 @@ namespace osu.Game.Online.Leaderboards
         /// </summary>
         public void FetchWithCriteria(LeaderboardCriteria newCriteria, bool forceRefresh = false)
         {
+            if (!ThreadSafety.IsUpdateThread)
+                throw new InvalidOperationException(@$"{nameof(FetchWithCriteria)} must be called from the update thread.");
+
             if (!forceRefresh && CurrentCriteria?.Equals(newCriteria) == true && scores.Value?.FailState == null)
                 return;
 

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -54,7 +54,8 @@ namespace osu.Game.Screens.Ranking
                 if (globalScores.Value != null && leaderboardManager.CurrentCriteria?.Equals(criteria) == true)
                     requestTaskSource.TrySetResult(globalScores.Value);
             });
-            leaderboardManager.FetchWithCriteria(criteria, forceRefresh: true);
+
+            Schedule(() => leaderboardManager.FetchWithCriteria(criteria, forceRefresh: true));
 
             var result = await requestTaskSource.Task.ConfigureAwait(false);
 

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Screens.Ranking
     {
         private readonly IBindable<LeaderboardScores?> globalScores = new Bindable<LeaderboardScores?>();
 
+        private TaskCompletionSource<LeaderboardScores>? requestTaskSource;
+
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
@@ -37,6 +39,14 @@ namespace osu.Game.Screens.Ranking
             globalScores.BindTo(leaderboardManager.Scores);
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (requestTaskSource?.Task.IsCompleted == false)
+                requestTaskSource.SetCanceled();
+        }
+
         protected override async Task<ScoreInfo[]> FetchScores()
         {
             Debug.Assert(Score != null);
@@ -48,7 +58,11 @@ namespace osu.Game.Screens.Ranking
                 leaderboardManager.CurrentCriteria?.Scope ?? BeatmapLeaderboardScope.Global,
                 leaderboardManager.CurrentCriteria?.ExactMods
             );
-            var requestTaskSource = new TaskCompletionSource<LeaderboardScores>();
+
+            Debug.Assert(requestTaskSource == null || requestTaskSource.Task.IsCompleted);
+
+            requestTaskSource = new TaskCompletionSource<LeaderboardScores>();
+
             globalScores.BindValueChanged(_ =>
             {
                 if (globalScores.Value != null && leaderboardManager.CurrentCriteria?.Equals(criteria) == true)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33799
- Supersedes and closes https://github.com/ppy/osu/pull/33870

Stack trace from thread above:
```
2025-06-21 17:47:23 [error]: An unobserved error has occurred.
2025-06-21 17:47:23 [error]: osu.Framework.Graphics.Drawable+InvalidThreadForMutationException: Cannot mutate the Transforms on a Loaded Drawable while not on the update thread. Consider using Schedule to schedule the mutation operation.
2025-06-21 17:47:23 [error]: at osu.Framework.Graphics.Drawable.EnsureMutationAllowed(String action)
2025-06-21 17:47:23 [error]: at osu.Framework.Graphics.Transforms.Transformable.AddTransform(Transform transform, Nullable`1 customTransformID)
2025-06-21 17:47:23 [error]: at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis](TThis t, Transform transform)
2025-06-21 17:47:23 [error]: at osu.Game.Graphics.UserInterface.LoadingSpinner.PopOut()
2025-06-21 17:47:23 [error]: at osu.Game.Graphics.UserInterface.LoadingLayer.PopOut()
2025-06-21 17:47:23 [error]: at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
2025-06-21 17:47:23 [error]: at osu.Game.Screens.SelectV2.BeatmapLeaderboardWedge.SetState(LeaderboardState state)
2025-06-21 17:47:23 [error]: at osu.Game.Screens.SelectV2.BeatmapLeaderboardWedge.updateScores()
```

`SoloResultsScreen` fetches the leaderboard in an asynchronous method (`FetchScores`), and since the beatmap is unavailable, the `Scores` bindable is updated to reflect that (in the asynchronous thread). This defines that the `Scores` bindable is not always thread safe, and all callbacks of the bindable should be scheduled to ensure thread safety. I've documented the bindable as such.

Alternatively, all updates to the bindable in `FetchWithCriteria` should be scheduled. Not 100% sure if it's the right choice though.