### PR TITLE
Apply flooring and half-millisecond-adjustments to hit windows

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
@@ -19,7 +19,6 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Mania.Tests
 {
-    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneLegacyReplayPlayback : LegacyReplayPlaybackTestScene
     {
         protected override Ruleset CreateRuleset() => new ManiaRuleset();
@@ -72,13 +71,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -137d, HitResult.Miss },
             new object[] { 5f, -138d, HitResult.Miss },
             new object[] { 5f, 111d, HitResult.Ok },
-            new object[] { 5f, 112d, HitResult.Miss },
-            new object[] { 5f, 113d, HitResult.Miss },
-            new object[] { 5f, 114d, HitResult.Miss },
-            new object[] { 5f, 135d, HitResult.Miss },
-            new object[] { 5f, 136d, HitResult.Miss },
-            new object[] { 5f, 137d, HitResult.Miss },
-            new object[] { 5f, 138d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 5f, 112d, HitResult.Miss },
+            // new object[] { 5f, 113d, HitResult.Miss },
+            // new object[] { 5f, 114d, HitResult.Miss },
+            // new object[] { 5f, 135d, HitResult.Miss },
+            // new object[] { 5f, 136d, HitResult.Miss },
+            // new object[] { 5f, 137d, HitResult.Miss },
+            // new object[] { 5f, 138d, HitResult.Miss },
 
             // OD = 9.3 test cases.
             // PERFECT hit window is [ -14ms,  14ms]
@@ -99,13 +99,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 9.3f, 70d, HitResult.Ok },
             new object[] { 9.3f, 71d, HitResult.Ok },
             new object[] { 9.3f, 98d, HitResult.Ok },
-            new object[] { 9.3f, 99d, HitResult.Miss },
-            new object[] { 9.3f, 100d, HitResult.Miss },
-            new object[] { 9.3f, 101d, HitResult.Miss },
-            new object[] { 9.3f, 122d, HitResult.Miss },
-            new object[] { 9.3f, 123d, HitResult.Miss },
-            new object[] { 9.3f, 124d, HitResult.Miss },
-            new object[] { 9.3f, 125d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 9.3f, 99d, HitResult.Miss },
+            // new object[] { 9.3f, 100d, HitResult.Miss },
+            // new object[] { 9.3f, 101d, HitResult.Miss },
+            // new object[] { 9.3f, 122d, HitResult.Miss },
+            // new object[] { 9.3f, 123d, HitResult.Miss },
+            // new object[] { 9.3f, 124d, HitResult.Miss },
+            // new object[] { 9.3f, 125d, HitResult.Miss },
             new object[] { 9.3f, -98d, HitResult.Ok },
             new object[] { 9.3f, -99d, HitResult.Ok },
             new object[] { 9.3f, -100d, HitResult.Meh },
@@ -145,13 +146,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -137d, HitResult.Miss },
             new object[] { 5f, -138d, HitResult.Miss },
             new object[] { 5f, 111d, HitResult.Ok },
-            new object[] { 5f, 112d, HitResult.Miss },
-            new object[] { 5f, 113d, HitResult.Miss },
-            new object[] { 5f, 114d, HitResult.Miss },
-            new object[] { 5f, 135d, HitResult.Miss },
-            new object[] { 5f, 136d, HitResult.Miss },
-            new object[] { 5f, 137d, HitResult.Miss },
-            new object[] { 5f, 138d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 5f, 112d, HitResult.Miss },
+            // new object[] { 5f, 113d, HitResult.Miss },
+            // new object[] { 5f, 114d, HitResult.Miss },
+            // new object[] { 5f, 135d, HitResult.Miss },
+            // new object[] { 5f, 136d, HitResult.Miss },
+            // new object[] { 5f, 137d, HitResult.Miss },
+            // new object[] { 5f, 138d, HitResult.Miss },
 
             // OD = 9.3 test cases.
             // PERFECT hit window is [ -16ms,  16ms]
@@ -172,13 +174,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 9.3f, 70d, HitResult.Ok },
             new object[] { 9.3f, 71d, HitResult.Ok },
             new object[] { 9.3f, 98d, HitResult.Ok },
-            new object[] { 9.3f, 99d, HitResult.Miss },
-            new object[] { 9.3f, 100d, HitResult.Miss },
-            new object[] { 9.3f, 101d, HitResult.Miss },
-            new object[] { 9.3f, 122d, HitResult.Miss },
-            new object[] { 9.3f, 123d, HitResult.Miss },
-            new object[] { 9.3f, 124d, HitResult.Miss },
-            new object[] { 9.3f, 125d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 9.3f, 99d, HitResult.Miss },
+            // new object[] { 9.3f, 100d, HitResult.Miss },
+            // new object[] { 9.3f, 101d, HitResult.Miss },
+            // new object[] { 9.3f, 122d, HitResult.Miss },
+            // new object[] { 9.3f, 123d, HitResult.Miss },
+            // new object[] { 9.3f, 124d, HitResult.Miss },
+            // new object[] { 9.3f, 125d, HitResult.Miss },
             new object[] { 9.3f, -98d, HitResult.Ok },
             new object[] { 9.3f, -99d, HitResult.Ok },
             new object[] { 9.3f, -100d, HitResult.Meh },
