### PR TITLE
Display sorting metric instead of total score in leaderboard

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -32,7 +32,9 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
 using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
 using osu.Game.Users.Drawables;
 using osu.Game.Utils;
@@ -71,6 +73,9 @@ namespace osu.Game.Screens.SelectV2
 
         [Resolved]
         private ScoreManager scoreManager { get; set; } = null!;
+
+        [Resolved]
+        private LeaderboardManager leaderboardManager { get; set; } = null!;
 
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
@@ -438,7 +443,7 @@ namespace osu.Game.Screens.SelectV2
                                                         Anchor = Anchor.TopRight,
                                                         Origin = Anchor.TopRight,
                                                         UseFullGlyphHeight = false,
-                                                        Current = scoreManager.GetBindableTotalScoreString(Score),
+                                                        Current = getMainMetricString(),
                                                         Spacing = new Vector2(-1.5f),
                                                         Font = OsuFont.Style.Subtitle.With(weight: FontWeight.Light, fixedWidth: true),
                                                         Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
@@ -463,6 +468,29 @@ namespace osu.Game.Screens.SelectV2
                 }
             };
             innerAvatar.OnLoadComplete += d => d.FadeInFromZero(200);
+        }
+
+        private Bindable<string> getMainMetricString()
+        {
+            var leaderboardSortMode = leaderboardManager.CurrentCriteria?.Sorting ?? LeaderboardSortMode.Score;
+
+            switch (leaderboardSortMode)
+            {
+                case LeaderboardSortMode.Accuracy:
+                    return new Bindable<string>(Score.DisplayAccuracy.GetDisplayString());
+
+                case LeaderboardSortMode.MaxCombo:
+                    return new Bindable<string>($"{Score.MaxCombo}x");
+
+                case LeaderboardSortMode.Misses:
+                    return new Bindable<string>($"{Score.GetCountMiss() ?? 0}");
+
+                case LeaderboardSortMode.Date:
+                    return new Bindable<string>(Score.Date.ToString("dd/MM/yy"));
+
+                default:
+                    return scoreManager.GetBindableTotalScoreString(Score);
+            }
         }
 
         private ColourInfo getHighlightColour(HighlightType? highlightType, float lightenAmount = 0)


### PR DESCRIPTION
Creating as draft to open discussion on how it should look.

Two accuracies in "accuracy" sorting. Should left accuracy field be replaced with total score? Or this shouldn't display accuracy instead of total score at all?
<img width="885" height="285" alt="image" src="https://github.com/user-attachments/assets/61cf079b-ee04-4864-866d-338da1cf6687" />

Same as with accuracy.
<img width="886" height="267" alt="image" src="https://github.com/user-attachments/assets/3040d4a7-5ba5-45ef-b8c7-cebbdf748739" />

Sorting by "misses" feels empty. Also, there's no total score at all. I don't know if it's a problem.
<img width="876" height="286" alt="image" src="https://github.com/user-attachments/assets/a17219f7-d222-4139-8092-ec402c4bd5c3" />

With "date" I don't sure it's necessary to display date in the first place.
<img width="883" height="270" alt="image" src="https://github.com/user-attachments/assets/4a09facb-f0e8-4543-8bbe-0ebe22e0d874" />
