### PR TITLE
Implement "my maps" grouping mode

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -161,14 +161,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         protected void WaitForFiltering() => AddUntilStep("wait for filtering", () => !SongSelect.IsFiltering);
 
-        protected void ImportBeatmapForRuleset(params int[] rulesetIds)
+        protected void ImportBeatmapForRuleset(params int[] rulesetIds) => ImportBeatmapForRuleset(_ => { }, rulesetIds);
+
+        protected void ImportBeatmapForRuleset(Action<BeatmapSetInfo> applyToBeatmap, params int[] rulesetIds)
         {
             int beatmapsCount = 0;
 
             AddStep($"import test map for ruleset {rulesetIds}", () =>
             {
                 beatmapsCount = SongSelect.IsNull() ? 0 : Carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single().SetItems.Count;
-                Beatmaps.Import(TestResources.CreateTestBeatmapSetInfo(3, Rulesets.AvailableRulesets.Where(r => rulesetIds.Contains(r.OnlineID)).ToArray()));
+
+                var beatmapSet = TestResources.CreateTestBeatmapSetInfo(3, Rulesets.AvailableRulesets.Where(r => rulesetIds.Contains(r.OnlineID)).ToArray());
+                applyToBeatmap(beatmapSet);
+                Beatmaps.Import(beatmapSet);
             });
 
             // This is specifically for cases where the add is happening post song select load.

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectGrouping.cs
@@ -3,6 +3,8 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Extensions;
@@ -146,14 +148,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddAssert("'my maps' present", () =>
             {
-                var group = grouping.GroupItems.Single(g => g.Key.Title == "My maps");
-                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[0]);
-            });
-
-            AddAssert("'not my maps' present", () =>
-            {
-                var group = grouping.GroupItems.Single(g => g.Key.Title == "Not my maps");
-                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().SequenceEqual(new[] { beatmapSets[1], beatmapSets[2] });
+                var group = grouping.GroupItems.Single();
+                return group.Key.Title == "My maps" && group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[0]);
             });
         }
 
@@ -184,14 +180,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddAssert("'my maps' present", () =>
             {
-                var group = grouping.GroupItems.Single(g => g.Key.Title == "My maps");
-                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[0]);
-            });
-
-            AddAssert("'not my maps' present", () =>
-            {
-                var group = grouping.GroupItems.Single(g => g.Key.Title == "Not my maps");
-                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().SequenceEqual(new[] { beatmapSets[1], beatmapSets[2] });
+                var group = grouping.GroupItems.Single();
+                return group.Key.Title == "My maps" && group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[0]);
             });
         }
 
@@ -212,11 +202,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             GroupBy(GroupMode.MyMaps);
             WaitForFiltering();
 
-            AddAssert("only 'not my maps' present", () =>
-            {
-                var group = grouping.GroupItems.Single();
-                return group.Key.Title == "Not my maps" && group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().SequenceEqual(new[] { beatmapSets[0], beatmapSets[1], beatmapSets[2] });
-            });
+            AddUntilStep("wait for placeholder visible", () => getPlaceholder()?.State.Value == Visibility.Visible);
+            checkMatchedBeatmaps(0);
 
             AddStep("log in", () =>
             {
@@ -228,17 +215,15 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddAssert("'my maps' present", () =>
             {
-                var group = grouping.GroupItems.Single(g => g.Key.Title == "My maps");
-                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[1]);
-            });
-
-            AddAssert("'not my maps' present", () =>
-            {
-                var group = grouping.GroupItems.Single(g => g.Key.Title == "Not my maps");
-                return group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().SequenceEqual(new[] { beatmapSets[0], beatmapSets[2] });
+                var group = grouping.GroupItems.Single();
+                return group.Key.Title == "My maps" && group.Value.Select(i => i.Model).OfType<BeatmapSetInfo>().Single().Equals(beatmapSets[1]);
             });
         }
 
         #endregion
