### PR TITLE
Only show slider toolbox group when slider tool is active

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -28,6 +28,10 @@ namespace osu.Game.Rulesets.Osu.Configuration
             SetDefault(OsuRulesetSetting.ReplayCursorPathEnabled, false);
             SetDefault(OsuRulesetSetting.ReplayCursorHideEnabled, false);
             SetDefault(OsuRulesetSetting.ReplayAnalysisDisplayLength, 800);
+
+            SetDefault(OsuRulesetSetting.EditorFreehandSliderTolerance, 90, min: 5, max: 100);
+            SetDefault(OsuRulesetSetting.EditorFreehandSliderCornerThreshold, 40, min: 5, max: 100);
+            SetDefault(OsuRulesetSetting.EditorFreehandSliderCircleThreshold, 30, min: 0, max: 100);
         }
     }
 
@@ -45,5 +49,10 @@ namespace osu.Game.Rulesets.Osu.Configuration
         ReplayCursorPathEnabled,
         ReplayCursorHideEnabled,
         ReplayAnalysisDisplayLength,
+
+        // Editor
+        EditorFreehandSliderTolerance,
+        EditorFreehandSliderCornerThreshold,
+        EditorFreehandSliderCircleThreshold,
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -48,8 +48,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         [Resolved]
         private IDistanceSnapProvider? distanceSnapProvider { get; set; }
 
-        [Resolved]
-        private FreehandSliderToolboxGroup? freehandToolboxGroup { get; set; }
+        private FreehandSliderToolboxGroup? freehandToolboxGroup;
 
         [Resolved]
         private EditorClock? editorClock { get; set; }
@@ -59,6 +58,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private readonly IncrementalBSplineBuilder bSplineBuilder = new IncrementalBSplineBuilder { Degree = 4 };
 
         protected override bool IsValidForPlacement => HitObject.Path.HasValidLengthForPlacement;
+
+        public override EditorToolboxGroup CreateToolboxGroup() => freehandToolboxGroup = new FreehandSliderToolboxGroup();
 
         public SliderPlacementBlueprint()
             : base(new Slider())

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Osu.Configuration;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -62,8 +63,12 @@ namespace osu.Game.Rulesets.Osu.Edit
         private ExpandableSlider<int> circleThresholdSlider = null!;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuRulesetConfigManager? config)
         {
+            config?.BindWith(OsuRulesetSetting.EditorFreehandSliderTolerance, displayTolerance);
+            config?.BindWith(OsuRulesetSetting.EditorFreehandSliderCornerThreshold, displayCornerThreshold);
+            config?.BindWith(OsuRulesetSetting.EditorFreehandSliderCircleThreshold, displayCircleThreshold);
+
             Children = new Drawable[]
             {
                 toleranceSlider = new ExpandableSlider<int>

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -77,9 +77,6 @@ namespace osu.Game.Rulesets.Osu.Edit
         [Cached]
         protected readonly OsuGridToolboxGroup OsuGridToolboxGroup = new OsuGridToolboxGroup();
 
-        [Cached]
-        protected readonly FreehandSliderToolboxGroup FreehandSliderToolboxGroup = new FreehandSliderToolboxGroup();
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -118,7 +115,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                         GridToolbox = OsuGridToolboxGroup,
                     },
                     new GenerateToolboxGroup(),
-                    FreehandSliderToolboxGroup
                 }
             );
         }

