### PR TITLE
Add support for specifying multiple user tag filters at once

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -305,7 +305,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestCriteriaMatchingUserTags(string query, bool filtered)
         {
             var beatmap = getExampleBeatmap();
-            var criteria = new FilterCriteria { UserTag = { SearchTerm = query } };
+            var criteria = new FilterCriteria { UserTags = [new FilterCriteria.OptionalTextFilter { SearchTerm = query }] };
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
@@ -313,10 +313,46 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
+        public void TestCriteriaMatchingMultipleTagsAtOnce()
+        {
+            var beatmap = getExampleBeatmap();
+            var criteria = new FilterCriteria
+            {
+                UserTags =
+                [
+                    new FilterCriteria.OptionalTextFilter { SearchTerm = "\"song representation/simple\"!" },
+                    new FilterCriteria.OptionalTextFilter { SearchTerm = "\"style/clean\"!" }
+                ]
+            };
+            var carouselItem = new CarouselBeatmap(beatmap);
+            carouselItem.Filter(criteria);
+
+            Assert.AreEqual(false, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        public void TestCriteriaAllTagFiltersMustMatch()
+        {
+            var beatmap = getExampleBeatmap();
+            var criteria = new FilterCriteria
+            {
+                UserTags =
+                [
+                    new FilterCriteria.OptionalTextFilter { SearchTerm = "\"song representation/simple\"!" },
+                    new FilterCriteria.OptionalTextFilter { SearchTerm = "\"style/dirty\"!" }
+                ]
+            };
+            var carouselItem = new CarouselBeatmap(beatmap);
+            carouselItem.Filter(criteria);
+
+            Assert.AreEqual(true, carouselItem.Filtered.Value);
+        }
+
+        [Test]
         public void TestBeatmapMustHaveAtLeastOneTagIfUserTagFilterActive()
         {
             var beatmap = getExampleBeatmap();
-            var criteria = new FilterCriteria { UserTag = { SearchTerm = "simple" } };
+            var criteria = new FilterCriteria { UserTags = [new FilterCriteria.OptionalTextFilter { SearchTerm = "simple" }] };
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.BeatmapInfo.Metadata.UserTags.Clear();
             carouselItem.Filter(criteria);

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -756,5 +756,17 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
             Assert.AreEqual(matched, filterCriteria.LastPlayed.IsInRange(reference));
         }
+
+        [Test]
+        public void TestMultipleTextFilters()
+        {
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, "tag=\"simple\" tag=\"clean\"!");
+            Assert.That(filterCriteria.UserTags, Has.Count.EqualTo(2));
+            Assert.That(filterCriteria.UserTags[0].SearchTerm, Is.EqualTo("simple"));
+            Assert.That(filterCriteria.UserTags[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
+            Assert.That(filterCriteria.UserTags[1].SearchTerm, Is.EqualTo("clean"));
+            Assert.That(filterCriteria.UserTags[1].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
+        }
     }
 }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -84,12 +84,17 @@ namespace osu.Game.Screens.Select.Carousel
             match &= !criteria.DifficultyName.HasFilter || criteria.DifficultyName.Matches(BeatmapInfo.DifficultyName);
             match &= !criteria.Source.HasFilter || criteria.Source.Matches(BeatmapInfo.Metadata.Source);
 
-            if (criteria.UserTag.HasFilter)
+            if (criteria.UserTags.Any())
             {
-                bool anyTagMatched = false;
-                foreach (string tag in BeatmapInfo.Metadata.UserTags)
-                    anyTagMatched |= criteria.UserTag.Matches(tag);
-                match &= anyTagMatched;
+                foreach (var tagFilter in criteria.UserTags)
+                {
+                    bool anyTagMatched = false;
+
+                    foreach (string tag in BeatmapInfo.Metadata.UserTags)
+                        anyTagMatched |= tagFilter.Matches(tag);
+
+                    match &= anyTagMatched;
+                }
             }
 
             match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(BeatmapInfo.StarRating);

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.Select
         public OptionalTextFilter Title;
         public OptionalTextFilter DifficultyName;
         public OptionalTextFilter Source;
-        public OptionalTextFilter UserTag;
+        public List<OptionalTextFilter> UserTags = [];
 
         public OptionalRange<double> UserStarDifficulty = new OptionalRange<double>
         {

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -117,7 +117,10 @@ namespace osu.Game.Screens.Select
                     return TryUpdateCriteriaText(ref criteria.Source, op, value);
 
                 case "tag":
-                    return TryUpdateCriteriaText(ref criteria.UserTag, op, value);
+                    var tagFilter = new FilterCriteria.OptionalTextFilter();
+                    TryUpdateCriteriaText(ref tagFilter, op, value);
+                    criteria.UserTags.Add(tagFilter);
+                    return true;
 
                 default:
                     return criteria.RulesetCriteria?.TryParseCustomKeywordCriteria(key, op, value) ?? false;

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Select
     public static class FilterQueryParser
     {
         private static readonly Regex query_syntax_regex = new Regex(
-            @"\b(?<key>\w+)(?<op>(!?(:|=)|(>|<)(:|=)?))(?<value>("".*""[!]?)|(\S*))",
+            @"\b(?<key>\w+)(?<op>(!?(:|=)|(>|<)(:|=)?))(?<value>("".*?""[!]?)|(\S*))",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         internal static void ApplyQueries(FilterCriteria criteria, string query)

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -103,12 +103,17 @@ namespace osu.Game.Screens.SelectV2
             match &= !criteria.DifficultyName.HasFilter || criteria.DifficultyName.Matches(beatmap.DifficultyName);
             match &= !criteria.Source.HasFilter || criteria.Source.Matches(beatmap.Metadata.Source);
 
-            if (criteria.UserTag.HasFilter)
+            if (criteria.UserTags.Any())
             {
-                bool anyTagMatched = false;
-                foreach (string tag in beatmap.Metadata.UserTags)
-                    anyTagMatched |= criteria.UserTag.Matches(tag);
-                match &= anyTagMatched;
+                foreach (var tagFilter in criteria.UserTags)
+                {
+                    bool anyTagMatched = false;
+
+                    foreach (string tag in beatmap.Metadata.UserTags)
+                        anyTagMatched |= tagFilter.Matches(tag);
+
+                    match &= anyTagMatched;
+                }
             }
 
             match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(beatmap.StarRating);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34634.

## [Fix keyword filters potentially being wrongly merged together due to regex wildcard greedy matching](https://github.com/ppy/osu/commit/08a0025e31ed0569c663ed02965d75fd7cdcaddb)

Because of greedy matching, a filter of

    tag="style/clean"! tag="song representation/simple"!

would not parse into 2 separate filters like

    (tag, =, "style/clean"!)
    (tag, =, "song representation/simple"!)

but rather a single one like

    (tag, =, "style/clean"! tag="song representation/simple"!)

This sort of matches what web did in https://github.com/ppy/osu-web/pull/12044, except web does some stuff with quote escaping that I'd rather not, and also the search syntax seems to slightly deviate because web seems to be using single quotes and double quotes to open the value part of the filter. I'm not sure what the difference is and I'd rather not go into all that right now.

## [Fix `FilterCriteria` only being able to support one tag filter at once](https://github.com/ppy/osu/commit/3fb1880466d4e3ecb531dd1379328d3395d3e6d4)

Other textual keyword filters did a thing wherein if you did `artist=a artist=b` the second filter would overwrite the second, but in those cases the query is against a single field, so attempting to put multiple search criteria in conjunction on a single field is kind of nonsensical, so it was sort of fine to do that.

Which is not the case for user tags, which are multi-valued.