### PR TITLE
Improve safety of external skin edit operation in several scenarios

### DIFF
--- a/osu.Game/Overlays/SkinEditor/ExternalEditOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/ExternalEditOverlay.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         private ExternalEditOperation<SkinInfo>? editOperation;
         private TaskCompletionSource? taskCompletionSource;
+        private bool finishingEdit;
 
         protected override bool DimMainContent => false;
 
@@ -181,6 +182,11 @@ namespace osu.Game.Overlays.SkinEditor
 
         private async Task finish()
         {
+            if (finishingEdit)
+                return;
+
+            finishingEdit = true;
+
             Debug.Assert(taskCompletionSource != null);
 
             showSpinner("Cleaning up...");
@@ -236,6 +242,7 @@ namespace osu.Game.Overlays.SkinEditor
             {
                 // Set everything to a clean state
                 editOperation = null;
+                finishingEdit = false;
                 flow.Children = Array.Empty<Drawable>();
             });
         }
@@ -249,7 +256,8 @@ namespace osu.Game.Overlays.SkinEditor
             {
                 case GlobalAction.Back:
                 case GlobalAction.Select:
-                    if (editOperation == null) return base.OnPressed(e);
+                    if (editOperation == null)
+                        return false;
 
                     finish().FireAndForget();
                     return true;

--- a/osu.Game/Overlays/SkinEditor/ExternalEditOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/ExternalEditOverlay.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -96,6 +97,8 @@ namespace osu.Game.Overlays.SkinEditor
                     }
                 }
             };
+
+            gameHost.ExitRequested += tryFinishOnExit;
         }
 
         public async Task<Task> Begin(SkinInfo skinInfo)
@@ -178,6 +181,12 @@ namespace osu.Game.Overlays.SkinEditor
                 return;
 
             gameHost.OpenFileExternally(editOperation.MountedPath.TrimDirectorySeparator() + Path.DirectorySeparatorChar);
+        }
+
+        private void tryFinishOnExit()
+        {
+            if (editOperation != null && !finishingEdit)
+                finish().FireAndForget(onSuccess: () => Schedule(() => finishingEdit = false));
         }
 
         private async Task finish()
@@ -287,6 +296,14 @@ namespace osu.Game.Overlays.SkinEditor
                     State = { Value = Visibility.Visible }
                 },
             };
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (gameHost.IsNotNull())
+                gameHost.ExitRequested -= tryFinishOnExit;
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -249,7 +249,8 @@ namespace osu.Game.Overlays.SkinEditor
                 Scheduler.AddOnce(updateScreenSizing);
 
                 game.Toolbar.Hide();
-                game.CloseAllOverlays();
+                if (externalEditOverlay.State.Value != Visibility.Visible)
+                    game.CloseAllOverlays();
             }
             else
             {
@@ -298,7 +299,8 @@ namespace osu.Game.Overlays.SkinEditor
 
             if (skinEditor.State.Value == Visibility.Visible)
             {
-                skinEditor.Save(false);
+                if (externalEditOverlay.State.Value != Visibility.Visible)
+                    skinEditor.Save(false);
                 skinEditor.UpdateTargetScreen(target);
                 disableNestedInputManagers();
             }


### PR DESCRIPTION
Scenarios in question being:

- spamming esc during start/finish of the external operation (addresses  https://osu.ppy.sh/comments/3691012),
- screens changing while the external operation is taking place (closes https://github.com/ppy/osu/issues/34133).

Remember [when I asked as to why this thing was an overlay at all and not a full blocking screen?](https://github.com/ppy/osu/pull/30226#discussion_r1903929902) This is one of the reasons why I asked that because with this setup we expose ourselves to this silliness. https://github.com/ppy/osu/commit/fb179e8117e18a3289da5e95f855b148576c7240 is especially a "throws hands up in air" tier change.