### PR TITLE
Add more SFX to SSv2 components

### DIFF
--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.715.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.708.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.726.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
Specifically, adds SFX for the beatmap metadata 'wedges' and for beatmap leaderboards.

https://github.com/user-attachments/assets/b5c52402-ef1e-422e-8eac-a4c0554edf6b

The goal for the leaderboard SFX was for something subtle, but not completely inaudible, that also didn't get annoying after hearing it repeatedly while scrolling through beatmaps. The beatmap metadata wedge SFX is slightly less subtle, but I feel it's fine considering how less frequently it's triggered.

---

- [x] depends on ppy/osu-resources#374
- resolves #34247 