### PR TITLE
osu!taiko consistency factor changes using object strains

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private double strainLengthBonus;
         private double patternMultiplier;
 
+        private bool isRelax;
         private bool isConvert;
 
         public override int Version => 20250306;
@@ -46,6 +47,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
 
             isConvert = beatmap.BeatmapInfo.Ruleset.OnlineID == 0;
+            isRelax = mods.Any(h => h is TaikoModRelax);
 
             return new Skill[]
             {
@@ -100,8 +102,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (beatmap.HitObjects.Count == 0)
                 return new TaikoDifficultyAttributes { Mods = mods };
 
-            bool isRelax = mods.Any(h => h is TaikoModRelax);
-
             var rhythm = skills.OfType<Rhythm>().Single();
             var reading = skills.OfType<Reading>().Single();
             var colour = skills.OfType<Colour>().Single();
@@ -122,7 +122,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             strainLengthBonus = 1 + 0.15 * DifficultyCalculationUtils.ReverseLerp(staminaDifficultStrains, 1000, 1555);
 
-            double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, isRelax, isConvert, out double consistencyFactor);
+            double combinedRating = combinedDifficultyValue(rhythm, reading, colour, stamina, out double consistencyFactor);
             double starRating = rescale(combinedRating * 1.4);
 
             // Calculate proportional contribution of each skill to the combinedRating.
@@ -159,14 +159,47 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// For each section, the peak strains of all separate skills are combined into a single peak strain for the section.
         /// The resulting partial rating of the beatmap is a weighted sum of the combined peaks (higher peaks are weighted more).
         /// </remarks>
-        private double combinedDifficultyValue(Rhythm rhythm, Reading reading, Colour colour, Stamina stamina, bool isRelax, bool isConvert, out double consistencyFactor)
+        private double combinedDifficultyValue(Rhythm rhythm, Reading reading, Colour colour, Stamina stamina, out double consistencyFactor)
         {
-            List<double> peaks = new List<double>();
+            List<double> peaks = combinePeaks(
+                rhythm.GetCurrentStrainPeaks().ToList(),
+                reading.GetCurrentStrainPeaks().ToList(),
+                colour.GetCurrentStrainPeaks().ToList(),
+                stamina.GetCurrentStrainPeaks().ToList()
+            );
 
-            var rhythmPeaks = rhythm.GetCurrentStrainPeaks().ToList();
-            var readingPeaks = reading.GetCurrentStrainPeaks().ToList();
-            var colourPeaks = colour.GetCurrentStrainPeaks().ToList();
-            var staminaPeaks = stamina.GetCurrentStrainPeaks().ToList();
+            double difficulty = 0;
+            double weight = 1;
+
+            foreach (double strain in peaks.OrderDescending())
+            {
+                difficulty += strain * weight;
+                weight *= 0.9;
+            }
+
+            List<double> hitObjectStrainPeaks = combinePeaks(
+                rhythm.GetObjectStrains().ToList(),
+                reading.GetObjectStrains().ToList(),
+                colour.GetObjectStrains().ToList(),
+                stamina.GetObjectStrains().ToList()
+            );
+
+            // The average of the top 5% of strain peaks from hit objects.
+            double topAverageHitObjectStrain = hitObjectStrainPeaks.OrderDescending().Take(1 + hitObjectStrainPeaks.Count / 20).Average();
+
+            // Calculates a consistency factor as the sum of difficulty from hit objects compared to if every object were as hard as the hardest.
+            // The top average strain is used instead of the very hardest to prevent exceptionally hard objects lowering the factor.
+            consistencyFactor = hitObjectStrainPeaks.Sum() / (topAverageHitObjectStrain * hitObjectStrainPeaks.Count);
+
+            return difficulty;
+        }
+
+        /// <summary>
+        /// Combines lists of peak strains from multiple skills into a list of single peak strains for each section.
+        /// </summary>
+        private List<double> combinePeaks(List<double> rhythmPeaks, List<double> readingPeaks, List<double> colourPeaks, List<double> staminaPeaks)
+        {
+            var combinedPeaks = new List<double>();
 
             for (int i = 0; i < colourPeaks.Count; i++)
             {
@@ -181,45 +214,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
                 // These sections will not contribute to the difficulty.
                 if (peak > 0)
-                    peaks.Add(peak);
+                    combinedPeaks.Add(peak);
             }
 
-            double difficulty = 0;
-            double weight = 1;
-
-            foreach (double strain in peaks.OrderDescending())
-            {
-                difficulty += strain * weight;
-                weight *= 0.9;
-            }
-
-            consistencyFactor = calculateConsistencyFactor(peaks);
-
-            return difficulty;
-        }
-
-        /// <summary>
-        /// Calculates a consistency factor based on how 'spiked' the strain peaks are.
-        /// Higher values indicate more consistent difficulty, lower values indicate diff-spike heavy maps.
-        /// </summary>
-        private double calculateConsistencyFactor(List<double> peaks)
-        {
-            // If there are too few sections in a map, assume it is consistent.
-            if (peaks.Count < 3)
-                return 1.0;
-
-            List<double> sorted = peaks.OrderDescending().ToList();
-
-            double topPeak = sorted[0];
-            double secondTopPeak = sorted.Count > 1 ? sorted[1] : topPeak;
-
-            // Compute the average of the middle 50% of strain values.
-            double midAvg = sorted.Skip(sorted.Count / 4).Take(sorted.Count / 2).Average();
-
-            // A higher ratio means the top sections are much harder than the average, indicating inconsistency.
-            double spikeSeverity = (topPeak + secondTopPeak) / 2.0 / midAvg;
-
-            return 1.0 / spikeSeverity;
+            return combinedPeaks;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceAttributes.cs
@@ -15,9 +15,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("accuracy")]
         public double Accuracy { get; set; }
 
