### PR TITLE
Attempt to properly quantify the impact of mania Hard Rock / Easy mod application on overall difficulty

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchRateAdjustedDisplayDifficultyTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchRateAdjustedDisplayDifficultyTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Mods;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             var ruleset = new CatchRuleset();
             var difficulty = new BeatmapDifficulty { ApproachRate = originalApproachRate };
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 1);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, []);
 
             Assert.That(adjustedDifficulty.ApproachRate, Is.EqualTo(originalApproachRate));
         }
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             var ruleset = new CatchRuleset();
             var difficulty = new BeatmapDifficulty();
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 0.75);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, [new CatchModHalfTime()]);
 
             Assert.That(adjustedDifficulty.ApproachRate, Is.EqualTo(1.67).Within(0.01));
         }
@@ -44,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             var ruleset = new CatchRuleset();
             var difficulty = new BeatmapDifficulty();
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 1.5);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, [new CatchModDoubleTime()]);
 
             Assert.That(adjustedDifficulty.ApproachRate, Is.EqualTo(7.67).Within(0.01));
         }

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -33,6 +33,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch
@@ -265,9 +266,10 @@ namespace osu.Game.Rulesets.Catch
         }
 
         /// <seealso cref="CatchHitObject.ApplyDefaultsToSelf"/>
-        public override BeatmapDifficulty GetRateAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, double rate)
+        public override BeatmapDifficulty GetAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, IReadOnlyCollection<Mod> mods)
         {
             BeatmapDifficulty adjustedDifficulty = new BeatmapDifficulty(difficulty);
+            double rate = ModUtils.CalculateRateWithMods(mods);
 
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(adjustedDifficulty.ApproachRate, CatchHitObject.PREEMPT_MAX, CatchHitObject.PREEMPT_MID, CatchHitObject.PREEMPT_MIN);
             preempt /= rate;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModEasy.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModEasy.cs
@@ -13,19 +13,19 @@ namespace osu.Game.Rulesets.Mania.Mods
     {
         public override LocalisableString Description => @"More forgiving HP drain, less accuracy required, and extra lives!";
 
+        public const double HIT_WINDOW_DIFFICULTY_MULTIPLIER = 1 / 1.4;
+
         void IApplicableToHitObject.ApplyToHitObject(HitObject hitObject)
         {
-            const double multiplier = 1 / 1.4;
-
             switch (hitObject)
             {
                 case Note:
-                    ((ManiaHitWindows)hitObject.HitWindows).DifficultyMultiplier = multiplier;
+                    ((ManiaHitWindows)hitObject.HitWindows).DifficultyMultiplier = HIT_WINDOW_DIFFICULTY_MULTIPLIER;
                     break;
 
                 case HoldNote hold:
-                    ((ManiaHitWindows)hold.Head.HitWindows).DifficultyMultiplier = multiplier;
-                    ((ManiaHitWindows)hold.Tail.HitWindows).DifficultyMultiplier = multiplier;
+                    ((ManiaHitWindows)hold.Head.HitWindows).DifficultyMultiplier = HIT_WINDOW_DIFFICULTY_MULTIPLIER;
+                    ((ManiaHitWindows)hold.Tail.HitWindows).DifficultyMultiplier = HIT_WINDOW_DIFFICULTY_MULTIPLIER;
                     break;
             }
         }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
@@ -13,19 +13,19 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override double ScoreMultiplier => 1;
         public override bool Ranked => false;
 
+        public const double HIT_WINDOW_DIFFICULTY_MULTIPLIER = 1.4;
+
         void IApplicableToHitObject.ApplyToHitObject(HitObject hitObject)
         {
-            const double multiplier = 1.4;
-
             switch (hitObject)
             {
                 case Note:
-                    ((ManiaHitWindows)hitObject.HitWindows).DifficultyMultiplier = multiplier;
+                    ((ManiaHitWindows)hitObject.HitWindows).DifficultyMultiplier = HIT_WINDOW_DIFFICULTY_MULTIPLIER;
                     break;
 
                 case HoldNote hold:
-                    ((ManiaHitWindows)hold.Head.HitWindows).DifficultyMultiplier = multiplier;
-                    ((ManiaHitWindows)hold.Tail.HitWindows).DifficultyMultiplier = multiplier;
+                    ((ManiaHitWindows)hold.Head.HitWindows).DifficultyMultiplier = HIT_WINDOW_DIFFICULTY_MULTIPLIER;
+                    ((ManiaHitWindows)hold.Tail.HitWindows).DifficultyMultiplier = HIT_WINDOW_DIFFICULTY_MULTIPLIER;
                     break;
             }
         }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Mania.Scoring
 {
     public class ManiaHitWindows : HitWindows
     {
-        private static readonly DifficultyRange perfect_window_range = new DifficultyRange(22.4D, 19.4D, 13.9D);
+        public static readonly DifficultyRange PERFECT_WINDOW_RANGE = new DifficultyRange(22.4D, 19.4D, 13.9D);
         private static readonly DifficultyRange great_window_range = new DifficultyRange(64, 49, 34);
         private static readonly DifficultyRange good_window_range = new DifficultyRange(97, 82, 67);
         private static readonly DifficultyRange ok_window_range = new DifficultyRange(127, 112, 97);
@@ -151,7 +151,7 @@ namespace osu.Game.Rulesets.Mania.Scoring
             }
             else
             {
-                perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, perfect_window_range) * totalMultiplier) + 0.5;
+                perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, PERFECT_WINDOW_RANGE) * totalMultiplier) + 0.5;
                 great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, great_window_range) * totalMultiplier) + 0.5;
                 good = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, good_window_range) * totalMultiplier) + 0.5;
                 ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, ok_window_range) * totalMultiplier) + 0.5;