--- a/osu.Game.Tests/Visual/Editing/TestSceneContextualExpandingToolbox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneContextualExpandingToolbox.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Edit;
+using osu.Game.Screens.Edit.Components.RadioButtons;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    [TestFixture]
+    public partial class TestSceneContextualExpandingToolbox : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        private HitObjectComposer composer => Editor.ChildrenOfType<HitObjectComposer>().First();
+
+        private ContextualExpandingToolboxContainer rightToolbox => Editor.ChildrenOfType<ContextualExpandingToolboxContainer>().First();
+
+        private HitObjectCompositionToolButton toolButton<T>() where T : CompositionTool => composer.ChildrenOfType<EditorRadioButton>()
+                                                                                                    .Select(it => it.Button as HitObjectCompositionToolButton)
+                                                                                                    .OfType<HitObjectCompositionToolButton>()
+                                                                                                    .First(it => it.Tool is T);
+
+        [Test]
+        public void TestContextualToolboxGroupPresence()
+        {
+            AddStep("add slider toolbox group", () => rightToolbox.ContextualToolboxGroup = new FreehandSliderToolboxGroup());
+            AddAssert("slider toolbox group is present", () => rightToolbox.ChildrenOfType<FreehandSliderToolboxGroup>().Count() == 1);
+
+            AddStep("remove slider toolbox group", () => rightToolbox.ContextualToolboxGroup = null);
+            AddAssert("slider toolbox group is not present", () => !rightToolbox.ChildrenOfType<FreehandSliderToolboxGroup>().Any());
+        }
+
+        [Test]
+        public void TestContextualToolboxGroupActivationOnToolSwitch()
+        {
+            AddStep("select slider tool", () => toolButton<SliderCompositionTool>().Select());
+            AddAssert("slider toolbox group visible", () => rightToolbox.ContextualToolboxGroup is FreehandSliderToolboxGroup);
+
+            AddStep("select circle tool", () => toolButton<HitCircleCompositionTool>().Select());
+            AddAssert("slider toolbox group not visible", () => rightToolbox.ContextualToolboxGroup == null);
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Graphics.UserInterface
     {
         private readonly OsuSpriteText label;
         private readonly TSlider slider;
+        private readonly Container sliderContainer;
 
         private LocalisableString contractedLabelText;
 
@@ -96,10 +97,15 @@ namespace osu.Game.Graphics.UserInterface
                 Children = new Drawable[]
                 {
                     label = new OsuSpriteText(),
-                    slider = new TSlider
+                    sliderContainer = new Container
                     {
+                        AutoSizeAxes = Axes.Y,
                         RelativeSizeAxes = Axes.X,
-                    },
+                        Child = slider = new TSlider
+                        {
+                            RelativeSizeAxes = Axes.X,
+                        },
+                    }
                 }
             };
         }
@@ -116,17 +122,19 @@ namespace osu.Game.Graphics.UserInterface
                 Expanded.Value = containerExpanded.NewValue;
             }, true);
 
-            Expanded.BindValueChanged(v =>
-            {
-                label.Text = v.NewValue ? expandedLabelText : contractedLabelText;
-                slider.FadeTo(v.NewValue ? Current.Disabled ? 0.3f : 1f : 0f, 500, Easing.OutQuint);
-                slider.BypassAutoSizeAxes = !v.NewValue ? Axes.Y : Axes.None;
-            }, true);
+            Expanded.BindValueChanged(_ => updateVisibility());
+            Current.BindDisabledChanged(_ => updateVisibility(animated: false));
+            updateVisibility(animated: false);
+        }
 
-            Current.BindDisabledChanged(disabled =>
-            {
-                slider.Alpha = Expanded.Value ? disabled ? 0.3f : 1 : 0f;
-            });
+        private void updateVisibility(bool animated = true)
+        {
+            label.Text = Expanded.Value ? expandedLabelText : contractedLabelText;
+            slider.FadeTo(Current.Disabled ? 0.3f : 1f, animated ? 500 : 0, Easing.OutQuint);
+
+            // some sliders update their own alpha internally based on disabled state, so the fade needs to be done on a parent drawable to avoid race conditions
+            sliderContainer.FadeTo(Expanded.Value ? 1 : 0, animated ? 500 : 0, Easing.OutQuint);
+            sliderContainer.BypassAutoSizeAxes = !Expanded.Value ? Axes.Y : Axes.None;
         }
     }
 

--- a/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Graphics.UserInterface
             label.Text = Expanded.Value ? expandedLabelText : contractedLabelText;
             slider.FadeTo(Current.Disabled ? 0.3f : 1f, animated ? 500 : 0, Easing.OutQuint);
 
