### PR TITLE
Improve song select's automatic selection behaviour when current selection is no longer valid

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -159,14 +159,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
         }
 
-        protected void ImportBeatmapForRuleset(int rulesetId)
+        protected void ImportBeatmapForRuleset(params int[] rulesetIds)
         {
             int beatmapsCount = 0;
 
-            AddStep($"import test map for ruleset {rulesetId}", () =>
+            AddStep($"import test map for ruleset {rulesetIds}", () =>
             {
                 beatmapsCount = SongSelect.IsNull() ? 0 : Carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single().SetItems.Count;
-                Beatmaps.Import(TestResources.CreateTestBeatmapSetInfo(3, Rulesets.AvailableRulesets.Where(r => r.OnlineID == rulesetId).ToArray()));
+                Beatmaps.Import(TestResources.CreateTestBeatmapSetInfo(3, Rulesets.AvailableRulesets.Where(r => rulesetIds.Contains(r.OnlineID)).ToArray()));
             });
 
             // This is specifically for cases where the add is happening post song select load.

--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -143,6 +144,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("load screen", () => Stack.Push(SongSelect = new SoloSongSelect()));
             AddUntilStep("wait for load", () => Stack.CurrentScreen == SongSelect && SongSelect.IsLoaded);
             AddUntilStep("wait for filtering", () => !Carousel.IsFiltering);
+        }
+
+        protected void SortBy(SortMode mode) => AddStep($"sort by {mode.GetDescription().ToLowerInvariant()}", () => Config.SetValue(OsuSetting.SongSelectSortingMode, mode));
+
+        protected void GroupBy(GroupMode mode) => AddStep($"group by {mode.GetDescription().ToLowerInvariant()}", () => Config.SetValue(OsuSetting.SongSelectGroupMode, mode));
+
+        protected void SortAndGroupBy(SortMode sort, GroupMode group)
+        {
+            AddStep($"sort by {sort.GetDescription().ToLowerInvariant()} & group by {group.GetDescription().ToLowerInvariant()}", () =>
+            {
+                Config.SetValue(OsuSetting.SongSelectSortingMode, sort);
+                Config.SetValue(OsuSetting.SongSelectGroupMode, group);
+            });
         }
 
         protected void ImportBeatmapForRuleset(int rulesetId)

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
@@ -1,0 +1,198 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    /// <summary>
+    /// The fallback behaviour guaranteed by SongSelect is that a random selection will happen in worst case scenario.
+    /// Every case we're testing here is expected to have a *custom behaviour* – engaging and overriding this random selection fallback.
+    ///
+    /// The scenarios we care abouts are:
+    /// - Beatmap set deleted (select closest valid beatmap post-deletion)
+    ///
+    /// We are working with 5 sets, each with 3 difficulties (all osu! ruleset).
+    /// </summary>
+    public partial class TestSceneSongSelectCurrentSelectionInvalidated : SongSelectTestScene
+    {
+        private BeatmapInfo? selectedBeatmap => (BeatmapInfo?)Carousel.CurrentSelection;
+        private BeatmapSetInfo? selectedBeatmapSet => selectedBeatmap?.BeatmapSet;
+
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            for (int i = 0; i < 5; i++)
+                ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+        }
+
+        /// <summary>
+        /// Make sure that deleting all sets doesn't hit some weird edge case / crash.
+        /// </summary>
+        [TestCase(SortMode.Title)]
+        [TestCase(SortMode.Artist)]
+        [TestCase(SortMode.Difficulty)]
+        public void TestDeleteAllSets(SortMode sortMode)
+        {
+            int filterCount = sortMode != SortMode.Title ? 2 : 1;
+
+            SortBy(sortMode);
+            waitForFiltering(filterCount);
+
+            BeatmapSetInfo deletedSet = null!;
+
+            for (int i = 0; i < 4; i++)
+            {
+                AddStep("delete selected", () => Beatmaps.Delete(deletedSet = selectedBeatmapSet!));
+                waitForFiltering(filterCount + 1 + i);
+                selectionChangedFrom(() => deletedSet);
+            }
+
+            // The carousel still holds an invalid selection after the final deletion. Probably fine?
+            AddStep("delete selected", () => Beatmaps.Delete(deletedSet = selectedBeatmapSet!));
+            AddUntilStep("wait for no global selection", () => Beatmap.IsDefault, () => Is.True);
+        }
+
+        [Test]
+        public void DifficultiesGrouped_DeleteSet_SelectsAdjacent()
+        {
+            SortAndGroupBy(SortMode.Difficulty, GroupMode.Difficulty);
+            waitForFiltering(2);
+
+            makePanelSelected<PanelGroupStarDifficulty>(2);
+            makePanelSelected<PanelBeatmapStandalone>(3);
+
+            // Deleting second-last, should select last
+            BeatmapSetInfo deletedSet = null!;
+            AddStep("delete selected", () => Beatmaps.Delete(deletedSet = selectedBeatmapSet!));
+            waitForFiltering(3);
+
+            selectionChangedFrom(() => deletedSet);
+            assertPanelSelected<PanelBeatmapStandalone>(3);
+
+            // Deleting last, should select previous
+            AddStep("delete selected", () => Beatmaps.Delete(deletedSet = selectedBeatmapSet!));
+            waitForFiltering(4);
+
+            selectionChangedFrom(() => deletedSet);
+            assertPanelSelected<PanelBeatmapStandalone>(2);
+        }
+
+        [TestCase(SortMode.Title)]
+        [TestCase(SortMode.Artist)]
+        public void SetsGrouped_DeleteSet_SelectsAdjacent(SortMode sortMode)
+        {
+            int filterCount = sortMode != SortMode.Title ? 2 : 1;
+
+            SortBy(sortMode);
+            waitForFiltering(filterCount);
+
+            makePanelSelected<PanelBeatmapSet>(3);
+
+            // Deleting second-last, should select last
+            BeatmapSetInfo deletedSet = null!;
+            AddStep("delete selected", () => Beatmaps.Delete(deletedSet = selectedBeatmapSet!));
+            waitForFiltering(filterCount + 1);
+
+            selectionChangedFrom(() => deletedSet);
+            assertPanelSelected<PanelBeatmapSet>(3);
+            assertPanelSelected<PanelBeatmap>(0);
+
+            // Deleting last, should select previous
+            AddStep("delete selected", () => Beatmaps.Delete(deletedSet = selectedBeatmapSet!));
+            waitForFiltering(filterCount + 2);
+
+            selectionChangedFrom(() => deletedSet);
+            assertPanelSelected<PanelBeatmapSet>(2);
+            assertPanelSelected<PanelBeatmap>(0);
+        }
+
+        // Same scenario as the test case above, but where selected difficulty before deletion is not first index in the expanded set.
+        // Basically ensures that the reselection is running `RequestRecommendedSelection` and not just relying on indices.
+        [TestCase(SortMode.Title)]
+        [TestCase(SortMode.Artist)]
+        public void SetsGrouped_DeleteSet_SelectsNextSetRecommendedDifficulty(SortMode sortMode)
+        {
+            int filterCount = sortMode != SortMode.Title ? 2 : 1;
+
+            SortBy(sortMode);
+            waitForFiltering(filterCount);
+
+            makePanelSelected<PanelBeatmapSet>(2);
+            makePanelSelected<PanelBeatmap>(2);
+
+            AddUntilStep("wait for beatmap to be selected", () => selectedBeatmapSet != null);
+
+            BeatmapSetInfo deletedSet = null!;
+            AddStep("delete selected", () => Beatmaps.Delete(deletedSet = selectedBeatmapSet!));
+            waitForFiltering(++filterCount);
+
+            selectionChangedFrom(() => deletedSet);
+            assertPanelSelected<PanelBeatmapSet>(2);
+            assertPanelSelected<PanelBeatmap>(0);
+        }
+
+        private void waitForFiltering(int filterCount = 1)
+        {
+            AddUntilStep("wait for filter count", () => Carousel.FilterCount, () => Is.EqualTo(filterCount));
+            AddUntilStep("filtering finished", () => Carousel.IsFiltering, () => Is.False);
+        }
+
+        private void makePanelSelected<T>(int index)
+            where T : Panel
+        {
+            AddStep($"click panel at index {index} if not selected", () =>
+            {
+                var panel = allPanels<T>().ElementAt(index).ChildrenOfType<Panel>().Single();
+
+                // May have already been selected randomly. Don't click a second time or gameplay will start.
+                if (!panel.Selected.Value)
+                    panel.TriggerClick();
+            });
+
+            assertPanelSelected<T>(index);
+        }
+
+        private void selectionChangedFrom(Func<BeatmapSetInfo> deletedSet) =>
+            AddUntilStep("selection changed", () => selectedBeatmapSet, () => Is.Not.EqualTo(deletedSet()));
+
+        private void assertPanelSelected<T>(int index)
+            where T : Panel
+            => AddUntilStep($"selected panel at index {index}", getActivePanelIndex<T>, () => Is.EqualTo(index));
+
+        private int getActivePanelIndex<T>()
+            where T : Panel
+            => allPanels<T>().ToList().FindIndex(p =>
+            {
+                switch (p)
+                {
+                    case PanelBeatmapStandalone pb:
+                        return pb.Selected.Value;
+
+                    case PanelBeatmap pb:
+                        return pb.Selected.Value;
+
+                    case Panel pbs:
+                        return pbs.Expanded.Value;
+
+                    default:
+                        throw new InvalidOperationException();
+                }
+            });
+
+        private IEnumerable<T> allPanels<T>()
+            where T : Panel
+            => Carousel.ChildrenOfType<T>().Where(p => p.Item != null).OrderBy(p => p.Y);
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
     /// Every case we're testing here is expected to have a *custom behaviour* – engaging and overriding this random selection fallback.
     ///
     /// The scenarios we care abouts are:
+    /// - Ruleset change (select another difficulty from same set for the new ruleset, if possible).
+    /// - Beatmap difficulty hidden (select closest valid difficulty from same set)
     /// - Beatmap set deleted (select closest valid beatmap post-deletion)
     ///
     /// We are working with 5 sets, each with 3 difficulties (all osu! ruleset).
@@ -140,6 +142,27 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             selectionChangedFrom(() => deletedSet);
             assertPanelSelected<PanelBeatmapSet>(2);
+            assertPanelSelected<PanelBeatmap>(0);
+        }
+
+        [Test]
+        public void TestHideBeatmap()
+        {
+            makePanelSelected<PanelBeatmapSet>(2);
+            makePanelSelected<PanelBeatmap>(1);
+
+            BeatmapInfo hiddenBeatmap = null!;
+
+            AddStep("hide selected", () => Beatmaps.Hide(hiddenBeatmap = selectedBeatmap!));
+            waitForFiltering(2);
+
+            AddAssert("selected beatmap below", () => selectedBeatmap, () => Is.Not.EqualTo(hiddenBeatmap));
+            assertPanelSelected<PanelBeatmap>(1);
+
+            AddStep("hide selected", () => Beatmaps.Hide(hiddenBeatmap = selectedBeatmap!));
+            waitForFiltering(3);
+
+            AddAssert("selected difficulty above", () => selectedBeatmap, () => Is.Not.EqualTo(hiddenBeatmap));
             assertPanelSelected<PanelBeatmap>(0);
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 
@@ -37,6 +38,38 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 ImportBeatmapForRuleset(0);
 
             LoadSongSelect();
+        }
+
+        [Test]
+        public void TestRulesetChange()
+        {
+            AddStep("disable converts", () => Config.SetValue(OsuSetting.ShowConvertedBeatmaps, false));
+
+            ImportBeatmapForRuleset(0, 1);
+            ImportBeatmapForRuleset(0, 1);
+            ImportBeatmapForRuleset(0, 2);
+            waitForFiltering(5);
+
+            ChangeRuleset(1);
+            waitForFiltering(6);
+
+            BeatmapInfo? initiallySelected = null;
+            AddAssert("selected is taiko", () => (initiallySelected = selectedBeatmap)?.Ruleset.OnlineID, () => Is.EqualTo(1));
+
+            ChangeRuleset(0);
+            waitForFiltering(7);
+            AddAssert("selected is osu", () => selectedBeatmap?.Ruleset.OnlineID, () => Is.EqualTo(0));
+            AddAssert("selected is same set as original", () => selectedBeatmap?.BeatmapSet, () => Is.EqualTo(initiallySelected!.BeatmapSet));
+
+            ChangeRuleset(1);
+            waitForFiltering(8);
+            AddAssert("selected is taiko", () => selectedBeatmap?.Ruleset.OnlineID, () => Is.EqualTo(1));
+            AddAssert("selected is same set as original", () => selectedBeatmap?.BeatmapSet, () => Is.EqualTo(initiallySelected!.BeatmapSet));
+
+            ChangeRuleset(2);
+            waitForFiltering(9);
+            AddAssert("selected is catch", () => selectedBeatmap?.Ruleset.OnlineID, () => Is.EqualTo(2));
+            AddAssert("selected is different set", () => selectedBeatmap?.BeatmapSet, () => Is.Not.EqualTo(initiallySelected!.BeatmapSet));
         }
 
         /// <summary>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