--- a/osu.Game.Rulesets.Osu.Tests/OsuRateAdjustedDisplayDifficultyTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuRateAdjustedDisplayDifficultyTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             var ruleset = new OsuRuleset();
             var difficulty = new BeatmapDifficulty { ApproachRate = originalApproachRate };
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 1);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, []);
 
             Assert.That(adjustedDifficulty.ApproachRate, Is.EqualTo(originalApproachRate));
         }
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             var ruleset = new OsuRuleset();
             var difficulty = new BeatmapDifficulty { OverallDifficulty = originalOverallDifficulty };
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 1);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, []);
 
             Assert.That(adjustedDifficulty.OverallDifficulty, Is.EqualTo(originalOverallDifficulty));
         }
@@ -44,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             var ruleset = new OsuRuleset();
             var difficulty = new BeatmapDifficulty();
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 0.75);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, [new OsuModHalfTime()]);
 
             Assert.That(adjustedDifficulty.ApproachRate, Is.EqualTo(1.67).Within(0.01));
             Assert.That(adjustedDifficulty.OverallDifficulty, Is.EqualTo(2.22).Within(0.01));
@@ -56,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             var ruleset = new OsuRuleset();
             var difficulty = new BeatmapDifficulty();
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 1.5);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, [new OsuModDoubleTime()]);
 
             Assert.That(adjustedDifficulty.ApproachRate, Is.EqualTo(7.67).Within(0.01));
             Assert.That(adjustedDifficulty.OverallDifficulty, Is.EqualTo(7.77).Within(0.01));

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -40,6 +40,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu
@@ -365,9 +366,10 @@ namespace osu.Game.Rulesets.Osu
 
         /// <seealso cref="OsuHitObject.ApplyDefaultsToSelf"/>
         /// <seealso cref="OsuHitWindows"/>
-        public override BeatmapDifficulty GetRateAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, double rate)
+        public override BeatmapDifficulty GetAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, IReadOnlyCollection<Mod> mods)
         {
             BeatmapDifficulty adjustedDifficulty = new BeatmapDifficulty(difficulty);
+            double rate = ModUtils.CalculateRateWithMods(mods);
 
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(adjustedDifficulty.ApproachRate, OsuHitObject.PREEMPT_MAX, OsuHitObject.PREEMPT_MID, OsuHitObject.PREEMPT_MIN);
             preempt /= rate;

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoRateAdjustedDisplayDifficultyTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoRateAdjustedDisplayDifficultyTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Taiko.Mods;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             var ruleset = new TaikoRuleset();
             var difficulty = new BeatmapDifficulty { OverallDifficulty = originalOverallDifficulty };
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 1);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, []);
 
             Assert.That(adjustedDifficulty.OverallDifficulty, Is.EqualTo(originalOverallDifficulty));
         }
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             var ruleset = new TaikoRuleset();
             var difficulty = new BeatmapDifficulty();
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 0.75);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, [new TaikoModHalfTime()]);
 
             Assert.That(adjustedDifficulty.OverallDifficulty, Is.EqualTo(1.11).Within(0.01));
         }
