### PR TITLE
Refactor beatmap overlay leaderboard to use `SoloScoreInfo`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             dependencies.Cache(Realm);
             dependencies.Cache(Beatmaps = new BeatmapManager(LocalStorage, Realm, null, Dependencies.Get<AudioManager>(), Resources, Dependencies.Get<GameHost>(), Beatmap.Default));
             dependencies.Cache(Config = new OsuConfigManager(LocalStorage));
-            dependencies.Cache(ScoreManager = new ScoreManager(Rulesets, () => Beatmaps, LocalStorage, Realm, API, Config));
+            dependencies.Cache(ScoreManager = new ScoreManager(Rulesets, () => Beatmaps, LocalStorage, Realm, API));
 
             dependencies.CacheAs<BeatmapStore>(beatmapStore = new RealmDetachedBeatmapStore());
 

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -159,8 +159,8 @@ namespace osu.Game.Online.API.Requests.Responses
         IUser IScoreInfo.User => User!;
         DateTimeOffset IScoreInfo.Date => EndedAt;
         long IScoreInfo.LegacyOnlineID => (long?)LegacyScoreId ?? -1;
-        IBeatmapInfo IScoreInfo.Beatmap => Beatmap!;
-        IRulesetInfo IScoreInfo.Ruleset => Beatmap!.Ruleset;
+        IBeatmapInfo? IScoreInfo.Beatmap => Beatmap;
+        IRulesetInfo IScoreInfo.Ruleset => new APIBeatmap.APIRuleset { OnlineID = RulesetID };
 
         #endregion
 

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -18,6 +18,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
+using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -86,6 +87,9 @@ namespace osu.Game.Online.Leaderboards
 
         [Resolved]
         private ScoreManager scoreManager { get; set; } = null!;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
 
         public LeaderboardScore(ScoreInfo score, int? rank, bool isOnlineScope = true, bool highlightFriend = true)
         {
@@ -230,7 +234,7 @@ namespace osu.Game.Online.Leaderboards
                                         {
                                             TextColour = Color4.White,
                                             GlowColour = Color4Extensions.FromHex(@"83ccfa"),
-                                            Current = scoreManager.GetBindableTotalScoreString(Score),
+                                            Current = Score.GetBindableTotalScoreString(config),
                                             Font = OsuFont.Numeric.With(size: 23),
                                             Margin = new MarginPadding { Top = 1 },
                                         },

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -320,7 +320,7 @@ namespace osu.Game
             dependencies.Cache(difficultyCache = new BeatmapDifficultyCache());
 
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()
-            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, API, LocalConfig));
+            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, API));
 
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, realm, API, Audio, Resources, Host, defaultBeatmap, difficultyCache, performOnlineLookups: true));
             dependencies.CacheAs<IWorkingBeatmapCache>(BeatmapManager);

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
@@ -9,7 +9,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Scoring;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
 
@@ -19,7 +20,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
     {
         private readonly Box background;
 
-        public DrawableTopScore(ScoreInfo score, int? position = 1)
+        public DrawableTopScore(SoloScoreInfo score, APIBeatmap beatmap, Ruleset ruleset, int? position = 1)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -59,19 +60,16 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                             {
                                 new Drawable[]
                                 {
-                                    new TopScoreUserSection
+                                    new TopScoreUserSection(score, position)
                                     {
                                         Anchor = Anchor.CentreLeft,
                                         Origin = Anchor.CentreLeft,
-                                        Score = score,
-                                        ScorePosition = position,
                                     },
                                     null,
-                                    new TopScoreStatisticsSection
+                                    new TopScoreStatisticsSection(score, beatmap, ruleset)
                                     {
                                         Anchor = Anchor.CentreRight,
                                         Origin = Anchor.CentreRight,
-                                        Score = score,
                                     }
                                 },
                             },

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -23,6 +23,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Mods;
 
@@ -35,7 +36,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         private const int text_size = 12;
 
         [Resolved]
-        private ScoreManager scoreManager { get; set; }
+        private OsuConfigManager config { get; set; }
 
         private readonly FillFlowContainer backgroundFlow;
 
@@ -148,7 +149,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 new OsuSpriteText
                 {
                     Margin = new MarginPadding { Right = horizontal_inset },
-                    Current = scoreManager.GetBindableTotalScoreString(score),
+                    Current = score.GetBindableTotalScoreString(config),
                     Font = OsuFont.GetFont(size: text_size, weight: index == 0 ? FontWeight.Bold : FontWeight.Medium)
                 },
                 new StatisticText(score.Accuracy, 1, showTooltip: false)

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -6,6 +6,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
@@ -23,9 +24,13 @@ using osu.Framework.Localisation;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -64,23 +69,20 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         /// </summary>
         private readonly List<LocalisableString> statisticResultNames = new List<LocalisableString>();
 
-        private bool showPerformancePoints;
-
-        public void DisplayScores(IReadOnlyList<ScoreInfo> scores, bool showPerformanceColumn)
+        public void DisplayScores(IReadOnlyList<SoloScoreInfo> scores, APIBeatmap beatmap, Ruleset ruleset)
         {
             ClearScores();
 
             if (!scores.Any())
                 return;
 
-            showPerformancePoints = showPerformanceColumn;
             statisticResultNames.Clear();
 
             for (int i = 0; i < scores.Count; i++)
                 backgroundFlow.Add(new ScoreTableRowBackground(i, scores[i], row_height));
 
-            Columns = createHeaders(scores);
-            Content = scores.Select((s, i) => createContent(i, s)).ToArray().ToRectangular();
+            Columns = createHeaders(scores, beatmap, ruleset);
+            Content = scores.Select((s, i) => createContent(i, s, beatmap, ruleset)).ToArray().ToRectangular();
         }
 
         public void ClearScores()
@@ -89,7 +91,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             backgroundFlow.Clear();
         }
 
