### PR TITLE
Support mania-specific hit window quirks

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModEasy.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModEasy.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Catch.Mods
@@ -9,5 +10,12 @@ namespace osu.Game.Rulesets.Catch.Mods
     public class CatchModEasy : ModEasyWithExtraLives
     {
         public override LocalisableString Description => @"Larger fruits, more forgiving HP drain, less accuracy required, and extra lives!";
+
+        public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
+        {
+            base.ApplyToDifficulty(difficulty);
+
+            difficulty.OverallDifficulty *= ADJUST_RATIO;
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         {
             base.ApplyToDifficulty(difficulty);
 
+            difficulty.OverallDifficulty = Math.Min(difficulty.OverallDifficulty * ADJUST_RATIO, 10.0f);
             difficulty.CircleSize = Math.Min(difficulty.CircleSize * 1.3f, 10.0f); // CS uses a custom 1.3 ratio.
             difficulty.ApproachRate = Math.Min(difficulty.ApproachRate * ADJUST_RATIO, 10.0f);
         }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
@@ -5,7 +5,6 @@ using System;
 using NUnit.Framework;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets.Mania.Mods;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Rulesets.Mania.Tests
@@ -38,7 +37,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { LegacyMods.Key2, new[] { typeof(ManiaModKey2) } },
             new object[] { LegacyMods.Mirror, new[] { typeof(ManiaModMirror) } },
             new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(ManiaModHardRock), typeof(ManiaModDoubleTime) } },
