### PR TITLE
Disallow changing release stream on fixed installs

### DIFF
--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -82,22 +82,22 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Check with your package manager / provider for other release streams."
         /// </summary>
-        public static LocalisableString ChangeReleaseStreamPackageManagerWarning => new TranslatableString(getKey(@"change_release stream_package_warning"), @"Check with your package manager / provider for other release streams.");
+        public static LocalisableString ChangeReleaseStreamPackageManagerWarning => new TranslatableString(getKey(@"change_release_stream_package_warning"), @"Check with your package manager / provider for other release streams.");
 
         /// <summary>
         /// "Check with your app store (testflight, etc) for other release streams."
         /// </summary>
-        public static LocalisableString ChangeReleaseStreamMobileWarning => new TranslatableString(getKey(@"change_release stream_mobile_warning"), @"Check with your app store (testflight, etc) for other release streams.");
+        public static LocalisableString ChangeReleaseStreamMobileWarning => new TranslatableString(getKey(@"change_release_stream_mobile_warning"), @"Check with your app store (testflight, etc) for other release streams.");
 
         /// <summary>
         /// "Are you sure you want to run a potentially unstable version of the game?"
         /// </summary>
-        public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release stream_confirmation"), @"Are you sure you want to run a potentially unstable version of the game?");
+        public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release_stream_confirmation"), @"Are you sure you want to run a potentially unstable version of the game?");
 
         /// <summary>
         /// "If you run into issues starting the game, you can usually run the installer from the official site to recover."
         /// </summary>
-        public static LocalisableString ChangeReleaseStreamConfirmationInfo => new TranslatableString(getKey(@"change_release stream_confirmation_info"), @"If you run into issues starting the game, you can usually run the installer from the official site to recover.");
+        public static LocalisableString ChangeReleaseStreamConfirmationInfo => new TranslatableString(getKey(@"change_release_stream_confirmation_info"), @"If you run into issues starting the game, you can usually run the installer from the official site to recover.");
 
         /// <summary>
         /// "You are running the latest release ({0})"

--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -85,11 +85,6 @@ namespace osu.Game.Localisation
         public static LocalisableString ChangeReleaseStreamPackageManagerWarning => new TranslatableString(getKey(@"change_release_stream_package_warning"), @"Check with your package manager / provider for other release streams.");
 
         /// <summary>
-        /// "Check with your app store (testflight, etc) for other release streams."
-        /// </summary>
-        public static LocalisableString ChangeReleaseStreamMobileWarning => new TranslatableString(getKey(@"change_release_stream_mobile_warning"), @"Check with your app store (testflight, etc) for other release streams.");
-
-        /// <summary>
         /// "Are you sure you want to run a potentially unstable version of the game?"
         /// </summary>
         public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release_stream_confirmation"), @"Are you sure you want to run a potentially unstable version of the game?");

--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -80,22 +80,30 @@ namespace osu.Game.Localisation
         public static LocalisableString LearnMoreAboutLazerTooltip => new TranslatableString(getKey(@"check_out_the_feature_comparison"), @"Check out the feature comparison and FAQ");
 
         /// <summary>
+        /// "Check with your package manager / provider for other release streams."
+        /// </summary>
+        public static LocalisableString ChangeReleaseStreamPackageManagerWarning => new TranslatableString(getKey(@"change_release stream_package_warning"), @"Check with your package manager / provider for other release streams.");
+
+        /// <summary>
+        /// "Check with your app store (testflight, etc) for other release streams."
+        /// </summary>
+        public static LocalisableString ChangeReleaseStreamMobileWarning => new TranslatableString(getKey(@"change_release stream_mobile_warning"), @"Check with your app store (testflight, etc) for other release streams.");
+
+        /// <summary>
         /// "Are you sure you want to run a potentially unstable version of the game?"
         /// </summary>
-        public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release stream_confirmation"),
-            @"Are you sure you want to run a potentially unstable version of the game?");
+        public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release stream_confirmation"), @"Are you sure you want to run a potentially unstable version of the game?");
 
         /// <summary>
         /// "If you run into issues starting the game, you can usually run the installer from the official site to recover."
         /// </summary>
-        public static LocalisableString ChangeReleaseStreamConfirmationInfo => new TranslatableString(getKey(@"change_release stream_confirmation_info"),
-            @"If you run into issues starting the game, you can usually run the installer from the official site to recover.");
+        public static LocalisableString ChangeReleaseStreamConfirmationInfo => new TranslatableString(getKey(@"change_release stream_confirmation_info"), @"If you run into issues starting the game, you can usually run the installer from the official site to recover.");
 
         /// <summary>
         /// "You are running the latest release ({0})"
         /// </summary>
         public static LocalisableString RunningLatestRelease(string version) => new TranslatableString(getKey(@"running_latest_release"), @"You are running the latest release ({0})", version);
 
-        private static string getKey(string key) => $"{prefix}:{key}";
+        private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -28,9 +28,9 @@ namespace osu.Game.Overlays.Settings.Sections.General
         protected override LocalisableString Header => GeneralSettingsStrings.UpdateHeader;
 
         private SettingsButton checkForUpdatesButton = null!;
