### PR TITLE
Fix failed to load beatmap detail host by deleted user

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -10,6 +10,8 @@ using osu.Game.Rulesets;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics.Sprites;
@@ -193,7 +195,8 @@ namespace osu.Game.Tests.Visual.Online
                 overlay.ShowBeatmapSet(set);
             });
 
-            AddAssert("shown beatmaps of current ruleset", () => overlay.Header.HeaderContent.Picker.Difficulties.All(b => b.Beatmap.Ruleset.OnlineID == overlay.Header.RulesetSelector.Current.Value.OnlineID));
+            AddAssert("shown beatmaps of current ruleset",
+                () => overlay.Header.HeaderContent.Picker.Difficulties.All(b => b.Beatmap.Ruleset.OnlineID == overlay.Header.RulesetSelector.Current.Value.OnlineID));
             AddAssert("left-most beatmap selected", () => overlay.Header.HeaderContent.Picker.Difficulties.First().State == BeatmapPicker.DifficultySelectorState.Selected);
         }
 
@@ -370,6 +373,39 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("move mouse to guest difficulty", () =>
             {
                 InputManager.MoveMouseTo(overlay.ChildrenOfType<DifficultyIcon>().ElementAt(1));
+            });
+        }
+
+        [Test]
+        public void TestBeatmapsetWithDeletedUser()
+        {
+            AddStep("show map with deleted user", () =>
+            {
+                JObject jsonBlob = JObject.FromObject(getBeatmapSet(), new JsonSerializer
+                {
+                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                });
+
+                jsonBlob["user"] = JToken.Parse(
+                    """
+                    {
+                        "avatar_url": null,
+                        "country_code": null,
+                        "default_group": "default",
+                        "id": null,
+                        "is_active": false,
+                        "is_bot": false,
+                        "is_deleted": true,
+                        "is_online": false,
+                        "is_supporter": false,
+                        "last_visit": null,
+                        "pm_friends_only": false,
+                        "profile_colour": null,
+                        "username": "[deleted user]"
+                    }
+                    """);
+
+                overlay.ShowBeatmapSet(JsonConvert.DeserializeObject<APIBeatmapSet>(JsonConvert.SerializeObject(jsonBlob)));
             });
         }
 

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -84,11 +84,26 @@ namespace osu.Game.Online.API.Requests.Responses
         /// The creator of this beatmap set.
         /// </summary>
         /// <remarks>
-        /// This is not included when the set is retrieved via <see cref="SearchBeatmapSetsRequest"/>,
-        /// but the creator's ID and username will be filled in this property from the <see cref="AuthorID"/> and <see cref="AuthorString"/> properties.
+        /// This property is set differently depending on the API endpoint. When retrieved via <see cref="SearchBeatmapSetsRequest"/>,
+        /// detailed user info is not included and the creator's ID and username are filled from the <see cref="AuthorID"/> and
+        /// <see cref="AuthorString"/> properties. For other API endpoints, this property is set by the <see cref="author"/> setter.
+        /// </remarks>
+        public APIUser Author = new APIUser();
+
+        /// <summary>
+        /// Helper property to deserialize the detailed user info to <see cref="Author"/>
+        /// </summary>
+        /// <remarks>
+        /// This setter implements special handling for deleted users. When received a user with ID 1, it indicates
+        /// the original user has been deleted. In such cases, the existing <see cref="Author"/> data
+        /// (filled from <see cref="AuthorID"/> and <see cref="AuthorString"/>) is preserved. For valid user,
+        /// the provided user info replaces the existing <see cref="Author"/>.
         /// </remarks>
         [JsonProperty(@"user")]
-        public APIUser Author = new APIUser();
+        private APIUser author
+        {
+            set => Author = value.Id != 1 ? value : Author;
+        }
 
         /// <summary>
         /// The ID of the beatmap set's creator.

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public const int SYSTEM_USER_ID = 0;
 
         /// <summary>
-        /// In osu-web, deleted users have a null ID. When deserializing, we ignore the null value and use -1 instead.
+        /// In osu-web, deleted users have a null ID. When deserializing, we ignore the null value and use 1 instead.
         /// </summary>
         [JsonProperty(@"id", NullValueHandling = NullValueHandling.Ignore)]
         public int Id { get; set; } = 1;

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -22,7 +22,10 @@ namespace osu.Game.Online.API.Requests.Responses
         /// </summary>
         public const int SYSTEM_USER_ID = 0;
 
-        [JsonProperty(@"id")]
+        /// <summary>
+        /// In osu-web, deleted users have a null ID. When deserializing, we ignore the null value and use -1 instead.
+        /// </summary>
+        [JsonProperty(@"id", NullValueHandling = NullValueHandling.Ignore)]
         public int Id { get; set; } = 1;
 
         [JsonProperty(@"join_date")]

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -22,9 +22,7 @@ namespace osu.Game.Online.API.Requests.Responses
         /// </summary>
         public const int SYSTEM_USER_ID = 0;
 
-        /// <summary>
-        /// In osu-web, deleted users have a null ID. When deserializing, we ignore the null value and use 1 instead.
-        /// </summary>
+        // In osu-web, deleted users have a null ID. When deserializing, we ignore the null value and use 1 instead.
         [JsonProperty(@"id", NullValueHandling = NullValueHandling.Ignore)]
         public int Id { get; set; } = 1;
 


### PR DESCRIPTION
I found that the current version cannot open the beatmap detail created by a deleted account.

This bug is introduced by https://github.com/ppy/osu/pull/33783 .

The reason is that `user.id` in the JSON returned by osu-web is null, which causes the `APIUser` fail to deserialize. 

<img width="505" height="611" alt="Screenshot 2025-07-12 213518" src="https://github.com/user-attachments/assets/8c12cc83-bf87-43bb-aaeb-d9f4a05ec545" />

Because the `Id` of `APIUser` is `int`, it cannot be null.
I don't want to change Id to `int?`, so in this PR i added `NullValueHandling.Ignore` to it. This way, null values will be ignored during deserialize, and `Id` will still retain its default value (i.e. `1`)
