### PR TITLE
Add verify check for inconsistent timing control points

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckInconsistentTimingControlPointsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckInconsistentTimingControlPointsTest.cs
@@ -1,0 +1,256 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    [TestFixture]
+    public class CheckInconsistentTimingControlPointsTest
+    {
+        private CheckInconsistentTimingControlPoints check = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckInconsistentTimingControlPoints();
+        }
+
+        [Test]
+        public void TestConsistentTiming()
+        {
+            var beatmaps = createBeatmapSetWithTiming(
+                new[] { 1000.0, 2000.0 }, // Timing at 1000ms and 2000ms
+                new[] { 1000.0, 2000.0 } // Same timing
+            );
+
+            var context = createContext(beatmaps[0], beatmaps);
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestMissingTimingPoint()
+        {
+            var beatmaps = createBeatmapSetWithTiming(
+                new[] { 1000.0, 2000.0 }, // Reference has timing at 1000ms and 2000ms
+                new[] { 1000.0 } // Second difficulty missing timing at 2000ms
+            );
+
+            var context = createContext(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.All(issue => issue.Template is CheckInconsistentTimingControlPoints.IssueTemplateMissingTimingPoint));
+        }
+
+        [Test]
+        public void TestInconsistentBPM()
+        {
+            var beatmaps = createBeatmapSetWithBPM(
+                new[] { (1000.0, 500.0) }, // Reference: 120 BPM (500ms beat length)
+                new[] { (1000.0, 600.0) } // Second: 100 BPM (600ms beat length)
+            );
+
+            var context = createContext(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.All(issue => issue.Template is CheckInconsistentTimingControlPoints.IssueTemplateInconsistentBPM));
+        }
+
+        [Test]
+        public void TestInconsistentMeter()
+        {
+            var beatmaps = createBeatmapSetWithMeter(
+                new[] { (1000.0, TimeSignature.SimpleQuadruple) }, // Reference: 4/4
+                new[] { (1000.0, TimeSignature.SimpleTriple) } // Second: 3/4
+            );
+
+            var context = createContext(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.All(issue => issue.Template is CheckInconsistentTimingControlPoints.IssueTemplateInconsistentMeter));
+        }
+
+        [Test]
+        public void TestDecimalOffset()
+        {
+            var beatmaps = createBeatmapSetWithTiming(
+                new[] { 1000.0 }, // Reference at exactly 1000ms
+                new[] { 1000.5 } // Second at 1000.5ms (decimal difference)
+            );
+
+            var context = createContext(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(2));
+            Assert.That(issues.All(issue => issue.Template is CheckInconsistentTimingControlPoints.IssueTemplateMissingTimingPointMinor));
+        }
+
+        [Test]
+        public void TestSingleDifficulty()
+        {
+            var beatmaps = createBeatmapSetWithTiming(
+                new[] { 1000.0, 2000.0 } // Only one difficulty
+            );
+
+            var context = createContext(beatmaps[0], beatmaps);
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestExtraTimingPoint()
+        {
+            var beatmaps = createBeatmapSetWithTiming(
+                new[] { 1000.0 }, // Reference has timing at 1000ms
+                new[] { 1000.0, 2000.0 } // Second has additional timing at 2000ms
+            );
+
+            var context = createContext(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.All(issue => issue.Template is CheckInconsistentTimingControlPoints.IssueTemplateExtraTimingPoint));
+        }
+
+        private IBeatmap[] createBeatmapSetWithTiming(params double[][] timingPoints)
+        {
+            var beatmapSet = new BeatmapSetInfo();
+            var beatmaps = new IBeatmap[timingPoints.Length];
+
+            for (int i = 0; i < timingPoints.Length; i++)
+            {
+                beatmaps[i] = createBeatmapWithTiming(timingPoints[i], $"Difficulty {i + 1}");
+                beatmaps[i].BeatmapInfo.BeatmapSet = beatmapSet;
+            }
+
+            foreach (var beatmap in beatmaps)
+                beatmapSet.Beatmaps.Add(beatmap.BeatmapInfo);
+
+            return beatmaps;
+        }
+
+        private IBeatmap[] createBeatmapSetWithBPM(params (double time, double beatLength)[][] timingData)
+        {
+            var beatmapSet = new BeatmapSetInfo();
+            var beatmaps = new IBeatmap[timingData.Length];
+
+            for (int i = 0; i < timingData.Length; i++)
+            {
+                beatmaps[i] = createBeatmapWithBPM(timingData[i], $"Difficulty {i + 1}");
+                beatmaps[i].BeatmapInfo.BeatmapSet = beatmapSet;
+            }
+
+            foreach (var beatmap in beatmaps)
+                beatmapSet.Beatmaps.Add(beatmap.BeatmapInfo);
+
+            return beatmaps;
+        }
+
+        private IBeatmap[] createBeatmapSetWithMeter(params (double time, TimeSignature meter)[][] timingData)
+        {
+            var beatmapSet = new BeatmapSetInfo();
+            var beatmaps = new IBeatmap[timingData.Length];
+
+            for (int i = 0; i < timingData.Length; i++)
+            {
+                beatmaps[i] = createBeatmapWithMeter(timingData[i], $"Difficulty {i + 1}");
+                beatmaps[i].BeatmapInfo.BeatmapSet = beatmapSet;
+            }
+
+            foreach (var beatmap in beatmaps)
+                beatmapSet.Beatmaps.Add(beatmap.BeatmapInfo);
+
+            return beatmaps;
+        }
+
+        private IBeatmap createBeatmapWithTiming(double[] timingPoints, string difficultyName)
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    DifficultyName = difficultyName,
+                    Metadata = new BeatmapMetadata()
+                },
+                ControlPointInfo = new ControlPointInfo()
+            };
+
+            foreach (double time in timingPoints)
+            {
+                beatmap.ControlPointInfo.Add(time, new TimingControlPoint
+                {
+                    BeatLength = 500 // 120 BPM
+                });
+            }
+
+            return beatmap;
+        }
+
+        private IBeatmap createBeatmapWithBPM((double time, double beatLength)[] timingData, string difficultyName)
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    DifficultyName = difficultyName,
+                    Metadata = new BeatmapMetadata()
+                },
+                ControlPointInfo = new ControlPointInfo()
+            };
+
+            foreach ((double time, double beatLength) in timingData)
+            {
+                beatmap.ControlPointInfo.Add(time, new TimingControlPoint
+                {
+                    BeatLength = beatLength
+                });
+            }
+
+            return beatmap;
+        }
+
+        private IBeatmap createBeatmapWithMeter((double time, TimeSignature meter)[] timingData, string difficultyName)
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    DifficultyName = difficultyName,
+                    Metadata = new BeatmapMetadata()
+                },
+                ControlPointInfo = new ControlPointInfo()
+            };
+
+            foreach ((double time, var meter) in timingData)
+            {
+                beatmap.ControlPointInfo.Add(time, new TimingControlPoint
+                {
+                    BeatLength = 500, // 120 BPM
+                    TimeSignature = meter
+                });
+            }
+
+            return beatmap;
+        }
+
+        private BeatmapVerifierContext createContext(IBeatmap currentBeatmap, IBeatmap[] allDifficulties)
+        {
+            return new BeatmapVerifierContext(
+                currentBeatmap,
+                new TestWorkingBeatmap(currentBeatmap),
+                DifficultyRating.ExpertPlus,
+                beatmapInfo => allDifficulties.FirstOrDefault(b => b.BeatmapInfo.Equals(beatmapInfo))
+            );
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Rulesets.Edit
 
             // Timing
             new CheckPreviewTime(),
+            new CheckInconsistentTimingControlPoints(),
 
             // Events
             new CheckBreaks(),

--- a/osu.Game/Rulesets/Edit/Checks/CheckInconsistentTimingControlPoints.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckInconsistentTimingControlPoints.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Edit.Checks
                         }
 
                         // Check for BPM inconsistency
