### PR TITLE
Editor UI scale adjustment: compose screen sidebars

### DIFF
--- a/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public ExpandableSlider()
         {
+            const float slider_bar_scale = 0.8f;
+
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
@@ -102,8 +104,8 @@ namespace osu.Game.Graphics.UserInterface
                     slider = new TSlider
                     {
                         RelativeSizeAxes = Axes.X,
-                        Scale = new Vector2(0.8f),
-                        Width = 1 / 0.8f,
+                        Scale = new Vector2(slider_bar_scale),
+                        Width = 1 / slider_bar_scale,
                     },
                 }
             };

--- a/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Screens.Edit;
 using Vector2 = osuTK.Vector2;
 
 namespace osu.Game.Graphics.UserInterface
@@ -99,7 +100,7 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     label = new OsuSpriteText
                     {
-                        Font = OsuFont.Style.Caption2,
+                        Font = Editor.Fonts.Default,
                     },
                     slider = new TSlider
                     {

--- a/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
@@ -95,10 +95,15 @@ namespace osu.Game.Graphics.UserInterface
                 Spacing = new Vector2(0f, 10f),
                 Children = new Drawable[]
                 {
-                    label = new OsuSpriteText(),
+                    label = new OsuSpriteText
+                    {
+                        Font = OsuFont.Style.Caption2,
+                    },
                     slider = new TSlider
                     {
                         RelativeSizeAxes = Axes.X,
+                        Scale = new Vector2(0.8f),
+                        Width = 1 / 0.8f,
                     },
                 }
             };

--- a/osu.Game/Rulesets/Edit/EditorToolboxGroup.cs
+++ b/osu.Game/Rulesets/Edit/EditorToolboxGroup.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Screens.Edit;
 using osuTK;
 using osuTK.Graphics;
 
@@ -109,7 +110,7 @@ namespace osu.Game.Rulesets.Edit
                                     Origin = Anchor.CentreLeft,
                                     Anchor = Anchor.CentreLeft,
                                     Text = title.ToUpperInvariant(),
-                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                                    Font = Editor.Fonts.Heading,
                                     Padding = new MarginPadding { Left = ContentPadding.Left, Right = 24 },
                                 },
                                 expandButton = new IconButton

