### PR TITLE
Add full Emoji support to osu

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkEmojiStore.cs
+++ b/osu.Game.Benchmarks/BenchmarkEmojiStore.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Rendering.Dummy;
+using osu.Framework.IO.Stores;
+using osu.Framework.Text;
+using osu.Game.Graphics;
+using osu.Game.Resources;
+
+namespace osu.Game.Benchmarks
+{
+    public class BenchmarkEmojiStore : BenchmarkTest
+    {
+        private TestEmojiStore store = null!;
+        private ITexturedCharacterGlyph? glyph = null;
+
+        public override void SetUp()
+        {
+            store = new TestEmojiStore(new DummyRenderer(), new ResourceStore<byte[]>(new DllResourceStore(OsuResources.ResourceAssembly)));
+        }
+
+        [Benchmark]
+        [Arguments(1)]
+        [Arguments(10)]
+        [Arguments(100)]
+        public void BenchmarkToGetResource(int n)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                // from 🐀 (U+1F400) we have enough consecutive emojis to test
+                glyph = store.Get(null, (Grapheme)new Rune(0x1f400 + i));
+                // clear texture cache, for consistent results
+                store.Purge(glyph!);
+            }
+        }
+
+        [Benchmark]
+        public void BenchmarkMissingEmoji()
+        {
+            glyph = store.Get(null, new Grapheme(" "));
+            Assert.Null(glyph);
+        }
+
+        private class TestEmojiStore : EmojiStore
+        {
+            public TestEmojiStore(IRenderer renderer, ResourceStore<byte[]> resourceStore)
+                : base(renderer, resourceStore) { }
+
+            public void Purge(ITexturedCharacterGlyph glyph)
+            {
+                Purge(glyph.Texture);
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/EmojiStore.cs
+++ b/osu.Game/Graphics/EmojiStore.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Text;
+
+namespace osu.Game.Graphics
+{
+    public class EmojiStore : ITextureStore, ITexturedGlyphLookupStore
+    {
+        public const string FONT_NAME = @"Emoji";
+
+        private readonly TextureStore textures;
+
+        public EmojiStore(TextureStore textures)
+        {
+            this.textures = textures;
+        }
+
+        public ITexturedCharacterGlyph? Get(string? fontName, Grapheme character)
+        {
+            if (string.IsNullOrEmpty(fontName) || fontName == FONT_NAME)
+            {
+                var texture = textures.Get($@"{FONT_NAME}/{string.Join(
+                    "_",
+                    character.ToString().EnumerateRunes().Select(rune => rune.Value.ToString("X").ToLower(CultureInfo.InvariantCulture)))}");
+                return texture != null ? new EmojiGlyph(texture, character) : null;
+            }
+
+            return null;
+        }
+
+        public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, Grapheme character) => Task.Run(() => Get(fontName, character));
+
+        public Texture? Get(string name, WrapMode wrapModeS, WrapMode wrapModeT) => null;
+
+        public Texture Get(string name) => throw new NotImplementedException();
+
+        public Task<Texture> GetAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public Stream GetStream(string name) => throw new NotImplementedException();
+
+        public IEnumerable<string> GetAvailableResources() => throw new NotImplementedException();
+
+        public Task<Texture?> GetAsync(string name, WrapMode wrapModeS, WrapMode wrapModeT, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public class EmojiGlyph : ITexturedCharacterGlyph
+        {
+            public float XOffset => default;
+            public float YOffset => default;
+            public float XAdvance => 1;
+            public float Baseline => 0.79f;
+            public Grapheme Character { get; }
+
+            public float GetKerning<T>(T lastGlyph) where T : ICharacterGlyph => 0;
+
+            public Texture Texture { get; }
+            public float Width => 1;
+            public float Height => 1;
+            public bool Coloured => true;
+
+            public EmojiGlyph(Texture texture, Grapheme character)
+            {
+                Texture = texture;
+                Character = character;
+            }
+        }
+
+        public void Dispose()
+        {
+            textures.Dispose();
+        }
+    }
+}

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -411,15 +411,15 @@ namespace osu.Game.Graphics
                 this.textures = textures;
             }
 
