### PR TITLE
refactor `APIBeatmap` to remove hardcoded names

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -27,7 +27,6 @@ using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Models;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
@@ -1309,14 +1308,14 @@ namespace osu.Game.Database
 
         private string? getRulesetShortNameFromLegacyID(long rulesetId)
         {
-            try
+            return rulesetId switch
             {
-                return new APIBeatmap.APIRuleset { OnlineID = (int)rulesetId }.ShortName;
-            }
-            catch
-            {
-                return null;
-            }
+                0 => @"osu",
+                1 => @"taiko",
+                2 => @"fruits",
+                3 => @"mania",
+                _ => null
+            };
         }
 
         /// <summary>

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         public string MD5Hash => Checksum;
 
-        public IRulesetInfo Ruleset => new APIRuleset { OnlineID = RulesetID };
+        public IRulesetInfo Ruleset => new RulesetInfo { OnlineID = RulesetID };
 
         [JsonIgnore]
         public string Hash => throw new NotImplementedException();
@@ -139,50 +139,6 @@ namespace osu.Game.Online.API.Requests.Responses
         #endregion
 
         public bool Equals(IBeatmapInfo? other) => other is APIBeatmap b && this.MatchesOnlineID(b);
-
-        public class APIRuleset : IRulesetInfo
-        {
-            public int OnlineID { get; set; } = -1;
-
-            public string Name => $@"{nameof(APIRuleset)} (ID: {OnlineID})";
-
-            public string ShortName
-            {
-                get
-                {
-                    // TODO: this should really not exist.
-                    switch (OnlineID)
-                    {
-                        case 0: return "osu";
-
-                        case 1: return "taiko";
-
-                        case 2: return "fruits";
-
-                        case 3: return "mania";
-
-                        default: throw new ArgumentOutOfRangeException();
-                    }
-                }
-            }
-
-            public string InstantiationInfo => string.Empty;
-
-            public Ruleset CreateInstance() => throw new NotImplementedException();
-
-            public bool Equals(IRulesetInfo? other) => other is APIRuleset r && this.MatchesOnlineID(r);
-
-            public int CompareTo(IRulesetInfo? other)
-            {
-                if (!(other is APIRuleset ruleset))
-                    throw new ArgumentException($@"Object is not of type {nameof(APIRuleset)}.", nameof(other));
-
-                return OnlineID.CompareTo(ruleset.OnlineID);
-            }
-
-            // ReSharper disable once NonReadonlyMemberInGetHashCode
-            public override int GetHashCode() => OnlineID;
-        }
 
         public class BeatmapOwner
         {


### PR DESCRIPTION
addresses [this](https://github.com/uwuclxdy/osu/blob/6bb84e4364256df75949a56cc4d67023a773f00c/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs#L153)

- completely removed `APIRuleset` class
- `Ruleset` property now returns `RulesetInfo` only with `OnlineID` populated
- names are hardcoded only in `RealmAccess.cs` for legacy migrations