### PR TITLE
Add grouping separator to PP display in user profile overlay (also display decimal value in tooltip)

### DIFF
--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Origin = Anchor.BottomLeft,
                         Font = font,
                         Text = Score.PP.ToLocalisableString(@"N0"),
-                        TooltipText = Score.PP.ToLocalisableString(@"#,0.###"),
+                        TooltipText = Score.PP.ToLocalisableString(@"N1"),
                         Colour = colourProvider.Highlight1,
                     },
                     new SpriteTextWithTooltip
@@ -284,7 +284,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Origin = Anchor.BottomLeft,
                         Font = font.With(size: 12),
                         Text = "pp",
-                        TooltipText = Score.PP.ToLocalisableString(@"#,0.###"),
+                        TooltipText = Score.PP.ToLocalisableString(@"N1"),
                         Colour = colourProvider.Light3,
                     }
                 }

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -263,6 +263,8 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                 };
             }
 
+            var ppTooltipText = LocalisableString.Interpolate($@"{Score.PP:N1}pp");
+
             return new FillFlowContainer
             {
                 AutoSizeAxes = Axes.Both,
@@ -275,7 +277,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Origin = Anchor.BottomLeft,
                         Font = font,
                         Text = Score.PP.ToLocalisableString(@"N0"),
-                        TooltipText = Score.PP.ToLocalisableString(@"N1"),
+                        TooltipText = ppTooltipText,
                         Colour = colourProvider.Highlight1,
                     },
                     new SpriteTextWithTooltip
@@ -283,8 +285,8 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Anchor = Anchor.BottomLeft,
                         Origin = Anchor.BottomLeft,
                         Font = font.With(size: 12),
-                        Text = "pp",
-                        TooltipText = Score.PP.ToLocalisableString(@"N1"),
+                        Text = @"pp",
+                        TooltipText = ppTooltipText,
                         Colour = colourProvider.Light3,
                     }
                 }

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -268,21 +269,23 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                 Direction = FillDirection.Horizontal,
                 Children = new[]
                 {
-                    new OsuSpriteText
+                    new SpriteTextWithTooltip
                     {
                         Anchor = Anchor.BottomLeft,
                         Origin = Anchor.BottomLeft,
                         Font = font,
-                        Text = $"{Score.PP:0}",
-                        Colour = colourProvider.Highlight1
+                        Text = Score.PP.ToLocalisableString(@"N0"),
+                        TooltipText = Score.PP.ToLocalisableString(@"N"),
+                        Colour = colourProvider.Highlight1,
                     },
-                    new OsuSpriteText
+                    new SpriteTextWithTooltip
                     {
                         Anchor = Anchor.BottomLeft,
                         Origin = Anchor.BottomLeft,
                         Font = font.With(size: 12),
                         Text = "pp",
-                        Colour = colourProvider.Light3
+                        TooltipText = Score.PP.ToLocalisableString(@"N"),
+                        Colour = colourProvider.Light3,
                     }
                 }
             };

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Origin = Anchor.BottomLeft,
                         Font = font,
                         Text = Score.PP.ToLocalisableString(@"N0"),
-                        TooltipText = Score.PP.ToLocalisableString(@"0.###"),
+                        TooltipText = Score.PP.ToLocalisableString(@"#,0.###"),
                         Colour = colourProvider.Highlight1,
                     },
                     new SpriteTextWithTooltip
@@ -284,7 +284,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Origin = Anchor.BottomLeft,
                         Font = font.With(size: 12),
                         Text = "pp",
-                        TooltipText = Score.PP.ToLocalisableString(@"0.###"),
+                        TooltipText = Score.PP.ToLocalisableString(@"#,0.###"),
                         Colour = colourProvider.Light3,
                     }
                 }

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Origin = Anchor.BottomLeft,
                         Font = font,
                         Text = Score.PP.ToLocalisableString(@"N0"),
-                        TooltipText = Score.PP.ToLocalisableString(@"N"),
+                        TooltipText = Score.PP.ToLocalisableString(@"0.###"),
                         Colour = colourProvider.Highlight1,
                     },
                     new SpriteTextWithTooltip
@@ -284,7 +284,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         Origin = Anchor.BottomLeft,
                         Font = font.With(size: 12),
                         Text = "pp",
-                        TooltipText = Score.PP.ToLocalisableString(@"N"),
+                        TooltipText = Score.PP.ToLocalisableString(@"0.###"),
                         Colour = colourProvider.Light3,
                     }
                 }

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
@@ -44,7 +45,9 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                             Child = new OsuSpriteText
                             {
                                 Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold, italics: true),
-                                Text = Score.PP.HasValue ? $"{Score.PP * weight:0}pp" : string.Empty,
+                                Text = Score.PP.HasValue
+                                    ? LocalisableString.Interpolate($"{Score.PP * weight:N0}pp")
+                                    : string.Empty,
                             },
                         }
                     }


### PR DESCRIPTION
Noticed on passing. Tested with https://osu.ppy.sh/users/7562902.