### PR TITLE
Write only fixed release streams back to config

### DIFF
--- a/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
+++ b/osu.Game.Tests/NonVisual/TestSceneUpdateManager.cs
@@ -136,13 +136,38 @@ namespace osu.Game.Tests.NonVisual
             AddUntilStep("no check pending", () => !manager.IsPending);
         }
 
+        [Test]
+        public void TestFixedReleaseStreamWrittenToConfig()
+        {
+            AddStep("add manager", () =>
+            {
+                config = new OsuConfigManager(LocalStorage);
+                config.SetValue(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
+
+                Child = new DependencyProvidingContainer
+                {
+                    CachedDependencies = [(typeof(OsuConfigManager), config)],
+                    Child = manager = new TestUpdateManager(ReleaseStream.Tachyon)
+                };
+            });
+
+            AddAssert("release stream set to tachyon", () => config.Get<ReleaseStream>(OsuSetting.ReleaseStream), () => Is.EqualTo(ReleaseStream.Tachyon));
+        }
+
         private partial class TestUpdateManager : UpdateManager
         {
+            public override ReleaseStream? FixedReleaseStream { get; }
+
             public bool IsPending { get; private set; }
             public int Invocations { get; private set; }
             public int Completions { get; private set; }
 
             private TaskCompletionSource<bool>? pendingCheck;
+
+            public TestUpdateManager(ReleaseStream? fixedReleaseStream = null)
+            {
+                FixedReleaseStream = fixedReleaseStream;
+            }
 
             protected override async Task<bool> PerformUpdateCheck(CancellationToken cancellationToken)
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Humanizer;
@@ -1054,9 +1053,6 @@ namespace osu.Game
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            if (RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>() == null)
-                Logger.Log(NotificationsStrings.NotOfficialBuild.ToString());
 
             var languages = Enum.GetValues<Language>();
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1058,10 +1058,6 @@ namespace osu.Game
             if (RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>() == null)
                 Logger.Log(NotificationsStrings.NotOfficialBuild.ToString());
 
-            // Make sure the release stream setting matches the build which was just run.
-            if (Enum.TryParse<ReleaseStream>(Version.Split('-').Last(), true, out var releaseStream))
-                LocalConfig.SetValue(OsuSetting.ReleaseStream, releaseStream);
-
             var languages = Enum.GetValues<Language>();
 
             var mappings = languages.Select(language =>

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -56,11 +56,15 @@ namespace osu.Game.Updater
             string version = game.Version;
             string lastVersion = config.Get<string>(OsuSetting.Version);
 
-            if (game.IsDeployedBuild && version != lastVersion)
+            if (game.IsDeployedBuild)
             {
                 // only show a notification if we've previously saved a version to the config file (ie. not the first run).
-                if (!string.IsNullOrEmpty(lastVersion))
+                if (!string.IsNullOrEmpty(lastVersion) && version != lastVersion)
                     Notifications.Post(new UpdateCompleteNotification(version));
+
+                // make sure the release stream setting matches the build which was just run.
+                if (FixedReleaseStream != null)
+                    config.SetValue(OsuSetting.ReleaseStream, FixedReleaseStream.Value);
 
                 if (RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>() == null)
                     Notifications.Post(new SimpleNotification { Text = NotificationsStrings.NotOfficialBuild });

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
@@ -66,8 +67,15 @@ namespace osu.Game.Updater
                 if (FixedReleaseStream != null)
                     config.SetValue(OsuSetting.ReleaseStream, FixedReleaseStream.Value);
 
+                // notify the user if they're using a build that is not officially sanctioned.
                 if (RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>() == null)
                     Notifications.Post(new SimpleNotification { Text = NotificationsStrings.NotOfficialBuild });
+            }
+            else
+            {
+                // log that this is not an official build, for if users build their own game without an assembly version.
+                // this is only logged because a notification would be too spammy in local test builds.
+                Logger.Log(NotificationsStrings.NotOfficialBuild.ToString());
             }
 
             // debug / local compilations will reset to a non-release string.


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/34118

Tested:
- [x] Debug build doesn't show "official build" notification.
- [x] Debug build logs "official build" notification.
- [x] `NoActionUpdateManager` with `OSU_EXTERNAL_UPDATE_STREAM=tachyon` writes `tachyon` to config. Mobile updater works similarly so this covers both cases.

https://github.com/user-attachments/assets/1405d12a-d6c3-475c-ac7a-602a1c57a449