-            new object[] { LegacyMods.ScoreV2, new[] { typeof(ModScoreV2) } },
+            new object[] { LegacyMods.ScoreV2, new[] { typeof(ManiaModScoreV2) } },
         };
 
         [TestCaseSource(nameof(mania_mod_mapping))]

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
@@ -527,7 +527,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV2 single note @ OD{overallDifficulty}", beatmap, $@"SV2 {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
-        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1NonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -555,7 +554,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1 single note @ OD{overallDifficulty}", beatmap, $@"SV1 {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
-        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_convert_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1Convert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -584,7 +582,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1 convert single note @ OD{overallDifficulty}", beatmap, $@"SV1 convert {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
-        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_hard_rock_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndHardRockNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -613,7 +610,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1+HR single note @ OD{overallDifficulty}", beatmap, $@"SV1+HR {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
-        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_easy_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndEasyNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -642,7 +638,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1+EZ single note @ OD{overallDifficulty}", beatmap, $@"SV1+EZ {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
-        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_double_time_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndDoubleTimeNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {
@@ -671,7 +666,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             RunTest($@"SV1+DT single note @ OD{overallDifficulty}", beatmap, $@"SV1+DT {hitOffset}ms @ OD{overallDifficulty} = {expectedResult}", score, [expectedResult]);
         }
 
-        [Ignore("Tests expected to fail until stable's detailed treatment of hit windows in mania is reproduced.")]
         [TestCaseSource(nameof(score_v1_non_convert_half_time_test_cases))]
         public void TestHitWindowTreatmentWithScoreV1AndHalfTimeNonConvert(float overallDifficulty, double hitOffset, HitResult expectedResult)
         {

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneLegacyReplayPlayback.cs
@@ -9,7 +9,6 @@ using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Replays;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
@@ -521,7 +520,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 ScoreInfo = new ScoreInfo
                 {
                     Ruleset = CreateRuleset().RulesetInfo,
-                    Mods = [new ModScoreV2()]
+                    Mods = [new ManiaModScoreV2()]
                 }
             };
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Rulesets.Mania
                 yield return new ManiaModMirror();
 
             if (mods.HasFlag(LegacyMods.ScoreV2))
-                yield return new ModScoreV2();
+                yield return new ManiaModScoreV2();
         }
 
         public override LegacyMods ConvertToLegacyMods(Mod[] mods)
@@ -296,7 +296,7 @@ namespace osu.Game.Rulesets.Mania
                 case ModType.System:
                     return new Mod[]
                     {
-                        new ModScoreV2(),
+                        new ManiaModScoreV2(),
                     };
 
                 default:

--- a/osu.Game.Rulesets.Mania/Mods/IManiaRateAdjustmentMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/IManiaRateAdjustmentMod.cs
@@ -2,12 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -17,29 +15,21 @@ namespace osu.Game.Rulesets.Mania.Mods
     /// <remarks>
     /// Historically, in osu!mania, hit windows are expected to adjust relative to the gameplay rate such that the real-world hit window remains the same.
     /// </remarks>
-    public interface IManiaRateAdjustmentMod : IApplicableToDifficulty, IApplicableToHitObject
+    public interface IManiaRateAdjustmentMod : IApplicableToHitObject
     {
         BindableNumber<double> SpeedChange { get; }
-
-        HitWindows HitWindows { get; set; }
-
-        void IApplicableToDifficulty.ApplyToDifficulty(BeatmapDifficulty difficulty)
-        {
-            HitWindows = new ManiaHitWindows(SpeedChange.Value);
-            HitWindows.SetDifficulty(difficulty.OverallDifficulty);
-        }
 
         void IApplicableToHitObject.ApplyToHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
                 case Note:
-                    hitObject.HitWindows = HitWindows;
+                    ((ManiaHitWindows)hitObject.HitWindows).SpeedMultiplier = SpeedChange.Value;
                     break;
 
                 case HoldNote hold:
-                    hold.Head.HitWindows = HitWindows;
-                    hold.Tail.HitWindows = HitWindows;
+                    ((ManiaHitWindows)hold.Head.HitWindows).SpeedMultiplier = SpeedChange.Value;
+                    ((ManiaHitWindows)hold.Tail.HitWindows).SpeedMultiplier = SpeedChange.Value;
                     break;
             }
         }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDaycore.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDaycore.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModDaycore : ModDaycore, IManiaRateAdjustmentMod
     {
-        public HitWindows HitWindows { get; set; } = new ManiaHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
@@ -1,16 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModDoubleTime : ModDoubleTime, IManiaRateAdjustmentMod
     {
-        public HitWindows HitWindows { get; set; } = new ManiaHitWindows();
-
         // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
         // make the map harder and is more of a personal preference.
         // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModEasy.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModEasy.cs
@@ -2,12 +2,32 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModEasy : ModEasyWithExtraLives
+    public class ManiaModEasy : ModEasyWithExtraLives, IApplicableToHitObject
     {
         public override LocalisableString Description => @"More forgiving HP drain, less accuracy required, and extra lives!";
+
+        void IApplicableToHitObject.ApplyToHitObject(HitObject hitObject)
+        {
+            const double multiplier = 1 / 1.4;
+
+            switch (hitObject)
+            {
+                case Note:
+                    ((ManiaHitWindows)hitObject.HitWindows).DifficultyMultiplier = multiplier;
+                    break;
+
+                case HoldNote hold:
+                    ((ManiaHitWindows)hold.Head.HitWindows).DifficultyMultiplier = multiplier;
+                    ((ManiaHitWindows)hold.Tail.HitWindows).DifficultyMultiplier = multiplier;
+                    break;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHalfTime.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHalfTime.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModHalfTime : ModHalfTime, IManiaRateAdjustmentMod
     {
-        public HitWindows HitWindows { get; set; } = new ManiaHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
@@ -1,13 +1,33 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModHardRock : ModHardRock
+    public class ManiaModHardRock : ModHardRock, IApplicableToHitObject
     {
         public override double ScoreMultiplier => 1;
         public override bool Ranked => false;
+
+        void IApplicableToHitObject.ApplyToHitObject(HitObject hitObject)
+        {
+            const double multiplier = 1.4;
+
+            switch (hitObject)
+            {
+                case Note:
+                    ((ManiaHitWindows)hitObject.HitWindows).DifficultyMultiplier = multiplier;
+                    break;
+
+                case HoldNote hold:
+                    ((ManiaHitWindows)hold.Head.HitWindows).DifficultyMultiplier = multiplier;
+                    ((ManiaHitWindows)hold.Tail.HitWindows).DifficultyMultiplier = multiplier;
+                    break;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
@@ -2,16 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModNightcore : ModNightcore<ManiaHitObject>, IManiaRateAdjustmentMod
     {
-        public HitWindows HitWindows { get; set; } = new ManiaHitWindows();
-
         // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
         // make the map any harder and is more of a personal preference.
         // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModScoreV2.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModScoreV2.cs
@@ -8,12 +8,10 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModClassic : ModClassic, IApplicableToBeatmap
+    public class ManiaModScoreV2 : ModScoreV2, IApplicableToBeatmap
     {
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
-            bool isConvert = !beatmap.BeatmapInfo.Ruleset.Equals(new ManiaRuleset().RulesetInfo);
-
             foreach (var ho in beatmap.HitObjects)
             {
                 switch (ho)
@@ -21,8 +19,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                     case Note note:
                     {
                         var hitWindows = (ManiaHitWindows)note.HitWindows;
-                        hitWindows.IsConvert = isConvert;
-                        hitWindows.ClassicModActive = true;
+                        hitWindows.ScoreV2Active = true;
                         break;
                     }
 
@@ -30,8 +27,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                     {
                         var headWindows = (ManiaHitWindows)hold.Head.HitWindows;
                         var tailWindows = (ManiaHitWindows)hold.Tail.HitWindows;
-                        headWindows.IsConvert = tailWindows.IsConvert = isConvert;
-                        headWindows.ClassicModActive = tailWindows.ClassicModActive = true;
+                        headWindows.ScoreV2Active = tailWindows.ScoreV2Active = true;
                         break;
                     }
                 }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
@@ -18,6 +18,14 @@ namespace osu.Game.Rulesets.Mania.Scoring
 
         private double speedMultiplier = 1;
 
+        /// <summary>
+        /// Multiplier used to compensate for the playback speed of the track speeding up or slowing down.
+        /// The goal of this multiplier is to keep hit windows independent of track speed.
+        /// <list type="bullet">
+        /// <item>When the track speed is above 1, the hit window ranges are multiplied by <see cref="SpeedMultiplier"/>, because the time elapses faster.</item>
+        /// <item>When the track speed is below 1, the hit window ranges are also multiplied by <see cref="SpeedMultiplier"/>, because the time elapses slower.</item>
+        /// </list>
+        /// </summary>
         public double SpeedMultiplier
         {
             get => speedMultiplier;
@@ -27,6 +35,27 @@ namespace osu.Game.Rulesets.Mania.Scoring
                 updateWindows();
             }
         }
+
+        private double difficultyMultiplier = 1;
+
+        /// <summary>
+        /// Multiplier used to make the gameplay more or less difficult.
+        /// <list type="bullet">
+        /// <item>When the <see cref="DifficultyMultiplier"/> is above 1, the hit windows decrease to make the gameplay harder.</item>
+        /// <item>When the <see cref="DifficultyMultiplier"/> is below 1, the hit windows increase to make the gameplay easier.</item>
+        /// </list>
+        /// </summary>
+        public double DifficultyMultiplier
+        {
+            get => difficultyMultiplier;
+            set
+            {
+                difficultyMultiplier = value;
+                updateWindows();
+            }
+        }
+
+        private double totalMultiplier => speedMultiplier / difficultyMultiplier;
 
         private double overallDifficulty;
 
@@ -101,33 +130,33 @@ namespace osu.Game.Rulesets.Mania.Scoring
             {
                 if (IsConvert)
                 {
-                    perfect = Math.Floor(16 * speedMultiplier) + 0.5;
-                    great = Math.Floor((Math.Round(overallDifficulty) > 4 ? 34 : 47) * speedMultiplier) + 0.5;
-                    good = Math.Floor((Math.Round(overallDifficulty) > 4 ? 67 : 77) * speedMultiplier) + 0.5;
-                    ok = Math.Floor(97 * speedMultiplier) + 0.5;
-                    meh = Math.Floor(121 * speedMultiplier) + 0.5;
-                    miss = Math.Floor(158 * speedMultiplier) + 0.5;
+                    perfect = Math.Floor(16 * totalMultiplier) + 0.5;
+                    great = Math.Floor((Math.Round(overallDifficulty) > 4 ? 34 : 47) * totalMultiplier) + 0.5;
+                    good = Math.Floor((Math.Round(overallDifficulty) > 4 ? 67 : 77) * totalMultiplier) + 0.5;
+                    ok = Math.Floor(97 * totalMultiplier) + 0.5;
+                    meh = Math.Floor(121 * totalMultiplier) + 0.5;
+                    miss = Math.Floor(158 * totalMultiplier) + 0.5;
                 }
                 else
                 {
                     double invertedOd = Math.Clamp(10 - overallDifficulty, 0, 10);
 
-                    perfect = Math.Floor(16 * speedMultiplier) + 0.5;
-                    great = Math.Floor((34 + 3 * invertedOd) * speedMultiplier) + 0.5;
-                    good = Math.Floor((67 + 3 * invertedOd) * speedMultiplier) + 0.5;
-                    ok = Math.Floor((97 + 3 * invertedOd) * speedMultiplier) + 0.5;
-                    meh = Math.Floor((121 + 3 * invertedOd) * speedMultiplier) + 0.5;
-                    miss = Math.Floor((158 + 3 * invertedOd) * speedMultiplier) + 0.5;
+                    perfect = Math.Floor(16 * totalMultiplier) + 0.5;
+                    great = Math.Floor((34 + 3 * invertedOd) * totalMultiplier) + 0.5;
+                    good = Math.Floor((67 + 3 * invertedOd) * totalMultiplier) + 0.5;
+                    ok = Math.Floor((97 + 3 * invertedOd) * totalMultiplier) + 0.5;
+                    meh = Math.Floor((121 + 3 * invertedOd) * totalMultiplier) + 0.5;
+                    miss = Math.Floor((158 + 3 * invertedOd) * totalMultiplier) + 0.5;
                 }
             }
             else
             {
-                perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, perfect_window_range) * speedMultiplier) + 0.5;
-                great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, great_window_range) * speedMultiplier) + 0.5;
-                good = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, good_window_range) * speedMultiplier) + 0.5;
-                ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, ok_window_range) * speedMultiplier) + 0.5;
-                meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, meh_window_range) * speedMultiplier) + 0.5;
-                miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, miss_window_range) * speedMultiplier) + 0.5;
+                perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, perfect_window_range) * totalMultiplier) + 0.5;
+                great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, great_window_range) * totalMultiplier) + 0.5;
+                good = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, good_window_range) * totalMultiplier) + 0.5;
+                ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, ok_window_range) * totalMultiplier) + 0.5;
+                meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, meh_window_range) * totalMultiplier) + 0.5;
+                miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, miss_window_range) * totalMultiplier) + 0.5;
             }
         }
 

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
@@ -16,7 +16,55 @@ namespace osu.Game.Rulesets.Mania.Scoring
         private static readonly DifficultyRange meh_window_range = new DifficultyRange(151, 136, 121);
         private static readonly DifficultyRange miss_window_range = new DifficultyRange(188, 173, 158);
 