--- a/osu.Game/Rulesets/Edit/EditorToolboxGroup.cs
+++ b/osu.Game/Rulesets/Edit/EditorToolboxGroup.cs
@@ -1,18 +1,209 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+using osu.Framework.Utils;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Edit
 {
-    public partial class EditorToolboxGroup : SettingsToolboxGroup
+    public partial class EditorToolboxGroup : Container, IExpandable
     {
-        public EditorToolboxGroup(string title)
-            : base(title)
+        private readonly string title;
+
+        private const float transition_duration = 250;
+        private const int header_height = 24;
+        private const int corner_radius = 4;
+
+        protected override Container<Drawable> Content => content;
+
+        private readonly FillFlowContainer content = new FillFlowContainer
         {
+            Name = @"Content",
+            Origin = Anchor.TopCentre,
+            Anchor = Anchor.TopCentre,
+            Direction = FillDirection.Vertical,
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Padding = new MarginPadding { Horizontal = 10, Top = 5, Bottom = 10 },
+            Spacing = new Vector2(0, 8),
+        };
+
+        public MarginPadding ContentPadding
+        {
+            get => content.Padding;
+            set => content.Padding = value;
+        }
+
+        public BindableBool Expanded { get; } = new BindableBool(true);
+
+        private OsuSpriteText headerText = null!;
+
+        private Container headerContent = null!;
+
+        private Box background = null!;
+
+        private IconButton expandButton = null!;
+
+        private InputManager inputManager = null!;
+
+        private Drawable? draggedChild;
+
+        /// <summary>
+        /// Create a new instance.
+        /// </summary>
+        /// <param name="title">The title to be displayed in the header of this group.</param>
+        public EditorToolboxGroup(string title)
+        {
+            this.title = title;
+
             RelativeSizeAxes = Axes.X;
-            Width = 1;
+            AutoSizeAxes = Axes.Y;
+            Masking = true;
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(OverlayColourProvider? colourProvider)
+        {
+            CornerRadius = corner_radius;
+
+            InternalChildren = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.1f,
+                    Colour = colourProvider?.Background4 ?? Color4.Black,
+                },
+                new FillFlowContainer
+                {
+                    Direction = FillDirection.Vertical,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Children = new Drawable[]
+                    {
+                        headerContent = new Container
+                        {
+                            Name = @"Header",
+                            Origin = Anchor.TopCentre,
+                            Anchor = Anchor.TopCentre,
+                            RelativeSizeAxes = Axes.X,
+                            Height = header_height,
+                            Children = new Drawable[]
+                            {
+                                headerText = new OsuSpriteText
+                                {
+                                    Origin = Anchor.CentreLeft,
+                                    Anchor = Anchor.CentreLeft,
+                                    Text = title.ToUpperInvariant(),
+                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                                    Padding = new MarginPadding { Left = ContentPadding.Left, Right = 24 },
+                                },
+                                expandButton = new IconButton
+                                {
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.CentreRight,
+                                    Position = new Vector2(-(ContentPadding.Right + 5), 0),
+                                    Icon = FontAwesome.Solid.Bars,
+                                    Scale = new Vector2(0.65f),
+                                    Action = () => Expanded.Toggle(),
+                                },
+                            }
+                        },
+                        content
+                    }
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inputManager = GetContainingInputManager()!;
+
+            Expanded.BindValueChanged(_ => updateExpandedState(true));
+            updateExpandedState(false);
+
+            this.Delay(600).Schedule(updateFadeState);
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateFadeState();
+            updateExpandedState(true);
+            return false;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            updateFadeState();
+            updateExpandedState(true);
+            base.OnHoverLost(e);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // These toolbox grouped may be contracted to only show icons.
+            // For now, let's hide the header to avoid text truncation weirdness in such cases.
+            headerText.Alpha = (float)Interpolation.DampContinuously(headerText.Alpha, headerText.DrawWidth < DrawWidth ? 1 : 0, 40, Time.Elapsed);
+
+            // Dragged child finished its drag operation.
+            if (draggedChild != null && inputManager.DraggedDrawable != draggedChild)
+            {
+                draggedChild = null;
+                updateExpandedState(true);
+            }
+        }
+
+        private void updateExpandedState(bool animate)
+        {
+            // before we collapse down, let's double check the user is not dragging a UI control contained within us.
+            if (inputManager.DraggedDrawable.IsRootedAt(this))
+            {
+                draggedChild = inputManager.DraggedDrawable;
+            }
+
+            // clearing transforms is necessary to avoid a previous height transform
+            // potentially continuing to get processed while content has changed to autosize.
+            content.ClearTransforms();
+
+            if (Expanded.Value || IsHovered || draggedChild != null)
+            {
+                content.AutoSizeAxes = Axes.Y;
+                content.AutoSizeDuration = animate ? transition_duration : 0;
+                content.AutoSizeEasing = Easing.OutQuint;
+            }
+            else
+            {
+                content.AutoSizeAxes = Axes.None;
+                content.ResizeHeightTo(0, animate ? transition_duration : 0, Easing.OutQuint);
+            }
+
+            headerContent.FadeColour(Expanded.Value ? Color4.White : OsuColour.Gray(0.7f), 200, Easing.OutQuint);
+        }
+
+        private void updateFadeState()
+        {
+            const float fade_duration = 500;
+
+            background.FadeTo(IsHovered ? 1 : 0.1f, fade_duration, Easing.OutQuint);
+            expandButton.FadeTo(IsHovered ? 1 : 0, fade_duration, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -66,6 +66,11 @@ namespace osu.Game.Rulesets.Edit
         [Resolved(canBeNull: true)]
         private IExpandingContainer? expandingContainer { get; set; }
 
+        public ExpandableButton()
+        {
+            Height = 30;
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -83,7 +88,7 @@ namespace osu.Game.Rulesets.Edit
                 {
                     SpriteText.Anchor = Anchor.Centre;
                     SpriteText.Origin = Anchor.Centre;
-                    SpriteText.Font = OsuFont.GetFont(weight: FontWeight.Bold);
+                    SpriteText.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold);
                     base.Height = actualHeight;
                     Background.Show();
                     Triangles?.Show();
@@ -92,7 +97,7 @@ namespace osu.Game.Rulesets.Edit
                 {
                     SpriteText.Anchor = Anchor.CentreLeft;
                     SpriteText.Origin = Anchor.CentreLeft;
-                    SpriteText.Font = OsuFont.GetFont(weight: FontWeight.Regular);
+                    SpriteText.Font = OsuFont.Style.Caption2;
                     base.Height = actualHeight / 2;
                     Background.Hide();
                     Triangles?.Hide();

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -5,9 +5,11 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Screens.Edit;
+using FontWeight = osu.Game.Graphics.FontWeight;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -88,7 +90,7 @@ namespace osu.Game.Rulesets.Edit
                 {
                     SpriteText.Anchor = Anchor.Centre;
                     SpriteText.Origin = Anchor.Centre;
-                    SpriteText.Font = Editor.Fonts.Default;
+                    SpriteText.Font = Editor.Fonts.Default.With(weight: FontWeight.Bold);
                     base.Height = actualHeight;
                     Background.Show();
                     Triangles?.Show();

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Screens.Edit;
@@ -89,7 +88,7 @@ namespace osu.Game.Rulesets.Edit
                 {
                     SpriteText.Anchor = Anchor.Centre;
                     SpriteText.Origin = Anchor.Centre;
-                    SpriteText.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold);
+                    SpriteText.Font = Editor.Fonts.Default;
                     base.Height = actualHeight;
                     Background.Show();
                     Triangles?.Show();
@@ -98,7 +97,7 @@ namespace osu.Game.Rulesets.Edit
                 {
                     SpriteText.Anchor = Anchor.CentreLeft;
                     SpriteText.Origin = Anchor.CentreLeft;
-                    SpriteText.Font = OsuFont.Style.Caption2;
+                    SpriteText.Font = Editor.Fonts.Default;
                     base.Height = actualHeight / 2;
                     Background.Hide();
                     Triangles?.Hide();

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -68,7 +69,7 @@ namespace osu.Game.Rulesets.Edit
 
         public ExpandableButton()
         {
-            Height = 30;
+            Height = Editor.BUTTON_HEIGHT;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -19,7 +19,6 @@ using osu.Framework.Logging;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Edit.Tools;
@@ -208,7 +207,7 @@ namespace osu.Game.Rulesets.Edit
                                                         X = 0.25f,
                                                         Origin = Anchor.TopCentre,
                                                         Anchor = Anchor.TopLeft,
-                                                        Font = OsuFont.Style.Caption1,
+                                                        Font = Editor.Fonts.Default,
                                                     },
                                                     new ExpandableSpriteText
                                                     {
@@ -219,7 +218,7 @@ namespace osu.Game.Rulesets.Edit
                                                         X = 0.75f,
                                                         Origin = Anchor.TopCentre,
                                                         Anchor = Anchor.TopLeft,
-                                                        Font = OsuFont.Style.Caption1,
+                                                        Font = Editor.Fonts.Default,
                                                     },
                                                 }
                                             },

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Rulesets.Edit
                             Colour = colourProvider.Background5,
                             RelativeSizeAxes = Axes.Both,
                         },
-                        LeftToolbox = new ExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_LEFT, 160)
+                        LeftToolbox = new ExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_LEFT, 170)
                         {
                             Children = new Drawable[]
                             {

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -247,7 +247,7 @@ namespace osu.Game.Rulesets.Edit
                             Colour = colourProvider.Background5,
                             RelativeSizeAxes = Axes.Both,
                         },
-                        RightToolbox = new ExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_RIGHT, 250)
+                        RightToolbox = new ExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_RIGHT, 180)
                         {
                             Child = new EditorToolboxGroup("inspector")
                             {
@@ -577,7 +577,7 @@ namespace osu.Game.Rulesets.Edit
     public abstract partial class HitObjectComposer : CompositeDrawable
     {
         public const float TOOLBOX_CONTRACTED_SIZE_LEFT = 60;
-        public const float TOOLBOX_CONTRACTED_SIZE_RIGHT = 120;
+        public const float TOOLBOX_CONTRACTED_SIZE_RIGHT = 100;
 
         public readonly Ruleset Ruleset;
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -168,12 +168,12 @@ namespace osu.Game.Rulesets.Edit
                             {
                                 new EditorToolboxGroup("toolbox (1-9)")
                                 {
-                                    ContentPadding = new MarginPadding(5),
+                                    ContentPadding = new MarginPadding(TOOLBAR_PADDING),
                                     Child = toolboxCollection = new EditorRadioButtonCollection { RelativeSizeAxes = Axes.X },
                                 },
                                 new EditorToolboxGroup("toggles (Q~P)")
                                 {
-                                    ContentPadding = new MarginPadding(5),
+                                    ContentPadding = new MarginPadding(TOOLBAR_PADDING),
                                     Child = togglesCollection = new FillFlowContainer
                                     {
                                         RelativeSizeAxes = Axes.X,
@@ -184,7 +184,7 @@ namespace osu.Game.Rulesets.Edit
                                 },
                                 new EditorToolboxGroup("bank (Shift/Alt-Q~R)")
                                 {
-                                    ContentPadding = new MarginPadding(5),
+                                    ContentPadding = new MarginPadding(TOOLBAR_PADDING),
                                     Child = new FillFlowContainer
                                     {
                                         RelativeSizeAxes = Axes.X,
@@ -579,7 +579,8 @@ namespace osu.Game.Rulesets.Edit
     [Cached]
     public abstract partial class HitObjectComposer : CompositeDrawable
     {
-        public const float TOOLBOX_CONTRACTED_SIZE_LEFT = 40;
+        public const float TOOLBAR_PADDING = 5;
+        public const float TOOLBOX_CONTRACTED_SIZE_LEFT = Editor.BUTTON_HEIGHT + TOOLBAR_PADDING * 2;
         public const float TOOLBOX_CONTRACTED_SIZE_RIGHT = 100;
 
         public readonly Ruleset Ruleset;

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -162,16 +162,18 @@ namespace osu.Game.Rulesets.Edit
                             Colour = colourProvider.Background5,
                             RelativeSizeAxes = Axes.Both,
                         },
-                        LeftToolbox = new ExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_LEFT, 200)
+                        LeftToolbox = new ExpandingToolboxContainer(TOOLBOX_CONTRACTED_SIZE_LEFT, 160)
                         {
                             Children = new Drawable[]
                             {
                                 new EditorToolboxGroup("toolbox (1-9)")
                                 {
-                                    Child = toolboxCollection = new EditorRadioButtonCollection { RelativeSizeAxes = Axes.X }
+                                    ContentPadding = new MarginPadding(5),
+                                    Child = toolboxCollection = new EditorRadioButtonCollection { RelativeSizeAxes = Axes.X },
                                 },
                                 new EditorToolboxGroup("toggles (Q~P)")
                                 {
+                                    ContentPadding = new MarginPadding(5),
                                     Child = togglesCollection = new FillFlowContainer
                                     {
                                         RelativeSizeAxes = Axes.X,
@@ -182,6 +184,7 @@ namespace osu.Game.Rulesets.Edit
                                 },
                                 new EditorToolboxGroup("bank (Shift/Alt-Q~R)")
                                 {
+                                    ContentPadding = new MarginPadding(5),
                                     Child = new FillFlowContainer
                                     {
                                         RelativeSizeAxes = Axes.X,
@@ -205,7 +208,7 @@ namespace osu.Game.Rulesets.Edit
                                                         X = 0.25f,
                                                         Origin = Anchor.TopCentre,
                                                         Anchor = Anchor.TopLeft,
-                                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 17),
+                                                        Font = OsuFont.Style.Caption1,
                                                     },
                                                     new ExpandableSpriteText
                                                     {
@@ -216,7 +219,7 @@ namespace osu.Game.Rulesets.Edit
                                                         X = 0.75f,
                                                         Origin = Anchor.TopCentre,
                                                         Anchor = Anchor.TopLeft,
-                                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 17),
+                                                        Font = OsuFont.Style.Caption1,
                                                     },
                                                 }
                                             },
@@ -576,7 +579,7 @@ namespace osu.Game.Rulesets.Edit
     [Cached]
     public abstract partial class HitObjectComposer : CompositeDrawable
     {
-        public const float TOOLBOX_CONTRACTED_SIZE_LEFT = 60;
+        public const float TOOLBOX_CONTRACTED_SIZE_LEFT = 40;
         public const float TOOLBOX_CONTRACTED_SIZE_RIGHT = 100;
 
         public readonly Ruleset Ruleset;

--- a/osu.Game/Screens/Edit/Components/EditorToolButton.cs
+++ b/osu.Game/Screens/Edit/Components/EditorToolButton.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -95,7 +94,7 @@ namespace osu.Game.Screens.Edit.Components
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
             X = Editor.BUTTON_HEIGHT,
-            Font = OsuFont.Style.Caption2
+            Font = Editor.Fonts.Default,
         };
 
         public Popover? GetPopover() => Enabled.Value

--- a/osu.Game/Screens/Edit/Components/EditorToolButton.cs
+++ b/osu.Game/Screens/Edit/Components/EditorToolButton.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Screens.Edit.Components
             this.createPopover = createPopover;
 
             RelativeSizeAxes = Axes.X;
-            Height = 30;
+            Height = Editor.BUTTON_HEIGHT;
 
-            Content.CornerRadius = 3;
+            Content.CornerRadius = Editor.BUTTON_CORNER_RADIUS;
         }
 
         [BackgroundDependencyLoader]
@@ -61,8 +61,8 @@ namespace osu.Game.Screens.Edit.Components
                 b.Blending = BlendingParameters.Additive;
                 b.Anchor = Anchor.CentreLeft;
                 b.Origin = Anchor.CentreLeft;
-                b.Size = new Vector2(14);
-                b.X = 8;
+                b.Size = new Vector2(Editor.BUTTON_ICON_SIZE);
+                b.X = (Editor.BUTTON_HEIGHT - Editor.BUTTON_ICON_SIZE) / 2;
             }));
 
             Action = Selected.Toggle;
@@ -94,7 +94,7 @@ namespace osu.Game.Screens.Edit.Components
             Depth = -1,
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
-            X = 30f,
+            X = Editor.BUTTON_HEIGHT,
             Font = OsuFont.Style.Caption2
         };
 

--- a/osu.Game/Screens/Edit/Components/EditorToolButton.cs
+++ b/osu.Game/Screens/Edit/Components/EditorToolButton.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -41,6 +42,9 @@ namespace osu.Game.Screens.Edit.Components
             this.createPopover = createPopover;
 
             RelativeSizeAxes = Axes.X;
+            Height = 30;
+
+            Content.CornerRadius = 3;
         }
 
         [BackgroundDependencyLoader]
@@ -57,8 +61,8 @@ namespace osu.Game.Screens.Edit.Components
                 b.Blending = BlendingParameters.Additive;
                 b.Anchor = Anchor.CentreLeft;
                 b.Origin = Anchor.CentreLeft;
-                b.Size = new Vector2(20);
-                b.X = 10;
+                b.Size = new Vector2(14);
+                b.X = 8;
             }));
 
             Action = Selected.Toggle;
