### PR TITLE
Fix song select group count pills shaking when expanding/collapsing

### DIFF
--- a/osu.Game/Screens/SelectV2/PanelGroup.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroup.cs
@@ -150,9 +150,9 @@ namespace osu.Game.Screens.SelectV2
             countText.Text = Item.NestedItemCount.ToString("N0");
         }
 
-        protected override void Update()
+        protected override void UpdateAfterChildren()
         {
-            base.Update();
+            base.UpdateAfterChildren();
 
             // Move the count pill in the opposite direction to keep it pinned to the screen regardless of the X position of TopLevelContent.
             countPill.X = -TopLevelContent.X;


### PR DESCRIPTION
This is more noticeable with single thread, as shown below.

Before:

https://github.com/user-attachments/assets/2c1f13ca-5029-457b-af18-4102743b7560

After:

https://github.com/user-attachments/assets/a0549cfb-ff63-4966-8d3c-f9bef91bcea4

