### PR TITLE
Display extended information about effect of beatmap attributes on gameplay in tooltip when hovering

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -292,7 +292,7 @@ namespace osu.Game.Rulesets.Catch
                 Description = "Affects the size of fruits.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (CatchHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize)).ToLocalisableString("0.##"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (CatchHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize)).ToLocalisableString("0.#"))
                 ]
             };
             yield return new RulesetBeatmapAttribute(SongSelectStrings.ApproachRate, @"AR", originalDifficulty.ApproachRate, effectiveDifficulty.ApproachRate, 10)
@@ -300,7 +300,7 @@ namespace osu.Game.Rulesets.Catch
                 Description = "Affects how early fruits fade in on the screen.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Fade-in time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, CatchHitObject.PREEMPT_RANGE):#,0.##}ms"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Fade-in time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, CatchHitObject.PREEMPT_RANGE):#,0.##} ms"))
                 ]
             };
             yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, effectiveDifficulty.DrainRate, 10)

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -26,6 +27,7 @@ using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
@@ -283,11 +285,28 @@ namespace osu.Game.Rulesets.Catch
         public override IEnumerable<RulesetBeatmapAttribute> GetBeatmapAttributesForDisplay(IBeatmapInfo beatmapInfo, IReadOnlyCollection<Mod> mods)
         {
             var originalDifficulty = beatmapInfo.Difficulty;
-            var adjustedDifficulty = GetAdjustedDisplayDifficulty(beatmapInfo, mods);
+            var effectiveDifficulty = GetAdjustedDisplayDifficulty(beatmapInfo, mods);
 
-            yield return new RulesetBeatmapAttribute(SongSelectStrings.CircleSize, @"CS", originalDifficulty.CircleSize, adjustedDifficulty.CircleSize, 10);
-            yield return new RulesetBeatmapAttribute(SongSelectStrings.ApproachRate, @"AR", originalDifficulty.ApproachRate, adjustedDifficulty.ApproachRate, 10);
-            yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, adjustedDifficulty.DrainRate, 10);
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.CircleSize, @"CS", originalDifficulty.CircleSize, effectiveDifficulty.CircleSize, 10)
+            {
+                Description = "Affects the size of fruits.",
+                AdditionalMetrics =
+                [
+                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (CatchHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize)).ToLocalisableString("N1"))
+                ]
+            };
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.ApproachRate, @"AR", originalDifficulty.ApproachRate, effectiveDifficulty.ApproachRate, 10)
+            {
+                Description = "Affects how early fruits fade in on the screen.",
+                AdditionalMetrics =
+                [
+                    new RulesetBeatmapAttribute.AdditionalMetric("Fade-in time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, CatchHitObject.PREEMPT_RANGE):N0}ms"))
+                ]
+            };
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, effectiveDifficulty.DrainRate, 10)
+            {
+                Description = "Affects the harshness of health drain and the health penalties for missing."
+            };
         }
 
         public override bool EditorShowScrollSpeed => false;

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -292,7 +292,7 @@ namespace osu.Game.Rulesets.Catch
                 Description = "Affects the size of fruits.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (CatchHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize)).ToLocalisableString("N1"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (CatchHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize)).ToLocalisableString("0.##"))
                 ]
             };
             yield return new RulesetBeatmapAttribute(SongSelectStrings.ApproachRate, @"AR", originalDifficulty.ApproachRate, effectiveDifficulty.ApproachRate, 10)
@@ -300,7 +300,7 @@ namespace osu.Game.Rulesets.Catch
                 Description = "Affects how early fruits fade in on the screen.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Fade-in time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, CatchHitObject.PREEMPT_RANGE):N0}ms"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Fade-in time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, CatchHitObject.PREEMPT_RANGE):#,0.##}ms"))
                 ]
             };
             yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, effectiveDifficulty.DrainRate, 10)

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Catch.Objects
         {
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
-            TimePreempt = (float)IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, PREEMPT_MAX, PREEMPT_MID, PREEMPT_MIN);
+            TimePreempt = (float)IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, PREEMPT_RANGE);
 
             Scale = LegacyRulesetExtensions.CalculateScaleFromCircleSize(difficulty.CircleSize);
         }
@@ -202,6 +202,8 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// Maximum preempt time at AR=0.
         /// </summary>
         public const double PREEMPT_MAX = 1800;
+
+        public static readonly DifficultyRange PREEMPT_RANGE = new DifficultyRange(PREEMPT_MAX, PREEMPT_MID, PREEMPT_MIN);
 
         /// <summary>
         /// The Y position of the hit object is not used in the normal osu!catch gameplay.

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -469,7 +469,7 @@ namespace osu.Game.Rulesets.Mania
                                               .Reverse()
                                               .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
                                                   $"{window.result.GetDescription().ToUpperInvariant()} hit window",
-                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result):0.##}ms"),
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result):0.##} ms"),
                                                   colours.ForHitResult(window.result)
                                               )).ToArray()
             };

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -464,12 +464,12 @@ namespace osu.Game.Rulesets.Mania
                 Description = "Affects timing requirements for notes.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("PERFECT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Perfect):N1}ms"), colours.ForHitResult(HitResult.Perfect)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great):N1}ms"), colours.ForHitResult(HitResult.Great)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("GOOD hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Good):N1}ms"), colours.ForHitResult(HitResult.Good)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok):N1}ms"), colours.ForHitResult(HitResult.Ok)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh):N1}ms"), colours.ForHitResult(HitResult.Meh)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss):N1}ms"), colours.ForHitResult(HitResult.Miss)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("PERFECT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Perfect):0.##}ms"), colours.ForHitResult(HitResult.Perfect)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great):0.##}ms"), colours.ForHitResult(HitResult.Great)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("GOOD hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Good):0.##}ms"), colours.ForHitResult(HitResult.Good)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok):0.##}ms"), colours.ForHitResult(HitResult.Ok)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh):0.##}ms"), colours.ForHitResult(HitResult.Meh)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss):0.##}ms"), colours.ForHitResult(HitResult.Miss)),
                 ]
             };
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
@@ -464,15 +465,13 @@ namespace osu.Game.Rulesets.Mania
             yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, adjustedDifficulty.OverallDifficulty, 10)
             {
                 Description = "Affects timing requirements for notes.",
-                AdditionalMetrics =
-                [
-                    new RulesetBeatmapAttribute.AdditionalMetric("PERFECT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Perfect):0.##}ms"), colours.ForHitResult(HitResult.Perfect)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great):0.##}ms"), colours.ForHitResult(HitResult.Great)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("GOOD hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Good):0.##}ms"), colours.ForHitResult(HitResult.Good)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok):0.##}ms"), colours.ForHitResult(HitResult.Ok)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh):0.##}ms"), colours.ForHitResult(HitResult.Meh)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss):0.##}ms"), colours.ForHitResult(HitResult.Miss)),
-                ]
+                AdditionalMetrics = hitWindows.GetAllAvailableWindows()
+                                              .Reverse()
+                                              .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
+                                                  $"{window.result.GetDescription().ToUpperInvariant()} hit window",
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result):0.##}ms"),
+                                                  colours.ForHitResult(window.result)
+                                              )).ToArray()
             };
 
             yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, adjustedDifficulty.DrainRate, 10)

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -459,6 +459,8 @@ namespace osu.Game.Rulesets.Mania
 
             var hitWindows = new ManiaHitWindows();
             hitWindows.SetDifficulty(adjustedDifficulty.OverallDifficulty);
