### PR TITLE
Fix beatmap update button restarting animation at every hover

### DIFF
--- a/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
+++ b/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
@@ -165,13 +165,13 @@ namespace osu.Game.Screens.Select.Carousel
 
         protected override bool OnHover(HoverEvent e)
         {
-            icon.Spin(400, RotationDirection.Clockwise);
+            icon.Spin(400, RotationDirection.Clockwise, icon.Rotation);
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            icon.Spin(4000, RotationDirection.Clockwise);
+            icon.Spin(4000, RotationDirection.Clockwise, icon.Rotation);
             base.OnHoverLost(e);
         }
     }

--- a/osu.Game/Screens/SelectV2/PanelUpdateBeatmapButton.cs
+++ b/osu.Game/Screens/SelectV2/PanelUpdateBeatmapButton.cs
@@ -132,13 +132,13 @@ namespace osu.Game.Screens.SelectV2
 
         protected override bool OnHover(HoverEvent e)
         {
-            icon.Spin(400, RotationDirection.Clockwise);
+            icon.Spin(400, RotationDirection.Clockwise, icon.Rotation);
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            icon.Spin(4000, RotationDirection.Clockwise);
+            icon.Spin(4000, RotationDirection.Clockwise, icon.Rotation);
             base.OnHoverLost(e);
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34101

Fixed the issue "Beatmap update button restarts animation at every hover" which was caused by the Spin method not being provided a startRotation (which defaulted it to 0F). This is a relatively small edit (2 lines plus its something visual), and in addition to that I don't really know how to test code, thats why there are no tests. (If you have time please tell me how)
This is my first proper pull request so please do tell me what I can do better later on!