### PR TITLE
Add setting for adjusting beatmap offset automatically based on last play

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -108,6 +108,8 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.AudioOffset, 0, -500.0, 500.0, 1);
 
+            SetDefault(OsuSetting.AutomaticallyAdjustBeatmapOffset, false);
+
             // Input
             SetDefault(OsuSetting.MenuCursorSize, 1.0f, 0.5f, 2f, 0.01f);
             SetDefault(OsuSetting.GameplayCursorSize, 1.0f, 0.1f, 2f, 0.01f);
@@ -482,5 +484,7 @@ namespace osu.Game.Configuration
         WasSupporter,
 
         LastOnlineTagsPopulation,
+
+        AutomaticallyAdjustBeatmapOffset,
     }
 }

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -89,6 +89,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString OffsetWizard => new TranslatableString(getKey(@"offset_wizard"), @"Offset wizard");
 
+        /// <summary>
+        /// "Adjust beatmap offset automatically"
+        /// </summary>
+        public static LocalisableString AdjustBeatmapOffsetAutomatically => new TranslatableString(getKey(@"adjust_beatmap_offset_automatically"), @"Adjust beatmap offset automatically");
+
+        /// <summary>
+        /// "If enabled, the offset suggested from last play on a beatmap is automatically applied."
+        /// </summary>
+        public static LocalisableString AdjustBeatmapOffsetAutomaticallyTooltip => new TranslatableString(getKey(@"adjust_beatmap_offset_automatically_tooltip"), @"If enabled, the offset suggested from last play on a beatmap is automatically applied.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
@@ -26,6 +26,12 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 {
                     Current = config.GetBindable<double>(OsuSetting.AudioOffset),
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = AudioSettingsStrings.AdjustBeatmapOffsetAutomatically,
+                    TooltipText = AudioSettingsStrings.AdjustBeatmapOffsetAutomaticallyTooltip,
+                    Current = config.GetBindable<bool>(OsuSetting.AutomaticallyAdjustBeatmapOffset),
+                }
             };
         }
     }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -152,6 +152,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
             // Calibration button may be hidden due to automatic offset adjustment, but it should be visible when the user manually adjusts their offset away from the applied suggestion.
             calibrateFromLastPlayButton?.Show();
 
+            // This is intentionally not scheduled as the offset may be changed while the control is hidden and cannot process its scheduler.
+            // This is the case when auto-adjustment is enabled and the offset is adjusted while the player is quick-retrying.
             writeOffsetToBeatmap();
         }
 

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -153,6 +153,9 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 // Negative is applied here because the play graph is considering a hit offset, not track (as we currently use for clocks).
                 lastPlayGraph?.UpdateOffset(-adjustmentSinceLastPlay);
 
+                // Calibration button may be hidden due to automatic offset adjustment, but it should be visible when the user manually adjusts their offset away from the applied suggestion.
+                calibrateFromLastPlayButton?.Show();
+
                 // ensure the previous write has completed. ignoring performance concerns, if we don't do this, the async writes could be out of sequence.
                 if (realmWriteTask?.IsCompleted == false)
                 {

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -266,11 +266,15 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
             if (config.Get<bool>(OsuSetting.AutomaticallyAdjustBeatmapOffset))
             {
-                applySuggestedOffset(proportionalToUnstableRate: true);
+                bool offsetChanged = applySuggestedOffset(proportionalToUnstableRate: true);
+
                 calibrateFromLastPlayButton.Hide();
 
-                offsetText.AddText($"Beatmap offset has automatically been adjusted to {Current.Value.ToStandardFormattedString(1)} ms.", t => t.Font = OsuFont.Style.Caption1);
-                offsetText.NewParagraph();
+                if (offsetChanged)
+                {
+                    offsetText.AddText($"Beatmap offset was adjusted to {Current.Value.ToStandardFormattedString(1)} ms.", t => t.Font = OsuFont.Style.Caption1);
+                    offsetText.NewParagraph();
+                }
             }
 
             offsetText.AddText("You can also ", t => t.Font = OsuFont.Style.Caption2);
@@ -278,7 +282,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             offsetText.AddText(" based off this play.", t => t.Font = OsuFont.Style.Caption2);
         }
 