+            hitWindows.IsConvert = !beatmapInfo.Ruleset.Equals(RulesetInfo);
+            hitWindows.ClassicModActive = mods.Any(m => m is ManiaModClassic);
             yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, adjustedDifficulty.OverallDifficulty, 10)
             {
                 Description = "Affects timing requirements for notes.",

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -450,10 +450,33 @@ namespace osu.Game.Rulesets.Mania
                 CircleSize = ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), [])
             };
             var adjustedDifficulty = GetAdjustedDisplayDifficulty(beatmapInfo, mods);
+            var colours = new OsuColour();
 
-            yield return new RulesetBeatmapAttribute(SongSelectStrings.KeyCount, @"KC", originalDifficulty.CircleSize, adjustedDifficulty.CircleSize, 18);
-            yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, adjustedDifficulty.OverallDifficulty, 10);
-            yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, adjustedDifficulty.DrainRate, 10);
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.KeyCount, @"KC", originalDifficulty.CircleSize, adjustedDifficulty.CircleSize, 18)
+            {
+                Description = "Affects the number of key columns on the playfield."
+            };
+
+            var hitWindows = new ManiaHitWindows();
+            hitWindows.SetDifficulty(adjustedDifficulty.OverallDifficulty);
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, adjustedDifficulty.OverallDifficulty, 10)
+            {
+                Description = "Affects timing requirements for notes.",
+                AdditionalMetrics =
+                [
+                    new RulesetBeatmapAttribute.AdditionalMetric("PERFECT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Perfect):N1}ms"), colours.ForHitResult(HitResult.Perfect)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great):N1}ms"), colours.ForHitResult(HitResult.Great)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("GOOD hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Good):N1}ms"), colours.ForHitResult(HitResult.Good)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok):N1}ms"), colours.ForHitResult(HitResult.Ok)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh):N1}ms"), colours.ForHitResult(HitResult.Meh)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss):N1}ms"), colours.ForHitResult(HitResult.Miss)),
+                ]
+            };
+
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, adjustedDifficulty.DrainRate, 10)
+            {
+                Description = "Affects the harshness of health drain and the health penalties for missing."
+            };
         }
 
         public override IRulesetFilterCriteria CreateRulesetFilterCriteria()

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// </summary>
         public const double PREEMPT_MAX = 1800;
 
+        public static readonly DifficultyRange PREEMPT_RANGE = new DifficultyRange(PREEMPT_MAX, PREEMPT_MID, PREEMPT_MIN);
+
         public double TimePreempt { get; set; } = 600;
         public double TimeFadeIn = 400;
 
@@ -169,7 +171,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         {
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
-            TimePreempt = (float)IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, PREEMPT_MAX, PREEMPT_MID, PREEMPT_MIN);
+            TimePreempt = (float)IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, PREEMPT_RANGE);
 
             // Preempt time can go below 450ms. Normally, this is achieved via the DT mod which uniformly speeds up all animations game wide regardless of AR.
             // This uniform speedup is hard to match 1:1, however we can at least make AR>10 (via mods) feel good by extending the upper linear function above.

--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -21,12 +21,12 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// <summary>
         /// The RPM required to clear the spinner at ODs [ 0, 5, 10 ].
         /// </summary>
-        private static readonly DifficultyRange clear_rpm_range = new DifficultyRange(90, 150, 225);
+        public static readonly DifficultyRange CLEAR_RPM_RANGE = new DifficultyRange(90, 150, 225);
 
         /// <summary>
         /// The RPM required to complete the spinner and receive full score at ODs [ 0, 5, 10 ].
         /// </summary>
-        private static readonly DifficultyRange complete_rpm_range = new DifficultyRange(250, 380, 430);
+        public static readonly DifficultyRange COMPLETE_RPM_RANGE = new DifficultyRange(250, 380, 430);
 
         public double EndTime
         {
@@ -63,10 +63,10 @@ namespace osu.Game.Rulesets.Osu.Objects
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
             // The average RPS required over the length of the spinner to clear the spinner.
-            double minRps = IBeatmapDifficultyInfo.DifficultyRange(difficulty.OverallDifficulty, clear_rpm_range) / 60;
+            double minRps = IBeatmapDifficultyInfo.DifficultyRange(difficulty.OverallDifficulty, CLEAR_RPM_RANGE) / 60;
 
             // The RPS required over the length of the spinner to receive full score (all normal + bonus ticks).
-            double maxRps = IBeatmapDifficultyInfo.DifficultyRange(difficulty.OverallDifficulty, complete_rpm_range) / 60;
+            double maxRps = IBeatmapDifficultyInfo.DifficultyRange(difficulty.OverallDifficulty, COMPLETE_RPM_RANGE) / 60;
 
             double secondsDuration = Duration / 1000;
 

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -402,7 +402,7 @@ namespace osu.Game.Rulesets.Osu
                 Description = "Affects the size of hit circles and sliders.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize, applyFudge: true)).ToLocalisableString("0.##"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize, applyFudge: true)).ToLocalisableString("0.#"))
                 ]
             };
 
@@ -412,7 +412,7 @@ namespace osu.Game.Rulesets.Osu
                 Description = "Affects how early objects appear on screen relative to their hit time.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Approach time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, OsuHitObject.PREEMPT_RANGE):#,0.##}ms"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Approach time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, OsuHitObject.PREEMPT_RANGE):#,0.##} ms"))
                 ]
             };
 
@@ -432,7 +432,7 @@ namespace osu.Game.Rulesets.Osu
                                               .Reverse()
                                               .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
                                                   $"{window.result.GetDescription().ToUpperInvariant()} hit window",
