### PR TITLE
osu!taiko reduce multiplier for hidden on lazer

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -96,7 +96,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             difficultyValue *= Math.Pow(missPenalty, effectiveMissCount);
 
             if (score.Mods.Any(m => m is ModHidden))
-                difficultyValue *= (isConvert) ? 1.025 : 1.1;
+            {
+                if (score.Mods.Any(m => m is ModClassic)) difficultyValue *= 1.025;
+                if (!isConvert) difficultyValue *= 1.02;
+                if (score.Mods.Any(m => m is ModClassic) && !isConvert) difficultyValue *= 1.05;
+            }
 
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= Math.Max(1, 1.050 - Math.Min(attributes.MonoStaminaFactor / 50, 1) * lengthBonus);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -98,10 +98,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             if (score.Mods.Any(m => m is ModHidden))
             {
-                double hiddenBonus = (isConvert) ? 0.025 : 0.1;
+                double hiddenBonus = isConvert ? 0.025 : 0.1;
 
                 // A penalty is applied to the bonus for hidden on non-classic scores, as the playfield can be made wider to make fast reading easier.
-                if (!isClassic) hiddenBonus *= 0.2;
+                if (!isClassic) 
+                    hiddenBonus *= 0.2;
 
                 difficultyValue *= 1 + hiddenBonus;
             }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 double hiddenBonus = isConvert ? 0.025 : 0.1;
 
                 // A penalty is applied to the bonus for hidden on non-classic scores, as the playfield can be made wider to make fast reading easier.
-                if (!isClassic) 
+                if (!isClassic)
                     hiddenBonus *= 0.2;
 
                 difficultyValue *= 1 + hiddenBonus;


### PR DESCRIPTION
This change is a bandaid fix nerfing the multiplier given to plays with hidden without the classic mod. Because lazer allows you to see as much as a 16:9 playfield with hidden compared to the maximum 4:3 on stable (this is intended as far as i know), players are able to add hidden to maps on lazer that would be much harder on stable for the same pp. Until a proper reading rework accounting for effective note velocity with hidden, this is probably the best we can do