-        [JsonProperty("effective_miss_count")]
-        public double EffectiveMissCount { get; set; }
-
         [JsonProperty("estimated_unstable_rate")]
         public double? EstimatedUnstableRate { get; set; }
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private double clockRate;
         private double greatHitWindow;
 
-        private double effectiveMissCount;
+        private double totalDifficultHits;
 
         public TaikoPerformanceCalculator()
             : base(new TaikoRuleset())
@@ -56,12 +56,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             estimatedUnstableRate = computeDeviationUpperBound() * 10;
 
-            // Effective miss count is calculated by raising the fraction of hits missed to a power based on the map's consistency factor.
-            // This is because in less consistently difficult maps, each miss removes more of the map's total difficulty.
-            effectiveMissCount = totalHits * Math.Pow(
-                (double)countMiss / totalHits,
-                Math.Pow(taikoAttributes.ConsistencyFactor, 0.2)
-            );
+            // Total difficult hits measures the total difficulty of a map based on its consistency factor.
+            totalDifficultHits = totalHits * taikoAttributes.ConsistencyFactor;
 
             // Converts are detected and omitted from mod-specific bonuses due to the scope of current difficulty calculation.
             bool isConvert = score.BeatmapInfo!.Ruleset.OnlineID != 1;
@@ -73,7 +69,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             {
                 Difficulty = difficultyValue,
                 Accuracy = accuracyValue,
-                EffectiveMissCount = effectiveMissCount,
                 EstimatedUnstableRate = estimatedUnstableRate,
                 Total = difficultyValue + accuracyValue
             };
@@ -86,14 +81,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             difficultyValue *= 1 + 0.10 * Math.Max(0, attributes.StarRating - 10);
 
-            // Applies a bonus to maps with more total difficulty, calculating this with a map's total hits and consistency factor.
-            double totalDifficultHits = totalHits * Math.Pow(attributes.ConsistencyFactor, 0.5);
+            // Applies a bonus to maps with more total difficulty.
             double lengthBonus = 1 + 0.25 * totalDifficultHits / (totalDifficultHits + 4000);
             difficultyValue *= lengthBonus;
 
-            // Scales miss penalty by the total hits of a map, making misses more punishing on maps with fewer objects.
-            double missPenalty = Math.Pow(0.5, 30.0 / totalHits);
-            difficultyValue *= Math.Pow(missPenalty, effectiveMissCount);
+            // Scales miss penalty by the total difficult hits of a map, making misses more punishing on maps with less total difficulty.
+            double missPenalty = Math.Pow(0.5, 30.0 / totalDifficultHits);
+            difficultyValue *= Math.Pow(missPenalty, countMiss);
 
             if (score.Mods.Any(m => m is ModHidden))
                 difficultyValue *= (isConvert) ? 1.025 : 1.1;
@@ -122,9 +116,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 accuracyValue *= 1.075;
 
             // Applies a bonus to maps with more total difficulty, calculating this with a map's total hits and consistency factor.
-            double totalDifficultHits = totalHits * Math.Pow(attributes.ConsistencyFactor, 0.5);
-            double lengthBonus = 1 + 0.4 * totalDifficultHits / (totalDifficultHits + 4000);
-            accuracyValue *= lengthBonus;
+            accuracyValue *= 1 + 0.4 * totalDifficultHits / (totalDifficultHits + 4000);
 
             // Applies a bonus to maps with more total memory required with HDFL.
             double memoryLengthBonus = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -116,6 +116,8 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public IEnumerable<double> GetCurrentStrainPeaks() => strainPeaks.Append(currentSectionPeak);
 
+        public IEnumerable<double> GetObjectStrains() => ObjectStrains;
+
         /// <summary>
         /// Returns the calculated difficulty value representing all <see cref="DifficultyHitObject"/>s that have been processed up to this point.
         /// </summary>


### PR DESCRIPTION
With how the consistency factor is currently used, adding easy strains can nerf a map's length bonus and miss penalty. These changes fix that by calculating the consistency factor using `object strains` such that `total difficult hits` (total hits * consistency factor) will never decrease when easy objects (outside the top 5% of object strains) are added. I factored out the peak combining code in TaikoDifficultyCalculator to avoid duplication but the diffs are really confusing, I recommend looking at the file itself if necessary. This also eliminates the need for `effectiveMissCount`
 