### PR TITLE
Fix flaky tests due to async disposal

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
@@ -13,7 +13,6 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Replays;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -22,21 +21,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
 {
     public partial class TestSceneOsuModRelax : OsuModTestScene
     {
-        private readonly HitCircle hitObject;
-        private readonly HitWindows hitWindows = new OsuHitWindows();
-
-        public TestSceneOsuModRelax()
-        {
-            hitWindows.SetDifficulty(9);
-
-            hitObject = new HitCircle
-            {
-                StartTime = 1000,
-                Position = new Vector2(100, 100),
-                HitWindows = hitWindows
-            };
-        }
-
         protected override TestPlayer CreateModPlayer(Ruleset ruleset) => new ModRelaxTestPlayer(CurrentTestData, AllowFail);
 
         [Test]
@@ -46,12 +30,21 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
-                HitObjects = new List<HitObject> { hitObject }
+                Difficulty = { OverallDifficulty = 9 },
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 1000,
+                        Position = new Vector2(100, 100),
+                        HitWindows = new OsuHitWindows()
+                    }
+                }
             },
             ReplayFrames = new List<ReplayFrame>
             {
                 new OsuReplayFrame(0, new Vector2()),
-                new OsuReplayFrame(hitObject.StartTime, hitObject.Position),
+                new OsuReplayFrame(100, new Vector2(100)),
             },
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 1
         });
@@ -63,13 +56,22 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {
-                HitObjects = new List<HitObject> { hitObject }
+                Difficulty = { OverallDifficulty = 9 },
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 1000,
+                        Position = new Vector2(100, 100),
+                        HitWindows = new OsuHitWindows()
+                    }
+                }
             },
             ReplayFrames = new List<ReplayFrame>
             {
-                new OsuReplayFrame(0, new Vector2(hitObject.X - 22, hitObject.Y - 22)), // must be an edge hit for the cursor to not stay on the object for too long
-                new OsuReplayFrame(hitObject.StartTime - OsuModRelax.RELAX_LENIENCY, new Vector2(hitObject.X - 22, hitObject.Y - 22)),
-                new OsuReplayFrame(hitObject.StartTime, new Vector2(0)),
+                new OsuReplayFrame(0, new Vector2(78, 78)), // must be an edge hit for the cursor to not stay on the object for too long
+                new OsuReplayFrame(1000 - OsuModRelax.RELAX_LENIENCY, new Vector2(78, 78)),
+                new OsuReplayFrame(1000, new Vector2(0)),
             },
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 1
         });

--- a/osu.Game/Tests/Visual/ReplayStabilityTestScene.cs
+++ b/osu.Game/Tests/Visual/ReplayStabilityTestScene.cs
@@ -57,6 +57,11 @@ namespace osu.Game.Tests.Visual
 
             AddStep(@"exit player", () => currentPlayer.Exit());
 
+            // The incoming beatmap is ruleset-typed in every usage, so the incoming hitobjects will be used as-is rather than being converted.
+            // Because we'll be re-using the beatmap (thus also the hitobjects), we need to make sure the previous player has been fully disposed.
+            AddUntilStep("player exited", () => !currentPlayer.IsCurrentScreen());
+            AddStep("dispose player", () => currentPlayer.Dispose());
+
             AddStep(@"encode and decode score", () =>
             {
                 var encoder = new LegacyScoreEncoder(originalScore, beatmap);


### PR DESCRIPTION
See: https://github.com/ppy/osu/actions/runs/15921735738/job/44909862713?pr=33904

I ran a large subset of tests and found one other case where this could come up (relax mod tests). These are cases where hitobjects/beatmaps are reused between tests, which thankfully isn't common to do.

Repro:

```diff
diff --git a/osu.Game/Screens/Play/Player.cs b/osu.Game/Screens/Play/Player.cs
index 6ee3ed13a0..778709ca95 100644
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1164,6 +1164,12 @@ public override void OnSuspending(ScreenTransitionEvent e)
             base.OnSuspending(e);
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            Thread.Sleep(1000);
+            base.Dispose(isDisposing);
+        }
+
         public override bool OnExiting(ScreenExitEvent e)
         {
             screenSuspension?.RemoveAndDisposeImmediately();

```