### PR TITLE
Add verify check for missing genre/language tags

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckMissingGenreLanguageTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckMissingGenreLanguageTest.cs
@@ -1,0 +1,184 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    [TestFixture]
+    public class CheckMissingGenreLanguageTest
+    {
+        private CheckMissingGenreLanguage check = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckMissingGenreLanguage();
+        }
+
+        [Test]
+        public void TestHasGenreAndLanguage()
+        {
+            var beatmap = createBeatmapWithTags("rock english instrumental");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestHasGenreOnly()
+        {
+            var beatmap = createBeatmapWithTags("electronic pop");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckMissingGenreLanguage.IssueTemplateMissingLanguage);
+        }
+
+        [Test]
+        public void TestHasLanguageOnly()
+        {
+            var beatmap = createBeatmapWithTags("japanese instrumental");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckMissingGenreLanguage.IssueTemplateMissingGenre);
+        }
+
+        [Test]
+        public void TestMissingBoth()
+        {
+            var beatmap = createBeatmapWithTags("tag1 tag2 tag3");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(2));
+            Assert.That(issues.Any(issue => issue.Template is CheckMissingGenreLanguage.IssueTemplateMissingGenre));
+            Assert.That(issues.Any(issue => issue.Template is CheckMissingGenreLanguage.IssueTemplateMissingLanguage));
+        }
+
+        [Test]
+        public void TestMultiWordGenreHipHop()
+        {
+            var beatmap = createBeatmapWithTags("hip hop music");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckMissingGenreLanguage.IssueTemplateMissingLanguage);
+        }
+
+        [Test]
+        public void TestScatteredMultiWordGenre()
+        {
+            var beatmap = createBeatmapWithTags("video hip game hop ost");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckMissingGenreLanguage.IssueTemplateMissingLanguage);
+        }
+
+        [Test]
+        public void TestCaseInsensitive()
+        {
+            var beatmap = createBeatmapWithTags("ROCK JAPANESE");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestMixedCase()
+        {
+            var beatmap = createBeatmapWithTags("Rock Japanese");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestSingleWordGenre()
+        {
+            var beatmap = createBeatmapWithTags("electronic");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckMissingGenreLanguage.IssueTemplateMissingLanguage);
+        }
+
+        [Test]
+        public void TestSingleWordLanguage()
+        {
+            var beatmap = createBeatmapWithTags("instrumental");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckMissingGenreLanguage.IssueTemplateMissingGenre);
+        }
+
+        [Test]
+        public void TestEmptyTags()
+        {
+            var beatmap = createBeatmapWithTags("");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(2));
+            Assert.That(issues.Any(issue => issue.Template is CheckMissingGenreLanguage.IssueTemplateMissingGenre));
+            Assert.That(issues.Any(issue => issue.Template is CheckMissingGenreLanguage.IssueTemplateMissingLanguage));
+        }
+
+        [Test]
+        public void TestPartialMultiWordMatch()
+        {
+            // Should not match if only one word is found
+            var beatmap = createBeatmapWithTags("hip music");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(2));
+            Assert.That(issues.Any(issue => issue.Template is CheckMissingGenreLanguage.IssueTemplateMissingGenre));
+            Assert.That(issues.Any(issue => issue.Template is CheckMissingGenreLanguage.IssueTemplateMissingLanguage));
+        }
+
+        [Test]
+        public void TestGenreAndLanguageWithExtraTags()
+        {
+            var beatmap = createBeatmapWithTags("tag1 rock tag2 english tag3");
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        private IBeatmap createBeatmapWithTags(string tags)
+        {
+            return new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Metadata = new BeatmapMetadata { Tags = tags }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Rulesets.Edit
             // Metadata
             new CheckTitleMarkers(),
             new CheckInconsistentMetadata(),
+            new CheckMissingGenreLanguage(),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)

--- a/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
@@ -34,9 +34,10 @@ namespace osu.Game.Rulesets.Edit.Checks
                 yield return new IssueTemplateMissingLanguage(this).Create();
         }
 
