### PR TITLE
Prevent Back input while holding QuickRetry chord to avoid accidental return to Song Select

### DIFF
--- a/osu.Game/Screens/Play/HotkeyRetryOverlay.cs
+++ b/osu.Game/Screens/Play/HotkeyRetryOverlay.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
@@ -10,22 +12,46 @@ namespace osu.Game.Screens.Play
 {
     public partial class HotkeyRetryOverlay : HoldToConfirmOverlay, IKeyBindingHandler<GlobalAction>
     {
+        private KeyCombination[] quickRetryChords = null!;
+        private InputManager inputManager = null!;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inputManager = GetContainingInputManager()!;
+
+            quickRetryChords = GlobalActionContainer
+                               .GetDefaultBindingsFor(GlobalActionCategory.InGame)
+                               .Where(b => b.Action is GlobalAction.QuickRetry)
+                               .Select(b => b.KeyCombination)
+                               .ToArray();
+        }
+
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (e.Repeat)
-                return false;
+            if (e.Action == GlobalAction.Back && isQuickRetryChordHeld())
+                return true;
 
-            if (e.Action != GlobalAction.QuickRetry) return false;
+            if (e.Action == GlobalAction.QuickRetry && !e.Repeat)
+            {
+                BeginConfirm();
+                return true;
+            }
 
-            BeginConfirm();
-            return true;
+            return false;
         }
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
-            if (e.Action != GlobalAction.QuickRetry) return;
+            if (e.Action == GlobalAction.QuickRetry)
+                AbortConfirm();
+        }
 
-            AbortConfirm();
+        private bool isQuickRetryChordHeld()
+        {
+            var pressed = inputManager.CurrentState.Keyboard.Keys.Select(k => (InputKey)k);
+            return quickRetryChords.Any(chord => chord.Keys.All(pressed.Contains));
         }
     }
 }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -248,6 +248,7 @@ namespace osu.Game.Screens.Play
                     },
                 },
                 idleTracker = new IdleTracker(1500),
+                new HotkeyRetryOverlay(),
                 sampleRestart = new SkinnableSound(new SampleInfo(@"Gameplay/restart", @"pause-retry-click"))
             };
 


### PR DESCRIPTION
### Before and after:
https://github.com/user-attachments/assets/f2cb3957-53b4-459b-b6da-b3bdfbdc08e2



In the default keybinding setup, `QuickRetry` is bound to the key <kbd>~</kbd> (tilde), and `Back` is bound to <kbd>Escape</kbd>, keys that are physically right next to each other.  
While I was retrying frequently (uhm... farming...), it was _surprisingly common_ to unintentionally press both at once. 
This causes the game to exit back to **Song Select**, interrupting gameplay and breaking flow.
The fact that ultra-fast magnetic keyboards are more and more common also makes it a more common occurance. If I barely touch the corner of the key, it'd count.

Although this has existed in lazer since I have memory, it hasn't bothered anyone enough to list it as an Issue.
After noticing this issue affecting my own gameplay over many sessions, I finally decided to try fixing it directly.

I've taken many approaches over the weeks, and this one seems to work best and avoids touching some stuff that shouldn't be touched. This approach (as far as my testing went) doesn't break anything else related to keybinds.

Basically supress `Back` input during that small time, and also detects when a full `QuickRetry` chord is currently being held. The expected retry interaction is preserved.

I still don't fully understand the origin of this problem/bug. I'm open to feedback or alternative suggestions if there's a better way to solve this. 
Thanks for reading!
