### PR TITLE
Fix user tags moving in the control after voting

### DIFF
--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -43,6 +44,8 @@ namespace osu.Game.Screens.Ranking
         private readonly Bindable<APIBeatmap?> apiBeatmap = new Bindable<APIBeatmap?>();
 
         private AddNewTagUserTag addNewTagUserTag = null!;
+
+        private InputManager inputManager = null!;
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -124,6 +127,8 @@ namespace osu.Game.Screens.Ranking
             updateTags();
 
             displayedTags.BindCollectionChanged(displayTags, true);
+
+            inputManager = GetContainingInputManager()!;
         }
 
         private void updateTags()
@@ -251,7 +256,7 @@ namespace osu.Game.Screens.Ranking
         {
             base.Update();
 
-            if (!layout.IsValid && !IsHovered)
+            if (!layout.IsValid && !Contains(inputManager.CurrentState.Mouse.Position))
             {
                 var sortedTags = new Dictionary<UserTag, int>(
                     displayedTags.OrderByDescending(t => t.VoteCount.Value)

--- a/osu.Game/Screens/Ranking/UserTagControl_DrawableUserTag.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl_DrawableUserTag.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Ranking
 {
     public partial class UserTagControl
     {
-        private partial class DrawableUserTag : OsuAnimatedButton
+        public partial class DrawableUserTag : OsuAnimatedButton
         {
             public readonly UserTag UserTag;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33877.

Most likely regressed when the user tags were changed such that the loading spinner that shows on adding/removing a vote was introduced to every individual tag separately. This in turn means that the `LoadingLayer` responsible for showing the spinner also briefly consumes all input when visible, which also means that the control briefly becomes unhovered, breaking the logic.

This probably doesn't work on mobile because mobile input sucks. On iOS simulator it looks somewhat fine in that the tags don't move until you touch the screen anywhere else which seems okay if that's what actually what happens on device as well. And if it isn't I'm not sure I can do anything sane about it anyway.