### PR TITLE
Store pause timestamps to scores

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -321,6 +321,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 CountryCode = CountryCode.PL
             };
             scoreInfo.ClientVersion = "2023.1221.0";
+            scoreInfo.PauseCount = 3;
 
             var beatmap = new TestBeatmap(ruleset);
             var score = new Score
@@ -345,6 +346,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(decodedAfterEncode.ScoreInfo.Mods, Is.EqualTo(scoreInfo.Mods));
                 Assert.That(decodedAfterEncode.ScoreInfo.ClientVersion, Is.EqualTo("2023.1221.0"));
                 Assert.That(decodedAfterEncode.ScoreInfo.RealmUser.OnlineID, Is.EqualTo(3035836));
+                Assert.That(decodedAfterEncode.ScoreInfo.PauseCount, Is.EqualTo(3));
             });
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -13,6 +13,7 @@ using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Beatmaps.Legacy;
+using osu.Game.Extensions;
 using osu.Game.IO.Legacy;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Replays;
@@ -321,7 +322,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 CountryCode = CountryCode.PL
             };
             scoreInfo.ClientVersion = "2023.1221.0";
-            scoreInfo.PauseCount = 3;
+            scoreInfo.Pauses.AddRange([111111, 222222, 333333]);
 
             var beatmap = new TestBeatmap(ruleset);
             var score = new Score
@@ -346,7 +347,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(decodedAfterEncode.ScoreInfo.Mods, Is.EqualTo(scoreInfo.Mods));
                 Assert.That(decodedAfterEncode.ScoreInfo.ClientVersion, Is.EqualTo("2023.1221.0"));
                 Assert.That(decodedAfterEncode.ScoreInfo.RealmUser.OnlineID, Is.EqualTo(3035836));
-                Assert.That(decodedAfterEncode.ScoreInfo.PauseCount, Is.EqualTo(3));
+                Assert.That(decodedAfterEncode.ScoreInfo.Pauses, Is.EquivalentTo(new[] { 111111, 222222, 333333 }));
             });
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseViaBackAction();
             pauseViaBackAction();
             confirmPausedWithNoOverlay();
-            AddAssert("score pause count incremented", () => Player.Score.ScoreInfo.PauseCount, () => Is.EqualTo(1));
+            AddAssert("pause recorded", () => Player.Score.ScoreInfo.Pauses, () => Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseViaPauseGameplayAction();
             pauseViaPauseGameplayAction();
             confirmPausedWithNoOverlay();
-            AddAssert("score pause count incremented", () => Player.Score.ScoreInfo.PauseCount, () => Is.EqualTo(1));
+            AddAssert("pause recorded", () => Player.Score.ScoreInfo.Pauses, () => Has.Length.EqualTo(1));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseViaBackAction();
             pauseViaBackAction();
             confirmPausedWithNoOverlay();
-            AddAssert("pause recorded", () => Player.Score.ScoreInfo.Pauses, () => Has.Length.EqualTo(1));
+            AddAssert("pause recorded", () => Player.Score.ScoreInfo.Pauses, () => Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseViaPauseGameplayAction();
             pauseViaPauseGameplayAction();
             confirmPausedWithNoOverlay();
-            AddAssert("pause recorded", () => Player.Score.ScoreInfo.Pauses, () => Has.Length.EqualTo(1));
+            AddAssert("pause recorded", () => Player.Score.ScoreInfo.Pauses, () => Has.Count.EqualTo(1));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -69,6 +69,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseViaBackAction();
             pauseViaBackAction();
             confirmPausedWithNoOverlay();
+            AddAssert("score pause count incremented", () => Player.Score.ScoreInfo.PauseCount, () => Is.EqualTo(1));
         }
 
         [Test]
@@ -77,6 +78,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseViaPauseGameplayAction();
             pauseViaPauseGameplayAction();
             confirmPausedWithNoOverlay();
+            AddAssert("score pause count incremented", () => Player.Score.ScoreInfo.PauseCount, () => Is.EqualTo(1));
         }
 
         [Test]

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Database
         /// 48   2025-03-19    Clear online status for all qualified beatmaps (some were stuck in a qualified state due to local caching issues).
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
-        /// 51   2025-07-22    Add ScoreInfo.PauseCount.
+        /// 51   2025-07-22    Add ScoreInfo.Pauses.
         /// </summary>
         private const int schema_version = 51;
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -99,8 +99,9 @@ namespace osu.Game.Database
         /// 47   2025-01-21    Remove right mouse button binding for absolute scroll. Never use mouse buttons (or scroll) for global actions.
         /// 48   2025-03-19    Clear online status for all qualified beatmaps (some were stuck in a qualified state due to local caching issues).
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
+        /// 50   2025-07-07    Add ScoreInfo.PauseCount.
         /// </summary>
-        private const int schema_version = 49;
+        private const int schema_version = 50;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -87,6 +87,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("legacy_score_id")]
         public ulong? LegacyScoreId { get; set; }
 
+        [JsonProperty("pause_count")]
+        public int PauseCount { get; set; }
+
         #region osu-web API additions (not stored to database).
 
         [JsonProperty("id")]
@@ -260,6 +263,7 @@ namespace osu.Game.Online.API.Requests.Responses
             Mods = score.APIMods,
             Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(),
             MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(),
+            PauseCount = score.PauseCount,
         };
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -87,8 +87,8 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("legacy_score_id")]
         public ulong? LegacyScoreId { get; set; }
 