-        private TableColumn[] createHeaders(IReadOnlyList<ScoreInfo> scores)
+        private TableColumn[] createHeaders(IReadOnlyList<SoloScoreInfo> scores, APIBeatmap beatmap, Ruleset ruleset)
         {
             var columns = new List<TableColumn>
             {
@@ -103,9 +105,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             };
 
             // All statistics across all scores, unordered.
-            var allScoreStatistics = scores.SelectMany(s => s.GetStatisticsForDisplay().Select(stat => stat.Result)).ToHashSet();
-
-            var ruleset = scores.First().Ruleset.CreateInstance();
+            var allScoreStatistics = scores.SelectMany(s => s.GetStatisticsForDisplay(ruleset).Select(stat => stat.Result)).ToHashSet();
 
             foreach (var resultGroup in ruleset.GetHitResults().GroupBy(r => r.displayName))
             {
@@ -121,7 +121,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 statisticResultNames.Add(resultGroup.Key);
             }
 
-            if (showPerformancePoints)
+            if (beatmap.Status.GrantsPerformancePoints())
                 columns.Add(new TableColumn(BeatmapsetsStrings.ShowScoreboardHeaderspp, Anchor.CentreLeft, new Dimension(GridSizeMode.Absolute, 30)));
 
             columns.Add(new TableColumn(BeatmapsetsStrings.ShowScoreboardHeadersTime, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize)));
@@ -130,9 +130,11 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             return columns.ToArray();
         }
 
-        private Drawable[] createContent(int index, ScoreInfo score)
+        private Drawable[] createContent(int index, SoloScoreInfo score, APIBeatmap beatmap, Ruleset ruleset)
         {
             var username = new LinkFlowContainer(t => t.Font = OsuFont.GetFont(size: text_size)) { AutoSizeAxes = Axes.Both };
+
+            Debug.Assert(score.User != null);
             username.AddUserLink(score.User);
 
             var content = new List<Drawable>
@@ -155,7 +157,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 new StatisticText(score.Accuracy, 1, showTooltip: false)
                 {
                     Margin = new MarginPadding { Right = horizontal_inset },
-                    Text = score.DisplayAccuracy,
+                    Text = score.Accuracy.FormatAccuracy(),
                 },
                 new UpdateableFlag(score.User.CountryCode)
                 {
@@ -176,11 +178,11 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     }
                 },
 #pragma warning disable 618
-                new StatisticText(score.MaxCombo, score.BeatmapInfo!.MaxCombo, @"0\x"),
+                new StatisticText(score.MaxCombo, beatmap.MaxCombo, @"0\x"),
 #pragma warning restore 618
             };
 
