### PR TITLE
Performance gain by caching playable beatmaps

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Beatmaps
             {
                 mods ??= Array.Empty<Mod>();
                 string currentRulesetShortName = ruleset.ShortName;
-                string currentModsHash = string.Join(",", mods.Select(static m => m.Acronym).OrderBy(static a => a));
+                string currentModsHash = string.Join(',', mods.Select(static m => m.Acronym).Order());
 
                 if (cachedPlayableBeatmap != null && cachedRulesetShortName == currentRulesetShortName && cachedModsHash == currentModsHash)
                     return cachedPlayableBeatmap;

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -266,7 +266,6 @@ namespace osu.Game.Screens.SelectV2
                 Task.Run(() =>
                 {
                     // This can take time as it is a synchronous task.
-                    // TODO: We're calling `GetPlayableBeatmap` multiple times every map load at song select.
                     var playableBeatmap = beatmap.Value.GetPlayableBeatmap(ruleset.Value);
                     var statistics = playableBeatmap.GetStatistics()
                                                     .Select(s => new StatisticDifficulty.Data(s.Name, s.BarDisplayLength ?? 0, s.BarDisplayLength ?? 0, 1, s.Content))


### PR DESCRIPTION
addresses [this todo comment](https://github.com/uwuclxdy/osu/blob/cb73717a3419afb539764d37df53b3fc50aa5f91/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs#L269)

Improves frequent calls of `GetPlayableBeatmap()`. Noticeable when rapidly changing the selected map.


https://github.com/user-attachments/assets/12078ea3-0fde-4ae8-8ce9-c1a3df1b484d