@@ -189,13 +189,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("hide selected", () => Beatmaps.Hide(hiddenBeatmap = selectedBeatmap!));
             waitForFiltering(2);
 
-            AddAssert("selected beatmap below", () => selectedBeatmap, () => Is.Not.EqualTo(hiddenBeatmap));
-            assertPanelSelected<PanelBeatmap>(1);
+            AddAssert("selected beatmap below", () => selectedBeatmap!.BeatmapSet, () => Is.EqualTo(hiddenBeatmap.BeatmapSet));
 
             AddStep("hide selected", () => Beatmaps.Hide(hiddenBeatmap = selectedBeatmap!));
             waitForFiltering(3);
 
-            AddAssert("selected difficulty above", () => selectedBeatmap, () => Is.Not.EqualTo(hiddenBeatmap));
+            AddAssert("selected beatmap below", () => selectedBeatmap!.BeatmapSet, () => Is.EqualTo(hiddenBeatmap.BeatmapSet));
             assertPanelSelected<PanelBeatmap>(0);
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -117,14 +117,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             // TODO: old test has this step, but there doesn't seem to be any purpose for it.
             // AddUntilStep("random map selected", () => Beatmap.Value != defaultBeatmap);
 
-            AddStep(@"Sort by Artist", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Artist));
-            AddStep(@"Sort by Title", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Title));
-            AddStep(@"Sort by Author", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Author));
-            AddStep(@"Sort by DateAdded", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.DateAdded));
-            AddStep(@"Sort by BPM", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.BPM));
-            AddStep(@"Sort by Length", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Length));
-            AddStep(@"Sort by Difficulty", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Difficulty));
-            AddStep(@"Sort by Source", () => Config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Source));
+            SortBy(SortMode.Artist);
+            SortBy(SortMode.Title);
+            SortBy(SortMode.Author);
+            SortBy(SortMode.DateAdded);
+            SortBy(SortMode.BPM);
+            SortBy(SortMode.Length);
+            SortBy(SortMode.Difficulty);
+            SortBy(SortMode.Source);
         }
 
         [Test]

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -307,7 +307,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// Retrieve a list of all <see cref="CarouselItem"/>s currently displayed.
         /// </summary>
