### PR TITLE
Account for almost concurrent case in concurrent objects check

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/Checks/CheckManiaConcurrentObjectsTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/Checks/CheckManiaConcurrentObjectsTest.cs
@@ -75,7 +75,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor.Checks
             var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
-            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentSame));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrent));
+            Assert.That(issues.All(issue => issue.ToString().Contains("s are concurrent here")));
         }
 
         private void assertAlmostConcurrentSame(List<HitObject> hitobjects)
@@ -83,7 +84,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor.Checks
             var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
-            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrentSame));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrent));
+            Assert.That(issues.All(issue => issue.ToString().Contains("s are less than 10ms apart")));
         }
 
         private BeatmapVerifierContext getContext(List<HitObject> hitobjects)

--- a/osu.Game.Rulesets.Mania.Tests/Editor/Checks/CheckManiaConcurrentObjectsTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/Checks/CheckManiaConcurrentObjectsTest.cs
@@ -55,6 +55,16 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor.Checks
             });
         }
 
+        [Test]
+        public void TestHoldNotesAlmostConcurrentOnSameColumn()
+        {
+            assertAlmostConcurrentSame(new List<HitObject>
+            {
+                createHoldNote(startTime: 100, endTime: 400.75d, column: 1),
+                createHoldNote(startTime: 408, endTime: 700.75d, column: 1)
+            });
+        }
+
         private void assertOk(List<HitObject> hitobjects)
         {
             Assert.That(check.Run(getContext(hitobjects)), Is.Empty);
@@ -66,6 +76,14 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor.Checks
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentSame));
+        }
+
+        private void assertAlmostConcurrentSame(List<HitObject> hitobjects)
+        {
+            var issues = check.Run(getContext(hitobjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrentSame));
         }
 
         private BeatmapVerifierContext getContext(List<HitObject> hitobjects)

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -32,19 +32,15 @@ namespace osu.Game.Rulesets.Mania.Edit.Checks
                     if (!AreConcurrent(hitobject, nextHitobject) && !AreAlmostConcurrent(hitobject, nextHitobject))
                         break;
 
+                    bool sameType = hitobject.GetType() == nextHitobject.GetType();
+
                     if (AreConcurrent(hitobject, nextHitobject))
                     {
-                        if (hitobject.GetType() == nextHitobject.GetType())
-                            yield return new IssueTemplateConcurrentSame(this).Create(hitobject, nextHitobject);
-                        else
-                            yield return new IssueTemplateConcurrentDifferent(this).Create(hitobject, nextHitobject);
+                        yield return new IssueTemplateConcurrent(this).Create(hitobject, nextHitobject, sameType);
                     }
                     else if (AreAlmostConcurrent(hitobject, nextHitobject))
                     {
-                        if (hitobject.GetType() == nextHitobject.GetType())
-                            yield return new IssueTemplateAlmostConcurrentSame(this).Create(hitobject, nextHitobject);
-                        else
-                            yield return new IssueTemplateAlmostConcurrentDifferent(this).Create(hitobject, nextHitobject);
+                        yield return new IssueTemplateAlmostConcurrent(this).Create(hitobject, nextHitobject, sameType);
                     }
                 }
             }

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -32,8 +32,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Checks
                     if (!AreConcurrent(hitobject, nextHitobject) && !AreAlmostConcurrent(hitobject, nextHitobject))
                         break;
 
