### PR TITLE
Fix Flashlight having increased radius when Barrel Roll is active

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Beatmaps;
@@ -36,22 +35,21 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         [Test]
         public void TestPlayfieldBasedSize()
         {
-            ModFlashlight mod = new OsuModFlashlight();
+            OsuModFlashlight flashlight;
             CreateModTest(new ModTestData
             {
-                Mod = mod,
+                Mods = [flashlight = new OsuModFlashlight(), new OsuModBarrelRoll()],
                 PassCondition = () =>
                 {
                     var flashlightOverlay = Player.DrawableRuleset.Overlays
                                                   .ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>()
                                                   .First();
 
-                    return Precision.AlmostEquals(mod.DefaultFlashlightSize * .5f, flashlightOverlay.GetSize());
+                    // the combo check is here because the flashlight radius decreases for the first time at 100 combo
+                    // and hardcoding it here eliminates the need to meddle in flashlight internals further by e.g. exposing `GetComboScaleFor()`
+                    return flashlightOverlay.GetSize() < flashlight.DefaultFlashlightSize && Player.GameplayState.ScoreProcessor.Combo.Value < 100;
                 }
             });
-
-            AddStep("adjust playfield scale", () =>
-                Player.DrawableRuleset.Playfield.Scale = new Vector2(.5f));
         }
 
         [Test]

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Mods
             flashlight.Colour = Color4.Black;
 
             flashlight.Combo.BindTo(Combo);
-            flashlight.GetPlayfieldScale = () => drawableRuleset.Playfield.Scale;
+            flashlight.GetPlayfieldScale = () => drawableRuleset.PlayfieldAdjustmentContainer.Scale;
 
             drawableRuleset.Overlays.Add(new Container
             {


### PR DESCRIPTION
## [Make Flashlight test case exercising playfield scaling not useless](https://github.com/ppy/osu/commit/19abd4fbcab047153f6cd64eeb18c7b6256a0a69)

It was doing a "if I touch the game in this very specific manner everything works" which will light up in very nice green colours but is actually useless for preventing regressions.

## [Fix Flashlight having increased radius when Barrel Roll is active](https://github.com/ppy/osu/commit/96569e78295123f6c27d60aa94edecfe63536c89)

Closes https://github.com/ppy/osu/issues/33893.

Regressed in https://github.com/ppy/osu/pull/29841.

This sucks but I don't have better ideas.

| | FL | FL, BR |
| :-: | :-: | :-: |
| master | ![osu_2025-06-27_13-32-47](https://github.com/user-attachments/assets/0129f6cc-5411-4117-b99a-3410f36c8e42) | ![osu_2025-06-27_13-33-04](https://github.com/user-attachments/assets/5b386d75-752f-4965-9a5b-a247fe21c224) |
| this PR | ![osu_2025-06-27_13-36-04](https://github.com/user-attachments/assets/e452b135-ae43-4ba2-82b3-00528b3a4d39) | ![osu_2025-06-27_13-36-22](https://github.com/user-attachments/assets/7000f39e-5af0-4233-a252-b57c9a22be4f) |