+
+        private NoResultsPlaceholder? getPlaceholder() => SongSelect.ChildrenOfType<NoResultsPlaceholder>().FirstOrDefault();
+
+        private void checkMatchedBeatmaps(int expected) => AddUntilStep($"{expected} matching shown", () => Carousel.MatchedBeatmapsCount, () => Is.EqualTo(expected));
     }
 }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -345,11 +345,6 @@ namespace osu.Game.Graphics.Carousel
                     {
                         log($"Performing {filter.GetType().ReadableName()}");
                         items = await filter.Run(items, cts.Token).ConfigureAwait(false);
-
-                        // To avoid shooting ourselves in the foot, ensure that we manifest a list after each filter.
-                        //
-                        // A future improvement may be passing a reference list through each filter rather than copying each time,
-                        // but this is the safest approach.
                     }
 
                     log("Updating Y positions");

--- a/osu.Game/Graphics/Carousel/ICarouselFilter.cs
+++ b/osu.Game/Graphics/Carousel/ICarouselFilter.cs
@@ -19,5 +19,10 @@ namespace osu.Game.Graphics.Carousel
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The post-filtered items.</returns>
         Task<List<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// The total number of beatmap difficulties displayed post filter.
+        /// </summary>
+        int BeatmapItemsCount { get; }
     }
 }

--- a/osu.Game/Screens/Select/Filter/GroupMode.cs
+++ b/osu.Game/Screens/Select/Filter/GroupMode.cs
@@ -41,8 +41,8 @@ namespace osu.Game.Screens.Select.Filter
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Length))]
         Length,
 
-        // [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.MyMaps))]
-        // MyMaps,
+        [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.MyMaps))]
+        MyMaps,
 
         // [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.RankAchieved))]
         // RankAchieved,

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -118,6 +118,18 @@ namespace osu.Game.Screens.Select
 
         public IRulesetFilterCriteria? RulesetCriteria { get; set; }
 
+        /// <summary>
+        /// The user ID of the current local user, used to filter to own maps when <see cref="GroupMode.MyMaps"/> is selected.
+        /// Or null if the user is not logged in.
+        /// </summary>
+        public int? LocalUserId { get; set; }
+
+        /// <summary>
+        /// The username of the current local user, used to filter to own maps when <see cref="GroupMode.MyMaps"/> is selected.
+        /// Or null if the user is not logged in.
+        /// </summary>
+        public string? LocalUserUsername { get; set; }
+
         public readonly struct OptionalSet<T> : IEquatable<OptionalSet<T>>
             where T : struct, Enum
         {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -49,13 +49,12 @@ namespace osu.Game.Screens.SelectV2
 
         private readonly LoadingLayer loading;
 
-        private readonly BeatmapCarouselFilterMatching matching;
         private readonly BeatmapCarouselFilterGrouping grouping;
 
         /// <summary>
         /// Total number of beatmap difficulties displayed with the filter.
         /// </summary>
-        public int MatchedBeatmapsCount => matching.BeatmapItemsCount;
+        public int MatchedBeatmapsCount => grouping.BeatmapItemsCount;
 
         protected override float GetSpacingBetweenPanels(CarouselItem top, CarouselItem bottom)
         {
@@ -97,7 +96,7 @@ namespace osu.Game.Screens.SelectV2
 
             Filters = new ICarouselFilter[]
             {
-                matching = new BeatmapCarouselFilterMatching(() => Criteria!),
+                new BeatmapCarouselFilterMatching(() => Criteria!),
                 new BeatmapCarouselFilterSorting(() => Criteria!),
                 grouping = new BeatmapCarouselFilterGrouping(() => Criteria!, () => detachedCollections())
             };

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.SelectV2
         /// <summary>
         /// Total number of beatmap difficulties displayed with the filter.
         /// </summary>
-        public int MatchedBeatmapsCount => grouping.BeatmapItemsCount;
+        public int MatchedBeatmapsCount => Filters.Last().BeatmapItemsCount;
 
         protected override float GetSpacingBetweenPanels(CarouselItem top, CarouselItem bottom)
         {

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -220,11 +220,11 @@ namespace osu.Game.Screens.SelectV2
                     var collections = getCollections?.Invoke() ?? Enumerable.Empty<BeatmapCollection>();
                     return getGroupsBy(b => defineGroupByCollection(b, collections), items);
 
+                case GroupMode.MyMaps:
+                    return getGroupsBy(b => defineGroupByOwnMaps(b, criteria.LocalUserId, criteria.LocalUserUsername), items);
+
                 // TODO: need implementation
                 // case GroupMode.Favourites:
-                //     goto case GroupMode.None;
-                //
-                // case GroupMode.MyMaps:
                 //     goto case GroupMode.None;
                 //
                 // case GroupMode.RankAchieved:
@@ -393,6 +393,16 @@ namespace osu.Game.Screens.SelectV2
             }
 
             return new GroupDefinition(1, "Not in collection");
+        }
+
+        private GroupDefinition defineGroupByOwnMaps(BeatmapInfo beatmap, int? localUserId, string? localUserUsername)
+        {
+            var author = beatmap.BeatmapSet!.Metadata.Author;
+
+            if (author.OnlineID == localUserId || author.Username == localUserUsername)
+                return new GroupDefinition(0, "My maps");
+
+            return new GroupDefinition(1, "Not my maps");
         }
 
         private static T? aggregateMax<T>(BeatmapInfo b, Func<BeatmapInfo, T> func)

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -399,7 +399,7 @@ namespace osu.Game.Screens.SelectV2
         {
             var author = beatmap.BeatmapSet!.Metadata.Author;
 
-            if (author.OnlineID == localUserId || author.Username == localUserUsername)
+            if (author.OnlineID == localUserId || (author.OnlineID <= 1 && author.Username == localUserUsername))
                 return new GroupDefinition(0, "My maps");
 
             return new GroupDefinition(1, "Not my maps");

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -235,11 +235,12 @@ namespace osu.Game.Screens.SelectV2
             }
         }
 
