### PR TITLE
Reduce number of realm subscription triggers from song select online lookups

### DIFF
--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -700,9 +700,17 @@ namespace osu.Game.Database
                         if (lookupSucceeded)
                         {
                             Debug.Assert(result != null);
-                            beatmap.Metadata.UserTags.Clear();
-                            beatmap.Metadata.UserTags.AddRange(result.UserTags);
-                            return beatmap.Metadata.UserTags.Any();
+
+                            var userTags = result.UserTags.ToHashSet();
+
+                            if (!userTags.SetEquals(beatmap.Metadata.UserTags))
+                            {
+                                beatmap.Metadata.UserTags.Clear();
+                                beatmap.Metadata.UserTags.AddRange(userTags);
+                                return true;
+                            }
+
+                            return false;
                         }
 
                         Logger.Log(@$"Could not find {beatmap.GetDisplayString()} in local cache while backpopulating missing user tags");

--- a/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
+++ b/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
@@ -13,6 +13,7 @@ using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using Realms;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -57,46 +58,49 @@ namespace osu.Game.Screens.SelectV2
                     return;
                 }
 
-                var tagsById = (onlineBeatmapSet.RelatedTags ?? []).ToDictionary(t => t.Id);
-                var onlineBeatmaps = onlineBeatmapSet.Beatmaps.ToDictionary(b => b.OnlineID);
-                await realm.WriteAsync(r =>
-                {
-                    var beatmapSet = r.All<BeatmapSetInfo>().Where(b => b.OnlineID == id);
-
-                    foreach (var dbBeatmapSet in beatmapSet)
-                    {
-                        dbBeatmapSet.Status = onlineBeatmapSet.Status;
-
-                        foreach (var dbBeatmap in dbBeatmapSet.Beatmaps)
-                        {
-                            if (onlineBeatmaps.TryGetValue(dbBeatmap.OnlineID, out var onlineBeatmap))
-                            {
-                                // compare `BeatmapUpdaterMetadataLookup`
-                                dbBeatmap.OnlineMD5Hash = onlineBeatmap.MD5Hash;
-                                dbBeatmap.LastOnlineUpdate = onlineBeatmap.LastUpdated;
-
-                                if (dbBeatmap.MatchesOnlineVersion)
-                                    dbBeatmap.Status = onlineBeatmap.Status;
-
-                                string[] userTagsArray = onlineBeatmap.TopTags?
-                                                                      .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
-                                                                      .Where(t => t.relatedTag != null)
-                                                                      // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
-                                                                      .OrderByDescending(t => t.topTag.VoteCount)
-                                                                      .ThenBy(t => t.relatedTag!.Name)
-                                                                      .Select(t => t.relatedTag!.Name)
-                                                                      .ToArray() ?? [];
-                                dbBeatmap.Metadata.UserTags.Clear();
-                                dbBeatmap.Metadata.UserTags.AddRange(userTagsArray);
-                            }
-                        }
-                    }
-                }).ConfigureAwait(true);
+                await realm.WriteAsync(r => updateRealmBeatmapSet(r, onlineBeatmapSet)).ConfigureAwait(true);
                 tcs.SetResult(onlineBeatmapSet);
             };
             request.Failure += tcs.SetException;
             api.Queue(request);
             return tcs.Task;
+        }
+
+        private static void updateRealmBeatmapSet(Realm r, APIBeatmapSet onlineBeatmapSet)
+        {
+            var tagsById = (onlineBeatmapSet.RelatedTags ?? []).ToDictionary(t => t.Id);
+            var onlineBeatmaps = onlineBeatmapSet.Beatmaps.ToDictionary(b => b.OnlineID);
+
+            var dbBeatmapSets = r.All<BeatmapSetInfo>().Where(b => b.OnlineID == onlineBeatmapSet.OnlineID);
+
+            foreach (var dbBeatmapSet in dbBeatmapSets)
+            {
+                dbBeatmapSet.Status = onlineBeatmapSet.Status;
+
+                foreach (var dbBeatmap in dbBeatmapSet.Beatmaps)
+                {
+                    if (onlineBeatmaps.TryGetValue(dbBeatmap.OnlineID, out var onlineBeatmap))
+                    {
+                        // compare `BeatmapUpdaterMetadataLookup`
+                        dbBeatmap.OnlineMD5Hash = onlineBeatmap.MD5Hash;
+                        dbBeatmap.LastOnlineUpdate = onlineBeatmap.LastUpdated;
+
+                        if (dbBeatmap.MatchesOnlineVersion)
+                            dbBeatmap.Status = onlineBeatmap.Status;
+
+                        string[] userTagsArray = onlineBeatmap.TopTags?
+                                                              .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
+                                                              .Where(t => t.relatedTag != null)
+                                                              // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
+                                                              .OrderByDescending(t => t.topTag.VoteCount)
+                                                              .ThenBy(t => t.relatedTag!.Name)
+                                                              .Select(t => t.relatedTag!.Name)
+                                                              .ToArray() ?? [];
+                        dbBeatmap.Metadata.UserTags.Clear();
+                        dbBeatmap.Metadata.UserTags.AddRange(userTagsArray);
+                    }
+                }
+            }
         }
     }
 }

