### PR TITLE
Constrain hit window floor-and-round behaviour to classic mod only

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplayStability.cs
@@ -21,79 +21,87 @@ namespace osu.Game.Rulesets.Mania.Tests
             // while round brackets `()` represent *open* or *exclusive* bounds.
 
             // OD = 5 test cases.
-            // PERFECT hit window is [ -19.5ms,  19.5ms]
-            // GREAT   hit window is [ -49.5ms,  49.5ms]
-            // GOOD    hit window is [ -82.5ms,  82.5ms]
-            // OK      hit window is [-112.5ms, 112.5ms]
-            // MEH     hit window is [-136.5ms, 136.5ms]
-            // MISS    hit window is [-173.5ms, 173.5ms]
+            // PERFECT hit window is [ -19.4ms,  19.4ms]
+            // GREAT   hit window is [ -49.0ms,  49.0ms]
+            // GOOD    hit window is [ -82.0ms,  82.0ms]
+            // OK      hit window is [-112.0ms, 112.0ms]
+            // MEH     hit window is [-136.0ms, 136.0ms]
+            // MISS    hit window is [-173.0ms, 173.0ms]
             new object[] { 5f, -19d, HitResult.Perfect },
             new object[] { 5f, -19.2d, HitResult.Perfect },
+            new object[] { 5f, -19.38d, HitResult.Perfect },
+            // new object[] { 5f, -19.4d, HitResult.Perfect }, <- in theory this should work, in practice it does not (fails even before encode & rounding due to floating point precision issues)
+            new object[] { 5f, -19.44d, HitResult.Great },
             new object[] { 5f, -19.7d, HitResult.Great },
             new object[] { 5f, -20d, HitResult.Great },
             new object[] { 5f, -48d, HitResult.Great },
             new object[] { 5f, -48.4d, HitResult.Great },
             new object[] { 5f, -48.7d, HitResult.Great },
             new object[] { 5f, -49d, HitResult.Great },
-            new object[] { 5f, -49.2d, HitResult.Great },
+            new object[] { 5f, -49.2d, HitResult.Good },
             new object[] { 5f, -49.7d, HitResult.Good },
             new object[] { 5f, -50d, HitResult.Good },
             new object[] { 5f, -81d, HitResult.Good },
             new object[] { 5f, -81.2d, HitResult.Good },
             new object[] { 5f, -81.7d, HitResult.Good },
             new object[] { 5f, -82d, HitResult.Good },
-            new object[] { 5f, -82.2d, HitResult.Good },
+            new object[] { 5f, -82.2d, HitResult.Ok },
             new object[] { 5f, -82.7d, HitResult.Ok },
             new object[] { 5f, -83d, HitResult.Ok },
             new object[] { 5f, -111d, HitResult.Ok },
             new object[] { 5f, -111.2d, HitResult.Ok },
             new object[] { 5f, -111.7d, HitResult.Ok },
             new object[] { 5f, -112d, HitResult.Ok },
-            new object[] { 5f, -112.2d, HitResult.Ok },
+            new object[] { 5f, -112.2d, HitResult.Meh },
             new object[] { 5f, -112.7d, HitResult.Meh },
             new object[] { 5f, -113d, HitResult.Meh },
             new object[] { 5f, -135d, HitResult.Meh },
             new object[] { 5f, -135.2d, HitResult.Meh },
             new object[] { 5f, -135.8d, HitResult.Meh },
             new object[] { 5f, -136d, HitResult.Meh },
-            new object[] { 5f, -136.2d, HitResult.Meh },
+            new object[] { 5f, -136.2d, HitResult.Miss },
             new object[] { 5f, -136.7d, HitResult.Miss },
             new object[] { 5f, -137d, HitResult.Miss },
 
             // OD = 9.3 test cases.
-            // PERFECT hit window is [ -14.5ms,  14.5ms]
-            // GREAT   hit window is [ -36.5ms,  36.5ms]
-            // GOOD    hit window is [ -69.5ms,  69.5ms]
-            // OK      hit window is [ -99.5ms,  99.5ms]
-            // MEH     hit window is [-123.5ms, 123.5ms]
-            // MISS    hit window is [-160.5ms, 160.5ms]
+            // PERFECT hit window is [ -14.67ms,  14.67ms]
+            // GREAT   hit window is [ -36.10ms,  36.10ms]
+            // GOOD    hit window is [ -69.10ms,  69.10ms]
+            // OK      hit window is [ -99.10ms,  99.10ms]
+            // MEH     hit window is [-123.10ms, 123.10ms]
+            // MISS    hit window is [-160.10ms, 160.10ms]
             new object[] { 9.3f, 14d, HitResult.Perfect },
             new object[] { 9.3f, 14.2d, HitResult.Perfect },
