### PR TITLE
Ensure global leaderboard state matches beatmap when loading player

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -26,12 +26,14 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input;
 using osu.Game.Localisation;
+using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.Volume;
 using osu.Game.Performance;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.PlayerSettings;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Skinning;
 using osu.Game.Users;
 using osu.Game.Utils;
@@ -175,6 +177,9 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private IHighPerformanceSessionManager? highPerformanceSessionManager { get; set; }
 
+        [Resolved]
+        private LeaderboardManager? leaderboardManager { get; set; }
+
         public PlayerLoader(Func<Player> createPlayer)
         {
             this.createPlayer = createPlayer;
@@ -269,6 +274,12 @@ namespace osu.Game.Screens.Play
 
             showStoryboards.BindValueChanged(val => epilepsyWarning?.FadeTo(val.NewValue ? 1 : 0, 250, Easing.OutQuint), true);
             epilepsyWarning?.FinishTransforms(true);
+
+            leaderboardManager?.FetchWithCriteria(new LeaderboardCriteria(
+                Beatmap.Value.BeatmapInfo,
+                Ruleset.Value,
+                leaderboardManager?.CurrentCriteria?.Scope ?? BeatmapLeaderboardScope.Global,
+                leaderboardManager?.CurrentCriteria?.ExactMods));
         }
 
         #region Screen handling


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33835.

I love fixing issues multiple times.

Notably the refetch is not forced so this should be a no-op if the global state is already correct.

https://github.com/ppy/osu/issues/33835#issuecomment-2998897932 says

> but we should also consider adding a force `RunTask` of the pending debounce before entering gameplay, probably around here:
>
> https://github.com/ppy/osu/blob/3192eaa2a20f20495db8431d3d6f35af7c705a94/osu.Game/Screens/SelectV2/SongSelect.cs#L420

but I am not confident in making that change as I have no idea whether it is correct or not.