### PR TITLE
Prevent playing sliding sounds in hold notes when beatmap is not converted

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapSampleConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapSampleConversionTest.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         [TestCase("convert-samples")]
         [TestCase("mania-samples")]
+        [TestCase("mania-slider")] // e.g. second and fourth notes of https://osu.ppy.sh/beatmapsets/73883#mania/216407
         [TestCase("slider-convert-samples")]
         public void Test(string name) => base.Test(name);
 
@@ -32,6 +33,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 StartTime = hitObject.StartTime,
                 EndTime = hitObject.GetEndTime(),
                 Column = ((ManiaHitObject)hitObject).Column,
+                PlaySlidingSamples = hitObject is HoldNote holdNote && holdNote.PlaySlidingSamples,
                 Samples = getSampleNames(hitObject.Samples),
                 NodeSamples = getNodeSampleNames((hitObject as HoldNote)?.NodeSamples)
             };
@@ -57,12 +59,14 @@ namespace osu.Game.Rulesets.Mania.Tests
         public double StartTime;
         public double EndTime;
         public int Column;
+        public bool PlaySlidingSamples;
         public IList<string> Samples;
         public IList<IList<string>> NodeSamples;
 
         public bool Equals(SampleConvertValue other)
             => Precision.AlmostEquals(StartTime, other.StartTime, conversion_lenience)
                && Precision.AlmostEquals(EndTime, other.EndTime, conversion_lenience)
+               && PlaySlidingSamples == other.PlaySlidingSamples
                && samplesEqual(Samples, other.Samples)
                && nodeSamplesEqual(NodeSamples, other.NodeSamples);
 

--- a/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/convert-samples-expected-conversion.json
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/convert-samples-expected-conversion.json
@@ -5,6 +5,7 @@
       "StartTime": 1000.0,
       "EndTime": 2750.0,
       "Column": 1,
+      "PlaySlidingSamples": true,
       "NodeSamples": [
         ["Gameplay/normal-hitnormal"],
         ["Gameplay/soft-hitnormal"],
@@ -15,6 +16,7 @@
       "StartTime": 1875.0,
       "EndTime": 2750.0,
       "Column": 0,
+      "PlaySlidingSamples": true,
       "NodeSamples": [
         ["Gameplay/soft-hitnormal"],
         ["Gameplay/drum-hitnormal"]

--- a/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/mania-samples-expected-conversion.json
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/mania-samples-expected-conversion.json
@@ -5,6 +5,7 @@
       "StartTime": 500.0,
       "EndTime": 1500.0,
       "Column": 0,
+      "PlaySlidingSamples": false,
       "NodeSamples": [
         ["Gameplay/normal-hitnormal"],
         []
@@ -17,6 +18,7 @@
       "StartTime": 2000.0,
       "EndTime": 3000.0,
       "Column": 2,
+      "PlaySlidingSamples": false,
       "NodeSamples": [
         ["Gameplay/drum-hitnormal"],
         []

--- a/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/mania-slider-expected-conversion.json
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/mania-slider-expected-conversion.json
@@ -1,0 +1,18 @@
+{
+  "Mappings": [{
+    "StartTime": 500.0,
+    "Objects": [{
+      "StartTime": 500.0,
+      "EndTime": 2500,
+      "Column": 2,
+      "PlaySlidingSamples": true,
+      "NodeSamples": [
+        ["Gameplay/soft-hitnormal"],
+        ["Gameplay/soft-hitnormal"],
+        ["Gameplay/soft-hitnormal"],
+        ["Gameplay/soft-hitnormal"]
+      ],
+      "Samples": ["Gameplay/soft-hitnormal"]
+    }]
+  }]
+}

--- a/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/mania-slider.osu
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/mania-slider.osu
@@ -1,0 +1,29 @@
+osu file format v5
+
+[General]
+StackLeniency: 0.7
+Mode: 3
+
+[Difficulty]
+HPDrainRate:2
+CircleSize:5
+OverallDifficulty:2
+SliderMultiplier:1
+SliderTickRate:2
+
+[Events]
+//Background and Video events
+//Break Periods
+//Storyboard Layer 0 (Background)
+//Storyboard Layer 1 (Failing)
+//Storyboard Layer 2 (Passing)
+//Storyboard Layer 3 (Foreground)
+//Storyboard Sound Samples
+//Background Colour Transformations
+3,100,163,162,255
+
+[TimingPoints]
+355,476.190476190476,4,2,1,60,1,0
+
+[HitObjects]
+256,352,500,2,0,L|256:208,3,140

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PassThroughPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PassThroughPatternGenerator.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
 
             if (HitObject is IHasDuration endTimeData)
             {
-                // despite the beatmap originally made for mania, if the object is parsed as a slider rather than a hold, sliding samples should still be played.
+                // despite the beatmap originally being made for mania, if the object is parsed as a slider rather than a hold, sliding samples should still be played.
                 // this is seemingly only possible to achieve by modifying the .osu file directly, but online beatmaps that do that exist
                 // (see second and fourth notes of https://osu.ppy.sh/beatmapsets/73883#mania/216407)
                 bool playSlidingSamples = (HitObject is IHasLegacyHitObjectType hasType && hasType.LegacyType == LegacyHitObjectType.Slider) || HitObject is IHasPath;

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PassThroughPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PassThroughPatternGenerator.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Utils;
 
@@ -30,12 +32,18 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
 
             if (HitObject is IHasDuration endTimeData)
             {
+                // despite the beatmap originally made for mania, if the object is parsed as a slider rather than a hold, sliding samples should still be played.
+                // this is seemingly only possible to achieve by modifying the .osu file directly, but online beatmaps that do that exist
+                // (see second and fourth notes of https://osu.ppy.sh/beatmapsets/73883#mania/216407)
+                bool playSlidingSamples = (HitObject is IHasLegacyHitObjectType hasType && hasType.LegacyType == LegacyHitObjectType.Slider) || HitObject is IHasPath;
+
                 pattern.Add(new HoldNote
                 {
                     StartTime = HitObject.StartTime,
                     Duration = endTimeData.Duration,
                     Column = column,
                     Samples = HitObject.Samples,
+                    PlaySlidingSamples = playSlidingSamples,
                     NodeSamples = (HitObject as IHasRepeats)?.NodeSamples ?? HoldNote.CreateDefaultNodeSamples(HitObject)
                 });
             }

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/SliderPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/SliderPatternGenerator.cs
@@ -521,6 +521,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
                     Duration = endTime - startTime,
                     Column = column,
                     Samples = HitObject.Samples,
+                    PlaySlidingSamples = true,
                     NodeSamples = nodeSamplesAt(startTime)
                 };
             }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                         StartTime = locations[i].startTime,
                         Duration = duration,
                         NodeSamples = new List<IList<HitSampleInfo>> { locations[i].samples, Array.Empty<HitSampleInfo>() }
+                        // intentionally don't play sliding samples here, it doesn't work in this mod.
                     });
                 }
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -80,7 +80,9 @@ namespace osu.Game.Rulesets.Mania.Mods
                 StartTime = hold.StartTime;
                 Duration = hold.Duration;
                 Column = hold.Column;