-            var availableStatistics = score.GetStatisticsForDisplay().ToLookup(tuple => tuple.DisplayName);
+            var availableStatistics = score.GetStatisticsForDisplay(ruleset).ToLookup(tuple => tuple.DisplayName);
 
             foreach (var columnName in statisticResultNames)
             {
@@ -201,11 +203,10 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 content.Add(new StatisticText(count, maxCount, @"N0") { Colour = count == 0 ? Color4.Gray : Color4.White });
             }
 
-            // TODO: all this should be using the same sort of logic as `DrawableProfileScore` is, but that's not easily done
-            // unless the ENTIRE overlay can be weaned off of `ScoreInfo` and use `SoloScoreInfo` instead
-            if (showPerformancePoints)
+            if (beatmap.Status.GrantsPerformancePoints())
             {
-                if (!score.Ranked)
+                // cross-reference: https://github.com/ppy/osu-web/blob/a6afee076f4f68bb56dea0cb8f18db63651763a7/resources/js/scores/pp-value.tsx#L19-L39
+                if (!score.Ranked || !score.Preserve || (score.PP == null && score.Processed))
                 {
                     content.Add(new SpriteTextWithTooltip
                     {
@@ -227,7 +228,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     content.Add(new StatisticText(score.PP, format: @"N0"));
             }
 
-            content.Add(new ScoreboardTime(score.Date, text_size)
+            content.Add(new ScoreboardTime(score.EndedAt, text_size)
             {
                 Margin = new MarginPadding { Right = 10 }
             });
@@ -237,7 +238,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 Direction = FillDirection.Horizontal,
                 AutoSizeAxes = Axes.Both,
                 Spacing = new Vector2(1),
-                ChildrenEnumerable = score.Mods.AsOrdered().Select(m => new ModIcon(m)
+                ChildrenEnumerable = score.Mods.Select(m => m.ToMod(ruleset)).AsOrdered().Select(m => new ModIcon(m)
                 {
                     AutoSizeAxes = Axes.Both,
                     Scale = new Vector2(0.3f)

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTableRowBackground.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTableRowBackground.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Online.API;
-using osu.Game.Scoring;
+using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -20,9 +20,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         private readonly Box background;
 
         private readonly int index;
-        private readonly ScoreInfo score;
+        private readonly SoloScoreInfo score;
 
-        public ScoreTableRowBackground(int index, ScoreInfo score, float height)
+        public ScoreTableRowBackground(int index, SoloScoreInfo score, float height)
         {
             this.index = index;
             this.score = score;

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     return;
 
                 var scores = value.Scores.OrderByTotalScore().ToArray();
-                var rulesetInstance = rulesets.GetRuleset(ruleset.Value.OnlineID)!.CreateInstance();
+                var rulesetInstance = rulesets.GetRuleset(scores.First().RulesetID)!.CreateInstance();
 
                 scoreTable.DisplayScores(scores, Beatmap.Value, rulesetInstance);
                 scoreTable.Show();

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -44,6 +45,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
 
         [Resolved]
         private ScoreManager scoreManager { get; set; }
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
 
         public TopScoreStatisticsSection()
         {
@@ -99,7 +103,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         {
             if (score != null)
             {
-                totalScoreColumn.Current = scoreManager.GetBindableTotalScoreString(score);
+                totalScoreColumn.Current = score.GetBindableTotalScoreString(config);
 
                 if (score.Accuracy == 1.0) accuracyColumn.TextColour = colours.GreenLight;
 #pragma warning disable CS0618
@@ -155,7 +159,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 modsColumn.Mods = value.Mods;
 
                 if (scoreManager != null)
-                    totalScoreColumn.Current = scoreManager.GetBindableTotalScoreString(value);
+                    totalScoreColumn.Current = value.GetBindableTotalScoreString(config);
             }
         }
 

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -18,10 +18,13 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
@@ -38,21 +41,22 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         private readonly TotalScoreColumn totalScoreColumn;
         private readonly TextColumn accuracyColumn;
         private readonly TextColumn maxComboColumn;
-        private readonly TextColumn ppColumn;
-
-        private readonly FillFlowContainer<InfoColumn> statisticsColumns;
-        private readonly ModsInfoColumn modsColumn;
-
-        [Resolved]
-        private ScoreManager scoreManager { get; set; }
 
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
 
-        public TopScoreStatisticsSection()
+        private readonly SoloScoreInfo score;
+        private readonly APIBeatmap beatmap;
+
+        public TopScoreStatisticsSection(SoloScoreInfo score, APIBeatmap beatmap, Ruleset ruleset)
         {
+            this.score = score;
+            this.beatmap = beatmap;
+
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
+
+            TextColumn ppColumn;
 
             InternalChild = new FillFlowContainer
             {
@@ -70,9 +74,18 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         Spacing = new Vector2(margin, 0),
                         Children = new Drawable[]
                         {
-                            totalScoreColumn = new TotalScoreColumn(BeatmapsetsStrings.ShowScoreboardHeadersScoreTotal, largeFont, top_columns_min_width),
-                            accuracyColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, largeFont, top_columns_min_width),
+                            totalScoreColumn = new TotalScoreColumn(BeatmapsetsStrings.ShowScoreboardHeadersScoreTotal, largeFont, top_columns_min_width)
+                            {
+                                Current = score.GetBindableTotalScoreString(config),
+                            },
+                            accuracyColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, largeFont, top_columns_min_width)
+                            {
+                                Text = score.Accuracy.FormatAccuracy(),
+                            },
                             maxComboColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeadersCombo, largeFont, top_columns_min_width)
+                            {
+                                Text = score.MaxCombo.ToLocalisableString(@"0\x"),
+                            }
                         }
                     },
                     new FillFlowContainer
@@ -84,18 +97,47 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         Spacing = new Vector2(margin, 0),
                         Children = new Drawable[]
                         {
-                            statisticsColumns = new FillFlowContainer<InfoColumn>
+                            new FillFlowContainer<InfoColumn>
                             {
                                 AutoSizeAxes = Axes.Both,
                                 Direction = FillDirection.Horizontal,
                                 Spacing = new Vector2(margin, 0),
+                                ChildrenEnumerable = score.GetStatisticsForDisplay(ruleset).Select(createStatisticsColumn),
                             },
-                            ppColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeaderspp, smallFont, bottom_columns_min_width),
-                            modsColumn = new ModsInfoColumn(),
+                            ppColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeaderspp, smallFont, bottom_columns_min_width)
+                            {
+                                Alpha = beatmap.Status.GrantsPerformancePoints() ? 1 : 0,
+                            },
+                            new ModsInfoColumn
+                            {
+                                Mods = score.Mods.Select(m => m.ToMod(ruleset)),
+                            },
                         }
                     },
                 }
             };
+
+            // cross-reference: https://github.com/ppy/osu-web/blob/a6afee076f4f68bb56dea0cb8f18db63651763a7/resources/js/scores/pp-value.tsx#L19-L39
+            if (!score.Ranked || !score.Preserve || (score.PP == null && score.Processed))
+            {
+                ppColumn.Drawable = new SpriteTextWithTooltip
+                {
+                    Text = "-",
+                    Font = smallFont,
+                    TooltipText = ScoresStrings.StatusNoPp
+                };
+            }
+            else if (score.PP is not double pp)
+            {
+                ppColumn.Drawable = new SpriteIconWithTooltip
+                {
+                    Icon = FontAwesome.Solid.Sync,
+                    Size = new Vector2(smallFont.Size),
+                    TooltipText = ScoresStrings.StatusProcessing,
+                };
+            }
+            else
+                ppColumn.Text = pp.ToLocalisableString(@"N0");
         }
 
         [BackgroundDependencyLoader]
@@ -105,61 +147,11 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             {
                 totalScoreColumn.Current = score.GetBindableTotalScoreString(config);
 
-                if (score.Accuracy == 1.0) accuracyColumn.TextColour = colours.GreenLight;
-#pragma warning disable CS0618
-                if (score.MaxCombo == score.BeatmapInfo!.MaxCombo) maxComboColumn.TextColour = colours.GreenLight;
-#pragma warning restore CS0618
-            }
-        }
+                if (score.Accuracy == 1.0)
+                    accuracyColumn.TextColour = colours.GreenLight;
 
