### PR TITLE
Use difficulty background on standalone beatmap panels

### DIFF
--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -227,8 +226,7 @@ namespace osu.Game.Screens.SelectV2
             var beatmap = (BeatmapInfo)Item.Model;
             var beatmapSet = beatmap.BeatmapSet!;
 
-            // Choice of background image matches BSS implementation (always uses the lowest `beatmap_id` from the set).
-            background.Beatmap = beatmaps.GetWorkingBeatmap(beatmapSet.Beatmaps.MinBy(b => b.OnlineID));
+            background.Beatmap = beatmaps.GetWorkingBeatmap(beatmap);
 
             titleText.Text = new RomanisableString(beatmapSet.Metadata.TitleUnicode, beatmapSet.Metadata.Title);
             artistText.Text = new RomanisableString(beatmapSet.Metadata.ArtistUnicode, beatmapSet.Metadata.Artist);


### PR DESCRIPTION
- Addresses https://osu.ppy.sh/comments/3690365 I think?

| Before | After | Stable |
| --- | --- | --- |
| <img width="517" height="558" alt="Screenshot 2025-07-11 at 11 48 58 PM" src="https://github.com/user-attachments/assets/1b76045a-a9e4-4bed-a029-44a352f8058f" /> | <img width="517" height="558" alt="Screenshot 2025-07-11 at 11 47 28 PM" src="https://github.com/user-attachments/assets/129289c2-0978-43f7-8628-1324546c7062" /> | <img width="739" height="759" alt="Screenshot 2025-07-12 at 12 02 49 AM" src="https://github.com/user-attachments/assets/93205df0-41c2-4006-964c-957e43ac9600" /> |

Note that this doesn't match stable, and lazer has yet to distinguish different sets (stable darkens them):
<img width="853" height="494" alt="Screenshot 2025-07-12 at 12 06 51 AM" src="https://github.com/user-attachments/assets/2474dbdf-3a31-45b7-ba9a-a5b07f5f110d" />