### PR TITLE
Support `.ogg`-specific bitrate limit in audio quality verify check

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(int? audioBitrate, bool useOgg = false)
         {
-            // Update the audio file name and beatmap set files based on the format being tested
+            // Update the audio filename and beatmapset files based on the format being tested
             string audioFileName = useOgg ? "abc123.ogg" : "abc123.mp3";
             string fileExtension = useOgg ? "ogg" : "mp3";
 

--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using ManagedBass;
 using Moq;
 using NUnit.Framework;
 using osu.Framework.Audio.Track;
@@ -10,7 +11,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual;
+using osuTK.Audio;
 
 namespace osu.Game.Tests.Editing.Checks
 {
@@ -28,9 +31,13 @@ namespace osu.Game.Tests.Editing.Checks
             {
                 BeatmapInfo = new BeatmapInfo
                 {
-                    Metadata = new BeatmapMetadata { AudioFile = "abc123.jpg" }
+                    Metadata = new BeatmapMetadata()
                 }
             };
+
+            // 0 = No output device. This still allows decoding.
+            if (!Bass.Init(0) && Bass.LastError != Errors.Already)
+                throw new AudioException("Could not initialize Bass.");
         }
 
         [Test]
@@ -50,6 +57,14 @@ namespace osu.Game.Tests.Editing.Checks
         public void TestAcceptable()
         {
             var context = getContext(192);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestAcceptableOgg()
+        {
+            var context = getContext(208, useOgg: true);
 
             Assert.That(check.Run(context), Is.Empty);
         }
@@ -88,6 +103,17 @@ namespace osu.Game.Tests.Editing.Checks
         }
 
         [Test]
+        public void TestTooHighBitrateOgg()
+        {
+            var context = getContext(250, useOgg: true);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooHighBitrate);
+        }
+
+        [Test]
         public void TestTooLowBitrate()
         {
             var context = getContext(64);
@@ -98,23 +124,40 @@ namespace osu.Game.Tests.Editing.Checks
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooLowBitrate);
         }
 
-        private BeatmapVerifierContext getContext(int? audioBitrate)
+        private BeatmapVerifierContext getContext(int? audioBitrate, bool useOgg = false)
         {
-            return new BeatmapVerifierContext(beatmap, getMockWorkingBeatmap(audioBitrate).Object);
+            // Update the audio file name and beatmap set files based on the format being tested
+            string audioFileName = useOgg ? "abc123.ogg" : "abc123.mp3";
+            string fileExtension = useOgg ? "ogg" : "mp3";
+
+            beatmap.Metadata.AudioFile = audioFileName;
+            beatmap.BeatmapInfo.BeatmapSet = new BeatmapSetInfo
+            {
+                Files = { CheckTestHelpers.CreateMockFile(fileExtension) }
+            };
+
+            return new BeatmapVerifierContext(beatmap, getMockWorkingBeatmap(audioBitrate, useOgg).Object);
         }
 
         /// <summary>
         /// Returns the mock of the working beatmap with the given audio properties.
         /// </summary>
         /// <param name="audioBitrate">The bitrate of the audio file the beatmap uses.</param>