-                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result) / rate:0.##}ms"),
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result) / rate:0.##} ms"),
                                                   colours.ForHitResult(window.result)
                                               )).Concat([
                                                   new RulesetBeatmapAttribute.AdditionalMetric("RPM required to clear spinners", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -418,7 +418,8 @@ namespace osu.Game.Rulesets.Osu
 
             // for OD is where it gets difficult.
             // when displaying hit window ranges with rate-changing mods active, we will want to adjust for rate ourselves, as `effectiveDifficulty` may not be accurate
-            // because `OsuHitWindows` applies a floor-and-round operation that will result in inaccurate results.
+            // because `OsuHitWindows` applies a floor-and-round operation that will result in inaccurate results
+            // (the floor-and-round needs to happen *before* rate is taken into account, not after).
             // for spinner RPM requirements, we do not want to involve rate-changing mods *at all*,
             // because rate-adjusting mods do not change the spin requirement (see `SpinnerRotationTracker.AddRotation()`).
             var hitWindows = new OsuHitWindows();

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -401,7 +401,7 @@ namespace osu.Game.Rulesets.Osu
                 Description = "Affects the size of hit circles and sliders.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize)).ToLocalisableString("N1"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize, applyFudge: true)).ToLocalisableString("0.##"))
                 ]
             };
 
@@ -411,7 +411,7 @@ namespace osu.Game.Rulesets.Osu
                 Description = "Affects how early objects appear on screen relative to their hit time.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("Approach time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, OsuHitObject.PREEMPT_RANGE):N0}ms"))
+                    new RulesetBeatmapAttribute.AdditionalMetric("Approach time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, OsuHitObject.PREEMPT_RANGE):#,0.##}ms"))
                 ]
             };
 
@@ -428,10 +428,10 @@ namespace osu.Game.Rulesets.Osu
                 Description = "Affects timing requirements for hit circles and spin speed requirements for spinners.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great) / rate:N1}ms"), colours.ForHitResult(HitResult.Great)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok) / rate:N1}ms"), colours.ForHitResult(HitResult.Ok)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh) / rate:N1}ms"), colours.ForHitResult(HitResult.Meh)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss) / rate:N1}ms"), colours.ForHitResult(HitResult.Miss)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great) / rate:0.##}ms"), colours.ForHitResult(HitResult.Great)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok) / rate:0.##}ms"), colours.ForHitResult(HitResult.Ok)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh) / rate:0.##}ms"), colours.ForHitResult(HitResult.Meh)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss) / rate:0.##}ms"), colours.ForHitResult(HitResult.Miss)),
                     new RulesetBeatmapAttribute.AdditionalMetric("RPM required to clear spinners", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),
                     new RulesetBeatmapAttribute.AdditionalMetric("RPM required to get full spinner bonus", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.COMPLETE_RPM_RANGE):N0} RPM")),
                 ]

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -432,7 +432,7 @@ namespace osu.Game.Rulesets.Osu
                                               .Reverse()
                                               .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
                                                   $"{window.result.GetDescription().ToUpperInvariant()} hit window",
-                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result):0.##}ms"),
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result) / rate:0.##}ms"),
                                                   colours.ForHitResult(window.result)
                                               )).Concat([
                                                   new RulesetBeatmapAttribute.AdditionalMetric("RPM required to clear spinners", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -426,15 +427,16 @@ namespace osu.Game.Rulesets.Osu
             yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, effectiveDifficulty.OverallDifficulty, 10)
             {
                 Description = "Affects timing requirements for hit circles and spin speed requirements for spinners.",
-                AdditionalMetrics =
-                [
-                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great) / rate:0.##}ms"), colours.ForHitResult(HitResult.Great)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok) / rate:0.##}ms"), colours.ForHitResult(HitResult.Ok)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh) / rate:0.##}ms"), colours.ForHitResult(HitResult.Meh)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss) / rate:0.##}ms"), colours.ForHitResult(HitResult.Miss)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("RPM required to clear spinners", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),
-                    new RulesetBeatmapAttribute.AdditionalMetric("RPM required to get full spinner bonus", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.COMPLETE_RPM_RANGE):N0} RPM")),
-                ]
+                AdditionalMetrics = hitWindows.GetAllAvailableWindows()
+                                              .Reverse()
+                                              .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
+                                                  $"{window.result.GetDescription().ToUpperInvariant()} hit window",
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result):0.##}ms"),
+                                                  colours.ForHitResult(window.result)
+                                              )).Concat([
+                                                  new RulesetBeatmapAttribute.AdditionalMetric("RPM required to clear spinners", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),
+                                                  new RulesetBeatmapAttribute.AdditionalMetric("RPM required to get full spinner bonus", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.COMPLETE_RPM_RANGE):N0} RPM")),
+                                              ]).ToArray()
             };
 
             // HP drain is thankfully simple enough.

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -13,11 +14,13 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Difficulty;
@@ -380,6 +383,65 @@ namespace osu.Game.Rulesets.Osu
             adjustedDifficulty.OverallDifficulty = (float)IBeatmapDifficultyInfo.InverseDifficultyRange(greatHitWindow, OsuHitWindows.GREAT_WINDOW_RANGE);
 
             return adjustedDifficulty;
