### PR TITLE
Fix editor background not updating in certain scenarios

### DIFF
--- a/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
+++ b/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Screens.Backgrounds
 {
     public partial class EditorBackgroundScreen : BackgroundScreen
     {
-        private readonly IBindable<WorkingBeatmap> beatmap;
         private readonly Container dimContainer;
 
         private CancellationTokenSource? cancellationTokenSource;
@@ -31,10 +30,14 @@ namespace osu.Game.Screens.Backgrounds
 
         private IFrameBasedClock? clockSource;
 
-        public EditorBackgroundScreen(IBindable<WorkingBeatmap> beatmap)
-        {
-            this.beatmap = beatmap;
+        // We retrieve IBindable<WorkingBeatmap> from our dependency cache instead of passing WorkingBeatmap directly into EditorBackgroundScreen.
+        // Otherwise, DummyWorkingBeatmap will be erroneously passed in whenever creating a new beatmap (since the Schedule() in the Editor that populates
+        // a new WorkingBeatmap with correct values generally runs after EditorBackgroundScreen is created), which causes any background changes to not be displayed.
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
+        public EditorBackgroundScreen()
+        {
             InternalChild = dimContainer = new Container
             {
                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -480,7 +480,7 @@ namespace osu.Game.Screens.Edit
         [Resolved]
         private MusicController musicController { get; set; }
 
-        protected override BackgroundScreen CreateBackground() => new EditorBackgroundScreen(Beatmap);
+        protected override BackgroundScreen CreateBackground() => new EditorBackgroundScreen();
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -480,7 +480,7 @@ namespace osu.Game.Screens.Edit
         [Resolved]
         private MusicController musicController { get; set; }
 
-        protected override BackgroundScreen CreateBackground() => new EditorBackgroundScreen(Beatmap.Value);
+        protected override BackgroundScreen CreateBackground() => new EditorBackgroundScreen(Beatmap);
 
         protected override void LoadComplete()
         {


### PR DESCRIPTION
Fixes #34242, fixes #26001

The first issue is caused by the cancellation token being cancelled on subsequent background changes and then being reused, which then cancels the refresh from happening. I've simply modified to create a new source on each refresh.

The second issue is caused because when we pass `IBindable<WorkingBeatmap> Beatmap.Value` into `EditorBackgroundScreen`, the background is null and stays null even when the background has been changed, so we just always fall back to the default background when a refresh occurs. I've changed `EditorBackgroundScreen` to instead take in `IBindable<WorkingBeatmap>` rather than `WorkingBeatmap`, which seems like the most straightforward fix?