### PR TITLE
Allow grouping beatmaps by collections

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
@@ -357,7 +357,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         private static async Task<List<CarouselItem>> runGrouping(GroupMode group, List<BeatmapSetInfo> beatmapSets)
         {
-            var groupingFilter = new BeatmapCarouselFilterGrouping(() => new FilterCriteria { Group = group });
+            var groupingFilter = new BeatmapCarouselFilterGrouping(() => new FilterCriteria { Group = group }, () => null);
             return await groupingFilter.Run(beatmapSets.SelectMany(s => s.Beatmaps.Select(b => new CarouselItem(b))).ToList(), CancellationToken.None);
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -159,11 +159,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
         }
 
-        protected void WaitForFiltering()
-        {
-            AddUntilStep("wait for debounce", () => SongSelect.IsFilterPendingDebounce);
-            AddUntilStep("wait for filtering", () => !Carousel.IsFiltering);
-        }
+        protected void WaitForFiltering() => AddUntilStep("wait for filtering", () => !SongSelect.IsFiltering);
 
         protected void ImportBeatmapForRuleset(params int[] rulesetIds)
         {

--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -159,6 +159,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
         }
 
+        protected void WaitForFiltering()
+        {
+            AddUntilStep("wait for debounce", () => SongSelect.IsFilterPendingDebounce);
+            AddUntilStep("wait for filtering", () => !Carousel.IsFiltering);
+        }
+
         protected void ImportBeatmapForRuleset(params int[] rulesetIds)
         {
             int beatmapsCount = 0;

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapFilterControl.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -18,14 +19,24 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            Child = new Container
+            BeatmapCollectionStore collectionStore;
+
+            Child = new DependencyProvidingContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Child = filterControl = new FilterControl
+                CachedDependencies = new (Type, object)[]
                 {
-                    State = { Value = Visibility.Visible },
-                    RelativeSizeAxes = Axes.X,
+                    (typeof(BeatmapCollectionStore), collectionStore = new BeatmapCollectionStore()),
+                },
+                Children = new Drawable[]
+                {
+                    collectionStore,
+                    filterControl = new FilterControl
+                    {
+                        State = { Value = Visibility.Visible },
+                        RelativeSizeAxes = Axes.X,
+                    }
                 },
             };
         });

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneCollectionDropdown.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneCollectionDropdown.cs
@@ -18,6 +18,7 @@ using osu.Game.Collections;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
+using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Resources;
 using osuTK.Input;
 using Realms;
@@ -48,17 +49,27 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             writeAndRefresh(r => r.RemoveAll<BeatmapCollection>());
 
-            Child = new Container
+            BeatmapCollectionStore collectionStore;
+
+            Child = new DependencyProvidingContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Child = dropdown = new CollectionDropdown
+                CachedDependencies = new (Type, object)[]
                 {
-                    Width = 300,
-                    Y = 100,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
+                    (typeof(BeatmapCollectionStore), collectionStore = new BeatmapCollectionStore())
                 },
+                Children = new Drawable[]
+                {
+                    collectionStore,
+                    dropdown = new CollectionDropdown
+                    {
+                        Width = 300,
+                        Y = 100,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                    }
+                }
             };
         });
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectGrouping.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Collections;
+using osu.Game.Screens.Select.Filter;
+using osu.Game.Screens.SelectV2;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    public partial class TestSceneSongSelectGrouping : SongSelectTestScene
+    {
+        private BeatmapCarouselFilterGrouping grouping => Carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single();
+
+        [Test]
+        public void TestCollectionGrouping()
+        {
+            ImportBeatmapForRuleset(0);
+            ImportBeatmapForRuleset(0);
+            ImportBeatmapForRuleset(0);
+
+            BeatmapSetInfo[] beatmapSets = null!;
+
+            AddStep("add collections", () =>
+            {
+                beatmapSets = Beatmaps.GetAllUsableBeatmapSets().OrderBy(b => b.OnlineID).ToArray();
+
+                Realm.Write(r =>
+                {
+                    r.RemoveAll<BeatmapCollection>();
+                    r.Add(new BeatmapCollection("My Collection #1", beatmapSets[0].Beatmaps.Select(b => b.MD5Hash).ToList()));
+                    r.Add(new BeatmapCollection("My Collection #2", beatmapSets[1].Beatmaps.Select(b => b.MD5Hash).ToList()));
+                    r.Add(new BeatmapCollection("My Collection #3"));
+                });
+            });
+
+            LoadSongSelect();
+            GroupBy(GroupMode.Collections);
+            WaitForFiltering();
+
+            AddAssert("first collection present", () =>
+            {
+                var group = grouping.GroupItems.Single(g => g.Key.Title == "My Collection #1");
+                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[0]);
+            });
+
+            AddAssert("second collection present", () =>
+            {
+                var group = grouping.GroupItems.Single(g => g.Key.Title == "My Collection #2");
+                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[1]);
+            });
+
+            AddAssert("third collection not present", () => grouping.GroupItems.All(g => g.Key.Title != "My Collection #3"));
+
+            AddAssert("no-collection group present", () =>
+            {
+                var group = grouping.GroupItems.Single(g => g.Key.Title == "Not in collection");
+                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[2]);
+            });
+        }
+    }
+}

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -10,6 +10,7 @@ using AutoMapper;
 using AutoMapper.Internal;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