+            new object[] { 9.3f, 14.6d, HitResult.Perfect },
+            // new object[] { 9.3f, 14.67d, HitResult.Perfect }, <- in theory this should work, in practice it does not (fails even before encode & rounding due to floating point precision issues)
             new object[] { 9.3f, 14.7d, HitResult.Great },
             new object[] { 9.3f, 15d, HitResult.Great },
             new object[] { 9.3f, 35d, HitResult.Great },
             new object[] { 9.3f, 35.3d, HitResult.Great },
             new object[] { 9.3f, 35.8d, HitResult.Great },
-            new object[] { 9.3f, 36.3d, HitResult.Great },
+            new object[] { 9.3f, 36.05d, HitResult.Great },
+            new object[] { 9.3f, 36.3d, HitResult.Good },
             new object[] { 9.3f, 36.7d, HitResult.Good },
             new object[] { 9.3f, 37d, HitResult.Good },
             new object[] { 9.3f, 68d, HitResult.Good },
             new object[] { 9.3f, 68.4d, HitResult.Good },
             new object[] { 9.3f, 68.9d, HitResult.Good },
-            new object[] { 9.3f, 69.25d, HitResult.Good },
+            new object[] { 9.3f, 69.07d, HitResult.Good },
+            new object[] { 9.3f, 69.25d, HitResult.Ok },
             new object[] { 9.3f, 69.85d, HitResult.Ok },
             new object[] { 9.3f, 70d, HitResult.Ok },
             new object[] { 9.3f, 98d, HitResult.Ok },
             new object[] { 9.3f, 98.3d, HitResult.Ok },
             new object[] { 9.3f, 98.6d, HitResult.Ok },
             new object[] { 9.3f, 99d, HitResult.Ok },
-            new object[] { 9.3f, 99.3d, HitResult.Ok },
+            new object[] { 9.3f, 99.3d, HitResult.Meh },
             new object[] { 9.3f, 99.7d, HitResult.Meh },
             new object[] { 9.3f, 100d, HitResult.Meh },
             new object[] { 9.3f, 122d, HitResult.Meh },
             new object[] { 9.3f, 122.34d, HitResult.Meh },
             new object[] { 9.3f, 122.57d, HitResult.Meh },
-            new object[] { 9.3f, 123.45d, HitResult.Meh },
+            new object[] { 9.3f, 123.04d, HitResult.Meh },
+            new object[] { 9.3f, 123.45d, HitResult.Miss },
             new object[] { 9.3f, 123.95d, HitResult.Miss },
             new object[] { 9.3f, 124d, HitResult.Miss },
         };

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
@@ -148,15 +148,25 @@ namespace osu.Game.Rulesets.Mania.Scoring
                     meh = Math.Floor((121 + 3 * invertedOd) * totalMultiplier) + 0.5;
                     miss = Math.Floor((158 + 3 * invertedOd) * totalMultiplier) + 0.5;
                 }
+
+                return;
             }
-            else
+
+            perfect = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, PERFECT_WINDOW_RANGE) * totalMultiplier;
+            great = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, great_window_range) * totalMultiplier;
+            good = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, good_window_range) * totalMultiplier;
+            ok = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, ok_window_range) * totalMultiplier;
+            meh = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, meh_window_range) * totalMultiplier;
+            miss = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, miss_window_range) * totalMultiplier;
+
+            if (ClassicModActive)
             {
-                perfect = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, PERFECT_WINDOW_RANGE) * totalMultiplier) + 0.5;
-                great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, great_window_range) * totalMultiplier) + 0.5;
-                good = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, good_window_range) * totalMultiplier) + 0.5;
-                ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, ok_window_range) * totalMultiplier) + 0.5;
-                meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, meh_window_range) * totalMultiplier) + 0.5;
-                miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, miss_window_range) * totalMultiplier) + 0.5;
+                perfect = Math.Floor(perfect) + 0.5;
+                great = Math.Floor(great) + 0.5;
+                good = Math.Floor(good) + 0.5;
+                ok = Math.Floor(ok) + 0.5;
+                meh = Math.Floor(meh) + 0.5;
+                miss = Math.Floor(miss) + 0.5;
             }
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneReplayStability.cs
@@ -22,49 +22,53 @@ namespace osu.Game.Rulesets.Osu.Tests
             // while round brackets `()` represent *open* or *exclusive* bounds.
 
             // OD = 5 test cases.
