### PR TITLE
Update menu tip design

### DIFF
--- a/osu.Game/Screens/Menu/MenuTipDisplay.cs
+++ b/osu.Game/Screens/Menu/MenuTipDisplay.cs
@@ -4,6 +4,8 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -45,14 +47,14 @@ namespace osu.Game.Screens.Menu
                     RelativeSizeAxes = Axes.Both,
                     Masking = true,
                     CornerExponent = 2.5f,
-                    CornerRadius = 15,
+                    CornerRadius = 10,
                     Children = new Drawable[]
                     {
                         new Box
                         {
-                            Colour = Color4.Black,
+                            Colour = Color4Extensions.FromHex("#171A1C"),
                             RelativeSizeAxes = Axes.Both,
-                            Alpha = 0.4f,
+                            Alpha = 0.75f,
                         },
                     }
                 },
@@ -84,12 +86,22 @@ namespace osu.Game.Screens.Menu
             }
 
             static void formatRegular(SpriteText t) => t.Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular);
-            static void formatSemiBold(SpriteText t) => t.Font = OsuFont.GetFont(size: 16, weight: FontWeight.SemiBold);
+
+            static void formatSemiBold(SpriteText t)
+            {
+                t.Font = OsuFont.GetFont(size: 16, weight: FontWeight.SemiBold);
+                t.Colour = Color4Extensions.FromHex("#FF99C7");
+            }
 
             var tip = getRandomTip();
 
             textFlow.Clear();
-            textFlow.AddParagraph(MenuTipStrings.MenuTipTitle, formatSemiBold);
+            textFlow.AddIcon(FontAwesome.Solid.Lightbulb, icon =>
+            {
+                icon.Colour = Color4Extensions.FromHex("#FF99C7");
+                icon.Size = new Vector2(16);
+            });
+            textFlow.AddText(MenuTipStrings.MenuTipTitle.ToSentence(), formatSemiBold);
             textFlow.AddParagraph(tip, formatRegular);
 
             this

--- a/osu.Game/Screens/Menu/MenuTipDisplay.cs
+++ b/osu.Game/Screens/Menu/MenuTipDisplay.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Screens.Menu
 
             static void formatSemiBold(SpriteText t)
             {
-                t.Font = OsuFont.GetFont(size: 16, weight: FontWeight.SemiBold);
+                t.Font = OsuFont.GetFont(Typeface.TorusAlternate, 16, weight: FontWeight.SemiBold);
                 t.Colour = Color4Extensions.FromHex("#FF99C7");
             }
 

--- a/osu.Game/Screens/Menu/MenuTipDisplay.cs
+++ b/osu.Game/Screens/Menu/MenuTipDisplay.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Screens.Menu
                 icon.Colour = Color4Extensions.FromHex("#FF99C7");
                 icon.Size = new Vector2(16);
             });
-            textFlow.AddText(MenuTipStrings.MenuTipTitle.ToSentence(), formatSemiBold);
+            textFlow.AddText(" " + MenuTipStrings.MenuTipTitle.ToSentence(), formatSemiBold);
             textFlow.AddParagraph(tip, formatRegular);
 
             this

--- a/osu.Game/Screens/Menu/MenuTipDisplay.cs
+++ b/osu.Game/Screens/Menu/MenuTipDisplay.cs
@@ -18,7 +18,6 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osuTK;
-using osuTK.Graphics;
 using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Menu
@@ -27,6 +26,9 @@ namespace osu.Game.Screens.Menu
     {
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
 
         private LinkFlowContainer textFlow = null!;
 
@@ -87,10 +89,10 @@ namespace osu.Game.Screens.Menu
 
             static void formatRegular(SpriteText t) => t.Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular);
 
-            static void formatSemiBold(SpriteText t)
+            void formatSemiBold(SpriteText t)
             {
                 t.Font = OsuFont.GetFont(Typeface.TorusAlternate, 16, weight: FontWeight.SemiBold);
-                t.Colour = Color4Extensions.FromHex("#FF99C7");
+                t.Colour = colours.Pink0;
             }
 
             var tip = getRandomTip();
@@ -98,7 +100,7 @@ namespace osu.Game.Screens.Menu
             textFlow.Clear();
             textFlow.AddIcon(FontAwesome.Solid.Lightbulb, icon =>
             {
-                icon.Colour = Color4Extensions.FromHex("#FF99C7");
+                icon.Colour = colours.Pink0;
                 icon.Size = new Vector2(16);
             });
             textFlow.AddText(" " + MenuTipStrings.MenuTipTitle.ToSentence(), formatSemiBold);
@@ -124,10 +126,12 @@ namespace osu.Game.Screens.Menu
             switch (tipIndex)
             {
                 case 0:
-                    return MenuTipStrings.ToggleToolbarShortcut(keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleToolbar).FirstOrDefault() ?? InputSettingsStrings.ActionHasNoKeyBinding);
+                    return MenuTipStrings.ToggleToolbarShortcut(
+                        keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleToolbar).FirstOrDefault() ?? InputSettingsStrings.ActionHasNoKeyBinding);
 
                 case 1:
-                    return MenuTipStrings.GameSettingsShortcut(keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleSettings).FirstOrDefault() ?? InputSettingsStrings.ActionHasNoKeyBinding);
+                    return MenuTipStrings.GameSettingsShortcut(
+                        keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleSettings).FirstOrDefault() ?? InputSettingsStrings.ActionHasNoKeyBinding);
 
                 case 2:
                     return MenuTipStrings.DynamicSettings;
@@ -142,7 +146,8 @@ namespace osu.Game.Screens.Menu
                     return MenuTipStrings.ScreenScalingSettings;
 
                 case 6:
-                    return MenuTipStrings.FreeOsuDirect(keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleBeatmapListing).FirstOrDefault() ?? InputSettingsStrings.ActionHasNoKeyBinding);
+                    return MenuTipStrings.FreeOsuDirect(keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleBeatmapListing).FirstOrDefault()
+                                                        ?? InputSettingsStrings.ActionHasNoKeyBinding);
 
                 case 7:
                     return MenuTipStrings.ReplaySeeking;
@@ -196,7 +201,8 @@ namespace osu.Game.Screens.Menu
                     return MenuTipStrings.RandomSkinShortcut(keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.RandomSkin).FirstOrDefault() ?? InputSettingsStrings.ActionHasNoKeyBinding);
 
                 case 24:
-                    return MenuTipStrings.ToggleReplaySettingsShortcut(keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleReplaySettings).FirstOrDefault() ?? InputSettingsStrings.ActionHasNoKeyBinding);
+                    return MenuTipStrings.ToggleReplaySettingsShortcut(keyBindingStore.GetReadableKeyCombinationsFor(GlobalAction.ToggleReplaySettings).FirstOrDefault()
+                                                                       ?? InputSettingsStrings.ActionHasNoKeyBinding);
 
                 case 25:
                     return MenuTipStrings.CopyModsFromScore;


### PR DESCRIPTION
Updated the design to match current looks, and to make it a bit more readable and noticeable.
Had the go from peppy to open a PR so here it is 👍 
(It's also my first one, hopefully I followed the guidelines correctly)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7d4795e5-700c-4c28-b6f2-ac2d4fc504a6" />
<img width="932" height="158" alt="image" src="https://github.com/user-attachments/assets/95fb6f3b-0179-4555-925c-178cba33084c" />
