### PR TITLE
Fix inconsistent rounding strategy for PP

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbarUserButton.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbarUserButton.cs
@@ -150,6 +150,24 @@ namespace osu.Game.Tests.Visual.Menus
                     });
             });
 
+            // cross-reference: `TestSceneOverallRanking.TestRoundingTreatment()`.
+            AddStep("Test rounding treatment", () =>
+            {
+                var transientUpdateDisplay = this.ChildrenOfType<TransientUserStatisticsUpdateDisplay>().Single();
+                transientUpdateDisplay.LatestUpdate.Value = new ScoreBasedUserStatisticsUpdate(
+                    new ScoreInfo(),
+                    new UserStatistics
+                    {
+                        GlobalRank = 111_111,
+                        PP = 5071.495M
+                    },
+                    new UserStatistics
+                    {
+                        GlobalRank = 111_111,
+                        PP = 5072.99M
+                    });
+            });
+
             AddStep("No change 1", () =>
             {
                 var transientUpdateDisplay = this.ChildrenOfType<TransientUserStatisticsUpdateDisplay>().Single();

--- a/osu.Game.Tests/Visual/Ranking/TestSceneOverallRanking.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneOverallRanking.cs
@@ -46,6 +46,32 @@ namespace osu.Game.Tests.Visual.Ranking
                 });
         }
 
+        // cross-reference: `TestSceneToolbarUserButton.TestTransientUserStatisticsDisplay()`, "Test rounding treatment" step.
+        [Test]
+        public void TestRoundingTreatment()
+        {
+            createDisplay();
+            displayUpdate(
+                new UserStatistics
+                {
+                    GlobalRank = 12_345,
+                    Accuracy = 98.99,
+                    MaxCombo = 2_322,
+                    RankedScore = 23_123_543_456,
+                    TotalScore = 123_123_543_456,
+                    PP = 5_071.495M
+                },
+                new UserStatistics
+                {
+                    GlobalRank = 12_345,
+                    Accuracy = 98.99,
+                    MaxCombo = 2_322,
+                    RankedScore = 23_123_543_456,
+                    TotalScore = 123_123_543_456,
+                    PP = 5_072.99M
+                });
+        }
+
         [Test]
         public void TestAllDecreased()
         {

--- a/osu.Game/Overlays/Toolbar/TransientUserStatisticsUpdateDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/TransientUserStatisticsUpdateDisplay.cs
@@ -83,7 +83,12 @@ namespace osu.Game.Overlays.Toolbar
                 }
 
                 if (update.After.PP != null)
-                    pp.Display((int)(update.Before.PP ?? update.After.PP.Value), (int)Math.Abs(((int?)update.After.PP - (int?)update.Before.PP) ?? 0M), (int)update.After.PP.Value);
+                {
+                    int before = (int)Math.Round(update.Before.PP ?? update.After.PP.Value);
+                    int after = (int)Math.Round(update.After.PP.Value);
+                    int delta = Math.Abs(after - before);
+                    pp.Display(before, delta, after);
+                }
 
                 this.Delay(5000).FadeOut(500, Easing.OutQuint);
             });

--- a/osu.Game/Screens/Ranking/Statistics/User/PerformancePointsChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/PerformancePointsChangeRow.cs
@@ -1,25 +1,26 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Ranking.Statistics.User
 {
-    public partial class PerformancePointsChangeRow : RankingChangeRow<decimal?>
+    public partial class PerformancePointsChangeRow : RankingChangeRow<int?>
     {
         public PerformancePointsChangeRow()
-            : base(stats => stats.PP)
+            : base(stats => stats.PP != null ? (int)Math.Round(stats.PP.Value) : null)
         {
         }
 
         protected override LocalisableString Label => RankingsStrings.StatPerformance;
 
-        protected override LocalisableString FormatCurrentValue(decimal? current)
+        protected override LocalisableString FormatCurrentValue(int? current)
             => current == null ? string.Empty : LocalisableString.Interpolate($@"{current:N0}pp");
 
-        protected override int CalculateDifference(decimal? previous, decimal? current, out LocalisableString formattedDifference)
+        protected override int CalculateDifference(int? previous, int? current, out LocalisableString formattedDifference)
         {
             if (previous == null && current == null)
             {


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/890ad313-cf6d-4685-9d0d-b0359572afde" height="800px"/>

I've noticed that after a game, the UserStatisticsUpdateDisplay next to the user's avatar directly truncates the decimal places of the PP value instead of rounding it like everywhere else.