### PR TITLE
Add mode for grouping beatmaps by their source

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
@@ -333,22 +333,32 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         #endregion
 
+        #region Source grouping
+
+        [Test]
+        public async Task TestGroupingBySource()
+        {
+            int total = 0;
+
+            var beatmapSets = new List<BeatmapSetInfo>();
+            addBeatmapSet(s => s.Beatmaps[0].Metadata.Source = "Cool Game", beatmapSets, out var beatmapCoolGame);
+            addBeatmapSet(s => s.Beatmaps[0].Metadata.Source = "Cool game", beatmapSets, out var beatmapCoolGameB);
+            addBeatmapSet(s => s.Beatmaps[0].Metadata.Source = "Nice Movie", beatmapSets, out var beatmapNiceMovie);
+            addBeatmapSet(s => s.Beatmaps[0].Metadata.Source = string.Empty, beatmapSets, out var beatmapUnsourced);
+
+            var results = await runGrouping(GroupMode.Source, beatmapSets);
+            assertGroup(results, 0, "Cool Game", new[] { beatmapCoolGame, beatmapCoolGameB }, ref total);
+            assertGroup(results, 1, "Nice Movie", new[] { beatmapNiceMovie }, ref total);
+            assertGroup(results, 2, "Unsourced", new[] { beatmapUnsourced }, ref total);
+            assertTotal(results, total);
+        }
+
+        #endregion
+
         private static async Task<List<CarouselItem>> runGrouping(GroupMode group, List<BeatmapSetInfo> beatmapSets)
         {
             var groupingFilter = new BeatmapCarouselFilterGrouping(() => new FilterCriteria { Group = group });
-            var carouselItems = await groupingFilter.Run(beatmapSets.SelectMany(s => s.Beatmaps.Select(b => new CarouselItem(b))).ToList(), CancellationToken.None);
-
-            // sanity check to ensure no detection of two group items with equal order value.
-            var groups = carouselItems.Select(i => i.Model).OfType<GroupDefinition>();
-
-            foreach (var header in groups)
-            {
-                var sameOrder = groups.FirstOrDefault(g => g != header && g.Order == header.Order);
-                if (sameOrder != null)
-                    Assert.Fail($"Detected two groups with equal order number: \"{header.Title}\" vs. \"{sameOrder.Title}\"");
-            }
-
-            return carouselItems;
+            return await groupingFilter.Run(beatmapSets.SelectMany(s => s.Beatmaps.Select(b => new CarouselItem(b))).ToList(), CancellationToken.None);
         }
 
         private static void assertGroup(List<CarouselItem> items, int index, string expectedTitle, IEnumerable<BeatmapSetInfo> expectedBeatmapSets, ref int totalItems)

--- a/osu.Game/Screens/Select/Filter/GroupMode.cs
+++ b/osu.Game/Screens/Select/Filter/GroupMode.cs
@@ -34,6 +34,9 @@ namespace osu.Game.Screens.Select.Filter
         // [Description("Favourites")]
         // Favourites,
 
+        [Description("Last Played")]
+        LastPlayed,
+
         [Description("Length")]
         Length,
 
@@ -46,8 +49,8 @@ namespace osu.Game.Screens.Select.Filter
         [Description("Ranked Status")]
         RankedStatus,
 
-        [Description("Last Played")]
-        LastPlayed,
+        [Description("Source")]
+        Source,
 
         [Description("Title")]
         Title,

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -823,9 +823,31 @@ namespace osu.Game.Screens.SelectV2
     /// <summary>
     /// Defines a grouping header for a set of carousel items.
     /// </summary>
-    /// <param name="Order">The order of this group in the carousel, sorted using ascending order.</param>
-    /// <param name="Title">The title of this group.</param>
-    public record GroupDefinition(int Order, string Title);
+    public record GroupDefinition
+    {
+        /// <summary>
+        /// The order of this group in the carousel, sorted using ascending order.
+        /// </summary>
+        public int Order { get; }
+
+        /// <summary>
+        /// The title of this group.
+        /// </summary>
+        public string Title { get; }
+
+        private readonly string uncasedTitle;
+
+        public GroupDefinition(int order, string title)
+        {
+            Order = order;
+            Title = title;
+            uncasedTitle = title.ToLowerInvariant();
+        }
+
+        public virtual bool Equals(GroupDefinition? other) => uncasedTitle == other?.uncasedTitle;
+
+        public override int GetHashCode() => HashCode.Combine(uncasedTitle);
+    }
 
     /// <summary>
     /// Defines a grouping header for a set of carousel items grouped by star difficulty.

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -202,6 +202,9 @@ namespace osu.Game.Screens.SelectV2
                         return defineGroupByLength(length);
                     }, items);
 
+                case GroupMode.Source:
+                    return getGroupsBy(b => defineGroupBySource(b.BeatmapSet!.Metadata.Source), items);
+
                 // TODO: need implementation
                 //
                 // case GroupMode.Collections:
@@ -225,6 +228,7 @@ namespace osu.Game.Screens.SelectV2
         {
             return items.GroupBy(i => getGroup((BeatmapInfo)i.Model))
                         .OrderBy(s => s.Key.Order)
+                        .ThenBy(s => s.Key.Title)
                         .Select(g => new GroupMapping(g.Key, g.ToList()))
                         .ToList();
         }
@@ -352,6 +356,14 @@ namespace osu.Game.Screens.SelectV2
                 return new GroupDefinition(10, "10 minutes or less");
 
             return new GroupDefinition(11, "Over 10 minutes");
+        }
+
+        private GroupDefinition defineGroupBySource(string source)
+        {
+            if (string.IsNullOrEmpty(source))
+                return new GroupDefinition(1, "Unsourced");
+
+            return new GroupDefinition(0, source);
         }
 
         private static T? aggregateMax<T>(BeatmapInfo b, Func<BeatmapInfo, T> func)


### PR DESCRIPTION
![CleanShot 2025-06-26 at 09 57 58](https://github.com/user-attachments/assets/738ea75f-a026-45a1-9845-274e7a89e47b)

---

- Closes #6647 

This also includes a change to `GroupDefinition` which makes it case insensitive, to handle scenarios such as [beatmap 1](https://osu.ppy.sh/beatmapsets/140662#osu/351189) and [beatmap 2](https://osu.ppy.sh/beatmapsets/3847#osu/22739) sharing the same source but being different in casing. Not sure if that's a rare occurrence and we shouldn't handle it, but handling it is not hard so might as well.

Also bundled a change to reorder "Last Played" group mode to its correct place in the enum (since the enum seems to be sorted alphabetically).