### PR TITLE
Fix various sources of memory leaks during tests

### DIFF
--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Tournament.IPC;
@@ -42,6 +43,7 @@ namespace osu.Game.Tournament.Screens.Setup
         [Resolved]
         private TournamentSceneManager? sceneManager { get; set; }
 
+        private readonly IBindable<APIUser> localUser = new Bindable<APIUser>();
         private Bindable<Size> windowSize = null!;
 
         [BackgroundDependencyLoader]
@@ -70,7 +72,8 @@ namespace osu.Game.Tournament.Screens.Setup
                 },
             };
 
-            api.LocalUser.BindValueChanged(_ => Schedule(reload));
+            localUser.BindTo(api.LocalUser);
+            localUser.BindValueChanged(_ => Schedule(reload));
             stableInfo.OnStableInfoSaved += () => Schedule(reload);
             reload();
         }

--- a/osu.Game/Online/LocalUserStatisticsProvider.cs
+++ b/osu.Game/Online/LocalUserStatisticsProvider.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Users;
 
@@ -35,6 +37,8 @@ namespace osu.Game.Online
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
+        private readonly IBindable<APIUser> localUser = new Bindable<APIUser>();
+
         private readonly Dictionary<string, UserStatistics> statisticsCache = new Dictionary<string, UserStatistics>();
 
         /// <summary>
