### PR TITLE
Fix clicking beatmap carousel group & set headers not working (or crashing) during a filter

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -79,6 +79,8 @@ namespace osu.Game.Screens.SelectV2
 
                     foreach (var item in itemsInGroup)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         var beatmap = (BeatmapInfo)item.Model;
 
                         bool newBeatmapSet = lastBeatmap?.BeatmapSet!.ID != beatmap.BeatmapSet!.ID;
@@ -125,6 +127,8 @@ namespace osu.Game.Screens.SelectV2
                         i.IsVisible = i.Model is GroupDefinition || (group == null && (i.Model is BeatmapSetInfo || !BeatmapSetsGroupedTogether));
                     }
                 }
+
+                cancellationToken.ThrowIfCancellationRequested();
 
                 Interlocked.Exchange(ref setMap, newSetMap);
                 Interlocked.Exchange(ref groupMap, newGroupMap);


### PR DESCRIPTION
## [Fix clicking group & set headers not working (or crashing) during a filter](https://github.com/ppy/osu/commit/6b73308955ad4d4b4124de52768be7387ad3059a)

This papers over the user-facing side of https://github.com/ppy/osu/issues/34507.

The full failure scenario is:

- user selects a beatmap set
- online lookups fire
- online lookups are populated back to realm
- the realm changes trigger subscription, which triggers detached store replace, which triggers refilter
- refilter takes a while
- during the refilter user may be unable to select some sets because the set header mapping is incomplete

This only papers over the last bullet of that, in making sure that the set header mapping is not externally accessed while it's being rebuilt. It doesn't fix the insane amount of refilters caused by everything preceding the refilter being overeager to trigger said refilter.

## [Be more aggressive about cancelling grouping filter](https://github.com/ppy/osu/commit/a10eaf7f2b317d15093912118a095c1765daeadd)

This is also papering over the larger issue of the insane refilter count and is basically a drive-by fix but rider is bugging me with a bunch of yellow highlights from memory churn which looks somewhat easily preventable.

Basically the cancellation of filters could only take place between full groups. If there are few groups with lots of beatmaps, it could be a *looooong* while before the cancellation of the filter would actually take place. Hence the added extra cancellation check before every individual group item, and one extra check before performing the set mapping exchange and items return.