### PR TITLE
Bring back minimal debug settings

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
@@ -1,11 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
@@ -22,7 +19,7 @@ namespace osu.Game.Overlays.FirstRunSetup
     [LocalisableDescription(typeof(FirstRunSetupOverlayStrings), nameof(FirstRunSetupOverlayStrings.Behaviour))]
     public partial class ScreenBehaviour : WizardScreen
     {
-        private SearchContainer<SettingsSection> searchContainer;
+        private SearchContainer<SettingsSection> searchContainer = null!;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -91,13 +88,11 @@ namespace osu.Game.Overlays.FirstRunSetup
                         new GraphicsSection(),
                         new OnlineSection(),
                         new MaintenanceSection(),
+                        new DebugSection()
                     },
                     SearchTerm = SettingsItem<bool>.CLASSIC_DEFAULT_SEARCH_TERM,
                 }
             };
-
-            if (DebugUtils.IsDebugBuild)
-                searchContainer.Add(new DebugSection());
         }
 
         private void applyClassic()

--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -21,10 +21,11 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public DebugSection()
         {
-            Add(new GeneralSettings());
-
             if (DebugUtils.IsDebugBuild)
+            {
+                Add(new GeneralSettings());
                 Add(new BatchImportSettings());
+            }
 
             Add(new MemorySettings());
         }

--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -20,12 +21,12 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public DebugSection()
         {
-            Children = new Drawable[]
-            {
-                new GeneralSettings(),
-                new BatchImportSettings(),
-                new MemorySettings(),
-            };
+            Add(new GeneralSettings());
+
+            if (DebugUtils.IsDebugBuild)
+                Add(new BatchImportSettings());
+
+            Add(new MemorySettings());
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
-using osu.Framework.Development;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.DebugSettings
@@ -21,14 +20,11 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                 Current = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay)
             });
 
-            if (DebugUtils.IsDebugBuild)
+            Add(new SettingsCheckbox
             {
-                Add(new SettingsCheckbox
-                {
-                    LabelText = @"Bypass front-to-back render pass",
-                    Current = config.GetBindable<bool>(DebugSetting.BypassFrontToBackPass)
-                });
-            }
+                LabelText = @"Bypass front-to-back render pass",
+                Current = config.GetBindable<bool>(DebugSetting.BypassFrontToBackPass)
+            });
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
@@ -3,7 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
-using osu.Framework.Graphics;
+using osu.Framework.Development;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.DebugSettings
@@ -15,19 +15,20 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager config, FrameworkConfigManager frameworkConfig)
         {
-            Children = new Drawable[]
+            Add(new SettingsCheckbox
             {
-                new SettingsCheckbox
-                {
-                    LabelText = @"Show log overlay",
-                    Current = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay)
-                },
-                new SettingsCheckbox
+                LabelText = @"Show log overlay",
+                Current = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay)
+            });
+
+            if (DebugUtils.IsDebugBuild)
+            {
+                Add(new SettingsCheckbox
                 {
                     LabelText = @"Bypass front-to-back render pass",
                     Current = config.GetBindable<bool>(DebugSetting.BypassFrontToBackPass)
-                },
-            };
+                });
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -28,7 +28,13 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
             Add(new SettingsButton
             {
                 Text = @"Clear all caches",
-                Action = host.Collect
+                Action = () =>
+                {
+                    host.Collect();
+
+                    // host.Collect() uses GCCollectionMode.Optimized, but we should be as aggressive as possible here.
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
+                }
             });
 
             if (DebugUtils.IsDebugBuild)

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
@@ -34,6 +35,27 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 
                     // host.Collect() uses GCCollectionMode.Optimized, but we should be as aggressive as possible here.
                     GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