-            // GREAT hit window is [ -49.5ms,  49.5ms]
-            // OK    hit window is [ -99.5ms,  99.5ms]
-            // MEH   hit window is [-149.5ms, 149.5ms]
+            // GREAT hit window is [ -50ms,  50ms]
+            // OK    hit window is [-100ms, 100ms]
+            // MEH   hit window is [-150ms, 150ms]
+            // MISS  hit window is [-400ms, 400ms]
             new object[] { 5f, 49d, HitResult.Great },
             new object[] { 5f, 49.2d, HitResult.Great },
-            new object[] { 5f, 49.7d, HitResult.Ok },
-            new object[] { 5f, 50d, HitResult.Ok },
+            new object[] { 5f, 49.7d, HitResult.Great },
+            new object[] { 5f, 50d, HitResult.Great },
             new object[] { 5f, 50.4d, HitResult.Ok },
             new object[] { 5f, 50.9d, HitResult.Ok },
             new object[] { 5f, 51d, HitResult.Ok },
             new object[] { 5f, 99d, HitResult.Ok },
             new object[] { 5f, 99.2d, HitResult.Ok },
-            new object[] { 5f, 99.7d, HitResult.Meh },
-            new object[] { 5f, 100d, HitResult.Meh },
+            new object[] { 5f, 99.7d, HitResult.Ok },
+            new object[] { 5f, 100d, HitResult.Ok },
             new object[] { 5f, 100.4d, HitResult.Meh },
             new object[] { 5f, 100.9d, HitResult.Meh },
             new object[] { 5f, 101d, HitResult.Meh },
             new object[] { 5f, 149d, HitResult.Meh },
             new object[] { 5f, 149.2d, HitResult.Meh },
-            new object[] { 5f, 149.7d, HitResult.Miss },
-            new object[] { 5f, 150d, HitResult.Miss },
+            new object[] { 5f, 149.7d, HitResult.Meh },
+            new object[] { 5f, 150d, HitResult.Meh },
             new object[] { 5f, 150.4d, HitResult.Miss },
             new object[] { 5f, 150.9d, HitResult.Miss },
             new object[] { 5f, 151d, HitResult.Miss },
 
             // OD = 5.7 test cases.
-            // GREAT hit window is [ -44.5ms,  44.5ms]
-            // OK    hit window is [ -93.5ms,  93.5ms]
-            // MEH   hit window is [-142.5ms, 142.5ms]
-            new object[] { 5.7f, 44d, HitResult.Great },
-            new object[] { 5.7f, 44.2d, HitResult.Great },
-            new object[] { 5.7f, 44.8d, HitResult.Ok },
-            new object[] { 5.7f, 45d, HitResult.Ok },
-            new object[] { 5.7f, 45.4d, HitResult.Ok },
-            new object[] { 5.7f, 93d, HitResult.Ok },
-            new object[] { 5.7f, 93.4d, HitResult.Ok },
-            new object[] { 5.7f, 93.9d, HitResult.Meh },
-            new object[] { 5.7f, 94d, HitResult.Meh },
-            new object[] { 5.7f, 94.4d, HitResult.Meh },
+            // GREAT hit window is [ -45.8ms,  45.8ms]
+            // OK    hit window is [ -94.4ms,  94.4ms]
+            // MEH   hit window is [-143.0ms, 143.0ms]
+            // MISS  hit window is [-400.0ms, 400.0ms]
+            new object[] { 5.7f, 45d, HitResult.Great },
+            new object[] { 5.7f, 45.2d, HitResult.Great },
+            new object[] { 5.7f, 45.8d, HitResult.Great },
+            new object[] { 5.7f, 45.9d, HitResult.Ok },
+            new object[] { 5.7f, 46d, HitResult.Ok },
+            new object[] { 5.7f, 46.4d, HitResult.Ok },
+            new object[] { 5.7f, 94d, HitResult.Ok },
+            new object[] { 5.7f, 94.2d, HitResult.Ok },
+            new object[] { 5.7f, 94.4d, HitResult.Ok },
+            new object[] { 5.7f, 94.48d, HitResult.Meh },
+            new object[] { 5.7f, 94.9d, HitResult.Meh },
+            new object[] { 5.7f, 95d, HitResult.Meh },
+            new object[] { 5.7f, 95.4d, HitResult.Meh },
             new object[] { 5.7f, 142d, HitResult.Meh },
