### PR TITLE
Remove unnecessary skin settings descriptions

### DIFF
--- a/osu.Game/Localisation/SkinComponents/BeatmapAttributeTextStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/BeatmapAttributeTextStrings.cs
@@ -15,11 +15,6 @@ namespace osu.Game.Localisation.SkinComponents
         public static LocalisableString Attribute => new TranslatableString(getKey(@"attribute"), @"Attribute");
 
         /// <summary>
-        /// "The attribute to be displayed."
-        /// </summary>
-        public static LocalisableString AttributeDescription => new TranslatableString(getKey(@"attribute_description"), @"The attribute to be displayed.");
-
-        /// <summary>
         /// "Template"
         /// </summary>
         public static LocalisableString Template => new TranslatableString(getKey(@"template"), @"Template");

--- a/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
@@ -15,29 +15,14 @@ namespace osu.Game.Localisation.SkinComponents
         public static LocalisableString SpriteName => new TranslatableString(getKey(@"sprite_name"), @"Sprite name");
 
         /// <summary>
-        /// "The filename of the sprite"
-        /// </summary>
-        public static LocalisableString SpriteNameDescription => new TranslatableString(getKey(@"sprite_name_description"), @"The filename of the sprite");
-
-        /// <summary>
         /// "Font"
         /// </summary>
         public static LocalisableString Font => new TranslatableString(getKey(@"font"), @"Font");
 
         /// <summary>
-        /// "The font to use."
-        /// </summary>
-        public static LocalisableString FontDescription => new TranslatableString(getKey(@"font_description"), @"The font to use.");
-
-        /// <summary>
         /// "Text"
         /// </summary>
         public static LocalisableString TextElementText => new TranslatableString(getKey(@"text_element_text"), @"Text");
-
-        /// <summary>
-        /// "The text to be displayed."
-        /// </summary>
-        public static LocalisableString TextElementTextDescription => new TranslatableString(getKey(@"text_element_text_description"), @"The text to be displayed.");
 
         /// <summary>
         /// "Corner radius"
@@ -55,29 +40,14 @@ namespace osu.Game.Localisation.SkinComponents
         public static LocalisableString ShowLabel => new TranslatableString(getKey(@"show_label"), @"Show label");
 
         /// <summary>
-        /// "Whether the component&#39;s label should be shown."
-        /// </summary>
-        public static LocalisableString ShowLabelDescription => new TranslatableString(getKey(@"show_label_description"), @"Whether the component's label should be shown.");
-
-        /// <summary>
         /// "Colour"
         /// </summary>
         public static LocalisableString Colour => new TranslatableString(getKey(@"colour"), @"Colour");
 
         /// <summary>
-        /// "The colour of the component."
-        /// </summary>
-        public static LocalisableString ColourDescription => new TranslatableString(getKey(@"colour_description"), @"The colour of the component.");
-
-        /// <summary>
         /// "Text colour"
         /// </summary>
         public static LocalisableString TextColour => new TranslatableString(getKey(@"text_colour"), @"Text colour");
-
-        /// <summary>
-        /// "The colour of the text."
-        /// </summary>
-        public static LocalisableString TextColourDescription => new TranslatableString(getKey(@"text_colour_description"), @"The colour of the text.");
 
         /// <summary>
         /// "Text weight"

--- a/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Play.HUD
             MaxValue = 1,
         };
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel))]
         public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
         public bool UsesFixedAnchor { get; set; }

--- a/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Play.HUD
             MaxValue = 1,
         };
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel))]
         public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Play/HUD/ArgonPerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonPerformancePointsCounter.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Play.HUD
             MaxValue = 1,
         };
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel))]
         public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
         public override bool IsValid

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Play.HUD
             MaxValue = 1,
         };
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel))]
         public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
         public bool UsesFixedAnchor { get; set; }

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.UseRelativeSize))]
         public BindableBool UseRelativeSize { get; } = new BindableBool(true);
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour))]
         public BindableColour4 AccentColour { get; } = new BindableColour4(Colour4.White);
 
         [Resolved]