-        private bool hasTags<T>(string tags) where T : Enum
+        private bool hasTags<T>(string tags)
+            where T : struct, Enum
         {
-            foreach (T value in Enum.GetValues(typeof(T)))
+            foreach (var value in Enum.GetValues<T>())
             {
                 string description = getGenreLanguageString(value);
                 string[] words = description.ToLowerInvariant().Split(' ');

--- a/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using osu.Game.Overlays.BeatmapListing;
+using osu.Game.Rulesets.Edit.Checks.Components;
+
+namespace osu.Game.Rulesets.Edit.Checks
+{
+    public class CheckMissingGenreLanguage : ICheck
+    {
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Metadata, "Missing Genre/Language Tags", CheckScope.BeatmapSet);
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateMissingGenre(this),
+            new IssueTemplateMissingLanguage(this),
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            var metadata = context.Beatmap.BeatmapInfo.Metadata;
+
+            string tags = metadata.Tags.ToLowerInvariant();
+
+            bool genreFound = false;
+            bool languageFound = false;
+
+            foreach (SearchGenre genre in Enum.GetValues(typeof(SearchGenre)))
+            {
+                string genreString = getGenreLanguageString(genre);
+
+                if (containsAllWords(genreString, tags))
+                {
+                    genreFound = true;
+                    break;
+                }
+            }
+
+            foreach (SearchLanguage language in Enum.GetValues(typeof(SearchLanguage)))
+            {
+                string languageString = getGenreLanguageString(language);
+
+                if (containsAllWords(languageString, tags))
+                {
+                    languageFound = true;
+                    break;
+                }
+            }
+
+            if (!genreFound)
+                yield return new IssueTemplateMissingGenre(this).Create();
+
+            if (!languageFound)
+                yield return new IssueTemplateMissingLanguage(this).Create();
+        }
+
+        private static bool containsAllWords(string description, string tags)
+        {
+            string[] words = description.ToLowerInvariant().Split(' ');
+            return words.All(tags.Contains);
+        }
+
+        // "Video Game" and "Hip Hop" are multiple words that are properly formatted in the enum's description attribute,
+        // so we need to use that and fall back to the enum's string value for the rest.
+        private static string getGenreLanguageString(Enum value)
+        {
+            var field = value.GetType().GetField(value.ToString());
+            var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+            return attribute?.Description ?? value.ToString();
+        }
+
+        public class IssueTemplateMissingGenre : IssueTemplate
+        {
+            public IssueTemplateMissingGenre(ICheck check)
+                : base(check, IssueType.Problem, "Missing genre tag (\"rock\", \"pop\", \"electronic\", etc), ignore if none fit.")
+            {
+            }
+
+            public Issue Create() => new Issue(this);
+        }
+
+        public class IssueTemplateMissingLanguage : IssueTemplate
+        {
+            public IssueTemplateMissingLanguage(ICheck check)
+                : base(check, IssueType.Problem, "Missing language tag (\"english\", \"japanese\", \"instrumental\", etc), ignore if none fit.")
+            {
+            }
+
+            public Issue Create() => new Issue(this);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
@@ -27,47 +27,30 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             string tags = metadata.Tags.ToLowerInvariant();
 
-            bool genreFound = false;
-            bool languageFound = false;
-
-            foreach (SearchGenre genre in Enum.GetValues(typeof(SearchGenre)))
-            {
-                string genreString = getGenreLanguageString(genre);
-
-                if (containsAllWords(genreString, tags))
-                {
-                    genreFound = true;
-                    break;
-                }
-            }
-
-            foreach (SearchLanguage language in Enum.GetValues(typeof(SearchLanguage)))
-            {
-                string languageString = getGenreLanguageString(language);
-
-                if (containsAllWords(languageString, tags))
-                {
-                    languageFound = true;
-                    break;
-                }
-            }
-
-            if (!genreFound)
+            if (!hasTags<SearchGenre>(tags))
                 yield return new IssueTemplateMissingGenre(this).Create();
 
-            if (!languageFound)
+            if (!hasTags<SearchLanguage>(tags))
                 yield return new IssueTemplateMissingLanguage(this).Create();
         }
 
-        private static bool containsAllWords(string description, string tags)
+        private bool hasTags<T>(string tags) where T : Enum
         {
-            string[] words = description.ToLowerInvariant().Split(' ');
-            return words.All(tags.Contains);
+            foreach (T value in Enum.GetValues(typeof(T)))
+            {
+                string description = getGenreLanguageString(value);
+                string[] words = description.ToLowerInvariant().Split(' ');
+
+                if (words.All(tags.Contains))
+                    return true;
+            }
+
+            return false;
         }
 
         // "Video Game" and "Hip Hop" are multiple words that are properly formatted in the enum's description attribute,
         // so we need to use that and fall back to the enum's string value for the rest.
-        private static string getGenreLanguageString(Enum value)
+        private string getGenreLanguageString(Enum value)
         {
             var field = value.GetType().GetField(value.ToString());
             var attribute = field?.GetCustomAttribute<DescriptionAttribute>();

--- a/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMissingGenreLanguage.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
+using osu.Framework.Extensions;
 using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
@@ -39,23 +38,13 @@ namespace osu.Game.Rulesets.Edit.Checks
         {
             foreach (var value in Enum.GetValues<T>())
             {
-                string description = getGenreLanguageString(value);
-                string[] words = description.ToLowerInvariant().Split(' ');
+                string[] words = value.GetDescription().ToLowerInvariant().Split(' ');
 
                 if (words.All(tags.Contains))
                     return true;
             }
 
             return false;
-        }
-
-        // "Video Game" and "Hip Hop" are multiple words that are properly formatted in the enum's description attribute,
-        // so we need to use that and fall back to the enum's string value for the rest.
-        private string getGenreLanguageString(Enum value)
-        {
-            var field = value.GetType().GetField(value.ToString());
-            var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
-            return attribute?.Description ?? value.ToString();
         }
 
         public class IssueTemplateMissingGenre : IssueTemplate


### PR DESCRIPTION
Part of https://github.com/ppy/osu/issues/12091

Ports [the following check](https://github.com/Naxesss/MapsetVerifier/blob/6e48f1269b0a484490a0ddc75df23b3400037a3d/src/Checks/AllModes/General/Metadata/CheckGenreLanguage.cs) from MV.

Had to use `SearchGenre` and `SearchLanguage` enums from `osu.Game.Overlays.BeatmapListing` because I don't have any other alternatives, given that's the only place where I can get available genres/languages in the project, and MV hardcodes said tags.

I also initially wanted to enhance the check via checking against the beatmap's online genre/language and see if *those* are present in the tags, but I had no reasonable way of accessing the online beatmap info without some significant reconsiderations with the verifier context, so that idea is shelved for now.