### PR TITLE
Add verify check for inconsistent settings

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
@@ -3,10 +3,13 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
+using osuTK;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Tests.Beatmaps;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Tests.Editing.Checks
 {
@@ -134,13 +137,25 @@ namespace osu.Game.Tests.Editing.Checks
         }
 
         [Test]
-        public void TestInconsistentWidescreenStoryboard()
+        public void TestInconsistentWidescreenSupport()
         {
             var beatmaps = createBeatmapSetWithSettings(
                 createSettings(widescreenStoryboard: true),
                 createSettings(widescreenStoryboard: false)
             );
             var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestInconsistentWidescreenSupportWithStoryboard()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(widescreenStoryboard: true),
+                createSettings(widescreenStoryboard: false)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps, hasStoryboard: true);
 
             var issues = check.Run(context).ToList();
 
@@ -238,11 +253,19 @@ namespace osu.Game.Tests.Editing.Checks
             return beatmaps;
         }
 
-        private BeatmapVerifierContext createContextWithMultipleDifficulties(IBeatmap currentBeatmap, IBeatmap[] allDifficulties)
+        private BeatmapVerifierContext createContextWithMultipleDifficulties(IBeatmap currentBeatmap, IBeatmap[] allDifficulties, bool hasStoryboard = false)
         {
+            Storyboard? storyboard = null;
+
+            if (hasStoryboard)
+            {
+                storyboard = new Storyboard();
+                storyboard.GetLayer("Background").Add(new StoryboardSprite("test.png", Anchor.Centre, Vector2.Zero));
+            }
+
             return new BeatmapVerifierContext(
                 currentBeatmap,
-                new TestWorkingBeatmap(currentBeatmap),
+                new TestWorkingBeatmap(currentBeatmap, storyboard),
                 DifficultyRating.ExpertPlus,
                 beatmapInfo => allDifficulties.FirstOrDefault(b => b.BeatmapInfo.Equals(beatmapInfo))
             );

--- a/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
@@ -1,0 +1,251 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    [TestFixture]
+    public class CheckInconsistentSettingsTest
+    {
+        private CheckInconsistentSettings check = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckInconsistentSettings();
+        }
+
+        [Test]
+        public void TestConsistentSettings()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(audioLeadIn: 1000, countdown: CountdownType.Normal, epilepsyWarning: false),
+                createSettings(audioLeadIn: 1000, countdown: CountdownType.Normal, epilepsyWarning: false)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestInconsistentAudioLeadIn()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(audioLeadIn: 1000),
+                createSettings(audioLeadIn: 2000)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("audio lead-in"));
+            Assert.That(issues[0].ToString(), Contains.Substring("1000"));
+            Assert.That(issues[0].ToString(), Contains.Substring("2000"));
+        }
+
+        [Test]
+        public void TestInconsistentCountdown()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(countdown: CountdownType.Normal),
+                createSettings(countdown: CountdownType.None)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("countdown"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Normal"));
+            Assert.That(issues[0].ToString(), Contains.Substring("None"));
+        }
+
+        [Test]
+        public void TestInconsistentCountdownOffset()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(countdownOffset: 100),
+                createSettings(countdownOffset: 200)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("countdown offset"));
+        }
+
+        [Test]
+        public void TestInconsistentEpilepsyWarning()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(epilepsyWarning: true),
+                createSettings(epilepsyWarning: false)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("epilepsy warning"));
+        }
+
+        [Test]
+        public void TestInconsistentLetterboxInBreaks()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(letterboxInBreaks: true),
+                createSettings(letterboxInBreaks: false)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("letterbox in breaks"));
+        }
+
+        [Test]
+        public void TestInconsistentSamplesMatchPlaybackRate()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(samplesMatchPlaybackRate: true),
+                createSettings(samplesMatchPlaybackRate: false)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("samples match playback rate"));
+        }
+
+        [Test]
+        public void TestInconsistentWidescreenStoryboard()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(widescreenStoryboard: true),
+                createSettings(widescreenStoryboard: false)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("widescreen storyboard"));
+        }
+
+        [Test]
+        public void TestInconsistentSliderTickRate()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(sliderTickRate: 1.0),
+                createSettings(sliderTickRate: 2.0)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
+            Assert.That(issues[0].ToString(), Contains.Substring("slider tick rate"));
+        }
+
+        [Test]
+        public void TestMultipleInconsistencies()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(audioLeadIn: 1000, countdown: CountdownType.Normal, epilepsyWarning: false),
+                createSettings(audioLeadIn: 2000, countdown: CountdownType.None, epilepsyWarning: true)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(3));
+            Assert.That(issues.Count(i => i.ToString().Contains("audio lead-in")), Is.EqualTo(1));
+            Assert.That(issues.Count(i => i.ToString().Contains("countdown")), Is.EqualTo(1));
+            Assert.That(issues.Count(i => i.ToString().Contains("epilepsy warning")), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestSingleDifficulty()
+        {
+            var beatmaps = createBeatmapSetWithSettings(
+                createSettings(audioLeadIn: 1000)
+            );
+            var context = createContextWithMultipleDifficulties(beatmaps.First(), beatmaps);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        private Beatmap createSettings(
+            double audioLeadIn = 0,
+            CountdownType countdown = CountdownType.None,
+            int countdownOffset = 0,
+            bool epilepsyWarning = false,
+            bool letterboxInBreaks = false,
+            bool samplesMatchPlaybackRate = false,
+            bool widescreenStoryboard = false,
+            double sliderTickRate = 1.0)
+        {
+            return new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    DifficultyName = "Test Difficulty",
+                    StarRating = 5.0
+                },
+                AudioLeadIn = audioLeadIn,
+                Countdown = countdown,
+                CountdownOffset = countdownOffset,
+                EpilepsyWarning = epilepsyWarning,
+                LetterboxInBreaks = letterboxInBreaks,
+                SamplesMatchPlaybackRate = samplesMatchPlaybackRate,
+                WidescreenStoryboard = widescreenStoryboard,
+                Difficulty = new BeatmapDifficulty
+                {
+                    SliderTickRate = sliderTickRate
+                }
+            };
+        }
+
+        private IBeatmap[] createBeatmapSetWithSettings(params IBeatmap[] beatmaps)
+        {
+            var beatmapSet = new BeatmapSetInfo();
+
+            for (int i = 0; i < beatmaps.Length; i++)
+            {
+                beatmaps[i].BeatmapInfo.DifficultyName = $"Difficulty {i + 1}";
+                beatmaps[i].BeatmapInfo.BeatmapSet = beatmapSet;
+                beatmapSet.Beatmaps.Add(beatmaps[i].BeatmapInfo);
+            }
+
+            return beatmaps;
+        }
+
+        private BeatmapVerifierContext createContextWithMultipleDifficulties(IBeatmap currentBeatmap, IBeatmap[] allDifficulties)
+        {
+            return new BeatmapVerifierContext(
+                currentBeatmap,
+                new TestWorkingBeatmap(currentBeatmap),
+                DifficultyRating.ExpertPlus,
+                beatmapInfo => allDifficulties.FirstOrDefault(b => b.BeatmapInfo.Equals(beatmapInfo))
+            );
+        }
+    }
+}