@@ -90,7 +94,8 @@ namespace osu.Game.Screens.Edit.Components
             Depth = -1,
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
-            X = 40f
+            X = 30f,
+            Font = OsuFont.Style.Caption2
         };
 
         public Popover? GetPopover() => Enabled.Value

--- a/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
+++ b/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
             Action = button.Select;
 
             RelativeSizeAxes = Axes.X;
-            Height = 30;
+            Height = Editor.BUTTON_HEIGHT;
 
-            Content.CornerRadius = 3;
+            Content.CornerRadius = Editor.BUTTON_CORNER_RADIUS;
         }
 
         [BackgroundDependencyLoader]
@@ -61,8 +61,8 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
                 b.Blending = BlendingParameters.Additive;
                 b.Anchor = Anchor.CentreLeft;
                 b.Origin = Anchor.CentreLeft;
-                b.Size = new Vector2(14);
-                b.X = 8;
+                b.Size = new Vector2(Editor.BUTTON_ICON_SIZE);
+                b.X = (Editor.BUTTON_HEIGHT - Editor.BUTTON_ICON_SIZE) / 2;
             }));
         }
 
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
             Depth = -1,
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
-            X = 30f,
+            X = Editor.BUTTON_HEIGHT,
             Font = OsuFont.Style.Caption2,
         };
 