-        private Mock<IWorkingBeatmap> getMockWorkingBeatmap(int? audioBitrate)
+        /// <param name="useOgg">Whether to use an OGG sample instead of MP3.</param>
+        private Mock<IWorkingBeatmap> getMockWorkingBeatmap(int? audioBitrate, bool useOgg = false)
         {
             var mockTrack = new Mock<OsuTestScene.ClockBackedTestWorkingBeatmap.TrackVirtualManual>(new FramedClock(), "virtual");
             mockTrack.SetupGet(t => t.Bitrate).Returns(audioBitrate);
 
+            // Use real audio samples for format detection
+            string samplePath = useOgg ? "Samples/test-sample.ogg" : "Samples/test-sample-cut.mp3";
+
             var mockWorkingBeatmap = new Mock<IWorkingBeatmap>();
             mockWorkingBeatmap.SetupGet(w => w.Beatmap).Returns(beatmap);
             mockWorkingBeatmap.SetupGet(w => w.Track).Returns(mockTrack.Object);
+
+            // Return a fresh stream each time GetStream is called to avoid disposed stream issues
+            mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(() => TestResources.OpenResource(samplePath));
 
             return mockWorkingBeatmap;
         }

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using ManagedBass;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
@@ -9,8 +10,9 @@ namespace osu.Game.Rulesets.Edit.Checks
     public class CheckAudioQuality : ICheck
     {
         // This is a requirement as stated in the Ranking Criteria.
-        // See https://osu.ppy.sh/wiki/en/Ranking_Criteria#rules.4
-        private const int max_bitrate = 192;
+        // See https://osu.ppy.sh/wiki/en/Ranking_criteria#audio
+        private const int max_bitrate_default = 192;
+        private const int max_bitrate_ogg = 208;
 
         // "A song's audio file /.../ must be of reasonable quality. Try to find the highest quality source file available"
         // There not existing a version with a bitrate of 128 kbps or higher is extremely rare.
@@ -35,10 +37,17 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             if (track?.Bitrate == null || track.Bitrate.Value == 0)
                 yield return new IssueTemplateNoBitrate(this).Create();
-            else if (track.Bitrate.Value > max_bitrate)
-                yield return new IssueTemplateTooHighBitrate(this).Create(track.Bitrate.Value);
-            else if (track.Bitrate.Value < min_bitrate)
-                yield return new IssueTemplateTooLowBitrate(this).Create(track.Bitrate.Value);
+            else
+            {
+                // Determine max bitrate based on audio format
+                var audioFormat = AudioCheckUtils.GetAudioFormatFromFile(context, audioFile);
+                int upperBitrateLimit = audioFormat.HasFlag(ChannelType.OGG) ? max_bitrate_ogg : max_bitrate_default;
+
+                if (track.Bitrate.Value > upperBitrateLimit)
+                    yield return new IssueTemplateTooHighBitrate(this).Create(track.Bitrate.Value, upperBitrateLimit);
+                else if (track.Bitrate.Value < min_bitrate)
+                    yield return new IssueTemplateTooLowBitrate(this).Create(track.Bitrate.Value);
+            }
         }
 
         public class IssueTemplateTooHighBitrate : IssueTemplate
@@ -48,7 +57,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             {
             }
 
-            public Issue Create(int bitrate) => new Issue(this, bitrate, max_bitrate);
+            public Issue Create(int bitrate, int maxBitrate) => new Issue(this, bitrate, maxBitrate);
         }
 
         public class IssueTemplateTooLowBitrate : IssueTemplate

--- a/osu.Game/Rulesets/Edit/Checks/CheckSongFormat.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckSongFormat.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (audioFormat == 0)
             {
                 yield return new IssueTemplateFormatUnsupported(this).Create(audioFile.Filename);
+
                 yield break;
             }
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckSongFormat.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckSongFormat.cs
@@ -2,12 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using ManagedBass;
-using osu.Framework.Audio.Callbacks;
 using osu.Game.Beatmaps;
-using osu.Game.Extensions;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
@@ -36,28 +33,17 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (beatmapSet == null) yield break;
             if (audioFile == null) yield break;
 