+        }
+
+        public override IEnumerable<RulesetBeatmapAttribute> GetBeatmapAttributesForDisplay(IBeatmapInfo beatmapInfo, IReadOnlyCollection<Mod> mods)
+        {
+            var originalDifficulty = beatmapInfo.Difficulty;
+            // `modAdjustedDifficulty` contains only the direct effect of mods.
+            // `effectiveDifficulty` contains the "perceived" effect of rate-adjusting mods on OD and AR.
+            // we make a distinction here, because some of the calculations below will require very careful maneuvering between the two for correct results.
+            var modAdjustedDifficulty = base.GetAdjustedDisplayDifficulty(beatmapInfo, mods);
+            var effectiveDifficulty = GetAdjustedDisplayDifficulty(beatmapInfo, mods);
+            var colours = new OsuColour();
+
+            // for circle size, we can use `effectiveDifficulty` directly
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.CircleSize, @"CS", originalDifficulty.CircleSize, effectiveDifficulty.CircleSize, 10)
+            {
+                Description = "Affects the size of hit circles and sliders.",
+                AdditionalMetrics =
+                [
+                    new RulesetBeatmapAttribute.AdditionalMetric("Hit circle radius", (OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize)).ToLocalisableString("N1"))
+                ]
+            };
+
+            // for approach rate, we can use `effectiveDifficulty` directly, and it is even convenient to do so (it correctly handles rate-changing mods like DT/HT)
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.ApproachRate, @"AR", originalDifficulty.ApproachRate, effectiveDifficulty.ApproachRate, 10)
+            {
+                Description = "Affects how early objects appear on screen relative to their hit time.",
+                AdditionalMetrics =
+                [
+                    new RulesetBeatmapAttribute.AdditionalMetric("Approach time", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(effectiveDifficulty.ApproachRate, OsuHitObject.PREEMPT_RANGE):N0}ms"))
+                ]
+            };
+
+            // for OD is where it gets difficult.
+            // when displaying hit window ranges with rate-changing mods active, we will want to adjust for rate ourselves, as `effectiveDifficulty` may not be accurate
+            // because `OsuHitWindows` applies a floor-and-round operation that will result in inaccurate results.
+            // for spinner RPM requirements, we do not want to involve rate-changing mods *at all*,
+            // because rate-adjusting mods do not change the spin requirement (see `SpinnerRotationTracker.AddRotation()`).
+            var hitWindows = new OsuHitWindows();
+            hitWindows.SetDifficulty(modAdjustedDifficulty.OverallDifficulty);
+            double rate = ModUtils.CalculateRateWithMods(mods);
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, effectiveDifficulty.OverallDifficulty, 10)
+            {
+                Description = "Affects timing requirements for hit circles and spin speed requirements for spinners.",
+                AdditionalMetrics =
+                [
+                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great) / rate:N1}ms"), colours.ForHitResult(HitResult.Great)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok) / rate:N1}ms"), colours.ForHitResult(HitResult.Ok)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MEH hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Meh) / rate:N1}ms"), colours.ForHitResult(HitResult.Meh)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss) / rate:N1}ms"), colours.ForHitResult(HitResult.Miss)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("RPM required to clear spinners", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),
+                    new RulesetBeatmapAttribute.AdditionalMetric("RPM required to get full spinner bonus", LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.COMPLETE_RPM_RANGE):N0} RPM")),
+                ]
+            };
+
+            // HP drain is thankfully simple enough.
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, effectiveDifficulty.DrainRate, 10)
+            {
+                Description = "Affects the harshness of health drain and the health penalties for missing."
+            };
         }
 
         public override bool EditorShowScrollSpeed => false;

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
 
                 case IHasDuration endTimeData:
                 {
-                    double hitMultiplier = IBeatmapDifficultyInfo.DifficultyRange(beatmap.Difficulty.OverallDifficulty, 3, 5, 7.5) * swell_hit_multiplier;
+                    double hitMultiplier = RequiredSwellHitsPerSecond(beatmap.Difficulty.OverallDifficulty);
 
                     yield return new Swell
                     {
@@ -171,6 +171,9 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 }
             }
         }
+
+        public static double RequiredSwellHitsPerSecond(double overallDifficulty)
+            => IBeatmapDifficultyInfo.DifficultyRange(overallDifficulty, 3, 5, 7.5) * swell_hit_multiplier;
 
         private bool shouldConvertSliderToHits(HitObject obj, IBeatmap beatmap, IHasPath pathData, out int taikoDuration, out double tickSpacing)
         {

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -304,10 +304,10 @@ namespace osu.Game.Rulesets.Taiko
                 Description = "Affects timing requirements for hits and mash rate requirements for swells.",
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great) / rate:N1}ms"), colours.ForHitResult(HitResult.Great)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok) / rate:N1}ms"), colours.ForHitResult(HitResult.Ok)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss) / rate:N1}ms"), colours.ForHitResult(HitResult.Miss)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("Hits per second required to clear swells", LocalisableString.Interpolate($@"{TaikoBeatmapConverter.RequiredSwellHitsPerSecond(modAdjustedDifficulty.OverallDifficulty):N1}")),
+                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great) / rate:0.##}ms"), colours.ForHitResult(HitResult.Great)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok) / rate:0.##}ms"), colours.ForHitResult(HitResult.Ok)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss) / rate:0.##}ms"), colours.ForHitResult(HitResult.Miss)),
+                    new RulesetBeatmapAttribute.AdditionalMetric("Hits per second required to clear swells", LocalisableString.Interpolate($@"{TaikoBeatmapConverter.RequiredSwellHitsPerSecond(modAdjustedDifficulty.OverallDifficulty):0.##}")),
                 ]
             };
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -296,7 +296,8 @@ namespace osu.Game.Rulesets.Taiko
             var colours = new OsuColour();
 
             // when displaying hit window ranges with rate-changing mods active, we will want to adjust for rate ourselves, as `effectiveDifficulty` may not be accurate
-            // because `TaikoHitWindows` applies a floor-and-round operation that will result in inaccurate results.
+            // because `TaikoHitWindows` applies a floor-and-round operation that will result in inaccurate results
+            // (the floor-and-round needs to happen *before* rate is taken into account, not after).
             var hitWindows = new TaikoHitWindows();
             hitWindows.SetDifficulty(modAdjustedDifficulty.OverallDifficulty);
             double rate = ModUtils.CalculateRateWithMods(mods);

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -308,7 +308,7 @@ namespace osu.Game.Rulesets.Taiko
                                               .Reverse()
                                               .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
                                                   $"{window.result.GetDescription().ToUpperInvariant()} hit window",
-                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result):0.##}ms"),
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result) / rate:0.##}ms"),
                                                   colours.ForHitResult(window.result)
                                               ))
                                               .Append(new RulesetBeatmapAttribute.AdditionalMetric("Hits per second required to clear swells", LocalisableString.Interpolate($@"{TaikoBeatmapConverter.RequiredSwellHitsPerSecond(modAdjustedDifficulty.OverallDifficulty):0.##}")))

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -308,10 +308,10 @@ namespace osu.Game.Rulesets.Taiko
                                               .Reverse()
                                               .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
                                                   $"{window.result.GetDescription().ToUpperInvariant()} hit window",
-                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result) / rate:0.##}ms"),
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result) / rate:0.##} ms"),
                                                   colours.ForHitResult(window.result)
                                               ))