--- a/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
+++ b/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -41,6 +42,9 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
             Action = button.Select;
 
             RelativeSizeAxes = Axes.X;
+            Height = 30;
+
+            Content.CornerRadius = 3;
         }
 
         [BackgroundDependencyLoader]
@@ -57,8 +61,8 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
                 b.Blending = BlendingParameters.Additive;
                 b.Anchor = Anchor.CentreLeft;
                 b.Origin = Anchor.CentreLeft;
-                b.Size = new Vector2(20);
-                b.X = 10;
+                b.Size = new Vector2(14);
+                b.X = 8;
             }));
         }
 
@@ -91,7 +95,8 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
             Depth = -1,
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
-            X = 40f
+            X = 30f,
+            Font = OsuFont.Style.Caption2,
         };
 
         public LocalisableString TooltipText => Button.TooltipText;

--- a/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
+++ b/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -96,7 +95,7 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
             X = Editor.BUTTON_HEIGHT,
-            Font = OsuFont.Style.Caption2,
+            Font = Editor.Fonts.Default,
         };
 
         public LocalisableString TooltipText => Button.TooltipText;

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
@@ -53,8 +53,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
         public DrawableTernaryButton()
         {
             RelativeSizeAxes = Axes.X;
-            Height = 30;
-            Content.CornerRadius = 3;
+            Height = Editor.BUTTON_HEIGHT;
+            Content.CornerRadius = Editor.BUTTON_CORNER_RADIUS;
         }
 
         [BackgroundDependencyLoader]
