### PR TITLE
Add basic score pinning support

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -223,6 +223,33 @@ namespace osu.Game.Tests.Visual.Online
             });
         }
 
+        [Test]
+        public void TestPinnableScore()
+        {
+            AddStep("Load unpinned score", () =>
+            {
+                var allScores = createScores();
+
+                allScores.Scores[0].CurrentUserAttributes = new SoloScoreInfo.ScoreCurrentUserAttributes
+                {
+                    Pin = new SoloScoreInfo.ScorePinAttributes(),
+                };
+
+                scoresContainer.Scores = allScores;
+            });
+            AddStep("Load pinned score", () =>
+            {
+                var allScores = createScores();
+
+                allScores.Scores[0].CurrentUserAttributes = new SoloScoreInfo.ScoreCurrentUserAttributes
+                {
+                    Pin = new SoloScoreInfo.ScorePinAttributes { IsPinned = true },
+                };
+
+                scoresContainer.Scores = allScores;
+            });
+        }
+
         private ulong onlineID = 1;
 
         private APIScoresCollection createScores()

--- a/osu.Game/Online/API/Requests/PinScoreRequest.cs
+++ b/osu.Game/Online/API/Requests/PinScoreRequest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Net.Http;
+using osu.Framework.IO.Network;
+using osu.Game.Scoring;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class PinScoreRequest : APIRequest
+    {
+        private readonly IScoreInfo score;
+
+        public PinScoreRequest(IScoreInfo score)
+        {
+            this.score = score;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var request = base.CreateWebRequest();
+            request.Method = HttpMethod.Put;
+            return request;
+        }
+
+        protected override string Target => $"score-pins/{score.OnlineID}";
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -127,6 +127,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("processed")]
         public bool Processed { get; set; }
 
+        [JsonProperty("current_user_attributes")]
+        public ScoreCurrentUserAttributes? CurrentUserAttributes { get; set; }
+
         // These properties are calculated or not relevant to any external usage.
         public bool ShouldSerializeID() => false;
         public bool ShouldSerializeUser() => false;
@@ -261,5 +264,17 @@ namespace osu.Game.Online.API.Requests.Responses
             Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(),
             MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(),
         };
+
+        public struct ScoreCurrentUserAttributes
+        {
+            [JsonProperty("pin")]
+            public ScorePinAttributes? Pin { get; set; }
+        }
+
+        public struct ScorePinAttributes
+        {
+            [JsonProperty("is_pinned")]
+            public bool IsPinned { get; set; }
+        }
     }
 }

--- a/osu.Game/Online/API/Requests/UnpinScoreRequest.cs
+++ b/osu.Game/Online/API/Requests/UnpinScoreRequest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Net.Http;
+using osu.Framework.IO.Network;
+using osu.Game.Scoring;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class UnpinScoreRequest : APIRequest
+    {
+        private readonly IScoreInfo score;
+
+        public UnpinScoreRequest(IScoreInfo score)
+        {
+            this.score = score;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var request = base.CreateWebRequest();
+            request.Method = HttpMethod.Delete;
+            return request;
+        }
+
+        protected override string Target => $"score-pins/{score.OnlineID}";
+    }
+}

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Scoring;
 using osuTK;
 using osuTK.Graphics;
@@ -19,7 +20,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
     {
         private readonly Box background;
 
-        public DrawableTopScore(ScoreInfo score, int? position = 1)
+        public DrawableTopScore(ScoreInfo score, int? position = 1, SoloScoreInfo.ScorePinAttributes? pinAttributes = null)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -72,6 +73,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                         Anchor = Anchor.CentreRight,
                                         Origin = Anchor.CentreRight,
                                         Score = score,
+                                        PinAttributes = pinAttributes,
                                     }
                                 },
                             },

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -84,19 +84,22 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     MD5Hash = apiBeatmap.MD5Hash
                 };
 
-                var scores = value.Scores.Select(s => s.ToScoreInfo(rulesets, beatmapInfo)).OrderByTotalScore().ToArray();
+                var scores = value.Scores.OrderByTotalScore().ToArray();
                 var topScore = scores.First();
 
-                scoreTable.DisplayScores(scores, apiBeatmap.Status.GrantsPerformancePoints());
+                var scoreInfos = scores.Select(s => s.ToScoreInfo(rulesets, beatmapInfo)).ToArray();
+                var topScoreInfo = scoreInfos.First();
+
+                scoreTable.DisplayScores(scoreInfos, apiBeatmap.Status.GrantsPerformancePoints());
                 scoreTable.Show();
 
                 var userScore = value.UserScore;
                 var userScoreInfo = userScore?.Score.ToScoreInfo(rulesets, beatmapInfo);
 