-        private readonly double multiplier;
+        private double speedMultiplier = 1;
+
+        public double SpeedMultiplier
+        {
+            get => speedMultiplier;
+            set
+            {
+                speedMultiplier = value;
+                updateWindows();
+            }
+        }
+
+        private double overallDifficulty;
+
+        private bool classicModActive;
+
+        public bool ClassicModActive
+        {
+            get => classicModActive;
+            set
+            {
+                classicModActive = value;
+                updateWindows();
+            }
+        }
+
+        private bool scoreV2Active;
+
+        public bool ScoreV2Active
+        {
+            get => scoreV2Active;
+            set
+            {
+                scoreV2Active = value;
+                updateWindows();
+            }
+        }
+
+        private bool isConvert;
+
+        public bool IsConvert
+        {
+            get => isConvert;
+            set
+            {
+                isConvert = value;
+                updateWindows();
+            }
+        }
 
         private double perfect;
         private double great;
@@ -24,16 +72,6 @@ namespace osu.Game.Rulesets.Mania.Scoring
         private double ok;
         private double meh;
         private double miss;
-
-        public ManiaHitWindows()
-            : this(1)
-        {
-        }
-
-        public ManiaHitWindows(double multiplier)
-        {
-            this.multiplier = multiplier;
-        }
 
         public override bool IsHitResultAllowed(HitResult result)
         {
@@ -53,12 +91,44 @@ namespace osu.Game.Rulesets.Mania.Scoring
 
         public override void SetDifficulty(double difficulty)
         {
-            perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, perfect_window_range) * multiplier) + 0.5;
-            great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, great_window_range) * multiplier) + 0.5;
-            good = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, good_window_range) * multiplier) + 0.5;
-            ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, ok_window_range) * multiplier) + 0.5;
-            meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, meh_window_range) * multiplier) + 0.5;
-            miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, miss_window_range) * multiplier) + 0.5;
+            overallDifficulty = difficulty;
+            updateWindows();
+        }
+
+        private void updateWindows()
+        {
+            if (ClassicModActive && !ScoreV2Active)
+            {
+                if (IsConvert)
+                {
+                    perfect = Math.Floor(16 * speedMultiplier) + 0.5;
+                    great = Math.Floor((Math.Round(overallDifficulty) > 4 ? 34 : 47) * speedMultiplier) + 0.5;
+                    good = Math.Floor((Math.Round(overallDifficulty) > 4 ? 67 : 77) * speedMultiplier) + 0.5;
+                    ok = Math.Floor(97 * speedMultiplier) + 0.5;
+                    meh = Math.Floor(121 * speedMultiplier) + 0.5;
+                    miss = Math.Floor(158 * speedMultiplier) + 0.5;
+                }
+                else
+                {
+                    double invertedOd = Math.Clamp(10 - overallDifficulty, 0, 10);
+
+                    perfect = Math.Floor(16 * speedMultiplier) + 0.5;
+                    great = Math.Floor((34 + 3 * invertedOd) * speedMultiplier) + 0.5;
+                    good = Math.Floor((67 + 3 * invertedOd) * speedMultiplier) + 0.5;
+                    ok = Math.Floor((97 + 3 * invertedOd) * speedMultiplier) + 0.5;
+                    meh = Math.Floor((121 + 3 * invertedOd) * speedMultiplier) + 0.5;
+                    miss = Math.Floor((158 + 3 * invertedOd) * speedMultiplier) + 0.5;
+                }
+            }
+            else
+            {
+                perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, perfect_window_range) * speedMultiplier) + 0.5;
+                great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, great_window_range) * speedMultiplier) + 0.5;
+                good = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, good_window_range) * speedMultiplier) + 0.5;
+                ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, ok_window_range) * speedMultiplier) + 0.5;
+                meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, meh_window_range) * speedMultiplier) + 0.5;
+                miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, miss_window_range) * speedMultiplier) + 0.5;
+            }
         }
 
         public override double WindowFor(HitResult result)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModEasy.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModEasy.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Osu.Mods
