### PR TITLE
Fix multiplayer duration by having it set on beatmap population.

### DIFF
--- a/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
@@ -99,15 +99,18 @@ namespace osu.Game.Screens.OnlinePlay
             private readonly PlaylistItem item;
             private double itemLength;
             private int beatmapSetId;
+            [Resolved]
+            private RealmAccess realm { get; set; } = null!;
 
             public DifficultySelectFilterControl(PlaylistItem item)
             {
                 this.item = item;
             }
 
-            [BackgroundDependencyLoader]
-            private void load(RealmAccess realm)
+            public override FilterCriteria CreateCriteria()
             {
+                var criteria = base.CreateCriteria();
+
                 realm.Run(r =>
                 {
                     int beatmapId = item.Beatmap.OnlineID;
@@ -116,11 +119,6 @@ namespace osu.Game.Screens.OnlinePlay
                     itemLength = beatmap?.Length ?? 0;
                     beatmapSetId = beatmap?.BeatmapSet?.OnlineID ?? 0;
                 });
-            }
-
-            public override FilterCriteria CreateCriteria()
-            {
-                var criteria = base.CreateCriteria();
 
                 // Must be from the same set as the playlist item.
                 criteria.BeatmapSetId = beatmapSetId;

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
@@ -99,6 +99,7 @@ namespace osu.Game.Screens.OnlinePlay
             private readonly PlaylistItem item;
             private double itemLength;
             private int beatmapSetId;
+
             [Resolved]
             private RealmAccess realm { get; set; } = null!;
 

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
@@ -97,8 +97,6 @@ namespace osu.Game.Screens.OnlinePlay
         private partial class DifficultySelectFilterControl : FilterControl
         {
             private readonly PlaylistItem item;
-            private double itemLength;
-            private int beatmapSetId;
 
             [Resolved]
             private RealmAccess realm { get; set; } = null!;
@@ -111,6 +109,9 @@ namespace osu.Game.Screens.OnlinePlay
             public override FilterCriteria CreateCriteria()
             {
                 var criteria = base.CreateCriteria();
+
+                double itemLength = 0;
+                int beatmapSetId = 0;
 
                 realm.Run(r =>
                 {
@@ -130,7 +131,6 @@ namespace osu.Game.Screens.OnlinePlay
                 criteria.Length.Max = itemLength + 30000;
                 criteria.Length.IsLowerInclusive = true;
                 criteria.Length.IsUpperInclusive = true;
-
                 return criteria;
             }
         }


### PR DESCRIPTION
Fixes #34172 

Before:

https://github.com/user-attachments/assets/1911b113-e402-4691-81e6-84c508ab6908

After:

https://github.com/user-attachments/assets/71488188-1abc-4cc0-8db2-1b57c8311e0f

Tested in a lobby, seems to no longer have the issue that was caused in the mentioned issue.