### PR TITLE
Fade music back in when returning from song select from gameplay

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -598,6 +598,18 @@ namespace osu.Game.Screens.SelectV2
 
             if (ControlGlobalMusic)
             {
+                // Avoid abruptly starting playback at preview point.
+                if (!music.IsPlaying)
+                {
+                    music.DuckMomentarily(0, new DuckParameters
+                    {
+                        DuckDuration = 0,
+                        DuckVolumeTo = 0,
+                        RestoreDuration = 800,
+                        RestoreEasing = Easing.OutQuint
+                    });
+                }
+
                 // restart playback on returning to song select, regardless.
                 // not sure this should be a permanent thing (we may want to leave a user pause paused even on returning)
                 music.ResetTrackAdjustments();

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -404,9 +404,6 @@ namespace osu.Game.Screens.SelectV2
 
         private void beginLooping()
         {
-            if (!ControlGlobalMusic)
-                return;
-
             Debug.Assert(!isHandlingLooping);
 
             isHandlingLooping = true;
@@ -598,18 +595,6 @@ namespace osu.Game.Screens.SelectV2
 
             if (ControlGlobalMusic)
             {
-                // Avoid abruptly starting playback at preview point.
-                if (!music.IsPlaying)
-                {
-                    music.DuckMomentarily(0, new DuckParameters
-                    {
-                        DuckDuration = 0,
-                        DuckVolumeTo = 0,
-                        RestoreDuration = 800,
-                        RestoreEasing = Easing.OutQuint
-                    });
-                }
-
                 // restart playback on returning to song select, regardless.
                 // not sure this should be a permanent thing (we may want to leave a user pause paused even on returning)
                 music.ResetTrackAdjustments();
@@ -646,7 +631,23 @@ namespace osu.Game.Screens.SelectV2
 
             updateWedgeVisibility();
 
-            beginLooping();
+            if (ControlGlobalMusic)
+            {
+                // Avoid abruptly starting playback at preview point.
+                // Importantly, this should be done before looping is setup to ensure we get the correct imminent `IsPlaying` state.
+                if (!music.IsPlaying)
+                {
+                    music.DuckMomentarily(0, new DuckParameters
+                    {
+                        DuckDuration = 0,
+                        DuckVolumeTo = 0,
+                        RestoreDuration = 800,
+                        RestoreEasing = Easing.OutQuint
+                    });
+                }
+
+                beginLooping();
+            }
 
             ensureGlobalBeatmapValid();
 


### PR DESCRIPTION
Addresses abrupt playback pointed out in https://github.com/ppy/osu/discussions/34472.

In cases where the music is already playing, this isn't required (ie when returning from the player loading screen before gameplay starts).