--- a/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("audio lead-in"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Audio lead-in"));
             Assert.That(issues[0].ToString(), Contains.Substring("1000"));
             Assert.That(issues[0].ToString(), Contains.Substring("2000"));
         }
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("countdown"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Countdown"));
             Assert.That(issues[0].ToString(), Contains.Substring("Normal"));
             Assert.That(issues[0].ToString(), Contains.Substring("None"));
         }
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("countdown offset"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Countdown offset"));
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("epilepsy warning"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Epilepsy warning"));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("letterbox in breaks"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Letterbox during breaks"));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("samples match playback rate"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Samples match playback rate"));
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("widescreen storyboard"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Widescreen support"));
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues[0].Template is CheckInconsistentSettings.IssueTemplateInconsistentSetting);
-            Assert.That(issues[0].ToString(), Contains.Substring("slider tick rate"));
+            Assert.That(issues[0].ToString(), Contains.Substring("Tick Rate"));
         }
 
         [Test]
@@ -177,9 +177,9 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(3));
-            Assert.That(issues.Count(i => i.ToString().Contains("audio lead-in")), Is.EqualTo(1));
-            Assert.That(issues.Count(i => i.ToString().Contains("countdown")), Is.EqualTo(1));
-            Assert.That(issues.Count(i => i.ToString().Contains("epilepsy warning")), Is.EqualTo(1));
+            Assert.That(issues.Count(i => i.ToString().Contains("Audio lead-in")), Is.EqualTo(1));
+            Assert.That(issues.Count(i => i.ToString().Contains("Countdown")), Is.EqualTo(1));
+            Assert.That(issues.Count(i => i.ToString().Contains("Epilepsy warning")), Is.EqualTo(1));
         }
 
         [Test]

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Rulesets.Edit
             new CheckTitleMarkers(),
             new CheckInconsistentMetadata(),
             new CheckMissingGenreLanguage(),
