### PR TITLE
Implement score pinning from user profile rank listings for #32888:

### DIFF
--- a/osu.Game/Online/API/Requests/PinScoreRequest.cs
+++ b/osu.Game/Online/API/Requests/PinScoreRequest.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Net.Http;
+using osu.Framework.IO.Network;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class PinScoreRequest : APIRequest
+    {
+        private readonly long scoreId;
+
+        public PinScoreRequest(long scoreId)
+        {
+            this.scoreId = scoreId;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+            req.Method = HttpMethod.Put;
+            return req;
+        }
+
+        protected override string Target => $@"score-pins/{scoreId}";
+    }
+
+    public class UnpinScoreRequest : APIRequest
+    {
+        private readonly long scoreId;
+
+        public UnpinScoreRequest(long scoreId)
+        {
+            this.scoreId = scoreId;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+            req.Method = HttpMethod.Delete;
+            return req;
+        }
+
+        protected override string Target => $@"score-pins/{scoreId}";
+    }
+
+    public class ReorderPinnedScoresRequest : APIRequest
+    {
+        private readonly long scoreId;
+        private readonly int newPosition;
+
+        public ReorderPinnedScoresRequest(long scoreId, int newPosition)
+        {
+            this.scoreId = scoreId;
+            this.newPosition = newPosition;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+            req.Method = HttpMethod.Post;
+            req.AddParameter("position", newPosition.ToString());
+            return req;
+        }
+
+        protected override string Target => $@"score-pins/{scoreId}/reorder";
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -118,6 +118,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("has_replay")]
         public bool HasReplay { get; set; }
 
+        [JsonProperty("is_pinned")]
+        public bool IsPinned { get; set; }
+
         [JsonProperty("ranked")]
         public bool Ranked { get; set; }
 
@@ -129,6 +132,8 @@ namespace osu.Game.Online.API.Requests.Responses
         public bool ShouldSerializePP() => false;
         public bool ShouldSerializeOnlineID() => false;
         public bool ShouldSerializeHasReplay() => false;
+        public bool ShouldSerializeIsPinned() => false;
+
 
         // These fields only need to be serialised if they hold values.
         // Generally this is required because this model may be used by server-side components, but

--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -4,14 +4,26 @@
 using osu.Framework.Graphics.Containers;
 using osu.Game.Online.API.Requests;
 using System;
+using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Input;
 using osu.Game.Online.API.Requests.Responses;
 using System.Collections.Generic;
 using osu.Game.Online.API;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
+using osu.Framework.Graphics.UserInterface;
 using APIUser = osu.Game.Online.API.Requests.Responses.APIUser;
