### PR TITLE
Fix potential null reference in `RoomNameLine`

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
@@ -569,8 +569,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         public partial class RoomNameLine : FillFlowContainer
         {
-            private TruncatingSpriteText spriteText = null!;
-            private ExternalLinkButton linkButton = null!;
+            private readonly TruncatingSpriteText spriteText;
+            private readonly ExternalLinkButton linkButton;
 
             public LocalisableString Text
             {
@@ -590,8 +590,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 }
             }
 
-            [BackgroundDependencyLoader]
-            private void load()
+            public RoomNameLine()
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;


### PR DESCRIPTION
As suspected in https://github.com/ppy/osu/pull/33858#discussion_r2170288579, `RoomNameLine` is loaded asynchronously, there's a chance it's used by `RoomPanel` while it hasn't loaded yet.