### PR TITLE
Fix playlists leaderboard provider not being thread safe

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/IGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/IGameplayLeaderboardProvider.cs
@@ -13,6 +13,9 @@ namespace osu.Game.Screens.Select.Leaderboards
         /// <summary>
         /// List of all scores to display on the leaderboard.
         /// </summary>
+        /// <remarks>
+        /// Implementors should ensure that this list is only mutated from the update thread.
+        /// </remarks>
         IBindableList<GameplayLeaderboardScore> Scores { get; }
     }
 


### PR DESCRIPTION
Should close https://github.com/ppy/osu/issues/34222.

I haven't exactly managed to reproduce the issue myself but I'm relatively confident in the imagined mode of failure here. See

https://github.com/ppy/osu/blob/861a7e1db4b72ccfec67ef5f9a6a19faa0978d3f/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs#L25-L37

https://github.com/ppy/osu/blob/861a7e1db4b72ccfec67ef5f9a6a19faa0978d3f/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs#L53

Also comes with a side of (slightly) reduced number of collection change events fired.