### PR TITLE
Fix failing to parse bundle version on iOS

### DIFF
--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -19,7 +19,16 @@ namespace osu.iOS
     public partial class OsuGameIOS : OsuGame
     {
         private readonly AppDelegate appDelegate;
-        public override Version AssemblyVersion => new Version(NSBundle.MainBundle.InfoDictionary["CFBundleVersion"].ToString());
+
+        public override Version AssemblyVersion
+        {
+            get
+            {
+                // Example: 2025.613.0-tachyon
+                string bundleVersion = NSBundle.MainBundle.InfoDictionary["CFBundleVersion"].ToString();
+                return new Version(bundleVersion.Split('-')[0]);
+            }
+        }
 
         public override bool HideUnlicensedContent => true;
 


### PR DESCRIPTION
Regressed from the release stream being included in the version string.