-        private ScoreInfo score;
-
-        /// <summary>
-        /// Sets the score to be displayed.
-        /// </summary>
-        public ScoreInfo Score
-        {
-            set
-            {
-                if (score == null && value == null)
-                    return;
-
-                if (score?.Equals(value) == true)
-                    return;
-
-                score = value;
-
-                accuracyColumn.Text = value.DisplayAccuracy;
-                maxComboColumn.Text = value.MaxCombo.ToLocalisableString(@"0\x");
-
-                ppColumn.Alpha = value.BeatmapInfo!.Status.GrantsPerformancePoints() ? 1 : 0;
-
-                if (!value.Ranked)
-                {
-                    ppColumn.Drawable = new SpriteTextWithTooltip
-                    {
-                        Text = "-",
-                        Font = smallFont,
-                        TooltipText = ScoresStrings.StatusNoPp
-                    };
-                }
-                else if (value.PP is not double pp)
-                {
-                    ppColumn.Drawable = new SpriteIconWithTooltip
-                    {
-                        Icon = FontAwesome.Solid.Sync,
-                        Size = new Vector2(smallFont.Size),
-                        TooltipText = ScoresStrings.StatusProcessing,
-                    };
-                }
-                else
-                    ppColumn.Text = pp.ToLocalisableString(@"N0");
-
-                statisticsColumns.ChildrenEnumerable = value.GetStatisticsForDisplay().Select(createStatisticsColumn);
-                modsColumn.Mods = value.Mods;
-
-                if (scoreManager != null)
-                    totalScoreColumn.Current = value.GetBindableTotalScoreString(config);
+                if (score.MaxCombo == beatmap.MaxCombo)
+                    maxComboColumn.TextColour = colours.GreenLight;
             }
         }
 

