### PR TITLE
Use input blocking container for mod display bar

### DIFF
--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -415,6 +415,8 @@ namespace osu.Game.Screens.SelectV2
             }
 
             protected override bool OnMouseDown(MouseDownEvent e) => true;
+
+            protected override bool OnHover(HoverEvent e) => true;
         }
     }
 }

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Screens.SelectV2
             {
                 base.LoadComplete();
 
-                Mods.BindValueChanged(_ => updateDisplay());
+                Mods.BindValueChanged(_ => updateDisplay(), true);
             }
 
             protected override void Update()

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.SelectV2
             AddRange(new[]
             {
                 unrankedBadge = new UnrankedBadge(),
-                modDisplayBar = new Container
+                modDisplayBar = new InputBlockingContainer
                 {
                     Y = -5f,
                     Depth = float.MaxValue,

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -378,6 +378,8 @@ namespace osu.Game.Screens.SelectV2
                     }
                 };
             }
+
+            protected override bool OnMouseDown(MouseDownEvent e) => true;
         }
     }
 }


### PR DESCRIPTION
see https://github.com/ppy/osu/discussions/34079

https://github.com/user-attachments/assets/5f52391e-8742-402f-9247-443ec810b0bd

309c46f4ec6417adbc7b95042532fee30bd89b0c is for consistency since the mod bar display now also consumes event on mouse down (probably need to add a comment there)