### PR TITLE
Add `Hits Per Play` statistic to profile overlay

### DIFF
--- a/osu.Game/Overlays/Profile/Header/Components/ExtendedDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExtendedDetails.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private SpriteText playCount = null!;
         private SpriteText totalScore = null!;
         private SpriteText totalHits = null!;
+        private SpriteText hitsPerPlay = null!;
         private SpriteText maximumCombo = null!;
         private SpriteText replaysWatched = null!;
 
@@ -56,6 +57,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsPlayCount },
                             new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsTotalScore },
                             new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsTotalHits },
+                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsHitsPerPlay },
                             new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsMaximumCombo },
                             new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsReplaysWatchedByOthers },
                         }
@@ -73,6 +75,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             playCount = new OsuSpriteText { Font = font },
                             totalScore = new OsuSpriteText { Font = font },
                             totalHits = new OsuSpriteText { Font = font },
+                            hitsPerPlay = new OsuSpriteText { Font = font },
                             maximumCombo = new OsuSpriteText { Font = font },
                             replaysWatched = new OsuSpriteText { Font = font },
                         }
@@ -86,6 +89,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
             base.LoadComplete();
 
             User.BindValueChanged(user => updateStatistics(user.NewValue?.User.Statistics), true);
+        }
+
+        private int getHitsPerPlay(UserStatistics statistics)
+        {
+            return statistics.PlayCount == 0 ? 0 : statistics.TotalHits / statistics.PlayCount;
         }
 
         private void updateStatistics(UserStatistics? statistics)
@@ -103,6 +111,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             playCount.Text = statistics.PlayCount.ToLocalisableString(@"N0");
             totalScore.Text = statistics.TotalScore.ToLocalisableString(@"N0");
             totalHits.Text = statistics.TotalHits.ToLocalisableString(@"N0");
+            hitsPerPlay.Text = getHitsPerPlay(statistics).ToLocalisableString(@"N0");
             maximumCombo.Text = statistics.MaxCombo.ToLocalisableString(@"N0");
             replaysWatched.Text = statistics.ReplaysWatched.ToLocalisableString(@"N0");
         }


### PR DESCRIPTION
matches `osu! web`

| master | pr |
|-|-|
| <img width="1920" height="1080" alt="osu_2025-07-27_22-27-13" src="https://github.com/user-attachments/assets/c64c152c-2514-49a8-9ead-04d9669817a3" /> | <img width="1920" height="1080" alt="osu_2025-07-27_22-25-02" src="https://github.com/user-attachments/assets/6954ae57-57db-4ae6-aa3e-c3ba99693e15" /> |