### PR TITLE
Display user avatar and content in chat notifications, also display avatar in friend presence notifications

### DIFF
--- a/osu.Game.Tests/Online/Chat/MessageNotifierTest.cs
+++ b/osu.Game.Tests/Online/Chat/MessageNotifierTest.cs
@@ -12,79 +12,79 @@ namespace osu.Game.Tests.Online.Chat
         [Test]
         public void TestContainsUsernameMidlinePositive()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("This is a test message", "Test"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("This is a test message", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameStartOfLinePositive()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("Test message", "Test"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("Test message", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameEndOfLinePositive()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("This is a test", "Test"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("This is a test", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameMidlineNegative()
         {
-            Assert.IsFalse(MessageNotifier.CheckContainsUsername("This is a testmessage for notifications", "Test"));
+            Assert.IsFalse(MessageNotifier.MatchUsername("This is a testmessage for notifications", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameStartOfLineNegative()
         {
-            Assert.IsFalse(MessageNotifier.CheckContainsUsername("Testmessage", "Test"));
+            Assert.IsFalse(MessageNotifier.MatchUsername("Testmessage", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameEndOfLineNegative()
         {
-            Assert.IsFalse(MessageNotifier.CheckContainsUsername("This is a notificationtest", "Test"));
+            Assert.IsFalse(MessageNotifier.MatchUsername("This is a notificationtest", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameBetweenPunctuation()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("Hello 'test'-message", "Test"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("Hello 'test'-message", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameUnicode()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("Test \u0460\u0460 message", "\u0460\u0460"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("Test \u0460\u0460 message", "\u0460\u0460").Success);
         }
 
         [Test]
         public void TestContainsUsernameUnicodeNegative()
         {
-            Assert.IsFalse(MessageNotifier.CheckContainsUsername("Test ha\u0460\u0460o message", "\u0460\u0460"));
+            Assert.IsFalse(MessageNotifier.MatchUsername("Test ha\u0460\u0460o message", "\u0460\u0460").Success);
         }
 
         [Test]
         public void TestContainsUsernameSpecialCharactersPositive()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("Test [#^-^#] message", "[#^-^#]"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("Test [#^-^#] message", "[#^-^#]").Success);
         }
 
         [Test]
         public void TestContainsUsernameSpecialCharactersNegative()
         {
-            Assert.IsFalse(MessageNotifier.CheckContainsUsername("Test pad[#^-^#]oru message", "[#^-^#]"));
+            Assert.IsFalse(MessageNotifier.MatchUsername("Test pad[#^-^#]oru message", "[#^-^#]").Success);
         }
 
         [Test]
         public void TestContainsUsernameAtSign()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("@username hi", "username"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("@username hi", "username").Success);
         }
 
         [Test]
         public void TestContainsUsernameColon()
         {
-            Assert.IsTrue(MessageNotifier.CheckContainsUsername("username: hi", "username"));
+            Assert.IsTrue(MessageNotifier.MatchUsername("username: hi", "username").Success);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
@@ -40,8 +40,8 @@ namespace osu.Game.Tests.Visual.Online
                 daa.HandleRequest = dummyAPIHandleRequest;
             }
 
-            friend = new APIUser { Id = 0, Username = "Friend" };
-            publicChannel = new Channel { Id = 1, Name = "osu" };
+            friend = new APIUser { Id = 0, Username = "SomeFriend" };
+            publicChannel = new Channel { Id = 1, Name = "#osu" };
             privateMessageChannel = new Channel(friend) { Id = 2, Name = friend.Username, Type = ChannelType.PM };
 
             Schedule(() =>

--- a/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
@@ -94,6 +94,17 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
+        public void TestLongMessages()
+        {
+            AddStep("close overlay", () => testContainer.ChatOverlay.Hide());
+
+            AddStep("long public", () => receiveMessage(friend, publicChannel, $"For some reason there were no tests testing very long messages, even though there should have been. Why {API.LocalUser.Value.Username} why?"));
+
+            AddStep("long private",
+                () => receiveMessage(friend, privateMessageChannel, "For no good reason, we were not testing very long messages and how the notifications display when the message can't fit"));
+        }
+
+        [Test]
         public void TestPublicChannelMention()
         {
             AddStep("switch to PMs", () => testContainer.ChannelManager.CurrentChannel.Value = privateMessageChannel);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -65,7 +64,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep(@"simple #2", sendAmazingNotification);
             AddStep(@"progress #1", sendUploadProgress);
             AddStep(@"progress #2", sendDownloadProgress);
-            AddStep(@"User notification", sendUserNotification);
 
             checkProgressingCount(2);
 
@@ -575,16 +573,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             };
             notificationOverlay.Post(n);
             progressingNotifications.Add(n);
-        }
-
-        private void sendUserNotification()
-        {
-            var user = userLookupCache.GetUserAsync(0).GetResultSafely();
-            if (user == null) return;
-
-            var n = new UserAvatarNotification(user, $"{user.Username} invited you to a multiplayer match!");
-
-            notificationOverlay.Post(n);
         }
 
         private void sendUploadProgress()

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -130,6 +130,11 @@ Click to see what's new!", version);
         /// </summary>
         public static LocalisableString MultiplayerRoomEnded => new TranslatableString(getKey(@"multiplayer_room_ended"), @"This multiplayer room has ended. Click to display room results.");
 
+        /// <summary>
+        /// "Mentioned in {0}"
+        /// </summary>
+        public static LocalisableString MentionedInChannel(string channel) => new TranslatableString(getKey(@"mentioned_in_channel"), @"Mentioned in {0}", channel);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -131,9 +131,9 @@ Click to see what's new!", version);
         public static LocalisableString MultiplayerRoomEnded => new TranslatableString(getKey(@"multiplayer_room_ended"), @"This multiplayer room has ended. Click to display room results.");
 
         /// <summary>
-        /// "Mentioned in {0}"
+        /// "Mention"
         /// </summary>
-        public static LocalisableString MentionedInChannel(string channel) => new TranslatableString(getKey(@"mentioned_in_channel"), @"Mentioned in {0}", channel);
+        public static LocalisableString Mention => new TranslatableString(getKey(@"mention"), @"Mention");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -84,16 +84,6 @@ Please try changing your audio device to a working setting.");
         public static LocalisableString LinkTypeNotSupported => new TranslatableString(getKey(@"unsupported_link_type"), @"This link type is not yet supported!");
 
         /// <summary>
-        /// "You received a private message from &#39;{0}&#39;. Click to read it!"
-        /// </summary>
-        public static LocalisableString PrivateMessageReceived(string username) => new TranslatableString(getKey(@"private_message_received"), @"You received a private message from '{0}'. Click to read it!", username);
-
-        /// <summary>
-        /// "Your name was mentioned in chat by &#39;{0}&#39;. Click to find out why!"
-        /// </summary>
-        public static LocalisableString YourNameWasMentioned(string username) => new TranslatableString(getKey(@"your_name_was_mentioned"), @"Your name was mentioned in chat by '{0}'. Click to find out why!", username);
-
-        /// <summary>
         /// "{0} invited you to the multiplayer match &quot;{1}&quot;! Click to join."
         /// </summary>
         public static LocalisableString InvitedYouToTheMultiplayer(string username, string roomName) => new TranslatableString(getKey(@"invited_you_to_the_multiplayer"), @"{0} invited you to the multiplayer match ""{1}""! Click to join.", username, roomName);

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -158,6 +159,8 @@ namespace osu.Game.Online.Chat
             return Regex.Match(message, $@"(^|\W)({fullName}|{underscoreName})($|\W)", RegexOptions.IgnoreCase);
         }
 
+        private const int truncate_length = 60;
+
         public partial class PrivateMessageNotification : UserAvatarNotification
         {
             private readonly Message message;
@@ -173,20 +176,14 @@ namespace osu.Game.Online.Chat
             [BackgroundDependencyLoader]
             private void load(ChatOverlay chatOverlay, INotificationOverlay notificationOverlay, OverlayColourProvider colourProvider)
             {
-                // Sane maximum height to avoid the notification becoming too tall on long messages.
-                // The height is ballparked to display two lines.
-                TextFlow.AutoSizeAxes = Axes.None;
-                TextFlow.Height = 45;
-
-                TextFlow.ParagraphSpacing = 0.25f;
-
                 TextFlow.AddText(NotificationsStrings.ItemChannelChannelDefault.ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
-                TextFlow.AddText($" – {message.Sender.Username}", s =>
+                TextFlow.NewLine();
+                TextFlow.AddText($"{message.Sender.Username}", s =>
                 {
                     s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.SemiBold);
                     s.Colour = colourProvider.Content2;
                 });
-                TextFlow.AddParagraph($"\"{message.Content}\"");
+                TextFlow.AddParagraph($"\"{message.Content.Truncate(truncate_length)}\"");
 
                 Avatar.Colour = OsuColour.Gray(0.4f);
                 Icon = FontAwesome.Solid.Comments;
@@ -219,15 +216,9 @@ namespace osu.Game.Online.Chat
             [BackgroundDependencyLoader]
             private void load(ChatOverlay chatOverlay, INotificationOverlay notificationOverlay, OverlayColourProvider colourProvider)
             {
-                // Sane maximum height to avoid the notification becoming too tall on long messages.
-                // The height is ballparked to display two lines.
-                TextFlow.AutoSizeAxes = Axes.None;
-                TextFlow.Height = 45;
-
-                TextFlow.ParagraphSpacing = 0.25f;
-
-                TextFlow.AddParagraph(Localisation.NotificationsStrings.Mention.ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
-                TextFlow.AddText($" – {message.Sender.Username} in {channel.Name}", s =>
+                TextFlow.AddText(Localisation.NotificationsStrings.Mention.ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
+                TextFlow.NewLine();
+                TextFlow.AddText($"{message.Sender.Username} in {channel.Name}", s =>
                 {
                     s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.SemiBold);
                     s.Colour = colourProvider.Content2;
@@ -236,13 +227,13 @@ namespace osu.Game.Online.Chat
                 int start = match.Index;
                 int end = match.Index + match.Length;
 
-                TextFlow.AddParagraph($"\"{message.Content[..start]}");
+                TextFlow.AddParagraph($"\"{message.Content[..start].Truncate(truncate_length / 2, "…", from: TruncateFrom.Left)}");
                 TextFlow.AddText(message.Content[start..end], s =>
                 {
                     s.Font = s.Font.With(weight: FontWeight.SemiBold);
                     s.Colour = colourProvider.Colour0;
                 });
-                TextFlow.AddText($"{message.Content[end..]}\"");
+                TextFlow.AddText($"{message.Content[end..].Truncate(truncate_length / 2, "…", from: TruncateFrom.Right)}\"");
 
                 Avatar.Colour = OsuColour.Gray(0.4f);
                 Icon = FontAwesome.Solid.At;

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -10,7 +10,9 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -18,6 +20,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Online.Chat
 {
@@ -176,8 +179,12 @@ namespace osu.Game.Online.Chat
                 TextFlow.Height = 45;
 
                 TextFlow.ParagraphSpacing = 0.25f;
-                TextFlow.AddParagraph(message.Sender.Username, s => s.Font = s.Font.With(weight: FontWeight.SemiBold));
-                TextFlow.AddParagraph(message.Content);
+
+                TextFlow.AddParagraph(NotificationsStrings.ItemChannelChannelDefault.ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
+                TextFlow.AddParagraph(NotificationsStrings.ItemChannelChannelPmChannelMessage(message.Sender.Username, message.Content));
+
+                Avatar.Colour = OsuColour.Gray(0.4f);
+                Icon = FontAwesome.Solid.Comments;
 
                 Activated = delegate
                 {
@@ -213,14 +220,9 @@ namespace osu.Game.Online.Chat
                 TextFlow.Height = 45;
 
                 TextFlow.ParagraphSpacing = 0.25f;
-                TextFlow.AddText(message.Sender.Username, s => s.Font = s.Font.With(weight: FontWeight.SemiBold));
-                TextFlow.AddText($" in {channel.Name}", s =>
-                {
-                    s.Font = s.Font.With(weight: FontWeight.SemiBold);
-                    s.Colour = colourProvider.Content2;
-                });
 
-                TextFlow.NewParagraph();
+                TextFlow.AddParagraph(Localisation.NotificationsStrings.MentionedInChannel(channel.Name).ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
+                TextFlow.AddParagraph($"{message.Sender.Username} says \"");
 
                 int start = match.Index;
                 int end = match.Index + match.Length;
@@ -231,7 +233,10 @@ namespace osu.Game.Online.Chat
                     s.Font = s.Font.With(weight: FontWeight.SemiBold);
                     s.Colour = colourProvider.Colour0;
                 });
-                TextFlow.AddText(message.Content[end..]);
+                TextFlow.AddText(message.Content[end..] + "\"");
+
+                Avatar.Colour = OsuColour.Gray(0.4f);
+                Icon = FontAwesome.Solid.At;
 
                 Activated = delegate
                 {

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Online.Chat
             }
 
             [BackgroundDependencyLoader]
-            private void load(ChatOverlay chatOverlay, INotificationOverlay notificationOverlay)
+            private void load(ChatOverlay chatOverlay, INotificationOverlay notificationOverlay, OverlayColourProvider colourProvider)
             {
                 // Sane maximum height to avoid the notification becoming too tall on long messages.
                 // The height is ballparked to display two lines.
@@ -180,8 +180,13 @@ namespace osu.Game.Online.Chat
 
                 TextFlow.ParagraphSpacing = 0.25f;
 
-                TextFlow.AddParagraph(NotificationsStrings.ItemChannelChannelDefault.ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
-                TextFlow.AddParagraph(NotificationsStrings.ItemChannelChannelPmChannelMessage(message.Sender.Username, message.Content));
+                TextFlow.AddText(NotificationsStrings.ItemChannelChannelDefault.ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
+                TextFlow.AddText($" – {message.Sender.Username}", s =>
+                {
+                    s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.SemiBold);
+                    s.Colour = colourProvider.Content2;
+                });
+                TextFlow.AddParagraph($"\"{message.Content}\"");
 
                 Avatar.Colour = OsuColour.Gray(0.4f);
                 Icon = FontAwesome.Solid.Comments;
@@ -221,19 +226,23 @@ namespace osu.Game.Online.Chat
 
                 TextFlow.ParagraphSpacing = 0.25f;
 
-                TextFlow.AddParagraph(Localisation.NotificationsStrings.MentionedInChannel(channel.Name).ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
-                TextFlow.AddParagraph($"{message.Sender.Username} says \"");
+                TextFlow.AddParagraph(Localisation.NotificationsStrings.Mention.ToUpper(), s => s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold));
+                TextFlow.AddText($" – {message.Sender.Username} in {channel.Name}", s =>
+                {
+                    s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.SemiBold);
+                    s.Colour = colourProvider.Content2;
+                });
 
                 int start = match.Index;
                 int end = match.Index + match.Length;
 
-                TextFlow.AddText(message.Content[..start]);
+                TextFlow.AddParagraph($"\"{message.Content[..start]}");
                 TextFlow.AddText(message.Content[start..end], s =>
                 {
                     s.Font = s.Font.With(weight: FontWeight.SemiBold);
                     s.Colour = colourProvider.Colour0;
                 });
-                TextFlow.AddText(message.Content[end..] + "\"");
+                TextFlow.AddText($"{message.Content[end..]}\"");
 
                 Avatar.Colour = OsuColour.Gray(0.4f);
                 Icon = FontAwesome.Solid.At;

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Database;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
@@ -549,16 +550,14 @@ namespace osu.Game.Online.Multiplayer
 
             if (apiUser == null || apiRoom == null) return;
 
-            PostNotification?.Invoke(
-                new UserAvatarNotification(apiUser, NotificationsStrings.InvitedYouToTheMultiplayer(apiUser.Username, apiRoom.Name))
+            PostNotification?.Invoke(new MultiplayerInvitationNotification(apiUser, apiRoom)
+            {
+                Activated = () =>
                 {
-                    Activated = () =>
-                    {
-                        PresentMatch?.Invoke(apiRoom, password);
-                        return true;
-                    }
+                    PresentMatch?.Invoke(apiRoom, password);
+                    return true;
                 }
-            );
+            });
 
             Task<Room?> getRoomAsync(long id)
             {
@@ -981,6 +980,16 @@ namespace osu.Game.Online.Multiplayer
                 DisconnectInternal();
             });
             return Task.CompletedTask;
+        }
+
+        private partial class MultiplayerInvitationNotification : UserAvatarNotification
+        {
+            protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
+
+            public MultiplayerInvitationNotification(APIUser user, Room room)
+                : base(user, NotificationsStrings.InvitedYouToTheMultiplayer(user.Username, room.Name))
+            {
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -292,7 +292,7 @@ namespace osu.Game.Overlays.Chat
             // remove non-existent channels from the link list
             message.Links.RemoveAll(link => link.Action == LinkAction.OpenChannel && chatManager?.AvailableChannels.Any(c => c.Name == link.Argument.ToString()) != true);
 
-            isMention = MessageNotifier.CheckContainsUsername(message.DisplayContent, api.LocalUser.Value.Username);
+            isMention = MessageNotifier.MatchUsername(message.DisplayContent, api.LocalUser.Value.Username).Success;
 
             drawableContentFlow.Clear();
             drawableContentFlow.AddLinks(message.DisplayContent, message.Links);

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -24,8 +24,7 @@ namespace osu.Game.Overlays.Notifications
             set
             {
                 text = value;
-                if (textDrawable != null)
-                    textDrawable.Text = text;
+                TextFlow.Text = text;
             }
         }
 
@@ -37,8 +36,7 @@ namespace osu.Game.Overlays.Notifications
             set
             {
                 icon = value;
-                if (iconDrawable != null)
-                    iconDrawable.Icon = icon;
+                IconDrawable.Icon = icon;
             }
         }
 
@@ -46,39 +44,6 @@ namespace osu.Game.Overlays.Notifications
         {
             get => IconContent.Colour;
             set => IconContent.Colour = value;
-        }
-
-        private TextFlowContainer? textDrawable;
-
-        private SpriteIcon? iconDrawable;
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours, OverlayColourProvider colourProvider)
-        {
-            Light.Colour = colours.Green;
-
-            IconContent.AddRange(new Drawable[]
-            {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
-                iconDrawable = new SpriteIcon
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Icon = icon,
-                    Size = new Vector2(16),
-                }
-            });
-
-            Content.Add(textDrawable = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 14, weight: FontWeight.Medium))
-            {
-                AutoSizeAxes = Axes.Y,
-                RelativeSizeAxes = Axes.X,
-                Text = text
-            });
         }
 
         public override bool Read
@@ -91,6 +56,43 @@ namespace osu.Game.Overlays.Notifications
                 base.Read = value;
                 Light.FadeTo(value ? 0 : 1, 100);
             }
+        }
+
+        protected TextFlowContainer TextFlow { get; }
+        protected SpriteIcon IconDrawable { get; }
+
+        private readonly Box iconBackground;
+
+        public SimpleNotification()
+        {
+            IconContent.AddRange(new Drawable[]
+            {
+                iconBackground = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                IconDrawable = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = icon,
+                    Size = new Vector2(16),
+                }
+            });
+
+            Content.Add(TextFlow = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 14, weight: FontWeight.Medium))
+            {
+                AutoSizeAxes = Axes.Y,
+                RelativeSizeAxes = Axes.X,
+                Text = text
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, OverlayColourProvider colourProvider)
+        {
+            Light.Colour = colours.Green;
+            iconBackground.Colour = colourProvider.Background5;
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
+++ b/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
@@ -3,72 +3,40 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Users.Drawables;
 
 namespace osu.Game.Overlays.Notifications
 {
-    public partial class UserAvatarNotification : Notification
+    public partial class UserAvatarNotification : SimpleNotification
     {
-        private LocalisableString text;
+        private readonly APIUser? user;
 
-        public override LocalisableString Text
-        {
-            get => text;
-            set
-            {
-                text = value;
-                if (textDrawable != null)
-                    textDrawable.Text = text;
-            }
-        }
+        protected DrawableAvatar Avatar { get; private set; } = null!;
 
-        private TextFlowContainer? textDrawable;
-
-        private readonly APIUser user;
-
-        public UserAvatarNotification(APIUser user, LocalisableString text)
+        public UserAvatarNotification(APIUser? user, LocalisableString text = default)
         {
             this.user = user;
+
+            Icon = default;
             Text = text;
         }
 
-        protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
-
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, OverlayColourProvider colourProvider)
+        private void load()
         {
-            Light.Colour = colours.Orange2;
-
-            Content.Add(textDrawable = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 14, weight: FontWeight.Medium))
+            if (user != null)
             {
-                AutoSizeAxes = Axes.Y,
-                RelativeSizeAxes = Axes.X,
-                Text = text
-            });
+                IconContent.Masking = true;
+                IconContent.CornerRadius = CORNER_RADIUS;
+                IconContent.ChangeChildDepth(IconDrawable, float.MinValue);
 
-            IconContent.Masking = true;
-            IconContent.CornerRadius = CORNER_RADIUS;
-
-            IconContent.AddRange(new Drawable[]
-            {
-                new Box
+                LoadComponentAsync(Avatar = new DrawableAvatar(user)
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
-            });
-
-            LoadComponentAsync(new DrawableAvatar(user)
-            {
-                FillMode = FillMode.Fill,
-            }, IconContent.Add);
+                    FillMode = FillMode.Fill,
+                }, IconContent.Add);
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
+++ b/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
@@ -9,13 +9,13 @@ using osu.Game.Users.Drawables;
 
 namespace osu.Game.Overlays.Notifications
 {
-    public partial class UserAvatarNotification : SimpleNotification
+    public abstract partial class UserAvatarNotification : SimpleNotification
     {
         private readonly APIUser? user;
 
         protected DrawableAvatar Avatar { get; private set; } = null!;
 
-        public UserAvatarNotification(APIUser? user, LocalisableString text = default)
+        protected UserAvatarNotification(APIUser? user, LocalisableString text = default)
         {
             this.user = user;
 


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/33945

I wanted to split each change into its own PR, but that causes stupid dependency chains to occur. So instead, I've grouped everything in this PR, and I'll scratch out any change that's not good.

| Before | After |
|--------|-------|
| ![CleanShot 2025-07-03 at 11 26 36](https://github.com/user-attachments/assets/7634a096-604f-4b1e-a639-898af2fb448c) | ![CleanShot 2025-07-08 at 14 37 27](https://github.com/user-attachments/assets/9546c9e5-764e-4506-97f5-1598caa71e18) |

![CleanShot 2025-07-03 at 11 45 30](https://github.com/user-attachments/assets/28f279af-e738-4741-933e-472a96b78ef1)
![CleanShot 2025-07-03 at 11 45 19](https://github.com/user-attachments/assets/ab31fee9-07a3-4056-9309-afbf99ea60ef)

When many users become online/offline at once, the old design is still retained:

![CleanShot 2025-07-03 at 11 56 26](https://github.com/user-attachments/assets/bb21a130-b4a7-4812-96f5-dc20380713f8)

