### PR TITLE
Add fade transition in BeatmapLearderboardWedge

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
@@ -397,8 +397,7 @@ namespace osu.Game.Screens.SelectV2
             float fadeBottom = (float)(scoresScroll.Current + scoresScroll.DrawHeight);
             float fadeTop = (float)(scoresScroll.Current);
 
-            if (!scoresScroll.IsScrolledToStart())
-                fadeTop += height;
+            fadeTop += (float)Math.Min(height, Math.Log10(Math.Max(fadeTop, 0) + 1) * height);
 
             foreach (var c in scoresContainer)
             {


### PR DESCRIPTION
The fade effect appeared unnatural when scrolling up BeatmapLeaderboardWedge, so I added a smooth transition to improve it.

Before:

https://github.com/user-attachments/assets/64a69530-70f7-497d-b94e-b6100fad555f

After:

https://github.com/user-attachments/assets/0a071ab8-7ac7-4f4f-a1f6-24db3a0ba60d

