### PR TITLE
Fix beatmap skin sample lookups falling back to non-custom sample banks if the custom bank sample was not found

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuHitObjectSamples.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuHitObjectSamples.cs
@@ -14,26 +14,27 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         protected override IResourceStore<byte[]> RulesetResources => new DllResourceStore(Assembly.GetAssembly(typeof(TestSceneOsuHitObjectSamples)));
 
-        [TestCase("normal-hitnormal")]
-        [TestCase("hitnormal")]
-        public void TestDefaultCustomSampleFromBeatmap(string expectedSample)
+        [TestCase("normal-hitnormal2", "normal-hitnormal")]
+        [TestCase("hitnormal", "hitnormal")]
+        public void TestDefaultCustomSampleFromBeatmap(string beatmapSkinSampleName, string userSkinSampleName)
         {
-            SetupSkins(expectedSample, expectedSample);
+            SetupSkins(beatmapSkinSampleName, userSkinSampleName);
 
             CreateTestWithBeatmap("osu-hitobject-beatmap-custom-sample-bank.osu");
 
-            AssertBeatmapLookup(expectedSample);
+            AssertBeatmapLookup(beatmapSkinSampleName);
         }
 
-        [TestCase("normal-hitnormal")]
-        [TestCase("hitnormal")]
-        public void TestDefaultCustomSampleFromUserSkinFallback(string expectedSample)
+        [TestCase("", "normal-hitnormal")]
+        [TestCase("normal-hitnormal", "normal-hitnormal")]
+        [TestCase("", "hitnormal")]
+        public void TestDefaultCustomSampleFromUserSkinFallback(string beatmapSkinSampleName, string userSkinSampleName)
         {
-            SetupSkins(string.Empty, expectedSample);
+            SetupSkins(beatmapSkinSampleName, userSkinSampleName);
 
             CreateTestWithBeatmap("osu-hitobject-beatmap-custom-sample-bank.osu");
 
-            AssertUserLookup(expectedSample);
+            AssertUserLookup(userSkinSampleName);
         }
 
         [TestCase("normal-hitnormal2")]

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
@@ -14,26 +14,27 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         protected override IResourceStore<byte[]> RulesetResources => new DllResourceStore(Assembly.GetAssembly(typeof(TestSceneTaikoHitObjectSamples)));
 
-        [TestCase("taiko-normal-hitnormal")]
-        [TestCase("hitnormal")]
-        public void TestDefaultCustomSampleFromBeatmap(string expectedSample)
+        [TestCase("taiko-normal-hitnormal2", "taiko-normal-hitnormal")]
+        [TestCase("hitnormal", "hitnormal")]
+        public void TestDefaultCustomSampleFromBeatmap(string beatmapSkinSampleName, string userSkinSampleName)
         {
-            SetupSkins(expectedSample, expectedSample);
+            SetupSkins(beatmapSkinSampleName, userSkinSampleName);
 
             CreateTestWithBeatmap("taiko-hitobject-beatmap-custom-sample-bank.osu");
 
-            AssertBeatmapLookup(expectedSample);
+            AssertBeatmapLookup(beatmapSkinSampleName);
         }
 
-        [TestCase("taiko-normal-hitnormal")]
-        [TestCase("hitnormal")]
-        public void TestDefaultCustomSampleFromUserSkinFallback(string expectedSample)
+        [TestCase("", "taiko-normal-hitnormal")]
+        [TestCase("taiko-normal-hitnormal", "taiko-normal-hitnormal")]
+        [TestCase("", "hitnormal")]
+        public void TestDefaultCustomSampleFromUserSkinFallback(string beatmapSkinSampleName, string userSkinSampleName)
         {
-            SetupSkins(string.Empty, expectedSample);
+            SetupSkins(beatmapSkinSampleName, userSkinSampleName);
 
             CreateTestWithBeatmap("taiko-hitobject-beatmap-custom-sample-bank.osu");
 
-            AssertUserLookup(expectedSample);
+            AssertUserLookup(userSkinSampleName);
         }
 
         [TestCase("taiko-normal-hitnormal2")]

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
@@ -64,11 +64,9 @@ namespace osu.Game.Tests.Gameplay
         /// <summary>
         /// Tests that a hitobject which provides a custom sample set of 2 retrieves the following samples from the beatmap skin:
         /// normal-hitnormal2