@@ -207,13 +210,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 3.1f, 88d, HitResult.Ok },
             new object[] { 3.1f, 89d, HitResult.Ok },
             new object[] { 3.1f, 116d, HitResult.Ok },
-            new object[] { 3.1f, 117d, HitResult.Miss },
-            new object[] { 3.1f, 118d, HitResult.Miss },
-            new object[] { 3.1f, 119d, HitResult.Miss },
-            new object[] { 3.1f, 140d, HitResult.Miss },
-            new object[] { 3.1f, 141d, HitResult.Miss },
-            new object[] { 3.1f, 142d, HitResult.Miss },
-            new object[] { 3.1f, 143d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 3.1f, 117d, HitResult.Miss },
+            // new object[] { 3.1f, 118d, HitResult.Miss },
+            // new object[] { 3.1f, 119d, HitResult.Miss },
+            // new object[] { 3.1f, 140d, HitResult.Miss },
+            // new object[] { 3.1f, 141d, HitResult.Miss },
+            // new object[] { 3.1f, 142d, HitResult.Miss },
+            // new object[] { 3.1f, 143d, HitResult.Miss },
             new object[] { 3.1f, -116d, HitResult.Ok },
             new object[] { 3.1f, -117d, HitResult.Ok },
             new object[] { 3.1f, -118d, HitResult.Meh },
@@ -253,13 +257,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -122d, HitResult.Miss },
             new object[] { 5f, -123d, HitResult.Miss },
             new object[] { 5f, 96d, HitResult.Ok },
-            new object[] { 5f, 97d, HitResult.Miss },
-            new object[] { 5f, 98d, HitResult.Miss },
-            new object[] { 5f, 99d, HitResult.Miss },
-            new object[] { 5f, 120d, HitResult.Miss },
-            new object[] { 5f, 121d, HitResult.Miss },
-            new object[] { 5f, 122d, HitResult.Miss },
-            new object[] { 5f, 123d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 5f, 97d, HitResult.Miss },
+            // new object[] { 5f, 98d, HitResult.Miss },
+            // new object[] { 5f, 99d, HitResult.Miss },
+            // new object[] { 5f, 120d, HitResult.Miss },
+            // new object[] { 5f, 121d, HitResult.Miss },
+            // new object[] { 5f, 122d, HitResult.Miss },
+            // new object[] { 5f, 123d, HitResult.Miss },
 
             // OD = 3.1 test cases.
             // PERFECT hit window is [ -16ms,  16ms]
@@ -280,13 +285,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 3.1f, 78d, HitResult.Ok },
             new object[] { 3.1f, 79d, HitResult.Ok },
             new object[] { 3.1f, 96d, HitResult.Ok },
-            new object[] { 3.1f, 97d, HitResult.Miss },
-            new object[] { 3.1f, 98d, HitResult.Miss },
-            new object[] { 3.1f, 99d, HitResult.Miss },
-            new object[] { 3.1f, 120d, HitResult.Miss },
-            new object[] { 3.1f, 121d, HitResult.Miss },
-            new object[] { 3.1f, 122d, HitResult.Miss },
-            new object[] { 3.1f, 123d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 3.1f, 97d, HitResult.Miss },
+            // new object[] { 3.1f, 98d, HitResult.Miss },
+            // new object[] { 3.1f, 99d, HitResult.Miss },
+            // new object[] { 3.1f, 120d, HitResult.Miss },
+            // new object[] { 3.1f, 121d, HitResult.Miss },
+            // new object[] { 3.1f, 122d, HitResult.Miss },
+            // new object[] { 3.1f, 123d, HitResult.Miss },
             new object[] { 3.1f, -96d, HitResult.Ok },
             new object[] { 3.1f, -97d, HitResult.Ok },
             new object[] { 3.1f, -98d, HitResult.Meh },
@@ -327,13 +333,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -98d, HitResult.Miss },
             new object[] { 5f, -99d, HitResult.Miss },
             new object[] { 5f, 79d, HitResult.Ok },
-            new object[] { 5f, 80d, HitResult.Miss },
-            new object[] { 5f, 81d, HitResult.Miss },
-            new object[] { 5f, 82d, HitResult.Miss },
-            new object[] { 5f, 96d, HitResult.Miss },
-            new object[] { 5f, 97d, HitResult.Miss },
-            new object[] { 5f, 98d, HitResult.Miss },
-            new object[] { 5f, 99d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 5f, 80d, HitResult.Miss },
+            // new object[] { 5f, 81d, HitResult.Miss },
+            // new object[] { 5f, 82d, HitResult.Miss },
+            // new object[] { 5f, 96d, HitResult.Miss },
+            // new object[] { 5f, 97d, HitResult.Miss },
+            // new object[] { 5f, 98d, HitResult.Miss },
+            // new object[] { 5f, 99d, HitResult.Miss },
 
             // OD = 9.3 test cases.
             // This leads to "effective" OD of 13.02.
@@ -356,13 +363,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 9.3f, 50d, HitResult.Ok },
             new object[] { 9.3f, 51d, HitResult.Ok },
             new object[] { 9.3f, 69d, HitResult.Ok },