@@ -44,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             var ruleset = new TaikoRuleset();
             var difficulty = new BeatmapDifficulty();
 
-            var adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(difficulty, 1.5);
+            var adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(difficulty, [new TaikoModDoubleTime()]);
 
             Assert.That(adjustedDifficulty.OverallDifficulty, Is.EqualTo(8.89).Within(0.01));
         }

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -38,6 +38,7 @@ using osu.Game.Rulesets.Taiko.Configuration;
 using osu.Game.Rulesets.Taiko.Edit.Setup;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Screens.Edit.Setup;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Taiko
 {
@@ -270,9 +271,10 @@ namespace osu.Game.Rulesets.Taiko
         }
 
         /// <seealso cref="TaikoHitWindows"/>
-        public override BeatmapDifficulty GetRateAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, double rate)
+        public override BeatmapDifficulty GetAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, IReadOnlyCollection<Mod> mods)
         {
             BeatmapDifficulty adjustedDifficulty = new BeatmapDifficulty(difficulty);
+            double rate = ModUtils.CalculateRateWithMods(mods);
 
             double greatHitWindow = IBeatmapDifficultyInfo.DifficultyRange(adjustedDifficulty.OverallDifficulty, TaikoHitWindows.GREAT_WINDOW_RANGE);
             greatHitWindow /= rate;

--- a/osu.Game/Beatmaps/Drawables/DifficultyIconTooltip.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIconTooltip.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Beatmaps.Drawables
             }
 
             Ruleset ruleset = displayedContent.Ruleset.CreateInstance();
-            BeatmapDifficulty adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(originalDifficulty, rate);
+            BeatmapDifficulty adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(originalDifficulty, displayedContent.Mods ?? []);
 
             circleSize.Text = @"CS: " + adjustedDifficulty.CircleSize.ToString(@"0.##");
             drainRate.Text = @" HP: " + adjustedDifficulty.DrainRate.ToString(@"0.##");

--- a/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Overlays.Mods
                 mod.ApplyToDifficulty(adjustedDifficulty);
 
             Ruleset ruleset = GameRuleset.Value.CreateInstance();
-            adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(adjustedDifficulty, rate);
+            adjustedDifficulty = ruleset.GetAdjustedDisplayDifficulty(adjustedDifficulty, Mods.Value);
 
             TooltipContent = new AdjustedAttributesTooltip.Data(originalDifficulty, adjustedDifficulty);
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -380,15 +380,15 @@ namespace osu.Game.Rulesets
         public virtual LocalisableString GetDisplayNameForHitResult(HitResult result) => result.GetLocalisableDescription();
 
         /// <summary>
-        /// Applies changes to difficulty attributes for presenting to a user a rough estimate of how rate adjust mods affect difficulty.
+        /// Applies changes to difficulty attributes for presenting to a user a rough estimate of how mods affect difficulty.
         /// Importantly, this should NOT BE USED FOR ANY CALCULATIONS.
         ///
         /// It is also not always correct, and arguably is never correct depending on your frame of mind.
         /// </summary>
         /// <param name="difficulty">>The <see cref="IBeatmapDifficultyInfo"/> that will be adjusted.</param>
-        /// <param name="rate">The rate adjustment multiplier from mods. For example 1.5 for DT.</param>
+        /// <param name="mods">The active mods.</param>
         /// <returns>The adjusted difficulty attributes.</returns>
