### PR TITLE
Improve user style selection UX based on local beatmap state

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -1184,7 +1184,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddStep("open user style selection", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().ShowUserStyleSelect());
-            AddAssert("style selection screen still open", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
+            AddUntilStep("style selection screen opened", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
 
             AddStep("change beatmap set", () => multiplayerClient.EditPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem(multiplayerClient.ServerRoom!.Playlist[0])
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -1154,10 +1154,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("open user style selection", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().ShowUserStyleSelect());
             AddUntilStep("style selection screen opened", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
 
-            AddStep("change beatmap", () => multiplayerClient.EditPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem(multiplayerClient.ServerRoom!.Playlist[0])
+            AddStep("change beatmap", () =>
             {
-                Beatmap = importedSet.Beatmaps.Last(),
-            })));
+                var newItem = multiplayerClient.ServerRoom!.Playlist[0].Clone();
+                var newBeatmap = importedSet.Beatmaps.Last();
+                newItem.BeatmapID = newBeatmap.OnlineID;
+                newItem.BeatmapChecksum = newBeatmap.MD5Hash;
+
+                multiplayerClient.EditPlaylistItem(newItem);
+            });
 
             AddWaitStep("wait for potential beatmap change", 2);
             AddAssert("style selection screen still open", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
@@ -1186,10 +1191,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("open user style selection", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().ShowUserStyleSelect());
             AddUntilStep("style selection screen opened", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
 
-            AddStep("change beatmap set", () => multiplayerClient.EditPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem(multiplayerClient.ServerRoom!.Playlist[0])
+            AddStep("change beatmap set", () =>
             {
-                Beatmap = importedSet2.Beatmaps.First(),
-            })));
+                var newItem = multiplayerClient.ServerRoom!.Playlist[0].Clone();
+                var newBeatmap = importedSet2.Beatmaps.Last();
+                newItem.BeatmapID = newBeatmap.OnlineID;
+                newItem.BeatmapChecksum = newBeatmap.MD5Hash;
+
+                multiplayerClient.EditPlaylistItem(newItem);
+            });
 
             AddUntilStep("selected beatmap changed", () => Beatmap.Value.BeatmapInfo.Equals(importedSet2.Beatmaps.First()));
             AddUntilStep("style selection screen closed", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() != true);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
     {
         private BeatmapManager beatmaps = null!;
         private BeatmapSetInfo importedSet = null!;
+        private BeatmapSetInfo importedSet2 = null!;
 
         private TestMultiplayerComponents multiplayerComponents = null!;
 
@@ -81,12 +82,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("import beatmap", () =>
             {
                 beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
+
+                importedSet = beatmaps.GetAllUsableBeatmapSets().First();
+                importedSet2 = beatmaps.Import(CreateBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapSet!)!.Value.Detach();
+
                 Realm.Write(r =>
                 {
                     foreach (var beatmapInfo in r.All<BeatmapInfo>())
                         beatmapInfo.OnlineMD5Hash = beatmapInfo.MD5Hash;
                 });
-                importedSet = beatmaps.GetAllUsableBeatmapSets().First();
             });
 
             AddStep("load multiplayer", () => LoadScreen(multiplayerComponents = new TestMultiplayerComponents()));
@@ -1093,6 +1097,102 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("global beatmap still matches first playlist item", () => Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(multiplayerClient.ClientRoom!.Playlist[0].BeatmapID));
             AddStep("return to match", () => multiplayerComponents.Exit());
             AddAssert("global beatmap matches second playlist item", () => Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(multiplayerClient.ClientRoom!.Playlist[1].BeatmapID));
+        }
+
+        /// <summary>
+        /// Tests that the local user is not able to change their play style if they haven't downloaded the beatmap (beatmap carousel will be empty).
+        /// </summary>
+        [Test]
+        public void TestCanNotEditDifficultyIfNotDownloaded()
+        {
+            IBeatmap roomBeatmap = null!;
+
+            createRoom(() =>
+            {
+                roomBeatmap = CreateBeatmap(new OsuRuleset().RulesetInfo);
+
+                return new Room
+                {
+                    Name = "Test Room",
+                    QueueMode = QueueMode.AllPlayers,
+                    Playlist =
+                    [
+                        new PlaylistItem(CreateAPIBeatmap(roomBeatmap.BeatmapInfo))
+                        {
+                            RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                            Freestyle = true
+                        }
+                    ]
+                };
+            });
+
+            AddAssert("editing disallowed", () => !this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().UserStyleEditingEnabled);
+            AddStep("import beatmap", () => beatmaps.Import(roomBeatmap.BeatmapInfo.BeatmapSet!));
+            AddAssert("editing allowed", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().UserStyleEditingEnabled);
+        }
+
+        /// <summary>
+        /// Test that the user selection screen is not exited when the beatmap is changed to the same set.
+        /// </summary>
+        [Test]
+        public void TestUserStyleSelectionDoesNotExitWhenBeatmapSetNotChanged()
+        {
+            createRoom(() => new Room
+            {
+                Name = "Test Room",
+                QueueMode = QueueMode.AllPlayers,
+                Playlist =
+                [
+                    new PlaylistItem(importedSet.Beatmaps.First())
+                    {
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                        Freestyle = true
+                    }
+                ]
+            });
+
+            AddStep("open user style selection", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().ShowUserStyleSelect());
+            AddUntilStep("style selection screen opened", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
+
+            AddStep("change beatmap", () => multiplayerClient.EditPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem(multiplayerClient.ServerRoom!.Playlist[0])
+            {
+                Beatmap = importedSet.Beatmaps.Last(),
+            })));
+
+            AddWaitStep("wait for potential beatmap change", 2);
+            AddAssert("style selection screen still open", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
+        }
+
+        /// <summary>
+        /// Tests that the user selection screen is exited when the beatmap is changed to another set.
+        /// </summary>
+        [Test]
+        public void TestUserStyleSelectionExitedWhenBeatmapSetChanged()
+        {
+            createRoom(() => new Room
+            {
+                Name = "Test Room",
+                QueueMode = QueueMode.AllPlayers,
+                Playlist =
+                [
+                    new PlaylistItem(importedSet.Beatmaps.First())
+                    {
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                        Freestyle = true
+                    }
+                ]
+            });
+
+            AddStep("open user style selection", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().ShowUserStyleSelect());
+            AddAssert("style selection screen still open", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() == true);
+
+            AddStep("change beatmap set", () => multiplayerClient.EditPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem(multiplayerClient.ServerRoom!.Playlist[0])
+            {
+                Beatmap = importedSet2.Beatmaps.First(),
+            })));
+
+            AddUntilStep("selected beatmap changed", () => Beatmap.Value.BeatmapInfo.Equals(importedSet2.Beatmaps.First()));
+            AddUntilStep("style selection screen closed", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() != true);
         }
 
         private void enterGameplay()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -13,6 +13,7 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
