### PR TITLE
Add skinnable icon element

### DIFF
--- a/osu.Game/Collections/CollectionDropdown.cs
+++ b/osu.Game/Collections/CollectionDropdown.cs
@@ -270,7 +270,7 @@ namespace osu.Game.Collections
                 });
             }
 
-            protected override Drawable CreateContent() => (Content)base.CreateContent();
+            protected override Drawable CreateContent() => (ItemContent)base.CreateContent();
 
             private partial class NoFocusChangeIconButton : IconButton
             {

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -18,7 +18,9 @@ namespace osu.Game.Graphics
     {
         #region Legacy spritesheet-based icons
 
-        private static IconUsage get(int icon) => new IconUsage((char)icon, @"osuFont");
+        public const string LEGACY_FONT_NAME = @"osuFont";
+
+        private static IconUsage get(int icon) => new IconUsage((char)icon, LEGACY_FONT_NAME);
 
         // ruleset icons in circles
         public static IconUsage RulesetOsu => get(0xe000);

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -181,6 +181,8 @@ namespace osu.Game.Graphics.UserInterface
                     }
                 }
 
+                protected new ItemContent Content => (ItemContent)base.Content;
+
                 private void updateColours()
                 {
                     BackgroundColour = BackgroundColourHover.Opacity(0);
@@ -220,13 +222,13 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     base.UpdateForegroundColour();
 
-                    if (Foreground.Children.FirstOrDefault() is Content content)
+                    if (Content is ItemContent content)
                         content.Hovering = IsHovered;
                 }
 
-                protected override Drawable CreateContent() => new Content();
+                protected override Drawable CreateContent() => new ItemContent();
 
-                protected new partial class Content : CompositeDrawable, IHasText
+                protected partial class ItemContent : CompositeDrawable, IHasText
                 {
                     public LocalisableString Text
                     {
@@ -239,7 +241,7 @@ namespace osu.Game.Graphics.UserInterface
 
                     private const float chevron_offset = -3;
 
-                    public Content()
+                    public ItemContent()
                     {
                         RelativeSizeAxes = Axes.X;
                         AutoSizeAxes = Axes.Y;

--- a/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
@@ -90,6 +90,21 @@ namespace osu.Game.Localisation.SkinComponents
         public static LocalisableString CollapseDuringGameplay => new TranslatableString(getKey(@"collapse_during_gameplay"), @"Collapse during gameplay");
 
         /// <summary>
+        /// "Icon"
+        /// </summary>
+        public static LocalisableString Icon => new TranslatableString(getKey(@"icon"), @"Icon");
+
+        /// <summary>
+        /// "Icon colour"
+        /// </summary>
+        public static LocalisableString IconColour => new TranslatableString(getKey(@"icon_colour"), @"Icon colour");
+
+        /// <summary>
+        /// "The colour of the icon."
+        /// </summary>
+        public static LocalisableString IconColourDescription => new TranslatableString(getKey(@"icon_colour_description"), @"The colour of the icon.");
+
+        /// <summary>
         /// "If enabled, the leaderboard will become more compact during active gameplay."
         /// </summary>
         public static LocalisableString CollapseDuringGameplayDescription =>

--- a/osu.Game/Screens/SelectV2/CollectionDropdown.cs
+++ b/osu.Game/Screens/SelectV2/CollectionDropdown.cs
@@ -260,7 +260,7 @@ namespace osu.Game.Screens.SelectV2
                 });
             }
 