-        private void applySuggestedOffset(bool proportionalToUnstableRate)
+        private bool applySuggestedOffset(bool proportionalToUnstableRate)
         {
             const double ur_adjustment_cutoff = 90;
             const double exponential_factor = -0.0116;
@@ -292,6 +296,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
             Current.Value = lastPlayBeatmapOffset - offsetAdjustment;
             lastAppliedScore.Value = lastValidScore;
+
+            return Math.Abs(Current.Value - lastPlayBeatmapOffset) > Current.Precision;
         }
 
         [Resolved]

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             double lastOffset = Current.Value;
 
-            Current.Value = computeSuggestedOffset(lastPlayMedian, lastPlayUnstableRate, lastPlayBeatmapOffset, proportionalToUnstableRate: autoAdjustBeatmapOffset.Value);
+            Current.Value = computeSuggestedOffset(lastPlayMedian, lastPlayUnstableRate, lastPlayBeatmapOffset);
             lastAppliedScore.Value = lastValidScore;
 
             return !Precision.AlmostEquals(Current.Value, lastOffset, Current.Precision / 2);
@@ -314,7 +314,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
             if (calibrateFromLastPlayButton != null)
             {
-                double suggestedOffset = computeSuggestedOffset(lastPlayMedian, lastPlayUnstableRate, lastPlayBeatmapOffset, proportionalToUnstableRate: autoAdjustBeatmapOffset.Value);
+                double suggestedOffset = computeSuggestedOffset(lastPlayMedian, lastPlayUnstableRate, lastPlayBeatmapOffset);
                 calibrateFromLastPlayButton.Enabled.Value = allow && !Precision.AlmostEquals(suggestedOffset, Current.Value, Current.Precision / 2);
             }
 
@@ -350,17 +350,19 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
         }
 
-        private static double computeSuggestedOffset(double median, double unstableRate, double currentOffset, bool proportionalToUnstableRate)
+        private static double computeSuggestedOffset(double median, double unstableRate, double currentOffset)
         {
             const double ur_adjustment_cutoff = 90;
             const double exponential_factor = -0.0116;
 
             double offsetAdjustment = median;
 
-            if (proportionalToUnstableRate && unstableRate >= ur_adjustment_cutoff)
+            if (unstableRate >= ur_adjustment_cutoff)
+            {
                 // A demonstrative graph of this algorithm is embedded in https://github.com/ppy/osu/discussions/30521.
                 // This ultimately prevents scores with high unstable rate from suggesting potentially invalid offsets.
                 offsetAdjustment *= Math.Exp(exponential_factor * (unstableRate - ur_adjustment_cutoff));
+            }
 
             return currentOffset - offsetAdjustment;
         }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -296,7 +296,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             Current.Value = suggestedOffset;
             lastAppliedScore.Value = lastValidScore;
 
-            return Math.Abs(Current.Value - lastPlayBeatmapOffset) > Current.Precision;
+            return !Precision.AlmostEquals(Current.Value, lastOffset, Current.Precision / 2);
         }
 
         [Resolved]

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
@@ -19,10 +19,23 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// </summary>
         protected string Value
         {
-            set => this.value.Text = value;
+            set => valueText.Text = value;
         }
 
-        private readonly OsuSpriteText value;
+        /// <summary>
+        /// The font size preferred for the displayed texts.
+        /// </summary>
+        public float FontSize
+        {
+            set
+            {
+                nameText.Font = nameText.Font.With(size: value);
+                valueText.Font = valueText.Font.With(size: value);
+            }
+        }
+
+        private readonly OsuSpriteText nameText;
+        private readonly OsuSpriteText valueText;
 
         /// <summary>
         /// Creates a new simple statistic item.
@@ -37,14 +50,14 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             AddRange(new[]
             {
-                new OsuSpriteText
+                nameText = new OsuSpriteText
                 {
                     Text = Name,
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                     Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE)
                 },
-                value = new OsuSpriteText
+                valueText = new OsuSpriteText
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/30521
- Supersedes https://github.com/ppy/osu/pull/30586

This re-attempts the PR above while also providing UI/UX feedback and supporting adjust offset on quick restarts. @Inconsist's algorithm to handle scores with high unstable rate has been ported across verbatim (see https://github.com/ppy/osu/discussions/30521#discussion-7432380).

