### PR TITLE
Ensure scores are re-fetched with correct criteria on re-entering song select

### DIFF
--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -41,12 +41,12 @@ namespace osu.Game.Screens.Ranking
         {
             Debug.Assert(Score != null);
 
+            // sort mode intentionally omitted to default to score - results screen only supports sorting by score, so don't pass any other to avoid confusion
             var criteria = new LeaderboardCriteria(
                 Score.BeatmapInfo!,
                 Score.Ruleset,
                 leaderboardManager.CurrentCriteria?.Scope ?? BeatmapLeaderboardScope.Global,
-                leaderboardManager.CurrentCriteria?.ExactMods,
-                leaderboardManager.CurrentCriteria?.Sorting ?? LeaderboardSortMode.Score
+                leaderboardManager.CurrentCriteria?.ExactMods
             );
             var requestTaskSource = new TaskCompletionSource<LeaderboardScores>();
             globalScores.BindValueChanged(_ =>

--- a/osu.Game/Screens/SelectV2/BeatmapDetailsArea.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapDetailsArea.cs
@@ -97,5 +97,11 @@ namespace osu.Game.Screens.SelectV2
             contentContainer.Add(currentContent);
             currentContent.Show();
         }
+
+        public void Refresh()
+        {
+            if (currentContent is BeatmapLeaderboardWedge leaderboardWedge)
+                leaderboardWedge.RefetchScores();
+        }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs
@@ -189,14 +189,14 @@ namespace osu.Game.Screens.SelectV2
         {
             base.LoadComplete();
 
-            Scope.BindValueChanged(_ => refetchScores());
-            Sorting.BindValueChanged(_ => refetchScores());
-            FilterBySelectedMods.BindValueChanged(_ => refetchScores());
-            beatmap.BindValueChanged(_ => refetchScores());
-            ruleset.BindValueChanged(_ => refetchScores());
+            Scope.BindValueChanged(_ => RefetchScores());
+            Sorting.BindValueChanged(_ => RefetchScores());
+            FilterBySelectedMods.BindValueChanged(_ => RefetchScores());
+            beatmap.BindValueChanged(_ => RefetchScores());
+            ruleset.BindValueChanged(_ => RefetchScores());
             mods.BindValueChanged(_ => refetchScoresFromMods());
 
-            refetchScores();
+            RefetchScores();
         }
 
         protected override void PopIn()
@@ -212,14 +212,14 @@ namespace osu.Game.Screens.SelectV2
         private void refetchScoresFromMods()
         {
             if (FilterBySelectedMods.Value)
-                refetchScores();
+                RefetchScores();
         }
 
         private bool initialFetchComplete;
 
         private ScheduledDelegate? refetchOperation;
 
-        private void refetchScores()
+        public void RefetchScores()
         {
             SetScores(Array.Empty<ScoreInfo>());
 
@@ -477,7 +477,7 @@ namespace osu.Game.Screens.SelectV2
                 case LeaderboardState.NetworkFailure:
                     return new ClickablePlaceholder(LeaderboardStrings.CouldntFetchScores, FontAwesome.Solid.Sync)
                     {
-                        Action = refetchScores
+                        Action = RefetchScores
                     };
 
                 case LeaderboardState.NoneSelected:

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -595,6 +595,8 @@ namespace osu.Game.Screens.SelectV2
 
             ensureGlobalBeatmapValid();
 
+            detailsArea.Refresh();
+
             if (ControlGlobalMusic)
             {
                 // restart playback on returning to song select, regardless.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34445.

The primary issue is that song select is the only one that supports non-score sort mode, and therefore if any other component changes the sort mode in a way opaque to song select to score, then song select will lose the sort mode because it's using the global leaderboard manager's state which will contain scores sorted by total.

Notably, the bug this is fixing requires specific circumstances. For instance, getting the bug to present requires going through the results screen; it is not enough to just *start gameplay* for the bug to manifest, because starting gameplay causes a working beatmap refetch:

https://github.com/ppy/osu/blob/4b73afd1957a9161e2956fc4191c8114d9958372/osu.Game/Screens/SelectV2/SongSelect.cs#L456-L457

which will trigger a *delayed schedule refetch* of the scores:

https://github.com/ppy/osu/blob/d2d3d14f1572ff8fc68fd01ea43c2ef68b5882fa/osu.Game/Screens/SelectV2/BeatmapLeaderboardWedge.cs#L235-L253

and because the refetch is thusly delayed, there's a very high chance it *will not run before the screen is resumed* because the wedge will not have its scheduler run until that point in time.

This conundrum is also why there is no test coverage for this, because the above makes test coverage setup rather annoying.