### PR TITLE
Refactor `APIRuleset` class (marked with todo)

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
@@ -142,29 +143,21 @@ namespace osu.Game.Online.API.Requests.Responses
 
         public class APIRuleset : IRulesetInfo
         {
+            private static readonly Dictionary<int, string> id_to_short_name = new Dictionary<int, string>
+            {
+                { 0, "osu" },
+                { 1, "taiko" },
+                { 2, "fruits" },
+                { 3, "mania" }
+            };
+
             public int OnlineID { get; set; } = -1;
 
             public string Name => $@"{nameof(APIRuleset)} (ID: {OnlineID})";
 
-            public string ShortName
-            {
-                get
-                {
-                    // TODO: this should really not exist.
-                    switch (OnlineID)
-                    {
-                        case 0: return "osu";
-
-                        case 1: return "taiko";
-
-                        case 2: return "fruits";
-
-                        case 3: return "mania";
-
-                        default: throw new ArgumentOutOfRangeException();
-                    }
-                }
-            }
+            public string ShortName => id_to_short_name.TryGetValue(OnlineID, out string? shortName)
+                ? shortName
+                : throw new ArgumentOutOfRangeException(nameof(OnlineID), OnlineID, "Unknown ruleset online ID");
 
             public string InstantiationInfo => string.Empty;
 

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -155,9 +155,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
             public string Name => $@"{nameof(APIRuleset)} (ID: {OnlineID})";
 
-            public string ShortName => id_to_short_name.TryGetValue(OnlineID, out string? shortName)
-                ? shortName
-                : throw new ArgumentOutOfRangeException(nameof(OnlineID), OnlineID, "Unknown ruleset online ID");
+            public string ShortName => getShortName();
 
             public string InstantiationInfo => string.Empty;
 
@@ -175,6 +173,14 @@ namespace osu.Game.Online.API.Requests.Responses
 
             // ReSharper disable once NonReadonlyMemberInGetHashCode
             public override int GetHashCode() => OnlineID;
+
+            private string getShortName()
+            {
+                if (id_to_short_name.TryGetValue(OnlineID, out string? shortName))
+                    return shortName;
+
+                throw new ArgumentOutOfRangeException(nameof(OnlineID), OnlineID, "Unknown ruleset online ID");
+            }
         }
 
         public class BeatmapOwner


### PR DESCRIPTION
addresses [this todo comment](https://github.com/uwuclxdy/osu/blob/6bb84e4364256df75949a56cc4d67023a773f00c/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs#L153).

also removes the *Exceptions should never be thrown in property getters* warning by getting the `ShortName` in a separate function.

feedback is appreciated