### PR TITLE
Don't require pixel precision to expand editor toolboxes

### DIFF
--- a/osu.Game/Graphics/Containers/ExpandingContainer.cs
+++ b/osu.Game/Graphics/Containers/ExpandingContainer.cs
@@ -76,12 +76,6 @@ namespace osu.Game.Graphics.Containers
             return true;
         }
 
-        protected override bool OnMouseMove(MouseMoveEvent e)
-        {
-            updateHoverExpansion();
-            return base.OnMouseMove(e);
-        }
-
         protected override void OnHoverLost(HoverLostEvent e)
         {
             if (hoverExpandEvent != null)


### PR DESCRIPTION
I don't think this takes away from usability and it's the easiest solution to fix an actual issue.

Closes https://github.com/ppy/osu/issues/34471.