### PR TITLE
Add initial support for filtering by user tags in song select

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -40,6 +40,11 @@ namespace osu.Game.Tests.NonVisual.Filtering
                 Author = { Username = "The Author" },
                 Source = "unit tests",
                 Tags = "look for tags too",
+                UserTags =
+                {
+                    "song representation/simple",
+                    "style/clean",
+                }
             },
             DifficultyName = "version as well",
             Length = 2500,
@@ -290,6 +295,33 @@ namespace osu.Game.Tests.NonVisual.Filtering
             carouselItem.Filter(criteria);
 
             Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [TestCase("simple", false)]
+        [TestCase("\"style/clean\"", false)]
+        [TestCase("\"style/clean\"!", false)]
+        [TestCase("iNiS-style", true)]
+        [TestCase("\"reading/visually dense\"!", true)]
+        public void TestCriteriaMatchingUserTags(string query, bool filtered)
+        {
+            var beatmap = getExampleBeatmap();
+            var criteria = new FilterCriteria { UserTag = { SearchTerm = query } };
+            var carouselItem = new CarouselBeatmap(beatmap);
+            carouselItem.Filter(criteria);
+
+            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        public void TestBeatmapMustHaveAtLeastOneTagIfUserTagFilterActive()
+        {
+            var beatmap = getExampleBeatmap();
+            var criteria = new FilterCriteria { UserTag = { SearchTerm = "simple" } };
+            var carouselItem = new CarouselBeatmap(beatmap);
+            carouselItem.BeatmapInfo.Metadata.UserTags.Clear();
+            carouselItem.Filter(criteria);
+
+            Assert.True(carouselItem.Filtered.Value);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -25,9 +26,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             base.LoadComplete();
 
-            Child = wedge = new BeatmapMetadataWedge
+            var lookupSource = new RealmPopulatingOnlineLookupSource();
+            Child = new DependencyProvidingContainer
             {
-                State = { Value = Visibility.Visible },
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = [(typeof(RealmPopulatingOnlineLookupSource), lookupSource)],
+                Children =
+                [
+                    lookupSource,
+                    wedge = new BeatmapMetadataWedge
+                    {
+                        State = { Value = Visibility.Visible },
+                    }
+                ]
             };
         }
 

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Game.Models;
+using osu.Game.Screens.SelectV2;
 using osu.Game.Users;
 using osu.Game.Utils;
 using Realms;
@@ -15,10 +17,10 @@ namespace osu.Game.Beatmaps
     /// A realm model containing metadata for a beatmap.
     /// </summary>
     /// <remarks>
-    /// This is currently stored against each beatmap difficulty, even when it is duplicated.
+    /// An instance of this object is stored against each beatmap difficulty.
     /// It is also provided via <see cref="BeatmapSetInfo"/> for convenience and historical purposes.
-    /// A future effort could see this converted to an <see cref="EmbeddedObject"/> or potentially de-duped
-    /// and shared across multiple difficulties in the same set, if required.
+    /// Note that accessing the metadata via <see cref="BeatmapSetInfo"/> may result in indeterminate results
+    /// as metadata can meaningfully differ per beatmap in a set.
     ///
     /// Note that difficulty name is not stored in this metadata but in <see cref="BeatmapInfo"/>.
     /// </remarks>
@@ -42,6 +44,13 @@ namespace osu.Game.Beatmaps
 
         [JsonProperty(@"tags")]
         public string Tags { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The list of user-voted tags applicable to this beatmap.
+        /// This information is populated from online sources (<see cref="RealmPopulatingOnlineLookupSource"/>)
+        /// and can meaningfully differ between beatmaps of a single set.
+        /// </summary>
+        public IList<string> UserTags { get; } = null!;
 
         /// <summary>
         /// The time in milliseconds to begin playing the track for preview purposes.

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -99,8 +99,9 @@ namespace osu.Game.Database
         /// 47   2025-01-21    Remove right mouse button binding for absolute scroll. Never use mouse buttons (or scroll) for global actions.
         /// 48   2025-03-19    Clear online status for all qualified beatmaps (some were stuck in a qualified state due to local caching issues).
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
+        /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// </summary>
-        private const int schema_version = 49;
+        private const int schema_version = 50;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -83,6 +83,15 @@ namespace osu.Game.Screens.Select.Carousel
                      criteria.Title.Matches(BeatmapInfo.Metadata.TitleUnicode);
             match &= !criteria.DifficultyName.HasFilter || criteria.DifficultyName.Matches(BeatmapInfo.DifficultyName);
             match &= !criteria.Source.HasFilter || criteria.Source.Matches(BeatmapInfo.Metadata.Source);
+
+            if (criteria.UserTag.HasFilter)
+            {
+                bool anyTagMatched = false;
+                foreach (string tag in BeatmapInfo.Metadata.UserTags)
+                    anyTagMatched |= criteria.UserTag.Matches(tag);
+                match &= anyTagMatched;
+            }
+
             match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(BeatmapInfo.StarRating);
 
             if (!match) return false;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Screens.Select
         public OptionalTextFilter Title;
         public OptionalTextFilter DifficultyName;
         public OptionalTextFilter Source;
+        public OptionalTextFilter UserTag;
 
         public OptionalRange<double> UserStarDifficulty = new OptionalRange<double>
         {

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -116,6 +116,9 @@ namespace osu.Game.Screens.Select
                 case "source":
                     return TryUpdateCriteriaText(ref criteria.Source, op, value);
 
+                case "tag":
+                    return TryUpdateCriteriaText(ref criteria.UserTag, op, value);
+
                 default:
                     return criteria.RulesetCriteria?.TryParseCustomKeywordCriteria(key, op, value) ?? false;
             }

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -105,6 +105,15 @@ namespace osu.Game.Screens.SelectV2
                      criteria.Title.Matches(beatmap.Metadata.TitleUnicode);
             match &= !criteria.DifficultyName.HasFilter || criteria.DifficultyName.Matches(beatmap.DifficultyName);
             match &= !criteria.Source.HasFilter || criteria.Source.Matches(beatmap.Metadata.Source);
+
+            if (criteria.UserTag.HasFilter)
+            {
+                bool anyTagMatched = false;
+                foreach (string tag in beatmap.Metadata.UserTags)
+                    anyTagMatched |= criteria.UserTag.Matches(tag);
+                match &= anyTagMatched;
+            }
+
             match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(beatmap.StarRating);
 
             if (!match) return false;

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -2,18 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Graphics.Containers;
 using osu.Game.Localisation;
 using osu.Game.Online;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Resources.Localisation.Web;
@@ -50,6 +53,12 @@ namespace osu.Game.Screens.SelectV2
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private RealmPopulatingOnlineLookupSource onlineLookupSource { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
 
         private IBindable<APIState> apiState = null!;
 
@@ -314,34 +323,34 @@ namespace osu.Game.Screens.SelectV2
         }
 
         private APIBeatmapSet? currentOnlineBeatmapSet;
-        private GetBeatmapSetRequest? currentRequest;
+        private CancellationTokenSource? cancellationTokenSource;
+        private Task<APIBeatmapSet?>? currentFetchTask;
 
         private void refetchBeatmapSet()
         {
             var beatmapSetInfo = beatmap.Value.BeatmapSetInfo;
 
-            currentRequest?.Cancel();
-            currentRequest = null;
+            cancellationTokenSource?.Cancel();
             currentOnlineBeatmapSet = null;
 
             if (beatmapSetInfo.OnlineID >= 1)
             {
-                // todo: consider introducing a BeatmapSetLookupCache for caching benefits.
-                currentRequest = new GetBeatmapSetRequest(beatmapSetInfo.OnlineID);
-                currentRequest.Failure += _ => updateOnlineDisplay();
-                currentRequest.Success += s =>
+                cancellationTokenSource = new CancellationTokenSource();
+                currentFetchTask = onlineLookupSource.GetBeatmapSetAsync(beatmapSetInfo.OnlineID);
+                currentFetchTask.ContinueWith(t =>
                 {
-                    currentOnlineBeatmapSet = s;
-                    updateOnlineDisplay();
-                };
-
-                api.Queue(currentRequest);
+                    if (t.IsCompletedSuccessfully)
+                        currentOnlineBeatmapSet = t.GetResultSafely();
+                    if (t.Exception != null)
+                        Logger.Log($"Error when fetching online beatmap set: {t.Exception}", LoggingTarget.Network);
+                    Scheduler.AddOnce(updateOnlineDisplay);
+                });
             }
         }
 
         private void updateOnlineDisplay()
         {
-            if (currentRequest?.CompletionState == APIRequestCompletionState.Waiting)
+            if (currentFetchTask?.IsCompleted == false)
             {
                 genre.Data = null;
                 language.Data = null;
@@ -379,28 +388,21 @@ namespace osu.Game.Screens.SelectV2
 
         private void updateUserTags()
         {
-            var beatmapInfo = beatmap.Value.BeatmapInfo;
-            var onlineBeatmapSet = currentOnlineBeatmapSet;
-            var onlineBeatmap = onlineBeatmapSet?.Beatmaps.SingleOrDefault(b => b.OnlineID == beatmapInfo.OnlineID);
+            string[] tags = realm.Run(r =>
+            {
+                // need to refetch because `beatmap.Value.BeatmapInfo` is not going to have the latest tags
+                var refetchedBeatmap = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID);
+                return refetchedBeatmap?.Metadata.UserTags.ToArray() ?? [];
+            });
 
-            if (onlineBeatmap?.TopTags == null || onlineBeatmap.TopTags.Length == 0 || onlineBeatmapSet?.RelatedTags == null)
+            if (tags.Length == 0)
             {
                 userTags.FadeOut(transition_duration, Easing.OutQuint);
                 return;
             }
 
-            var tagsById = onlineBeatmapSet.RelatedTags.ToDictionary(t => t.Id);
-            string[] userTagsArray = onlineBeatmap.TopTags
-                                                  .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
-                                                  .Where(t => t.relatedTag != null)
-                                                  // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
-                                                  .OrderByDescending(t => t.topTag.VoteCount)
-                                                  .ThenBy(t => t.relatedTag!.Name)
-                                                  .Select(t => t.relatedTag!.Name)
-                                                  .ToArray();
-
             userTags.FadeIn(transition_duration, Easing.OutQuint);
-            userTags.Tags = (userTagsArray, t => songSelect?.Search(t));
+            userTags.Tags = (tags, t => songSelect?.Search($@"tag=""{t}""!"));
         }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
@@ -56,12 +56,12 @@ namespace osu.Game.Screens.SelectV2
                 }
             }
 
