### PR TITLE
Fix jumping back to beatmaps after scrolling away from them

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -453,6 +453,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 ActivationCount++;
                 base.HandleItemActivated(item);
             }
+            public Framework.Caching.Cached GetSetSelectionValid()
+            {
+                return SelectionValid;
+            }
 
             protected override async Task<IEnumerable<CarouselItem>> FilterAsync(bool clearExistingPanels = false)
             {

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -107,6 +107,23 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
+        /// <summary>
+        /// Previously it was possible for selection to become invalid even if the value
+        /// that it is set to is the same as it is stored. This caused selection to become
+        /// "invalid" even though the selection was still correct.
+        /// </summary>
+        [Test]
+        public void TestSelectionValid()
+        {
+            Carousel.CurrentSelection = baseTestBeatmap.Beatmaps[0];
+            Carousel.GetSetSelectionValid().Validate();
+            object? selection = Carousel.CurrentSelection;            
+            Carousel.CurrentSelection = selection;
+            Assert.True(Carousel.GetSetSelectionValid().IsValid);
+            Carousel.CurrentSelection = selection;
+            Assert.True(Carousel.GetSetSelectionValid().IsValid);
+        }
+
         [Test] // Checks that we keep selection based on online ID where possible.
         public void TestSelectionHeldDifficultyNameChanged()
         {

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Graphics.Carousel
                     // Even if the current selection matches, let's ensure the keyboard selection is reset
                     // to the newly selected object. This matches user expectations (for now).
                     currentKeyboardSelection = currentSelection;
-                    selectionValid.Invalidate();
+                    //selectionValid.Invalidate();
                 }
             }
         }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -117,16 +117,6 @@ namespace osu.Game.Graphics.Carousel
                     currentSelection = currentKeyboardSelection;
                     selectionValid.Invalidate();
                 }
-                else if (currentKeyboardSelection.Model != value)
-                {
-                    // Even if the current selection matches, let's ensure the keyboard selection is reset
-                    // to the newly selected object. This matches user expectations (for now).
-                    currentKeyboardSelection = currentSelection;
-
-                    // The following line is commented out due to causing a weird bug
-                    // where the selection would jump back after scrolling away
-                    //selectionValid.Invalidate();
-                }
             }
         }
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -122,6 +122,9 @@ namespace osu.Game.Graphics.Carousel
                     // Even if the current selection matches, let's ensure the keyboard selection is reset
                     // to the newly selected object. This matches user expectations (for now).
                     currentKeyboardSelection = currentSelection;
+
+                    // The following line is commented out due to causing a weird bug
+                    // where the selection would jump back after scrolling away
                     //selectionValid.Invalidate();
                 }
             }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -117,10 +117,6 @@ namespace osu.Game.Graphics.Carousel
                     currentSelection = currentKeyboardSelection;
                     SelectionValid.Invalidate();
                 }
-                else if (currentKeyboardSelection.Model != value)
-                {
-                    SelectionValid.Invalidate();
-                }
             }
         }
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -117,6 +117,13 @@ namespace osu.Game.Graphics.Carousel
                     currentSelection = currentKeyboardSelection;
                     SelectionValid.Invalidate();
                 }
+                else if (!CheckModelEquality(currentKeyboardSelection.Model, value))
+                {
+                    // Even if the current selection matches, let's ensure the keyboard selection is reset
+                    // to the newly selected object. This matches user expectations (for now).
+                    currentKeyboardSelection = currentSelection;
+                    SelectionValid.Invalidate();
+                }
             }
         }
 

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -115,7 +115,11 @@ namespace osu.Game.Graphics.Carousel
 
                     currentKeyboardSelection = new Selection(value);
                     currentSelection = currentKeyboardSelection;
-                    selectionValid.Invalidate();
+                    SelectionValid.Invalidate();
+                }
+                else if (currentKeyboardSelection.Model != value)
+                {
+                    SelectionValid.Invalidate();
                 }
             }
         }
@@ -134,7 +138,7 @@ namespace osu.Game.Graphics.Carousel
             (GetMaterialisedDrawableForItem(item) as ICarouselPanel)?.Activated();
             HandleItemActivated(item);
 
-            selectionValid.Invalidate();
+            SelectionValid.Invalidate();
         }
 
         /// <summary>
@@ -685,7 +689,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// Becomes invalid when the current selection has changed and needs to be updated visually.
         /// </summary>
-        private readonly Cached selectionValid = new Cached();
+        protected readonly Cached SelectionValid = new Cached();
 
         private Selection currentKeyboardSelection = new Selection();
         private Selection currentSelection = new Selection();
@@ -693,7 +697,7 @@ namespace osu.Game.Graphics.Carousel
         private void setKeyboardSelection(object? model)
         {
             currentKeyboardSelection = new Selection(model);
-            selectionValid.Invalidate();
+            SelectionValid.Invalidate();
         }
 
         /// <summary>
@@ -792,14 +796,14 @@ namespace osu.Game.Graphics.Carousel
             visibleUpperBound = (float)(Scroll.Current - BleedTop);
             visibleHalfHeight = (DrawHeight + BleedBottom + BleedTop) / 2;
 
-            if (!selectionValid.IsValid)
+            if (!SelectionValid.IsValid)
             {
                 refreshAfterSelection();
 
                 // Always scroll to selection in this case (regardless of `UserScrolling` state), centering the selection.
                 ScrollToSelection();
 
-                selectionValid.Validate();
+                SelectionValid.Validate();
             }
 
             var range = getDisplayRange();
@@ -992,7 +996,7 @@ namespace osu.Game.Graphics.Carousel
         {
             // handles the vertical size of the carousel changing (ie. on window resize when aspect ratio has changed).
             if (invalidation.HasFlag(Invalidation.DrawSize))
-                selectionValid.Invalidate();
+                SelectionValid.Invalidate();
 
             return base.OnInvalidate(invalidation, source);
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/33458

After a lot of debugging and ctrl + shift + f later I found this line that is responsible for this. With this one line commented everything still behaves the same, but at the same time fixes the jumping back to beatmaps after scrolling away.
Before:
https://github.com/user-attachments/assets/b0ae0f11-8087-4d62-9199-c633afd5c397

After:
https://github.com/user-attachments/assets/48e0fe45-f593-46d5-96f2-2ffff19d06b8