### PR TITLE
Disallow hiding beatmap difficulties if only one difficulty remains

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -309,6 +309,24 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             checkMatchedBeatmaps(3);
         }
 
+        [Test]
+        public void TestCantHideAllBeatmaps()
+        {
+            LoadSongSelect();
+            ImportBeatmapForRuleset(0);
+
+            checkMatchedBeatmaps(3);
+
+            AddStep("hide selected", () => Beatmaps.Hide(Beatmap.Value.BeatmapInfo));
+            checkMatchedBeatmaps(2);
+
+            AddStep("hide selected", () => Beatmaps.Hide(Beatmap.Value.BeatmapInfo));
+            checkMatchedBeatmaps(1);
+
+            AddAssert("hide fails", () => Beatmaps.Hide(Beatmap.Value.BeatmapInfo), () => Is.False);
+            checkMatchedBeatmaps(1);
+        }
+
         private NoResultsPlaceholder? getPlaceholder() => SongSelect.ChildrenOfType<NoResultsPlaceholder>().FirstOrDefault();
 
         private void checkMatchedBeatmaps(int expected) => AddUntilStep($"{expected} matching shown", () => Carousel.MatchedBeatmapsCount, () => Is.EqualTo(expected));

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
 
             if (manager != null)
-                hideRequested = manager.Hide;
+                hideRequested = b => manager.Hide(b);
 
             Header.Children = new Drawable[]
             {

--- a/osu.Game/Screens/SelectV2/SoloSongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SoloSongSelect.cs
@@ -84,7 +84,9 @@ namespace osu.Game.Screens.SelectV2
             {
                 Icon = FontAwesome.Solid.Eraser
             };
-            yield return new OsuMenuItem(WebCommonStrings.ButtonsHide.ToSentence(), MenuItemType.Destructive, () => beatmaps.Hide(beatmap));
+
+            if (beatmaps.CanHide(beatmap))
+                yield return new OsuMenuItem(WebCommonStrings.ButtonsHide.ToSentence(), MenuItemType.Destructive, () => beatmaps.Hide(beatmap));
         }
 
         protected override void OnStart()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/20636

We don't have a way for users to easily recover from this state. For now let's disallow it.