+                }
+            });
+
+            SettingsEnumDropdown<GCLatencyMode> latencyModeDropdown;
+            Add(latencyModeDropdown = new SettingsEnumDropdown<GCLatencyMode>
+            {
+                LabelText = "GC mode",
+            });
+
+            latencyModeDropdown.Current.BindValueChanged(mode =>
+            {
+                switch (mode.NewValue)
+                {
+                    case GCLatencyMode.Default:
+                        // https://github.com/ppy/osu-framework/blob/1d5301018dfed1a28702be56e1d53c4835b199f2/osu.Framework/Platform/GameHost.cs#L703
+                        GCSettings.LatencyMode = System.Runtime.GCLatencyMode.SustainedLowLatency;
+                        break;
+
+                    case GCLatencyMode.Interactive:
+                        GCSettings.LatencyMode = System.Runtime.GCLatencyMode.Interactive;
+                        break;
                 }
             });
 
@@ -102,6 +124,12 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                     }
                 };
             }
+        }
+
+        private enum GCLatencyMode
+        {
+            Default,
+            Interactive,
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 
             latencyModeDropdown.Current.BindValueChanged(mode =>
             {
+                Logger.Log($"Changing latency mode: {mode.NewValue}");
+
                 switch (mode.NewValue)
                 {
                     case GCLatencyMode.Default:

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -31,7 +30,7 @@ namespace osu.Game.Overlays
 
         protected override IEnumerable<SettingsSection> CreateSections()
         {
-            var sections = new List<SettingsSection>
+            return new List<SettingsSection>
             {
                 // This list should be kept in sync with ScreenBehaviour.
                 new GeneralSection(),
@@ -44,12 +43,8 @@ namespace osu.Game.Overlays
                 new GraphicsSection(),
                 new OnlineSection(),
                 new MaintenanceSection(),
+                new DebugSection()
             };
-
-            if (DebugUtils.IsDebugBuild)
-                sections.Add(new DebugSection());
-
-            return sections;
         }
 
         private readonly List<SettingsSubPanel> subPanels = new List<SettingsSubPanel>();


### PR DESCRIPTION
I will provide specific testing instructions in https://github.com/ppy/osu/issues/34042 when a release is made available with these changes.

---

## [Re-enable debug settings](https://github.com/ppy/osu/pull/34221/commits/c59447c407c8bc705df3f7a0e0270727909324a2)

I want to use debug settings to get a general idea of how the Satori GC is behaving. Instead of disabling the entire section, this now selectively disables items that users shouldn't ever touch such as blocking realm.

<img width="524" height="433" alt="image" src="https://github.com/user-attachments/assets/08586f3a-c666-4560-ac93-63d12cc457cf" />

## [Clear caches as aggressively as possible](https://github.com/ppy/osu/pull/34221/commits/adc054f08eece15c0e9f002d7c27826c4a8de347)

The most important thing for me to have here is a way to programmatically invoke a gen-2 `GC.Collect()`, which will allow the Satori trimmer to return memory back to the system:

https://github.com/VSadov/Satori/blob/b01b32a00945300073f803414c9bf2e77359253a/src/coreclr/gc/satori/SatoriTrimmer.cpp#L80-L89

I've changed this to also be as aggressive as possible, doubling up on the framework's own `GC.Collect()`. Note that although `compact: true` is being passed here, Satori documents forced compaction as [not-yet-implemented](https://github.com/VSadov/Satori/blob/b01b32a00945300073f803414c9bf2e77359253a/src/coreclr/gc/satori/SatoriGC.cpp#L250).

## [Add GC mode dropdown](https://github.com/ppy/osu/pull/34221/commits/1c243b25b23127ddfc47c02bdd31ff9d96b975f8)

On top of the above blocking collection, I noticed that we may be skipping relocations because the framework runs in constant SLL mode:

https://github.com/VSadov/Satori/blob/b01b32a00945300073f803414c9bf2e77359253a/src/coreclr/gc/satori/SatoriRecycler.cpp#L1216-L1221

This appears to have an effect in local testing. I'm not sure yet if this means that forced compaction actually is implemented.