--- a/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
+++ b/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
@@ -75,29 +75,39 @@ namespace osu.Game.Screens.SelectV2
 
             foreach (var dbBeatmapSet in dbBeatmapSets)
             {
-                dbBeatmapSet.Status = onlineBeatmapSet.Status;
+                // note that every single write to realm models is preceded by a guard, even if it technically would write the same value back.
+                // the reason this matters is that doing so avoids triggering realm subscription callbacks.
+                // unfortunately in terms of subscriptions realm treats *every* write to any realm object as a modification,
+                // even if the write was redundant and had no observable effect.
+
+                if (dbBeatmapSet.Status != onlineBeatmapSet.Status)
+                    dbBeatmapSet.Status = onlineBeatmapSet.Status;
 
                 foreach (var dbBeatmap in dbBeatmapSet.Beatmaps)
                 {
                     if (onlineBeatmaps.TryGetValue(dbBeatmap.OnlineID, out var onlineBeatmap))
                     {
                         // compare `BeatmapUpdaterMetadataLookup`
-                        dbBeatmap.OnlineMD5Hash = onlineBeatmap.MD5Hash;
-                        dbBeatmap.LastOnlineUpdate = onlineBeatmap.LastUpdated;
+                        if (dbBeatmap.OnlineMD5Hash != onlineBeatmap.MD5Hash)
+                            dbBeatmap.OnlineMD5Hash = onlineBeatmap.MD5Hash;
 
-                        if (dbBeatmap.MatchesOnlineVersion)
+                        if (dbBeatmap.LastOnlineUpdate != onlineBeatmap.LastUpdated)
+                            dbBeatmap.LastOnlineUpdate = onlineBeatmap.LastUpdated;
+
+                        if (dbBeatmap.MatchesOnlineVersion && dbBeatmap.Status != onlineBeatmap.Status)
                             dbBeatmap.Status = onlineBeatmap.Status;
 
-                        string[] userTagsArray = onlineBeatmap.TopTags?
-                                                              .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
-                                                              .Where(t => t.relatedTag != null)
-                                                              // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
-                                                              .OrderByDescending(t => t.topTag.VoteCount)
-                                                              .ThenBy(t => t.relatedTag!.Name)
-                                                              .Select(t => t.relatedTag!.Name)
-                                                              .ToArray() ?? [];
-                        dbBeatmap.Metadata.UserTags.Clear();
-                        dbBeatmap.Metadata.UserTags.AddRange(userTagsArray);
+                        HashSet<string> userTags = onlineBeatmap.TopTags?
+                                                                .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
+                                                                .Where(t => t.relatedTag != null)
+                                                                .Select(t => t.relatedTag!.Name)
+                                                                .ToHashSet() ?? [];
+
+                        if (!userTags.SetEquals(dbBeatmap.Metadata.UserTags))
+                        {
+                            dbBeatmap.Metadata.UserTags.Clear();
+                            dbBeatmap.Metadata.UserTags.AddRange(userTags);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Noticed by @peppy. Realm subscriptions are not smart enough to tell when a write is redundant because it's writing the same value back; to avoid them firing we need to guard ourselves.

This will alleviate https://github.com/ppy/osu/issues/34511 somewhat but will not completely fix it, because if the online lookup does mutate the realm beatmap(set) because there are actual changes to apply, the subscriptions will still fire etc.

Same thing applies for https://github.com/ppy/osu/issues/34583.

This should probably have been a change in https://github.com/ppy/osu/pull/34525, but I somehow didn't realise that this was happening.

The actual change is https://github.com/ppy/osu/commit/29b93ca0d779082e7bbfcc6914b529c04f82b853. https://github.com/ppy/osu/commit/72b48e5677c70cce278d2296e6d950521027471c is something I just did for code quality because the levels of nesting were starting to bother me. It can be dropped if need be.