-            public ITexturedCharacterGlyph? Get(string? fontName, char character)
+            public ITexturedCharacterGlyph? Get(string? fontName, Grapheme character)
             {
                 if (fontName == FONT_NAME)
-                    return new Glyph(textures.Get($@"{fontName}/{((OsuIconMapping)character).GetDescription()}"));
+                    return new Glyph(textures.Get($@"{fontName}/{((OsuIconMapping)character.CharValue).GetDescription()}"));
 
                 return null;
             }
 
-            public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
+            public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, Grapheme character) => Task.Run(() => Get(fontName, character));
 
             public Texture? Get(string name, WrapMode wrapModeS, WrapMode wrapModeT) => null;
 
@@ -439,13 +439,14 @@ namespace osu.Game.Graphics
                 public float YOffset => default;
                 public float XAdvance => default;
                 public float Baseline => default;
-                public char Character => default;
+                public Grapheme Character => default;
 
                 public float GetKerning<T>(T lastGlyph) where T : ICharacterGlyph => throw new NotImplementedException();
 
                 public Texture Texture { get; }
                 public float Width => Texture.Width;
                 public float Height => Texture.Height;
+                public bool Coloured => false;
 
                 public Glyph(Texture texture)
                 {

--- a/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
@@ -14,13 +14,14 @@ using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
+using osu.Framework.Text;
 using osu.Game.Localisation;
 
 namespace osu.Game.Graphics.UserInterface
 {
     public partial class OsuPasswordTextBox : OsuTextBox
     {
-        protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
+        protected override Drawable GetDrawableCharacter(Grapheme c) => new FallingDownContainer
         {
             AutoSizeAxes = Axes.Both,
             Child = new PasswordMaskChar(FontSize),

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -16,6 +16,7 @@ using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Text;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
@@ -274,7 +275,7 @@ namespace osu.Game.Graphics.UserInterface
             base.OnFocusLost(e);
         }
 
-        protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
+        protected override Drawable GetDrawableCharacter(Grapheme c) => new FallingDownContainer
         {
             AutoSizeAxes = Axes.Both,
             Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: FontSize) },

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Framework.Text;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
@@ -141,7 +142,7 @@ namespace osu.Game.Graphics.UserInterface
                 }
             }
 
-            protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
+            protected override Drawable GetDrawableCharacter(Grapheme c) => new FallingDownContainer
             {
                 AutoSizeAxes = Axes.Both,
                 Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: 20, weight: FontWeight.SemiBold) },

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -498,6 +498,7 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Venera/Venera-Bold");
             AddFont(Resources, @"Fonts/Venera/Venera-Black");
 
+            Fonts.AddStore(new EmojiStore(Textures));
             Fonts.AddStore(new OsuIcon.OsuIconStore(Textures));
         }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -498,7 +498,7 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Venera/Venera-Bold");
             AddFont(Resources, @"Fonts/Venera/Venera-Black");
 
-            Fonts.AddStore(new EmojiStore(Textures));
+            Fonts.AddStore(new EmojiStore(Host.Renderer, Resources));
             Fonts.AddStore(new OsuIcon.OsuIconStore(Textures));
         }
 

--- a/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
@@ -151,9 +151,9 @@ namespace osu.Game.Screens.Play.HUD
 
                 // cache common lookups ahead of time.
                 foreach (char c in new[] { '.', '%', 'x' })
-                    glyphStore.Get(font_name, c);
+                    glyphStore.Get(font_name, new Grapheme(c));
                 for (int i = 0; i < 10; i++)
-                    glyphStore.Get(font_name, (char)('0' + i));
+                    glyphStore.Get(font_name, new Grapheme((char)('0' + i)));
             }
 
             protected override TextBuilder CreateTextBuilder(ITexturedGlyphLookupStore store) => base.CreateTextBuilder(glyphStore);
@@ -173,16 +173,16 @@ namespace osu.Game.Screens.Play.HUD
                     this.getLookup = getLookup;
                 }
 