@@ -71,8 +71,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 b.Blending = BlendingParameters.Additive;
                 b.Anchor = Anchor.CentreLeft;
                 b.Origin = Anchor.CentreLeft;
-                b.Size = new Vector2(14);
-                b.X = 8;
+                b.Size = new Vector2(Editor.BUTTON_ICON_SIZE);
+                b.X = (Editor.BUTTON_HEIGHT - Editor.BUTTON_ICON_SIZE) / 2;
             }));
         }
 
@@ -137,7 +137,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             Depth = -1,
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
-            X = 30f,
+            X = Editor.BUTTON_HEIGHT,
             Font = OsuFont.Style.Caption2,
         };
     }

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -52,6 +53,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
         public DrawableTernaryButton()
         {
             RelativeSizeAxes = Axes.X;
+            Height = 30;
+            Content.CornerRadius = 3;
         }
 
         [BackgroundDependencyLoader]
@@ -68,8 +71,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 b.Blending = BlendingParameters.Additive;
                 b.Anchor = Anchor.CentreLeft;
                 b.Origin = Anchor.CentreLeft;
-                b.Size = new Vector2(20);
-                b.X = 10;
+                b.Size = new Vector2(14);
+                b.X = 8;
             }));
         }
 
@@ -134,7 +137,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             Depth = -1,
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
-            X = 40f
+            X = 30f,
+            Font = OsuFont.Style.Caption2,
         };
     }
 }

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -138,7 +137,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
             X = Editor.BUTTON_HEIGHT,