-        [JsonProperty("pause_count")]
-        public int PauseCount { get; set; }
+        [JsonProperty("pauses")]
+        public int[] Pauses { get; set; } = [];
 
         #region osu-web API additions (not stored to database).
 
@@ -263,7 +263,7 @@ namespace osu.Game.Online.API.Requests.Responses
             Mods = score.APIMods,
             Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(),
             MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(),
-            PauseCount = score.PauseCount,
+            Pauses = score.Pauses.ToArray(),
         };
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
+++ b/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
@@ -49,8 +49,8 @@ namespace osu.Game.Scoring.Legacy
         [JsonProperty("total_score_without_mods")]
         public long? TotalScoreWithoutMods { get; set; }
 
-        [JsonProperty("pause_count")]
-        public int PauseCount { get; set; }
+        [JsonProperty("pauses")]
+        public int[] Pauses { get; set; } = [];
 
         public static LegacyReplaySoloScoreInfo FromScore(ScoreInfo score) => new LegacyReplaySoloScoreInfo
         {
@@ -62,7 +62,7 @@ namespace osu.Game.Scoring.Legacy
             Rank = score.Rank,
             UserID = score.User.OnlineID,
             TotalScoreWithoutMods = score.TotalScoreWithoutMods > 0 ? score.TotalScoreWithoutMods : null,
-            PauseCount = score.PauseCount,
+            Pauses = score.Pauses.ToArray(),
         };
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
+++ b/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
@@ -49,6 +49,9 @@ namespace osu.Game.Scoring.Legacy
         [JsonProperty("total_score_without_mods")]
         public long? TotalScoreWithoutMods { get; set; }
 
+        [JsonProperty("pause_count")]
+        public int PauseCount { get; set; }
+
         public static LegacyReplaySoloScoreInfo FromScore(ScoreInfo score) => new LegacyReplaySoloScoreInfo
         {
             OnlineID = score.OnlineID,
@@ -59,6 +62,7 @@ namespace osu.Game.Scoring.Legacy
             Rank = score.Rank,
             UserID = score.User.OnlineID,
             TotalScoreWithoutMods = score.TotalScoreWithoutMods > 0 ? score.TotalScoreWithoutMods : null,
+            PauseCount = score.PauseCount,
         };
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -142,6 +142,8 @@ namespace osu.Game.Scoring.Legacy
                             score.ScoreInfo.TotalScoreWithoutMods = totalScoreWithoutMods;
                         else
                             PopulateTotalScoreWithoutMods(score.ScoreInfo);
+
+                        score.ScoreInfo.PauseCount = readScore.PauseCount;
                     });
                 }
             }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -13,6 +13,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.IO.Legacy;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Replays;
@@ -143,7 +144,7 @@ namespace osu.Game.Scoring.Legacy
                         else
                             PopulateTotalScoreWithoutMods(score.ScoreInfo);
 
-                        score.ScoreInfo.PauseCount = readScore.PauseCount;
+                        score.ScoreInfo.Pauses.AddRange(readScore.Pauses);
                     });
                 }
             }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -155,6 +155,9 @@ namespace osu.Game.Scoring
         [MapTo("MaximumStatistics")]
         public string MaximumStatisticsJson { get; set; } = string.Empty;
 
+        [Ignored]
+        public int PauseCount { get; set; }
+
         public ScoreInfo(BeatmapInfo? beatmap = null, RulesetInfo? ruleset = null, RealmUser? realmUser = null)
         {
             Ruleset = ruleset ?? new RulesetInfo();

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -155,7 +155,6 @@ namespace osu.Game.Scoring
         [MapTo("MaximumStatistics")]
         public string MaximumStatisticsJson { get; set; } = string.Empty;
 
-        [Ignored]
         public int PauseCount { get; set; }
 
         public ScoreInfo(BeatmapInfo? beatmap = null, RulesetInfo? ruleset = null, RealmUser? realmUser = null)

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Scoring
         [MapTo("MaximumStatistics")]
         public string MaximumStatisticsJson { get; set; } = string.Empty;
 
-        public int PauseCount { get; set; }
+        public IList<int> Pauses { get; } = null!;
 
         public ScoreInfo(BeatmapInfo? beatmap = null, RulesetInfo? ruleset = null, RealmUser? realmUser = null)
         {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1046,7 +1046,7 @@ namespace osu.Game.Screens.Play
             // already resuming
             && !IsResuming;
 
-        public bool Pause()
+        public virtual bool Pause()
         {
             if (!pausingSupportedByCurrentState) return false;
 

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -234,6 +234,18 @@ namespace osu.Game.Screens.Play
             spectatorClient.BeginPlaying(token, GameplayState, Score);
         }
 
+        public override bool Pause()
+        {
+            bool wasPaused = GameplayClockContainer.IsPaused.Value;
+
+            bool paused = base.Pause();
+
+            if (!wasPaused && paused)
+                Score.ScoreInfo.PauseCount++;
+
+            return paused;
+        }
+
         protected override void OnFail()
         {
             base.OnFail();

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -241,7 +241,7 @@ namespace osu.Game.Screens.Play
             bool paused = base.Pause();
 
             if (!wasPaused && paused)
-                Score.ScoreInfo.PauseCount++;
+                Score.ScoreInfo.Pauses.Add((int)Math.Round(GameplayClockContainer.CurrentTime));
 
             return paused;
         }


### PR DESCRIPTION
For future use.

Namely, this is storing the count to all possible relevant places: to realm database, to replays, and sending it to web (wherein it won't be used or stored without web-side changes). If that's overkill any of the last 3 commits here can be dropped, I've added it everywhere because @peppy's pitch for this was a bit vague.