### PR TITLE
Fix rotating objects in the skin editor not rotating as expected

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinSelectionRotationHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionRotationHandler.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.SkinEditor
             objectsInRotation = selectedItems.Cast<Drawable>().ToArray();
             originalRotations = objectsInRotation.ToDictionary(d => d, d => d.Rotation);
             originalPositions = objectsInRotation.ToDictionary(d => d, d => d.ToScreenSpace(d.OriginPosition));
-            DefaultOrigin = GeometryUtils.GetSurroundingQuad(objectsInRotation.SelectMany(d => d.ScreenSpaceDrawQuad.GetVertices().ToArray())).Centre;
+            DefaultOrigin = GeometryUtils.GetSurroundingQuad(objectsInRotation.SelectMany(d => ToLocalSpace(d.ScreenSpaceDrawQuad).GetVertices().ToArray())).Centre;
 
             base.Begin();
         }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionRotationHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionRotationHandler.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Implementation-defined origin point to rotate around when no explicit origin is provided.
         /// This field is only assigned during a rotation operation.
+        ///
+        /// Coordinates are in local space for this container.
         /// </summary>
         public Vector2? DefaultOrigin { get; protected set; }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33845.

Not sure if this ever worked but it was definitely wrong for a while now.

Notably, rotating multiple objects at once doesn't work too well, but I'm not going to fix that here (and not sure if it is expected to work; looks like it may require a much larger refactoring).