@@ -48,7 +52,8 @@ namespace osu.Game.Online
         {
             base.LoadComplete();
 
-            api.LocalUser.BindValueChanged(_ =>
+            localUser.BindTo(api.LocalUser);
+            localUser.BindValueChanged(_ =>
             {
                 // queuing up requests directly on user change is unsafe, as the API status may have not been updated yet.
                 // schedule a frame to allow the API to be in its correct state sending requests.

--- a/osu.Game/Online/OnlineStatusNotifier.cs
+++ b/osu.Game/Online/OnlineStatusNotifier.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Online
             base.Dispose(isDisposing);
 
             if (notificationsClient.IsNotNull())
-                notificationsClient.MessageReceived += notifyAboutForcedDisconnection;
+                notificationsClient.MessageReceived -= notifyAboutForcedDisconnection;
 
             if (spectatorClient.IsNotNull())
                 spectatorClient.Disconnecting -= notifyAboutForcedDisconnection;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -113,6 +113,9 @@ namespace osu.Game
         /// </summary>
         public const float SCREEN_EDGE_MARGIN = 12f;
 
+        private const double general_log_debounce = 60000;
+        private const string tablet_log_prefix = @"[Tablet] ";
+
         public Toolbar Toolbar { get; private set; }
 
         private ChatOverlay chatOverlay;
@@ -241,12 +244,26 @@ namespace osu.Game
         /// </summary>
         public virtual bool HideUnlicensedContent => false;
 
+        private bool tabletLogNotifyOnWarning = true;
+        private bool tabletLogNotifyOnError = true;
+        private int generalLogRecentCount;
+
         public OsuGame(string[] args = null)
         {
             this.args = args;
 
-            forwardGeneralLogsToNotifications();
-            forwardTabletLogsToNotifications();
+            Logger.NewEntry += forwardGeneralLogToNotifications;
+            Logger.NewEntry += forwardTabletLogToNotifications;
+
+            Schedule(() =>
+            {
+                ITabletHandler tablet = Host.AvailableInputHandlers.OfType<ITabletHandler>().SingleOrDefault();
+                tablet?.Tablet.BindValueChanged(_ =>
+                {
+                    tabletLogNotifyOnWarning = true;
+                    tabletLogNotifyOnError = true;
+                }, true);
+            });
         }
 
         #region IOverlayManager
@@ -1010,6 +1027,9 @@ namespace osu.Game
 
             base.Dispose(isDisposing);
             SentryLogger.Dispose();
+
+            Logger.NewEntry -= forwardGeneralLogToNotifications;
+            Logger.NewEntry -= forwardTabletLogToNotifications;
         }
 
         protected override IDictionary<FrameworkSetting, object> GetFrameworkConfigDefaults()
@@ -1365,115 +1385,90 @@ namespace osu.Game
                 overlay.Depth = (float)-Clock.CurrentTime;
         }
 
-        private void forwardGeneralLogsToNotifications()
+        private void forwardGeneralLogToNotifications(LogEntry entry)
         {
-            int recentLogCount = 0;
+            if (entry.Level < LogLevel.Important || entry.Target > LoggingTarget.Database || entry.Target == null) return;
 
-            const double debounce = 60000;
+            if (entry.Exception is SentryOnlyDiagnosticsException)
+                return;
 
-            Logger.NewEntry += entry =>
+            const int short_term_display_limit = 3;
+
+            if (generalLogRecentCount < short_term_display_limit)
             {
-                if (entry.Level < LogLevel.Important || entry.Target > LoggingTarget.Database || entry.Target == null) return;
-
-                if (entry.Exception is SentryOnlyDiagnosticsException)
-                    return;
-
-                const int short_term_display_limit = 3;
-
-                if (recentLogCount < short_term_display_limit)
+                Schedule(() => Notifications.Post(new SimpleErrorNotification
                 {
-                    Schedule(() => Notifications.Post(new SimpleErrorNotification
-                    {
-                        Icon = entry.Level == LogLevel.Important ? FontAwesome.Solid.ExclamationCircle : FontAwesome.Solid.Bomb,
-                        Text = entry.Message.Truncate(256) + (entry.Exception != null && IsDeployedBuild ? "\n\nThis error has been automatically reported to the devs." : string.Empty),
-                    }));
-                }
-                else if (recentLogCount == short_term_display_limit)
+                    Icon = entry.Level == LogLevel.Important ? FontAwesome.Solid.ExclamationCircle : FontAwesome.Solid.Bomb,
+                    Text = entry.Message.Truncate(256) + (entry.Exception != null && IsDeployedBuild ? "\n\nThis error has been automatically reported to the devs." : string.Empty),
+                }));
+            }
+            else if (generalLogRecentCount == short_term_display_limit)
+            {
+                string logFile = Logger.GetLogger(entry.Target.Value).Filename;
+
+                Schedule(() => Notifications.Post(new SimpleNotification
                 {
-                    string logFile = Logger.GetLogger(entry.Target.Value).Filename;
-
-                    Schedule(() => Notifications.Post(new SimpleNotification
+                    Icon = FontAwesome.Solid.EllipsisH,
+                    Text = NotificationsStrings.SubsequentMessagesLogged,
+                    Activated = () =>
                     {
-                        Icon = FontAwesome.Solid.EllipsisH,
-                        Text = NotificationsStrings.SubsequentMessagesLogged,
-                        Activated = () =>
-                        {
-                            Logger.Storage.PresentFileExternally(logFile);
-                            return true;
-                        }
-                    }));
-                }
+                        Logger.Storage.PresentFileExternally(logFile);
+                        return true;
+                    }
+                }));
+            }
 
-                Interlocked.Increment(ref recentLogCount);
-                Scheduler.AddDelayed(() => Interlocked.Decrement(ref recentLogCount), debounce);
-            };
+            Interlocked.Increment(ref generalLogRecentCount);
+            Scheduler.AddDelayed(() => Interlocked.Decrement(ref generalLogRecentCount), general_log_debounce);
         }
 