-                                              .Append(new RulesetBeatmapAttribute.AdditionalMetric("Hits per second required to clear swells", LocalisableString.Interpolate($@"{TaikoBeatmapConverter.RequiredSwellHitsPerSecond(modAdjustedDifficulty.OverallDifficulty):0.##}")))
+                                              .Append(new RulesetBeatmapAttribute.AdditionalMetric("Hits per second required to clear swells", LocalisableString.Interpolate($@"{TaikoBeatmapConverter.RequiredSwellHitsPerSecond(modAdjustedDifficulty.OverallDifficulty):0.#}")))
                                               .ToArray()
             };
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
@@ -302,13 +303,15 @@ namespace osu.Game.Rulesets.Taiko
             yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, effectiveDifficulty.OverallDifficulty, 10)
             {
                 Description = "Affects timing requirements for hits and mash rate requirements for swells.",
-                AdditionalMetrics =
-                [
-                    new RulesetBeatmapAttribute.AdditionalMetric("GREAT hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Great) / rate:0.##}ms"), colours.ForHitResult(HitResult.Great)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("OK hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Ok) / rate:0.##}ms"), colours.ForHitResult(HitResult.Ok)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("MISS hit window", LocalisableString.Interpolate($@"±{hitWindows.WindowFor(HitResult.Miss) / rate:0.##}ms"), colours.ForHitResult(HitResult.Miss)),
-                    new RulesetBeatmapAttribute.AdditionalMetric("Hits per second required to clear swells", LocalisableString.Interpolate($@"{TaikoBeatmapConverter.RequiredSwellHitsPerSecond(modAdjustedDifficulty.OverallDifficulty):0.##}")),
-                ]
+                AdditionalMetrics = hitWindows.GetAllAvailableWindows()
+                                              .Reverse()
+                                              .Select(window => new RulesetBeatmapAttribute.AdditionalMetric(
+                                                  $"{window.result.GetDescription().ToUpperInvariant()} hit window",
+                                                  LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result):0.##}ms"),
+                                                  colours.ForHitResult(window.result)
+                                              ))
+                                              .Append(new RulesetBeatmapAttribute.AdditionalMetric("Hits per second required to clear swells", LocalisableString.Interpolate($@"{TaikoBeatmapConverter.RequiredSwellHitsPerSecond(modAdjustedDifficulty.OverallDifficulty):0.##}")))
+                                              .ToArray()
             };
 
             yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, effectiveDifficulty.DrainRate, 10)

--- a/osu.Game/Overlays/Mods/BeatmapAttributeTooltip.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributeTooltip.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Difficulty;
 using osuTK;
@@ -23,7 +24,7 @@ namespace osu.Game.Overlays.Mods
 
         private RulesetBeatmapAttribute? attribute;
         private OsuSpriteText adjustedByModsText = null!;
-        private OsuSpriteText descriptionText = null!;
+        private OsuTextFlowContainer descriptionText = null!;
         private GridContainer metricsGrid = null!;
 
         [Resolved]
@@ -62,7 +63,11 @@ namespace osu.Game.Overlays.Mods
                             Spacing = new Vector2(10),
                             Children = new Drawable[]
                             {
-                                descriptionText = new OsuSpriteText(),
+                                descriptionText = new OsuTextFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    MaximumSize = new Vector2(380, 0),
+                                },
                                 metricsGrid = new GridContainer
                                 {
                                     AutoSizeAxes = Axes.Both,

--- a/osu.Game/Overlays/Mods/BeatmapAttributeTooltip.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributeTooltip.cs
@@ -99,18 +99,18 @@ namespace osu.Game.Overlays.Mods
                 {
                     new OsuSpriteText
                     {
-                        Font = OsuFont.Style.Caption1,
+                        Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold),
                         Text = metric.Name,
-                        Colour = metric.Colour ?? Colour4.White,
+                        Colour = metric.Colour ?? colourProvider?.Content2 ?? Colour4.White,
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                     },
                     Empty(),
                     new OsuSpriteText
                     {
-                        Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                        Font = OsuFont.Style.Caption1,
                         Text = metric.Value,
-                        Colour = metric.Colour ?? Colour4.White,
+                        Colour = Interpolation.ValueAt<Colour4>(0.85f, colourProvider?.Content1 ?? Colour4.White, metric.Colour ?? colourProvider?.Content1 ?? Colour4.White, 0, 1),
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                     }

--- a/osu.Game/Overlays/Mods/BeatmapAttributeTooltip.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributeTooltip.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Overlays.Mods
                                 },
                                 adjustedByModsText = new OsuSpriteText
                                 {
-                                    Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
                                 },
                             }
                         },
@@ -100,7 +100,8 @@ namespace osu.Game.Overlays.Mods
                     new OsuSpriteText
                     {
                         Font = OsuFont.Style.Caption1,
-                        Text = metric.name,
+                        Text = metric.Name,
+                        Colour = metric.Colour ?? Colour4.White,
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                     },
@@ -108,7 +109,8 @@ namespace osu.Game.Overlays.Mods
                     new OsuSpriteText
                     {
                         Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
-                        Text = metric.value,
+                        Text = metric.Value,
+                        Colour = metric.Colour ?? Colour4.White,
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                     }

--- a/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -27,7 +26,7 @@ namespace osu.Game.Overlays.Mods
     /// On the mod select overlay, this provides a local updating view of BPM, star rating and other
     /// difficulty attributes so the user can have a better insight into what mods are changing.
     /// </summary>
-    public partial class BeatmapAttributesDisplay : ModFooterInformationDisplay, IHasCustomTooltip<AdjustedAttributesTooltip.Data?>
+    public partial class BeatmapAttributesDisplay : ModFooterInformationDisplay
     {
         private StarRatingDisplay starRatingDisplay = null!;
         private BPMDisplay bpmDisplay = null!;
@@ -50,10 +49,6 @@ namespace osu.Game.Overlays.Mods
 
         private CancellationTokenSource? cancellationSource;
         private IBindable<StarDifficulty> starDifficulty = null!;
-
-        public ITooltip<AdjustedAttributesTooltip.Data?> GetCustomTooltip() => new AdjustedAttributesTooltip();
-
-        public AdjustedAttributesTooltip.Data? TooltipContent { get; private set; }
 
         private const float transition_duration = 250;
 
@@ -164,8 +159,6 @@ namespace osu.Game.Overlays.Mods
             Ruleset ruleset = GameRuleset.Value.CreateInstance();
             var displayAttributes = ruleset.GetBeatmapAttributesForDisplay(BeatmapInfo.Value, Mods.Value).ToList();
 
-            TooltipContent = new AdjustedAttributesTooltip.Data(displayAttributes);
-
             // if there are not enough attribute displays, make more
             for (int i = RightContent.Count; i < displayAttributes.Count; i++)
                 RightContent.Add(new VerticalAttributeDisplay { Shear = -OsuGame.SHEAR });
@@ -175,16 +168,12 @@ namespace osu.Game.Overlays.Mods
             {
                 var attribute = displayAttributes[i];
                 var display = (VerticalAttributeDisplay)RightContent[i];
-
-                display.Label = attribute.Acronym;
-                display.Current.Value = attribute.AdjustedValue;
-                display.AdjustType.Value = VerticalAttributeDisplay.CalculateEffect(attribute.OriginalValue, attribute.AdjustedValue);
-                display.Alpha = 1;
+                display.SetAttribute(attribute);
             }
 
             // and hide any extra ones
             for (int i = displayAttributes.Count; i < RightContent.Count; i++)
-                RightContent[i].Alpha = 0;
+                ((VerticalAttributeDisplay)RightContent[i]).SetAttribute(null);
         });
 
         private void updateCollapsedState()

