### PR TITLE
Fix update thread stutters upon completion of online beatmap lookup in song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
@@ -170,8 +170,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
             });
-            AddAssert("play count = 10000", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString() == "10,000");
-            AddAssert("favourites count = 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString() == "2,345");
+            AddUntilStep("play count is 10000", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("10,000"));
+            AddUntilStep("favourites count is 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,345"));
             AddStep("online beatmapset with local diff", () =>
             {
                 var (working, onlineSet) = createTestBeatmap();
@@ -181,8 +181,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
             });
-            AddAssert("play count = -", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString() == "-");
-            AddAssert("favourites count = 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString() == "2,345");
+            AddUntilStep("play count is -", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("-"));
+            AddUntilStep("favourites count is 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,345"));
             AddStep("local beatmapset", () =>
             {
                 var (working, _) = createTestBeatmap();
@@ -190,8 +190,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = null;
                 Beatmap.Value = working;
             });
-            AddAssert("play count = -", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString() == "-");
-            AddAssert("favourites count = -", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString() == "-");
+            AddUntilStep("play count is -", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("-"));
+            AddUntilStep("favourites count is -", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("-"));
         }
 
         [Test]
@@ -235,17 +235,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
             });
-            AddUntilStep("play count = 10000", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString() == "10,000");
-            AddUntilStep("favourites count = 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString() == "2,345");
+            AddUntilStep("play count is 10000", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("10,000"));
+            AddUntilStep("favourites count is 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,345"));
 
             AddStep("click favourite button", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().TriggerClick());
             AddStep("allow request to complete", () => resetEvent.Set());
-            AddAssert("favourites count = 2346", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString() == "2,346");
+            AddUntilStep("favourites count is 2346", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,346"));
 
             AddStep("reset event", () => resetEvent.Reset());
             AddStep("click favourite button", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().TriggerClick());
             AddStep("allow request to complete", () => resetEvent.Set());
-            AddAssert("favourites count = 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString() == "2,345");
+            AddUntilStep("favourites count is 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,345"));
 
             AddStep("reset event", () => resetEvent.Reset());
             AddStep("click favourite button", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().TriggerClick());
@@ -260,7 +260,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 Beatmap.Value = working;
             });
             AddStep("allow request to complete", () => resetEvent.Set());
-            AddAssert("favourites count = 9999", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString() == "9,999");
+            AddUntilStep("favourites count is 9999", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("9,999"));
 
             AddStep("set up request handler to fail", () =>
             {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34508

For whatever reason even on large collections this is not that noticeable on macOS and just completely horrible on windows. At least on the boxes I have access to...

| | before | after |
| :-: | :-: | :-: |
| macOS | <img width="1206" height="277" alt="image" src="https://github.com/user-attachments/assets/72df8f2e-a851-4bb8-9a66-5ecdb5f5c925" /> | <img width="1217" height="179" alt="image" src="https://github.com/user-attachments/assets/5cea7522-e2c9-4154-93a2-6406002c200c" /> |
| windows | <img width="911" height="325" alt="image" src="https://github.com/user-attachments/assets/7e9ef8db-15ac-4c33-aa6e-45a4a53a3e4f" /> | <img width="917" height="72" alt="image" src="https://github.com/user-attachments/assets/2a8473bb-16cc-4b05-9e87-5abbf26d36ed" /> |