### PR TITLE
Fix beatmap set cover not loading at screen edges

### DIFF
--- a/osu.Game/Beatmaps/Drawables/UpdateableOnlineBeatmapSetCover.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableOnlineBeatmapSetCover.cs
@@ -50,8 +50,7 @@ namespace osu.Game.Beatmaps.Drawables
         protected override DelayedLoadWrapper CreateDelayedLoadWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad)
             => new DelayedLoadUnloadWrapper(createContentFunc, timeBeforeLoad, timeBeforeUnload)
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
             };
 
         protected override Drawable CreateDrawable(IBeatmapSetOnlineInfo model)


### PR DESCRIPTION
In the beatmap list, beatmap cover at the edge of the screen not be loaded

<img width="768" height="432" alt="image" src="https://github.com/user-attachments/assets/7e41eafb-75f5-4d07-a7f9-30bc3f3417b9" />

This is because the `DelayedLoadWrapper` in the center of the cover and its size is 0. This PR set it to fill the size of the parent to solve the issue.

<img width="1020" height="783" alt="image" src="https://github.com/user-attachments/assets/737d65c5-5fbb-4005-a477-233571bd4057" />
