### PR TITLE
Increase margin and padding in beatmap panel to make it easier on the eyes

### DIFF
--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -108,8 +108,8 @@ namespace osu.Game.Screens.SelectV2
                 AutoSizeAxes = Axes.Both,
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
-                Spacing = new Vector2(3),
-                Margin = new MarginPadding { Left = 5 },
+                Spacing = new Vector2(5),
+                Margin = new MarginPadding { Left = 6.5f, Bottom = 3.5f },
                 Direction = FillDirection.Horizontal,
                 Children = new Drawable[]
                 {

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Screens.SelectV2
                         Origin = Anchor.CentreLeft,
                         Direction = FillDirection.Vertical,
                         AutoSizeAxes = Axes.Both,
-                        Margin = new MarginPadding { Bottom = 3.5f },
+                        Padding = new MarginPadding { Bottom = 3.5f },
                         Children = new Drawable[]
                         {
                             new FillFlowContainer

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Screens.SelectV2
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
                 Spacing = new Vector2(5),
-                Margin = new MarginPadding { Left = 6.5f, Bottom = 3.5f },
+                Margin = new MarginPadding { Left = 6.5f },
                 Direction = FillDirection.Horizontal,
                 Children = new Drawable[]
                 {
@@ -125,6 +125,7 @@ namespace osu.Game.Screens.SelectV2
                         Origin = Anchor.CentreLeft,
                         Direction = FillDirection.Vertical,
                         AutoSizeAxes = Axes.Both,
+                        Margin = new MarginPadding { Bottom = 3.5f },
                         Children = new Drawable[]
                         {
                             new FillFlowContainer

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -97,7 +97,9 @@ namespace osu.Game.Screens.SelectV2
                 {
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Vertical,
-                    Padding = new MarginPadding { Top = 7.5f, Left = 15, Bottom = 5 },
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Padding = new MarginPadding { Top = 7.5f, Left = 15, Bottom = 13 },
                     Children = new Drawable[]
                     {
                         titleText = new OsuSpriteText

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -98,8 +98,8 @@ namespace osu.Game.Screens.SelectV2
                 AutoSizeAxes = Axes.Both,
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
-                Spacing = new Vector2(3),
-                Margin = new MarginPadding { Left = 5 },
+                Spacing = new Vector2(5),
+                Margin = new MarginPadding { Left = 6.5f, Bottom = 2.8f },
                 Direction = FillDirection.Horizontal,
                 Children = new Drawable[]
                 {

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Screens.SelectV2
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
                 Spacing = new Vector2(5),
-                Margin = new MarginPadding { Left = 6.5f, Bottom = 2.8f },
+                Margin = new MarginPadding { Left = 6.5f },
                 Direction = FillDirection.Horizontal,
                 Children = new Drawable[]
                 {
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.SelectV2
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                         Direction = FillDirection.Vertical,
-                        Padding = new MarginPadding { Bottom = 2 },
+                        Padding = new MarginPadding { Bottom = 4.8f },
                         AutoSizeAxes = Axes.Both,
                         Children = new Drawable[]
                         {


### PR DESCRIPTION
 
![Group 52](https://github.com/user-attachments/assets/00e7bf7c-57d8-4be5-9794-222bedf1c32a)

![Group 53](https://github.com/user-attachments/assets/aba88450-4ba5-4ab2-b0aa-219b7dcc6ae0)

![Group 54](https://github.com/user-attachments/assets/55ce7f02-dc83-4e3c-a8b9-f80b17b10ce6)

The top and bottom margins for the beatmap panels were inconsistent so this PR aims to fix that. 