@@ -9,5 +10,12 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModEasy : ModEasyWithExtraLives
     {
         public override LocalisableString Description => @"Larger circles, more forgiving HP drain, less accuracy required, and extra lives!";
+
+        public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
+        {
+            base.ApplyToDifficulty(difficulty);
+
+            difficulty.OverallDifficulty *= ADJUST_RATIO;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             base.ApplyToDifficulty(difficulty);
 
+            difficulty.OverallDifficulty = Math.Min(difficulty.OverallDifficulty * ADJUST_RATIO, 10.0f);
             difficulty.CircleSize = Math.Min(difficulty.CircleSize * 1.3f, 10.0f); // CS uses a custom 1.3 ratio.
             difficulty.ApproachRate = Math.Min(difficulty.ApproachRate * ADJUST_RATIO, 10.0f);
         }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModEasy.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModEasy.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);
+
+            difficulty.OverallDifficulty *= ADJUST_RATIO;
             difficulty.SliderMultiplier *= slider_multiplier;
         }
     }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
@@ -23,6 +24,8 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);
+
+            difficulty.OverallDifficulty = Math.Min(difficulty.OverallDifficulty * ADJUST_RATIO, 10.0f);
             difficulty.SliderMultiplier *= slider_multiplier;
         }
     }