@@ -53,10 +54,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(Realm);
+            Dependencies.CacheAs<BeatmapStore>(new RealmDetachedBeatmapStore());
 
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 
             importedSet = beatmaps.GetAllUsableBeatmapSets().First();
+
+            Realm.Write(r =>
+            {
+                foreach (var beatmapInfo in r.All<BeatmapInfo>())
+                    beatmapInfo.OnlineMD5Hash = beatmapInfo.MD5Hash;
+            });
         }
 
         public override void SetUpSteps()

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Online.Rooms
         /// In many cases, this will *not* contain any usable information apart from OnlineID.
         /// </summary>
         [JsonIgnore]
-        public IBeatmapInfo Beatmap { get; private set; }
+        public IBeatmapInfo Beatmap { get; set; }
 
         [JsonIgnore]
         public IBindable<bool> Valid => valid;

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Online.Rooms
         /// In many cases, this will *not* contain any usable information apart from OnlineID.
         /// </summary>
         [JsonIgnore]
-        public IBeatmapInfo Beatmap { get; set; }
+        public IBeatmapInfo Beatmap { get; private set; }
 
         [JsonIgnore]
         public IBindable<bool> Valid => valid;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -673,18 +673,18 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 userStyleSection.Show();
 
                 PlaylistItem apiItem = new PlaylistItem(item).With(beatmap: new Optional<IBeatmapInfo>(new APIBeatmap { OnlineID = gameplayBeatmapId }), ruleset: gameplayRulesetId);
+                DrawableRoomPlaylistItem? currentDisplay = userStyleDisplayContainer.SingleOrDefault();
 
