### PR TITLE
Fix null reference in metadata wedge when accessing beatmap tags

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -298,7 +299,11 @@ namespace osu.Game.Screens.SelectV2
             else
                 source.Data = ("-", null);
 
-            mapperTags.Tags = (metadata.Tags.Split(' '), t => songSelect?.Search(t));
+            if (!string.IsNullOrEmpty(metadata.Tags))
+                mapperTags.Tags = (metadata.Tags.Split(' '), t => songSelect?.Search(t));
+            else
+                mapperTags.Tags = (Array.Empty<string>(), _ => { });
+
             submitted.Date = beatmapSetInfo.DateSubmitted;
             ranked.Date = beatmapSetInfo.DateRanked;
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33826

This is the only unguarded path in this method and it aligns with the database screenshot in the thread (`Tags` being null on some beatmaps).

I'm not sure what makes a beatmap to be imported with null source/tags, but almost every other place that accesses any of those properties ensure they're not null first.

It might be worthwhile to mark the properties as nullable as well but it's a bit involved diff-wise. I can still go through that if it sounds good.