### PR TITLE
Backpopulate user tag data using `online.db`

### DIFF
--- a/osu.Game/Beatmaps/APIBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/APIBeatmapMetadataSource.cs
@@ -63,7 +63,9 @@ namespace osu.Game.Beatmaps
                         DateRanked = res.BeatmapSet?.Ranked,
                         DateSubmitted = res.BeatmapSet?.Submitted,
                         MD5Hash = res.MD5Hash,
-                        LastUpdated = res.LastUpdated
+                        LastUpdated = res.LastUpdated,
+                        // Tags are not populated because the response does not contain tag data.
+                        // TODO: consider web change to include the tag data? or a second web request for the set to retrieve tags?
                     };
                     return true;
                 }

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -77,6 +77,7 @@ namespace osu.Game.Beatmaps
                 {
                     beatmapInfo.Status = res.BeatmapStatus;
                     beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
+                    beatmapInfo.Metadata.UserTags.Clear();
                     beatmapInfo.Metadata.UserTags.AddRange(res.UserTags);
                 }
             }

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Platform;
+using osu.Game.Extensions;
 using osu.Game.Online.API;
 
 namespace osu.Game.Beatmaps
@@ -76,6 +77,7 @@ namespace osu.Game.Beatmaps
                 {
                     beatmapInfo.Status = res.BeatmapStatus;
                     beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
+                    beatmapInfo.Metadata.UserTags.AddRange(res.UserTags);
                 }
             }
 

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Beatmaps
             this.storage = storage;
 
             if (shouldFetchCache())
-                prepareLocalCache();
+                FetchCache();
         }
 
         private bool shouldFetchCache()
@@ -131,7 +131,7 @@ namespace osu.Game.Beatmaps
                             return false;
 
                         tryPurgeCache();
-                        prepareLocalCache();
+                        FetchCache();
                         return false;
                 }
 
@@ -165,7 +165,7 @@ namespace osu.Game.Beatmaps
         private SqliteConnection getConnection() =>
             new SqliteConnection(string.Concat(@"Data Source=", storage.GetFullPath(@"online.db", true)));
 
-        private void prepareLocalCache()
+        public Task FetchCache()
         {
             bool isRefetch = storage.Exists(cache_database_name);
 
@@ -218,7 +218,7 @@ namespace osu.Game.Beatmaps
                 }
             };
 
