### PR TITLE
Fix skins containing subdirectories breaking on external edit on windows

### DIFF
--- a/osu.Game/Database/ModelManager.cs
+++ b/osu.Game/Database/ModelManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
@@ -85,6 +86,7 @@ namespace osu.Game.Database
         /// </summary>
         public void AddFile(TModel item, Stream contents, string filename, Realm realm)
         {
+            filename = filename.ToStandardisedPath();
             var existing = item.GetFile(filename);
 
             if (existing != null)


### PR DESCRIPTION
For anyone who broke their skins because of this, this change also allows them to be retroactively fixed by starting an external edit operation and immediately finishing it (you don't need to make any changes to the skin files).

---

Closes https://github.com/ppy/osu/issues/33994.

The reason for the breakage is that `Directory.EnumerateFiles()` used in

https://github.com/ppy/osu/blob/b1435d35e56eed08a57d1909fa0b16e67bd9c2a2/osu.Game/Skinning/SkinImporter.cs#L63

will use the primary platform directory separator character, which is `\` on windows and `/` on unices. The internal realm storage structure is expecting paths to be normalised to the unix convention, which is evident in

https://github.com/ppy/osu/blob/b1435d35e56eed08a57d1909fa0b16e67bd9c2a2/osu.Game/Database/RealmArchiveModelImporter.cs#L499

on the write side and in

https://github.com/ppy/osu/blob/b1435d35e56eed08a57d1909fa0b16e67bd9c2a2/osu.Game/Skinning/RealmBackedResourceStore.cs#L50

on the read side.

Rather than applying this locally to the skin importer I kinda think it's better to have this call in `ModelManager` to hopefully avoid future footgunnage of this kind.