-                public ITexturedCharacterGlyph? Get(string? fontName, char character)
+                public ITexturedCharacterGlyph? Get(string? fontName, Grapheme character)
                 {
                     // We only service one font.
                     if (fontName != this.fontName)
                         return null;
 
-                    if (cache.TryGetValue(character, out var cached))
+                    if (cache.TryGetValue(character.CharValue, out var cached))
                         return cached;
 
-                    string lookup = getLookup(character);
+                    string lookup = getLookup(character.CharValue);
                     var texture = textures.Get($"Gameplay/Fonts/{fontName}-{lookup}");
 
                     TexturedCharacterGlyph? glyph = null;
@@ -190,11 +190,11 @@ namespace osu.Game.Screens.Play.HUD
                     if (texture != null)
                         glyph = new TexturedCharacterGlyph(new CharacterGlyph(character, 0, 0, texture.Width, texture.Height, null), texture, 0.125f);
 
-                    cache[character] = glyph;
+                    cache[character.CharValue] = glyph;
                     return glyph;
                 }
 
-                public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
+                public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, Grapheme character) => Task.Run(() => Get(fontName, character));
             }
         }
     }

--- a/osu.Game/Skinning/LegacySpriteText.cs
+++ b/osu.Game/Skinning/LegacySpriteText.cs
@@ -53,9 +53,9 @@ namespace osu.Game.Skinning
 
             // cache common lookups ahead of time.
             foreach (char c in FixedWidthExcludeCharacters)
-                glyphStore.Get(fontPrefix, c);
+                glyphStore.Get(fontPrefix, new Grapheme(c));
             for (int i = 0; i < 10; i++)
-                glyphStore.Get(fontPrefix, (char)('0' + i));
+                glyphStore.Get(fontPrefix, new Grapheme((char)('0' + i)));
         }
 
         protected override TextBuilder CreateTextBuilder(ITexturedGlyphLookupStore store) => base.CreateTextBuilder(glyphStore);
@@ -67,7 +67,7 @@ namespace osu.Game.Skinning
 
             private readonly string fontName;
 
-            private readonly Dictionary<char, ITexturedCharacterGlyph?> cache = new Dictionary<char, ITexturedCharacterGlyph?>();
+            private readonly Dictionary<Grapheme, ITexturedCharacterGlyph?> cache = new Dictionary<Grapheme, ITexturedCharacterGlyph?>();
 
             public LegacyGlyphStore(string fontName, ISkin skin, Vector2? maxSize)
             {
@@ -76,7 +76,7 @@ namespace osu.Game.Skinning
                 this.maxSize = maxSize;
             }
 
-            public ITexturedCharacterGlyph? Get(string? fontName, char character)
+            public ITexturedCharacterGlyph? Get(string? fontName, Grapheme character)
             {
                 // We only service one font.
                 if (fontName != this.fontName)
@@ -103,9 +103,9 @@ namespace osu.Game.Skinning
                 return glyph;
             }
 
-            private static string getLookupName(char character)
+            private static string getLookupName(Grapheme character)
             {
-                switch (character)
+                switch (character.CharValue)
                 {
                     case ',':
                         return "comma";
@@ -121,7 +121,7 @@ namespace osu.Game.Skinning
                 }
             }
 
-            public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
+            public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, Grapheme character) => Task.Run(() => Get(fontName, character));
         }
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3047e757-5c98-4cd6-b53a-e1c414f5aa10)


This feature is divided into three PRs.

* In osu (This PR)
* In osu-framework https://github.com/ppy/osu-framework/pull/6599
* In osu-resources https://github.com/ppy/osu-resources/pull/369

---

In this PR

* Add `EmojiStore` to load Emoji Textures resources
* Adapting to type changes from framework

BenchmarkEmojiStore Result:

| Method                 | n   | Mean           | Error        | StdDev       | Gen0     | Gen1    | Gen2   | Allocated |
|----------------------- |---- |---------------:|-------------:|-------------:|---------:|--------:|-------:|----------:|
| BenchmarkMissingEmoji  | ?   |       172.7 ns |      2.09 ns |      1.95 ns |   0.0393 |       - |      - |     496 B |
| BenchmarkToGetResource | 1   |    26,381.3 ns |    509.04 ns |    499.95 ns |   5.8594 |  0.1221 |      - |   74005 B |
| BenchmarkToGetResource | 10  |   343,585.6 ns |  6,248.93 ns |  5,539.52 ns |  58.5938 |  1.9531 |      - |  741044 B |
| BenchmarkToGetResource | 100 | 3,514,988.6 ns | 62,320.43 ns | 58,294.57 ns | 593.7500 | 15.6250 | 3.9063 | 7410976 B |
