### PR TITLE
Fix text flow arbitrary drawable wrapper accessing child in an unsafe manner

### DIFF
--- a/osu.Game/Graphics/Containers/OsuTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuTextFlowContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
@@ -14,23 +12,27 @@ namespace osu.Game.Graphics.Containers
 {
     public partial class OsuTextFlowContainer : TextFlowContainer
     {
-        public OsuTextFlowContainer(Action<SpriteText> defaultCreationParameters = null)
+        public OsuTextFlowContainer(Action<SpriteText>? defaultCreationParameters = null)
             : base(defaultCreationParameters)
         {
         }
 
         protected override SpriteText CreateSpriteText() => new OsuSpriteText();
 
-        public ITextPart AddArbitraryDrawable(Drawable drawable) => AddPart(new TextPartManual(new ArbitraryDrawableWrapper { Child = drawable }.Yield()));
+        public ITextPart AddArbitraryDrawable(Drawable drawable) => AddPart(new TextPartManual(new ArbitraryDrawableWrapper(drawable).Yield()));
 
-        public ITextPart AddIcon(IconUsage icon, Action<SpriteText> creationParameters = null) => AddText(icon.Icon.ToString(), creationParameters);
+        public ITextPart AddIcon(IconUsage icon, Action<SpriteText>? creationParameters = null) => AddText(icon.Icon.ToString(), creationParameters);
 
         private partial class ArbitraryDrawableWrapper : Container, IHasLineBaseHeight
         {
-            public float LineBaseHeight => (Child as IHasLineBaseHeight)?.LineBaseHeight ?? DrawHeight;
+            private readonly IHasLineBaseHeight? lineBaseHeightSource;
 
-            public ArbitraryDrawableWrapper()
+            public float LineBaseHeight => lineBaseHeightSource?.LineBaseHeight ?? DrawHeight;
+
+            public ArbitraryDrawableWrapper(Drawable drawable)
             {
+                Child = drawable;
+                lineBaseHeightSource = drawable as IHasLineBaseHeight;
                 AutoSizeAxes = Axes.Both;
             }
         }

--- a/osu.Game/Screens/Menu/SupporterDisplay.cs
+++ b/osu.Game/Screens/Menu/SupporterDisplay.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Menu
 
                     Schedule(() =>
                     {
-                        heart?.FlashColour(Color4.White, 750, Easing.OutQuint).Loop();
+                        heart.FlashColour(Color4.White, 750, Easing.OutQuint).Loop();
                     });
                 });
             }, true);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34126.

I'm not really sure how that issue could have ever happened to begin with but I can see a way to make it hopefully safer. If it fails again then it's clearly goblins.