-            using (Stream data = context.WorkingBeatmap.GetStream(audioFile.File.GetStoragePath()))
+            var audioFormat = AudioCheckUtils.GetAudioFormatFromFile(context, context.Beatmap.Metadata.AudioFile);
+
+            // If the format is not supported by BASS
+            if (audioFormat == 0)
             {
-                if (data == null || data.Length <= 0) yield break;
-
-                var fileCallbacks = new FileCallbacks(new DataStreamFileProcedures(data));
-                int decodeStream = Bass.CreateStream(StreamSystem.NoBuffer, BassFlags.Decode, fileCallbacks.Callbacks, fileCallbacks.Handle);
-
-                // If the format is not supported by BASS
-                if (decodeStream == 0)
-                {
-                    yield return new IssueTemplateFormatUnsupported(this).Create(audioFile.Filename);
-
-                    yield break;
-                }
-
-                var audioInfo = Bass.ChannelGetInfo(decodeStream);
-
-                if (!allowedFormats.Contains(audioInfo.ChannelType))
-                    yield return new IssueTemplateIncorrectFormat(this).Create(audioFile.Filename);
-
-                Bass.StreamFree(decodeStream);
+                yield return new IssueTemplateFormatUnsupported(this).Create(audioFile.Filename);
+                yield break;
             }
+
+            if (!allowedFormats.Contains(audioFormat))
+                yield return new IssueTemplateIncorrectFormat(this).Create(audioFile.Filename);
         }
 
         public class IssueTemplateFormatUnsupported : IssueTemplate

--- a/osu.Game/Rulesets/Edit/Checks/Components/AudioCheckUtils.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/AudioCheckUtils.cs
@@ -3,6 +3,10 @@
 
 using System.IO;
 using System.Linq;
+using ManagedBass;
+using osu.Framework.Audio.Callbacks;
+using osu.Game.Beatmaps;
+using osu.Game.Extensions;
 using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Edit.Checks.Components
@@ -10,5 +14,47 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
     public static class AudioCheckUtils
     {
         public static bool HasAudioExtension(string filename) => SupportedExtensions.AUDIO_EXTENSIONS.Contains(Path.GetExtension(filename).ToLowerInvariant());
+
+        /// <summary>
+        /// Gets the audio format (ChannelType) from a stream using BASS.
+        /// </summary>
+        /// <param name="data">The audio file stream.</param>
+        /// <returns>The ChannelType of the audio, or 0 if detection fails.</returns>
+        public static ChannelType GetAudioFormat(Stream data)
+        {
+            if (data.Length <= 0)
+                return 0;
+
+            var fileCallbacks = new FileCallbacks(new DataStreamFileProcedures(data));
+            int decodeStream = Bass.CreateStream(StreamSystem.NoBuffer, BassFlags.Decode, fileCallbacks.Callbacks, fileCallbacks.Handle);
+
+            if (decodeStream == 0)
+                return 0;
+
+            var audioInfo = Bass.ChannelGetInfo(decodeStream);
+            Bass.StreamFree(decodeStream);
+
+            return audioInfo.ChannelType;
+        }
+
+        /// <summary>
+        /// Gets the audio format for a specific file in a beatmapset.
+        /// </summary>
+        /// <param name="context">The beatmap verifier context.</param>
+        /// <param name="filename">The filename to check.</param>
+        /// <returns>The ChannelType of the audio file, or 0 if detection fails.</returns>
+        public static ChannelType GetAudioFormatFromFile(BeatmapVerifierContext context, string filename)
+        {
+            var beatmapSet = context.Beatmap.BeatmapInfo.BeatmapSet;
+            var audioFile = beatmapSet?.GetFile(filename);
+
+            if (beatmapSet == null || audioFile == null)
+                return 0;
+
+            using (Stream data = context.WorkingBeatmap.GetStream(audioFile.File.GetStoragePath()))
+            {
+                return GetAudioFormat(data);
+            }
+        }
     }
 }


### PR DESCRIPTION
Upper bitrate limit in [audio RC](https://osu.ppy.sh/wiki/en/Ranking_criteria#audio) got updated a while ago to allow 192kbps for `.mp3` and 208kbps for `.ogg`. This PR reflects this change in the audio quality verify check.

Since there isn't a direct way to get an audio's format, I borrowed the existing functionality from from the `CheckSongFormat` check and moved it to shared audio check utils.

This also had me update the audio quality check tests to load real audio samples for format detection rather than solely having a mock of the bitrate.