### PR TITLE
Fix gameplay leaderboard showing for a split second on entering gameplay

### DIFF
--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -62,6 +62,7 @@ namespace osu.Game.Screens.Play.HUD
                     RelativeSizeAxes = Axes.Both,
                     Child = Flow = new FillFlowContainer<DrawableGameplayLeaderboardScore>
                     {
+                        Alpha = 0f,
                         RelativeSizeAxes = Axes.X,
                         X = DrawableGameplayLeaderboardScore.SHEAR_WIDTH,
                         AutoSizeAxes = Axes.Y,


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34433

The transform is too short (100ms) that it's hard to capture in desktop, but here's a slo-mo footage with my iPhone (although it's really obvious in code):

https://github.com/user-attachments/assets/35c6fa5e-81e4-4653-aebe-70e00efafc35

