### PR TITLE
Explicitly explain to users that failed plays do not give pp on results screen

### DIFF
--- a/osu.Game/Localisation/ResultsScreenStrings.cs
+++ b/osu.Game/Localisation/ResultsScreenStrings.cs
@@ -19,6 +19,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString NoPPForUnrankedMods => new TranslatableString(getKey(@"no_pp_for_unranked_mods"), @"Performance points are not granted for this score because of unranked mods.");
 
+        /// <summary>
+        /// "Performance points are not granted for failed scores."
+        /// </summary>
+        public static LocalisableString NoPPForFailedScores => new TranslatableString(getKey(@"no_pp_for_failed_scores"), @"Performance points are not granted for failed scores.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -79,6 +79,11 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
                     Alpha = 0.5f;
                     TooltipText = ResultsScreenStrings.NoPPForUnrankedMods;
                 }
+                else if (scoreInfo.Rank == ScoreRank.F)
+                {
+                    Alpha = 0.5f;
+                    TooltipText = ResultsScreenStrings.NoPPForFailedScores;
+                }
                 else
                 {
                     Alpha = 1f;


### PR DESCRIPTION
![Screenshot 2025-06-27 at 13 27 12](https://github.com/user-attachments/assets/59813cb4-3e18-4918-8db6-7e266608538d)

---

Addresses https://osu.ppy.sh/community/forums/topics/2096912.

Won't work for stable scores for reason already mentioned in https://github.com/ppy/osu/pull/33670:

> Scores coming from stable will never present F rank, because rank is not stored to the replay, and the lowest rank that can be produced by `StandardisedScoreMigrationTools` is D.

but it is what it is.