-                    bool sameType = hitobject.GetType() == nextHitobject.GetType();
-
                     if (AreConcurrent(hitobject, nextHitobject))
                     {
                         yield return new IssueTemplateConcurrent(this).Create(hitobject, nextHitobject);

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -28,14 +28,24 @@ namespace osu.Game.Rulesets.Mania.Edit.Checks
                         continue;
 
                     // Two hitobjects cannot be concurrent without also being concurrent with all objects in between.
-                    // So if the next object is not concurrent, then we know no future objects will be either.
-                    if (!AreConcurrent(hitobject, nextHitobject))
+                    // So if the next object is not concurrent or almost concurrent, then we know no future objects will be either.
+                    if (!AreConcurrent(hitobject, nextHitobject) && !AreAlmostConcurrent(hitobject, nextHitobject))
                         break;
 
-                    if (hitobject.GetType() == nextHitobject.GetType())
-                        yield return new IssueTemplateConcurrentSame(this).Create(hitobject, nextHitobject);
-                    else
-                        yield return new IssueTemplateConcurrentDifferent(this).Create(hitobject, nextHitobject);
+                    if (AreConcurrent(hitobject, nextHitobject))
+                    {
+                        if (hitobject.GetType() == nextHitobject.GetType())
+                            yield return new IssueTemplateConcurrentSame(this).Create(hitobject, nextHitobject);
+                        else
+                            yield return new IssueTemplateConcurrentDifferent(this).Create(hitobject, nextHitobject);
+                    }
+                    else if (AreAlmostConcurrent(hitobject, nextHitobject))
+                    {
+                        if (hitobject.GetType() == nextHitobject.GetType())
+                            yield return new IssueTemplateAlmostConcurrentSame(this).Create(hitobject, nextHitobject);
+                        else
+                            yield return new IssueTemplateAlmostConcurrentDifferent(this).Create(hitobject, nextHitobject);
+                    }
                 }
             }
         }

--- a/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Checks/CheckManiaConcurrentObjects.cs
@@ -36,11 +36,11 @@ namespace osu.Game.Rulesets.Mania.Edit.Checks
 
                     if (AreConcurrent(hitobject, nextHitobject))
                     {
-                        yield return new IssueTemplateConcurrent(this).Create(hitobject, nextHitobject, sameType);
+                        yield return new IssueTemplateConcurrent(this).Create(hitobject, nextHitobject);
                     }
                     else if (AreAlmostConcurrent(hitobject, nextHitobject))
                     {
-                        yield return new IssueTemplateAlmostConcurrent(this).Create(hitobject, nextHitobject, sameType);
+                        yield return new IssueTemplateAlmostConcurrent(this).Create(hitobject, nextHitobject);
                     }
                 }
             }

--- a/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
@@ -130,8 +130,14 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(3));
-            Assert.That(issues.Where(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentDifferent).ToList(), Has.Count.EqualTo(2));
-            Assert.That(issues.Any(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentSame));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrent));
+
+            // Should have 1 same-type concurrent (Slider & Slider) and 2 different-type concurrent (Slider & Circle)
+            var sameTypeIssues = issues.Where(issue => issue.ToString().Contains("s are concurrent here")).ToList();
+            var differentTypeIssues = issues.Where(issue => issue.ToString().Contains(" and ") && issue.ToString().Contains("are concurrent here")).ToList();
+
+            Assert.That(sameTypeIssues, Has.Count.EqualTo(1));
+            Assert.That(differentTypeIssues, Has.Count.EqualTo(2));
         }
 
         private Mock<Slider> getSliderMock(double startTime, double endTime, int repeats = 0)
@@ -164,7 +170,8 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
-            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentSame));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrent));
+            Assert.That(issues.All(issue => issue.ToString().Contains("s are concurrent here")));
         }
 
         private void assertConcurrentDifferent(List<HitObject> hitobjects, int count = 1)
@@ -172,7 +179,8 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
-            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentDifferent));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrent));
+            Assert.That(issues.All(issue => issue.ToString().Contains(" and ") && issue.ToString().Contains("are concurrent here")));
         }
 
         private void assertAlmostConcurrentSame(List<HitObject> hitobjects)
@@ -180,7 +188,8 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
-            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrentSame));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrent));
+            Assert.That(issues.All(issue => issue.ToString().Contains("s are less than 10ms apart")));
         }
 
         private void assertAlmostConcurrentDifferent(List<HitObject> hitobjects)
@@ -188,7 +197,8 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
-            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrentDifferent));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrent));
+            Assert.That(issues.All(issue => issue.ToString().Contains(" and ") && issue.ToString().Contains("are less than 10ms apart")));
         }
 
         private BeatmapVerifierContext getContext(List<HitObject> hitobjects)

--- a/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
@@ -58,6 +58,16 @@ namespace osu.Game.Tests.Editing.Checks
         }
 
         [Test]