--- a/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource("Inverted shear")]
         public BindableBool InvertShear { get; } = new BindableBool();
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour))]
         public BindableColour4 AccentColour { get; } = new BindableColour4(Color4Extensions.FromHex("#66CCFF"));
 
         public ArgonWedgePiece()

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.UseRelativeSize))]
         public BindableBool UseRelativeSize { get; } = new BindableBool(true);
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour))]
         public BindableColour4 AccentColour { get; } = new BindableColour4(Colour4.White);
 
         [Resolved]

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Skinning.Components
     [UsedImplicitly]
     public partial class BeatmapAttributeText : FontAdjustableSkinComponent
     {
-        [SettingSource(typeof(BeatmapAttributeTextStrings), nameof(BeatmapAttributeTextStrings.Attribute), nameof(BeatmapAttributeTextStrings.AttributeDescription))]
+        [SettingSource(typeof(BeatmapAttributeTextStrings), nameof(BeatmapAttributeTextStrings.Attribute))]
         public Bindable<BeatmapAttribute> Attribute { get; } = new Bindable<BeatmapAttribute>(BeatmapAttribute.StarRating);
 
         [SettingSource(typeof(BeatmapAttributeTextStrings), nameof(BeatmapAttributeTextStrings.Template), nameof(BeatmapAttributeTextStrings.TemplateDescription))]

--- a/osu.Game/Skinning/Components/BoxElement.cs
+++ b/osu.Game/Skinning/Components/BoxElement.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Skinning.Components
             Precision = 0.01f
         };
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour))]
         public BindableColour4 AccentColour { get; } = new BindableColour4(Colour4.White);
 
         public BoxElement()

--- a/osu.Game/Skinning/Components/TextElement.cs
+++ b/osu.Game/Skinning/Components/TextElement.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Skinning.Components
     [UsedImplicitly]
     public partial class TextElement : FontAdjustableSkinComponent
     {
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.TextElementText), nameof(SkinnableComponentStrings.TextElementTextDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.TextElementText))]
         public Bindable<string> Text { get; } = new Bindable<string>("Circles!");
 
         private readonly OsuSpriteText text;

--- a/osu.Game/Skinning/FontAdjustableSkinComponent.cs
+++ b/osu.Game/Skinning/FontAdjustableSkinComponent.cs
@@ -21,13 +21,13 @@ namespace osu.Game.Skinning
     {
         public bool UsesFixedAnchor { get; set; }
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font), nameof(SkinnableComponentStrings.FontDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font))]
         public Bindable<Typeface> Font { get; } = new Bindable<Typeface>(Typeface.Torus);
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.TextWeight), SettingControlType = typeof(WeightDropdown))]
         public Bindable<FontWeight> TextWeight { get; } = new Bindable<FontWeight>(FontWeight.Regular);
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.TextColour), nameof(SkinnableComponentStrings.TextColourDescription))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.TextColour))]
         public BindableColour4 TextColour { get; } = new BindableColour4(Colour4.White);
 
         /// <summary>

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Skinning
         [Resolved]
         private TextureStore textures { get; set; } = null!;
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.SpriteName), nameof(SkinnableComponentStrings.SpriteNameDescription), SettingControlType = typeof(SpriteSelectorControl))]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.SpriteName), SettingControlType = typeof(SpriteSelectorControl))]
         public Bindable<string> SpriteName { get; } = new Bindable<string>(string.Empty);
 
         [Resolved]


### PR DESCRIPTION
Came up in https://github.com/ppy/osu/pull/33888#discussion_r2168580910 / https://github.com/ppy/osu/pull/33888/commits/5485abd3a53102c6bca1e3eec790b304cba9fec6's description.

Took a read through all usages of the attribute with descriptions and removed those who are pretty much reflecting the setting's name itself. 