### PR TITLE
Fix back-to-top button handling input outside itself

### DIFF
--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -119,10 +119,13 @@ namespace osu.Game.Overlays
             private Sample scrollToTopSample;
             private Sample scrollToPreviousSample;
 
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => content.ReceivePositionalInputAt(screenSpacePos);
+
             public ScrollBackButton()
             {
                 Size = new Vector2(50);
                 Alpha = 0;
+
                 Add(content = new CircularContainer
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34382.

I'm aware that the animation now affects hit area. I think it's fine.