### PR TITLE
Bound DisplayStarsMinimum/Maximum to config

### DIFF
--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -179,8 +179,8 @@ namespace osu.Game.Screens.SelectV2
         {
             base.LoadComplete();
 
-            difficultyRangeSlider.LowerBound = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum);
-            difficultyRangeSlider.UpperBound = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
+            config.BindWith(OsuSetting.DisplayStarsMinimum, difficultyRangeSlider.LowerBound);
+            config.BindWith(OsuSetting.DisplayStarsMaximum, difficultyRangeSlider.UpperBound);
             config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmapsButton.Active);
             config.BindWith(OsuSetting.SongSelectSortingMode, sortDropdown.Current);
             config.BindWith(OsuSetting.SongSelectGroupMode, groupDropdown.Current);


### PR DESCRIPTION
so that it can be changed through the code from elsewhere and then also update in UI and view, as seen in the arcade branch / lazer arcade on COE.