+using osu.Game.Configuration;
+using osu.Game.Graphics.Cursor;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osuTK;
+using osuTK.Input;
+using osu.Framework.Utils;
+using osu.Framework.Graphics.Primitives;
 
 namespace osu.Game.Overlays.Profile.Sections.Ranks
 {
@@ -19,10 +31,15 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
     {
         private readonly ScoreType type;
 
-        public PaginatedScoreContainer(ScoreType type, Bindable<UserProfileData?> user, LocalisableString headerText)
+        public Action? OnScorePinChanged { get; set; }
+
+        private readonly HashSet<long> pinnedScoreIds;
+
+        public PaginatedScoreContainer(ScoreType type, Bindable<UserProfileData?> user, LocalisableString headerText, HashSet<long>? pinnedScoreIds = null)
             : base(user, headerText)
         {
             this.type = type;
+            this.pinnedScoreIds = pinnedScoreIds ?? new HashSet<long>();
         }
 
         [BackgroundDependencyLoader]
@@ -57,24 +74,193 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
             if (CurrentPage == null || CurrentPage?.Offset == 0)
                 drawableItemIndex = 0;
 
+            if (type == ScoreType.Pinned)
+            {
+                foreach (var item in items)
+                {
+                    item.IsPinned = true;
+                    pinnedScoreIds.Add(item.OnlineID);
+                }
+            }
+            else
+            {
+                foreach (var item in items)
+                {
+                    if (pinnedScoreIds.Contains(item.OnlineID))
+                    {
+                        item.IsPinned = true;
+                    }
+                }
+            }
+
             base.OnItemsReceived(items);
         }
 
-        protected override APIRequest<List<SoloScoreInfo>> CreateRequest(UserProfileData user, PaginationParameters pagination) =>
-            new GetUserScoresRequest(user.User.Id, type, pagination, user.Ruleset);
+        protected override APIRequest<List<SoloScoreInfo>> CreateRequest(UserProfileData user, PaginationParameters pagination)
+        {
+            return new GetUserScoresRequest(user.User.Id, type, pagination, user.Ruleset);
+        }
 
         private int drawableItemIndex;
 
-        protected override Drawable CreateDrawableItem(SoloScoreInfo model)
+        [Resolved]
+        private OsuConfigManager configManager { get; set; } = null!;
+
+        protected override Drawable? CreateDrawableItem(SoloScoreInfo model)
         {
             switch (type)
             {
                 default:
-                    return new DrawableProfileScore(model);
+                    return new DrawableProfileScoreRow(new DrawableProfileScore(model), model, OnScorePinChanged);
 
                 case ScoreType.Best:
-                    return new DrawableProfileWeightedScore(model, Math.Pow(0.95, drawableItemIndex++));
+                    double weight = Math.Pow(0.95, drawableItemIndex++);
+                    return new DrawableProfileScoreRow(new DrawableProfileWeightedScore(model, weight), model, OnScorePinChanged);
             }
         }
+    }
+
+    public partial class DrawableProfileScoreRow : CompositeDrawable
+    {
+        private readonly Container menuContainer;
+        private OsuMenu? currentMenu;
+        private ScoreActionsContainer? currentActionsContainer;
+
+        public DrawableProfileScoreRow(Drawable scoreDrawable, SoloScoreInfo score, Action? onScorePinChanged = null)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            var actionsContainer = new ScoreActionsContainer(score)
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            };
+
+            actionsContainer.OnMenuRequested = menu =>
+            {
+                showMenu(menu, actionsContainer);
+            };
+
+            actionsContainer.OnPinStatusChanged = () =>
+            {
+                hideMenu();
+                onScorePinChanged?.Invoke();
+            };
+
+            var mainContainer = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
+                {
+                    scoreDrawable,
+                    new Container
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreLeft,
+                        AutoSizeAxes = Axes.Both,
+                        X = 5,
+                        Padding = new MarginPadding { Left = 2 },
+                        Child = actionsContainer
+                    }
+                }
+            };
+
+            InternalChildren = new Drawable[]
+            {
+                mainContainer,
+                menuContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Depth = -1,
+                    RelativePositionAxes = Axes.Y,
+                    Y = 1f,
+                    Padding = new MarginPadding { Right = -20 }
+                }
+            };
+        }
+
+        private void showMenu(OsuMenu menu, ScoreActionsContainer button)
+        {
+            hideMenu();
+
+            currentMenu = menu;
+            currentActionsContainer = button;
+
+            menuContainer.Add(menu);
+
+            menu.Position = new Vector2(-100, 0);
+            menu.Anchor = Anchor.TopRight;
+            menu.Origin = Anchor.TopRight;
+            menu.Width = 100f;
+
+            menu.Open();
+
+            menu.StateChanged += state =>
+            {
+                if (state == MenuState.Closed)
+                {
+                    Scheduler.AddOnce(hideMenu);
+                }
+            };
+        }
+
+        private void hideMenu()
+        {
+            currentMenu?.Expire();
+            currentMenu = null;
+            currentActionsContainer = null;
+            menuContainer.Clear();
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (currentMenu?.State == MenuState.Open)
+            {
+                var menuBounds = currentMenu.ScreenSpaceDrawQuad;
+                var buttonBounds = currentActionsContainer?.ScreenSpaceDrawQuad ?? new Quad();
+
+                bool clickInMenu = menuBounds.Contains(e.ScreenSpaceMousePosition);
+                bool clickInButton = buttonBounds.Contains(e.ScreenSpaceMousePosition);
+
+                if (!clickInMenu && !clickInButton)
+                {
+                    hideMenu();
+                    return true;
+                }
+            }
+
+            return base.OnMouseDown(e);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (currentMenu?.State == MenuState.Open)
+            {
+                var inputManager = GetContainingInputManager();
+                if (inputManager != null && inputManager.CurrentState.Mouse.IsPressed(MouseButton.Left))
+                {
+                    var menuBounds = currentMenu.ScreenSpaceDrawQuad;
+                    var buttonBounds = currentActionsContainer?.ScreenSpaceDrawQuad ?? new Quad();
+                    var mousePos = inputManager.CurrentState.Mouse.Position;
+
+                    bool mouseInMenu = menuBounds.Contains(mousePos);
+                    bool mouseInButton = buttonBounds.Contains(mousePos);
+
+                    if (!mouseInMenu && !mouseInButton && !wasMousePressed)
+                    {
+                        hideMenu();
+                    }
+                }
+
+                wasMousePressed = inputManager?.CurrentState.Mouse.IsPressed(MouseButton.Left) ?? false;
+            }
+        }
+
+        private bool wasMousePressed;
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Ranks/ScoreActionsContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/ScoreActionsContainer.cs
@@ -1,0 +1,170 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.API.Requests;
+using osuTK;
+using osuTK.Graphics;
+using System;
+using System.Collections.Generic;
+using osu.Game.Online.API;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Overlays.Profile.Sections.Ranks
+{
+    public partial class ScoreActionsContainer : OsuClickableContainer
+    {
+        private readonly SoloScoreInfo score;
+        private readonly ScoreType scoreType;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved(CanBeNull = true)]
+        private INotificationOverlay? notifications { get; set; }
+
+        private SpriteIcon icon = null!;
+
+        public Action<OsuMenu>? OnMenuRequested;
+        public Action? OnPinStatusChanged;
+
+        public ScoreActionsContainer(SoloScoreInfo score, ScoreType scoreType = ScoreType.Best)
+        {
+            this.score = score;
+            this.scoreType = scoreType;
+
+            Size = new Vector2(26);  // Increased from 24 to give more room
+
+            Action = () =>
+            {
+                // Create menu fresh each time to ensure it has the latest state
+                var menu = createMenu();
+                OnMenuRequested?.Invoke(menu);
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = icon = new SpriteIcon
+            {
+                Icon = FontAwesome.Solid.EllipsisV,
+                Size = new Vector2(14),  // Reduced from 16 to prevent clipping
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Colour = colourProvider.Light1,
+            };
+        }
+
+        private OsuMenu createMenu()
+        {
+            var menu = new OsuMenu(Direction.Vertical, true)
+            {
+                Items = createMenuItems()
+            };
+
+            return menu;
+        }
+
+        private MenuItem[] createMenuItems()
+        {
+            var items = new List<MenuItem>();
+
+            if (score.OnlineID == -1)
+            {
+                items.Add(new OsuMenuItem("Cannot pin score (invalid ID)", MenuItemType.Standard)
+                {
+                    Action = { Disabled = true }
+                });
+            }
+            else
+            {
+                // For scores in the Pinned section, they are definitely pinned
+                // For scores in other sections, check the IsPinned property
+                bool isPinned = scoreType == ScoreType.Pinned || score.IsPinned;
+
+                Action togglePinAction = () =>
+                {
+                    if (isPinned)
+                    {
+                        var req = new UnpinScoreRequest(score.OnlineID);
+                        req.Success += () =>
+                        {
+                            score.IsPinned = false;
+                            Schedule(() => OnPinStatusChanged?.Invoke());
+                        };
+                        req.Failure += error =>
+                        {
+                            notifications?.Post(new SimpleNotification
+                            {
+                                Text = "Failed to unpin score. The feature may not be available yet.",
+                                Icon = FontAwesome.Solid.ExclamationTriangle,
+                            });
+                            // Still close the menu on failure
+                            Schedule(() => OnPinStatusChanged?.Invoke());
+                        };
+                        api.Queue(req);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[ScoreActionsContainer] Pinning score {score.OnlineID}");
+                        var req = new PinScoreRequest(score.OnlineID);
+                        req.Success += () =>
+                        {
+                            Console.WriteLine($"[ScoreActionsContainer] Successfully pinned score {score.OnlineID}");
+                            score.IsPinned = true;
+                            Schedule(() => OnPinStatusChanged?.Invoke());
+                        };
+                        req.Failure += error =>
+                        {
+                            Console.WriteLine($"[ScoreActionsContainer] Failed to pin score {score.OnlineID}: {error.Message}");
+                            notifications?.Post(new SimpleNotification
+                            {
+                                Text = "Failed to pin score. The feature may not be available yet.",
+                                Icon = FontAwesome.Solid.ExclamationTriangle,
+                            });
+                            // Still close the menu on failure
+                            Schedule(() => OnPinStatusChanged?.Invoke());
+                        };
+                        api.Queue(req);
+                    }
+                };
+
+                items.Add(new OsuMenuItem(isPinned ? "Unpin score" : "Pin score",
+                                         isPinned ? MenuItemType.Destructive : MenuItemType.Highlighted,
+                                         togglePinAction));
+            }
+
+            return items.ToArray();
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            icon.FadeColour(colourProvider.Content1, 200, Easing.OutQuint);
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            icon.FadeColour(colourProvider.Light1, 200, Easing.OutQuint);
+            base.OnHoverLost(e);
+        }
+    }
+}

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -5,6 +5,9 @@ using osu.Game.Overlays.Profile.Sections.Ranks;
 using osu.Game.Online.API.Requests;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Game.Online.API;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
