### PR TITLE
Calculate multiplayer room difficulty range based only on non-expired items when the room is open

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -87,10 +88,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        public void TestExpiredItemsNotIncluded()
+        public void TestExpiredItemsNotIncludedIfRoomOpen()
         {
-            AddStep("set playlist", () =>
+            AddStep("set up room", () =>
             {
+                room.EndDate = null;
                 room.Playlist =
                 [
                     new PlaylistItem(new BeatmapInfo { StarRating = 1 }) { ID = TestResources.GetNextTestID(), Expired = true },
@@ -104,6 +106,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
             AddAssert("minimum is 2.00*", () => this.ChildrenOfType<StarRatingDisplay>().ElementAt(0).Current.Value.Stars, () => Is.EqualTo(2));
             AddAssert("maximum is 5.00*", () => this.ChildrenOfType<StarRatingDisplay>().ElementAt(1).Current.Value.Stars, () => Is.EqualTo(5));
+        }
+
+        [Test]
+        public void TestExpiredItemsIncludedIfRoomEnded()
+        {
+            AddStep("set up room", () =>
+            {
+                room.EndDate = DateTimeOffset.Now;
+                room.Playlist =
+                [
+                    new PlaylistItem(new BeatmapInfo { StarRating = 1 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 2 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 3 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 4 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 5 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 6 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 7 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                ];
+            });
+            AddAssert("minimum is 1.00*", () => this.ChildrenOfType<StarRatingDisplay>().ElementAt(0).Current.Value.Stars, () => Is.EqualTo(1));
+            AddAssert("maximum is 7.00*", () => this.ChildrenOfType<StarRatingDisplay>().ElementAt(1).Current.Value.Stars, () => Is.EqualTo(7));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Tests.Resources;
@@ -81,6 +84,26 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     new PlaylistItem(new BeatmapInfo { StarRating = max }) { ID = TestResources.GetNextTestID() },
                 ];
             });
+        }
+
+        [Test]
+        public void TestExpiredItemsNotIncluded()
+        {
+            AddStep("set playlist", () =>
+            {
+                room.Playlist =
+                [
+                    new PlaylistItem(new BeatmapInfo { StarRating = 1 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 2 }) { ID = TestResources.GetNextTestID(), Expired = false },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 3 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 4 }) { ID = TestResources.GetNextTestID(), Expired = false },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 5 }) { ID = TestResources.GetNextTestID(), Expired = false },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 6 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                    new PlaylistItem(new BeatmapInfo { StarRating = 7 }) { ID = TestResources.GetNextTestID(), Expired = true },
+                ];
+            });
+            AddAssert("minimum is 2.00*", () => this.ChildrenOfType<StarRatingDisplay>().ElementAt(0).Current.Value.Stars, () => Is.EqualTo(2));
+            AddAssert("maximum is 5.00*", () => this.ChildrenOfType<StarRatingDisplay>().ElementAt(1).Current.Value.Stars, () => Is.EqualTo(5));
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -115,11 +116,14 @@ namespace osu.Game.Screens.OnlinePlay.Components
             else
             {
                 // When Playlist is not empty (in room) we compute actual range
-                var orderedDifficulties = room.Playlist
-                                              .Where(item => !item.Expired)
-                                              .Select(item => item.Beatmap)
-                                              .OrderBy(b => b.StarRating)
-                                              .ToArray();
+                IEnumerable<PlaylistItem> difficultyRangeSource = room.Playlist;
+
+                if (!room.HasEnded)
+                    difficultyRangeSource = difficultyRangeSource.Where(playlistItem => !playlistItem.Expired);
+
+                var orderedDifficulties = difficultyRangeSource.Select(item => item.Beatmap)
+                                                               .OrderBy(b => b.StarRating)
+                                                               .ToArray();
 
                 minDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[0].StarRating : 0, 0);
                 maxDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[^1].StarRating : 0, 0);

--- a/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
@@ -115,7 +115,11 @@ namespace osu.Game.Screens.OnlinePlay.Components
             else
             {
                 // When Playlist is not empty (in room) we compute actual range
-                var orderedDifficulties = room.Playlist.Select(p => p.Beatmap).OrderBy(b => b.StarRating).ToArray();
+                var orderedDifficulties = room.Playlist
+                                              .Where(item => !item.Expired)
+                                              .Select(item => item.Beatmap)
+                                              .OrderBy(b => b.StarRating)
+                                              .ToArray();
 
                 minDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[0].StarRating : 0, 0);
                 maxDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[^1].StarRating : 0, 0);


### PR DESCRIPTION
- Fixes one part of https://github.com/ppy/osu/issues/34379.
- See also: https://github.com/ppy/osu-web/pull/12325.

Note the caveat that this only applies ***when the room is open***. After the room has ended expired items are taken into account again. This is to avoid showing an empty [0.00*, 0.00*] range on ended rooms, since after all ended rooms should invariably have all of their playlist items expired.