-                        if (Math.Abs(referencePoint.BeatLength - matchingPoint.BeatLength) > TimingCheckUtils.TIMING_TOLERANCE)
+                        if (Math.Abs(referencePoint.BeatLength - matchingPoint.BeatLength) > TimingCheckUtils.TIME_OFFSET_TOLERANCE_MS)
                         {
                             yield return new IssueTemplateInconsistentBPM(this).Create(referencePoint.Time, beatmap.BeatmapInfo.DifficultyName);
                         }

--- a/osu.Game/Rulesets/Edit/Checks/CheckInconsistentTimingControlPoints.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckInconsistentTimingControlPoints.cs
@@ -1,0 +1,162 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Edit.Checks.Components;
+
+namespace osu.Game.Rulesets.Edit.Checks
+{
+    public class CheckInconsistentTimingControlPoints : ICheck
+    {
+        // Small tolerance for floating point comparison
+        private const double timing_tolerance = 0.01;
+
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Timing, "Inconsistent timing control points");
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateMissingTimingPoint(this),
+            new IssueTemplateExtraTimingPoint(this),
+            new IssueTemplateMissingTimingPointMinor(this),
+            new IssueTemplateInconsistentMeter(this),
+            new IssueTemplateInconsistentBPM(this)
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            var difficulties = context.BeatmapsetDifficulties;
+
+            if (difficulties.Count <= 1)
+                yield break;
+
+            // Use the current difficulty as reference
+            var referenceBeatmap = context.Beatmap;
+            var referenceTimingPoints = referenceBeatmap.ControlPointInfo.TimingPoints;
+
+            foreach (var beatmap in difficulties)
+            {
+                if (beatmap == referenceBeatmap)
+                    continue;
+
+                var timingPoints = beatmap.ControlPointInfo.TimingPoints;
+
+                // Check each timing point in the reference against this difficulty
+                foreach (var referencePoint in referenceTimingPoints)
+                {
+                    var matchingPoint = findMatchingTimingPoint(timingPoints, referencePoint.Time);
+                    var exactMatchingPoint = findExactMatchingTimingPoint(timingPoints, referencePoint.Time);
+
+                    if (matchingPoint == null)
+                    {
+                        yield return new IssueTemplateMissingTimingPoint(this).Create(referencePoint.Time, beatmap.BeatmapInfo.DifficultyName);
+                    }
+                    else
+                    {
+                        // Check for meter signature inconsistency
+                        if (!referencePoint.TimeSignature.Equals(matchingPoint.TimeSignature))
+                        {
+                            yield return new IssueTemplateInconsistentMeter(this).Create(referencePoint.Time, beatmap.BeatmapInfo.DifficultyName);
+                        }
+
+                        // Check for BPM inconsistency
+                        if (Math.Abs(referencePoint.BeatLength - matchingPoint.BeatLength) > timing_tolerance)
+                        {
+                            yield return new IssueTemplateInconsistentBPM(this).Create(referencePoint.Time, beatmap.BeatmapInfo.DifficultyName);
+                        }
+
+                        // Check for exact timing match (decimal precision)
+                        if (exactMatchingPoint == null)
+                        {
+                            yield return new IssueTemplateMissingTimingPointMinor(this).Create(referencePoint.Time, beatmap.BeatmapInfo.DifficultyName);
+                        }
+                    }
+                }
+
+                // Check timing points in this difficulty that aren't in the reference
+                foreach (var timingPoint in timingPoints)
+                {
+                    var matchingReferencePoint = findMatchingTimingPoint(referenceTimingPoints, timingPoint.Time);
+                    var exactMatchingReferencePoint = findExactMatchingTimingPoint(referenceTimingPoints, timingPoint.Time);
+
+                    if (matchingReferencePoint == null)
+                    {
+                        yield return new IssueTemplateExtraTimingPoint(this).Create(timingPoint.Time, beatmap.BeatmapInfo.DifficultyName);
+                    }
+                    else if (exactMatchingReferencePoint == null)
+                    {
+                        yield return new IssueTemplateMissingTimingPointMinor(this).Create(timingPoint.Time, beatmap.BeatmapInfo.DifficultyName);
+                    }
+                }
+            }
+        }
+
+        private static TimingControlPoint? findMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
+        {
+            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, Math.Round(time), 1.0));
+        }
+
+        private static TimingControlPoint? findExactMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
+        {
+            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, time, timing_tolerance));
+        }
+
+        public class IssueTemplateMissingTimingPoint : IssueTemplate
+        {
+            public IssueTemplateMissingTimingPoint(ICheck check)
+                : base(check, IssueType.Problem, "Missing timing control point in {0}.")
+            {
+            }
+
+            public Issue Create(double time, string difficultyName)
+                => new Issue(time, this, difficultyName);
+        }
+
+        public class IssueTemplateExtraTimingPoint : IssueTemplate
+        {
+            public IssueTemplateExtraTimingPoint(ICheck check)
+                : base(check, IssueType.Problem, "Extra timing control point in {0}.")
+            {
+            }
+
+            public Issue Create(double time, string difficultyName)
+                => new Issue(time, this, difficultyName);
+        }
+
+        public class IssueTemplateMissingTimingPointMinor : IssueTemplate
+        {
+            public IssueTemplateMissingTimingPointMinor(ICheck check)
+                : base(check, IssueType.Negligible, "Timing control point has decimally different offset in {0}.")
+            {
+            }
+
+            public Issue Create(double time, string difficultyName)
+                => new Issue(time, this, difficultyName);
+        }
+
+        public class IssueTemplateInconsistentMeter : IssueTemplate
+        {
+            public IssueTemplateInconsistentMeter(ICheck check)
+                : base(check, IssueType.Problem, "Inconsistent time signature in {0}.")
+            {
+            }
+
+            public Issue Create(double time, string difficultyName)
+                => new Issue(time, this, difficultyName);
+        }
+
+        public class IssueTemplateInconsistentBPM : IssueTemplate
+        {
+            public IssueTemplateInconsistentBPM(ICheck check)
+                : base(check, IssueType.Problem, "Inconsistent BPM in {0}.")
+            {
+            }
+
+            public Issue Create(double time, string difficultyName)
+                => new Issue(time, this, difficultyName);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckInconsistentTimingControlPoints.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckInconsistentTimingControlPoints.cs
@@ -3,18 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Utils;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
 {
     public class CheckInconsistentTimingControlPoints : ICheck
     {
-        // Small tolerance for floating point comparison
-        private const double timing_tolerance = 0.01;
-
         public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Timing, "Inconsistent timing control points");
 
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
@@ -47,8 +41,8 @@ namespace osu.Game.Rulesets.Edit.Checks
                 // Check each timing point in the reference against this difficulty
                 foreach (var referencePoint in referenceTimingPoints)
                 {
-                    var matchingPoint = findMatchingTimingPoint(timingPoints, referencePoint.Time);
-                    var exactMatchingPoint = findExactMatchingTimingPoint(timingPoints, referencePoint.Time);
+                    var matchingPoint = TimingCheckUtils.FindMatchingTimingPoint(timingPoints, referencePoint.Time);
+                    var exactMatchingPoint = TimingCheckUtils.FindExactMatchingTimingPoint(timingPoints, referencePoint.Time);
 
                     if (matchingPoint == null)
                     {
@@ -63,7 +57,7 @@ namespace osu.Game.Rulesets.Edit.Checks
                         }
 
                         // Check for BPM inconsistency
-                        if (Math.Abs(referencePoint.BeatLength - matchingPoint.BeatLength) > timing_tolerance)
+                        if (Math.Abs(referencePoint.BeatLength - matchingPoint.BeatLength) > TimingCheckUtils.TIMING_TOLERANCE)
                         {
                             yield return new IssueTemplateInconsistentBPM(this).Create(referencePoint.Time, beatmap.BeatmapInfo.DifficultyName);
                         }
@@ -79,8 +73,8 @@ namespace osu.Game.Rulesets.Edit.Checks
                 // Check timing points in this difficulty that aren't in the reference
                 foreach (var timingPoint in timingPoints)
                 {
-                    var matchingReferencePoint = findMatchingTimingPoint(referenceTimingPoints, timingPoint.Time);
-                    var exactMatchingReferencePoint = findExactMatchingTimingPoint(referenceTimingPoints, timingPoint.Time);
+                    var matchingReferencePoint = TimingCheckUtils.FindMatchingTimingPoint(referenceTimingPoints, timingPoint.Time);
+                    var exactMatchingReferencePoint = TimingCheckUtils.FindExactMatchingTimingPoint(referenceTimingPoints, timingPoint.Time);
 
                     if (matchingReferencePoint == null)
                     {
@@ -92,16 +86,6 @@ namespace osu.Game.Rulesets.Edit.Checks
                     }
                 }
             }
-        }
-
-        private static TimingControlPoint? findMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
-        {
-            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, Math.Round(time), 1.0));
-        }
-
-        private static TimingControlPoint? findExactMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
-        {
-            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, time, timing_tolerance));
         }
 
         public class IssueTemplateMissingTimingPoint : IssueTemplate

