### PR TITLE
Write new name to `skin.ini` when renaming skin via settings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -310,11 +310,11 @@ namespace osu.Game.Overlays.Settings.Sections
                 base.PopIn();
             }
 
-            private void rename() => skins.CurrentSkinInfo.Value.PerformWrite(skin =>
+            private void rename()
             {
-                skin.Name = textBox.Text;
+                skins.Rename(skins.CurrentSkinInfo.Value, textBox.Text);
                 PopOut();
-            });
+            }
         }
     }
 }

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -157,17 +157,17 @@ namespace osu.Game.Skinning
             // Regardless of whether this is an import or not, let's write the skin.ini if non-existing or non-matching.
             // This is (weirdly) done inside ComputeHash to avoid adding a new method to handle this case. After switching to realm it can be moved into another place.
             if (skinIniSourcedName != item.Name)
-                updateSkinIniMetadata(item, realm);
+                UpdateSkinIniMetadata(item, realm);
         }
 
-        private void updateSkinIniMetadata(SkinInfo item, Realm realm)
+        public void UpdateSkinIniMetadata(SkinInfo item, Realm realm)
         {
             string nameLine = @$"Name: {item.Name}";
             string authorLine = @$"Author: {item.Creator}";
 
             List<string> newLines = new List<string>
             {
-                @"// The following content was automatically added by osu! during import, based on filename / folder metadata.",
+                @"// The following content was automatically added by osu! in order to use metadata that more closely matches user expectations.",
                 @"[General]",
                 nameLine,
                 authorLine,

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -349,6 +349,15 @@ namespace osu.Game.Skinning
             });
         }
 
+        public void Rename(Live<SkinInfo> skin, string newName)
+        {
+            skin.PerformWrite(s =>
+            {
+                s.Name = newName;
+                skinImporter.UpdateSkinIniMetadata(s, s.Realm!);
+            });
+        }
+
         public void SetSkinFromConfiguration(string guidString)
         {
             Live<SkinInfo> skinInfo = null;


### PR DESCRIPTION
Reported at https://osu.ppy.sh/comments/3681620, with appropriate levels of rage bait (DID ANYONE TEST THIS?!?!?!?!?!?!?!?!?!111!!)

Reasoning for this is that without this, users' skin names can be dropped after an external edit because they're never persisted anywhere outside of realm.

The only other choice I see is to stop re-populating skin metadata from the `.ini` upon completing an external edit, which is very doable but seems worse than this. Dunno.