### PR TITLE
Don't apply high CS bonus to slider velocity bonus

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -155,12 +155,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Add in acute angle bonus or wide angle bonus, whichever is larger.
             aimStrain += Math.Max(acuteAngleBonus * acute_angle_multiplier, wideAngleBonus * wide_angle_multiplier);
 
+            // Apply high circle size bonus
+            aimStrain *= osuCurrObj.SmallCircleBonus;
+
             // Add in additional slider velocity bonus.
             if (withSliderTravelDistance)
                 aimStrain += sliderBonus * slider_multiplier;
-
-            // Apply high circle size bonus
-            aimStrain *= osuCurrObj.SmallCircleBonus;
 
             return aimStrain;
         }


### PR DESCRIPTION
This is not a very good solution, but it's a first local-scoped hotfix for this map - https://osu.ppy.sh/beatmapsets/879387#osu/5125702
I tried decreasing bonus instead of removing, but the nerf is too low in this case. 
With the current approach HDHR score is nerfed from 1419pp to 1286pp.