### PR TITLE
Prioritize maximized player as hitsound audio source in multiplayer

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
     {
         public const float ANIMATION_DELAY = 400;
 
+        public Action? OnMaximisationChanged;
+
         /// <summary>
         /// A temporary limitation on the number of players, because only layouts up to 16 players are supported for a single screen.
         /// Todo: Can be removed in the future with scrolling support + performance improvements.
@@ -130,6 +132,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             }
 
             facadeContainer.ScaleTo(hasMaximised ? 0.95f : 1, ANIMATION_DELAY, Easing.OutQuint);
+
+            OnMaximisationChanged?.Invoke();
         }
 
         protected override void Update()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
@@ -93,6 +93,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public IEnumerable<Drawable> Content => cellContainer.OrderBy(c => c.FacadeIndex).Select(c => c.Content);
 
+        /// <summary>
+        /// Gets the maximised or the room host's cell.
+        /// </summary>
+        public Cell? GetMaximisedCell() => cellContainer.FirstOrDefault(c => c.IsMaximised);
+
+        /// <summary>
+        /// Gets all cells in the grid.
+        /// </summary>
+        public IReadOnlyList<Cell> GetAllCells() => cellContainer.OrderBy(c => c.FacadeIndex).ToList();
+
         // A depth value that gets decremented every time a new instance is maximised in order to reduce underlaps.
         private float maximisedInstanceDepth;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// A cell of the grid. Contains the content and tracks to the linked facade.
         /// </summary>
-        private partial class Cell : CompositeDrawable
+        public partial class Cell : CompositeDrawable
         {
             /// <summary>
             /// The index of the original facade of this cell.


### PR DESCRIPTION
It just makes sense to play hitsounds of the player that you are always spectating rather than just the room host.

**How it used to work:**
- Room host is always the hitsound audio source.


**How it works now:**
- Room host is still the default source if none of the player cells are maximized.
- If you expand one player then the audio source will switch to that player, so the audio matches the gameplay.

*tried my best to demonstrate it as well:*


https://github.com/user-attachments/assets/ecbee638-d3dc-496b-b3ef-2b7114b85d12
