### PR TITLE
Fix various issues around metadata cache handling

### DIFF
--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -192,6 +192,13 @@ namespace osu.Game.Beatmaps
             {
                 try
                 {
+                    // `SqliteConnection` by default uses pooling.
+                    // disposing an `SqliteConnection` is not enough to get `Microsoft.Data.Sqlite` to close the database file.
+                    // this means that overwriting the file may fail if the pools are not cleared before trying.
+                    // this fails especially loudly on Windows because of Windows file delete semantics being exclusive-write
+                    // rather than Unix's "file is marked for deletion after last reader closes the fd".
+                    SqliteConnection.ClearAllPools();
+
                     using (var stream = File.OpenRead(cacheDownloadRequest.Filename))
                     using (var outStream = File.OpenWrite(cacheFilePath))
                     {

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -238,12 +238,20 @@ namespace osu.Game.Beatmaps
             });
         }
 
-        public int GetCacheVersion()
+        public bool IsAtLeastVersion(int version)
         {
-            using (var connection = getConnection())
+            try
             {
-                connection.Open();
-                return getCacheVersion(connection);
+                using (var connection = getConnection())
+                {
+                    connection.Open();
+                    return getCacheVersion(connection) >= version;
+                }
+            }
+            catch (SqliteException ex) when (ex.SqliteErrorCode == 26 || ex.SqliteErrorCode == 11) // SQLITE_NOTADB, SQLITE_CORRUPT
+            {
+                // if the database is corrupted then return `false` as the consumer may want to just refetch the db themselves
+                return false;
             }
         }
 

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -72,11 +72,15 @@ namespace osu.Game.Database
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
 
+        private LocalCachedBeatmapMetadataSource localMetadataSource = null!;
+
         protected virtual int TimeToSleepDuringGameplay => 30000;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            localMetadataSource = new LocalCachedBeatmapMetadataSource(storage);
 
             ProcessingTask = Task.Factory.StartNew(() =>
             {
@@ -532,8 +536,6 @@ namespace osu.Game.Database
 
         private void backpopulateMissingSubmissionAndRankDates()
         {
-            var localMetadataSource = new LocalCachedBeatmapMetadataSource(storage);
-
             if (!localMetadataSource.Available)
             {
                 Logger.Log("Cannot backpopulate missing submission/rank dates because the local metadata cache is missing.");
@@ -542,7 +544,7 @@ namespace osu.Game.Database
 
             try
             {
-                if (localMetadataSource.GetCacheVersion() < 2)
+                if (!localMetadataSource.IsAtLeastVersion(2))
                 {
                     Logger.Log("Cannot backpopulate missing submission/rank dates because the local metadata cache is too old.");
                     return;
@@ -630,14 +632,12 @@ namespace osu.Game.Database
 
         private void backpopulateUserTags()
         {
-            var localMetadataSource = new LocalCachedBeatmapMetadataSource(storage);
-
-            if (!localMetadataSource.Available || localMetadataSource.GetCacheVersion() < 3)
+            if (!localMetadataSource.Available || !localMetadataSource.IsAtLeastVersion(3))
             {
                 Logger.Log(@"Local metadata cache has too low version to backpopulate user tags, attempting refetch...");
                 localMetadataSource.FetchCache().WaitSafely();
 
-                if (!localMetadataSource.Available || localMetadataSource.GetCacheVersion() < 3)
+                if (!localMetadataSource.Available || !localMetadataSource.IsAtLeastVersion(3))
                 {
                     Logger.Log(@"Local metadata cache refetch failed. Aborting user tags backpopulation.");
                     return;


### PR DESCRIPTION
## [Fix metadata cache refetches failing on windows](https://github.com/ppy/osu/commit/7da94c4010615896af90e784a32cd0d8a270af28) 

Fixes the `online.db` portion of https://github.com/ppy/osu/issues/34513.

Only really visible on windows for reasons outlined in inline comment.

## [Fix metadata cache version queries failing hard if the image is corrupted](https://github.com/ppy/osu/commit/dac643121ae7f946ededdbcd16f176b099ea1324)

Apparently @smoogipoo and @frenzibyte were seeing this locally (please test). Not sure why.

This was not fatal but with this change it should recover in a slightly better way.

Also incidentally fixes the cache refetch potentially being attempted twice by each of the two background population tasks that use it. This may be why the cache got corrupted to begin with.