--- a/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
+++ b/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Overlays.Mods
             };
         }
 
-        public ITooltip<RulesetBeatmapAttribute?> GetCustomTooltip() => new AdjustedAttributeTooltip();
+        public ITooltip<RulesetBeatmapAttribute?> GetCustomTooltip() => new BeatmapAttributeTooltip();
         public RulesetBeatmapAttribute? TooltipContent { get; set; }
     }
 }

--- a/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
+++ b/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
@@ -7,28 +7,21 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Mods
 {
-    public partial class VerticalAttributeDisplay : Container, IHasCurrentValue<double>
+    public partial class VerticalAttributeDisplay : Container, IHasCustomTooltip<RulesetBeatmapAttribute?>
     {
-        public Bindable<double> Current
-        {
-            get => current.Current;
-            set => current.Current = value;
-        }
-
         private readonly BindableWithCurrent<double> current = new BindableWithCurrent<double>();
-
-        public Bindable<ModEffect> AdjustType = new Bindable<ModEffect>();
 
         /// <summary>
         /// Text to display in the top area of the display.
@@ -45,11 +38,70 @@ namespace osu.Game.Overlays.Mods
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
-        private void updateTextColor()
+        public VerticalAttributeDisplay()
+        {
+            AutoSizeAxes = Axes.X;
+            RelativeSizeAxes = Axes.Y;
+
+            Origin = Anchor.CentreLeft;
+            Anchor = Anchor.CentreLeft;
+
+            InternalChild = new FillFlowContainer
+            {
+                Origin = Anchor.CentreLeft,
+                Anchor = Anchor.CentreLeft,
+                RelativeSizeAxes = Axes.Y,
+                Width = 42,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    text = new OsuSpriteText
+                    {
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        Font = OsuFont.Default.With(size: 20, weight: FontWeight.Bold)
+                    },
+                    counter = new EffectCounter
+                    {
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        Current = { BindTarget = current },
+                    }
+                }
+            };
+        }
+
+        public void SetAttribute(RulesetBeatmapAttribute? attribute)
+        {
+            if (attribute != null)
+            {
+                text.Text = attribute.Acronym;
+                current.Value = attribute.AdjustedValue;
+                var effect = calculateEffect(attribute.OriginalValue, attribute.AdjustedValue);
+                updateTextColor(effect);
+                Alpha = 1;
+            }
+            else
+                Alpha = 0;
+
+            TooltipContent = attribute;
+        }
+
+        private static ModEffect calculateEffect(double oldValue, double newValue)
+        {
+            if (Precision.AlmostEquals(newValue, oldValue, 0.01))
+                return ModEffect.NotChanged;
+            if (newValue < oldValue)
+                return ModEffect.DifficultyReduction;
+
+            return ModEffect.DifficultyIncrease;
+        }
+
+        private void updateTextColor(ModEffect effect)
         {
             Color4 newColor;
 
-            switch (AdjustType.Value)
+            switch (effect)
             {
                 case ModEffect.NotChanged:
                     newColor = Color4.White;
@@ -64,56 +116,11 @@ namespace osu.Game.Overlays.Mods
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(AdjustType.Value));
+                    throw new ArgumentOutOfRangeException(nameof(effect), effect, null);
             }
 
             text.Colour = newColor;
             counter.Colour = newColor;
-        }
-
-        public VerticalAttributeDisplay()
-        {
-            AutoSizeAxes = Axes.X;
-
-            Origin = Anchor.CentreLeft;
-            Anchor = Anchor.CentreLeft;
-
-            AdjustType.BindValueChanged(_ => updateTextColor());
-
-            InternalChild = new FillFlowContainer
-            {
-                Origin = Anchor.CentreLeft,
-                Anchor = Anchor.CentreLeft,
-                AutoSizeAxes = Axes.Y,
-                Width = 50,
-                Direction = FillDirection.Vertical,
-                Children = new Drawable[]
-                {
-                    text = new OsuSpriteText
-                    {
-                        Origin = Anchor.Centre,
-                        Anchor = Anchor.Centre,
-                        Margin = new MarginPadding { Horizontal = 15 }, // to reserve space for 0.XX value
-                        Font = OsuFont.Default.With(size: 20, weight: FontWeight.Bold)
-                    },
-                    counter = new EffectCounter
-                    {
-                        Origin = Anchor.Centre,
-                        Anchor = Anchor.Centre,
-                        Current = { BindTarget = Current },
-                    }
-                }
-            };
-        }
-
-        public static ModEffect CalculateEffect(double oldValue, double newValue)
-        {
-            if (Precision.AlmostEquals(newValue, oldValue, 0.01))
-                return ModEffect.NotChanged;
-            if (newValue < oldValue)
-                return ModEffect.DifficultyReduction;
-
-            return ModEffect.DifficultyIncrease;
         }
 
         public enum ModEffect
@@ -134,5 +141,8 @@ namespace osu.Game.Overlays.Mods
                 Font = OsuFont.Default.With(size: 18, weight: FontWeight.SemiBold)
             };
         }
+
+        public ITooltip<RulesetBeatmapAttribute?> GetCustomTooltip() => new AdjustedAttributeTooltip();
+        public RulesetBeatmapAttribute? TooltipContent { get; set; }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/RulesetBeatmapDifficulty.cs
+++ b/osu.Game/Rulesets/Difficulty/RulesetBeatmapDifficulty.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 
@@ -50,7 +51,7 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// Contains any and all additional metrics about how this attribute affects gameplay to show to the users.
         /// </summary>
-        public (LocalisableString name, LocalisableString value)[] AdditionalMetrics { get; init; } = [];
+        public AdditionalMetric[] AdditionalMetrics { get; init; } = [];
 
         public RulesetBeatmapAttribute(LocalisableString label, string acronym, float originalValue, float adjustedValue, float maxValue)
         {
@@ -60,5 +61,7 @@ namespace osu.Game.Rulesets.Difficulty
             AdjustedValue = adjustedValue;
             MaxValue = maxValue;
         }
