### PR TITLE
Change colour of BeatDivisorControl icons from black to light gray

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -375,7 +375,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                IconColour = Color4.Black;
+                IconColour = colours.GrayB;
+                IconHoverColour = Color4.White;
                 HoverColour = colours.Gray7;
                 FlashColour = colours.Gray9;
             }

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -373,11 +373,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            private void load(OsuColour colours, OverlayColourProvider colourProvider)
             {
-                IconColour = colours.GrayB;
+                IconColour = colourProvider.Light3;
                 IconHoverColour = Color4.White;
-                HoverColour = colours.Gray7;
+                HoverColour = colours.Gray6;
                 FlashColour = colours.Gray9;
             }
         }


### PR DESCRIPTION
The fact that the beat divisor controls are pretty much the only thing using black as icon colour in the editor always kinda bothered me so hoping we could switch it to a lighter colour to make it fit in more nicely
| Before                                                                                    | After                                                                                     |
|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/1e43c4f8-7869-46b3-b5d3-ec2fc8ba7865) | ![image](https://github.com/user-attachments/assets/3a67da65-1e5e-4783-beaa-9a3004f6a75d) |