### PR TITLE
Fix edge case that estimates sliderbreaks in impossible scenarios

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double missCount = Math.Min(scoreBasedMissCount, maximumMissCount);
 
             // Every slider has *at least* 2 combo attributed in classic mechanics.
+            // If they broke on a slider with a tick, then this still works since they would have lost at least 2 combo (the tick and the end)
             // Using this as a max means a score that loses 1 combo on a map can't possibly have been a slider break.
             // It must have been a slider end.
             int maxPossibleSliderBreaks = Math.Min(attributes.SliderCount, (attributes.MaxCombo - score.MaxCombo) / 2);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -47,9 +47,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             scoreBasedMissCount = Math.Max(scoreBasedMissCount, 1);
 
             // Cap result by very harsh version of combo-based miss count
-            double missCount = Math.Min(scoreBasedMissCount, maximumMissCount);
-
-            return missCount;
+            return Math.Min(scoreBasedMissCount, maximumMissCount);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -49,19 +49,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // Cap result by very harsh version of combo-based miss count
             double missCount = Math.Min(scoreBasedMissCount, maximumMissCount);
 
-            // Every slider has *at least* 2 combo attributed in classic mechanics.
-            // If they broke on a slider with a tick, then this still works since they would have lost at least 2 combo (the tick and the end)
-            // Using this as a max means a score that loses 1 combo on a map can't possibly have been a slider break.
-            // It must have been a slider end.
-            int maxPossibleSliderBreaks = Math.Min(attributes.SliderCount, (attributes.MaxCombo - score.MaxCombo) / 2);
-
-            int scoreMissCount = score.Statistics.GetValueOrDefault(HitResult.Miss);
-
-            double sliderBreaks = missCount - scoreMissCount;
-
-            if (sliderBreaks > maxPossibleSliderBreaks)
-                missCount = scoreMissCount + maxPossibleSliderBreaks;
-
             return missCount;
         }
 
@@ -139,6 +126,19 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // In classic scores there can't be more misses than a sum of all non-perfect judgements
             missCount = Math.Min(missCount, totalImperfectHits);
+
+            // Every slider has *at least* 2 combo attributed in classic mechanics.
+            // If they broke on a slider with a tick, then this still works since they would have lost at least 2 combo (the tick and the end)
+            // Using this as a max means a score that loses 1 combo on a map can't possibly have been a slider break.
+            // It must have been a slider end.
+            int maxPossibleSliderBreaks = Math.Min(attributes.SliderCount, (attributes.MaxCombo - score.MaxCombo) / 2);
+
+            int scoreMissCount = score.Statistics.GetValueOrDefault(HitResult.Miss);
+
+            double sliderBreaks = missCount - scoreMissCount;
+
+            if (sliderBreaks > maxPossibleSliderBreaks)
+                missCount = scoreMissCount + maxPossibleSliderBreaks;
 
             return missCount;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -47,7 +47,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             scoreBasedMissCount = Math.Max(scoreBasedMissCount, 1);
 
             // Cap result by very harsh version of combo-based miss count
-            return Math.Min(scoreBasedMissCount, maximumMissCount);
+            double missCount = Math.Min(scoreBasedMissCount, maximumMissCount);
+
+            // Every slider has *at least* 2 combo attributed in classic mechanics.
+            // Using this as a max means a score that loses 1 combo on a map can't possibly have been a slider break.
+            // It must have been a slider end.
+            int maxPossibleSliderBreaks = Math.Min(attributes.SliderCount, (attributes.MaxCombo - score.MaxCombo) / 2);
+
+            int scoreMissCount = score.Statistics.GetValueOrDefault(HitResult.Miss);
+
+            double sliderBreaks = missCount - scoreMissCount;
+
+            if (sliderBreaks > maxPossibleSliderBreaks)
+                missCount = scoreMissCount + maxPossibleSliderBreaks;
+
+            return missCount;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -113,16 +113,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             effectiveMissCount = Math.Max(countMiss, effectiveMissCount);
             effectiveMissCount = Math.Min(totalHits, effectiveMissCount);
 
-            // Every slider has *at least* 2 combo attributed.
-            // Using this as a max means a score that loses 1 combo on a map with 2 sliders can't possibly have a slider break
-            // They must have been missed slider ends.
-            int maxPossibleSliderBreaks = Math.Min(osuAttributes.SliderCount, (osuAttributes.MaxCombo - scoreMaxCombo) / 2);
-
-            double sliderBreaks = effectiveMissCount - countMiss;
-
-            if (sliderBreaks > maxPossibleSliderBreaks)
-                effectiveMissCount = countMiss + maxPossibleSliderBreaks;
-
             double multiplier = OsuDifficultyCalculator.CalculateDifficultyMultiplier(score.Mods, totalHits, osuAttributes.SpinnerCount);
 
             if (score.Mods.Any(m => m is OsuModNoFail))

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -113,6 +113,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             effectiveMissCount = Math.Max(countMiss, effectiveMissCount);
             effectiveMissCount = Math.Min(totalHits, effectiveMissCount);
 
+            // Every slider has *at least* 2 combo attributed.
+            // Using this as a max means a score that loses 1 combo on a map with 2 sliders can't possibly have a slider break
+            // They must have been missed slider ends.
+            int maxPossibleSliderBreaks = Math.Min(osuAttributes.SliderCount, (osuAttributes.MaxCombo - scoreMaxCombo) / 2);
+
+            double sliderBreaks = effectiveMissCount - countMiss;
+
+            if (sliderBreaks > maxPossibleSliderBreaks)
+                effectiveMissCount = countMiss + maxPossibleSliderBreaks;
+
             double multiplier = OsuDifficultyCalculator.CalculateDifficultyMultiplier(score.Mods, totalHits, osuAttributes.SpinnerCount);
 
             if (score.Mods.Any(m => m is OsuModNoFail))

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -343,6 +343,17 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
                 // In classic scores there can't be more misses than a sum of all non-perfect judgements
                 missCount = Math.Min(missCount, totalImperfectHits);
+
+                // Every slider has *at least* 2 combo attributed in classic mechanics.
+                // If they broke on a slider with a tick, then this still works since they would have lost at least 2 combo (the tick and the end)
+                // Using this as a max means a score that loses 1 combo on a map can't possibly have been a slider break.
+                // It must have been a slider end.
+                int maxPossibleSliderBreaks = Math.Min(attributes.SliderCount, (attributes.MaxCombo - scoreMaxCombo) / 2);
+
+                double sliderBreaks = missCount - countMiss;
+
+                if (sliderBreaks > maxPossibleSliderBreaks)
+                    missCount = countMiss + maxPossibleSliderBreaks;
             }
             else
             {


### PR DESCRIPTION
This is built upon the assumption that, under legacy mechanics, a correctly hit slider will always award at least 2 combo (one for the head, one for the tail). This assumption means that if a score has no misses and is 1 combo below the maximum, then that dropped combo **must** be from a slider end and not a slider break.

An example score falsely nerfed (by ~30pp) for an impossible sliderbreak: https://osu.ppy.sh/scores/5249945306. In 99% of cases, this will make no difference.

This is not caused by recent sliderbreak estimation changes, as the problem is isolated specifically to the pre-existing combo-based estimations. ScoreV1 estimation uses combo-based estimation as a tiebreaker so even though this is estimated as a 0 miss by ScoreV1, it ends up being calculated as a 1 miss otherwise.