### PR TITLE
Change song select background blur checkbox into a slider in settings

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.ToolbarClockDisplayMode, ToolbarClockDisplayMode.Full);
 
-            SetDefault(OsuSetting.SongSelectBackgroundBlur, false);
+            SetDefault(OsuSetting.SongSelectBackgroundBlur, 0.0f, 0.0f, 1.0f, 0.01f);
 
             // Online settings
             SetDefault(OsuSetting.Username, string.Empty);

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -42,11 +42,12 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     Current = config.GetBindable<bool>(OsuSetting.ModSelectTextSearchStartsActive),
                     ClassicDefault = false
                 },
-                new SettingsCheckbox
+                new SettingsSlider<float>
                 {
                     LabelText = GameplaySettingsStrings.BackgroundBlur,
-                    Current = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur),
-                    ClassicDefault = false,
+                    Current = config.GetBindable<float>(OsuSetting.SongSelectBackgroundBlur),
+                    DisplayAsPercentage = true,
+                    KeyboardStep = 0.01f
                 }
             };
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -156,12 +156,12 @@ namespace osu.Game.Screens.Select
         [Resolved]
         internal IOverlayManager? OverlayManager { get; private set; }
 
-        private Bindable<bool> configBackgroundBlur = null!;
+        private Bindable<float> configBackgroundBlur = null!;
 
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, OsuColour colours, ManageCollectionsDialog? manageCollectionsDialog, DifficultyRecommender? recommender, OsuConfigManager config)
         {
-            configBackgroundBlur = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur);
+            configBackgroundBlur = config.GetBindable<float>(OsuSetting.SongSelectBackgroundBlur);
             configBackgroundBlur.BindValueChanged(e =>
             {
                 if (!this.IsCurrentScreen())
@@ -907,10 +907,10 @@ namespace osu.Game.Screens.Select
 
         private void applyBlurToBackground(BackgroundScreenBeatmap backgroundModeBeatmap)
         {
-            backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value ? BACKGROUND_BLUR : 0f;
-            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundBlur.Value ? 0 : 0.4f;
+            backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value * BACKGROUND_BLUR;
+            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = 0.1f;
 
-            wedgeBackground.FadeTo(configBackgroundBlur.Value ? 0.5f : 0.2f, UserDimContainer.BACKGROUND_FADE_DURATION, Easing.OutQuint);
+            wedgeBackground.FadeTo(0.2f, UserDimContainer.BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }
 
         private readonly WeakReference<ITrack?> lastTrack = new WeakReference<ITrack?>(null);

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private IDialogOverlay? dialogOverlay { get; set; }
 
-        private Bindable<bool> configBackgroundBlur = null!;
+        private Bindable<float> configBackgroundBlur = null!;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, OsuConfigManager config)
@@ -278,7 +278,7 @@ namespace osu.Game.Screens.SelectV2
                 modSelectOverlay,
             });
 
-            configBackgroundBlur = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur);
+            configBackgroundBlur = config.GetBindable<float>(OsuSetting.SongSelectBackgroundBlur);
             configBackgroundBlur.BindValueChanged(e =>
             {
                 if (!this.IsCurrentScreen())
@@ -725,7 +725,7 @@ namespace osu.Game.Screens.SelectV2
             // Probably needs more thought because this needs to be in every `ApplyToBackground` currently to restore sane defaults.
             backgroundModeBeatmap.FadeColour(Color4.White, 250);
 
-            backgroundModeBeatmap.BlurAmount.Value = revealingBackground == null && configBackgroundBlur.Value ? 20 : 0f;
+            backgroundModeBeatmap.BlurAmount.Value = (revealingBackground == null ? 1.0f : 0.0f) * configBackgroundBlur.Value * 20.0f;
         });
 
         #endregion


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/34115

The background blur option for gameplay in the settings menu is a slider and the song select background blur option isn't, they're both named background blur so I think both should be sliders

before:
<img width="556" height="672" alt="image" src="https://github.com/user-attachments/assets/8376afb9-d563-4263-8827-8f9666a886e4" />

after:
<img width="549" height="675" alt="image" src="https://github.com/user-attachments/assets/0c4af654-e12a-48b4-a022-1c39319cb5ba" />

I think this change might break compatibility with song select v1 but it's deprecated so I didn't bother fixing it