@@ -14,14 +17,51 @@ namespace osu.Game.Overlays.Profile.Sections
 
         public override string Identifier => @"top_ranks";
 
+        private PaginatedScoreContainer pinnedScoreContainer;
+        private PaginatedScoreContainer bestScoreContainer;
+        private PaginatedScoreContainer firstsScoreContainer;
+
+        private HashSet<long> pinnedScoreIds = new HashSet<long>();
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
         public RanksSection()
         {
             Children = new[]
             {
-                new PaginatedScoreContainer(ScoreType.Pinned, User, UsersStrings.ShowExtraTopRanksPinnedTitle),
-                new PaginatedScoreContainer(ScoreType.Best, User, UsersStrings.ShowExtraTopRanksBestTitle),
-                new PaginatedScoreContainer(ScoreType.Firsts, User, UsersStrings.ShowExtraTopRanksFirstTitle)
+                pinnedScoreContainer = new PaginatedScoreContainer(ScoreType.Pinned, User, UsersStrings.ShowExtraTopRanksPinnedTitle, pinnedScoreIds),
+                bestScoreContainer = new PaginatedScoreContainer(ScoreType.Best, User, UsersStrings.ShowExtraTopRanksBestTitle, pinnedScoreIds),
+                firstsScoreContainer = new PaginatedScoreContainer(ScoreType.Firsts, User, UsersStrings.ShowExtraTopRanksFirstTitle, pinnedScoreIds)
             };
+
+            pinnedScoreContainer.OnScorePinChanged = () => refreshAllSections();
+            bestScoreContainer.OnScorePinChanged = () => refreshAllSections();
+            firstsScoreContainer.OnScorePinChanged = () => refreshAllSections();
+        }
+
+        private void refreshAllSections()
+        {
+            pinnedScoreIds.Clear();
+
+            Schedule(() =>
+            {
+                var currentUser = User.Value;
+                if (currentUser?.User != null)
+                {
+                    var req = new GetUserRequest(currentUser.User.Id);
+                    req.Success += user =>
+                    {
+                        Schedule(() =>
+                        {
+                            if (User.Value != null)
+                            {
+                                User.Value = new UserProfileData(user, User.Value.Ruleset);
+                            }
+                        });
+                    };
+                    api.Queue(req);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Adds the ability for users to pin and unpin scores from their profile's "Best" and "Firsts" rank sections. A menu with "Pin" and "Unpin" options is added to each score row. New API request classes were added to handle score pin operations.  A new ScoreActionsContainer component was created to encapsulate the pin/unpin logic and UI. Add IsPinned property to SoloScoreInfo for pin state tracking. Implement refresh mechanism to update all sections on pin changes. Number of pinned scores shows the correct number of scores. Co-authored-by: Nuno Pelágio nunopelagio@tecnico.ulisboa.pt