-            protected override Drawable CreateContent() => (Content)base.CreateContent();
+            protected override Drawable CreateContent() => (ItemContent)base.CreateContent();
 
             private partial class NoFocusChangeIconButton : IconButton
             {

--- a/osu.Game/Skinning/Components/IconElement.cs
+++ b/osu.Game/Skinning/Components/IconElement.cs
@@ -1,0 +1,160 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation.SkinComponents;
+using osu.Game.Overlays.Settings;
+using osuTK;
+
+namespace osu.Game.Skinning.Components
+{
+    public partial class IconElement : Container, ISerialisableDrawable
+    {
+        private static readonly Type[] all_icon_types = new[]
+        {
+            typeof(FontAwesome.Regular),
+            typeof(FontAwesome.Solid),
+            typeof(FontAwesome.Brands),
+            typeof(OsuIcon),
+        };
+
+        private static readonly IconModel[] all_icons = all_icon_types.SelectMany(t => t.GetProperties(BindingFlags.Public | BindingFlags.Static))
+                                                                      .Select(p => new IconModel(p.Name, (IconUsage)p.GetValue(null)!))
+                                                                      .ToArray();
+
+        private SpriteIcon spriteIcon = null!;
+
+        public bool UsesFixedAnchor { get; set; }
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Icon), SettingControlType = typeof(SettingsIconDropdown))]
+        public BindableIcon Icon { get; } = new BindableIcon(all_icons.First());
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.IconColour), nameof(SkinnableComponentStrings.TextColourDescription))]
+        public BindableColour4 IconColour { get; } = new BindableColour4(Colour4.White);
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            Child = spriteIcon = new SpriteIcon
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(40),
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Icon.BindValueChanged(e => spriteIcon.Icon = e.NewValue.Icon, true);
+            IconColour.BindValueChanged(e => spriteIcon.Colour = e.NewValue, true);
+        }
+
+        public record IconModel(string Name, IconUsage Icon);
+
+        public partial class BindableIcon : Bindable<IconModel>
+        {
+            public BindableIcon(IconModel defaultValue)
+                : base(defaultValue)
+            {
+            }
+
+            public override void Parse(object? input, IFormatProvider provider)
+            {
+                // When IconElement is deserialised from the skin, the value is passed here in the form of JObject.
+                if (input is JObject jObject)
+                    base.Parse(jObject.ToObject<IconModel>(), provider);
+                else
+                    base.Parse(input, provider);
+            }
+        }
+
+        private partial class SettingsIconDropdown : SettingsDropdown<IconModel>
+        {
+            protected override OsuDropdown<IconModel> CreateDropdown() => new IconDropdown();
+
+            private partial class IconDropdown : DropdownControl
+            {
+                public IconDropdown()
+                {
+                    foreach (var icon in all_icons)
+                        AddDropdownItem(icon);
+
+                    AlwaysShowSearchBar = true;
+                }
+
+                protected override LocalisableString GenerateItemText(IconModel item)
+                {
+                    if (item.Icon.Family is OsuIcon.FONT_NAME or OsuIcon.LEGACY_FONT_NAME)
+                        return $"osu!/{item.Name}";
+
+                    return $"{item.Icon.Weight}/{item.Name}";
+                }
+
+                protected override DropdownMenu CreateMenu() => new IconDropdownMenu
+                {
+                    MaxHeight = 200,
+                };
+            }
+
+            private partial class IconDropdownMenu : DropdownControl.OsuDropdownMenu
+            {
+                protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new IconDropdownMenuItem(item);
+            }
+
+            private partial class IconDropdownMenuItem : DropdownControl.OsuDropdownMenu.DrawableOsuDropdownMenuItem
+            {
+                protected new IconItemContent Content => (IconItemContent)base.Content;
+
+                public IconDropdownMenuItem(MenuItem item)
+                    : base(item)
+                {
+                    var dropdownItem = (DropdownMenuItem<IconModel>)item;
+                    Content.Icon = dropdownItem.Value.Icon;
+                }
+
+                protected override Drawable CreateContent() => new IconItemContent();
+
+                protected partial class IconItemContent : ItemContent
+                {
+                    private readonly SpriteIcon spriteIcon;
+
+                    public IconUsage Icon
+                    {
+                        get => spriteIcon.Icon;
+                        set => spriteIcon.Icon = value;
+                    }
+
+                    public IconItemContent()
+                    {
+                        Label.Padding = new MarginPadding { Left = 35 };
+
+                        AddInternal(spriteIcon = new SpriteIcon
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            X = 15,
+                            Size = new Vector2(16),
+                        });
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/33791

One concern with this feature is the fact that all possible icons are contained within a single dropdown created every time the element is highlighted in the skin editor. There'll be  minor spikes every time the user clicks on the icon. Not sure how much of a blocker it is to having this feature live.

Preview:

https://github.com/user-attachments/assets/b604916a-5e3f-43e2-abea-22e4e235d4bc