### PR TITLE
Fix inconsistent localisation string in replay key bindings

### DIFF
--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -345,9 +345,9 @@ namespace osu.Game.Localisation
         public static LocalisableString SeekReplayBackward => new TranslatableString(getKey(@"seek_replay_backward"), @"Seek replay backward");
 
         /// <summary>
-        /// "Seek replay forward one frame"
+        /// "Step replay forward one frame"
         /// </summary>
-        public static LocalisableString StepReplayForward => new TranslatableString(getKey(@"step_replay_forward"), @"Seek replay forward one frame");
+        public static LocalisableString StepReplayForward => new TranslatableString(getKey(@"step_replay_forward"), @"Step replay forward one frame");
 
         /// <summary>
         /// "Step replay backward one frame"


### PR DESCRIPTION
Found this mistake when reading key configuration in osu