### PR TITLE
Fix grid placement completely breaking selection in certain scenarios

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/GridPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/GridPlacementBlueprint.cs
@@ -36,8 +36,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
 
             base.EndPlacement(commit);
 
-            // You typically only place the grid once, so we switch back to the last tool after placement.
-            // This may be committed due to switching to another tool, we don't want to change the tool if so.
+            // You typically only place the grid once, so we switch back to the last tool after placement -
+            // but only if the tool hasn't changed from under us (which is possible, as external tool changes will commit any ongoing placements, including this one)
             if (commit && hitObjectComposer?.BlueprintContainer.CurrentTool is GridFromPointsTool)
                 hitObjectComposer.SetLastTool();
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/GridPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/GridPlacementBlueprint.cs
@@ -37,8 +37,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
             base.EndPlacement(commit);
 
             // You typically only place the grid once, so we switch back to the last tool after placement.
-            if (commit && hitObjectComposer is OsuHitObjectComposer osuHitObjectComposer)
-                osuHitObjectComposer.SetLastTool();
+            // This may be committed due to switching to another tool, we don't want to change the tool if so.
+            if (commit && hitObjectComposer?.BlueprintContainer.CurrentTool is GridFromPointsTool)
+                hitObjectComposer.SetLastTool();
         }
 
         protected override bool OnClick(ClickEvent e)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34359

This situation is quite mind-blowing and questions the entirety of how editor selection is coded, but bear with me as I try to explain it. Here's the scenario broken down in technical details:
 - User selects grid tool and begins grid placement by clicking anywhere in the playfield.
 - User clicks on an object in the area that's outside the playfield region.
 - `SelectionHandler` responds to object selection and [signals that to other components](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs#L240-L241).
   - `HitObjectComposer` responds to selection change and [changes active tool to "Select"](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Rulesets/Edit/HitObjectComposer.cs#L508-L515).
     - Grid placement becomes committed [due to tool being changed](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs#L392-L393), but [committing grid placement calls `SetLastTool`](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game.Rulesets.Osu/Edit/Blueprints/GridPlacementBlueprint.cs#L39-L41)
     - `SetLastTool` changes active tool to "Grid", because the tool has since changed to "Select".
     - Changing active tool to "Grid" [clears selected hit objects](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Rulesets/Edit/HitObjectComposer.cs#L527-L528), marking the clicked object as deselected.
   - `BlueprintContainer` responds to selection change and [attempts to select the blueprint](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs#L66-L70), and since it was deselected by tool change, it fully proceeds through selection and [adds the blueprint to `selectedBlueprints`](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs#L243) (this is where things go downhill).
     - Normally when selecting any blueprint in general, this segment still occurs but nothing happens because the blueprint is already set as `Selected` from the beginning, and this selection attempt no-ops due to this [early return](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs#L64).
 - Finally, after signaling to all other components, execution returns to `SelectionHandler` and it finalises selecting the blueprint...which has...already become selected...by a bindable feedback...; [it adds the blueprint to `selectedBlueprints` again](https://github.com/ppy/osu/blob/619fe60dd1b1aa3e3b03b468a5346bef484aa35a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs#L243), so the list now has the blueprint twice.
 - Selection is dead permanently.

When attempting to deselect the cursed blueprint, `SelectionHandler` only removes it once, the other occurrence remains permanently which is the reason why the selection box persists covering it.

On following the scenario above, I noticed the source of breakage comes from `GridPlacementBlueprint` aggressively changing tool selection on placement. This is because placement may actually be caused by a tool change in itself, and changing tool as a result of a tool change is totally not good stuff.

The fix is to prevent `GridPlacementBlueprint` from changing tool if it's already not the current tool anymore (i.e. it was placed by a tool change). It might be a circumventing fix but I don't see any better way at the moment. Reviewing the scenario above shows we may want to turn the whole editor selection code upside down and tear it apart.