+
+        public record AdditionalMetric(LocalisableString Name, LocalisableString Value, Colour4? Colour = null);
     }
 }

--- a/osu.Game/Rulesets/Difficulty/RulesetBeatmapDifficulty.cs
+++ b/osu.Game/Rulesets/Difficulty/RulesetBeatmapDifficulty.cs
@@ -15,15 +15,50 @@ namespace osu.Game.Rulesets.Difficulty
     /// some want to provide specific extended information for a <see cref="BeatmapDifficulty"/> field
     /// or adjust the "effective display" in different ways.
     /// </summary>
-    /// <param name="Label">The long label for this beatmap attribute.</param>
-    /// <param name="Acronym">A two-letter acronym for this beatmap attribute.</param>
-    /// <param name="OriginalValue">The value of this attribute before application of mods.</param>
-    /// <param name="AdjustedValue">The "effective" value of this attribute after application of mods.</param>
-    /// <param name="MaxValue">The highest allowable value of this attribute.</param>
-    public record RulesetBeatmapAttribute(
-        LocalisableString Label,
-        string Acronym,
-        float OriginalValue,
-        float AdjustedValue,
-        float MaxValue);
+    public class RulesetBeatmapAttribute
+    {
+        /// <summary>
+        /// The long label for this beatmap attribute.
+        /// </summary>
+        public LocalisableString Label { get; }
+
+        /// <summary>
+        /// A two-letter acronym for this beatmap attribute.
+        /// </summary>
+        public string Acronym { get; }
+
+        /// <summary>
+        /// The value of this attribute before application of mods.
+        /// </summary>
+        public float OriginalValue { get; }
+
+        /// <summary>
+        /// The "effective" value of this attribute after application of mods.
+        /// </summary>
+        public float AdjustedValue { get; }
+
+        /// <summary>
+        /// The highest allowable value of this attribute.
+        /// </summary>
+        public float MaxValue { get; }
+
+        /// <summary>
+        /// An optional extended description of this attribute.
+        /// </summary>
+        public LocalisableString? Description { get; init; }
+
+        /// <summary>
+        /// Contains any and all additional metrics about how this attribute affects gameplay to show to the users.
+        /// </summary>
+        public (LocalisableString name, LocalisableString value)[] AdditionalMetrics { get; init; } = [];
+
+        public RulesetBeatmapAttribute(LocalisableString label, string acronym, float originalValue, float adjustedValue, float maxValue)
+        {
+            Label = label;
+            Acronym = acronym;
+            OriginalValue = originalValue;
+            AdjustedValue = adjustedValue;
+            MaxValue = maxValue;
+        }
+    }
 }

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -362,7 +362,7 @@ namespace osu.Game.Screens.Select.Details
                 TooltipContent = attribute;
             }
 
-            public ITooltip<RulesetBeatmapAttribute> GetCustomTooltip() => new AdjustedAttributeTooltip();
+            public ITooltip<RulesetBeatmapAttribute> GetCustomTooltip() => new BeatmapAttributeTooltip();
 
             [CanBeNull]
             public RulesetBeatmapAttribute TooltipContent { get; set; }

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using osu.Game.Rulesets.Mods;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Extensions;
 using osu.Framework.Localisation;
 using osu.Framework.Threading;
@@ -29,11 +30,12 @@ using osu.Game.Configuration;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Utils;
 
 namespace osu.Game.Screens.Select.Details
 {
-    public partial class AdvancedStats : Container, IHasCustomTooltip<AdjustedAttributesTooltip.Data>
+    public partial class AdvancedStats : Container
     {
         private readonly int columns;
 
@@ -42,9 +44,6 @@ namespace osu.Game.Screens.Select.Details
 
         protected FillFlowContainer Flow { get; private set; }
         private readonly StatisticRow starDifficulty;
-
-        public ITooltip<AdjustedAttributesTooltip.Data> GetCustomTooltip() => new AdjustedAttributesTooltip();
-        public AdjustedAttributesTooltip.Data TooltipContent { get; private set; }
 
         private IBeatmapInfo beatmapInfo;
 
@@ -160,7 +159,6 @@ namespace osu.Game.Screens.Select.Details
             if (BeatmapInfo != null && Ruleset.Value != null)
             {
                 var displayAttributes = Ruleset.Value.CreateInstance().GetBeatmapAttributesForDisplay(BeatmapInfo, Mods.Value).ToList();
-                TooltipContent = new AdjustedAttributesTooltip.Data(displayAttributes);
 
                 // if there are not enough attribute displays, make more
                 // the subtraction of 1 is to exclude the star rating row which is always present (and always last)
@@ -177,17 +175,13 @@ namespace osu.Game.Screens.Select.Details
                 for (int i = 0; i < displayAttributes.Count; i++)
                 {
                     var attribute = displayAttributes[i];
-                    var display = (StatisticRow)Flow.Where(r => r != starDifficulty).ElementAt(i);
-
-                    display.Title = attribute.Label;
-                    display.MaxValue = attribute.MaxValue;
-                    display.Value = (attribute.OriginalValue, attribute.AdjustedValue);
-                    display.Alpha = 1;
+                    var row = (StatisticRow)Flow.Where(r => r != starDifficulty).ElementAt(i);
+                    row.SetAttribute(attribute);
                 }
 
                 // and hide any extra ones
                 foreach (var row in Flow.Where(r => r != starDifficulty).Skip(displayAttributes.Count))
-                    row.Alpha = 0;
+                    ((StatisticRow)row).SetAttribute(null);
             }
 
             updateStarDifficulty();
@@ -233,7 +227,7 @@ namespace osu.Game.Screens.Select.Details
             starDifficultyCancellationSource?.Cancel();
         }
 
-        public partial class StatisticRow : Container, IHasAccentColour
+        public partial class StatisticRow : Container, IHasAccentColour, IHasCustomTooltip<RulesetBeatmapAttribute>
         {
             private const float value_width = 25;
             private const float name_width = 70;
@@ -352,6 +346,26 @@ namespace osu.Game.Screens.Select.Details
                     },
                 };
             }
