### PR TITLE
Fix hitwindow formula in osu! performance calculator

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, 1800, 1200, 450) / clockRate;
 
-            overallDifficulty = (80 - greatHitWindow) / 6;
+            overallDifficulty = (79.5 - greatHitWindow) / 6;
             approachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5;
 
             if (osuAttributes.SliderCount > 0)


### PR DESCRIPTION
The fact that this PR aims at master instead of pp-dev is intentional. Because pp values in master was changed due to the fact how new hitwindows work.
Since the hitwindow formula was changed - this PR is also updating reverse (hitwindow to OD) formula. This will still make values different from live but at least they would be correct.

Rate change conversion of OD in PerformanceCalculator:
Before:
OD10 -> OD10.0833
OD9.9 -> OD10.0833

After:
OD10 -> OD10
OD9.9 -> OD10
 