### PR TITLE
Fix missing disposal of Realm subscription

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardManager.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardManager.cs
@@ -188,6 +188,13 @@ namespace osu.Game.Online.Leaderboards
             var newScoresArray = newScores.ToArray();
             scores.Value = LeaderboardScores.Success(newScoresArray, newScoresArray.Length, null);
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            localScoreSubscription?.Dispose();
+        }
     }
 
     public record LeaderboardCriteria(


### PR DESCRIPTION
Test memory leak (it doesn't look like this would matter in practice), and also likely the cause of test failures: https://github.com/ppy/osu/pull/34473/checks?check_run_id=47257940528

As a bonus, I've gone through every usage of `RegisterForNotifications` and verified that disposals appear to be being done correctly elsewhere.