### PR TITLE
Fix leaderboard bottom padding not enough for last score to be fully visible

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
@@ -106,9 +106,6 @@ namespace osu.Game.Screens.SelectV2
                                 Top = 5,
                                 // Left padding offsets the shear to create a visually appealing list display.
                                 Left = 80f,
-                                // Bottom padding ensures the last entry's full width is displayed
-                                // (ie it is fully on screen after shear is considered).
-                                Bottom = BeatmapLeaderboardScore.HEIGHT * 3
                             },
                         },
                     },
@@ -384,10 +381,18 @@ namespace osu.Game.Screens.SelectV2
         {
             base.UpdateAfterChildren();
 
+            // Bottom padding ensures the last entry's full width is displayed (ie it is fully on screen after shear is considered).
+            // The padding is computed such that the leaderboard can be scrolled until the score is in the fifth position from the top (which is fully visible on screen).
+            // On high UI scales, the fifth position may be off-screen. A minimum sane value is set in place to handle this case (ensuring the last score sits above the footer by reasonable gap).
+            scoresContainer.Padding = scoresContainer.Padding with
+            {
+                Bottom = Math.Max(BeatmapLeaderboardScore.HEIGHT + 5, scoresScroll.DisplayableContent - BeatmapLeaderboardScore.HEIGHT * 5)
+            };
+
             const int height = BeatmapLeaderboardScore.HEIGHT;
 
             float fadeBottom = (float)(scoresScroll.Current + scoresScroll.DrawHeight);
-            float fadeTop = (float)(scoresScroll.Current);
+            float fadeTop = (float)scoresScroll.Current;
 
             if (!scoresScroll.IsScrolledToStart())
                 fadeTop += height;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33805

To resolve this amicably, we want the last leaderboard score to be at most positioned at roughly the place of the fifth score card from the top, since at that position the card remains fully visible with a comfortable gap on the left side.

But also, on high UI scales, the fifth position from top becomes off screen, so the padding is limited so that the last score still remains in screen.

Before:

https://github.com/user-attachments/assets/bb4b8f2b-1f60-4cea-a4c2-cc98ae742c39

After:

https://github.com/user-attachments/assets/1748551d-752a-4df9-8f67-0d0f7488ebe2

