### PR TITLE
Update beatmap online statuses when the set is selected in song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
@@ -43,6 +43,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         private APIBeatmapSet? currentOnlineSet;
 
+        [Cached]
+        private RealmPopulatingOnlineLookupSource lookupSource = new RealmPopulatingOnlineLookupSource();
+
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
         {
@@ -55,6 +58,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddRange(new Drawable[]
             {
+                lookupSource,
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -8,18 +8,19 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
@@ -69,10 +70,14 @@ namespace osu.Game.Screens.SelectV2
         private LocalisationManager localisation { get; set; } = null!;
 
         [Resolved]
-        private IAPIProvider api { get; set; } = null!;
+        private RealmPopulatingOnlineLookupSource onlineLookupSource { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
 
         private APIBeatmapSet? currentOnlineBeatmapSet;
-        private GetBeatmapSetRequest? currentRequest;
+        private CancellationTokenSource? cancellationTokenSource;
+        private Task<APIBeatmapSet?>? currentFetchTask;
 
         private FillFlowContainer statisticsFlow = null!;
 
@@ -291,28 +296,27 @@ namespace osu.Game.Screens.SelectV2
         {
             var beatmapSetInfo = working.Value.BeatmapSetInfo;
 
-            currentRequest?.Cancel();
-            currentRequest = null;
+            cancellationTokenSource?.Cancel();
             currentOnlineBeatmapSet = null;
 
             if (beatmapSetInfo.OnlineID >= 1)
             {
-                // todo: consider introducing a BeatmapSetLookupCache for caching benefits.
-                currentRequest = new GetBeatmapSetRequest(beatmapSetInfo.OnlineID);
-                currentRequest.Failure += _ => updateOnlineDisplay();
-                currentRequest.Success += s =>
+                cancellationTokenSource = new CancellationTokenSource();
+                currentFetchTask = onlineLookupSource.GetBeatmapSetAsync(beatmapSetInfo.OnlineID);
+                currentFetchTask.ContinueWith(t =>
                 {
-                    currentOnlineBeatmapSet = s;
-                    updateOnlineDisplay();
-                };
-
-                api.Queue(currentRequest);
+                    if (t.IsCompletedSuccessfully)
+                        currentOnlineBeatmapSet = t.GetResultSafely();
+                    if (t.Exception != null)
+                        Logger.Log($"Error when fetching online beatmap set: {t.Exception}", LoggingTarget.Network);
+                    Scheduler.AddOnce(updateOnlineDisplay);
+                });
             }
         }
 
         private void updateOnlineDisplay()
         {
-            if (currentRequest?.CompletionState == APIRequestCompletionState.Waiting)
+            if (currentFetchTask?.IsCompleted == false)
             {
                 playCount.Value = null;
                 favouriteButton.SetLoading();
@@ -322,6 +326,20 @@ namespace osu.Game.Screens.SelectV2
                 var onlineBeatmap = currentOnlineBeatmapSet?.Beatmaps.SingleOrDefault(b => b.OnlineID == working.Value.BeatmapInfo.OnlineID);
                 playCount.Value = new StatisticPlayCount.Data(onlineBeatmap?.PlayCount ?? -1, onlineBeatmap?.UserPlayCount ?? -1);
                 favouriteButton.SetBeatmapSet(currentOnlineBeatmapSet);
+
+                // the online fetch may have also updated the beatmap's status.
+                // this needs to be checked against the *local* beatmap model rather than the online one, because it's not known here whether the status change has occurred or not
+                // (think scenarios like the beatmap being locally modified).
+                // it also has to be handled explicitly like this because the working beatmap's `BeatmapInfo` will not receive these updates due to being detached
+                // (and because of https://github.com/ppy/osu/blob/4b73afd1957a9161e2956fc4191c8114d9958372/osu.Game/Screens/SelectV2/SongSelect.cs#L487-L488
+                // which prevents working beatmap refetches caused by changes to the realm model of perceived low importance).
+                var status = realm.Run(r =>
+                {
+                    var refetchedBeatmap = r.Find<BeatmapInfo>(working.Value.BeatmapInfo.ID);
+                    return refetchedBeatmap?.Status;
+                });
+                if (status != null)
+                    statusPill.Status = status.Value;
             }
         }
     }


### PR DESCRIPTION
This is the low effort attempt at fixing https://github.com/ppy/osu/issues/23804 in line with the suggestion from https://github.com/ppy/osu/discussions/34112#discussioncomment-13886201.

Why low effort?

- It doesn't fix the fact that the same API request is done by two wedges independently despite them being right next to each other (which was the case before I started touching any of this).
  - I could add a caching layer to `RealmPopulatingOnlineLookupSource` but that would imply that this cache now has to be purged at some point. At what point? Good question. Probably on re-entering song select? Or maybe never (...with the exception of unit tests)?
  - Or I could pull out this online beatmap set fetch to a higher level and pass only the result of it.

- It does a local realm refetch of the status. This is primarily required because of https://github.com/ppy/osu/pull/33515 - the guard added there prevents the global working beatmap from being refetched with the updated `BeatmapInfo` via beatmap carousel / detached beatmap store.

- It doesn't address https://github.com/ppy/osu/issues/20159 because that case concerns difficulties that are present online but *missing* locally. Resolving that would likely require a new database flag which would feed into https://github.com/ppy/osu/blob/3dced34775ddb0b97538593895b4a7bfbff583d1/osu.Game/Beatmaps/BeatmapSetInfo.cs#L107

- I've tested this manually because that's frankly easiest if you have realm studio working (open realm studio, select a beatmap in game, go to realm, change its status to something random, then go back to game, change to another set and change back - the status should revert to what it was). I can add automated tests but it's likely that will be *much* more annoying to set up.

Please advise how much of the above you'd see addressed and how. PRing as draft pending answers to these concerns.