### PR TITLE
Improve random button sound effects

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -667,7 +667,9 @@ namespace osu.Game.Screens.SelectV2
                 return false;
             }
 
-            Scheduler.Add(() =>
+            // CurrentSelectionItem won't be valid until UpdaterAfterChildren.
+            // We probably want to fix this at some point since a few places are working-around this quirk.
+            ScheduleAfterChildren(() =>
             {
                 if (selectionBefore != null && CurrentSelectionItem != null)
                     playSpinSample(distanceBetween(selectionBefore, CurrentSelectionItem), carouselItems.Count);

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -771,12 +771,12 @@ namespace osu.Game.Screens.SelectV2
             return true;
         }
 
-        public void PreviousRandom()
+        public bool PreviousRandom()
         {
             var carouselItems = GetCarouselItems();
 
             if (carouselItems?.Any() != true)
-                return;
+                return false;
 
             while (randomHistory.Any())
             {
@@ -786,7 +786,7 @@ namespace osu.Game.Screens.SelectV2
                 var previousBeatmapItem = carouselItems.FirstOrDefault(i => i.Model is BeatmapInfo b && b.Equals(previousBeatmap));
 
                 if (previousBeatmapItem == null)
-                    return;
+                    return false;
 
                 if (CurrentSelection is BeatmapInfo beatmapInfo)
                 {
@@ -800,8 +800,10 @@ namespace osu.Game.Screens.SelectV2
                 }
 
                 RequestSelection(previousBeatmap);
-                break;
+                return true;
             }
+
+            return false;
         }
 
         private double distanceBetween(CarouselItem item1, CarouselItem item2) => Math.Ceiling(Math.Abs(item1.CarouselYPosition - item2.CarouselYPosition) / PanelBeatmapSet.HEIGHT);

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -672,7 +672,7 @@ namespace osu.Game.Screens.SelectV2
             ScheduleAfterChildren(() =>
             {
                 if (selectionBefore != null && CurrentSelectionItem != null)
-                    playSpinSample(distanceBetween(selectionBefore, CurrentSelectionItem), carouselItems.Count);
+                    playSpinSample(visiblePanelCountBetweenItems(selectionBefore, CurrentSelectionItem));
             });
 
             return true;
@@ -794,9 +794,9 @@ namespace osu.Game.Screens.SelectV2
                         previouslyVisitedRandomBeatmaps.Remove(beatmapInfo);
 
                     if (CurrentSelectionItem == null)
-                        playSpinSample(0, carouselItems.Count);
+                        playSpinSample(0);
                     else
-                        playSpinSample(distanceBetween(previousBeatmapItem, CurrentSelectionItem), carouselItems.Count);
+                        playSpinSample(visiblePanelCountBetweenItems(previousBeatmapItem, CurrentSelectionItem));
                 }
 
                 RequestSelection(previousBeatmap);
@@ -806,15 +806,15 @@ namespace osu.Game.Screens.SelectV2
             return false;
         }
 
-        private double distanceBetween(CarouselItem item1, CarouselItem item2) => Math.Ceiling(Math.Abs(item1.CarouselYPosition - item2.CarouselYPosition) / PanelBeatmapSet.HEIGHT);
+        private double visiblePanelCountBetweenItems(CarouselItem item1, CarouselItem item2) => Math.Ceiling(Math.Abs(item1.CarouselYPosition - item2.CarouselYPosition) / PanelBeatmapSet.HEIGHT);
 
-        private void playSpinSample(double distance, int count)
+        private void playSpinSample(double distance)
         {
             var chan = spinSample?.GetChannel();
 
             if (chan != null)
             {
-                chan.Frequency.Value = 1f + Math.Min(1f, distance / count);
+                chan.Frequency.Value = 1f + Math.Clamp(distance / 200, 0, 1);
                 chan.Play();
             }
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -667,7 +667,7 @@ namespace osu.Game.Screens.SelectV2
                 return false;
             }
 
-            // CurrentSelectionItem won't be valid until UpdaterAfterChildren.
+            // CurrentSelectionItem won't be valid until UpdateAfterChildren.
             // We probably want to fix this at some point since a few places are working-around this quirk.
             ScheduleAfterChildren(() =>
             {

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -103,6 +105,8 @@ namespace osu.Game.Screens.SelectV2
 
         public override bool ShowFooter => true;
 
+        private Sample? errorSample;
+
         [Resolved]
         private OsuGameBase? game { get; set; }
 
@@ -128,8 +132,10 @@ namespace osu.Game.Screens.SelectV2
         private IDialogOverlay? dialogOverlay { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
+            errorSample = audio.Samples.Get(@"UI/generic-error");
+
             AddRangeInternal(new Drawable[]
             {
                 new GlobalScrollAdjustsVolume(),
@@ -286,8 +292,16 @@ namespace osu.Game.Screens.SelectV2
             },
             new FooterButtonRandom
             {
-                NextRandom = () => carousel.NextRandom(),
-                PreviousRandom = () => carousel.PreviousRandom()
+                NextRandom = () =>
+                {
+                    if (!carousel.NextRandom())
+                        errorSample?.Play();
+                },
+                PreviousRandom = () =>
+                {
+                    if (!carousel.PreviousRandom())
+                        errorSample?.Play();
+                }
             },
             new FooterButtonOptions
             {


### PR DESCRIPTION
- Now plays an error sound if random / rewind fails, to better inform the user of what happened.
- Adjusts the "swoosh" pitch to work more closely to how it did at v1 song select.
- Fixes regression causing sound to not play when it should

---

Closes https://github.com/ppy/osu/issues/33903.
