### PR TITLE
Fix pressing enter/escape/clicking off once to save and close for slider velocity and sampleset volume

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 base.LoadComplete();
                 ScheduleAfterChildren(() => GetContainingFocusManager()!.ChangeFocus(sliderVelocitySlider));
+                sliderVelocitySlider.OnCommit += (_, _) => this.HidePopover();
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -303,6 +303,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 togglesCollection.AddRange(createTernaryButtons());
             }
 
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                volume.OnCommit += (_, _) => this.HidePopover();
+            }
+
             private string? getCommonBank() => allRelevantSamples.Select(h => GetBankValue(h.samples)).Distinct().Count() == 1
                 ? GetBankValue(allRelevantSamples.First().samples)
                 : null;

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -49,6 +49,12 @@ namespace osu.Game.Screens.Edit.Timing
         private readonly SettingsSlider<T> slider;
         private readonly LabelledTextBox textBox;
 
+        public event TextBox.OnCommitHandler OnCommit
+        {
+            add => textBox.OnCommit += value;
+            remove => textBox.OnCommit -= value;
+        }
+
         /// <summary>
         /// Creates an <see cref="IndeterminateSliderWithTextBoxInput{T}"/>.
         /// </summary>


### PR DESCRIPTION
Partially addresses #34596.

This PR allows pressing enter or escape once in the slider velocity or sampleset volume box to save and close the popover window.

I have verified:
- Pressing enter, escape or clicking off closes the box and applies the relevant change successfully for the following:
  - Slider Velocity
  - Hitsound Volume 
- `dotnet run --project osu.Desktop` compiles
- `dotnet format` is a no-op on the files I created

This PR fixes only the parts of #34596 that can be **easily** solved by an additional `OnCommit` field. Other parts of the issue have fixes that are less obvious and should be addressed in a separate PR.

### Caveat
After adjusting changing the number in the textbox and then immediately dragging the slider to adjust it further, `OnCommit` immediately closes the window. We should expect the focus on the slider to continue to take effect.
This is a very niche thing that I do not expect a user to do, and the benefits of this PR far outweigh this edge case.

#### Note for Move, Rotate and Scale
For the above operations, when performing the caveat, the program crashes with the error `Cannot Update a rotate operation without calling Begin first!`. Hence, it is not part of this PR.

### Note for Hitsound Popover:
There is an argument for applying the same logic to the `Bank Name` text box, but I have decided against it for several reasons:
- It is likely that somebody might like to press enter on this box and have it cycle focus to the volume box
  - And perhaps, escape and clicking off will remove the popover entirely
- Pressing tab and shift tab could cycle focus
A separate PR as a feature should be made if these other default behaviours are desired.