-            new object[] { 9.3f, 70d, HitResult.Miss },
-            new object[] { 9.3f, 71d, HitResult.Miss },
-            new object[] { 9.3f, 72d, HitResult.Miss },
-            new object[] { 9.3f, 86d, HitResult.Miss },
-            new object[] { 9.3f, 87d, HitResult.Miss },
-            new object[] { 9.3f, 88d, HitResult.Miss },
-            new object[] { 9.3f, 89d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 9.3f, 70d, HitResult.Miss },
+            // new object[] { 9.3f, 71d, HitResult.Miss },
+            // new object[] { 9.3f, 72d, HitResult.Miss },
+            // new object[] { 9.3f, 86d, HitResult.Miss },
+            // new object[] { 9.3f, 87d, HitResult.Miss },
+            // new object[] { 9.3f, 88d, HitResult.Miss },
+            // new object[] { 9.3f, 89d, HitResult.Miss },
             new object[] { 9.3f, -69d, HitResult.Ok },
             new object[] { 9.3f, -70d, HitResult.Ok },
             new object[] { 9.3f, -71d, HitResult.Meh },
@@ -402,13 +410,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -191d, HitResult.Miss },
             new object[] { 5f, -192d, HitResult.Miss },
             new object[] { 5f, 155d, HitResult.Ok },
-            new object[] { 5f, 156d, HitResult.Miss },
-            new object[] { 5f, 157d, HitResult.Miss },
-            new object[] { 5f, 158d, HitResult.Miss },
-            new object[] { 5f, 189d, HitResult.Miss },
-            new object[] { 5f, 190d, HitResult.Miss },
-            new object[] { 5f, 191d, HitResult.Miss },
-            new object[] { 5f, 192d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 5f, 156d, HitResult.Miss },
+            // new object[] { 5f, 157d, HitResult.Miss },
+            // new object[] { 5f, 158d, HitResult.Miss },
+            // new object[] { 5f, 189d, HitResult.Miss },
+            // new object[] { 5f, 190d, HitResult.Miss },
+            // new object[] { 5f, 191d, HitResult.Miss },
+            // new object[] { 5f, 192d, HitResult.Miss },
         };
 
         private static readonly object[][] score_v1_non_convert_double_time_test_cases =
@@ -440,13 +449,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -205d, HitResult.Miss },
             new object[] { 5f, -206d, HitResult.Miss },
             new object[] { 5f, 167d, HitResult.Ok },
-            new object[] { 5f, 168d, HitResult.Miss },
-            new object[] { 5f, 169d, HitResult.Miss },
-            new object[] { 5f, 170d, HitResult.Miss },
-            new object[] { 5f, 203d, HitResult.Miss },
-            new object[] { 5f, 204d, HitResult.Miss },
-            new object[] { 5f, 205d, HitResult.Miss },
-            new object[] { 5f, 206d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 5f, 168d, HitResult.Miss },
+            // new object[] { 5f, 169d, HitResult.Miss },
+            // new object[] { 5f, 170d, HitResult.Miss },
+            // new object[] { 5f, 203d, HitResult.Miss },
+            // new object[] { 5f, 204d, HitResult.Miss },
+            // new object[] { 5f, 205d, HitResult.Miss },
+            // new object[] { 5f, 206d, HitResult.Miss },
         };
 
         private static readonly object[][] score_v1_non_convert_half_time_test_cases =
@@ -478,13 +488,14 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { 5f, -103d, HitResult.Miss },
             new object[] { 5f, -104d, HitResult.Miss },
             new object[] { 5f, 83d, HitResult.Ok },
-            new object[] { 5f, 84d, HitResult.Miss },
-            new object[] { 5f, 85d, HitResult.Miss },
-            new object[] { 5f, 86d, HitResult.Miss },
-            new object[] { 5f, 101d, HitResult.Miss },
-            new object[] { 5f, 102d, HitResult.Miss },
-            new object[] { 5f, 103d, HitResult.Miss },
-            new object[] { 5f, 104d, HitResult.Miss },
+            // coverage of broken "can't hit meh late" behaviour, which is intentionally not being reproduced
+            // new object[] { 5f, 84d, HitResult.Miss },
+            // new object[] { 5f, 85d, HitResult.Miss },
+            // new object[] { 5f, 86d, HitResult.Miss },
+            // new object[] { 5f, 101d, HitResult.Miss },
+            // new object[] { 5f, 102d, HitResult.Miss },
+            // new object[] { 5f, 103d, HitResult.Miss },
+            // new object[] { 5f, 104d, HitResult.Miss },
         };
 
         private const double note_time = 300;
