### PR TITLE
Fix tablet troubleshooting page linked incorrectly and not linked on macOS

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -113,15 +112,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                             AutoSizeAxes = Axes.Y,
                         }.With(t =>
                         {
-                            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows || RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
-                            {
-                                t.NewLine();
-                                var formattedSource = MessageFormatter.FormatText(localisation.GetLocalisedString(TabletSettingsStrings.NoTabletDetectedDescription(
-                                    RuntimeInfo.OS == RuntimeInfo.Platform.Windows
-                                        ? @"https://opentabletdriver.net/Wiki/FAQ/Windows"
-                                        : @"https://opentabletdriver.net/Wiki/FAQ/Linux")));
-                                t.AddLinks(formattedSource.Text, formattedSource.Links);
-                            }
+                            t.NewLine();
+
+                            const string url = @"https://opentabletdriver.net/Wiki/FAQ/General";
+                            var formattedSource = MessageFormatter.FormatText(localisation.GetLocalisedString(TabletSettingsStrings.NoTabletDetectedDescription(url)));
+
+                            t.AddLinks(formattedSource.Text, formattedSource.Links);
                         }),
                     }
                 },


### PR DESCRIPTION
- Removes per-platform linking as it's not recommended by the website itself:
  
  ![CleanShot 2025-07-02 at 13 26 04](https://github.com/user-attachments/assets/193cc510-cee8-43ca-897a-a69a2247ef8e)

  This makes sense because the general FAQ page starts by highlighting that the user's tablet may not be supported, we should forward the user there first.

- Fixes troubleshooting text not appearing on macOS, leading to confusion as has been in https://github.com/ppy/osu/discussions/33933.