+
+            public void SetAttribute([CanBeNull] RulesetBeatmapAttribute attribute)
+            {
+                if (attribute != null)
+                {
+                    Title = attribute.Label;
+                    MaxValue = attribute.MaxValue;
+                    Value = (attribute.OriginalValue, attribute.AdjustedValue);
+                    Alpha = 1;
+                }
+                else
+                    Alpha = 0;
+
+                TooltipContent = attribute;
+            }
+
+            public ITooltip<RulesetBeatmapAttribute> GetCustomTooltip() => new AdjustedAttributeTooltip();
+
+            [CanBeNull]
+            public RulesetBeatmapAttribute TooltipContent { get; set; }
         }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -11,7 +11,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
@@ -23,7 +22,6 @@ using osu.Game.Localisation;
 using osu.Game.Online;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osuTK.Graphics;
@@ -62,7 +60,7 @@ namespace osu.Game.Screens.SelectV2
 
             private GridContainer ratingAndNameContainer = null!;
             private DifficultyStatisticsDisplay countStatisticsDisplay = null!;
-            private AdjustableDifficultyStatisticsDisplay difficultyStatisticsDisplay = null!;
+            private DifficultyStatisticsDisplay difficultyStatisticsDisplay = null!;
 
             private CancellationTokenSource? cancellationSource;
 
@@ -195,7 +193,7 @@ namespace osu.Game.Screens.SelectV2
                                                         RelativeSizeAxes = Axes.X,
                                                     },
                                                     Empty(),
-                                                    difficultyStatisticsDisplay = new AdjustableDifficultyStatisticsDisplay(autoSize: true),
+                                                    difficultyStatisticsDisplay = new DifficultyStatisticsDisplay(autoSize: true),
                                                 }
                                             },
                                         }
@@ -289,7 +287,6 @@ namespace osu.Game.Screens.SelectV2
             {
                 if (beatmap.IsDefault || ruleset.Value == null)
                 {
-                    difficultyStatisticsDisplay.TooltipContent = null;
                     difficultyStatisticsDisplay.Statistics = Array.Empty<StatisticDifficulty.Data>();
                     return;
                 }
@@ -297,7 +294,6 @@ namespace osu.Game.Screens.SelectV2
                 Ruleset rulesetInstance = ruleset.Value.CreateInstance();
 
                 var displayAttributes = rulesetInstance.GetBeatmapAttributesForDisplay(beatmap.Value.BeatmapInfo, mods.Value).ToList();
-                difficultyStatisticsDisplay.TooltipContent = new AdjustedAttributesTooltip.Data(displayAttributes);
                 difficultyStatisticsDisplay.Statistics = displayAttributes.Select(a => new StatisticDifficulty.Data(a)).ToList();
             });
 
@@ -323,21 +319,6 @@ namespace osu.Game.Screens.SelectV2
                 {
                     TooltipText = ContextMenuStrings.ViewProfile;
                     IdleColour = overlayColourProvider?.Light2 ?? colours.Blue;
-                }
-            }
-
-            private partial class AdjustableDifficultyStatisticsDisplay : DifficultyStatisticsDisplay, IHasCustomTooltip<AdjustedAttributesTooltip.Data>
-            {
-                [Resolved]
-                private OverlayColourProvider colourProvider { get; set; } = null!;
-
-                public ITooltip<AdjustedAttributesTooltip.Data> GetCustomTooltip() => new AdjustedAttributesTooltip(colourProvider);
-
-                public AdjustedAttributesTooltip.Data? TooltipContent { get; set; }
-
-                public AdjustableDifficultyStatisticsDisplay(bool autoSize)
-                    : base(autoSize)
-                {
                 }
             }
         }

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_StatisticDifficulty.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_StatisticDifficulty.cs
@@ -7,12 +7,14 @@ using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Difficulty;
 using osuTK;
 using osuTK.Graphics;
@@ -21,7 +23,7 @@ namespace osu.Game.Screens.SelectV2
 {
     public partial class BeatmapTitleWedge
     {
-        public partial class StatisticDifficulty : CompositeDrawable, IHasAccentColour
+        public partial class StatisticDifficulty : CompositeDrawable, IHasAccentColour, IHasCustomTooltip<RulesetBeatmapAttribute?>
         {
             private Data value = new Data(string.Empty, 0, 0, 0);
 
@@ -192,13 +194,16 @@ namespace osu.Game.Screens.SelectV2
                 }
             }
 
-            public record Data(LocalisableString Label, float Value, float AdjustedValue, float Maximum, string? Content = null)
+            public record Data(LocalisableString Label, float Value, float AdjustedValue, float Maximum, string? Content = null, RulesetBeatmapAttribute? BeatmapAttribute = null)
             {
                 public Data(RulesetBeatmapAttribute attribute)
-                    : this(attribute.Label, attribute.OriginalValue, attribute.AdjustedValue, attribute.MaxValue)
+                    : this(attribute.Label, attribute.OriginalValue, attribute.AdjustedValue, attribute.MaxValue, BeatmapAttribute: attribute)
                 {
                 }
             }
+
+            public ITooltip<RulesetBeatmapAttribute?> GetCustomTooltip() => new AdjustedAttributeTooltip();
+            public RulesetBeatmapAttribute? TooltipContent => value.BeatmapAttribute;
         }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_StatisticDifficulty.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_StatisticDifficulty.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Screens.SelectV2
                 }
             }
 
-            public ITooltip<RulesetBeatmapAttribute?> GetCustomTooltip() => new AdjustedAttributeTooltip();
+            public ITooltip<RulesetBeatmapAttribute?> GetCustomTooltip() => new BeatmapAttributeTooltip();
             public RulesetBeatmapAttribute? TooltipContent => value.BeatmapAttribute;
         }
     }


### PR DESCRIPTION
The extended information in question being specifically: object radius and approach / fade-in time information in osu! and catch, and hit window thresholds in all rulesets but catch, among others.

https://github.com/user-attachments/assets/72fd6515-718f-4c7e-99b5-d900e95870a5

These tooltips display in both old and new song select, as well as in the attribute display in the lower right corner of the mod select screen.

---

Closes https://github.com/ppy/osu/issues/6202.

The diff is a bit large mostly because on master there is one giant tooltip for all beatmap attributes. That's also what stable has, but I kind of thought that I don't really like that and that it may be a better idea to have tooltips specific to a single beatmap attribute. This way it is very clear which attribute influences what on the map.

Due to that, if it helps, https://github.com/ppy/osu/commit/cb73717a3419afb539764d37df53b3fc50aa5f91 can probably be split off to a separate PR if it helps review.

I am not going to lie that the code that's calculating these properties does get very hairy at times. I don't have much of a defense to provide to that. That is the effect of inviting the amount of complexity that users have demanded from us.