+        public void TestCirclesAlmostConcurrentWarning()
+        {
+            assertAlmostConcurrentSame(new List<HitObject>
+            {
+                new HitCircle { StartTime = 100 },
+                new HitCircle { StartTime = 108 }
+            });
+        }
+
+        [Test]
         public void TestSlidersSeparate()
         {
             assertOk(new List<HitObject>
@@ -94,6 +104,16 @@ namespace osu.Game.Tests.Editing.Checks
             {
                 getSliderMock(startTime: 100, endTime: 400.75d).Object,
                 new HitCircle { StartTime = 300 }
+            });
+        }
+
+        [Test]
+        public void TestSliderAndCircleAlmostConcurrent()
+        {
+            assertAlmostConcurrentDifferent(new List<HitObject>
+            {
+                getSliderMock(startTime: 100, endTime: 400.75d).Object,
+                new HitCircle { StartTime = 408 }
             });
         }
 
@@ -153,6 +173,22 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentDifferent));
+        }
+
+        private void assertAlmostConcurrentSame(List<HitObject> hitobjects)
+        {
+            var issues = check.Run(getContext(hitobjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrentSame));
+        }
+
+        private void assertAlmostConcurrentDifferent(List<HitObject> hitobjects)
+        {
+            var issues = check.Run(getContext(hitobjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateAlmostConcurrentDifferent));
         }
 
         private BeatmapVerifierContext getContext(List<HitObject> hitobjects)

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -39,15 +39,13 @@ namespace osu.Game.Rulesets.Edit.Checks
                     if (!AreConcurrent(hitobject, nextHitobject) && !AreAlmostConcurrent(hitobject, nextHitobject))
                         break;
 
-                    bool sameType = hitobject.GetType() == nextHitobject.GetType();
-
                     if (AreConcurrent(hitobject, nextHitobject))
                     {
-                        yield return new IssueTemplateConcurrent(this).Create(hitobject, nextHitobject, sameType);
+                        yield return new IssueTemplateConcurrent(this).Create(hitobject, nextHitobject);
                     }
                     else if (AreAlmostConcurrent(hitobject, nextHitobject))
                     {
-                        yield return new IssueTemplateAlmostConcurrent(this).Create(hitobject, nextHitobject, sameType);
+                        yield return new IssueTemplateAlmostConcurrent(this).Create(hitobject, nextHitobject);
                     }
                 }
             }
@@ -65,10 +63,10 @@ namespace osu.Game.Rulesets.Edit.Checks
             {
             }
 
-            public Issue Create(HitObject hitobject, HitObject nextHitobject, bool sameType)
+            public Issue Create(HitObject hitobject, HitObject nextHitobject)
             {
                 var hitobjects = new List<HitObject> { hitobject, nextHitobject };
-                string message = sameType
+                string message = hitobject.GetType() == nextHitobject.GetType()
                     ? $"{hitobject.GetType().Name}s are concurrent here."
                     : $"{hitobject.GetType().Name} and {nextHitobject.GetType().Name} are concurrent here.";
 
@@ -86,12 +84,12 @@ namespace osu.Game.Rulesets.Edit.Checks
             {
             }
 
-            public Issue Create(HitObject hitobject, HitObject nextHitobject, bool sameType)
+            public Issue Create(HitObject hitobject, HitObject nextHitobject)
             {
                 var hitobjects = new List<HitObject> { hitobject, nextHitobject };
-                string message = sameType
-                    ? $"{hitobject.GetType().Name}s are less than 10ms apart."
-                    : $"{hitobject.GetType().Name} and {nextHitobject.GetType().Name} are less than 10ms apart.";
+                string message = hitobject.GetType() == nextHitobject.GetType()
+                    ? $"{hitobject.GetType().Name}s are less than {almost_concurrent_threshold}ms apart."
+                    : $"{hitobject.GetType().Name} and {nextHitobject.GetType().Name} are less than {almost_concurrent_threshold}ms apart.";
 
                 return new Issue(hitobjects, this, message)
                 {


### PR DESCRIPTION
Part of #12091

Opted to [match MV](https://github.com/Naxesss/MapsetVerifier/blob/main/src/Checks/AllModes/Compose/CheckConcurrent.cs#L58) by integrating this in the existing concurrent objects check.

Also refactored issue templates so there's no longer redundant definitions for "same" and "different" hitobject types (see commit https://github.com/ppy/osu/commit/c0ba8bc997165446a870be1b5219d67c4303b648)