### PR TITLE
Fix iOS bundle version

### DIFF
--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -20,15 +20,9 @@ namespace osu.iOS
     {
         private readonly AppDelegate appDelegate;
 
-        public override Version AssemblyVersion
-        {
-            get
-            {
-                // Example: 2025.613.0-tachyon
-                string bundleVersion = NSBundle.MainBundle.InfoDictionary["CFBundleVersion"].ToString();
-                return new Version(bundleVersion.Split('-')[0]);
-            }
-        }
+        public override Version AssemblyVersion => new Version(NSBundle.MainBundle.InfoDictionary["CFBundleVersion"].ToString());
+
+        public override string Version => NSBundle.MainBundle.InfoDictionary["OsuVersion"].ToString();
 
         public override bool HideUnlicensedContent => true;
 

--- a/osu.iOS/osu.iOS.csproj
+++ b/osu.iOS/osu.iOS.csproj
@@ -4,8 +4,12 @@
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <Version>0.1.0</Version>
-    <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">$(Version)</ApplicationVersion>
-    <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
+
+    <!-- Incoming version string will be e.g. 2025.723.0-tachyon -->
+    <VersionNoSuffix>$([System.String]::Copy('$(Version)').Split('-')[0])</VersionNoSuffix>
+
+    <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">$(VersionNoSuffix)</ApplicationVersion>
+    <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(VersionNoSuffix)</ApplicationDisplayVersion>
   </PropertyGroup>
   <Import Project="..\osu.iOS.props" />
   <ItemGroup>

--- a/osu.iOS/osu.iOS.csproj
+++ b/osu.iOS/osu.iOS.csproj
@@ -22,4 +22,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.3" />
   </ItemGroup>
+  <!-- https://github.com/dotnet/macios/blob/eabcdee2ac43a0cc8324396a1bf75f8797d71810/msbuild/Xamarin.Shared/Xamarin.Shared.targets#L1328 -->
+  <Target Name="AddOsuVersionToBundle" AfterTargets="_CreateAppBundle">
+    <PropertyGroup>
+      <PlistFilePath>$(AppBundleDir)/Info.plist</PlistFilePath>
+      <OsuVersionKey>OsuVersion</OsuVersionKey>
+    </PropertyGroup>
+    <Exec Command="bash -c &quot;(/usr/libexec/PlistBuddy -c 'Print :$(OsuVersionKey)' '$(PlistFilePath)' &gt;/dev/null 2&gt;&amp;1 \
+                                 &amp;&amp; /usr/libexec/PlistBuddy -c 'Set :$(OsuVersionKey) $(Version)' '$(PlistFilePath)') \
+                                 || /usr/libexec/PlistBuddy -c 'Add :$(OsuVersionKey) string $(Version)' '$(PlistFilePath)'&quot;"/>
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/34342

This seems to be the least-effort fix required.

```sh
$ dotnet publish -c Debug -r ios-arm64 -p:Version=2025.731.1-tachyon
$ plutil -p bin/Debug/net8.0-ios/ios-arm64/osu.iOS.app/Info.plist | grep "Version"
  "CFBundleInfoDictionaryVersion" => "6.0"
  "CFBundleShortVersionString" => "2025.731.1"
  "CFBundleVersion" => "2025.731.1"
    "Version" => "17.2.8053+sha.cf27e95d7"
  "DTPlatformVersion" => "18.5"
  "MinimumOSVersion" => "13.4"
  "OsuVersion" => "2025.731.1-tachyon"
```