-            new object[] { 5.7f, 142.2d, HitResult.Meh },
-            new object[] { 5.7f, 142.7d, HitResult.Miss },
-            new object[] { 5.7f, 143d, HitResult.Miss },
+            new object[] { 5.7f, 142.7d, HitResult.Meh },
+            new object[] { 5.7f, 143d, HitResult.Meh },
             new object[] { 5.7f, 143.4d, HitResult.Miss },
             new object[] { 5.7f, 143.9d, HitResult.Miss },
             new object[] { 5.7f, 144d, HitResult.Miss },

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -64,8 +64,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             var osuAttributes = (OsuDifficultyAttributes)attributes;
 
-            var classicMod = score.Mods.OfType<OsuModClassic>().SingleOrDefault();
-            usingClassicSliderAccuracy = classicMod?.NoSliderHeadAccuracy.Value == true;
+            usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value);
 
             accuracy = score.Accuracy;
             scoreMaxCombo = score.MaxCombo;
@@ -94,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, 1800, 1200, 450) / clockRate;
 
-            overallDifficulty = ((classicMod == null ? 80 : 79.5) - greatHitWindow) / 6;
+            overallDifficulty = (80 - greatHitWindow) / 6;
             approachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5;
 
             if (osuAttributes.SliderCount > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -64,7 +64,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             var osuAttributes = (OsuDifficultyAttributes)attributes;
 
-            usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value);
+            var classicMod = score.Mods.OfType<OsuModClassic>().SingleOrDefault();
+            usingClassicSliderAccuracy = classicMod?.NoSliderHeadAccuracy.Value == true;
 
             accuracy = score.Accuracy;
             scoreMaxCombo = score.MaxCombo;
@@ -93,7 +94,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, 1800, 1200, 450) / clockRate;
 
-            overallDifficulty = (79.5 - greatHitWindow) / 6;
+            overallDifficulty = ((classicMod == null ? 80 : 79.5) - greatHitWindow) / 6;
             approachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5;
 
             if (osuAttributes.SliderCount > 0)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -41,11 +41,13 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToHitObject(HitObject hitObject)
         {
-            switch (hitObject)
+            if (hitObject is Slider slider)
+                slider.ClassicSliderBehaviour = NoSliderHeadAccuracy.Value;
+
+            foreach (var ho in hitObject.EnumerateAllHitObjects())
             {
-                case Slider slider:
-                    slider.ClassicSliderBehaviour = NoSliderHeadAccuracy.Value;
-                    break;
+                if (ho.HitWindows is OsuHitWindows osuHitWindows)
+                    osuHitWindows.ClassicModActive = true;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHitWindows.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHitWindows.cs
@@ -18,6 +18,20 @@ namespace osu.Game.Rulesets.Osu.Scoring
         /// </summary>
         public const double MISS_WINDOW = 400;
 
+        private double overallDifficulty;
+
+        private bool classicModActive;
+
+        public bool ClassicModActive
+        {
+            get => classicModActive;
+            set
+            {
+                classicModActive = value;
+                updateWindows();
+            }
+        }
+
         private double great;
         private double ok;
         private double meh;
@@ -38,9 +52,22 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
         public override void SetDifficulty(double difficulty)
         {
-            great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, GREAT_WINDOW_RANGE)) - 0.5;
-            ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, OK_WINDOW_RANGE)) - 0.5;
-            meh = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, MEH_WINDOW_RANGE)) - 0.5;
+            overallDifficulty = difficulty;
+            updateWindows();
+        }
+
+        private void updateWindows()
+        {
+            great = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, GREAT_WINDOW_RANGE);
+            ok = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, OK_WINDOW_RANGE);
+            meh = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, MEH_WINDOW_RANGE);
+
+            if (ClassicModActive)
+            {
+                great = Math.Floor(great) - 0.5;
+                ok = Math.Floor(ok) - 0.5;
+                meh = Math.Floor(meh) - 0.5;
+            }
         }
 
         public override double WindowFor(HitResult result)

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneReplayStability.cs
@@ -21,38 +21,40 @@ namespace osu.Game.Rulesets.Taiko.Tests
             // while round brackets `()` represent *open* or *exclusive* bounds.
 
             // OD = 5 test cases.