-        private void forwardTabletLogsToNotifications()
+        private void forwardTabletLogToNotifications(LogEntry entry)
         {
-            const string tablet_prefix = @"[Tablet] ";
+            if (entry.Level < LogLevel.Important || entry.Target != LoggingTarget.Input || !entry.Message.StartsWith(tablet_log_prefix, StringComparison.OrdinalIgnoreCase))
+                return;
 
-            bool notifyOnWarning = true;
-            bool notifyOnError = true;
+            string message = entry.Message.Replace(tablet_log_prefix, string.Empty);
 
-            Logger.NewEntry += entry =>
+            if (entry.Level == LogLevel.Error)
             {
-                if (entry.Level < LogLevel.Important || entry.Target != LoggingTarget.Input || !entry.Message.StartsWith(tablet_prefix, StringComparison.OrdinalIgnoreCase))
+                if (!tabletLogNotifyOnError)
                     return;
 
-                string message = entry.Message.Replace(tablet_prefix, string.Empty);
+                tabletLogNotifyOnError = false;
 
-                if (entry.Level == LogLevel.Error)
+                Schedule(() =>
                 {
-                    if (!notifyOnError)
-                        return;
-
-                    notifyOnError = false;
-
-                    Schedule(() =>
+                    Notifications.Post(new SimpleNotification
                     {
-                        Notifications.Post(new SimpleNotification
-                        {
-                            Text = NotificationsStrings.TabletSupportDisabledDueToError(message),
-                            Icon = FontAwesome.Solid.PenSquare,
-                            IconColour = Colours.RedDark,
-                        });
-
-                        // We only have one tablet handler currently.
-                        // The loop here is weakly guarding against a future where more than one is added.
-                        // If this is ever the case, this logic needs adjustment as it should probably only
-                        // disable the relevant tablet handler rather than all.
-                        foreach (var tabletHandler in Host.AvailableInputHandlers.OfType<ITabletHandler>())
-                            tabletHandler.Enabled.Value = false;
-                    });
-                }
-                else if (notifyOnWarning)
-                {
-                    Schedule(() => Notifications.Post(new SimpleNotification
-                    {
-                        Text = NotificationsStrings.EncounteredTabletWarning,
+                        Text = NotificationsStrings.TabletSupportDisabledDueToError(message),
                         Icon = FontAwesome.Solid.PenSquare,
-                        IconColour = Colours.YellowDark,
-                        Activated = () =>
-                        {
-                            OpenUrlExternally("https://opentabletdriver.net/Tablets", LinkWarnMode.NeverWarn);
-                            return true;
-                        }
-                    }));
+                        IconColour = Colours.RedDark,
+                    });
 
-                    notifyOnWarning = false;
-                }
-            };
-
-            Schedule(() =>
+                    // We only have one tablet handler currently.
+                    // The loop here is weakly guarding against a future where more than one is added.
+                    // If this is ever the case, this logic needs adjustment as it should probably only
+                    // disable the relevant tablet handler rather than all.
+                    foreach (var tabletHandler in Host.AvailableInputHandlers.OfType<ITabletHandler>())
+                        tabletHandler.Enabled.Value = false;
+                });
+            }
+            else if (tabletLogNotifyOnWarning)
             {
-                ITabletHandler tablet = Host.AvailableInputHandlers.OfType<ITabletHandler>().SingleOrDefault();
-                tablet?.Tablet.BindValueChanged(_ =>
+                Schedule(() => Notifications.Post(new SimpleNotification
                 {
-                    notifyOnWarning = true;
-                    notifyOnError = true;
-                }, true);
-            });
+                    Text = NotificationsStrings.EncounteredTabletWarning,
+                    Icon = FontAwesome.Solid.PenSquare,
+                    IconColour = Colours.YellowDark,
+                    Activated = () =>
+                    {
+                        OpenUrlExternally("https://opentabletdriver.net/Tablets", LinkWarnMode.NeverWarn);
+                        return true;
+                    }
+                }));
+
+                tabletLogNotifyOnWarning = false;
+            }
         }
 
         private Task asyncLoadStream;

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -82,10 +82,11 @@ namespace osu.Game.Tests.Visual
         [TearDownSteps]
         public virtual void TearDownSteps()
         {
-            if (DebugUtils.IsNUnitRunning && Game != null)
+            if (DebugUtils.IsNUnitRunning)
             {
-                AddStep("exit game", () => Game.Exit());
-                AddUntilStep("wait for game exit", () => Game.Parent == null);
+                AddStep("exit game", () => Game?.Exit());
+                AddUntilStep("wait for game exit", () => Game?.Parent == null);
+                AddStep("dispose game", () => Game?.Dispose());
             }
         }
 


### PR DESCRIPTION
When running the `osu.Game.Tests.Navigation` tests, I noticed that my process would gradually creep up in memory.

This is how the full run looks now:

<img width="952" alt="image" src="https://github.com/user-attachments/assets/193a0629-c768-4f69-b70a-3dd717bb4015" />

Note that you're not going to see any improvements until o!f is updated to a version containing https://github.com/ppy/osu-framework/pull/6606.