-        private List<GroupMapping> getGroupsBy(Func<BeatmapInfo, GroupDefinition> getGroup, List<CarouselItem> items)
+        private List<GroupMapping> getGroupsBy(Func<BeatmapInfo, GroupDefinition?> getGroup, List<CarouselItem> items)
         {
             return items.GroupBy(i => getGroup((BeatmapInfo)i.Model))
-                        .OrderBy(s => s.Key.Order)
-                        .ThenBy(s => s.Key.Title)
+                        .Where(g => g.Key != null)
+                        .OrderBy(g => g.Key!.Order)
+                        .ThenBy(g => g.Key!.Title)
                         .Select(g => new GroupMapping(g.Key, g.ToList()))
                         .ToList();
         }
@@ -395,14 +396,15 @@ namespace osu.Game.Screens.SelectV2
             return new GroupDefinition(1, "Not in collection");
         }
 
-        private GroupDefinition defineGroupByOwnMaps(BeatmapInfo beatmap, int? localUserId, string? localUserUsername)
+        private GroupDefinition? defineGroupByOwnMaps(BeatmapInfo beatmap, int? localUserId, string? localUserUsername)
         {
             var author = beatmap.BeatmapSet!.Metadata.Author;
 
             if (author.OnlineID == localUserId || (author.OnlineID <= 1 && author.Username == localUserUsername))
                 return new GroupDefinition(0, "My maps");
 
-            return new GroupDefinition(1, "Not my maps");
+            // discard beatmaps not owned by the user.
+            return null;
         }
 
         private static T? aggregateMax<T>(BeatmapInfo b, Func<BeatmapInfo, T> func)

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -21,6 +21,11 @@ namespace osu.Game.Screens.SelectV2
         public bool BeatmapSetsGroupedTogether { get; private set; }
 
         /// <summary>
+        /// The total number of beatmap difficulties displayed post filter.
+        /// </summary>
+        public int BeatmapItemsCount { get; private set; }
+
+        /// <summary>
         /// Beatmap sets contain difficulties as related panels. This dictionary holds the relationships between set-difficulties to allow expanding them on selection.
         /// </summary>
         public IDictionary<BeatmapSetInfo, HashSet<CarouselItem>> SetItems => setMap;
@@ -56,6 +61,7 @@ namespace osu.Game.Screens.SelectV2
                 BeatmapSetsGroupedTogether = ShouldGroupBeatmapsTogether(criteria);
 
                 var groups = getGroups((List<CarouselItem>)items, criteria);
