### PR TITLE
Add "Bypass Approach Rate" Mod Setting to Hard Rock

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
@@ -13,6 +16,33 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModHardRock : ModHardRock, IApplicableToHitObject
     {
+        [SettingSource("Flipped axes", "Flip objects on the chosen axes.")]
+        public Bindable<MirrorType> Reflection { get; } = new Bindable<MirrorType>(MirrorType.Vertical);
+
+        [SettingSource("Accuracy Multiplier", "The multiplier applied to the beatmap's accuracy (overall difficulty).", SettingControlType = typeof(MultiplierSettingsSlider))]
+        public Bindable<double> OverallDifficultyRatio { get; } = new BindableDouble(ADJUST_RATIO)
+        {
+            MinValue = 1,
+            MaxValue = 2,
+            Precision = 0.01f,
+        };
+
+        [SettingSource("Circle Size Multiplier", "The multiplier applied to the beatmap's circle size (CS).", SettingControlType = typeof(MultiplierSettingsSlider))]
+        public Bindable<double> CircleSizeRatio { get; } = new BindableDouble(1.3f)
+        {
+            MinValue = 1,
+            MaxValue = 2,
+            Precision = 0.01f,
+        };
+
+        [SettingSource("Approach Rate Multiplier", "The multiplier applied to the beatmap's approach rate (AR).", SettingControlType = typeof(MultiplierSettingsSlider))]
+        public Bindable<double> ApproachRateRatio { get; } = new BindableDouble(ADJUST_RATIO)
+        {
+            MinValue = 1,
+            MaxValue = 2,
+            Precision = 0.01f,
+        };
+
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModMirror)).ToArray();
@@ -21,16 +51,38 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var osuObject = (OsuHitObject)hitObject;
 
-            OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(osuObject);
+            switch (Reflection.Value)
+            {
+                case MirrorType.Horizontal:
+                    OsuHitObjectGenerationUtils.ReflectHorizontallyAlongPlayfield(osuObject);
+                    break;
+
+                case MirrorType.Vertical:
+                    OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(osuObject);
+                    break;
+
+                case MirrorType.Both:
+                    OsuHitObjectGenerationUtils.ReflectHorizontallyAlongPlayfield(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(osuObject);
+                    break;
+            }
         }
 
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);
 
-            difficulty.OverallDifficulty = Math.Min(difficulty.OverallDifficulty * ADJUST_RATIO, 10.0f);
-            difficulty.CircleSize = Math.Min(difficulty.CircleSize * 1.3f, 10.0f); // CS uses a custom 1.3 ratio.
-            difficulty.ApproachRate = Math.Min(difficulty.ApproachRate * ADJUST_RATIO, 10.0f);
+            difficulty.OverallDifficulty = Math.Min(difficulty.OverallDifficulty * (float)OverallDifficultyRatio.Value, AdjustLimit);
+            difficulty.CircleSize = Math.Min(difficulty.CircleSize * (float)CircleSizeRatio.Value, AdjustLimit);
+            difficulty.ApproachRate = Math.Min(difficulty.ApproachRate * (float)ApproachRateRatio.Value, AdjustLimit);
+        }
+
+        public enum MirrorType
+        {
+            None,
+            Horizontal,
+            Vertical,
+            Both
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -2,13 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -25,23 +22,9 @@ namespace osu.Game.Rulesets.Mods
 
         protected const float ADJUST_RATIO = 1.4f;
 
-        [SettingSource("HP Drain Multiplier", "The multiplier applied to the beatmap's HP drain rate (HP).", SettingControlType = typeof(MultiplierSettingsSlider))]
-        public Bindable<double> DrainRateRatio { get; } = new BindableDouble(ADJUST_RATIO)
-        {
-            // Set a minimum value greater than 1 to ensure Hard Rock always does something
-            MinValue = 1.01f,
-            MaxValue = 2,
-            Precision = 0.01f,
-        };
-
-        [SettingSource("Extended Limits", "Adjust difficulty beyond sane limits.")]
-        public BindableBool ExtendedLimits { get; } = new BindableBool();
-
-        protected float AdjustLimit => ExtendedLimits.Value ? 11.0f : 10.0f;
-
         public virtual void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
-            difficulty.DrainRate = Math.Min(difficulty.DrainRate * (float)DrainRateRatio.Value, AdjustLimit);
+            difficulty.DrainRate = Math.Min(difficulty.DrainRate * ADJUST_RATIO, 10.0f);
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -2,10 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -22,9 +25,23 @@ namespace osu.Game.Rulesets.Mods
 
         protected const float ADJUST_RATIO = 1.4f;
 
+        [SettingSource("HP Drain Multiplier", "The multiplier applied to the beatmap's HP drain rate (HP).", SettingControlType = typeof(MultiplierSettingsSlider))]
+        public Bindable<double> DrainRateRatio { get; } = new BindableDouble(ADJUST_RATIO)
+        {
+            // Set a minimum value greater than 1 to ensure Hard Rock always does something
+            MinValue = 1.01f,
+            MaxValue = 2,
+            Precision = 0.01f,
+        };
+
+        [SettingSource("Extended Limits", "Adjust difficulty beyond sane limits.")]
+        public BindableBool ExtendedLimits { get; } = new BindableBool();
+
+        protected float AdjustLimit => ExtendedLimits.Value ? 11.0f : 10.0f;
+
         public virtual void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
-            difficulty.DrainRate = Math.Min(difficulty.DrainRate * ADJUST_RATIO, 10.0f);
+            difficulty.DrainRate = Math.Min(difficulty.DrainRate * (float)DrainRateRatio.Value, AdjustLimit);
         }
     }
 }


### PR DESCRIPTION
Adds a setting for the Hard Rock (HR) mod to bypass AR (Approach Rate) adjustments. This allows for +DTHR / +NCHR precision practice plays without necessitating the ability to read AR11. This also allows for more challenging low AR reading maps.

With the current implementation, using "Bypass Approach Rate" automatically makes the play Unranked and removes the bonus score multiplier from Hard Rock. (Using other mods like DT will adjust the AR as if Hard Rock was not applied).