### PR TITLE
Add possibility for ruleset-specific fail animation container and improve animations

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -193,6 +193,8 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new ManiaPlayfieldAdjustmentContainer(this);
 
+        public override FailAnimationContainer CreateFailAnimationContainer() => new ManiaFailAnimationContainer(this);
+
         protected override Playfield CreatePlayfield() => new ManiaPlayfield(Beatmap.Stages);
 
         public override int Variant => (int)(Beatmap.Stages.Count == 1 ? PlayfieldType.Single : PlayfieldType.Dual) + Beatmap.TotalColumns;

--- a/osu.Game.Rulesets.Mania/UI/ManiaFailAnimationContainer.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaFailAnimationContainer.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Screens.Play;
+using osuTK;
+
+namespace osu.Game.Rulesets.Mania.UI
+{
+    public partial class ManiaFailAnimationContainer : FailAnimationContainer
+    {
+        public ManiaFailAnimationContainer(DrawableManiaRuleset ruleset)
+            : base(ruleset)
+        {
+        }
+
+        protected override TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
+        {
+            Vector2 originalScale = hitObject.Scale;
+
+            return hitObject.RotateTo(rotation, DURATION)
+                            .ScaleTo(originalScale * 0.5f, DURATION);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/UI/ManiaFailAnimationContainer.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaFailAnimationContainer.cs
@@ -16,12 +16,10 @@ namespace osu.Game.Rulesets.Mania.UI
         {
         }
 
-        protected override TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
+        protected override void CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
         {
-            Vector2 originalScale = hitObject.Scale;
-
-            return hitObject.RotateTo(rotation, DURATION)
-                            .ScaleTo(originalScale * 0.5f, DURATION);
+            hitObject.RotateTo(rotation, DURATION)
+                     .ScaleTo(hitObject.Scale * 0.5f, DURATION);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -67,6 +67,8 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new OsuPlayfieldAdjustmentContainer { AlignWithStoryboard = true };
 
+        public override FailAnimationContainer CreateFailAnimationContainer() => new OsuFailAnimationContainer(this);
+
         protected override ResumeOverlay CreateResumeOverlay()
         {
             if (Mods.Any(m => m is OsuModAutopilot or OsuModTouchDevice))

--- a/osu.Game.Rulesets.Osu/UI/OsuFailAnimationContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuFailAnimationContainer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Screens.Play;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.UI
+{
+    public partial class OsuFailAnimationContainer : FailAnimationContainer
+    {
+        public OsuFailAnimationContainer(DrawableOsuRuleset ruleset)
+            : base(ruleset)
+        {
+        }
+
+        protected override TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
+        {
+            Vector2 originalPosition = hitObject.Position;
+            Vector2 originalScale = hitObject.Scale;
+
+            return hitObject.RotateTo(rotation, DURATION)
+                            .ScaleTo(originalScale * 0.5f, DURATION)
+                            .MoveTo(originalPosition + new Vector2(0, 400), DURATION);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/UI/OsuFailAnimationContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuFailAnimationContainer.cs
@@ -16,14 +16,11 @@ namespace osu.Game.Rulesets.Osu.UI
         {
         }
 
-        protected override TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
+        protected override void CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
         {
-            Vector2 originalPosition = hitObject.Position;
-            Vector2 originalScale = hitObject.Scale;
-
-            return hitObject.RotateTo(rotation, DURATION)
-                            .ScaleTo(originalScale * 0.5f, DURATION)
-                            .MoveTo(originalPosition + new Vector2(0, 400), DURATION);
+            hitObject.RotateTo(rotation, DURATION)
+                     .ScaleTo(hitObject.Scale * 0.5f, DURATION)
+                     .MoveTo(hitObject.Position + new Vector2(0, 400), DURATION);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -115,6 +115,8 @@ namespace osu.Game.Rulesets.Taiko.UI
             LockPlayfieldAspectRange = { BindTarget = LockPlayfieldAspectRange }
         };
 
+        public override FailAnimationContainer CreateFailAnimationContainer() => new TaikoFailAnimationContainer(this);
+
         protected override PassThroughInputManager CreateInputManager() => new TaikoInputManager(Ruleset.RulesetInfo);
 
         protected override Playfield CreatePlayfield() => new TaikoPlayfield();

--- a/osu.Game.Rulesets.Taiko/UI/TaikoFailAnimationContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoFailAnimationContainer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Screens.Play;
+using osuTK;
+
+namespace osu.Game.Rulesets.Taiko.UI
+{
+    public partial class TaikoFailAnimationContainer : FailAnimationContainer
+    {
+        public TaikoFailAnimationContainer(DrawableTaikoRuleset ruleset)
+            : base(ruleset)
+        {
+        }
+
+        protected override TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
+        {
+            Vector2 originalPosition = hitObject.Position;
+            Vector2 originalScale = hitObject.Scale;
+
+            return hitObject.RotateTo(rotation, DURATION)
+                            .ScaleTo(originalScale * 0.5f, DURATION)
+                            .FadeOutFromOne(DURATION)
+                            .MoveTo(originalPosition + new Vector2(0, 200), DURATION);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/TaikoFailAnimationContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoFailAnimationContainer.cs
@@ -16,15 +16,12 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
         }
 
-        protected override TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
+        protected override void CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
         {
-            Vector2 originalPosition = hitObject.Position;
-            Vector2 originalScale = hitObject.Scale;
-
-            return hitObject.RotateTo(rotation, DURATION)
-                            .ScaleTo(originalScale * 0.5f, DURATION)
-                            .FadeOutFromOne(DURATION)
-                            .MoveTo(originalPosition + new Vector2(0, 200), DURATION);
+            hitObject.RotateTo(rotation, DURATION)
+                     .ScaleTo(hitObject.Scale * 0.5f, DURATION)
+                     .FadeOutFromOne(DURATION)
+                     .MoveTo(hitObject.Position + new Vector2(0, 200), DURATION);
         }
     }
 }

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -573,6 +573,8 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         protected virtual ResumeOverlay CreateResumeOverlay() => null;
 
+        public virtual FailAnimationContainer CreateFailAnimationContainer() => new FailAnimationContainer(this);
+
         /// <summary>
         /// Whether to display gameplay overlays, such as <see cref="HUDOverlay"/> and <see cref="BreakOverlay"/>.
         /// </summary>

--- a/osu.Game/Screens/Play/FailAnimationContainer.cs
+++ b/osu.Game/Screens/Play/FailAnimationContainer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Transforms;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Audio.Effects;
@@ -21,7 +22,6 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osu.Game.Skinning;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Play
         private AudioFilter failLowPassFilter = null!;
         private AudioFilter failHighPassFilter = null!;
 
-        private const float duration = 2500;
+        protected const float DURATION = 2500;
 
         private SkinnableSound failSample = null!;
 
@@ -115,7 +115,7 @@ namespace osu.Game.Screens.Play
 
             started = true;
 
-            this.TransformBindableTo(trackFreq, 0, duration).OnComplete(_ =>
+            this.TransformBindableTo(trackFreq, 0, DURATION).OnComplete(_ =>
             {
                 // Don't reset frequency as the pause screen may appear post transform, causing a second frequency sweep.
                 removeFilters(false);
@@ -123,14 +123,14 @@ namespace osu.Game.Screens.Play
             });
 
             failHighPassFilter.CutoffTo(300);
-            failLowPassFilter.CutoffTo(300, duration, Easing.OutCubic);
+            failLowPassFilter.CutoffTo(300, DURATION, Easing.OutCubic);
             failSample.Play();
 
             track.AddAdjustment(AdjustableProperty.Frequency, trackFreq);
             track.AddAdjustment(AdjustableProperty.Volume, volumeAdjustment);
 
             applyToPlayfield(drawableRuleset.Playfield);
-            drawableRuleset.Playfield.HitObjectContainer.FadeOut(duration / 2);
+            drawableRuleset.Playfield.HitObjectContainer.FadeOut(DURATION / 2);
 
             if (config.Get<bool>(OsuSetting.FadePlayfieldWhenHealthLow))
                 redFlashLayer.FadeOutFromOne(1000);
@@ -144,9 +144,9 @@ namespace osu.Game.Screens.Play
                 Depth = float.MaxValue
             });
 
-            Content.ScaleTo(0.85f, duration, Easing.OutQuart);
-            Content.RotateTo(1, duration, Easing.OutQuart);
-            Content.FadeColour(Color4.Gray, duration);
+            Content.ScaleTo(0.85f, DURATION, Easing.OutQuart);
+            Content.RotateTo(1, DURATION, Easing.OutQuart);
+            Content.FadeColour(Color4.Gray, DURATION);
 
             // Will be restored by `ApplyToBackground` logic in `SongSelect`.
             Background?.FadeColour(OsuColour.Gray(0.3f), 60);
@@ -205,27 +205,27 @@ namespace osu.Game.Screens.Play
                 if (appliedObjects.Contains(obj))
                     continue;
 
-                float rotation = RNG.NextSingle(-90, 90);
-                Vector2 originalPosition = obj.Position;
-                Vector2 originalScale = obj.Scale;
+                float randomRotation = RNG.NextSingle(-90, 90);
 
-                dropOffScreen(obj, failTime, rotation, originalScale, originalPosition);
+                using (obj.BeginAbsoluteSequence(failTime))
+                    CreateHitObjectTransforms(obj, randomRotation);
 
                 // need to reapply the fail drop after judgement state changes
-                obj.ApplyCustomUpdateState += (_, _) => dropOffScreen(obj, failTime, rotation, originalScale, originalPosition);
+                obj.ApplyCustomUpdateState += (_, _) =>
+                {
+                    using (obj.BeginAbsoluteSequence(failTime))
+                        CreateHitObjectTransforms(obj, randomRotation);
+                };
 
                 appliedObjects.Add(obj);
             }
         }
 
-        private void dropOffScreen(DrawableHitObject obj, double failTime, float randomRotation, Vector2 originalScale, Vector2 originalPosition)
-        {
-            using (obj.BeginAbsoluteSequence(failTime))
-            {
-                obj.RotateTo(randomRotation, duration);
-                obj.ScaleTo(originalScale * 0.5f, duration);
-                obj.MoveTo(originalPosition + new Vector2(0, 400), duration);
-            }
-        }
+        /// <summary>
+        /// Creates a <see cref="TransformSequence{T}"/>  which will be applied to each <see cref="DrawableHitObject"/> when the player fails.
+        /// </summary>
+        /// <param name="hitObject">The specific DHO to apply the TransformSequence to.</param>
+        /// <param name="rotation">The random amount the DHO will be rotated if applicable.</param>
+        protected virtual TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation) => hitObject.FadeOutFromOne(DURATION);
     }
 }

--- a/osu.Game/Screens/Play/FailAnimationContainer.cs
+++ b/osu.Game/Screens/Play/FailAnimationContainer.cs
@@ -226,6 +226,9 @@ namespace osu.Game.Screens.Play
         /// </summary>
         /// <param name="hitObject">The specific DHO to apply the TransformSequence to.</param>
         /// <param name="rotation">The random amount the DHO will be rotated if applicable.</param>
-        protected virtual TransformSequence<DrawableHitObject> CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation) => hitObject.FadeOutFromOne(DURATION);
+        protected virtual void CreateHitObjectTransforms(DrawableHitObject hitObject, float rotation)
+        {
+            hitObject.FadeOutFromOne(DURATION);
+        }
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -302,18 +302,18 @@ namespace osu.Game.Screens.Play
             if (cancellationToken.IsCancellationRequested)
                 return;
 
+            failAnimationContainer = DrawableRuleset.CreateFailAnimationContainer();
+            failAnimationContainer.OnComplete = onFailComplete;
+            failAnimationContainer.Children = new[]
+            {
+                // underlay and gameplay should have access to the skinning sources.
+                createUnderlayComponents(Beatmap.Value),
+                createGameplayComponents(Beatmap.Value)
+            };
+
             rulesetSkinProvider.AddRange(new Drawable[]
             {
-                failAnimationContainer = new FailAnimationContainer(DrawableRuleset)
-                {
-                    OnComplete = onFailComplete,
-                    Children = new[]
-                    {
-                        // underlay and gameplay should have access to the skinning sources.
-                        createUnderlayComponents(Beatmap.Value),
-                        createGameplayComponents(Beatmap.Value)
-                    }
-                },
+                failAnimationContainer,
                 FailOverlay = new FailOverlay
                 {
                     SaveReplay = async () => await prepareAndImportScoreAsync(true).ConfigureAwait(false),


### PR DESCRIPTION
I made this change mainly because the mania fail animation looks broken at the moment, but I wrote it in a way that other rulesets can also benefit from the added flexibility. This includes custom rulesets. 

There might be less drastic ways to achieve the same result, this will need to be discussed before anyone spends too much time reviewing the code. Aditionally, this PR doesn't change *that* much visually so it might not be worth the added code complexity to begin with. Feel free to reject in that case.

The reason why the mania and catch animations look off is that all rulesets share the same transform sequence on fail (which was probably made with standard in mind):

https://github.com/ppy/osu/blob/a797c46d750c0d2fea8d65953d01e72b484a26be/osu.Game/Screens/Play/FailAnimationContainer.cs#L223-L228

Mania and catch scroll vertically and the `MoveTo()` transform interferes with this. `ScaleTo()` also doesn't play nicely with catch because it causes the fruit to move around weirdly. I therefore removed the `MoveTo()` transform in mania's own fail container and both transforms in the base `FailAnimationContainer`, which catch uses for now. For taiko's container, I reduced the distance of the `MoveTo()` so the notes don't go out of bounds of the parent container as much on legacy skins.  

The only transform in the base container is a `FadeOutFromOne()`, which I thought would be a good default because it works no matter the gameplay of the ruleset in question.

|  | master | PR |
|---|---|---|
| mania | ![mania_before](https://github.com/user-attachments/assets/101cbd85-337a-431e-b751-8ba55ae50248) | ![mania_pr](https://github.com/user-attachments/assets/68ff0279-1998-49b1-920b-da81a82174a6) |
| catch | ![catch_before](https://github.com/user-attachments/assets/4275f55c-8c01-4e08-ba6e-e90d810c33c4) | ![catch_pr](https://github.com/user-attachments/assets/6bfc230b-db79-4a19-97b7-25c77d2ca2bf) |
| taiko | ![taiko_before](https://github.com/user-attachments/assets/aa6fe444-e1d7-4da6-912f-d47640cae4d7) | ![taiko_pr](https://github.com/user-attachments/assets/bf653cb7-3bab-48b6-8d5c-41454bd98a7d) |

Standard's fail animation did not change in this PR. The other animations can of course still be improved simply by adjusting the transforms in the ruleset's fail animation container.

This can be tested using `TestSceneFailAnimation` (although no legacy skins).