--- a/osu.Game/Scoring/IScoreInfo.cs
+++ b/osu.Game/Scoring/IScoreInfo.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Users;
 
 namespace osu.Game.Scoring
@@ -33,6 +35,10 @@ namespace osu.Game.Scoring
         IRulesetInfo Ruleset { get; }
 
         ScoreRank Rank { get; }
+
+        Dictionary<HitResult, int> Statistics { get; }
+
+        Dictionary<HitResult, int> MaximumStatistics { get; }
 
         // Mods is currently missing from this interface as the `IMod` class has properties which can't be fulfilled by `APIMod`,
         // but also doesn't expose `Settings`. We can consider how to implement this in the future if required.

--- a/osu.Game/Scoring/IScoreInfo.cs
+++ b/osu.Game/Scoring/IScoreInfo.cs
@@ -42,7 +42,5 @@ namespace osu.Game.Scoring
 
         // Mods is currently missing from this interface as the `IMod` class has properties which can't be fulfilled by `APIMod`,
         // but also doesn't expose `Settings`. We can consider how to implement this in the future if required.
-
-        // Statistics is also missing. This can be reconsidered once changes in serialisation have been completed.
     }
 }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -357,36 +357,6 @@ namespace osu.Game.Scoring
                 : string.Empty;
         }
 
-        public IEnumerable<HitResultDisplayStatistic> GetStatisticsForDisplay()
-        {
-            foreach (var r in Ruleset.CreateInstance().GetHitResults())
-            {
-                int value = Statistics.GetValueOrDefault(r.result);
-
-                switch (r.result)
-                {
-                    case HitResult.SmallTickHit:
-                    case HitResult.LargeTickHit:
-                    case HitResult.SliderTailHit:
-                    case HitResult.LargeBonus:
-                    case HitResult.SmallBonus:
-                        if (MaximumStatistics.TryGetValue(r.result, out int count) && count > 0)
-                            yield return new HitResultDisplayStatistic(r.result, value, count, r.displayName);
-
-                        break;
-
-                    case HitResult.SmallTickMiss:
-                    case HitResult.LargeTickMiss:
-                        break;
-
-                    default:
-                        yield return new HitResultDisplayStatistic(r.result, value, null, r.displayName);
-
-                        break;
-                }
-            }
-        }
-
         #endregion
 
         public bool Equals(ScoreInfo? other) => other?.ID == ID;

--- a/osu.Game/Scoring/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/ScoreInfoExtensions.cs
@@ -16,11 +16,12 @@ namespace osu.Game.Scoring
         public static string GetDisplayTitle(this IScoreInfo scoreInfo) => $"{scoreInfo.User.Username} playing {scoreInfo.Beatmap?.GetDisplayTitle() ?? "unknown"}";
 
         /// <summary>
-        /// Orders an array of <see cref="ScoreInfo"/>s by total score.
+        /// Orders an array of <typeparamref name="TScoreInfo"/>s by total score.
         /// </summary>
-        /// <param name="scores">The array of <see cref="ScoreInfo"/>s to reorder.</param>
+        /// <param name="scores">The array of <typeparamref name="TScoreInfo"/>s to reorder.</param>
         /// <returns>The given <paramref name="scores"/> ordered by decreasing total score.</returns>