--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -19,13 +19,13 @@ namespace osu.Game.Rulesets.Mods
         public override bool Ranked => UsesDefaultConfiguration;
         public override bool ValidForFreestyleAsRequiredMod => true;
 
+        protected const float ADJUST_RATIO = 0.5f;
+
         public virtual void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
-            const float ratio = 0.5f;
-            difficulty.CircleSize *= ratio;
-            difficulty.ApproachRate *= ratio;
-            difficulty.DrainRate *= ratio;
-            difficulty.OverallDifficulty *= ratio;
+            difficulty.CircleSize *= ADJUST_RATIO;
+            difficulty.ApproachRate *= ADJUST_RATIO;
+            difficulty.DrainRate *= ADJUST_RATIO;
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Rulesets.Mods
         public virtual void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             difficulty.DrainRate = Math.Min(difficulty.DrainRate * ADJUST_RATIO, 10.0f);
-            difficulty.OverallDifficulty = Math.Min(difficulty.OverallDifficulty * ADJUST_RATIO, 10.0f);
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModScoreV2.cs
+++ b/osu.Game/Rulesets/Mods/ModScoreV2.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Mods
     /// This mod is used strictly to mark osu!stable scores set with the "Score V2" mod active.
     /// It should not be used in any real capacity going forward.
     /// </remarks>
-    public sealed class ModScoreV2 : Mod
+    public class ModScoreV2 : Mod
     {
         public override string Name => "Score V2";
         public override string Acronym => @"SV2";


### PR DESCRIPTION
Split from https://github.com/ppy/osu/pull/33078

## [Support mania-specific hit window quirks](https://github.com/ppy/osu/commit/6afdf99df8a42d91197c53692502bc7737610cfa)

The quirks in question being that lazer's hit windows in mania preceding this change are used in stable *if and only if* Score V2 is active. If Score V2 is *not* active, stable has two disparate other sets of hit window ranges, dependent on whether the beatmap is a convert or not.

With this commit, those hit windows are used in lazer when the Classic mod is active.

## [Fix mania Hard Rock & Easy mods not matching stable](https://github.com/ppy/osu/commit/8e53f47e78573562cc604f959d045ba36a65f559) 
The implementation in `master` was presuming that Hard Rock and Easy worked the same way across all rulesets, but actually, in stable mania, the two mods have special treatment as per [this](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/GameplayElements/HitObjectManagerMania.cs#L147-L150).

The open question here would be what this means for existing scores set on lazer using this mod.