@@ -517,6 +528,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV2 single note @ OD{overallDifficulty}", beatmap, $@"SV2 {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
+        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1NonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -544,6 +556,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1 single note @ OD{overallDifficulty}", beatmap, $@"SV1 {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
+        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_convert_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1Convert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -572,6 +585,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1 convert single note @ OD{overallDifficulty}", beatmap, $@"SV1 convert {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
+        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_hard_rock_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndHardRockNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -600,6 +614,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1+HR single note @ OD{overallDifficulty}", beatmap, $@"SV1+HR {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
+        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_easy_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndEasyNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -628,6 +643,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1+EZ single note @ OD{overallDifficulty}", beatmap, $@"SV1+EZ {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
+        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_double_time_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndDoubleTimeNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -656,6 +672,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1+DT single note @ OD{overallDifficulty}", beatmap, $@"SV1+DT {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
+        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_half_time_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndHalfTimeNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
@@ -12,7 +12,6 @@ using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests
 {
-    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneReplayStability : ReplayStabilityTestScene
     {
         private static readonly object[][] test_cases =
@@ -22,87 +21,79 @@ namespace osu.Game.Rulesets.Mania.Tests
             // while round brackets `()` represent *open* or *exclusive* bounds.
 
             // OD = 5 test cases.
-            // PERFECT hit window is [ -19.4ms,  19.4ms]
-            // GREAT   hit window is [ -49.0ms,  49.0ms]
-            // GOOD    hit window is [ -82.0ms,  82.0ms]
-            // OK      hit window is [-112.0ms, 112.0ms]
-            // MEH     hit window is [-136.0ms, 136.0ms]
-            // MISS    hit window is [-173.0ms, 173.0ms]
+            // PERFECT hit window is [ -19.5ms,  19.5ms]
+            // GREAT   hit window is [ -49.5ms,  49.5ms]
+            // GOOD    hit window is [ -82.5ms,  82.5ms]
+            // OK      hit window is [-112.5ms, 112.5ms]
+            // MEH     hit window is [-136.5ms, 136.5ms]
+            // MISS    hit window is [-173.5ms, 173.5ms]
             new object[] { 5f, -19d, HitResult.Perfect },
             new object[] { 5f, -19.2d, HitResult.Perfect },
-            new object[] { 5f, -19.38d, HitResult.Perfect },
-            // new object[] { 5f, -19.4d, HitResult.Perfect }, <- in theory this should work, in practice it does not (fails even before encode & rounding due to floating point precision issues)
-            new object[] { 5f, -19.44d, HitResult.Great },
             new object[] { 5f, -19.7d, HitResult.Great },
             new object[] { 5f, -20d, HitResult.Great },
             new object[] { 5f, -48d, HitResult.Great },
             new object[] { 5f, -48.4d, HitResult.Great },
             new object[] { 5f, -48.7d, HitResult.Great },
             new object[] { 5f, -49d, HitResult.Great },
-            new object[] { 5f, -49.2d, HitResult.Good },
+            new object[] { 5f, -49.2d, HitResult.Great },
             new object[] { 5f, -49.7d, HitResult.Good },
             new object[] { 5f, -50d, HitResult.Good },
             new object[] { 5f, -81d, HitResult.Good },
             new object[] { 5f, -81.2d, HitResult.Good },
             new object[] { 5f, -81.7d, HitResult.Good },
             new object[] { 5f, -82d, HitResult.Good },
-            new object[] { 5f, -82.2d, HitResult.Ok },
+            new object[] { 5f, -82.2d, HitResult.Good },
             new object[] { 5f, -82.7d, HitResult.Ok },
             new object[] { 5f, -83d, HitResult.Ok },
             new object[] { 5f, -111d, HitResult.Ok },
             new object[] { 5f, -111.2d, HitResult.Ok },
             new object[] { 5f, -111.7d, HitResult.Ok },
             new object[] { 5f, -112d, HitResult.Ok },
-            new object[] { 5f, -112.2d, HitResult.Meh },
+            new object[] { 5f, -112.2d, HitResult.Ok },
             new object[] { 5f, -112.7d, HitResult.Meh },
             new object[] { 5f, -113d, HitResult.Meh },
             new object[] { 5f, -135d, HitResult.Meh },
             new object[] { 5f, -135.2d, HitResult.Meh },
             new object[] { 5f, -135.8d, HitResult.Meh },
             new object[] { 5f, -136d, HitResult.Meh },
-            new object[] { 5f, -136.2d, HitResult.Miss },
+            new object[] { 5f, -136.2d, HitResult.Meh },
             new object[] { 5f, -136.7d, HitResult.Miss },
             new object[] { 5f, -137d, HitResult.Miss },
 
             // OD = 9.3 test cases.
-            // PERFECT hit window is [ -14.67ms,  14.67ms]
-            // GREAT   hit window is [ -36.10ms,  36.10ms]
-            // GOOD    hit window is [ -69.10ms,  69.10ms]
-            // OK      hit window is [ -99.10ms,  99.10ms]
-            // MEH     hit window is [-123.10ms, 123.10ms]
-            // MISS    hit window is [-160.10ms, 160.10ms]
+            // PERFECT hit window is [ -14.5ms,  14.5ms]
+            // GREAT   hit window is [ -36.5ms,  36.5ms]
+            // GOOD    hit window is [ -69.5ms,  69.5ms]
+            // OK      hit window is [ -99.5ms,  99.5ms]
+            // MEH     hit window is [-123.5ms, 123.5ms]
+            // MISS    hit window is [-160.5ms, 160.5ms]
             new object[] { 9.3f, 14d, HitResult.Perfect },
             new object[] { 9.3f, 14.2d, HitResult.Perfect },
-            new object[] { 9.3f, 14.6d, HitResult.Perfect },
-            // new object[] { 9.3f, 14.67d, HitResult.Perfect }, <- in theory this should work, in practice it does not (fails even before encode & rounding due to floating point precision issues)
             new object[] { 9.3f, 14.7d, HitResult.Great },
             new object[] { 9.3f, 15d, HitResult.Great },
             new object[] { 9.3f, 35d, HitResult.Great },
             new object[] { 9.3f, 35.3d, HitResult.Great },
             new object[] { 9.3f, 35.8d, HitResult.Great },
-            new object[] { 9.3f, 36.05d, HitResult.Great },
-            new object[] { 9.3f, 36.3d, HitResult.Good },
+            new object[] { 9.3f, 36.3d, HitResult.Great },
             new object[] { 9.3f, 36.7d, HitResult.Good },
             new object[] { 9.3f, 37d, HitResult.Good },
             new object[] { 9.3f, 68d, HitResult.Good },
             new object[] { 9.3f, 68.4d, HitResult.Good },
             new object[] { 9.3f, 68.9d, HitResult.Good },
-            new object[] { 9.3f, 69.07d, HitResult.Good },
-            new object[] { 9.3f, 69.25d, HitResult.Ok },
+            new object[] { 9.3f, 69.25d, HitResult.Good },
             new object[] { 9.3f, 69.85d, HitResult.Ok },
             new object[] { 9.3f, 70d, HitResult.Ok },
             new object[] { 9.3f, 98d, HitResult.Ok },
             new object[] { 9.3f, 98.3d, HitResult.Ok },
             new object[] { 9.3f, 98.6d, HitResult.Ok },
             new object[] { 9.3f, 99d, HitResult.Ok },
-            new object[] { 9.3f, 99.3d, HitResult.Meh },
+            new object[] { 9.3f, 99.3d, HitResult.Ok },
             new object[] { 9.3f, 99.7d, HitResult.Meh },
             new object[] { 9.3f, 100d, HitResult.Meh },
             new object[] { 9.3f, 122d, HitResult.Meh },
             new object[] { 9.3f, 122.34d, HitResult.Meh },
             new object[] { 9.3f, 122.57d, HitResult.Meh },
-            new object[] { 9.3f, 123.04d, HitResult.Meh },
-            new object[] { 9.3f, 123.45d, HitResult.Miss },
+            new object[] { 9.3f, 123.45d, HitResult.Meh },
             new object[] { 9.3f, 123.95d, HitResult.Miss },
             new object[] { 9.3f, 124d, HitResult.Miss },
         };
@@ -110,7 +101,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [TestCaseSource(nameof(test_cases))]
         public void TestHitWindowStability(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
-            const double note_time = 100;
+            const double note_time = 300;
 
             var beatmap = new ManiaBeatmap(new StageDefinition(1))
             {

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
@@ -53,12 +53,12 @@ namespace osu.Game.Rulesets.Mania.Scoring
 
         public override void SetDifficulty(double difficulty)
         {
-            perfect = IBeatmapDifficultyInfo.DifficultyRange(difficulty, perfect_window_range) * multiplier;
-            great = IBeatmapDifficultyInfo.DifficultyRange(difficulty, great_window_range) * multiplier;
-            good = IBeatmapDifficultyInfo.DifficultyRange(difficulty, good_window_range) * multiplier;
-            ok = IBeatmapDifficultyInfo.DifficultyRange(difficulty, ok_window_range) * multiplier;
-            meh = IBeatmapDifficultyInfo.DifficultyRange(difficulty, meh_window_range) * multiplier;
-            miss = IBeatmapDifficultyInfo.DifficultyRange(difficulty, miss_window_range) * multiplier;
+            perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, perfect_window_range) * multiplier) + 0.5;
+            great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, great_window_range) * multiplier) + 0.5;
+            good = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, good_window_range) * multiplier) + 0.5;
+            ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, ok_window_range) * multiplier) + 0.5;
+            meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, meh_window_range) * multiplier) + 0.5;
+            miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, miss_window_range) * multiplier) + 0.5;
         }
 
         public override double WindowFor(HitResult result)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyReplayPlayback.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyReplayPlayback.cs