+        private SettingsEnumDropdown<ReleaseStream> releaseStreamDropdown = null!;
 
         private readonly Bindable<ReleaseStream> configReleaseStream = new Bindable<ReleaseStream>();
-        private SettingsEnumDropdown<ReleaseStream> releaseStreamDropdown = null!;
 
         [Resolved]
         private UpdateManager? updateManager { get; set; }
@@ -58,11 +58,16 @@ namespace osu.Game.Overlays.Settings.Sections.General
                     Keywords = new[] { @"version" },
                 });
 
-                Add(checkForUpdatesButton = new SettingsButton
+                if (updateManager.FixedReleaseStream != null)
                 {
-                    Text = GeneralSettingsStrings.CheckUpdate,
-                    Action = () => checkForUpdates().FireAndForget()
-                });
+                    configReleaseStream.Value = updateManager.FixedReleaseStream.Value;
+
+                    releaseStreamDropdown.ShowsDefaultIndicator = false;
+                    releaseStreamDropdown.Items = [updateManager.FixedReleaseStream.Value];
+                    releaseStreamDropdown.SetNoticeText(RuntimeInfo.IsDesktop
+                        ? GeneralSettingsStrings.ChangeReleaseStreamPackageManagerWarning
+                        : GeneralSettingsStrings.ChangeReleaseStreamMobileWarning);
+                }
 
                 releaseStreamDropdown.Current.BindValueChanged(stream =>
                 {
@@ -85,6 +90,12 @@ namespace osu.Game.Overlays.Settings.Sections.General
                     }
 
                     configReleaseStream.Value = stream.NewValue;
+                });
+
+                Add(checkForUpdatesButton = new SettingsButton
+                {
+                    Text = GeneralSettingsStrings.CheckUpdate,
+                    Action = () => checkForUpdates().FireAndForget()
                 });
             }
 

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
         {
             config.BindWith(OsuSetting.ReleaseStream, configReleaseStream);
 
-            if (updateManager?.CanCheckForUpdate == true)
+            if (updateManager?.CanCheckForUpdate == true && !RuntimeInfo.IsMobile)
             {
                 Add(releaseStreamDropdown = new SettingsEnumDropdown<ReleaseStream>
                 {
@@ -64,9 +64,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
 
                     releaseStreamDropdown.ShowsDefaultIndicator = false;
                     releaseStreamDropdown.Items = [updateManager.FixedReleaseStream.Value];
-                    releaseStreamDropdown.SetNoticeText(RuntimeInfo.IsDesktop
-                        ? GeneralSettingsStrings.ChangeReleaseStreamPackageManagerWarning
-                        : GeneralSettingsStrings.ChangeReleaseStreamMobileWarning);
+                    releaseStreamDropdown.SetNoticeText(GeneralSettingsStrings.ChangeReleaseStreamPackageManagerWarning);
                 }
 
                 releaseStreamDropdown.Current.BindValueChanged(stream =>

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -116,8 +116,12 @@ namespace osu.Game.Overlays.Settings.Sections.General
             if (stream.NewValue == ReleaseStream.Tachyon)
             {
                 dialogOverlay?.Push(
-                    new ConfirmDialog(GeneralSettingsStrings.ChangeReleaseStreamConfirmation, () => { configReleaseStream.Value = ReleaseStream.Tachyon; },
-                        () => { releaseStreamDropdown.Current.Value = ReleaseStream.Lazer; }) { BodyText = GeneralSettingsStrings.ChangeReleaseStreamConfirmationInfo });
+                    new ConfirmDialog(GeneralSettingsStrings.ChangeReleaseStreamConfirmation,
+                        () => configReleaseStream.Value = ReleaseStream.Tachyon,
+                        () => releaseStreamDropdown.Current.Value = ReleaseStream.Lazer)
+                    {
+                        BodyText = GeneralSettingsStrings.ChangeReleaseStreamConfirmationInfo
+                    });
 
                 return;
             }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -45,7 +45,18 @@ namespace osu.Game.Overlays.Settings
 
         private OsuTextFlowContainer noticeText;
 
-        public bool ShowsDefaultIndicator = true;
+        private bool showsDefaultIndicator = true;
+
+        public bool ShowsDefaultIndicator
+        {
+            get => showsDefaultIndicator;
+            set
+            {
+                showsDefaultIndicator = value;
+                defaultValueIndicatorContainer.Alpha = value ? 1 : 0;
+            }
+        }
+
         private readonly Container defaultValueIndicatorContainer;
 
         public LocalisableString TooltipText { get; set; }
@@ -214,17 +225,14 @@ namespace osu.Game.Overlays.Settings
         [BackgroundDependencyLoader]
         private void load()
         {
-            // intentionally done before LoadComplete to avoid overhead.
-            if (ShowsDefaultIndicator)
+            defaultValueIndicatorContainer.Child = new RevertToDefaultButton<T>
             {
-                defaultValueIndicatorContainer.Add(new RevertToDefaultButton<T>
-                {
-                    Current = controlWithCurrent.Current,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
-                });
-                updateLayout();
-            }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Current = controlWithCurrent.Current,
+            };
+
+            updateLayout();
         }
 
         private void updateLayout()

--- a/osu.Game/Updater/MobileUpdateNotifier.cs
+++ b/osu.Game/Updater/MobileUpdateNotifier.cs
@@ -10,6 +10,7 @@ using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
+using osu.Game.Configuration;
 using osu.Game.Online.API;
 
 namespace osu.Game.Updater
@@ -20,6 +21,8 @@ namespace osu.Game.Updater
     /// </summary>
     public partial class MobileUpdateNotifier : UpdateManager
     {
+        public override ReleaseStream? FixedReleaseStream => Configuration.ReleaseStream.Lazer;
+
         private string version = null!;
 
         [Resolved]

--- a/osu.Game/Updater/MobileUpdateNotifier.cs
+++ b/osu.Game/Updater/MobileUpdateNotifier.cs
@@ -21,9 +21,10 @@ namespace osu.Game.Updater
     /// </summary>
     public partial class MobileUpdateNotifier : UpdateManager
     {
-        public override ReleaseStream? FixedReleaseStream => Configuration.ReleaseStream.Lazer;
+        public override ReleaseStream? FixedReleaseStream => stream;
 
         private string version = null!;
+        private ReleaseStream stream;
 
         [Resolved]
         private GameHost host { get; set; } = null!;
@@ -31,22 +32,25 @@ namespace osu.Game.Updater
         [BackgroundDependencyLoader]
         private void load(OsuGameBase game)
         {
-            version = game.Version;
+            version = game.Version.Split('-').First();
+            stream = Enum.TryParse(game.Version.Split('-').Last(), true, out ReleaseStream s) ? s : Configuration.ReleaseStream.Lazer;
         }
 
         protected override async Task<bool> PerformUpdateCheck(CancellationToken cancellationToken)
         {
             try
             {
-                var releases = new OsuJsonWebRequest<GitHubRelease>("https://api.github.com/repos/ppy/osu/releases/latest");
+                bool includePrerelease = stream == Configuration.ReleaseStream.Tachyon;
 
-                await releases.PerformAsync(cancellationToken).ConfigureAwait(false);
+                OsuJsonWebRequest<GitHubRelease[]> releasesRequest = new OsuJsonWebRequest<GitHubRelease[]>("https://api.github.com/repos/ppy/osu/releases?per_page=10&page=1");
+                await releasesRequest.PerformAsync(cancellationToken).ConfigureAwait(false);
 
-                var latest = releases.ResponseObject;
+                GitHubRelease[] releases = releasesRequest.ResponseObject;
+                GitHubRelease? latest = releases.OrderByDescending(r => r.PublishedAt).FirstOrDefault(r => includePrerelease || !r.Prerelease);
 
-                // avoid any discrepancies due to build suffixes for now.
-                // eventually we will want to support release streams and consider these.
-                version = version.Split('-').First();
+                if (latest == null)
+                    return false;
+
                 string latestTagName = latest.TagName.Split('-').First();
 
                 if (latestTagName != version && tryGetBestUrl(latest, out string? url))

--- a/osu.Game/Updater/NoActionUpdateManager.cs
+++ b/osu.Game/Updater/NoActionUpdateManager.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Updater
     /// </summary>
     public partial class NoActionUpdateManager : UpdateManager
     {
+        public override ReleaseStream? FixedReleaseStream => externalReleaseStream;
+
         private static ReleaseStream? externalReleaseStream => Enum.TryParse(Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_STREAM"), true, out ReleaseStream stream) ? stream : null;
 
         private string version = string.Empty;

--- a/osu.Game/Updater/NoActionUpdateManager.cs
+++ b/osu.Game/Updater/NoActionUpdateManager.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Updater
         [BackgroundDependencyLoader]
         private void load(OsuGameBase game)
         {
-            version = game.Version;
+            version = game.Version.Split('-').First();
         }
 
         protected override async Task<bool> PerformUpdateCheck(CancellationToken cancellationToken)
@@ -45,9 +45,6 @@ namespace osu.Game.Updater
                 if (latest == null)
                     return false;
 
-                // avoid any discrepancies due to build suffixes for now.
-                // eventually we will want to support release streams and consider these.
-                version = version.Split('-').First();
                 string latestTagName = latest.TagName.Split('-').First();
 
                 if (latestTagName != version)

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Updater
                                          // only implementations will actually check for updates.
                                          GetType() != typeof(UpdateManager);
 
+        public virtual ReleaseStream? FixedReleaseStream => null;
+
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
 


### PR DESCRIPTION
<img width="473" alt="image" src="https://github.com/user-attachments/assets/4ac3ad92-1830-462b-8db5-08a0b360015f" />

Also batched in a change to `MobileUpdateManager` here, because we now have Tachyon releases for mobile too. Code mostly follows the existing example set by `NoActionUpdateManager`, with the biggest difference being that the `ReleaseStream` is parsed from the game's version.