-            Task.Run(async () =>
+            return Task.Run(async () =>
             {
                 try
                 {

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -269,6 +269,16 @@ namespace osu.Game.Beatmaps
             }
         }
 
+        public DateTime? GetCacheFetchDate()
+        {
+            string path = storage.GetFullPath(cache_database_name);
+            var file = new FileInfo(path);
+            if (!file.Exists)
+                return null;
+
+            return file.LastWriteTime;
+        }
+
         private bool queryCacheVersion2(SqliteConnection db, BeatmapInfo beatmapInfo, out OnlineBeatmapMetadata? onlineMetadata)
         {
             Debug.Assert(beatmapInfo.BeatmapSet != null);

--- a/osu.Game/Beatmaps/OnlineBeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/OnlineBeatmapMetadata.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 
 namespace osu.Game.Beatmaps
 {
@@ -57,5 +58,10 @@ namespace osu.Game.Beatmaps
         /// The date when this metadata was last updated.
         /// </summary>
         public DateTimeOffset LastUpdated { get; init; }
+
+        /// <summary>
+        /// The list of tags that users have assigned to this beatmap.
+        /// </summary>
+        public List<string> UserTags { get; } = [];
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -227,6 +227,9 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorSubmissionLoadInBrowserAfterSubmission, true);
 
             SetDefault(OsuSetting.WasSupporter, false);
+
+            // intentionally uses `DateTime?` and not `DateTimeOffset?` because the latter fails due to `DateTimeOffset` not implementing `IConvertible`
+            SetDefault(OsuSetting.LastOnlineTagsPopulation, (DateTime?)null);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -473,6 +476,8 @@ namespace osu.Game.Configuration
         /// Cached state of whether local user is a supporter.
         /// Used to allow early checks (ie for startup samples) to be in the correct state, even if the API authentication process has not completed.
         /// </summary>
-        WasSupporter
+        WasSupporter,
+
+        LastOnlineTagsPopulation,
     }
 }

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -660,7 +660,7 @@ namespace osu.Game.Database
             Logger.Log(@"Querying for beatmaps that do not have user tags");
 
             // it is not an abnormal situation for a map not to have user tags.
-            // therefore there's some chance that this will run much too often and be annoying to users.
+            // while this is constrained to run every month or so (every time a new online.db cache is retrieved), there's some chance that this will still run much too often and be annoying to users.
             // if that turns out to be the case we may need a better way to debounce this (or just delete the backpopulation logic after some time has passed?)
             HashSet<Guid> beatmapIds = realmAccess.Run(r => new HashSet<Guid>(
                 r.All<BeatmapInfo>()

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -488,7 +488,7 @@ namespace osu.Game.Database
             if (scoreIds.Count == 0)
                 return;
 
-            var notification = showProgressNotification(scoreIds.Count, "Adjusting ranks of scores", "scores now have more correct ranks");
+            var notification = showProgressNotification(scoreIds.Count, "Adjusting ranks of scores", "scores now have more correct ranks.");
 
             int processedCount = 0;
             int failedCount = 0;
@@ -673,7 +673,7 @@ namespace osu.Game.Database
 
             Logger.Log($@"Found {beatmapIds.Count} beatmaps with missing user tags.");
 
-            var notification = showProgressNotification(beatmapIds.Count, @"Populating missing user tags", @"beatmaps now have user tags.");
+            var notification = showProgressNotification(beatmapIds.Count, @"Populating missing user tags", @"beatmaps have had their tags updated.");
 
             int processedCount = 0;
             int failedCount = 0;
@@ -691,7 +691,7 @@ namespace osu.Game.Database
                 {
                     // Can't use async overload because we're not on the update thread.
                     // ReSharper disable once MethodHasAsyncOverload
-                    bool succeeded = realmAccess.Write(r =>
+                    realmAccess.Write(r =>
                     {
                         BeatmapInfo beatmap = r.Find<BeatmapInfo>(id)!;
 
@@ -709,10 +709,7 @@ namespace osu.Game.Database
                         return false;
                     });
 
-                    if (succeeded)
-                        ++processedCount;
-                    // do not increment count if no tags were added - this is to show only the count of beatmaps that actually received tags in the completion notification
-                    // do not increment failure count either to avoid showing "check logs for failures" message as well - finding no user tags here is not a failure situation
+                    ++processedCount;
                 }
                 catch (ObjectDisposedException)
                 {


### PR DESCRIPTION
- [x] Depends on deployment of https://github.com/ppy/osu-onlinedb-generator/pull/12

I'm PRing this early and as draft because this has one major issue I don't know how to address, and that is *when to stop performing the backpopulation*.

User tags are pretty sparse. At this point in time it is more likely than not that if you open a random beatmap, it will not have any user tags. Therefore it's not like the backpopulations we've done previously where you can do a pass over every beatmap that has the data missing, because a beatmap having no user tags *is valid state*. So you end up doing redundant lookups because a backpopulation won't add user tags to a beatmap *that has no online user tags*.

This PR does the stupid variant, e.g. it tries to look up every beatmap with no user tags locally, but I worry that it's not going to stick and is going to annoy users through spamming notifications, especially ones with huge beatmap collections because this process takes minutes on those. Therefore a mechanism to one-shot this migration is likely desired, but I don't know what that mechanism would _be_ (some kind of `config.ini` flag?). Which is why I'm opening this early and listening to suggestions.

There's also the part of this wherein imports can now populate user tags as well but only when the local cache is used because the online cache can't do it using `GET /api/v2/beatmaps/lookup`. But that's kinda orthogonal to the point here so I don't particularly wish to dwell on that too hard.