### PR TITLE
Show actual score increase on spinners when using classic scoring

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -129,7 +129,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             PositionBindable.BindValueChanged(pos => Position = pos.NewValue);
 
-            if (config == null || scoreProcessor == null) {
+            if (config == null || scoreProcessor == null)
+            {
                 return;
             }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -51,18 +51,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private PausableSkinnableSound maxBonusSample;
 
-        private double classicMultiplier = 1.0;
+        private double scoreDisplayMultiplier = 1.0;
         private Bindable<ScoringMode> scoreDisplayMode;
 
         /// <summary>
         /// The amount of bonus score gained from spinning after the required number of spins, for display purposes.
         /// </summary>
-        public int CurrentBonusScore => (int)(classicMultiplier * score_per_tick * Math.Clamp(completedFullSpins.Value - HitObject.SpinsRequiredForBonus, 0, HitObject.MaximumBonusSpins));
+        public int CurrentBonusScore => (int)(scoreDisplayMultiplier * score_per_tick * Math.Clamp(completedFullSpins.Value - HitObject.SpinsRequiredForBonus, 0, HitObject.MaximumBonusSpins));
 
         /// <summary>
         /// The maximum amount of bonus score which can be achieved from extra spins.
         /// </summary>
-        public int MaximumBonusScore => (int)(classicMultiplier * score_per_tick * HitObject.MaximumBonusSpins);
+        public int MaximumBonusScore => (int)(scoreDisplayMultiplier * score_per_tick * HitObject.MaximumBonusSpins);
 
         public IBindable<int> CompletedFullSpins => completedFullSpins;
 
@@ -85,10 +85,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
         }
 
-#nullable enable
-
-        [BackgroundDependencyLoader]
-        private void load(OsuConfigManager? config = null, ScoreProcessor? scoreProcessor = null)
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuConfigManager config, ScoreProcessor scoreProcessor)
         {
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;
@@ -131,6 +129,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (config == null || scoreProcessor == null)
             {
+                scoreDisplayMultiplier = 1.0;
                 return;
             }
 
@@ -140,11 +139,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 switch (scoreMode.NewValue)
                 {
                     case ScoringMode.Standardised:
-                        classicMultiplier = 1.0;
+                        scoreDisplayMultiplier = 1.0;
                         break;
 
                     case ScoringMode.Classic:
-                        classicMultiplier = scoreProcessor.GetOsuClassicScoreMultiplier();
+                        int maxBasicJudgements = scoreProcessor.MaximumStatistics
+                                                 .Where(k => k.Key.IsBasic())
+                                                 .Select(k => k.Value)
+                                                 .DefaultIfEmpty(0)
+                                                 .Sum();
+
+                        scoreDisplayMultiplier = ScoreInfoExtensions.GetOsuClassicScoreMultiplier(maxBasicJudgements) * scoreProcessor.ScoreMultiplier;
                         break;
 
                     default:
@@ -152,8 +157,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 }
             }, true);
         }
-
-#nullable disable
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -175,6 +175,8 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         private double scoreMultiplier = 1;
 