-        /// normal-hitnormal
         /// hitnormal
         /// </summary>
         [TestCase("normal-hitnormal2")]
-        [TestCase("normal-hitnormal")]
         [TestCase("hitnormal")]
         public void TestDefaultCustomSampleFromBeatmap(string expectedSample)
         {
@@ -162,7 +160,6 @@ namespace osu.Game.Tests.Gameplay
         /// Tests that a control point that provides a custom sample of 2 causes <see cref="TestDefaultCustomSampleFromBeatmap"/>.
         /// </summary>
         [TestCase("normal-hitnormal2")]
-        [TestCase("normal-hitnormal")]
         [TestCase("hitnormal")]
         public void TestControlPointCustomSampleFromBeatmap(string sampleName)
         {

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -594,12 +594,17 @@ namespace osu.Game.Skinning
         {
             var lookupNames = hitSample.LookupNames.SelectMany(getFallbackSampleNames);
 
-            if (!UseCustomSampleBanks && !string.IsNullOrEmpty(hitSample.Suffix))
+            if (!string.IsNullOrEmpty(hitSample.Suffix))
             {
-                // for compatibility with stable, exclude the lookup names with the custom sample bank suffix, if they are not valid for use in this skin.
+                // for compatibility with stable:
+                // - if the skin can use custom sample banks, it MUST use the custom sample bank suffix. it is not allowed to fall back to a non-custom sound.
+                // - if the skin cannot use custom sample banks, it MUST NOT use the custom sample bank suffix.
                 // using .EndsWith() is intentional as it ensures parity in all edge cases
-                // (see LegacyTaikoSampleInfo for an example of one - prioritising the taiko prefix should still apply, but the sample bank should not).
-                lookupNames = lookupNames.Where(name => !name.EndsWith(hitSample.Suffix, StringComparison.Ordinal));
+                // (see LegacyTaikoSampleInfo for an example of one - prioritising the taiko prefix should still apply).
+                if (UseCustomSampleBanks)
+                    lookupNames = lookupNames.Where(name => name.EndsWith(hitSample.Suffix, StringComparison.Ordinal));
+                else
+                    lookupNames = lookupNames.Where(name => !name.EndsWith(hitSample.Suffix, StringComparison.Ordinal));
             }
 
             foreach (string l in lookupNames)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33900. I think. Stable's sample lookup logic is horrible.

The user in the issue claimed they were hearing `drum-hitfinish2`, but they were really hearing `drum-hitfinish`, because they're the same `.wav` file in the beatmap. Now the reason *why* they were hearing `drum-hitfinish` is that the sample control point was specifying something like:

	23946,-200,4,2,4,40,0,0

To decipher, this is:
- default sample bank of soft
- custom sample bank of 4

Taking one of the objects affected, namely 00:23:946 (2) - that's a slider with finish addition and drum addition bank on the slider head. The slider head is thus attempting to play `soft-hitnormal4` and `drum-hitfinish4`.

Neither `soft-hitnormal4` or `soft-hitnormal` exist in the beatmap, so that plays fine via falling back to user skin's `soft-hitnormal`, but `drum-hitfinish4` ends up falling back to `drum-hitfinish` which *does* exist in the beatmap skin and thus plays wrongly from the beatmap skin rather than the user skin.

I have no idea how to ensure this is correct across every beatmap and skin out there so my approach is to just spray and pray (and rely on issue reports I guess). I *think* this matches the stable logic which is nestled within [here](https://github.com/peppy/osu-stable-reference/blob/a5e5fe6ef240505d13526cf32783cad261e9bd8b/osu!/Audio/AudioEngine.cs#L1136-L1230) but honestly even if you put a gun to my head I couldn't be sure if it matches completely in every possible circumstance or not.