+
+            // Settings
+            new CheckInconsistentSettings(),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)

--- a/osu.Game/Rulesets/Edit/Checks/CheckInconsistentSettings.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckInconsistentSettings.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
             new IssueTemplateInconsistentSetting(this, IssueType.Warning),
-            new IssueTemplateInconsistentSetting(this, IssueType.Negligible),
+            new IssueTemplateInconsistentSetting(this, IssueType.Negligible)
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
@@ -27,6 +27,8 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             var referenceBeatmap = context.Beatmap;
 
+            bool hasStoryboard = ResourcesCheckUtils.HasAnyStoryboardElementPresent(context.WorkingBeatmap);
+
             // Define fields to check
             var fieldsToCheck = new (IssueType issueType, string fieldName, Func<IBeatmap, object> fieldSelector)[]
             {
@@ -36,7 +38,7 @@ namespace osu.Game.Rulesets.Edit.Checks
                 (IssueType.Warning, "Epilepsy warning", b => b.EpilepsyWarning),
                 (IssueType.Warning, "Letterbox during breaks", b => b.LetterboxInBreaks),
                 (IssueType.Warning, "Samples match playback rate", b => b.SamplesMatchPlaybackRate),
-                (IssueType.Warning, "Widescreen support", b => b.WidescreenStoryboard),
+                (IssueType.Warning, "Widescreen support", b => hasStoryboard && b.WidescreenStoryboard),
                 (IssueType.Negligible, "Tick Rate", b => b.Difficulty.SliderTickRate),
             };
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckInconsistentSettings.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckInconsistentSettings.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Edit.Checks
                 (IssueType.Warning, "Epilepsy warning", b => b.EpilepsyWarning.ToString()),
                 (IssueType.Warning, "Letterbox during breaks", b => b.LetterboxInBreaks.ToString()),
                 (IssueType.Warning, "Samples match playback rate", b => b.SamplesMatchPlaybackRate.ToString()),
