### PR TITLE
Change toolbar ruleset selector colour back to pink

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Overlays.Toolbar
             {
                 set => Scheduler.AddOnce(() =>
                 {
-                    IconContainer.Colour = value ? Color4Extensions.FromHex("#00FFAA") : colours.GrayF;
+                    IconContainer.Colour = value ? colours.PinkLight : colours.GrayF;
                 });
             }
 


### PR DESCRIPTION
This is a quick merge-or-dismiss PR without any prior discussion thread as the change is a one-liner. Was suggested by a friend at first, who recalls that the ruleset selector used to be pink before a redesign from long ago. I'm also not sure what our stance is on aquamarine colours in general, even in song select we moved away from it due to feeling like a weird/ugly mixture of green and blue. Pink feels more natural, and for a bonus it matches the second level text in the clock on the right. Can be closed on the spot if disagreed.

| Before | After |
|--------|-------|
| ![CleanShot 2025-07-04 at 09 33 15](https://github.com/user-attachments/assets/da1859b6-4a4e-4d7b-8d55-2ba48730467d) | ![CleanShot 2025-07-04 at 09 32 53](https://github.com/user-attachments/assets/6dc43869-ea09-49ec-a03e-0de7bcb286c5) |