+using osu.Game.Collections;
 using osu.Game.Input.Bindings;
 using osu.Game.Models;
 using osu.Game.Rulesets;
@@ -170,6 +171,7 @@ namespace osu.Game.Database
             });
 
             c.CreateMap<RealmKeyBinding, RealmKeyBinding>();
+            c.CreateMap<BeatmapCollection, BeatmapCollection>();
             c.CreateMap<BeatmapMetadata, BeatmapMetadata>();
             c.CreateMap<BeatmapUserSettings, BeatmapUserSettings>();
             c.CreateMap<BeatmapDifficulty, BeatmapDifficulty>();

--- a/osu.Game/Screens/Select/Filter/GroupMode.cs
+++ b/osu.Game/Screens/Select/Filter/GroupMode.cs
@@ -19,8 +19,8 @@ namespace osu.Game.Screens.Select.Filter
         [Description("BPM")]
         BPM,
 
-        // [Description("Collections")]
-        // Collections,
+        [Description("Collections")]
+        Collections,
 
         [Description("Date Added")]
         DateAdded,

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -18,6 +18,7 @@ using osu.Framework.Graphics.Pooling;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics;
@@ -31,6 +32,11 @@ namespace osu.Game.Screens.SelectV2
     public partial class BeatmapCarousel : Carousel<BeatmapInfo>
     {
         public Action<BeatmapInfo>? RequestPresentBeatmap { private get; init; }
+
+        /// <summary>
+        /// Retrieves all collections stored in the user's database.
+        /// </summary>
+        public Func<IEnumerable<BeatmapCollection>>? GetUserCollections { private get; init; }
 
         /// <summary>
         /// From the provided beatmaps, select the most appropriate one for the user's skill.
@@ -98,7 +104,7 @@ namespace osu.Game.Screens.SelectV2
             {
                 matching = new BeatmapCarouselFilterMatching(() => Criteria!),
                 new BeatmapCarouselFilterSorting(() => Criteria!),
-                grouping = new BeatmapCarouselFilterGrouping(() => Criteria!),
+                grouping = createFilterGrouping(() => Criteria!),
             };
 
             AddInternal(loading = new LoadingLayer());
@@ -882,6 +888,15 @@ namespace osu.Game.Screens.SelectV2
 
             randomSelectSample?.Play();
         }
+
+        #endregion
+
+        #region Grouping
+
+        private BeatmapCarouselFilterGrouping createFilterGrouping(Func<FilterCriteria> getCriteria) => new BeatmapCarouselFilterGrouping(getCriteria)
+        {
+            GetUserCollections = () => GetUserCollections?.Invoke() ?? Enumerable.Empty<BeatmapCollection>(),
+        };
 
         #endregion
     }

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -592,11 +592,16 @@ namespace osu.Game.Screens.SelectV2
 
         private ScheduledDelegate? loadingDebounce;
 
