### PR TITLE
Fix very short kiai sections not showing up on editor summary timeline

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/KiaiPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/KiaiPart.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
@@ -91,7 +92,8 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
                     section = value;
 
                     X = (float)value.StartTime;
-                    Width = (float)value.Duration;
+                    // Minimum width ensures that very short kiai sections still show a slither of colour.
+                    Width = (float)Math.Max(200, value.Duration);
                 }
             }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33836.