### PR TITLE
Use floored star rating when determining beatmap groupings by difficulty and when star rating is displayed in AdvancedStats

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
@@ -263,8 +263,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             var results = await runGrouping(GroupMode.Difficulty, beatmapSets);
             assertGroup(results, 0, "Below 1 Star", new[] { beatmapBelow1 }, ref total);
-            assertGroup(results, 1, "1 Star", new[] { beatmapAbove1 }, ref total);
-            assertGroup(results, 2, "2 Stars", new[] { beatmapAlmost2, beatmap2, beatmapAbove2 }, ref total);
+            assertGroup(results, 1, "1 Star", new[] { beatmapAbove1, beatmapAlmost2 }, ref total);
+            assertGroup(results, 2, "2 Stars", new[] { beatmap2, beatmapAbove2 }, ref total);
             assertGroup(results, 3, "7 Stars", new[] { beatmap7 }, ref total);
             assertTotal(results, total);
         }

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Screens.Select.Details
                 if (normalDifficulty == null || moddedDifficulty == null)
                     return;
 
-                starDifficulty.Value = ((float)normalDifficulty.Value.Stars, (float)moddedDifficulty.Value.Stars);
+                starDifficulty.Value = ((float)normalDifficulty.Value.Stars.FloorToDecimalDigits(2), (float)moddedDifficulty.Value.Stars.FloorToDecimalDigits(2));
             }), starDifficultyCancellationSource.Token, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Current);
         });
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -323,6 +323,7 @@ namespace osu.Game.Screens.SelectV2
 
         private GroupDefinition defineGroupByStars(double stars)
         {
+            // truncation is intentional - compare `FormatUtils.FormatStarRating()`
             int starInt = (int)stars;
             var starDifficulty = new StarDifficulty(starInt, 0);
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -11,7 +11,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
-using osu.Game.Utils;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -190,7 +189,7 @@ namespace osu.Game.Screens.SelectV2
                     }, items);
 
                 case GroupMode.Difficulty:
-                    return getGroupsBy(b => defineGroupByStars(b.StarRating.FloorToDecimalDigits(2)), items);
+                    return getGroupsBy(b => defineGroupByStars(b.StarRating), items);
 
                 case GroupMode.Length:
                     return getGroupsBy(b =>
@@ -324,7 +323,7 @@ namespace osu.Game.Screens.SelectV2
 
         private GroupDefinition defineGroupByStars(double stars)
         {
-            int starInt = (int)Math.Round(stars, 2);
+            int starInt = (int)stars;
             var starDifficulty = new StarDifficulty(starInt, 0);
 
             if (starInt == 0)

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Utils;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -189,7 +190,7 @@ namespace osu.Game.Screens.SelectV2
                     }, items);
 
                 case GroupMode.Difficulty:
-                    return getGroupsBy(b => defineGroupByStars(b.StarRating), items);
+                    return getGroupsBy(b => defineGroupByStars(b.StarRating.FloorToDecimalDigits(2)), items);
 
                 case GroupMode.Length:
                     return getGroupsBy(b =>


### PR DESCRIPTION
Quick update to use floored star rating in two areas to complement #33679:

- When grouping beatmaps by difficulty, otherwise we can have a map with a star rating of `5.995` being displayed as `5.99`, but is sorted into the `6*` group
- In the original song select under `AdvancedStats`, otherwise the star rating will be disjoint from what's displayed on `BeatmapInfoWedge` (i know this song select is on the way out, but it's still probably good to fix for now)

| Master | PR |
| ---------  | ---- |
| ![Screenshot From 2025-06-30 16-29-46](https://github.com/user-attachments/assets/3df8befa-dcd4-4bca-96fc-c93e7b795e9f)| ![Screenshot From 2025-06-30 16-45-14](https://github.com/user-attachments/assets/844ea756-6b7a-4995-91e1-d5c98047c95e) |
| ![Screenshot From 2025-06-30 17-37-09](https://github.com/user-attachments/assets/fa5df7ad-eea1-4eda-9326-276cd76db3bc) | ![Screenshot From 2025-06-30 17-41-06](https://github.com/user-attachments/assets/15f03db3-1c90-4846-9861-9f0a6b29fec3) |