-            // GREAT hit window is [-34.5ms, 34.5ms]
-            // OK    hit window is [-79.5ms, 79.5ms]
-            // MISS  hit window is [-94.5ms, 94.5ms]
+            // GREAT hit window is [-35ms, 35ms]
+            // OK    hit window is [-80ms, 80ms]
+            // MISS  hit window is [-95ms, 95ms]
             new object[] { 5f, -34d, HitResult.Great },
             new object[] { 5f, -34.2d, HitResult.Great },
-            new object[] { 5f, -34.7d, HitResult.Ok },
-            new object[] { 5f, -35d, HitResult.Ok },
+            new object[] { 5f, -34.7d, HitResult.Great },
+            new object[] { 5f, -35d, HitResult.Great },
             new object[] { 5f, -35.2d, HitResult.Ok },
             new object[] { 5f, -35.8d, HitResult.Ok },
             new object[] { 5f, -36d, HitResult.Ok },
             new object[] { 5f, -79d, HitResult.Ok },
             new object[] { 5f, -79.3d, HitResult.Ok },
-            new object[] { 5f, -79.7d, HitResult.Miss },
-            new object[] { 5f, -80d, HitResult.Miss },
+            new object[] { 5f, -79.7d, HitResult.Ok },
+            new object[] { 5f, -80d, HitResult.Ok },
             new object[] { 5f, -80.2d, HitResult.Miss },
             new object[] { 5f, -80.8d, HitResult.Miss },
             new object[] { 5f, -81d, HitResult.Miss },
 
             // OD = 7.8 test cases.
-            // GREAT hit window is [-25.5ms, 25.5ms]
-            // OK    hit window is [-62.5ms, 62.5ms]
-            // MISS  hit window is [-80.5ms, 80.5ms]
-            new object[] { 7.8f, -25d, HitResult.Great },
-            new object[] { 7.8f, -25.4d, HitResult.Great },
-            new object[] { 7.8f, -25.8d, HitResult.Ok },
-            new object[] { 7.8f, -26d, HitResult.Ok },
-            new object[] { 7.8f, -26.1d, HitResult.Ok },
-            new object[] { 7.8f, -62d, HitResult.Ok },
-            new object[] { 7.8f, -62.4d, HitResult.Ok },
-            new object[] { 7.8f, -62.7d, HitResult.Miss },
-            new object[] { 7.8f, -63d, HitResult.Miss },
-            new object[] { 7.8f, -63.2d, HitResult.Miss },
+            // GREAT hit window is [-26.6ms, 26.6ms]
+            // OK    hit window is [-63.2ms, 63.2ms]
+            // MISS  hit window is [-81.0ms, 81.0ms]
+            new object[] { 7.8f, -26d, HitResult.Great },
+            new object[] { 7.8f, -26.4d, HitResult.Great },
+            new object[] { 7.8f, -26.59d, HitResult.Great },
+            new object[] { 7.8f, -26.8d, HitResult.Ok },
+            new object[] { 7.8f, -27d, HitResult.Ok },
+            new object[] { 7.8f, -27.1d, HitResult.Ok },
+            new object[] { 7.8f, -63d, HitResult.Ok },
+            new object[] { 7.8f, -63.18d, HitResult.Ok },
+            new object[] { 7.8f, -63.4d, HitResult.Miss },
+            new object[] { 7.8f, -63.7d, HitResult.Miss },
+            new object[] { 7.8f, -64d, HitResult.Miss },
+            new object[] { 7.8f, -64.2d, HitResult.Miss },
         };
 
         [TestCaseSource(nameof(test_cases))]

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -2,16 +2,27 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Scoring;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>, IApplicableToDrawableHitObject
+    public class TaikoModClassic : ModClassic, IApplicableToHitObject, IApplicableToDrawableRuleset<TaikoHitObject>, IApplicableToDrawableHitObject
     {
+        public void ApplyToHitObject(HitObject hitObject)
+        {
+            foreach (var ho in hitObject.EnumerateAllHitObjects())
+            {
+                if (ho.HitWindows is TaikoHitWindows taikoHitWindows)
+                    taikoHitWindows.ClassicModActive = true;
+            }
+        }
+
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
             var drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoHitWindows.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoHitWindows.cs
@@ -17,6 +17,20 @@ namespace osu.Game.Rulesets.Taiko.Scoring
         private double ok;
         private double miss;
 
+        private double overallDifficulty;
+
+        private bool classicModActive;
+
+        public bool ClassicModActive
+        {
+            get => classicModActive;
+            set
+            {
+                classicModActive = value;
+                updateWindows();
+            }
+        }
+
         public override bool IsHitResultAllowed(HitResult result)
         {
             switch (result)
@@ -32,9 +46,22 @@ namespace osu.Game.Rulesets.Taiko.Scoring
 
         public override void SetDifficulty(double difficulty)
         {
-            great = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, GREAT_WINDOW_RANGE)) - 0.5;
-            ok = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, OK_WINDOW_RANGE)) - 0.5;
-            miss = Math.Floor(IBeatmapDifficultyInfo.DifficultyRange(difficulty, MISS_WINDOW_RANGE)) - 0.5;
+            overallDifficulty = difficulty;
+            updateWindows();
+        }
+
+        private void updateWindows()
+        {
+            great = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, GREAT_WINDOW_RANGE);
+            ok = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, OK_WINDOW_RANGE);
+            miss = IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, MISS_WINDOW_RANGE);
+
+            if (ClassicModActive)
+            {
+                great = Math.Floor(great) - 0.5;
+                ok = Math.Floor(ok) - 0.5;
+                miss = Math.Floor(miss) - 0.5;
+            }
         }
 
         public override double WindowFor(HitResult result)

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -256,5 +256,28 @@ namespace osu.Game.Rulesets.Objects
         /// <param name="hitObject">The object.</param>
         /// <returns>The end time of this object.</returns>
         public static double GetEndTime(this HitObject hitObject) => (hitObject as IHasDuration)?.EndTime ?? hitObject.StartTime;
