### PR TITLE
Add more predefined divisors to match stable

### DIFF
--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Edit
 {
     public class BindableBeatDivisor : BindableInt
     {
-        public static readonly int[] PREDEFINED_DIVISORS = { 1, 2, 3, 4, 6, 8, 12, 16 };
+        public static readonly int[] PREDEFINED_DIVISORS = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 16 };
 
         public const int MINIMUM_DIVISOR = 1;
         public const int MAXIMUM_DIVISOR = 64;


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/33929#discussioncomment-13681915 given 1/5,1/7, and 1/9 are also properly defined in stable.

Opted to not go with any UI changes to the snap selector given the current one is already pretty intuitive.