### PR TITLE
Fix dropdown search bar not having placeholder text

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -18,6 +18,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
 
@@ -440,6 +441,11 @@ namespace osu.Game.Graphics.UserInterface
 
                 private partial class DropdownSearchTextBox : OsuTextBox
                 {
+                    public DropdownSearchTextBox()
+                    {
+                        PlaceholderText = HomeStrings.SearchPlaceholder;
+                    }
+
                     [BackgroundDependencyLoader]
                     private void load(OverlayColourProvider? colourProvider)
                     {


### PR DESCRIPTION
Noticed while implementing skinnable icons (#33849). Regressed ever since the component was no longer inheriting `SearchTextBox`, i.e. all the way back in https://github.com/ppy/osu/pull/28632.