+
+        /// <summary>
+        /// Returns an enumerable containing the provided <paramref name="hitObject"/> and its nested objects.
+        /// </summary>
+        public static IEnumerable<HitObject> EnumerateAllHitObjects(this HitObject hitObject)
+        {
+            yield return hitObject;
+
+            foreach (var nested in hitObject.NestedHitObjects)
+                yield return nested;
+        }
+
+        /// <summary>
+        /// Returns an enumerable containing all top-level objects from <paramref name="hitObjects"/> and all their nested objects.
+        /// </summary>
+        public static IEnumerable<HitObject> EnumerateAllHitObjects(this IEnumerable<HitObject> hitObjects)
+        {
+            foreach (var topLevelObjects in hitObjects)
+            {
+                foreach (var ho in topLevelObjects.EnumerateAllHitObjects())
+                    yield return ho;
+            }
+        }
     }
 }


### PR DESCRIPTION
Due to overwhelmingly negative feedback on the previous release regarding the hit windows changes, they have now been constrained to apply to classic mod scores only.

The consequences of this decision are as follows:

- Hit windows in stable are now - again - materially different from lazer by between 0.5 to 1.5ms.
- Because the great hit window is one of the inputs in osu! pp calculation, classic scores and lazer scores with the exact same hit statistics may award different amounts of pp.
- In osu!mania it is no longer possible to play with the exact same hit windows as on stable score V2. Those hit windows will be used but only in replays set on stable with score V2. New lazer scores will use stable's score V2 hit windows but without the flooring and rounding.
- One of the reasons to apply this change is that it incidentally also worked around a longstanding issue wherein lazer replays would not play back accurately due to replay timestamps being stored as integers which are insufficient when compared with lazer's fractional hit windows.

  As part of this change, lazer will now emit replays with fractional timestamps, to 4 digits of decimal precision. Those replays will not be parsed by stable unless (until?) support for this format change is added to stable.

  This also increases the file size of replays. In internal back-of-envelope testing the overhead measured was about 25%. While this doesn't really impact end users in any way, it does impact server-side storage considerations.

  Additionally, while best efforts have been made to prevent the replay stability issues from returning, they may very well return due to the inexact characteristics of floating point arithmetics. If they do, the next step will be to deviate from stable's replay format even further, probably by directly storing recorded judgements to the replay.

---

This is the minimal viable change that would close https://github.com/ppy/osu/issues/34244.

When it comes to testing I'm basically relying on the test scenes here. Maybe this needs more manual testing. First I want to see everyone's reaction to this diff and the complexities it incurs.

"Look on my works, ye Mighty, and despair."

If you want to double check the claim that "hit windows can only be specified up to 2dp" then see [hitwindows.zip](https://github.com/user-attachments/files/21256378/hitwindows.zip) (contains a Numbers sheet with all rulesets' hit windows calculated as a function of OD in 0.1 steps). That only kinda works as long as OD *is* indeed enforced as having maximum 1dp but I'm not sure that's actually enforced anywhere.