### PR TITLE
Default to SDL3 for Tachyon builds

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -38,6 +38,11 @@ namespace osu.Desktop
             // last time has been fixed, let's not tempt fate.
             setupVelopack(args);
 
+#if DEBUG || TACHYON
+            if (Environment.GetEnvironmentVariable("OSU_SDL3") == null)
+                Environment.SetEnvironmentVariable("OSU_SDL3", "1");
+#endif
+
             if (OperatingSystem.IsWindows())
             {
                 var windowsVersion = Environment.OSVersion.Version;

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -13,6 +13,10 @@
     <FileVersion>0.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <IsTachyonRelease Condition="$([System.String]::Copy('$(Version)').EndsWith('-tachyon'))">true</IsTachyonRelease>
+    <DefineConstants Condition="'$(IsTachyonRelease)' == 'true'">$(DefineConstants);TACHYON</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
     <StartupObject>osu.Desktop.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup Label="Project References">


### PR DESCRIPTION
For whenever this is ready to be considered...

- Only applies to Tachyon builds.
- Allows `OSU_SDL3` to be used as a disable flag.