-                topScoresContainer.Add(new DrawableTopScore(topScore));
+                topScoresContainer.Add(new DrawableTopScore(topScoreInfo, pinAttributes: topScore.CurrentUserAttributes?.Pin));
 
-                if (userScoreInfo != null && userScoreInfo.OnlineID != topScore.OnlineID)
-                    topScoresContainer.Add(new DrawableTopScore(userScoreInfo, userScore.Position));
+                if (userScoreInfo != null && userScoreInfo.OnlineID != topScoreInfo.OnlineID)
+                    topScoresContainer.Add(new DrawableTopScore(userScoreInfo, userScore.Position, userScore.Score.CurrentUserAttributes?.Pin));
             });
         }
 

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileActionItem.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileActionItem.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Overlays.Profile.Header.Components
+{
+    public partial class ProfileActionItem : OsuClickableContainer
+    {
+        private readonly LocalisableString caption;
+        private readonly IconUsage? icon;
+
+        private Box background = null!;
+        private CircularContainer indicator = null!;
+
+        public ProfileActionItem(LocalisableString caption, IconUsage? icon = null)
+        {
+            this.icon = icon;
+            this.caption = caption;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            RelativeSizeAxes = Content.RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Content.AutoSizeAxes = Axes.Y;
+
+            Masking = true;
+            CornerRadius = 4;
+            Children = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background5,
+                    Alpha = 0,
+                },
+                indicator = new Circle
+                {
+                    Width = 4,
+                    Height = 14,
+                    X = 10,
+                    Colour = colourProvider.Highlight1,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.Centre,
+                    Alpha = 0,
+                },
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Y,
+                    RelativeSizeAxes = Axes.X,
+                    Padding = new MarginPadding { Horizontal = 25, Vertical = 8 },
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(5, 0),
+                    Children = new Drawable[]
+                    {
+                        new SpriteIcon
+                        {
+                            Alpha = icon.HasValue ? 1 : 0,
+                            Icon = icon ?? default,
+                            Size = new Vector2(11),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = caption,
+                            Font = OsuFont.Style.Body,
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            UseFullGlyphHeight = false,
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateState();
+            return true;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            updateState();
+            base.OnHoverLost(e);
+        }
+
+        private void updateState()
+        {
+            background.Alpha = indicator.Alpha = IsHovered ? 1 : 0;
+        }
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
@@ -12,11 +12,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
-using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -108,7 +104,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     Padding = new MarginPadding { Horizontal = 5, Vertical = 10 },
                     Children = new Drawable[]
                     {
-                        new UserAction(FontAwesome.Solid.Ban, userBlocked ? UsersStrings.BlocksButtonUnblock : UsersStrings.BlocksButtonBlock)
+                        new ProfileActionItem(userBlocked ? UsersStrings.BlocksButtonUnblock : UsersStrings.BlocksButtonBlock, FontAwesome.Solid.Ban)
                         {
                             Action = () =>
                             {
@@ -118,93 +114,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
                         }
                     }
                 };
-            }
-        }
-
-        private partial class UserAction : OsuClickableContainer
-        {
-            private readonly IconUsage icon;
-            private readonly LocalisableString caption;
-
-            private Box background = null!;
-            private CircularContainer indicator = null!;
-
-            public UserAction(IconUsage icon, LocalisableString caption)
-            {
-                this.icon = icon;
-                this.caption = caption;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                RelativeSizeAxes = Content.RelativeSizeAxes = Axes.X;
-                AutoSizeAxes = Content.AutoSizeAxes = Axes.Y;
-
-                Masking = true;
-                CornerRadius = 4;
-                Children = new Drawable[]
-                {
-                    background = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colourProvider.Background5,
-                        Alpha = 0,
-                    },
-                    indicator = new Circle
-                    {
-                        Width = 4,
-                        Height = 14,
-                        X = 10,
-                        Colour = colourProvider.Highlight1,
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.Centre,
-                        Alpha = 0,
-                    },
-                    new FillFlowContainer
-                    {
-                        AutoSizeAxes = Axes.Y,
-                        RelativeSizeAxes = Axes.X,
-                        Padding = new MarginPadding { Horizontal = 25, Vertical = 5 },
-                        Direction = FillDirection.Horizontal,
-                        Spacing = new Vector2(5, 0),
-                        Children = new Drawable[]
-                        {
-                            new SpriteIcon
-                            {
-                                Icon = icon,
-                                Size = new Vector2(11),
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                            },
-                            new OsuSpriteText
-                            {
-                                Text = caption,
-                                Font = OsuFont.Style.Body,
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                                UseFullGlyphHeight = false,
-                            }
-                        }
-                    }
-                };
-            }
-
-            protected override bool OnHover(HoverEvent e)
-            {
-                updateState();
-                return true;
-            }
-
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                updateState();
-                base.OnHoverLost(e);
-            }
-
-            private void updateState()
-            {
-                background.Alpha = indicator.Alpha = IsHovered ? 1 : 0;
             }
         }
     }