+                int displayedBeatmapsCount = 0;
 
                 foreach (var (group, itemsInGroup) in groups)
                 {
@@ -115,6 +121,7 @@ namespace osu.Game.Screens.SelectV2
 
                         addItem(item);
                         lastBeatmap = beatmap;
+                        displayedBeatmapsCount++;
                     }
 
                     void addItem(CarouselItem i)
@@ -132,6 +139,7 @@ namespace osu.Game.Screens.SelectV2
 
                 Interlocked.Exchange(ref setMap, newSetMap);
                 Interlocked.Exchange(ref groupMap, newGroupMap);
+                BeatmapItemsCount = displayedBeatmapsCount;
                 return newItems;
             }, cancellationToken).ConfigureAwait(false);
         }

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -17,9 +17,6 @@ namespace osu.Game.Screens.SelectV2
     {
         private readonly Func<FilterCriteria> getCriteria;
 
-        /// <summary>
-        /// The total number of beatmap difficulties displayed post filter.
-        /// </summary>
         public int BeatmapItemsCount { get; private set; }
 
         public BeatmapCarouselFilterMatching(Func<FilterCriteria> getCriteria)

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterSorting.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterSorting.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Screens.SelectV2
 {
     public class BeatmapCarouselFilterSorting : ICarouselFilter
     {
+        public int BeatmapItemsCount { get; private set; }
+
         private readonly Func<FilterCriteria> getCriteria;
 
         public BeatmapCarouselFilterSorting(Func<FilterCriteria> getCriteria)
@@ -28,6 +30,8 @@ namespace osu.Game.Screens.SelectV2
             var criteria = getCriteria();
 
             bool groupedSets = BeatmapCarouselFilterGrouping.ShouldGroupBeatmapsTogether(criteria);
+
+            BeatmapItemsCount = items.Count();
 
             return items.Order(Comparer<CarouselItem>.Create((a, b) =>
             {

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -56,10 +56,7 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        [Resolved]
-        private IAPIProvider api { get; set; } = null!;
-
-        private IBindable<APIUser>? localUser;
+        private IBindable<APIUser> localUser = null!;
 
         public LocalisableString StatusText
         {
@@ -74,7 +71,7 @@ namespace osu.Game.Screens.SelectV2
         private IDisposable? collectionsSubscription;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(IAPIProvider api)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -187,6 +184,8 @@ namespace osu.Game.Screens.SelectV2
                     },
                 }
             };
+
+            localUser = api.LocalUser.GetBoundCopy();
         }
 
         protected override void LoadComplete()
@@ -237,7 +236,6 @@ namespace osu.Game.Screens.SelectV2
                     updateCriteria();
             });
 
-            localUser = api.LocalUser.GetBoundCopy();
             localUser.BindValueChanged(_ => updateCriteria());
 
             updateCriteria();
@@ -255,7 +253,7 @@ namespace osu.Game.Screens.SelectV2
         public FilterCriteria CreateCriteria()
         {
             string query = searchTextBox.Current.Value;
-            bool isValidUser = api.LocalUser.Value.Id > 1;
+            bool isValidUser = localUser.Value.Id > 1;
 
             var criteria = new FilterCriteria
             {
@@ -265,8 +263,8 @@ namespace osu.Game.Screens.SelectV2
                 Ruleset = ruleset.Value,
                 Mods = mods.Value,
                 CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToImmutableHashSet(),
-                LocalUserId = isValidUser ? api.LocalUser.Value.Id : null,
-                LocalUserUsername = isValidUser ? api.LocalUser.Value.Username : null,
+                LocalUserId = isValidUser ? localUser.Value.Id : null,
+                LocalUserUsername = isValidUser ? localUser.Value.Username : null,
             };
 
             if (!difficultyRangeSlider.LowerBound.IsDefault)


### PR DESCRIPTION
- Closes #34493 

This works a little different from stable in two ways:
 - Beatmaps of the local user are determined not only by the username, but also by user ID. 
 - To be consistent with other grouping modes, all other beatmaps not owned by the user are stored in a separate group. Names are TBD (currently set as "My maps" and "Not my maps").