@@ -17,7 +17,6 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
-    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneLegacyReplayPlayback : LegacyReplayPlaybackTestScene
     {
         protected override Ruleset CreateRuleset() => new OsuRuleset();

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
@@ -13,7 +13,6 @@ using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
-    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneReplayStability : ReplayStabilityTestScene
     {
         private static readonly object[][] test_cases =
@@ -23,53 +22,49 @@ namespace osu.Game.Rulesets.Osu.Tests
             // while round brackets `()` represent *open* or *exclusive* bounds.
 
             // OD = 5 test cases.
-            // GREAT hit window is [ -50ms,  50ms]
-            // OK    hit window is [-100ms, 100ms]
-            // MEH   hit window is [-150ms, 150ms]
-            // MISS  hit window is [-400ms, 400ms]
+            // GREAT hit window is [ -49.5ms,  49.5ms]
+            // OK    hit window is [ -99.5ms,  99.5ms]
+            // MEH   hit window is [-149.5ms, 149.5ms]
             new object[] { 5f, 49d, HitResult.Great },
             new object[] { 5f, 49.2d, HitResult.Great },
-            new object[] { 5f, 49.7d, HitResult.Great },
-            new object[] { 5f, 50d, HitResult.Great },
+            new object[] { 5f, 49.7d, HitResult.Ok },
+            new object[] { 5f, 50d, HitResult.Ok },
             new object[] { 5f, 50.4d, HitResult.Ok },
             new object[] { 5f, 50.9d, HitResult.Ok },
             new object[] { 5f, 51d, HitResult.Ok },
             new object[] { 5f, 99d, HitResult.Ok },
             new object[] { 5f, 99.2d, HitResult.Ok },
-            new object[] { 5f, 99.7d, HitResult.Ok },
-            new object[] { 5f, 100d, HitResult.Ok },
+            new object[] { 5f, 99.7d, HitResult.Meh },
+            new object[] { 5f, 100d, HitResult.Meh },
             new object[] { 5f, 100.4d, HitResult.Meh },
             new object[] { 5f, 100.9d, HitResult.Meh },
             new object[] { 5f, 101d, HitResult.Meh },
             new object[] { 5f, 149d, HitResult.Meh },
             new object[] { 5f, 149.2d, HitResult.Meh },
-            new object[] { 5f, 149.7d, HitResult.Meh },
-            new object[] { 5f, 150d, HitResult.Meh },
+            new object[] { 5f, 149.7d, HitResult.Miss },
+            new object[] { 5f, 150d, HitResult.Miss },
             new object[] { 5f, 150.4d, HitResult.Miss },
             new object[] { 5f, 150.9d, HitResult.Miss },
             new object[] { 5f, 151d, HitResult.Miss },
 
             // OD = 5.7 test cases.
-            // GREAT hit window is [ -45.8ms,  45.8ms]
-            // OK    hit window is [ -94.4ms,  94.4ms]
-            // MEH   hit window is [-143.0ms, 143.0ms]
-            // MISS  hit window is [-400.0ms, 400.0ms]
-            new object[] { 5.7f, 45d, HitResult.Great },
-            new object[] { 5.7f, 45.2d, HitResult.Great },
-            new object[] { 5.7f, 45.8d, HitResult.Great },
-            new object[] { 5.7f, 45.9d, HitResult.Ok },
-            new object[] { 5.7f, 46d, HitResult.Ok },
-            new object[] { 5.7f, 46.4d, HitResult.Ok },
-            new object[] { 5.7f, 94d, HitResult.Ok },
-            new object[] { 5.7f, 94.2d, HitResult.Ok },
-            new object[] { 5.7f, 94.4d, HitResult.Ok },
-            new object[] { 5.7f, 94.48d, HitResult.Ok },
-            new object[] { 5.7f, 94.9d, HitResult.Meh },
-            new object[] { 5.7f, 95d, HitResult.Meh },
-            new object[] { 5.7f, 95.4d, HitResult.Meh },
+            // GREAT hit window is [ -44.5ms,  44.5ms]
+            // OK    hit window is [ -93.5ms,  93.5ms]
+            // MEH   hit window is [-142.5ms, 142.5ms]
+            new object[] { 5.7f, 44d, HitResult.Great },
+            new object[] { 5.7f, 44.2d, HitResult.Great },
+            new object[] { 5.7f, 44.8d, HitResult.Ok },
+            new object[] { 5.7f, 45d, HitResult.Ok },
+            new object[] { 5.7f, 45.4d, HitResult.Ok },
+            new object[] { 5.7f, 93d, HitResult.Ok },
+            new object[] { 5.7f, 93.4d, HitResult.Ok },
+            new object[] { 5.7f, 93.9d, HitResult.Meh },
+            new object[] { 5.7f, 94d, HitResult.Meh },
+            new object[] { 5.7f, 94.4d, HitResult.Meh },
             new object[] { 5.7f, 142d, HitResult.Meh },
-            new object[] { 5.7f, 142.7d, HitResult.Meh },
-            new object[] { 5.7f, 143d, HitResult.Meh },
+            new object[] { 5.7f, 142.2d, HitResult.Meh },
+            new object[] { 5.7f, 142.7d, HitResult.Miss },
+            new object[] { 5.7f, 143d, HitResult.Miss },
             new object[] { 5.7f, 143.4d, HitResult.Miss },
             new object[] { 5.7f, 143.9d, HitResult.Miss },
             new object[] { 5.7f, 144d, HitResult.Miss },

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderLateHitJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderLateHitJudgement.cs
@@ -52,8 +52,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 100, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 100, slider_end_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 99, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 99, slider_end_position, OsuAction.LeftButton),
             });
 
             assertHeadJudgement(HitResult.Ok);
