### PR TITLE
Adjust carousel sizing to better accommodate to ultra-wide-screen display

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Screens.SelectV2
                                     {
                                         new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 700),
                                         new Dimension(),
-                                        new Dimension(GridSizeMode.Relative, 0.5f, maxSize: 660),
+                                        new Dimension(GridSizeMode.Relative, 0.5f, minSize: 500, maxSize: 900),
                                     },
                                     Content = new[]
                                     {


### PR DESCRIPTION
Hopefully the final adjustment to things here.

Roughly matches old (lazer) song select now at ultra widescreen resolutions:

![Untitled 3](https://github.com/user-attachments/assets/efd2029e-aa81-47da-98ff-53b5d108c166)

Does not change things too much at standard 16:9 / 16:10 (but does bring things back further in line with what we had). I'm willing to push this a bit to see when we hit a point that people complain.

![Untitled 2](https://github.com/user-attachments/assets/ad42e884-c6fd-4a8c-b031-ab683a240333)

Addresses https://github.com/ppy/osu/discussions/33426#discussioncomment-13378199 probably.