+                Samples = hold.Samples;
                 NodeSamples = hold.NodeSamples;
+                PlaySlidingSamples = hold.PlaySlidingSamples;
             }
 
             protected override void CreateNestedHitObjects(CancellationToken cancellationToken)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -355,7 +355,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         private void updateSlidingSample(ValueChangedEvent<bool> tracking)
         {
-            if (tracking.NewValue)
+            if (tracking.NewValue && HitObject.PlaySlidingSamples)
                 slidingSample?.Play();
             else
                 slidingSample?.Stop();

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -86,6 +86,11 @@ namespace osu.Game.Rulesets.Mania.Objects
         /// </summary>
         public HoldNoteBody Body { get; protected set; }
 
+        /// <summary>
+        /// Whether sliding samples should be played when held.
+        /// </summary>
+        public bool PlaySlidingSamples { get; init; }
+
         public override double MaximumJudgementOffset => Tail.MaximumJudgementOffset;
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27126

Stable explicitly prevents from playing the sliding samples when the hold note is not converted from an osu! slider:
 - [code of stable overriding sliding samples on non-converted hold notes](https://github.com/peppy/osu-stable-reference/blob/0e91e49bc83fe8b21c3ba5f1eb2d5d06456eae84/osu!/GameplayElements/HitObjects/Mania/HitCircleManiaHold.cs#L22-L26)
 - [code to confirm stable uses a special type for non-converted hold notes](https://github.com/peppy/osu-stable-reference/blob/0e91e49bc83fe8b21c3ba5f1eb2d5d06456eae84/osu!/GameplayElements/HitObjects/Mania/HitFactoryMania.cs#L255-L261)
 - [code to confirm stable uses a different type for converted hold notes](https://github.com/peppy/osu-stable-reference/blob/0e91e49bc83fe8b21c3ba5f1eb2d5d06456eae84/osu!/GameplayElements/HitObjects/Mania/SliderMania.cs#L269-L281)

This attempts to closely match stable by...pretty much doing the same.

I've also found "No Release" mod to not preserve sliding samples, causing them to not be played on converted beatmaps. I've fixed that.

I've also added a comment in "Invert" mod stating that sliding samples cannot possibly be added as it alters the sound design of the map completely (sliding samples start playing completely randomly).

I'm not sure if test coverage is necessary for how simple the changes are, and I'm not sure how much time I'll have to spend writing them, but I can do so if found necessary.