### PR TITLE
Add ability to copy millisecond timestamp in the editor

### DIFF
--- a/osu.Game/Screens/Edit/BottomBar.cs
+++ b/osu.Game/Screens/Edit/BottomBar.cs
@@ -14,6 +14,7 @@ using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Edit
 {
@@ -94,7 +95,8 @@ namespace osu.Game.Screens.Edit
             }, true);
         }
 
-        protected override bool OnMouseDown(MouseDownEvent e) => true;
-        protected override bool OnClick(ClickEvent e) => true;
+        // Prevent click-through only for left button for now, otherwise it breaks the TimestampControl context menu.
+        protected override bool OnMouseDown(MouseDownEvent e) => e.Button == MouseButton.Left;
+        protected override bool OnClick(ClickEvent e) => e.Button == MouseButton.Left;
     }
 }

--- a/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
+++ b/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -77,11 +80,14 @@ namespace osu.Game.Screens.Edit.Components
             }
         }
 
-        private partial class TimestampControl : OsuClickableContainer
+        private partial class TimestampControl : OsuClickableContainer, IHasContextMenu
         {
             private Container hoverLayer = null!;
             private OsuSpriteText trackTimer = null!;
             private OsuTextBox inputTextBox = null!;
+
+            [Resolved]
+            private OsuGame? game { get; set; }
 
             [Resolved]
             private Editor? editor { get; set; }
@@ -181,6 +187,12 @@ namespace osu.Game.Screens.Edit.Components
                     showingHoverLayer = shouldShowHoverLayer;
                 }
             }
+
+            private string getMillisecondTimestamp() => ((long)Math.Round(editorClock.CurrentTime)).ToString();
+
+            public MenuItem[] ContextMenuItems => [
+                new OsuMenuItem("Copy timestamp (ms)", MenuItemType.Standard, () => game?.CopyToClipboard(getMillisecondTimestamp()))
+            ];
 
             private partial class TimestampTextBox : OsuTextBox
             {


### PR DESCRIPTION
Addresses #34109

<img width="256" height="65" alt="image" src="https://github.com/user-attachments/assets/4ad3f7ec-be55-463d-a269-62db5ae1d1d0" />

Feel free to close this if this isn't wanted, maybe should've waited for a response in the discussion but it was quite easy to implement.

This partially undoes the `BottomBar` click-through fix in https://github.com/ppy/osu/pull/32729 though.