--- a/osu.Game/Overlays/Profile/Sections/ProfileItemContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileItemContainer.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Overlays.Profile.Sections
         protected override bool OnHover(HoverEvent e)
         {
             fadeBackgroundColour(hover_duration);
-            return true;
+            return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -2,17 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Resources.Localisation.Web;
@@ -24,7 +28,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.Profile.Sections.Ranks
 {
-    public partial class DrawableProfileScore : CompositeDrawable
+    public partial class DrawableProfileScore : CompositeDrawable, IHasContextMenu
     {
         private const int height = 40;
         private const int performance_width = 100;
@@ -286,6 +290,31 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                     }
                 }
             };
+        }
+
+        [Resolved]
+        private ScorePinningManager? pinningManager { get; set; }
+
+        [Resolved]
+        private OsuGame? game { get; set; }
+
+        public MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                var items = new List<MenuItem>();
+
+                if (pinningManager?.CanPin(Score) == true)
+                {
+                    if (pinningManager.IsPinned(Score))
+                        items.Add(new OsuMenuItem(UsersStrings.ShowExtraTopRanksPinTo0, MenuItemType.Standard, () => pinningManager.UnpinScore(Score)));
+                    else
+                        items.Add(new OsuMenuItem(UsersStrings.ShowExtraTopRanksPinTo1, MenuItemType.Highlighted, () => pinningManager.PinScore(Score)));
+                }
+
+                items.Add(new OsuMenuItem(UsersStrings.ShowExtraTopRanksViewDetails, MenuItemType.Standard, () => game?.OpenUrlExternally($"/scores/{Score.OnlineID}")));
+                return items.ToArray();
+            }
         }
 
         private partial class ScoreBeatmapMetadataContainer : BeatmapMetadataContainer

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Game.Overlays.Profile.Sections.Ranks;
 using osu.Game.Online.API.Requests;
 using osu.Framework.Localisation;
@@ -14,14 +16,36 @@ namespace osu.Game.Overlays.Profile.Sections
 
         public override string Identifier => @"top_ranks";
 
+        private readonly PaginatedScoreContainer pinnedScores;
+
+        [Resolved]
+        private ScorePinningManager? pinningManager { get; set; }
+
         public RanksSection()
         {
-            Children = new[]
+            Children = new Drawable[]
             {
-                new PaginatedScoreContainer(ScoreType.Pinned, User, UsersStrings.ShowExtraTopRanksPinnedTitle),
+                pinnedScores = new PaginatedScoreContainer(ScoreType.Pinned, User, UsersStrings.ShowExtraTopRanksPinnedTitle),
                 new PaginatedScoreContainer(ScoreType.Best, User, UsersStrings.ShowExtraTopRanksBestTitle),
                 new PaginatedScoreContainer(ScoreType.Firsts, User, UsersStrings.ShowExtraTopRanksFirstTitle)
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (pinningManager != null)
+                pinningManager.PinsChanged += onPinsChanged;
+        }
+
+        private void onPinsChanged() => pinnedScores.Refresh(clearPrevious: false);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (pinningManager != null)
+                pinningManager.PinsChanged -= onPinsChanged;
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/ScorePinningManager.cs
+++ b/osu.Game/Overlays/Profile/Sections/ScorePinningManager.cs
@@ -1,0 +1,102 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Overlays.Profile.Sections
+{
+    public partial class ScorePinningManager : Component
+    {
+        public event Action? PinsChanged;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private INotificationOverlay? notifications { get; set; }
+
+        private readonly Dictionary<long, bool> scorePinMap = new Dictionary<long, bool>();
+
+        public bool CanPin(SoloScoreInfo score) => score.CurrentUserAttributes?.Pin != null && score.Passed;
+
+        public bool IsPinned(SoloScoreInfo score)
+        {
+            if (!CanPin(score))
+                return false;
+
+            if (!scorePinMap.TryGetValue(score.OnlineID, out bool pinned))
+            {
+                var pinAttributes = score.CurrentUserAttributes!.Value.Pin!.Value;
+                scorePinMap[score.OnlineID] = pinned = pinAttributes.IsPinned;
+            }
+
+            return pinned;
+        }
+
+        public void PinScore(SoloScoreInfo score)
+        {
+            if (!CanPin(score))
+                throw new InvalidOperationException("Attempting to pin a score not belonging to the local user.");
+
+            if (IsPinned(score))
+                return;
+
+            var request = new PinScoreRequest(score);
+
+            request.Success += () =>
+            {
+                scorePinMap[score.OnlineID] = true;
+                PinsChanged?.Invoke();
+            };
+
+            request.Failure += e =>
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = e.Message,
+                    Icon = FontAwesome.Solid.Times,
+                });
+            };
+
+            api.Queue(request);
+        }
+
+        public void UnpinScore(SoloScoreInfo score)
+        {
+            if (!CanPin(score))
+                throw new InvalidOperationException("Attempting to pin a score not belonging to the local user.");
+
+            if (!IsPinned(score))
+                return;
+
+            var request = new UnpinScoreRequest(score);
+
+            request.Success += () =>
+            {
+                scorePinMap[score.OnlineID] = false;
+                PinsChanged?.Invoke();
+            };
+
+            request.Failure += e =>
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = e.Message,
+                    Icon = FontAwesome.Solid.Times,
+                });
+            };
+
+            api.Queue(request);
+        }
+
+        public void Invalidate() => scorePinMap.Clear();
+    }
+}

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -48,6 +48,9 @@ namespace osu.Game.Overlays
         private IUser? user;
         private IRulesetInfo? ruleset;
 