+        public double ScoreMultiplier => scoreMultiplier;
+
         public Dictionary<HitResult, int> MaximumStatistics
         {
             get

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -173,9 +173,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The total score multiplier.
         /// </summary>
-        private double scoreMultiplier = 1;
-
-        public double ScoreMultiplier => scoreMultiplier;
+        public double ScoreMultiplier { get; private set; } = 1;
 
         public Dictionary<HitResult, int> MaximumStatistics
         {
@@ -208,10 +206,10 @@ namespace osu.Game.Rulesets.Scoring
 
             Mods.ValueChanged += mods =>
             {
-                scoreMultiplier = 1;
+                ScoreMultiplier = 1;
 
                 foreach (var m in mods.NewValue)
-                    scoreMultiplier *= m.ScoreMultiplier;
+                    ScoreMultiplier *= m.ScoreMultiplier;
 
                 updateScore();
                 updateRank();
@@ -386,7 +384,7 @@ namespace osu.Game.Rulesets.Scoring
             double accuracyProgress = maximumAccuracyJudgementCount > 0 ? (double)currentAccuracyJudgementCount / maximumAccuracyJudgementCount : 1;
 
             TotalScoreWithoutMods.Value = (long)Math.Round(ComputeTotalScore(comboProgress, accuracyProgress, currentBonusPortion));
-            TotalScore.Value = (long)Math.Round(TotalScoreWithoutMods.Value * scoreMultiplier);
+            TotalScore.Value = (long)Math.Round(TotalScoreWithoutMods.Value * ScoreMultiplier);
         }
 
         private void updateRank()

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -71,10 +71,10 @@ namespace osu.Game.Scoring.Legacy
         public static double GetOsuClassicScoreMultiplier(this ScoreProcessor scoreProcessor)
         {
             int maxBasicJudgements = scoreProcessor.MaximumStatistics
-                                     .Where(k => k.Key.IsBasic())
-                                     .Select(k => k.Value)
-                                     .DefaultIfEmpty(0)
-                                     .Sum();
+                                       .Where(k => k.Key.IsBasic())
+                                       .Select(k => k.Value)
+                                       .DefaultIfEmpty(0)
+                                       .Sum();
 
             return getOsuClassicScoreMultiplier(maxBasicJudgements);
         }

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Scoring.Legacy
             switch (rulesetId)
             {
                 case 0:
-                    return (long)Math.Round((Math.Pow(objectCount, 2) * 32.57 + 100000) * standardisedTotalScore / ScoreProcessor.MAX_SCORE);
+                    return (long)Math.Round(getOsuClassicScoreMultiplier(objectCount) * standardisedTotalScore);
 
                 case 1:
                     return (long)Math.Round((objectCount * 1109 + 100000) * standardisedTotalScore / ScoreProcessor.MAX_SCORE);
@@ -66,6 +66,21 @@ namespace osu.Game.Scoring.Legacy
                 default:
                     return standardisedTotalScore;
             }
+        }
+
+        public static double GetOsuClassicScoreMultiplier(this ScoreProcessor scoreProcessor)
+        {
+            int maxBasicJudgements = scoreProcessor.MaximumStatistics
+                                     .Where(k => k.Key.IsBasic())
+                                     .Select(k => k.Value)
+                                     .DefaultIfEmpty(0)
+                                     .Sum();
+
+            return getOsuClassicScoreMultiplier(maxBasicJudgements);
+        }
+
+        private static double getOsuClassicScoreMultiplier(int objectCount) {
+            return (Math.Pow(objectCount, 2) * 32.57 + 100000) / ScoreProcessor.MAX_SCORE;
         }
 
         public static int? GetCountGeki(this ScoreInfo scoreInfo)

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -79,7 +79,8 @@ namespace osu.Game.Scoring.Legacy
             return getOsuClassicScoreMultiplier(maxBasicJudgements);
         }
 
-        private static double getOsuClassicScoreMultiplier(int objectCount) {
+        private static double getOsuClassicScoreMultiplier(int objectCount)
+        {
             return (Math.Pow(objectCount, 2) * 32.57 + 100000) / ScoreProcessor.MAX_SCORE;
         }
 

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Scoring.Legacy
             switch (rulesetId)
             {
                 case 0:
-                    return (long)Math.Round(getOsuClassicScoreMultiplier(objectCount) * standardisedTotalScore);
+                    return (long)Math.Round(GetOsuClassicScoreMultiplier(objectCount) * standardisedTotalScore);
 
                 case 1:
                     return (long)Math.Round((objectCount * 1109 + 100000) * standardisedTotalScore / ScoreProcessor.MAX_SCORE);
@@ -68,18 +68,7 @@ namespace osu.Game.Scoring.Legacy
             }
         }
 
-        public static double GetOsuClassicScoreMultiplier(this ScoreProcessor scoreProcessor)
-        {
-            int maxBasicJudgements = scoreProcessor.MaximumStatistics
-                                       .Where(k => k.Key.IsBasic())
-                                       .Select(k => k.Value)
-                                       .DefaultIfEmpty(0)
-                                       .Sum();
-
-            return getOsuClassicScoreMultiplier(maxBasicJudgements);
-        }
-
-        private static double getOsuClassicScoreMultiplier(int objectCount)
+        public static double GetOsuClassicScoreMultiplier(int objectCount)
         {
             return (Math.Pow(objectCount, 2) * 32.57 + 100000) / ScoreProcessor.MAX_SCORE;
         }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/18680

## Preview

On a map with low total classic score :
![osu_2025-07-25_18-10-12](https://github.com/user-attachments/assets/4f422ae3-03f4-4279-ab25-51b2adbae4c4)

On a map with high total classic score :
![osu_2025-07-25_18-10-54](https://github.com/user-attachments/assets/a243442d-4537-42bd-a9e1-dd13f586ef97)