### PR TITLE
osu!taiko new acc pp formula + rhythm difficulty penalty

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -122,10 +122,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 return 0;
 
             // Scale accuracy more harshly on nearly-completely mono (single coloured) speed maps.
-            double accScalingExponent = 2 + attributes.MonoStaminaFactor;
-            double accScalingShift = 500 - 100 * (attributes.MonoStaminaFactor * 3);
+            double monoAccScalingExponent = 2 + attributes.MonoStaminaFactor;
+            double monoAccScalingShift = 500 - 100 * (attributes.MonoStaminaFactor * 3);
 
-            return difficultyValue * Math.Pow(DifficultyCalculationUtils.Erf(accScalingShift / (Math.Sqrt(2) * estimatedUnstableRate.Value)), accScalingExponent);
+            return difficultyValue * Math.Pow(DifficultyCalculationUtils.Erf(monoAccScalingShift / (Math.Sqrt(2) * estimatedUnstableRate.Value)), monoAccScalingExponent);
         }
 
         private double computeAccuracyValue(ScoreInfo score, TaikoDifficultyAttributes attributes, bool isConvert)

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -81,6 +81,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes, bool isConvert)
         {
+            if (estimatedUnstableRate == null)
+                return 0;
+
             // An estimation of the unstable rate expected for a SS at the map's star rating, at which all rhythm difficulty has been played successfully.
             double topExpectedUnstableRate = 75 + 150 / Math.Pow(10, attributes.StarRating / 9);
 
@@ -117,9 +120,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= Math.Max(1, 1.050 - Math.Min(attributes.MonoStaminaFactor / 50, 1) * lengthBonus);
-
-            if (estimatedUnstableRate == null)
-                return 0;
 
             // Scale accuracy more harshly on nearly-completely mono (single coloured) speed maps.
             double monoAccScalingExponent = 2 + attributes.MonoStaminaFactor;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -116,7 +116,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (greatHitWindow <= 0 || estimatedUnstableRate == null)
                 return 0;
 
-            double accuracyValue = Math.Pow(70 / estimatedUnstableRate.Value, 1.1) * Math.Pow(attributes.StarRating, 0.4) * 100.0;
+            double accuracyValue = 470 * Math.Pow(0.9885, estimatedUnstableRate.Value);
+
+            // Scales up the bonus for lower unstable rate as star rating increases.
+            accuracyValue *= 1 + Math.Pow(50 / estimatedUnstableRate.Value, 2) * Math.Pow(attributes.StarRating, 2) / 125;
 
             if (score.Mods.Any(m => m is ModHidden) && !isConvert)
                 accuracyValue *= 1.075;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -85,19 +85,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 return 0;
 
             // An estimation of the unstable rate expected for a SS at the map's star rating, at which all rhythm difficulty has been played successfully.
-            double topExpectedUnstableRate = 75 + 150 / Math.Pow(10, attributes.StarRating / 9);
+            double rhythmExpectedUnstableRate = 75 + 150 / Math.Pow(10, attributes.StarRating / 9);
 
             // The unstable rate at which it can be assumed all rhythm difficulty has been ignored.
-            double bottomExpectedUnstableRate = 2 * topExpectedUnstableRate;
+            double rhythmMaximumUnstableRate = 2 * rhythmExpectedUnstableRate;
 
-            // The fraction of star rating made up by rhythm difficulty, normalised between the range where rhythm most affects star rating.
+            // The fraction of star rating made up by rhythm difficulty, normalised to represent rhythm's perceived contribution to star rating.
             double rhythmFactor = DifficultyCalculationUtils.ReverseLerp(attributes.RhythmDifficulty / attributes.StarRating, 0.15, 0.35);
 
-            // A penalty removing ignored rhythm difficulty from star rating based on estimated unstable rate.
+            // A penalty removing improperly played rhythm difficulty from star rating based on estimated unstable rate.
             double rhythmPenalty = 1 - DifficultyCalculationUtils.Logistic(
                 estimatedUnstableRate.Value,
-                midpointOffset: (topExpectedUnstableRate + bottomExpectedUnstableRate) / 2,
-                multiplier: 10 / (bottomExpectedUnstableRate - topExpectedUnstableRate),
+                midpointOffset: (rhythmExpectedUnstableRate + rhythmMaximumUnstableRate) / 2,
+                multiplier: 10 / (rhythmMaximumUnstableRate - rhythmExpectedUnstableRate),
                 maxValue: 0.2 * Math.Pow(rhythmFactor, 2)
             );
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             greatHitWindow = hitWindows.WindowFor(HitResult.Great) / clockRate;
 
-            estimatedUnstableRate =  (countGreat == 0 || greatHitWindow <= 0)
+            estimatedUnstableRate = (countGreat == 0 || greatHitWindow <= 0)
                 ? null
                 : computeDeviationUpperBound(countGreat / (double)totalHits) * 10;
 


### PR DESCRIPTION
These changes replace the formula for accuracy pp, as well as penalise rhythm difficulty from pp based on estimated unstable rate.

More effort has been put in to balance this than my other recent changes. The new curve is steeper than the current (making improving your acc on a play more rewarding) and attempts to break even with the current curve at 98% accuracy on a nomod map of the given star rating, based on estimated UR data from a large number of ranked maps. See said data and how the curves compare here https://www.desmos.com/calculator/hwd2pjmqqr

The rhythm penalty uses the same data but for 100% acc rather than 98% to estimate the unstable rate at which all of a map's rhythm difficulty has been played successfully. 2x this unstable rate is around 90-91% on the same maps which is where I think it's safe to say all rhythm difficulty has been ignored. `Rhythm difficulty / star rating` has been a good measure of rhythm contribution to a map since https://github.com/ppy/osu/pull/32426, with around 0.15 being where rhythm starts to have any effect on star rating and 0.35 being maps like 3772247 (hard rhythm but mechanically easy) and 4543374 (very hard rhythm). Removing all rhythm strain from these 0.35 maps reduces star rating by ~20%, and doing the same on maps in the middle with 0.25 (such as 3658314 and 4725197) reduces star rating by ~5% which is why I went with `0.2 * rhythmFactor^2` for the penalty's max value.

I also renamed the mono acc scaling stuff for more clarity now that we have two acc related scalings in difficulty pp