@@ -70,8 +70,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 100, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 100, slider_end_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 99, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 99, slider_end_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.SliderVelocityMultiplier = 2;
@@ -91,8 +91,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_end_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_end_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.TickDistanceMultiplier = 0.2f;
@@ -116,8 +116,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_end_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_end_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.SliderVelocityMultiplier = 2;
@@ -165,8 +165,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_start_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.Path = new SliderPath(PathType.LINEAR, new[]
@@ -195,8 +195,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_start_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.Path = new SliderPath(PathType.LINEAR, new[]
@@ -224,8 +224,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_start_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.Path = new SliderPath(PathType.PERFECT_CURVE, new[]
@@ -259,8 +259,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_start_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.Path = new SliderPath(PathType.PERFECT_CURVE, new[]
@@ -289,8 +289,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position, OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_start_position, OsuAction.LeftButton),
             }, s =>
             {
                 s.Path = new SliderPath(PathType.PERFECT_CURVE, new[]
@@ -320,8 +320,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(new List<ReplayFrame>
             {
-                new OsuReplayFrame(time_slider_start + 150, slider_start_position - new Vector2(20), OsuAction.LeftButton),
-                new OsuReplayFrame(time_slider_end + 150, slider_start_position - new Vector2(20), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start + 149, slider_start_position - new Vector2(20), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end + 149, slider_start_position - new Vector2(20), OsuAction.LeftButton),
             }, s =>
             {
                 s.Path = new SliderPath(PathType.PERFECT_CURVE, new[]

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHitWindows.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHitWindows.cs
@@ -38,9 +38,9 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
         public override void SetDifficulty(double difficulty)
         {
-            great = IBeatmapDifficultyInfo.DifficultyRange(difficulty, GREAT_WINDOW_RANGE);
-            ok = IBeatmapDifficultyInfo.DifficultyRange(difficulty, OK_WINDOW_RANGE);
-            meh = IBeatmapDifficultyInfo.DifficultyRange(difficulty, MEH_WINDOW_RANGE);
+            great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, GREAT_WINDOW_RANGE)) - 0.5;
+            ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, OK_WINDOW_RANGE)) - 0.5;
+            meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, MEH_WINDOW_RANGE)) - 0.5;
         }
 
         public override double WindowFor(HitResult result)

--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
-                new TaikoReplayFrame(hit_time - hitWindows.WindowFor(HitResult.Great), TaikoAction.LeftCentre),
+                new TaikoReplayFrame(hit_time - (hitWindows.WindowFor(HitResult.Great) + 0.1), TaikoAction.LeftCentre),
             }, beatmap);
 
             AssertJudgementCount(1);

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneLegacyReplayPlayback.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneLegacyReplayPlayback.cs
@@ -15,7 +15,6 @@ using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {
-    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneLegacyReplayPlayback : LegacyReplayPlaybackTestScene
     {
         protected override string? ExportLocation => null;
@@ -177,7 +176,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 ScoreInfo = new ScoreInfo
                 {
                     Ruleset = CreateRuleset().RulesetInfo,
-                    Mods = [new TaikoModHardRock()]
+                    Mods = [new TaikoModEasy()]
                 }
             };
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
@@ -12,7 +12,6 @@ using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {
-    [Ignore("These tests are expected to fail until an acceptable solution for various replay playback issues concerning rounding of replay frame times & hit windows is found.")]
     public partial class TestSceneReplayStability : ReplayStabilityTestScene
     {
         private static readonly object[][] test_cases =
@@ -22,40 +21,38 @@ namespace osu.Game.Rulesets.Taiko.Tests
             // while round brackets `()` represent *open* or *exclusive* bounds.
 
             // OD = 5 test cases.
-            // GREAT hit window is [-35ms, 35ms]
-            // OK    hit window is [-80ms, 80ms]
-            // MISS  hit window is [-95ms, 95ms]
+            // GREAT hit window is [-34.5ms, 34.5ms]
+            // OK    hit window is [-79.5ms, 79.5ms]
+            // MISS  hit window is [-94.5ms, 94.5ms]
             new object[] { 5f, -34d, HitResult.Great },
             new object[] { 5f, -34.2d, HitResult.Great },
-            new object[] { 5f, -34.7d, HitResult.Great },
-            new object[] { 5f, -35d, HitResult.Great },
+            new object[] { 5f, -34.7d, HitResult.Ok },
+            new object[] { 5f, -35d, HitResult.Ok },
             new object[] { 5f, -35.2d, HitResult.Ok },
             new object[] { 5f, -35.8d, HitResult.Ok },
             new object[] { 5f, -36d, HitResult.Ok },
             new object[] { 5f, -79d, HitResult.Ok },
             new object[] { 5f, -79.3d, HitResult.Ok },
-            new object[] { 5f, -79.7d, HitResult.Ok },
-            new object[] { 5f, -80d, HitResult.Ok },
+            new object[] { 5f, -79.7d, HitResult.Miss },
+            new object[] { 5f, -80d, HitResult.Miss },
             new object[] { 5f, -80.2d, HitResult.Miss },
             new object[] { 5f, -80.8d, HitResult.Miss },
             new object[] { 5f, -81d, HitResult.Miss },
 
             // OD = 7.8 test cases.
-            // GREAT hit window is [-26.6ms, 26.6ms]
-            // OK    hit window is [-63.2ms, 63.2ms]
-            // MISS  hit window is [-81.0ms, 81.0ms]
-            new object[] { 7.8f, -26d, HitResult.Great },
-            new object[] { 7.8f, -26.4d, HitResult.Great },
-            new object[] { 7.8f, -26.59d, HitResult.Great },
-            new object[] { 7.8f, -26.8d, HitResult.Ok },
-            new object[] { 7.8f, -27d, HitResult.Ok },
-            new object[] { 7.8f, -27.1d, HitResult.Ok },
-            new object[] { 7.8f, -63d, HitResult.Ok },
-            new object[] { 7.8f, -63.18d, HitResult.Ok },
-            new object[] { 7.8f, -63.4d, HitResult.Ok },
-            new object[] { 7.8f, -63.7d, HitResult.Miss },
-            new object[] { 7.8f, -64d, HitResult.Miss },
-            new object[] { 7.8f, -64.2d, HitResult.Miss },
+            // GREAT hit window is [-25.5ms, 25.5ms]
+            // OK    hit window is [-62.5ms, 62.5ms]
+            // MISS  hit window is [-80.5ms, 80.5ms]
+            new object[] { 7.8f, -25d, HitResult.Great },
+            new object[] { 7.8f, -25.4d, HitResult.Great },
+            new object[] { 7.8f, -25.8d, HitResult.Ok },
+            new object[] { 7.8f, -26d, HitResult.Ok },
+            new object[] { 7.8f, -26.1d, HitResult.Ok },
+            new object[] { 7.8f, -62d, HitResult.Ok },
+            new object[] { 7.8f, -62.4d, HitResult.Ok },
+            new object[] { 7.8f, -62.7d, HitResult.Miss },
+            new object[] { 7.8f, -63d, HitResult.Miss },
+            new object[] { 7.8f, -63.2d, HitResult.Miss },
         };
 
         [TestCaseSource(nameof(test_cases))]

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoHitWindows.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoHitWindows.cs
@@ -32,9 +32,9 @@ namespace osu.Game.Rulesets.Taiko.Scoring
 
         public override void SetDifficulty(double difficulty)
         {
-            great = IBeatmapDifficultyInfo.DifficultyRange(difficulty, GREAT_WINDOW_RANGE);
-            ok = IBeatmapDifficultyInfo.DifficultyRange(difficulty, OK_WINDOW_RANGE);
-            miss = IBeatmapDifficultyInfo.DifficultyRange(difficulty, MISS_WINDOW_RANGE);
+            great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, GREAT_WINDOW_RANGE)) - 0.5;
+            ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, OK_WINDOW_RANGE)) - 0.5;
+            miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, MISS_WINDOW_RANGE)) - 0.5;
         }
 
         public override double WindowFor(HitResult result)


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/33078

