### PR TITLE
Make `ShearedButton` block mouse down events

### DIFF
--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             Content.ScaleTo(0.9f, 2000, Easing.OutQuint);
-            return base.OnMouseDown(e);
+            return true;
         }
 
         protected override void OnMouseUp(MouseUpEvent e)

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -81,6 +82,13 @@ namespace osu.Game.Screens.SelectV2
         private readonly IBindable<LeaderboardScores?> fetchedScores = new Bindable<LeaderboardScores?>();
 
         private const float personal_best_height = 112;
+
+        // Blocking mouse down is required to avoid song select's background reveal logic happening while hovering scores.
+        // Our horizontal alignment doesn't really align with the rest of the sheared components (protrudes a touch to the right) which makes
+        // it complicated to handle this at a higher level.
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => scoresScroll.ReceivePositionalInputAt(screenSpacePos);
+
+        protected override bool OnMouseDown(MouseDownEvent e) => true;
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/33748.

I (and tests) can't find any regressions from this. One would hope we aren't relying on fall-through mouse down anywhere beneath buttons..