### PR TITLE
Add DF flashlight rating reduction

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -288,6 +288,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 flashlightRating *= 0.7;
             else if (mods.Any(m => m is OsuModAutopilot))
                 flashlightRating *= 0.4;
+            else if (mods.Any(m => m is OsuModDeflate))
+            {
+                float deflateInitialScale = mods.OfType<OsuModDeflate>().First().StartScale.Value;
+                flashlightRating *= 1.0 - Math.Clamp((deflateInitialScale - 1) / 10, 0.0, 0.9);
+            }
 
             if (mods.Any(m => m is OsuModMagnetised))
             {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             else if (mods.Any(m => m is OsuModDeflate))
             {
                 float deflateInitialScale = mods.OfType<OsuModDeflate>().First().StartScale.Value;
-                flashlightRating *= 1.0 - Math.Clamp((deflateInitialScale - 1) / 10, 0.0, 0.9);
+                flashlightRating *= Math.Clamp(DifficultyCalculationUtils.ReverseLerp(deflateInitialScale, 11, 1), 0.1, 1);
             }
 
             if (mods.Any(m => m is OsuModMagnetised))


### PR DESCRIPTION
Similar to https://github.com/ppy/osu/pull/33004 this is meant to just fix some silliness and is not a proper mod support.

Deflate simplifies FL by quite a lot since more of the circle is visible most of the time. DF can scale up to 25, but starting from around 8 you can see circles pretty much all the time anyway

<img width="1290" height="282" alt="image" src="https://github.com/user-attachments/assets/a891e572-7e63-49c0-9098-09631ce039f0" />
