### PR TITLE
Allow beatmap cards' collapsible icon buttons to be accessible via context menu

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             }
         }
 
-        public MenuItem[] ContextMenuItems => new MenuItem[]
+        public virtual MenuItem[] ContextMenuItems => new MenuItem[]
         {
             new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, Action),
         };

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
@@ -1,14 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps.Drawables.Cards.Statistics;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapSet;
@@ -320,6 +324,22 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
             buttonContainer.ShowDetails.Value = showDetails;
             thumbnail.Dimmed.Value = showDetails;
+        }
+
+        public override MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                var items = base.ContextMenuItems.ToList();
+
+                foreach (var button in buttonContainer.Buttons)
+                {
+                    if (button.Enabled.Value)
+                        items.Add(new OsuMenuItem(button.TooltipText.ToSentence(), MenuItemType.Standard, () => button.TriggerClick()));
+                }
+
+                return items.ToArray();
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNano.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNano.cs
@@ -1,13 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
@@ -164,6 +168,22 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             bool showDetails = IsHovered;
 
             buttonContainer.ShowDetails.Value = showDetails;
+        }
+
+        public override MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                var items = base.ContextMenuItems.ToList();
+
+                foreach (var button in buttonContainer.Buttons)
+                {
+                    if (button.Enabled.Value)
+                        items.Add(new OsuMenuItem(button.TooltipText.ToSentence(), MenuItemType.Standard, () => button.TriggerClick()));
+                }
+
+                return items.ToArray();
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -2,14 +2,18 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps.Drawables.Cards.Statistics;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapSet;
@@ -290,6 +294,22 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             thumbnail.Dimmed.Value = showDetails;
 
             statisticsContainer.FadeTo(showDetails ? 1 : 0, TRANSITION_DURATION, Easing.OutQuint);
+        }
+
+        public override MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                var items = base.ContextMenuItems.ToList();
+
+                foreach (var button in buttonContainer.Buttons)
+                {
+                    if (button.Enabled.Value)
+                        items.Add(new OsuMenuItem(button.TooltipText.ToSentence(), MenuItemType.Standard, () => button.TriggerClick()));
+                }
+
+                return items.ToArray();
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/GoToBeatmapButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/GoToBeatmapButton.cs
@@ -40,7 +40,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 
         private void updateState()
         {
-            this.FadeTo(state.Value == DownloadState.LocallyAvailable ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            Enabled.Value = state.Value == DownloadState.LocallyAvailable;
+            this.FadeTo(Enabled.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -47,6 +48,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     updateState();
             }
         }
+
+        public IEnumerable<BeatmapCardIconButton> Buttons => buttons;
 
         protected override Container<Drawable> Content => mainContent;
 


### PR DESCRIPTION
<img width="462" height="170" alt="Screenshot 2025-07-17 at 12 59 30" src="https://github.com/user-attachments/assets/a94655d4-39b8-4004-86c4-142da600fbcd" />
<img width="507" height="169" alt="Screenshot 2025-07-17 at 13 00 51" src="https://github.com/user-attachments/assets/45719dbc-dd16-48c8-8710-2a2180f59c10" />

This change is primarily intended for mobile users who can't use the icon buttons like desktop users can.

---

- Closes https://github.com/ppy/osu/issues/31151
- Supersedes / closes https://github.com/ppy/osu/pull/31468

The setup is maybe a smidge unconventional but I did kind of want all of the buttons to be available to mobile users, and they contain a lot of non-trivial conditional and timing-based logic that I'd hate to duplicate.

Requesting reviews from everyone involved with the previous PR.