### PR TITLE
Fix lag when checking for update

### DIFF
--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Updater
         /// Immediately checks for any available update.
         /// </summary>
         /// <returns><c>true</c> if any updates are available, <c>false</c> otherwise.</returns>
-        public async Task<bool> CheckForUpdateAsync(CancellationToken cancellationToken = default)
+        public async Task<bool> CheckForUpdateAsync(CancellationToken cancellationToken = default) => await Task.Run(async () =>
         {
             if (!CanCheckForUpdate)
                 return false;
@@ -100,7 +100,7 @@ namespace osu.Game.Updater
                 await lastCts.CancelAsync().ConfigureAwait(false);
 
             return await PerformUpdateCheck(cts.Token).ConfigureAwait(false);
-        }
+        }, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Performs an asynchronous check for application updates.


### PR DESCRIPTION
Noticed that clicking the button on the deployed build would cause a brief pause for ~500ms.

All the `await`s up until the `Thread.Sleep()` in the repro below are the initial execution path, i.e. there have been no "continuations" yet, and so are executed inline on the calling context - in this case the update thread either via `LoadComplete` on game startup or by clicking the button in settings.

Forcing `CheckForUpdateAsync()` to be queued onto the threadpool via `Task.Run()` fixes this.

I don't believe this to be a regression from recent changes because the original code was even less async-y, by returning the `PerformUpdateCheck()` task back to the `CheckForUpdateAsync()` caller.

Repro:

```diff
diff --git a/osu.Desktop/OsuGameDesktop.cs b/osu.Desktop/OsuGameDesktop.cs
index 7290761d56..41a38c43b4 100644
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -115,7 +115,7 @@ protected override UpdateManager CreateUpdateManager()
             if (IsFirstRun)
                 LocalConfig.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
 
-            if (IsPackageManaged)
+            // if (IsPackageManaged)
                 return new NoActionUpdateManager();
 
             return new VelopackUpdateManager();
diff --git a/osu.Game/Updater/NoActionUpdateManager.cs b/osu.Game/Updater/NoActionUpdateManager.cs
index 0710797b60..2acd1e44c5 100644
--- a/osu.Game/Updater/NoActionUpdateManager.cs
+++ b/osu.Game/Updater/NoActionUpdateManager.cs
@@ -31,6 +31,8 @@ private void load(OsuGameBase game)
 
         protected override async Task<bool> PerformUpdateCheck(CancellationToken cancellationToken)
         {
+            Thread.Sleep(2000);
+
             try
             {
                 ReleaseStream stream = externalReleaseStream ?? ReleaseStream.Value;
diff --git a/osu.Game/Updater/UpdateManager.cs b/osu.Game/Updater/UpdateManager.cs
index 335f6085a9..481c255261 100644
--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -28,9 +28,7 @@ public partial class UpdateManager : CompositeDrawable
         /// <summary>
         /// Whether this UpdateManager should be or is capable of checking for updates.
         /// </summary>
-        public bool CanCheckForUpdate => game.IsDeployedBuild &&
-                                         // only implementations will actually check for updates.
-                                         GetType() != typeof(UpdateManager);
+        public bool CanCheckForUpdate => true;
 
         public virtual ReleaseStream? FixedReleaseStream => null;
 

```