This is a "two-birds-with-one-stone" change, which addresses both https://github.com/ppy/osu/issues/28744 and https://github.com/ppy/osu/issues/11311 simultaneously.

- The replay stability issue caused by time instants being rounded to nearest integer is fixed by this, because flooring and
  subtracting/adding 0.5 from the hit window threshold makes it impossible for a judgement to switch to anything else after replay rounding is applied - all hit windows are always a full integer plus 0.5 milliseconds, which immunizes them to rounding-to-full-ms issues.

- The direction of applying the 0.5 adjustment additionally fixes the disparity with stable - in osu! and taiko 0.5 is subtracted as hit window ranges in those rulesets are exclusive on stable, while in mania 0.5 is added, as the hit window ranges there are *inclusive* on stable.

As should be obvious, this materially changes hit windows. To what degree this is a *significant* change is up for discussion; I would say it is not since hitting half a millisecond changes would require 2000fps input recording, and we're still timestamping inputs using the update thread's clock, that gives a 1ms resolution at best.

In the worst case, in osu! and taiko, this can change a hit window range by 1.5ms (e.g. 300.9ms -> floored to 300ms -> 299.5ms after subtraction of the half). It's more than the best-case resolution of input timestamps, but not by much. Considering how cleanly this resolves the issues in question, I see it as an acceptable tradeoff.

Notably some tests are adjusted here. The replay stability tests needed adjustments because hit windows have been materially changed. What matters in the replay stability tests is covering the time instants near the hit window edges and ensuring that re-encode doesn't mutate the resulting judgements, not what the particular numbers used are.

Stable cross-reference, if you desire it:

- osu! ([[1]](https://github.com/peppy/osu-stable-reference/blob/35eb8402fae1ba9c2ceac93f16fcb68d20ba776f/osu!/GameplayElements/HitObjectManager.cs#L475-L477), [[2]](https://github.com/peppy/osu-stable-reference/blob/35eb8402fae1ba9c2ceac93f16fcb68d20ba776f/osu!/GameplayElements/HitObjects/HitCircle.cs#L21-L28))
- taiko ([[1]](https://github.com/peppy/osu-stable-reference/blob/35eb8402fae1ba9c2ceac93f16fcb68d20ba776f/osu!/GameplayElements/HitObjectManagerTaiko.cs#L96-L101), [[2]](https://github.com/peppy/osu-stable-reference/blob/35eb8402fae1ba9c2ceac93f16fcb68d20ba776f/osu!/GameplayElements/HitObjects/HitCircle.cs#L21-L28))
- [mania](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjects/Mania/HitCircleMania.cs#L98-L107)