### PR TITLE
Fix Difficulty Adjust extended mod icon information not showing with extended limits active

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         {
             get
             {
-                if (UserAdjustedSettingsCount != 1)
+                if (!IsExactlyOneSettingChanged(CircleSize, ApproachRate, OverallDifficulty, DrainRate))
                     return string.Empty;
 
                 if (!CircleSize.IsDefault) return format("CS", CircleSize);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             get
             {
-                if (UserAdjustedSettingsCount != 1)
+                if (!IsExactlyOneSettingChanged(CircleSize, ApproachRate, OverallDifficulty, DrainRate))
                     return string.Empty;
 
                 if (!CircleSize.IsDefault) return format("CS", CircleSize);

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         {
             get
             {
-                if (UserAdjustedSettingsCount != 1)
+                if (!IsExactlyOneSettingChanged(ScrollSpeed, OverallDifficulty, DrainRate))
                     return string.Empty;
 
                 if (!ScrollSpeed.IsDefault) return format("SC", ScrollSpeed);

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -28,13 +28,13 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 if (!IsExactlyOneSettingChanged(ScrollSpeed, OverallDifficulty, DrainRate))
                     return string.Empty;
 
-                if (!ScrollSpeed.IsDefault) return format("SC", ScrollSpeed);
-                if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
-                if (!DrainRate.IsDefault) return format("HP", DrainRate);
+                if (!ScrollSpeed.IsDefault) return format("SC", ScrollSpeed, 2);
+                if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty, 1);
+                if (!DrainRate.IsDefault) return format("HP", DrainRate, 1);
 
                 return string.Empty;
 
-                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+                string format(string acronym, DifficultyBindable bindable, int digits) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(digits)}";
             }
         }
 

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Mods
         {
             get
             {
-                if (UserAdjustedSettingsCount != 1)
+                if (!IsExactlyOneSettingChanged(OverallDifficulty, DrainRate))
                     return string.Empty;
 
                 if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
@@ -82,6 +82,24 @@ namespace osu.Game.Rulesets.Mods
 
                 string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
             }
+        }
+
+        protected bool IsExactlyOneSettingChanged(params DifficultyBindable[] difficultySettings)
+        {
+            DifficultyBindable? changedSetting = null;
+
+            foreach (var setting in difficultySettings)
+            {
+                if (setting.IsDefault)
+                    continue;
+
+                if (changedSetting != null)
+                    return false;
+
+                changedSetting = setting;
+            }
+
+            return changedSetting != null;
         }
 
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
@@ -106,27 +124,6 @@ namespace osu.Game.Rulesets.Mods
         {
             if (DrainRate.Value != null) difficulty.DrainRate = DrainRate.Value.Value;
             if (OverallDifficulty.Value != null) difficulty.OverallDifficulty = OverallDifficulty.Value.Value;
-        }
-
-        /// <summary>
-        /// The number of settings on this mod instance which have been adjusted by the user from their default values.
-        /// </summary>
-        protected int UserAdjustedSettingsCount
-        {
-            get
-            {
-                int count = 0;
-
-                foreach (var (_, property) in this.GetSettingsSourceProperties())
-                {
-                    var bindable = (IBindable)property.GetValue(this)!;
-
-                    if (!bindable.IsDefault)
-                        count++;
-                }
-
-                return count;
-            }
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33522.
- Alternative to / closes https://github.com/ppy/osu/pull/33561.

https://github.com/ppy/osu/commit/cae1f8bb88d4270c794259302d265301132ce375 is a drive-by display fix.