### PR TITLE
Calculate multiplayer room difficulty range based only on non-expired items

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -88,11 +87,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        public void TestExpiredItemsNotIncludedIfRoomOpen()
+        public void TestRangeUsesNonExpiredItemsIfThereAreAny()
         {
             AddStep("set up room", () =>
             {
-                room.EndDate = null;
                 room.Playlist =
                 [
                     new PlaylistItem(new BeatmapInfo { StarRating = 1 }) { ID = TestResources.GetNextTestID(), Expired = true },
@@ -109,11 +107,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        public void TestExpiredItemsIncludedIfRoomEnded()
+        public void TestRangeUsesAllItemsIfAllAreExpired()
         {
             AddStep("set up room", () =>
             {
-                room.EndDate = DateTimeOffset.Now;
                 room.Playlist =
                 [
                     new PlaylistItem(new BeatmapInfo { StarRating = 1 }) { ID = TestResources.GetNextTestID(), Expired = true },

--- a/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
@@ -116,10 +116,10 @@ namespace osu.Game.Screens.OnlinePlay.Components
             else
             {
                 // When Playlist is not empty (in room) we compute actual range
-                IEnumerable<PlaylistItem> difficultyRangeSource = room.Playlist;
+                IReadOnlyList<PlaylistItem> difficultyRangeSource = room.Playlist.Where(item => !item.Expired).ToList();
 
-                if (!room.HasEnded)
-                    difficultyRangeSource = difficultyRangeSource.Where(playlistItem => !playlistItem.Expired);
+                if (difficultyRangeSource.Count == 0)
+                    difficultyRangeSource = room.Playlist;
 
                 var orderedDifficulties = difficultyRangeSource.Select(item => item.Beatmap)
                                                                .OrderBy(b => b.StarRating)


### PR DESCRIPTION
Previously (https://github.com/ppy/osu/pull/34464) this was based on room status, but in review of the web-side change it was pointed out that even an open room could have no active items (https://github.com/ppy/osu-web/pull/12325#pullrequestreview-3082894354).

Closes https://github.com/ppy/osu/issues/34379.