-            public (string[] tags, Action<string> linkAction)? Tags
+            public (string[] tags, Action<string> searchAction)? Tags
             {
                 set
                 {
                     if (value != null)
-                        setTags(value.Value.tags, value.Value.linkAction);
+                        setTags(value.Value.tags, value.Value.searchAction);
                     else
                         setLoading();
                 }
@@ -161,12 +161,12 @@ namespace osu.Game.Screens.SelectV2
                 contentDate.Date = date;
             }
 
-            private void setTags(string[] tags, Action<string> link)
+            private void setTags(string[] tags, Action<string> searchAction)
             {
                 clear();
 
                 contentTags.Tags = tags;
-                contentTags.Action = link;
+                contentTags.PerformSearch = searchAction;
             }
 
             private void setLoading()

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Screens.SelectV2
                 public TagsOverflowPopover(string[] tags, Action<string>? performSearchAction)
                 {
                     this.tags = tags;
-                    this.performSearch = performSearchAction;
+                    performSearch = performSearchAction;
                 }
 
                 [BackgroundDependencyLoader]

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.SelectV2
                 }
             }
 
-            public Action<string>? Action;
+            public Action<string>? PerformSearch { get; set; }
 
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.SelectV2
                 ChildrenEnumerable = tags.Select(t => new OsuHoverContainer
                 {
                     AutoSizeAxes = Axes.Both,
-                    Action = () => Action?.Invoke(t),
+                    Action = () => PerformSearch?.Invoke(t),
                     IdleColour = colourProvider.Light2,
                     AlwaysPresent = true,
                     Alpha = 0f,
@@ -117,6 +117,7 @@ namespace osu.Game.Screens.SelectV2
                 Add(overflowButton = new TagsOverflowButton(tags)
                 {
                     Alpha = 0f,
+                    PerformSearch = PerformSearch,
                 });
 
                 drawSizeLayout.Invalidate();
@@ -132,10 +133,9 @@ namespace osu.Game.Screens.SelectV2
                 [Resolved]
                 private OverlayColourProvider colourProvider { get; set; } = null!;
 
-                [Resolved]
-                private ISongSelect? songSelect { get; set; }
-
                 public float LineBaseHeight => text.LineBaseHeight;
+
+                public Action<string>? PerformSearch { get; set; }
 
                 public TagsOverflowButton(string[] tags)
                 {
@@ -188,18 +188,18 @@ namespace osu.Game.Screens.SelectV2
                     return true;
                 }
 
-                public Popover GetPopover() => new TagsOverflowPopover(tags, songSelect);
+                public Popover GetPopover() => new TagsOverflowPopover(tags, PerformSearch);
             }
 
             public partial class TagsOverflowPopover : OsuPopover
             {
                 private readonly string[] tags;
-                private readonly ISongSelect? songSelect;
+                private readonly Action<string>? performSearch;
 
-                public TagsOverflowPopover(string[] tags, ISongSelect? songSelect)
+                public TagsOverflowPopover(string[] tags, Action<string>? performSearchAction)
                 {
                     this.tags = tags;
-                    this.songSelect = songSelect;
+                    this.performSearch = performSearchAction;
                 }
 
                 [BackgroundDependencyLoader]
@@ -215,7 +215,7 @@ namespace osu.Game.Screens.SelectV2
 
                     foreach (string tag in tags)
                     {
-                        textFlow.AddLink(tag, () => songSelect?.Search(tag));
+                        textFlow.AddLink(tag, () => performSearch?.Invoke(tag));
                         textFlow.AddText(" ");
                     }
                 }

--- a/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
+++ b/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Extensions;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using Realms;
+
+namespace osu.Game.Screens.SelectV2
+{
+    /// <summary>
+    /// This component is designed to perform lookups of online data
+    /// and store portions of it for later local use to the realm database.
+    /// </summary>
+    /// <example>
+    /// This component is designed to locally persist potentially-volatile online information such as:
+    /// <list type="bullet">
+    /// <item>user tags assigned to difficulties of a beatmap,</item>
+    /// <item>guest mappers assigned to difficulties of a beatmap,</item>
+    /// <item>the local user's best score on a given beatmap.</item>
+    /// </list>
+    /// </example>
+    public partial class RealmPopulatingOnlineLookupSource : Component
+    {
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        public Task<APIBeatmapSet?> GetBeatmapSetAsync(int id, CancellationToken token = default)
+        {
+            var request = new GetBeatmapSetRequest(id);
+            var tcs = new TaskCompletionSource<APIBeatmapSet?>();
+
+            request.Success += onlineBeatmapSet =>
+            {
+                if (token.IsCancellationRequested)
+                {
+                    tcs.SetCanceled(token);
+                    return;
+                }
+
+                var tagsById = (onlineBeatmapSet.RelatedTags ?? []).ToDictionary(t => t.Id);
+                var onlineBeatmaps = onlineBeatmapSet.Beatmaps.ToDictionary(b => b.OnlineID);
+                realm.Write(r =>
+                {
+                    foreach (var dbBeatmap in r.All<BeatmapInfo>().Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.OnlineID)} == $0", id))
+                    {
+                        if (onlineBeatmaps.TryGetValue(dbBeatmap.OnlineID, out var onlineBeatmap))
+                        {
+                            string[] userTagsArray = onlineBeatmap.TopTags?
+                                                                  .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
+                                                                  .Where(t => t.relatedTag != null)
+                                                                  // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
+                                                                  .OrderByDescending(t => t.topTag.VoteCount)
+                                                                  .ThenBy(t => t.relatedTag!.Name)
+                                                                  .Select(t => t.relatedTag!.Name)
+                                                                  .ToArray() ?? [];
+                            dbBeatmap.Metadata.UserTags.Clear();
+                            dbBeatmap.Metadata.UserTags.AddRange(userTagsArray);
+                        }
+                    }
+                });
+                tcs.SetResult(onlineBeatmapSet);
+            };
+            request.Failure += tcs.SetException;
+            api.Queue(request);
+            return tcs.Task;
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -133,6 +133,9 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private IDialogOverlay? dialogOverlay { get; set; }
 
+        [Cached]
+        private RealmPopulatingOnlineLookupSource onlineLookupSource = new RealmPopulatingOnlineLookupSource();
+
         private Bindable<bool> configBackgroundBlur = null!;
 
         [BackgroundDependencyLoader]
@@ -143,6 +146,7 @@ namespace osu.Game.Screens.SelectV2
             AddRangeInternal(new Drawable[]
             {
                 new GlobalScrollAdjustsVolume(),
+                onlineLookupSource,
                 mainContent = new Container
                 {
                     Anchor = Anchor.Centre,


### PR DESCRIPTION
RFC

Concludes https://github.com/ppy/osu/discussions/32568#discussioncomment-12612928

The way that this works is that it plugs into the online request to retrieve the beatmap set that the client is already performing, and stores user tag data to the local realm database.

This means that for now user tags will only populate for beatmaps that the user has displayed on song select which is obviously subpar. I plan to follow this change up by adding user tag state dumps to `online.db` and using that data for initial tag population to make the majority case (ranked beatmaps) work.

Note that several decisions were made here that are potential discussion points:

- `RealmPopulatingOnlineLookupSource` is set up such that it can be the middle man / redirection point for similar flows that we need and we are currently missing, such as storing guest difficulty information, or storing the user's current best score on a beatmap (handy for rank achieved sorting / filtering / etc.)

- The user tags are stored in `BeatmapMetadata` which breaks the longstanding assumption that you can arbitrarily pull out a metadata instance from any of the beatmaps in a set and get essentially the same object back.

  I've attempted to constrain this some by not adding user tags to the `IBeatmapMetadataInfo` interface through which `BeatmapSetInfo` exposes metadata further, but I warn in advance that this is a temporary state of affairs and I will make it worse in the future when `BeatmapMetadata.Author` becomes `Authors` plural in order to support guest mapper display (and direct guest difficulty submission).

  Therefore this is the decision point as to whether we want that sort of data in `BeatmapMetadata` or in `BeatmapInfo`.

- The syntax for searching via user tags is chosen to mostly match web - it's `tag=`, with support for all of the string matching modes song select already has (bare word for substring, `""` quotes for phrase isolated by whitespace, `""!` for exact full match).

Note that this contains a realm migration so if you've ever ran https://github.com/ppy/osu/pull/34058 you'll need to nuke `client_50.realm` to run this.