### PR TITLE
Add verify check for inconsistent osu!taiko barline omission

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Editor/Checks/CheckTaikoInconsistentSkipBarLineTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/Checks/CheckTaikoInconsistentSkipBarLineTest.cs
@@ -1,0 +1,222 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Taiko.Edit.Checks;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Editor.Checks
+{
+    [TestFixture]
+    public class CheckTaikoInconsistentSkipBarLineTest
+    {
+        private CheckTaikoInconsistentSkipBarLine check = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckTaikoInconsistentSkipBarLine();
+        }
+
+        [Test]
+        public void TestConsistentOmitFirstBarLine()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true) }, // Reference
+                new[] { (1000.0, false), (2000.0, true) } // Same settings
+            );
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestInconsistentOmitFirstBarLine()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true) }, // Reference
+                new[] { (1000.0, true), (2000.0, false) } // Different settings
+            );
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(2));
+            Assert.That(issues.All(issue => issue.Template is CheckTaikoInconsistentSkipBarLine.IssueTemplateInconsistentOmitFirstBarLine));
+            Assert.That(issues[0].Time, Is.EqualTo(1000.0));
+            Assert.That(issues[1].Time, Is.EqualTo(2000.0));
+        }
+
+        [Test]
+        public void TestPartiallyInconsistentOmitFirstBarLine()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true), (3000.0, false) }, // Reference
+                new[] { (1000.0, false), (2000.0, false), (3000.0, false) } // Only second differs
+            );
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckTaikoInconsistentSkipBarLine.IssueTemplateInconsistentOmitFirstBarLine);
+            Assert.That(issues[0].Time, Is.EqualTo(2000.0));
+        }
+
+        [Test]
+        public void TestSingleDifficulty()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true) } // Only one difficulty
+            );
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestNonTaikoBeatmaps()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true) }, // Reference
+                new[] { (1000.0, true), (2000.0, false) } // Different settings
+            );
+
+            // Make both beatmaps non-taiko
+            beatmaps[0].BeatmapInfo.Ruleset = new OsuRuleset().RulesetInfo;
+            beatmaps[1].BeatmapInfo.Ruleset = new OsuRuleset().RulesetInfo;
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestMixedRulesets()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true) }, // Reference
+                new[] { (1000.0, true), (2000.0, false) } // Different settings
+            );
+
+            // Make reference taiko, other non-taiko
+            beatmaps[0].BeatmapInfo.Ruleset = new TaikoRuleset().RulesetInfo;
+            beatmaps[1].BeatmapInfo.Ruleset = new OsuRuleset().RulesetInfo;
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestMissingTimingPoints()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true) }, // Reference has 2 points
+                new[] { (1000.0, false) } // Other has only 1 point (missing 2000.0)
+            );
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            // Should only check the existing timing point at 1000.0 (consistent, no issue)
+            // The missing 2000.0 point should be ignored by this check
+            Assert.That(issues, Is.Empty);
+        }
+
+        [Test]
+        public void TestExtraTimingPoints()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false) }, // Reference has 1 point
+                new[] { (1000.0, false), (2000.0, true) } // Other has extra point
+            );
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            // Should only check the existing timing point at 1000.0 (consistent, no issue)
+            // The extra 2000.0 point should be ignored by this check
+            Assert.That(issues, Is.Empty);
+        }
+
+        [Test]
+        public void TestMultipleDifficultiesWithInconsistencies()
+        {
+            var beatmaps = createBeatmapSetWithTimingPoints(
+                new[] { (1000.0, false), (2000.0, true) }, // Reference
+                new[] { (1000.0, true), (2000.0, true) }, // First differs
+                new[] { (1000.0, false), (2000.0, false) } // Second differs
+            );
+
+            var context = createContextWithMultipleDifficulties(beatmaps[0], beatmaps);
+            var issues = check.Run(context).ToList();
+
+            // Should have issues for both other difficulties
+            Assert.That(issues, Has.Count.EqualTo(2)); // 1000.0 from diff2, 2000.0 from diff3
+            Assert.That(issues.All(issue => issue.Template is CheckTaikoInconsistentSkipBarLine.IssueTemplateInconsistentOmitFirstBarLine));
+            Assert.That(issues[0].Time, Is.EqualTo(1000.0));
+            Assert.That(issues[1].Time, Is.EqualTo(2000.0));
+        }
+
+        private IBeatmap[] createBeatmapSetWithTimingPoints(params (double time, bool omitFirstBarLine)[][] timingData)
+        {
+            var beatmapSet = new BeatmapSetInfo();
+            var beatmaps = new IBeatmap[timingData.Length];
+
+            for (int i = 0; i < timingData.Length; i++)
+            {
+                beatmaps[i] = createBeatmapWithTimingPoints(timingData[i], $"Difficulty {i + 1}");
+                beatmaps[i].BeatmapInfo.BeatmapSet = beatmapSet;
+                beatmaps[i].BeatmapInfo.Ruleset = new TaikoRuleset().RulesetInfo;
+            }
+
+            // Configure the beatmapset to contain all the beatmap infos
+            foreach (var beatmap in beatmaps)
+                beatmapSet.Beatmaps.Add(beatmap.BeatmapInfo);
+
+            return beatmaps;
+        }
+
+        private IBeatmap createBeatmapWithTimingPoints((double time, bool omitFirstBarLine)[] timingData, string difficultyName)
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    DifficultyName = difficultyName,
+                    Metadata = new BeatmapMetadata()
+                }
+            };
+
+            foreach ((double time, bool omitFirstBarLine) in timingData)
+            {
+                beatmap.ControlPointInfo.Add(time, new TimingControlPoint
+                {
+                    BeatLength = 500, // Standard BPM
+                    OmitFirstBarLine = omitFirstBarLine
+                });
+            }
+
+            return beatmap;
+        }
+
+        private BeatmapVerifierContext createContextWithMultipleDifficulties(IBeatmap currentBeatmap, IBeatmap[] allDifficulties)
+        {
+            return new BeatmapVerifierContext(
+                currentBeatmap,
+                new TestWorkingBeatmap(currentBeatmap),
+                DifficultyRating.ExpertPlus,
+                beatmapInfo => allDifficulties.FirstOrDefault(b => b.BeatmapInfo.Equals(beatmapInfo))
+            );
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Edit/Checks/CheckTaikoInconsistentSkipBarLine.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Checks/CheckTaikoInconsistentSkipBarLine.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Checks
                     var matchingPoint = TimingCheckUtils.FindExactMatchingTimingPoint(timingPoints, referencePoint.Time);
 
                     if (matchingPoint == null)
-                        // Inconsistent timing points - that's handled by the main timing check, so skip
+                        // Inconsistent timing points - that's handled by `CheckInconsistentTimingControlPoints`, so skip
                         continue;
 
                     if (referencePoint.OmitFirstBarLine != matchingPoint.OmitFirstBarLine)

--- a/osu.Game.Rulesets.Taiko/Edit/Checks/CheckTaikoInconsistentSkipBarLine.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Checks/CheckTaikoInconsistentSkipBarLine.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+
+namespace osu.Game.Rulesets.Taiko.Edit.Checks
+{
+    public class CheckTaikoInconsistentSkipBarLine : ICheck
+    {
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Timing, "Inconsistent \"Skip Bar Line\" setting");
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateInconsistentOmitFirstBarLine(this)
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            var difficulties = context.BeatmapsetDifficulties;
+
+            if (difficulties.Count <= 1)
+                yield break;
+
+            // Inconsistent bar line omission only matters for osu!taiko difficulties, so only check those
+            var taikoBeatmaps = difficulties.Where(b => b.BeatmapInfo.Ruleset.ShortName == "taiko").ToList();
+
+            if (taikoBeatmaps.Count <= 1)
+                yield break;
+
+            var referenceBeatmap = context.Beatmap;
+            var referenceTimingPoints = referenceBeatmap.ControlPointInfo.TimingPoints;
+
+            foreach (var beatmap in taikoBeatmaps)
+            {
+                if (beatmap == referenceBeatmap)
+                    continue;
+
+                var timingPoints = beatmap.ControlPointInfo.TimingPoints;
+
+                foreach (var referencePoint in referenceTimingPoints)
+                {
+                    var matchingPoint = TimingCheckUtils.FindExactMatchingTimingPoint(timingPoints, referencePoint.Time);
+
+                    if (matchingPoint == null)
+                        // Inconsistent timing points - that's handled by the main timing check, so skip
+                        continue;
+
+                    if (referencePoint.OmitFirstBarLine != matchingPoint.OmitFirstBarLine)
+                    {
+                        yield return new IssueTemplateInconsistentOmitFirstBarLine(this).Create(referencePoint.Time, beatmap.BeatmapInfo.DifficultyName);
+                    }
+                }
+            }
+        }
+
+        public class IssueTemplateInconsistentOmitFirstBarLine : IssueTemplate
+        {
+            public IssueTemplateInconsistentOmitFirstBarLine(ICheck check)
+                : base(check, IssueType.Problem, "Inconsistent \"Skip Bar Line\" setting in {0}.")
+            {
+            }
+
+            public Issue Create(double time, string difficultyName)
+                => new Issue(time, this, difficultyName);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoBeatmapVerifier.cs
@@ -22,6 +22,9 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
             // Settings
             new CheckTaikoAbnormalDifficultySettings(),
+
+            // Timing
+            new CheckTaikoInconsistentSkipBarLine(),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)


### PR DESCRIPTION
Part of https://github.com/ppy/osu/issues/12091

Ports [the following check](https://github.com/Naxesss/MapsetVerifier/blob/6e48f1269b0a484490a0ddc75df23b3400037a3d/src/Checks/Taiko/Timing/CheckInconsistentBarLines.cs) from MV.