-                if (!apiItem.Equals(userStyleDisplayContainer.SingleOrDefault()?.Item))
+                if (!apiItem.Equals(currentDisplay?.Item))
                 {
-                    userStyleDisplayContainer.Child = new DrawableRoomPlaylistItem(apiItem, true)
+                    userStyleDisplayContainer.Child = currentDisplay = new DrawableRoomPlaylistItem(apiItem, true)
                     {
                         AllowReordering = false,
                         RequestEdit = _ => ShowUserStyleSelect()
                     };
                 }
 
-                DrawableRoomPlaylistItem panel = userStyleDisplayContainer.Single();
-                panel.AllowEditing = localBeatmap != null;
+                currentDisplay.AllowEditing = localBeatmap != null;
             }
             else
                 userStyleSection.Hide();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -83,6 +83,21 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// </summary>
         protected bool ExitConfirmed { get; private set; }
 
+        /// <summary>
+        /// Used for testing - whether the local user style can be edited.
+        /// False if the beatmap hasn't been downloaded yet, or if freestyle isn't enabled.
+        /// </summary>
+        internal bool UserStyleEditingEnabled
+        {
+            get
+            {
+                if (!userStyleDisplayContainer.IsPresent)
+                    return false;
+
+                return userStyleDisplayContainer.SingleOrDefault()?.AllowEditing == true;
+            }
+        }
+
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
@@ -677,7 +692,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// <summary>
         /// Shows the user style selection.
         /// </summary>
-        private void showUserStyleSelect()
+        public void ShowUserStyleSelect()
         {
             if (!this.IsCurrentScreen() || client.Room == null || client.LocalUser == null)
                 return;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -657,10 +657,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     userStyleDisplayContainer.Child = new DrawableRoomPlaylistItem(apiItem, true)
                     {
                         AllowReordering = false,
-                        AllowEditing = true,
-                        RequestEdit = _ => showUserStyleSelect()
+                        RequestEdit = _ => ShowUserStyleSelect()
                     };
                 }
+
+                DrawableRoomPlaylistItem panel = userStyleDisplayContainer.Single();
+                panel.AllowEditing = localBeatmap != null;
             }
             else
                 userStyleSection.Hide();

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -641,6 +641,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                         RequestEdit = _ => showUserStyleSelect()
                     };
                 }
+
+                DrawableRoomPlaylistItem panel = userStyleDisplayContainer.Single();
+                panel.AllowEditing = localBeatmap != null;
             }
             else
                 userStyleSection.Hide();

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -630,20 +630,18 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                 userStyleSection.Show();
 
                 PlaylistItem gameplayItem = item.With(ruleset: gameplayRuleset.OnlineID, beatmap: new Optional<IBeatmapInfo>(gameplayBeatmap));
-                PlaylistItem? currentItem = userStyleDisplayContainer.SingleOrDefault()?.Item;
+                DrawableRoomPlaylistItem? currentDisplay = userStyleDisplayContainer.SingleOrDefault();
 
-                if (!gameplayItem.Equals(currentItem))
+                if (!gameplayItem.Equals(currentDisplay?.Item))
                 {
-                    userStyleDisplayContainer.Child = new DrawableRoomPlaylistItem(gameplayItem, true)
+                    userStyleDisplayContainer.Child = currentDisplay = new DrawableRoomPlaylistItem(gameplayItem, true)
                     {
                         AllowReordering = false,
-                        AllowEditing = true,
                         RequestEdit = _ => showUserStyleSelect()
                     };
                 }
 
-                DrawableRoomPlaylistItem panel = userStyleDisplayContainer.Single();
-                panel.AllowEditing = localBeatmap != null;
+                currentDisplay.AllowEditing = localBeatmap != null;
             }
             else
                 userStyleSection.Hide();


### PR DESCRIPTION
https://github.com/user-attachments/assets/8e079e20-3814-4a94-b92d-699e63e5f3ab

A few items I noticed when playing around with freestyle in public games...

## Hide edit user style button if beatmap is not downloaded

The song select carousel would be empty anyway. Maybe this is something that can change in the future but the current UX makes no sense in this case... The same change has been applied to playlists, too.

## Exit user style selection when the active beatmap set is changed

It doesn't exit if the active beatmap is changed but still points to the same set, only if the set itself has changed at which point any operation the local user could do inside the style selection would be invalid.

---

I've based my tests around `TestSceneMultiplayer` for this round although the first change was also applied to playlists as a 1-1 port. If requested I can try to add a test in playlists too.