--- a/osu.Game/Rulesets/Edit/Checks/Components/TimingCheckUtils.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/TimingCheckUtils.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Utils;
@@ -11,8 +10,8 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
 {
     public static class TimingCheckUtils
     {
-        // Small tolerance for floating point comparison
-        public const double TIMING_TOLERANCE = 0.01;
+        // Tolerance for exact time offset matching (in milliseconds)
+        public const double TIME_OFFSET_TOLERANCE_MS = 0.01;
 
         /// <summary>
         /// Finds a timing control point that starts at approximately the same time (within 1ms after rounding).
@@ -22,7 +21,7 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// <returns>The matching timing control point, or null if none found.</returns>
         public static TimingControlPoint? FindMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
         {
-            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, Math.Round(time), 1.0));
+            return timingPoints.FirstOrDefault(tp => (int)tp.Time == (int)time);
         }
 
         /// <summary>
@@ -33,7 +32,7 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// <returns>The exact matching timing control point, or null if none found.</returns>
         public static TimingControlPoint? FindExactMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
         {
-            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, time, TIMING_TOLERANCE));
+            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, time, TIME_OFFSET_TOLERANCE_MS));
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/Components/TimingCheckUtils.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/TimingCheckUtils.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps.ControlPoints;
+
+namespace osu.Game.Rulesets.Edit.Checks.Components
+{
+    public static class TimingCheckUtils
+    {
+        // Small tolerance for floating point comparison
+        public const double TIMING_TOLERANCE = 0.01;
+
+        /// <summary>
+        /// Finds a timing control point that starts at approximately the same time (within 1ms after rounding).
+        /// </summary>
+        /// <param name="timingPoints">The collection of timing points to search.</param>
+        /// <param name="time">The time to match against.</param>
+        /// <returns>The matching timing control point, or null if none found.</returns>
+        public static TimingControlPoint? FindMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
+        {
+            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, Math.Round(time), 1.0));
+        }
+
+        /// <summary>
+        /// Finds a timing control point that starts at precisely the same time (within timing tolerance).
+        /// </summary>
+        /// <param name="timingPoints">The collection of timing points to search.</param>
+        /// <param name="time">The time to match against.</param>
+        /// <returns>The exact matching timing control point, or null if none found.</returns>
+        public static TimingControlPoint? FindExactMatchingTimingPoint(IEnumerable<TimingControlPoint> timingPoints, double time)
+        {
+            return timingPoints.FirstOrDefault(tp => Precision.AlmostEquals(tp.Time, time, TIMING_TOLERANCE));
+        }
+    }
+}


### PR DESCRIPTION
Part of #12091

Ports [the following check](https://github.com/Naxesss/MapsetVerifier/blob/main/src/Checks/AllModes/Timing/CheckInconsistentLines.cs) from MV.

Checks for missing/extra timing points, and BPM/time signature inconsistencies.

MV using the first diff as reference felt less intuitive in real usage and sometimes didn't work, this should be solved here.