### PR TITLE
Fix build version being lost on Android builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,22 @@
+﻿<Project>
+  <PropertyGroup>
+    <DeployPropertiesFile>DeployProperties.g.cs</DeployPropertiesFile>
+  </PropertyGroup>
+
+  <Target Name="WriteDeployProperties" BeforeTargets="BeforeCompile;CoreCompile" Outputs="$(IntermediateOutputPath)$(DeployPropertiesFile)">
+    <PropertyGroup>
+      <DeployPropertiesFilePath>$(IntermediateOutputPath)$(DeployPropertiesFile)</DeployPropertiesFilePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <DeployAttributes Include="osu.Game.Utils.OfficialBuildAttribute">
+        <_Parameter1>$(Version)</_Parameter1>
+      </DeployAttributes>
+    </ItemGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(DeployAttributes)" Language="C#" OutputFile="$(DeployPropertiesFilePath)">
+      <Output TaskParameter="OutputFile" ItemName="Compile"/>
+      <Output TaskParameter="OutputFile" ItemName="FileWrites"/>
+    </WriteCodeFragment>
+  </Target>
+</Project>

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -125,13 +125,9 @@ namespace osu.Game
                 if (!IsDeployedBuild)
                     return @"local " + (DebugUtils.IsDebugBuild ? @"debug" : @"release");
 
-                string informationalVersion = Assembly.GetEntryAssembly()?
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-                    .InformationalVersion;
-
-                // Example: [assembly: AssemblyInformationalVersion("2025.613.0-tachyon+d934e574b2539e8787956c3c9ecce9dadebb10ee")]
-                if (!string.IsNullOrEmpty(informationalVersion))
-                    return informationalVersion.Split('+').First();
+                OfficialBuildAttribute buildAttribute = RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>();
+                if (buildAttribute != null)
+                    return buildAttribute.Version;
 
                 Version version = AssemblyVersion;
                 return $@"{version.Major}.{version.Minor}.{version.Build}-lazer";

--- a/osu.Game/Utils/OfficialBuildAttribute.cs
+++ b/osu.Game/Utils/OfficialBuildAttribute.cs
@@ -2,11 +2,23 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using JetBrains.Annotations;
 
 namespace osu.Game.Utils
 {
-    [UsedImplicitly]
+    /// <summary>
+    /// This attribute is automatically attached to assemblies of projects built with a <c>Version</c> property specified.
+    /// It is purely informational - used to alert the user of the (lack of) online capabilities and of the game's version.
+    /// <p />
+    /// Refer to <c>Directory.Build.targets</c> in the repository root for how this attribute is attached.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Assembly)]
-    public class OfficialBuildAttribute : Attribute;
+    public class OfficialBuildAttribute : Attribute
+    {
+        public readonly string Version;
+
+        public OfficialBuildAttribute(string version)
+        {
+            Version = version;
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/34185
Initial commentary in https://github.com/ppy/osu/issues/34185#issuecomment-3072196472

I've had a similar hack here stashed away for another internal project. It generates the following file across all projects:
```
~/Repos/osu/osu.Desktop $ cat obj/Debug/net8.0/DeployProperties.g.cs
//------------------------------------------------------------------------------
// <auto-generated>
//     This code was generated by a tool.
//
//     Changes to this file may cause incorrect behavior and will be lost if
//     the code is regenerated.
// </auto-generated>
//------------------------------------------------------------------------------

using System;
using System.Reflection;

[assembly: osu.Game.Utils.OfficialBuildAttribute("2025.715.15-tachyon")]

// Generated by the MSBuild WriteCodeFragment class.
```

... which is the same thing our internal deploy project does, minus the version name which is added in this patch. Thus this also cleans up the deploy project a bit (see referring PRs).