-            Font = OsuFont.Style.Caption2,
+            Font = Editor.Fonts.Default,
         };
     }
 }

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 },
                 pickerButton = new ColourPickerButton
                 {
-                    Height = 30,
+                    Height = Editor.BUTTON_HEIGHT,
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
                     ComboColours = { BindTarget = comboColours }
@@ -93,6 +93,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 
         private void updateState()
         {
+            const float icon_offset = (Editor.BUTTON_HEIGHT - Editor.BUTTON_ICON_SIZE) / 2;
+
             if (Current.Value == TernaryState.True && selectedHitObjects.Count == 1 && selectedHitObjects.Single() is IHasComboInformation hasCombo && comboColours.Count > 1)
             {
                 float targetPickerButtonWidth = expanded.Value ? 25 : 7;
@@ -102,14 +104,14 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 pickerButton.Icon.Alpha = expanded.Value ? 1 : 0;
 
                 mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding { Right = targetPickerButtonWidth + 3 }, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
-                mainButton.Icon.MoveToX(expanded.Value ? 8 : 3f, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
+                mainButton.Icon.MoveToX(expanded.Value ? icon_offset / 2 : 3f, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
             }
             else
             {
                 pickerButton.ResizeWidthTo(0, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
 
                 mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding(), ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
-                mainButton.Icon.MoveToX(8, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
+                mainButton.Icon.MoveToX(icon_offset, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
             }
         }
 
@@ -129,12 +131,12 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             [BackgroundDependencyLoader]
             private void load()
             {
-                Content.CornerRadius = 3;
+                Content.CornerRadius = Editor.BUTTON_CORNER_RADIUS;
 
                 Add(Icon = new SpriteIcon
                 {
                     Icon = FontAwesome.Solid.Palette,
-                    Size = new Vector2(16),
+                    Size = new Vector2(Editor.BUTTON_ICON_SIZE),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 });

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
@@ -93,18 +93,24 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 
         private void updateState()
         {
+            const float button_spacing = 3;
+            const float target_picker_button_width_expanded = 25;
+            const float target_picker_button_width_collapsed = 7;
+
             const float icon_offset = (Editor.BUTTON_HEIGHT - Editor.BUTTON_ICON_SIZE) / 2;
+            const float icon_offset_collapsed = (Editor.BUTTON_HEIGHT - Editor.BUTTON_ICON_SIZE - target_picker_button_width_collapsed - button_spacing) / 2;
 
             if (Current.Value == TernaryState.True && selectedHitObjects.Count == 1 && selectedHitObjects.Single() is IHasComboInformation hasCombo && comboColours.Count > 1)
             {
-                float targetPickerButtonWidth = expanded.Value ? 25 : 7;
+                float targetPickerButtonWidth = expanded.Value ? target_picker_button_width_expanded : target_picker_button_width_collapsed;
 
                 pickerButton.ResizeWidthTo(targetPickerButtonWidth, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
                 pickerButton.SelectedHitObject.Value = hasCombo;
                 pickerButton.Icon.Alpha = expanded.Value ? 1 : 0;
 
-                mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding { Right = targetPickerButtonWidth + 3 }, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
-                mainButton.Icon.MoveToX(expanded.Value ? icon_offset / 2 : 3f, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
+                mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding { Right = targetPickerButtonWidth + button_spacing }, ExpandingContainer.TRANSITION_DURATION,
+                    Easing.OutQuint);
+                mainButton.Icon.MoveToX(expanded.Value ? icon_offset : icon_offset_collapsed, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
             }
             else
             {

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 },
                 pickerButton = new ColourPickerButton
                 {
+                    Height = 30,
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
                     ComboColours = { BindTarget = comboColours }
@@ -94,21 +95,21 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
         {
             if (Current.Value == TernaryState.True && selectedHitObjects.Count == 1 && selectedHitObjects.Single() is IHasComboInformation hasCombo && comboColours.Count > 1)
             {
-                float targetPickerButtonWidth = expanded.Value ? 25 : 10;
+                float targetPickerButtonWidth = expanded.Value ? 25 : 7;
 
                 pickerButton.ResizeWidthTo(targetPickerButtonWidth, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
                 pickerButton.SelectedHitObject.Value = hasCombo;
                 pickerButton.Icon.Alpha = expanded.Value ? 1 : 0;
 
-                mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding { Right = targetPickerButtonWidth + 5 }, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
-                mainButton.Icon.MoveToX(expanded.Value ? 10 : 2.5f, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
+                mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding { Right = targetPickerButtonWidth + 3 }, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
+                mainButton.Icon.MoveToX(expanded.Value ? 8 : 3f, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
             }
             else
             {
                 pickerButton.ResizeWidthTo(0, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
 
                 mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding(), ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
-                mainButton.Icon.MoveToX(10, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
+                mainButton.Icon.MoveToX(8, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
             }
         }
 
@@ -128,6 +129,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             [BackgroundDependencyLoader]
             private void load()
             {
+                Content.CornerRadius = 3;
+
                 Add(Icon = new SpriteIcon
                 {
                     Icon = FontAwesome.Solid.Palette,

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 
@@ -77,7 +78,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             {
                 Content.Masking = false;
                 Content.CornerRadius = 0;
-                Icon.X = 4.5f;
+                Icon.X = 4f;
             }
 
             protected override SpriteText CreateText() => new ExpandableSpriteText
@@ -85,7 +86,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 Depth = -1,
                 Origin = Anchor.CentreLeft,
                 Anchor = Anchor.CentreLeft,
-                X = 31f
+                X = 18f,
+                Font = OsuFont.Style.Caption2,
             };
         }
     }

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 
@@ -87,7 +86,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 Origin = Anchor.CentreLeft,
                 Anchor = Anchor.CentreLeft,
                 X = 18f,
-                Font = OsuFont.Style.Caption2,
+                Font = Editor.Fonts.Default,
             };
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -220,7 +220,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                Font = Editor.Fonts.Heading,
                 Text = $"{char.ToUpperInvariant(sampleName.First())}"
             };
         }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -221,7 +221,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Y = -1,
-                Font = OsuFont.Default.With(weight: FontWeight.Bold, size: 20),
+                Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
                 Text = $"{char.ToUpperInvariant(sampleName.First())}"
             };
         }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -220,7 +220,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Y = -1,
                 Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
                 Text = $"{char.ToUpperInvariant(sampleName.First())}"
             };

--- a/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
 
-            InternalChild = InspectorText = new OsuTextFlowContainer(d => d.Font = OsuFont.Style.Caption2)
+            InternalChild = InspectorText = new OsuTextFlowContainer(d => d.Font = Editor.Fonts.Default)
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
 
-            InternalChild = InspectorText = new OsuTextFlowContainer
+            InternalChild = InspectorText = new OsuTextFlowContainer(d => d.Font = OsuFont.Style.Caption2)
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
+                ParagraphSpacing = 0.1f,
             };
         }
 

--- a/osu.Game/Screens/Edit/Editor_UIConstants.cs
+++ b/osu.Game/Screens/Edit/Editor_UIConstants.cs
@@ -1,12 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+
 namespace osu.Game.Screens.Edit
 {
     public partial class Editor
     {
-        public const float BUTTON_HEIGHT = 30;
+        public const float BUTTON_HEIGHT = 32;
         public const float BUTTON_CORNER_RADIUS = 3;
-        public const float BUTTON_ICON_SIZE = 14;
+        public const float BUTTON_ICON_SIZE = 16;
+
+        public static class Fonts
+        {
+            public static FontUsage Default => OsuFont.GetFont(size: 13.5f, weight: FontWeight.Regular);
+
+            public static FontUsage Heading => OsuFont.GetFont(size: 15, weight: FontWeight.Bold);
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Editor_UIConstants.cs
+++ b/osu.Game/Screens/Edit/Editor_UIConstants.cs
@@ -14,9 +14,9 @@ namespace osu.Game.Screens.Edit
 
         public static class Fonts
         {
-            public static FontUsage Default => OsuFont.GetFont(size: 13.5f, weight: FontWeight.Regular);
+            public static FontUsage Default => OsuFont.Style.Caption1;
 
-            public static FontUsage Heading => OsuFont.GetFont(size: 15, weight: FontWeight.Bold);
+            public static FontUsage Heading => OsuFont.Style.Body.With(weight: FontWeight.Bold);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Editor_UIConstants.cs
+++ b/osu.Game/Screens/Edit/Editor_UIConstants.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Screens.Edit
+{
+    public partial class Editor
+    {
+        public const float BUTTON_HEIGHT = 30;
+        public const float BUTTON_CORNER_RADIUS = 3;
+        public const float BUTTON_ICON_SIZE = 14;
+    }
+}


### PR DESCRIPTION
RFC
Relevant discussion can be found on [discord](https://discord.com/channels/188630481301012481/188630652340404224/1389928628686422037).

Opening as draft for now since there's no agreed upon scaling yet, the main purpose for now is to figure out what size things should actually be.

Only adjusted the scale of the sidebars for now to keep the changeset small. Gut feeling tells me the scale might be a bit too small for some people (especially at 0.8x UI Scale). I mostly picked values based on 2 things:
- As mentioned in the discussion on discord above, the goal is to bring scaling in the editor more in line with other desktop software
- To keep things balanced in relation to `OsuFont.Style.Caption1` and `OsuFont.Style.Caption2` font sizes.

Any feedback regarding the UI scale, especially from mappers, is very welcome.

|                       | Expanded Sidebars                                                                                           | Contracted Sidebars                                                                                         |
|-----------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| Before (1x UI Scale)  | ![osu_2025-07-02_22-00-54](https://github.com/user-attachments/assets/37826522-4f18-49e6-a65f-60ddb0247f01) | ![osu_2025-07-02_21-36-42](https://github.com/user-attachments/assets/9e11e89b-3db6-4d44-b315-d12112433a16) |
| After (1x UI Scale)   | ![osu_2025-07-02_21-37-49](https://github.com/user-attachments/assets/b56aeef6-ef39-40b8-9829-83b42b947fad) | ![osu_2025-07-02_21-37-53](https://github.com/user-attachments/assets/9be3c345-dd38-4b1a-bf54-c2306a7eae15) |
| After (0.8x UI Scale) | ![osu_2025-07-02_21-38-32](https://github.com/user-attachments/assets/2e0e1f9e-cd81-4058-a52c-fbadd4fcb89b) | ![osu_2025-07-02_21-38-47](https://github.com/user-attachments/assets/d1885b2d-06c1-4f85-bc25-4d8c9403d100) |