-        public static IEnumerable<ScoreInfo> OrderByTotalScore(this IEnumerable<ScoreInfo> scores)
+        public static IEnumerable<TScoreInfo> OrderByTotalScore<TScoreInfo>(this IEnumerable<TScoreInfo> scores)
+            where TScoreInfo : IScoreInfo
             => scores.OrderByDescending(s => s.TotalScore)
                      .ThenBy(s => s.OnlineID)
                      // Local scores may not have an online ID. Fall back to date in these cases.

--- a/osu.Game/Scoring/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/ScoreInfoExtensions.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Scoring
 {
     public static class ScoreInfoExtensions
     {
+        /// <summary>
+        /// Computes the total score based on the given scoring mode.
+        /// </summary>
         public static long GetDisplayScore(this IScoreInfo score, ScoringMode mode)
         {
             switch (score)
@@ -48,16 +51,13 @@ namespace osu.Game.Scoring
                      .ThenBy(s => s.Date);
 
         /// <summary>
-        /// Retrieves the maximum achievable combo for the provided score.
+        /// Returns the list of hit result statistics applicable for this score.
         /// </summary>
-        /// <param name="score">The <see cref="ScoreInfo"/> to compute the maximum achievable combo for.</param>
-        /// <returns>The maximum achievable combo.</returns>
-        public static int GetMaximumAchievableCombo(this ScoreInfo score) => score.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Sum(kvp => kvp.Value);
-
-        public static IEnumerable<HitResultDisplayStatistic> GetStatisticsForDisplay(this ScoreInfo score) => score.GetStatisticsForDisplay(score.Ruleset.CreateInstance());
-
         public static IEnumerable<HitResultDisplayStatistic> GetStatisticsForDisplay(this IScoreInfo score, Ruleset ruleset)
         {
+            if (ruleset.RulesetInfo.OnlineID != score.Ruleset.OnlineID)
+                throw new InvalidOperationException($@"The ID of the given ruleset instance ({ruleset.RulesetInfo.OnlineID}) does not match the score's ruleset ({score.Ruleset.OnlineID})");
+
             foreach (var r in ruleset.GetHitResults())
             {
                 int value = score.Statistics.GetValueOrDefault(r.result);
@@ -107,6 +107,22 @@ namespace osu.Game.Scoring
         /// <param name="config">The <see cref="OsuConfigManager"/> to read and listen to the active scoring mode from.</param>
         /// <returns>The bindable containing the formatted total score string.</returns>
         public static Bindable<string> GetBindableTotalScoreString(this IScoreInfo score, OsuConfigManager config) => new TotalScoreStringBindable(GetBindableTotalScore(score, config));
+
+        #region ScoreInfo-specific extensions
+
+        /// <summary>
+        /// Retrieves the maximum achievable combo for the provided score.
+        /// </summary>
+        /// <param name="score">The <see cref="ScoreInfo"/> to compute the maximum achievable combo for.</param>
+        /// <returns>The maximum achievable combo.</returns>
+        public static int GetMaximumAchievableCombo(this ScoreInfo score) => score.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Sum(kvp => kvp.Value);
+
+        /// <summary>
+        /// Returns the list of hit result statistics applicable for this score.
+        /// </summary>
+        public static IEnumerable<HitResultDisplayStatistic> GetStatisticsForDisplay(this ScoreInfo score) => score.GetStatisticsForDisplay(score.Ruleset.CreateInstance());
+
+        #endregion
 
         /// <summary>
         /// Provides the total score of a <see cref="IScoreInfo"/>. Responds to changes in the currently-selected <see cref="ScoringMode"/>.

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps.Drawables;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Leaderboards;
@@ -36,7 +37,7 @@ namespace osu.Game.Screens.Ranking.Contracted
         private readonly ScoreInfo score;
 
         [Resolved]
-        private ScoreManager scoreManager { get; set; } = null!;
+        private OsuConfigManager config { get; set; } = null!;
 
         /// <summary>
         /// Creates a new <see cref="ContractedPanelMiddleContent"/>.
@@ -181,7 +182,7 @@ namespace osu.Game.Screens.Ranking.Contracted
                                     {
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.Centre,
-                                        Current = scoreManager.GetBindableTotalScoreString(score),
+                                        Current = score.GetBindableTotalScoreString(config),
                                         Font = OsuFont.GetFont(size: 20, weight: FontWeight.Medium, fixedWidth: true),
                                         Spacing = new Vector2(-1, 0)
                                     },

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Ranking.Expanded
         private RollingCounter<long> scoreCounter = null!;
 
         [Resolved]
-        private ScoreManager scoreManager { get; set; } = null!;
+        private OsuConfigManager config { get; set; } = null!;
 
         /// <summary>
         /// Creates a new <see cref="ExpandedPanelMiddleContent"/>.
@@ -250,7 +250,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                 using (BeginDelayedSequence(AccuracyCircle.ACCURACY_TRANSFORM_DELAY))
                 {
                     scoreCounter.FadeIn();
-                    scoreCounter.Current = scoreManager.GetBindableTotalScore(score);
+                    scoreCounter.Current = score.GetBindableTotalScore(config);
 
                     double delay = 0;
 

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -438,7 +438,7 @@ namespace osu.Game.Screens.SelectV2
                                                         Anchor = Anchor.TopRight,
                                                         Origin = Anchor.TopRight,
                                                         UseFullGlyphHeight = false,
-                                                        Current = scoreManager.GetBindableTotalScoreString(Score),
+                                                        Current = Score.GetBindableTotalScoreString(config),
                                                         Spacing = new Vector2(-1.5f),
                                                         Font = OsuFont.Style.Subtitle.With(weight: FontWeight.Light, fixedWidth: true),
                                                         Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore_Tooltip.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore_Tooltip.cs
@@ -398,7 +398,7 @@ namespace osu.Game.Screens.SelectV2
                 private OsuSpriteText totalScore = null!;
 
                 [Resolved]
-                private ScoreManager scoreManager { get; set; } = null!;
+                private OsuConfigManager config { get; set; } = null!;
 
                 public ScoreInfo Score
                 {
@@ -408,7 +408,7 @@ namespace osu.Game.Screens.SelectV2
                             OsuColour.ForRank(value.Rank).Opacity(0f),
                             OsuColour.ForRank(value.Rank).Opacity(0.5f));
                         rankContainer.Child = new DrawableRank(value.Rank);
-                        totalScore.Current = scoreManager.GetBindableTotalScoreString(value);
+                        totalScore.Current = value.GetBindableTotalScoreString(config);
                     }
                 }
 


### PR DESCRIPTION
The end goal of this change is to be able to access `SoloScoreInfo`-specific attributes, specifically pinning attributes for #33874 (see https://github.com/ppy/osu/pull/33874#discussion_r2168447898). However, this is also generally a good code quality change that resolves existing concerns in the leaderboard implementation (such as PP value potentially not displaying correctly due to lack of specific attributes).

This is a slightly heavy PR as it expands on the `IScoreInfo`/`SoloScoreInfo` API so that it can be used directly in the target components without resorting to `SoloScoreInfo`->`ScoreInfo` conversion.

Notably:
 - https://github.com/ppy/osu/commit/a5d0a6eeb60638bec6b4f45a0f7a90504759e373: Expands `OrderByTotalScore` extension method to all `IScoreInfo` models.
 - https://github.com/ppy/osu/commit/460294b4233d4ad3e89adfe9fbe489cf71f615e3: `ScoreInfo.GetStatisticsForDisplay` has been moved to an `IScoreInfo` extension method, as well as exposing `Statistics`/`MaximumStatistics` via the interface.
 - https://github.com/ppy/osu/commit/21a68de3c9bb08708fec07c79c32d7ec46474a9b: `ScoreManager.GetBindableTotalScore{String}` has been moved to an `IScoreInfo` extension method.
 - https://github.com/ppy/osu/commit/ba5032abf4e767f284451ad6fcdf782c34631269: Fixes `SoloScoreInfo`'s `IScoreInfo.Ruleset` implementation nullreffing when `Beatmap` is not included. This is the case on the beatmap-based `GetScoresRequest` endpoint. This specific implementation has not been used anywhere before, and is not used in this PR anywhere besides https://github.com/ppy/osu/commit/639db061d8e636b08b3028c60d1b6d640c56dbc7.

I've also applied minor refactors on the components of the leaderboard to work with `SoloScoreInfo` without introducing ugly code in every usage.

Normally I would've split the changes above to a dependency PR, but seeing that chains are frowned upon nowadays, I've chucked everything in a single PR. It shouldn't be hard to review either way.