### PR TITLE
Disallow Classic mod from being valid in freestyle as required mod

### DIFF
--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -342,12 +342,18 @@ namespace osu.Game.Tests.Mods
                 {
                     foreach (var mod in ruleset.CreateAllMods())
                     {
-                        if (mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && !commonAcronyms.Contains(mod.Acronym))
+                        if (mod.ValidForFreestyleAsRequiredMod && !mod.UserPlayable)
+                            Assert.Fail($"Mod {mod.GetType().ReadableName()} declares {nameof(Mod.ValidForFreestyleAsRequiredMod)} but is not playable!");
+
+                        if (mod.ValidForFreestyleAsRequiredMod && !mod.HasImplementation)
+                            Assert.Fail($"Mod {mod.GetType().ReadableName()} declares {nameof(Mod.ValidForFreestyleAsRequiredMod)} but is not implemented!");
+
+                        if (mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && mod.HasImplementation && !commonAcronyms.Contains(mod.Acronym))
                             Assert.Fail($"{mod.GetType().ReadableName()} declares {nameof(Mod.ValidForFreestyleAsRequiredMod)} but does not exist in all four basic rulesets!");
 
                         // downgraded to warning, because there are valid reasons why they may still not be specified to be valid for freestyle as required
                         // (see `TestModsValidForRequiredFreestyleAreConsistentlyCompatibleAcrossRulesets()` test case below).
-                        if (!mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && commonAcronyms.Contains(mod.Acronym))
+                        if (!mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && mod.HasImplementation && commonAcronyms.Contains(mod.Acronym))
                             Assert.Warn($"{mod.GetType().ReadableName()} does not declare {nameof(Mod.ValidForFreestyleAsRequiredMod)} but exists in all four basic rulesets.");
                     }
                 }

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -350,11 +350,6 @@ namespace osu.Game.Tests.Mods
 
                         if (mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && mod.HasImplementation && !commonAcronyms.Contains(mod.Acronym))
                             Assert.Fail($"{mod.GetType().ReadableName()} declares {nameof(Mod.ValidForFreestyleAsRequiredMod)} but does not exist in all four basic rulesets!");
-
-                        // downgraded to warning, because there are valid reasons why they may still not be specified to be valid for freestyle as required
-                        // (see `TestModsValidForRequiredFreestyleAreConsistentlyCompatibleAcrossRulesets()` test case below).
-                        if (!mod.ValidForFreestyleAsRequiredMod && mod.UserPlayable && mod.HasImplementation && commonAcronyms.Contains(mod.Acronym))
-                            Assert.Warn($"{mod.GetType().ReadableName()} does not declare {nameof(Mod.ValidForFreestyleAsRequiredMod)} but exists in all four basic rulesets.");
                     }
                 }
             });

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -31,6 +31,6 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         public sealed override bool Ranked => false;
 
-        public sealed override bool ValidForFreestyleAsRequiredMod => true;
+        public sealed override bool ValidForFreestyleAsRequiredMod => false;
     }
 }


### PR DESCRIPTION
Because it's not implemented for all rulesets.

Closes https://github.com/ppy/osu/issues/34004.