+        [Cached]
+        private readonly ScorePinningManager pinningManager;
+
         private readonly IBindable<APIState> apiState = new Bindable<APIState>();
 
         [Resolved]
@@ -61,6 +64,7 @@ namespace osu.Game.Overlays
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
+                    pinningManager = new ScorePinningManager(),
                     onlineViewContainer = new OnlineViewContainer($"Sign in to view the {Header.Title.Title}")
                     {
                         RelativeSizeAxes = Axes.Both
@@ -110,6 +114,8 @@ namespace osu.Game.Overlays
 
             userReq?.Cancel();
             lastSection = null;
+
+            pinningManager.Invalidate();
 
             sections = !user.IsBot
                 ? new ProfileSection[]

--- a/osu.Game/Scoring/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/ScoreInfoExtensions.cs
@@ -16,11 +16,12 @@ namespace osu.Game.Scoring
         public static string GetDisplayTitle(this IScoreInfo scoreInfo) => $"{scoreInfo.User.Username} playing {scoreInfo.Beatmap?.GetDisplayTitle() ?? "unknown"}";
 
         /// <summary>
-        /// Orders an array of <see cref="ScoreInfo"/>s by total score.
+        /// Orders an array of <see cref="IScoreInfo"/>s by total score.
         /// </summary>
-        /// <param name="scores">The array of <see cref="ScoreInfo"/>s to reorder.</param>
+        /// <param name="scores">The array of <see cref="IScoreInfo"/>s to reorder.</param>
         /// <returns>The given <paramref name="scores"/> ordered by decreasing total score.</returns>
-        public static IEnumerable<ScoreInfo> OrderByTotalScore(this IEnumerable<ScoreInfo> scores)
+        public static IEnumerable<T> OrderByTotalScore<T>(this IEnumerable<T> scores)
+            where T : IScoreInfo
             => scores.OrderByDescending(s => s.TotalScore)
                      .ThenBy(s => s.OnlineID)
                      // Local scores may not have an online ID. Fall back to date in these cases.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/32888

Few important notes:
 - This does not include reordering for now, implementing that requires further thought UI/UX-wise.
 - The counter pill next to the "Pinned Scores" header does not update when pinning/unpinning scores, because it relies on `User.PinnedScores` and that is only fetched once when the profile is loaded.
   - The best method I can see to solve this would be if web returns the total number of pinned scores after a pin/unpin operation. @ppy/team-web is that feasible?
 - The size of the loading spinner changing as the pin scores increase/decrease is slightly silly, and looks extremely broken when unpinning the last score there. Not sure how to go about fixing that.
 - This can be extended to allow pinning scores from song select / results screen, but I'm not yet sure how to go about approaching this and it's slowly increasing the complexity of this PR so I'm leaving it as a follow-up.
 - I was debating between having the backend of pinning scores as its own component or part of `APIAccess` in a similar manner to how blocks/friends are tracked, but I've went with the former as I felt isolated single-purpose components are always better.

Preview:

https://github.com/user-attachments/assets/8c38ef26-872d-4e0c-80b7-5737c148bd5a