-        public IReadOnlyCollection<CarouselItem>? GetCarouselItems() => carouselItems;
+        public IList<CarouselItem>? GetCarouselItems() => carouselItems;
 
         private List<CarouselItem>? carouselItems;
 
@@ -690,6 +690,11 @@ namespace osu.Game.Graphics.Carousel
         /// The currently selected <see cref="CarouselItem"/>, if any is selected.
         /// </summary>
         protected CarouselItem? CurrentSelectionItem => currentSelection.CarouselItem;
+
+        /// <summary>
+        /// The index in <see cref="GetCarouselItems"/> of the current selection, if available.
+        /// </summary>
+        protected int? CurrentSelectionIndex => currentSelection.Index;
 
         /// <summary>
         /// Becomes invalid when the current selection has changed and needs to be updated visually.

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -143,10 +143,77 @@ namespace osu.Game.Screens.SelectV2
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
+                    bool selectedSetDeleted = false;
+
                     foreach (var set in oldItems!)
                     {
                         foreach (var beatmap in set.Beatmaps)
+                        {
                             Items.RemoveAll(i => i is BeatmapInfo bi && beatmap.Equals(bi));
+                            selectedSetDeleted |= CheckModelEquality(CurrentSelection, beatmap);
+                        }
+                    }
+
+                    // After removing all items in this batch, we want to make an immediate reselection
+                    // based on adjacency to the previous selection if it was deleted.
+                    //
+                    // This needs to be done immediately to avoid song select making a random selection.
+                    // This needs to be done in this class because we need to know final display order.
+                    // This needs to be done with attention to detail of which beatmaps have not been deleted.
+                    if (selectedSetDeleted && CurrentSelectionIndex != null)
+                    {
+                        var items = GetCarouselItems()!;
+                        if (items.Count == 0)
+                            break;
+
+                        bool success = false;
+
+                        // Try selecting forwards first
+                        for (int i = CurrentSelectionIndex.Value + 1; i < items.Count; i++)
+                        {
+                            if (attemptSelection(items[i]))
+                            {
+                                success = true;
+                                break;
+                            }
+                        }
+
+                        if (success)
+                            break;
+
+                        // Then try backwards (we might be at the end of available items).
+                        for (int i = Math.Min(items.Count - 1, CurrentSelectionIndex.Value); i >= 0; i--)
+                        {
+                            if (attemptSelection(items[i]))
+                                break;
+                        }
+
+                        bool attemptSelection(CarouselItem item)
+                        {
+                            if (CheckValidForSetSelection(item))
+                            {
+                                if (item.Model is BeatmapInfo beatmapInfo)
+                                {
+                                    // check the new selection wasn't deleted above
+                                    if (!Items.Contains(beatmapInfo))
+                                        return false;
+
+                                    RequestSelection(beatmapInfo);
+                                    return true;
+                                }
+
+                                if (item.Model is BeatmapSetInfo beatmapSetInfo)
+                                {
+                                    if (oldItems.Contains(beatmapSetInfo))
+                                        return false;
+
+                                    RequestRecommendedSelection(beatmapSetInfo.Beatmaps);
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
                     }
 
                     break;

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -532,8 +532,7 @@ namespace osu.Game.Screens.SelectV2
 
             // If all else fails, use the default beatmap.
             Beatmap.SetDefault();
-            if (selectionDebounce?.State == ScheduledDelegate.RunState.Waiting)
-                selectionDebounce?.RunTask();
+            finaliseBeatmapSelection();
 
             return validSelection;
         }

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -502,18 +502,56 @@ namespace osu.Game.Screens.SelectV2
             var currentBeatmap = beatmaps.GetWorkingBeatmap(Beatmap.Value.BeatmapInfo, true);
             bool validSelection = checkBeatmapValidForSelection(currentBeatmap.BeatmapInfo, filterControl.CreateCriteria());
 
-            if (Beatmap.IsDefault || !validSelection)
+            if (validSelection)
+            {
+                carousel.CurrentSelection = currentBeatmap.BeatmapInfo;
+                return true;
+            }
+
+            // If there was no beatmap selected, pick a random one.
+            if (Beatmap.IsDefault)
             {
                 validSelection = carousel.NextRandom();
                 finaliseBeatmapSelection();
+                return validSelection;
             }
 
-            if (validSelection)
-                carousel.CurrentSelection = Beatmap.Value.BeatmapInfo;
-            else
-                Beatmap.SetDefault();
+            // If a previous non-default selection became non-valid, it was likely hidden or deleted.
+            if (!validSelection)
+            {
+                // In the case a difficulty was hidden or removed, prefer selecting another difficulty from the same set.
+                var activeSet = currentBeatmap.BeatmapSetInfo;
+                BeatmapInfo? nextValidBeatmap = findNextValidBeatmap(activeSet.Beatmaps, currentBeatmap.BeatmapInfo);
+
+                if (nextValidBeatmap != null)
+                {
+                    carousel.CurrentSelection = nextValidBeatmap;
+                    return true;
+                }
+            }
+
+            // If all else fails, use the default beatmap.
+            Beatmap.SetDefault();
+            if (selectionDebounce?.State == ScheduledDelegate.RunState.Waiting)
+                selectionDebounce?.RunTask();
 
             return validSelection;
+        }
+
+        private BeatmapInfo? findNextValidBeatmap(IEnumerable<BeatmapInfo> beatmaps, BeatmapInfo current)
+        {
+            beatmaps = beatmaps.OrderBy(b => b.StarRating).ToList();
+            var criteria = filterControl.CreateCriteria();
+
+            // Find the first valid beatmap after `current`.
+            BeatmapInfo? nextValidBeatmap = beatmaps.Reverse()
+                                                    .TakeWhile(b => !b.Equals(current))
+                                                    .LastOrDefault(b => checkBeatmapValidForSelection(b, criteria));
+
+            // If `current` is the last beatmap, we need to get the new last beatmap.
+            nextValidBeatmap ??= beatmaps.LastOrDefault(b => !b.Equals(current) && checkBeatmapValidForSelection(b, criteria));
+
+            return nextValidBeatmap;
         }
 
         private bool checkBeatmapValidForSelection(BeatmapInfo beatmap, FilterCriteria? criteria)


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu/pull/33595.
Closes https://github.com/ppy/osu/issues/33536
Closes https://github.com/ppy/osu/issues/33512

- [x] Add test coverage of ruleset changes

This change was quite painstaking for me so I'll take a brief detour to explain why. Contemplating on where to add this kind of documentation, or whether the whole thing needs a refactor to avoid *requiring* this documentation in the first place...

**everything below is unimportant to the actual change, but may help explain the time this change took to complete, or the decisions contained within**

## Issues with testing

### Multiple asynchronous operations going on

I was trying hard to avoid scenarios like this with SSv2, but here we are. When crafting tests, this can lead to frustrating scenarios.

#### Filter operations (`Carousel`) are asynchronous.

New filter operations cancel old ones and everything works well for end users, but during testing this can lead to weird failures unless accounted for correctly.

#### FilterCriteria changes are debounced (`SongSelect`)

See [filter debounce](https://github.com/ppy/osu/blob/aea4e96cd4bbf92cfd7b02385c7409e6b943efca/osu.Game/Screens/SelectV2/SongSelect.cs#L741-L756) logic.

Take this test code:

```csharp
// pushes the screen and runs an initial filter
LoadSongSelect(); 

// queues a filter operation, in addition to the initial filter
changeSort(SortMore.Artist);

// waits for filtering to complete
AddUntilStep(carousel.IsFiltering, Is.False);
```

The last step may complete before the artist filter criteria is applied, due to the song select filter debounce. The way to ensure filters have been run is to additionally check `FilterCount` to ensure it's run twice in the above scenario.

### Global beatmap selections are debounced (`SongSelect`)

See [selection debounce](https://github.com/ppy/osu/blob/aea4e96cd4bbf92cfd7b02385c7409e6b943efca/osu.Game/Screens/SelectV2/SongSelect.cs#L461-L477) logic.

This is also a frustration with testing and ensuring correctness in logic. In a case of beatmap deletion, things could get messy if a new valid beatmap isn't selected before the old one becomes invalid. If none is selected,

- The global beatmap will become `Default`
- Song select will decide it needs to make a selection (`ensureGlobalBeatmapValid`)
- The selection will likely be random, instead of a curated next selection we want.

There could also be a scenario where this selection ends up making a beatmap current, which a test step that `carousel.Activate`s causes gameplay to start rather than selection to occur.

## Issues with implementation

As the original developer pointed out, it's a struggle to figure out where to put this selection logic.

- We need it to be as early as possible after the deletion occurs (so, as above, song select doesn't get the chance to make an incorrect random selection).
- It needs to have logic of the visual ordering of carousel items, which is currently never exposed outside of `BeatmapCarousel`.
- We have generally avoided having `BeatmapCarousel` make selection changes itself, so it needs to (in the worst case scenario) use `Request..` methods to change selection.
- It needs to handle both grouping types separately, as to decide whether to select the next beatmap panel or request recommended selection of the next beatmap set panel.
- It needs to also select a previous panel if the current panel is the last available.
- It needs to account for the case where multiple consecutive sets/beatmaps were removed around the same location (may not happen in practice, but might – consider if realm operations are batched).