-        public void Filter(FilterCriteria criteria, bool showLoadingImmediately = false)
+        public void Filter(FilterCriteria? newCriteria = null, bool showLoadingImmediately = false)
         {
-            bool resetDisplay = grouping.BeatmapSetsGroupedTogether != BeatmapCarouselFilterGrouping.ShouldGroupBeatmapsTogether(criteria);
+            if (newCriteria != null)
+                Criteria = newCriteria;
 
-            Criteria = criteria;
+            // no initial criteria was provided yet, ignore this.
+            if (Criteria == null)
+                return;
+
+            bool resetDisplay = grouping.BeatmapSetsGroupedTogether != BeatmapCarouselFilterGrouping.ShouldGroupBeatmapsTogether(Criteria);
 
             loadingDebounce ??= Scheduler.AddDelayed(() =>
             {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -18,7 +18,6 @@ using osu.Framework.Graphics.Pooling;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
-using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics;
@@ -32,11 +31,6 @@ namespace osu.Game.Screens.SelectV2
     public partial class BeatmapCarousel : Carousel<BeatmapInfo>
     {
         public Action<BeatmapInfo>? RequestPresentBeatmap { private get; init; }
-
-        /// <summary>
-        /// Retrieves all collections stored in the user's database.
-        /// </summary>
-        public Func<IEnumerable<BeatmapCollection>>? GetUserCollections { private get; init; }
 
         /// <summary>
         /// From the provided beatmaps, select the most appropriate one for the user's skill.
@@ -56,6 +50,9 @@ namespace osu.Game.Screens.SelectV2
 
         private readonly BeatmapCarouselFilterMatching matching;
         private readonly BeatmapCarouselFilterGrouping grouping;
+
+        [Resolved]
+        private BeatmapCollectionStore? collectionStore { get; set; }
 
         /// <summary>
         /// Total number of beatmap difficulties displayed with the filter.
@@ -104,7 +101,7 @@ namespace osu.Game.Screens.SelectV2
             {
                 matching = new BeatmapCarouselFilterMatching(() => Criteria!),
                 new BeatmapCarouselFilterSorting(() => Criteria!),
-                grouping = createFilterGrouping(() => Criteria!),
+                grouping = new BeatmapCarouselFilterGrouping(() => Criteria!, () => collectionStore),
             };
 
             AddInternal(loading = new LoadingLayer());
@@ -893,15 +890,6 @@ namespace osu.Game.Screens.SelectV2
 
             randomSelectSample?.Play();
         }
-
-        #endregion
-
-        #region Grouping
-
-        private BeatmapCarouselFilterGrouping createFilterGrouping(Func<FilterCriteria> getCriteria) => new BeatmapCarouselFilterGrouping(getCriteria)
-        {
-            GetUserCollections = () => GetUserCollections?.Invoke() ?? Enumerable.Empty<BeatmapCollection>(),
-        };
 
         #endregion
     }

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -589,16 +589,11 @@ namespace osu.Game.Screens.SelectV2
 
         private ScheduledDelegate? loadingDebounce;
 
-        public void Filter(FilterCriteria? newCriteria = null, bool showLoadingImmediately = false)
+        public void Filter(FilterCriteria criteria, bool showLoadingImmediately = false)
         {
-            if (newCriteria != null)
-                Criteria = newCriteria;
+            bool resetDisplay = grouping.BeatmapSetsGroupedTogether != BeatmapCarouselFilterGrouping.ShouldGroupBeatmapsTogether(criteria);
 
-            // no initial criteria was provided yet, ignore this.
-            if (Criteria == null)
-                return;
-
-            bool resetDisplay = grouping.BeatmapSetsGroupedTogether != BeatmapCarouselFilterGrouping.ShouldGroupBeatmapsTogether(Criteria);
+            Criteria = criteria;
 
             loadingDebounce ??= Scheduler.AddDelayed(() =>
             {

--- a/osu.Game/Screens/SelectV2/BeatmapCollectionStore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCollectionStore.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Collections;
+using osu.Game.Database;
+using Realms;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class BeatmapCollectionStore : Component
+    {
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        private IDisposable? realmSubscription;
+
+        private readonly BindableList<BeatmapCollection> collections = new BindableList<BeatmapCollection>();
+
+        /// <summary>
+        /// Gets a thread-safe bound copy to the list of <see cref="BeatmapCollection"/> present in the user's database.
+        /// </summary>
+        public IBindableList<BeatmapCollection> GetCollections()
+        {
+            lock (collections)
+                return collections.GetBoundCopy();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.Name), onChanged);
+        }
+
+        private void onChanged(IRealmCollection<BeatmapCollection> sender, ChangeSet? changes)
+        {
+            lock (collections)
+            {
+                collections.Clear();
+
+                foreach (var c in sender)
+                    collections.Add(c.Detach());
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            realmSubscription?.Dispose();
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/CollectionDropdown.cs
+++ b/osu.Game/Screens/SelectV2/CollectionDropdown.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Screens.SelectV2
         /// </summary>
         protected virtual bool ShowManageCollectionsItem => true;
 
+        // todo: this is not used anywhere, it should probably be removed.
         public Action? RequestFilter { private get; set; }
 
         private readonly BindableList<CollectionFilterMenuItem> filters = new BindableList<CollectionFilterMenuItem>();

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -518,8 +518,7 @@ namespace osu.Game.Screens.SelectV2
 
             // While filtering, let's not ever attempt to change selection.
             // This will be resolved after the filter completes, see `newItemsPresented`.
-            bool carouselStateIsValid = filterDebounce?.State != ScheduledDelegate.RunState.Waiting && !carousel.IsFiltering;
-            if (!carouselStateIsValid)
+            if (IsFiltering)
                 return false;
 
             // Refetch to be confident that the current selection is still valid. It may have been deleted or hidden.
@@ -748,9 +747,9 @@ namespace osu.Game.Screens.SelectV2
         public bool CarouselItemsPresented { get; private set; }
 
         /// <summary>
-        /// Whether a filter operation is pending execution due to debouncing.
+        /// Whether the carousel is or will be undergoing a filter operation.
         /// </summary>
-        public bool IsFilterPendingDebounce => filterDebounce?.State == ScheduledDelegate.RunState.Waiting;
+        public bool IsFiltering => carousel.IsFiltering || filterDebounce?.State == ScheduledDelegate.RunState.Waiting;
 
         private const double filter_delay = 250;
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -341,7 +341,7 @@ namespace osu.Game.Screens.SelectV2
             base.LoadComplete();
 
             filterControl.CriteriaChanged += filter;
-            collections.BindCollectionChanged((_, _) => filter());
+            collections.BindCollectionChanged((_, _) => filterWithSameCriteria());
 
             modSelectOverlay.State.BindValueChanged(v =>
             {
@@ -756,7 +756,15 @@ namespace osu.Game.Screens.SelectV2
 
         private ScheduledDelegate? filterDebounce;
 
-        private void filter(FilterCriteria? newCriteria = null)
+        private void filterWithSameCriteria()
+        {
+            if (carousel.Criteria == null)
+                return;
+
+            filter(carousel.Criteria);
+        }
+
+        private void filter(FilterCriteria criteria)
         {
             filterDebounce?.Cancel();
 
@@ -764,9 +772,9 @@ namespace osu.Game.Screens.SelectV2
             bool isFirstFilter = filterDebounce == null;
 
             // Criteria change may have included a ruleset change which made the current selection invalid.
-            bool isSelectionValid = checkBeatmapValidForSelection(Beatmap.Value.BeatmapInfo, newCriteria ?? carousel.Criteria);
+            bool isSelectionValid = checkBeatmapValidForSelection(Beatmap.Value.BeatmapInfo, criteria);
 
-            filterDebounce = Scheduler.AddDelayed(() => carousel.Filter(newCriteria, !isSelectionValid), isFirstFilter || !isSelectionValid ? 0 : filter_delay);
+            filterDebounce = Scheduler.AddDelayed(() => carousel.Filter(criteria, !isSelectionValid), isFirstFilter || !isSelectionValid ? 0 : filter_delay);
         }
 
         private void newItemsPresented(IEnumerable<CarouselItem> carouselItems)

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -91,6 +91,9 @@ namespace osu.Game.Screens.SelectV2
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
+        private BeatmapCollectionStore beatmapCollectionStore = null!;
+        private IBindableList<BeatmapCollection> collections = null!;
+
         private BeatmapCarousel carousel = null!;
 
         private FilterControl filterControl = null!;
@@ -139,6 +142,8 @@ namespace osu.Game.Screens.SelectV2
         private void load(AudioManager audio, OsuConfigManager config)
         {
             errorSample = audio.Samples.Get(@"UI/generic-error");
+
+            AddInternal(beatmapCollectionStore = new BeatmapCollectionStore());
 
             AddRangeInternal(new Drawable[]
             {
@@ -286,6 +291,8 @@ namespace osu.Game.Screens.SelectV2
 
                 updateBackgroundDim();
             });
+
+            collections = beatmapCollectionStore.GetCollections();
         }
 
         private void requestRecommendedSelection(IEnumerable<BeatmapInfo> b)
@@ -980,13 +987,8 @@ namespace osu.Game.Screens.SelectV2
 
         protected IEnumerable<OsuMenuItem> CreateCollectionMenuActions(BeatmapInfo beatmap)
         {
-            var collectionItems = realm.Realm.All<BeatmapCollection>()
-                                       .OrderBy(c => c.Name)
-                                       .AsEnumerable()
-                                       .Select(c => new CollectionToggleMenuItem(c.ToLive(realm), beatmap)).Cast<OsuMenuItem>().ToList();
-
+            var collectionItems = collections.Select(c => new CollectionToggleMenuItem(c.ToLive(realm), beatmap)).Cast<OsuMenuItem>().ToList();
             collectionItems.Add(new OsuMenuItem("Manage...", MenuItemType.Standard, () => manageCollectionsDialog?.Show()));
-
             yield return new OsuMenuItem(CommonStrings.Collections) { Items = collectionItems };
         }
 

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -251,6 +251,7 @@ namespace osu.Game.Screens.SelectV2
                                                                 RequestSelection = queueBeatmapSelection,
                                                                 RequestRecommendedSelection = requestRecommendedSelection,
                                                                 NewItemsPresented = newItemsPresented,
+                                                                GetUserCollections = beatmapCollectionStore.GetCollections,
                                                             },
                                                             noResultsPlaceholder = new NoResultsPlaceholder
                                                             {

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -745,6 +745,11 @@ namespace osu.Game.Screens.SelectV2
         /// </summary>
         public bool CarouselItemsPresented { get; private set; }
 
+        /// <summary>
+        /// Whether a filter operation is pending execution due to debouncing.
+        /// </summary>
+        public bool IsFilterPendingDebounce => filterDebounce?.State == ScheduledDelegate.RunState.Waiting;
+
         private const double filter_delay = 250;
 
         private ScheduledDelegate? filterDebounce;

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -339,7 +339,8 @@ namespace osu.Game.Screens.SelectV2
         {
             base.LoadComplete();
 
-            filterControl.CriteriaChanged += criteriaChanged;
+            filterControl.CriteriaChanged += filter;
+            collections.BindCollectionChanged((_, _) => filter());
 
             modSelectOverlay.State.BindValueChanged(v =>
             {
@@ -754,7 +755,7 @@ namespace osu.Game.Screens.SelectV2
 
         private ScheduledDelegate? filterDebounce;
 
-        private void criteriaChanged(FilterCriteria criteria)
+        private void filter(FilterCriteria? newCriteria = null)
         {
             filterDebounce?.Cancel();
 
@@ -762,9 +763,9 @@ namespace osu.Game.Screens.SelectV2
             bool isFirstFilter = filterDebounce == null;
 
             // Criteria change may have included a ruleset change which made the current selection invalid.
-            bool isSelectionValid = checkBeatmapValidForSelection(Beatmap.Value.BeatmapInfo, criteria);
+            bool isSelectionValid = checkBeatmapValidForSelection(Beatmap.Value.BeatmapInfo, newCriteria ?? carousel.Criteria);
 
-            filterDebounce = Scheduler.AddDelayed(() => { carousel.Filter(criteria, !isSelectionValid); }, isFirstFilter || !isSelectionValid ? 0 : filter_delay);
+            filterDebounce = Scheduler.AddDelayed(() => carousel.Filter(newCriteria, !isSelectionValid), isFirstFilter || !isSelectionValid ? 0 : filter_delay);
         }
 
         private void newItemsPresented(IEnumerable<CarouselItem> carouselItems)


### PR DESCRIPTION
RFC. Some parts in this PR have not been discussed yet as I figured it's best to showcase it in one whole PR.

This PR mainly achieves the following:
 - Allow grouping beatmaps by collections
 - Re-filter when any collection is modified.

The latter part required subscribing to realm notifications for any changes to beatmap collections, and in an effort to keep `SongSelect` organised, I've created a separate component handling that, as well as containing the collection retrieval logic itself.

Note that this **does not** support showing the same beatmap in multiple collection groups, unlike in stable. This is probably important to consider this feature as fully implemented, but I will work towards that in a separate PR to reduce review complexity.

With the existence of this new beatmap collection "store", I foresee `CollectionDropdown` using that component rather than manually subscribing to Realm. I didn't bother doing that in this PR to keep changes in scope, but I can do that if it's deemed required.

Partially covers https://github.com/ppy/osu/issues/33604.