-            // some sliders update their own alpha internally based on disabled state, so the fade needs to be done on a parent drawable to avoid race conditions
+            // some sliders update their own alpha internally based on disabled state, so the fade needs to be done on a parent drawable
             sliderContainer.FadeTo(Expanded.Value ? 1 : 0, animated ? 500 : 0, Easing.OutQuint);
             sliderContainer.BypassAutoSizeAxes = !Expanded.Value ? Axes.Y : Axes.None;
         }

--- a/osu.Game/Rulesets/Edit/ContextualExpandingToolboxContainer.cs
+++ b/osu.Game/Rulesets/Edit/ContextualExpandingToolboxContainer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Edit
+{
+    /// <summary>
+    /// An <see cref="ExpandingToolboxContainer"/> that allows temporarily displaying contextual toolbox groups as ít's first item
+    /// </summary>
+    public partial class ContextualExpandingToolboxContainer : ExpandingToolboxContainer
+    {
+        public ContextualExpandingToolboxContainer(float contractedWidth, float expandedWidth)
+            : base(contractedWidth, expandedWidth)
+        {
+        }
+
+        private EditorToolboxGroup? contextualToolboxGroup;
+
+        public EditorToolboxGroup? ContextualToolboxGroup
+        {
+            get => contextualToolboxGroup;
+            set
+            {
+                if (contextualToolboxGroup == value)
+                    return;
+
+                if (contextualToolboxGroup != null)
+                    FillFlow.Remove(contextualToolboxGroup, true);
+
+                contextualToolboxGroup = value;
+
+                if (value != null)
+                    FillFlow.Insert(-1, value);
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Edit
 
         protected ExpandingToolboxContainer LeftToolbox { get; private set; }
 
-        protected ExpandingToolboxContainer RightToolbox { get; private set; }
+        protected ContextualExpandingToolboxContainer RightToolbox { get; private set; }
 
         private DrawableEditorRulesetWrapper<TObject> drawableRulesetWrapper;
 
@@ -247,7 +247,7 @@ namespace osu.Game.Rulesets.Edit
                             Colour = colourProvider.Background5,
                             RelativeSizeAxes = Axes.Both,
                         },
-                        RightToolbox = new ExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_RIGHT, 250)
+                        RightToolbox = new ContextualExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_RIGHT, 250)
                         {
                             Child = new EditorToolboxGroup("inspector")
                             {
@@ -526,6 +526,8 @@ namespace osu.Game.Rulesets.Edit
 
             if (!(tool is SelectTool))
                 EditorBeatmap.SelectedHitObjects.Clear();
+
+            RightToolbox.ContextualToolboxGroup = BlueprintContainer.CurrentPlacement?.CreateToolboxGroup();
         }
 
         #endregion

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -122,6 +122,12 @@ namespace osu.Game.Rulesets.Edit
         protected override void PopIn() => this.FadeIn();
         protected override void PopOut() => this.FadeOut();
 
+        /// <summary>
+        /// Creates a toolbox group to be displayed at the top of the <see cref="HitObjectComposer"/>'s right toolbox while this <see cref="PlacementBlueprint"/> is active.
+        /// </summary>
+        /// <returns>The toolbox group to display in the composer's toolbox</returns>
+        public virtual EditorToolboxGroup? CreateToolboxGroup() => null;
+
         public enum PlacementState
         {
             Waiting,


### PR DESCRIPTION
The slider toolbox group doesn't really serve any purpose currently when the tool isn't activated and should probably hidden unless the tool is active. If #33707 gets merged this could also lead to extra confusion as the slider won't change the velocity of the current selection.
This adds a mechanism for a `PlacementBlueprint` to create a toolbox group via `CreateToolboxGroup()` that will be displayed as the first item in the right toolbar while the tool is active.

https://github.com/user-attachments/assets/d9142b0f-ffc7-4638-9158-954b28cc6d2f