-        public virtual BeatmapDifficulty GetRateAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, double rate) => new BeatmapDifficulty(difficulty);
+        public virtual BeatmapDifficulty GetAdjustedDisplayDifficulty(IBeatmapDifficultyInfo difficulty, IReadOnlyCollection<Mod> mods) => new BeatmapDifficulty(difficulty);
 
         /// <summary>
         /// Creates ruleset-specific beatmap filter criteria to be used on the song select screen.

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -185,9 +185,7 @@ namespace osu.Game.Screens.Select.Details
 
                 if (Ruleset.Value != null)
                 {
-                    double rate = ModUtils.CalculateRateWithMods(Mods.Value);
-
-                    adjustedDifficulty = Ruleset.Value.CreateInstance().GetRateAdjustedDisplayDifficulty(originalDifficulty, rate);
+                    adjustedDifficulty = Ruleset.Value.CreateInstance().GetAdjustedDisplayDifficulty(originalDifficulty, Mods.Value);
 
                     TooltipContent = new AdjustedAttributesTooltip.Data(originalDifficulty, adjustedDifficulty);
                 }

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -26,7 +26,6 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Utils;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.SelectV2
@@ -302,9 +301,7 @@ namespace osu.Game.Screens.SelectV2
 
                 Ruleset rulesetInstance = ruleset.Value.CreateInstance();
 
-                double rate = ModUtils.CalculateRateWithMods(mods.Value);
-
-                adjustedDifficulty = rulesetInstance.GetRateAdjustedDisplayDifficulty(adjustedDifficulty, rate);
+                adjustedDifficulty = rulesetInstance.GetAdjustedDisplayDifficulty(adjustedDifficulty, mods.Value);
                 difficultyStatisticsDisplay.TooltipContent = new AdjustedAttributesTooltip.Data(originalDifficulty, adjustedDifficulty);
 
                 StatisticDifficulty.Data firstStatistic;

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -243,10 +243,7 @@ namespace osu.Game.Skinning.Components
                     mod.ApplyToDifficulty(difficulty);
 
                 if (ruleset.Value is RulesetInfo rulesetInfo)
-                {
-                    double rate = ModUtils.CalculateRateWithMods(mods.Value);
-                    difficulty = rulesetInfo.CreateInstance().GetRateAdjustedDisplayDifficulty(difficulty, rate);
-                }
+                    difficulty = rulesetInfo.CreateInstance().GetAdjustedDisplayDifficulty(difficulty, mods.Value);
 
                 return difficulty;
             }


### PR DESCRIPTION
In osu!stable's osu!mania implementation, "Hard Rock" and "Easy" mods do not work the same way as they do on all other rulesets. Rather than applying a multiplier to the map's base Overall Difficulty value, it applies multipliers to *the durations of hit windows themselves*.

Applying a multiplier to the map's OD instead of the hit windows is not the same thing. The second thing is actually *much harsher* in magnitude, to the point where applying HR to any map is almost guaranteed to exceed "the effective OD" of 10, and applying EZ to any map is almost guaranteed to result in "negative effective OD".

Prior to the last release, osu!lazer was oblivious to this reality and just treated mania HR / EZ as it did every other ruleset. Last release, for the sake for gameplay parity across rulesets, the mods in question were [adjusted to match stable](https://github.com/ppy/osu/pull/33982), but in the process, it made it look on the surface like HR / EZ were not changing OD anymore.

In actuality, the hit windows *were* still being adjusted (now matching stable), but this was no longer visible in the OD displayed at song select. 

This change attempts to convey that reality by displaying "effective OD", similar to what's already done in other rulesets when rate-changing mods are active. Note that the values this will display *do not match* stable *and that is correct*, because stable song select *lies* about the actual impact on OD by just assuming it can treat all rulesets in the same way.

---

Would close https://github.com/ppy/osu/issues/34150 I guess.

And yes I would like *all of the above* to land on the changelog if possible if this is merged.

For further convincing that this makes any semblance of sense please see the following: https://www.desmos.com/calculator/yigt7jycdv

[Citation for stable just lying about the OD.](https://github.com/peppy/osu-stable-reference/blob/e422af0e7e9fab4879a3b0ba8200e52406ef9d61/osu!/GameplayElements/Beatmaps/Beatmap.cs#L1134-L1157) Also note that stable just lies about DT/HT affecting OD on mania as well although it doesn't quantify by how much because it only shows a down/up triangle.