-                (IssueType.Warning, "widescreen support", b => b.WidescreenStoryboard.ToString()),
+                (IssueType.Warning, "Widescreen support", b => b.WidescreenStoryboard.ToString()),
                 (IssueType.Negligible, "Tick Rate", b => b.Difficulty.SliderTickRate.ToString(CultureInfo.InvariantCulture)),
             };
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckInconsistentSettings.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckInconsistentSettings.cs
@@ -1,0 +1,80 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit.Checks.Components;
+
+namespace osu.Game.Rulesets.Edit.Checks
+{
+    public class CheckInconsistentSettings : ICheck
+    {
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Settings, "Inconsistent settings", CheckScope.BeatmapSet);
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateInconsistentSetting(this, IssueType.Warning),
+            new IssueTemplateInconsistentSetting(this, IssueType.Negligible),
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            var difficulties = context.BeatmapsetDifficulties;
+
+            if (difficulties.Count <= 1)
+                yield break;
+
+            var referenceBeatmap = context.Beatmap;
+
+            // Define fields to check
+            var fieldsToCheck = new (IssueType issueType, string fieldName, Func<IBeatmap, string> fieldSelector)[]
+            {
+                (IssueType.Warning, "Audio lead-in", b => b.AudioLeadIn.ToString(CultureInfo.InvariantCulture)),
+                (IssueType.Warning, "Countdown", b => b.Countdown.ToString()),
+                (IssueType.Warning, "Countdown offset", b => b.CountdownOffset.ToString()),
+                (IssueType.Warning, "Epilepsy warning", b => b.EpilepsyWarning.ToString()),
+                (IssueType.Warning, "Letterbox during breaks", b => b.LetterboxInBreaks.ToString()),
+                (IssueType.Warning, "Samples match playback rate", b => b.SamplesMatchPlaybackRate.ToString()),
+                (IssueType.Warning, "widescreen support", b => b.WidescreenStoryboard.ToString()),
+                (IssueType.Negligible, "Tick Rate", b => b.Difficulty.SliderTickRate.ToString(CultureInfo.InvariantCulture)),
+            };
+
+            foreach (var beatmap in difficulties)
+            {
+                if (beatmap == referenceBeatmap)
+                    continue;
+
+                // Check each setting for inconsistencies
+                foreach ((var issueType, string fieldName, var fieldSelector) in fieldsToCheck)
+                {
+                    string referenceField = fieldSelector(referenceBeatmap);
+                    string currentField = fieldSelector(beatmap);
+
+                    if (referenceField != currentField)
+                    {
+                        yield return new IssueTemplateInconsistentSetting(this, issueType).Create(
+                            fieldName,
+                            referenceBeatmap.BeatmapInfo.DifficultyName,
+                            beatmap.BeatmapInfo.DifficultyName,
+                            referenceField,
+                            currentField
+                        );
+                    }
+                }
+            }
+        }
+
+        public class IssueTemplateInconsistentSetting : IssueTemplate
+        {
+            public IssueTemplateInconsistentSetting(ICheck check, IssueType issueType)
+                : base(check, issueType, "Inconsistent \"{0}\" setting between \"{1}\" and \"{2}\"; \"{3}\" and \"{4}\" respectively.")
+            {
+            }
+
+            public Issue Create(string fieldName, string referenceDifficulty, string currentDifficulty, string referenceValue, string currentValue)
+                => new Issue(this, fieldName, referenceDifficulty, currentDifficulty, referenceValue, currentValue);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckUnusedAudioAtEnd.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckUnusedAudioAtEnd.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
-using osu.Game.Storyboards;
 
 namespace osu.Game.Rulesets.Edit.Checks
 {
@@ -31,7 +30,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             {
                 double percentageLeft = Math.Abs(mappedPercentage - 100);
 
-                bool storyboardIsPresent = isAnyStoryboardElementPresent(context.WorkingBeatmap.Storyboard);
+                bool storyboardIsPresent = ResourcesCheckUtils.HasAnyStoryboardElementPresent(context.WorkingBeatmap);
 
                 if (storyboardIsPresent)
                 {
@@ -42,19 +41,6 @@ namespace osu.Game.Rulesets.Edit.Checks
                     yield return new IssueTemplateUnusedAudioAtEnd(this).Create(percentageLeft);
                 }
             }
-        }
-
-        private bool isAnyStoryboardElementPresent(Storyboard storyboard)
-        {
-            foreach (var layer in storyboard.Layers)
-            {
-                foreach (var _ in layer.Elements)
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         public class IssueTemplateUnusedAudioAtEnd : IssueTemplate

--- a/osu.Game/Rulesets/Edit/Checks/Components/ResourcesCheckUtils.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/ResourcesCheckUtils.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Edit.Checks.Components
+{
+    public static class ResourcesCheckUtils
+    {
+        /// <summary>
+        /// Checks if any storyboard element is present in the working beatmap.
+        /// </summary>
+        /// <param name="workingBeatmap">The working beatmap to check.</param>
+        /// <returns>True if any storyboard element is present, false otherwise.</returns>
+        public static bool HasAnyStoryboardElementPresent(IWorkingBeatmap workingBeatmap)
+        {
+            foreach (var layer in workingBeatmap.Storyboard.Layers)
+            {
+                foreach (var _ in layer.Elements)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Part of https://github.com/ppy/osu/issues/12091

Ports [the following check](https://github.com/Naxesss/MapsetVerifier/blob/6e48f1269b0a484490a0ddc75df23b3400037a3d/src/Checks/AllModes/Settings/CheckInconsistentSettings.cs) from MV.

Initially thought about integrating it with the main metadata check but felt it'd be better to keep concerns separate.

Doesn't include every setting in the MV check since they're either:
- Not easily checkable AND they're too rare to be worth the effort
- No longer a concern in lazer (namely the beatmap ID check)