### PR TITLE
Add verify check for inconsistent video usage

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckVideoUsageTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckVideoUsageTest.cs
@@ -1,0 +1,147 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    [TestFixture]
+    public class CheckVideoUsageTest
+    {
+        private CheckVideoUsage check = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckVideoUsage();
+        }
+
+        [Test]
+        public void TestConsistentVideoUsage()
+        {
+            var beatmap1 = createBeatmapWithVideo("Diff 1", "video.mp4", 1000);
+            var beatmap2 = createBeatmapWithVideo("Diff 2", "video.mp4", 1000);
+
+            var context = createContext(beatmap1, [beatmap2]);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        [Test]
+        public void TestDifferentVideoFile()
+        {
+            var beatmap1 = createBeatmapWithVideo("Diff 1", "videoA.mp4", 0);
+            var beatmap2 = createBeatmapWithVideo("Diff 2", "videoB.mp4", 500);
+
+            var context = createContext(beatmap1, [beatmap2]);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckVideoUsage.IssueTemplateDifferentVideo);
+        }
+
+        [Test]
+        public void TestDifferentStartTime()
+        {
+            var beatmap1 = createBeatmapWithVideo("Diff 1", "video.mp4", 0);
+            var beatmap2 = createBeatmapWithVideo("Diff 2", "video.mp4", 500);
+
+            var context = createContext(beatmap1, [beatmap2]);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckVideoUsage.IssueTemplateDifferentStartTime);
+        }
+
+        [Test]
+        public void TestOtherDifficultyMissingVideo()
+        {
+            var beatmap1 = createBeatmapWithVideo("Diff 1", "video.mp4", 0);
+            var beatmap2 = createBeatmapWithoutVideo("Diff 2");
+
+            var context = createContext(beatmap1, [beatmap2]);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckVideoUsage.IssueTemplateMissingVideo);
+        }
+
+        [Test]
+        public void TestCurrentDifficultyMissingVideo()
+        {
+            var beatmap1 = createBeatmapWithoutVideo("Diff 1");
+            var beatmap2 = createBeatmapWithVideo("Diff 2", "video.mp4", 0);
+
+            var context = createContext(beatmap1, [beatmap2]);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckVideoUsage.IssueTemplateMissingVideo);
+        }
+
+        [Test]
+        public void TestBothDifficultiesMissingVideo()
+        {
+            var beatmap1 = createBeatmapWithoutVideo("Diff 1");
+            var beatmap2 = createBeatmapWithoutVideo("Diff 2");
+
+            var context = createContext(beatmap1, [beatmap2]);
+
+            Assert.That(check.Run(context), Is.Empty);
+        }
+
+        private BeatmapVerifierContext.VerifiedBeatmap createBeatmapWithVideo(string difficultyName, string path, double startTime)
+        {
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    DifficultyName = difficultyName
+                }
+            };
+
+            var storyboard = new Storyboard();
+            storyboard.GetLayer("Video").Add(new StoryboardVideo(path, startTime));
+
+            var working = new TestWorkingBeatmap(beatmap, storyboard);
+            return new BeatmapVerifierContext.VerifiedBeatmap(working, beatmap);
+        }
+
+        private BeatmapVerifierContext.VerifiedBeatmap createBeatmapWithoutVideo(string difficultyName)
+        {
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    DifficultyName = difficultyName
+                }
+            };
+
+            var storyboard = new Storyboard();
+            // no video added
+            var working = new TestWorkingBeatmap(beatmap, storyboard);
+            return new BeatmapVerifierContext.VerifiedBeatmap(working, beatmap);
+        }
+
+        private BeatmapVerifierContext createContext(BeatmapVerifierContext.VerifiedBeatmap current, BeatmapVerifierContext.VerifiedBeatmap[] others)
+        {
+            return new BeatmapVerifierContext(
+                current,
+                others.ToList(),
+                DifficultyRating.ExpertPlus
+            );
+        }
+    }
+}
+
+

--- a/osu.Game.Tests/Editing/Checks/CheckVideoUsageTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckVideoUsageTest.cs
@@ -100,6 +100,38 @@ namespace osu.Game.Tests.Editing.Checks
             Assert.That(check.Run(context), Is.Empty);
         }
 
+        [Test]
+        public void TestPairwiseStartTimeMismatchAcrossNonCurrentDifficulties()
+        {
+            var beatmapCurrent = createBeatmapWithVideo("Diff A", "A.mp4", 0);
+            var beatmapB = createBeatmapWithVideo("Diff B", "X.mp4", 1000);
+            var beatmapC = createBeatmapWithVideo("Diff C", "X.mp4", 2000);
+
+            var context = createContext(beatmapCurrent, [beatmapB, beatmapC]);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(3));
+            Assert.That(issues.Count(i => i.Template is CheckVideoUsage.IssueTemplateDifferentVideo), Is.EqualTo(2));
+            Assert.That(issues.Count(i => i.Template is CheckVideoUsage.IssueTemplateDifferentStartTime), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestPairwiseStartTimeMismatchWhenCurrentMissingVideo()
+        {
+            var beatmapCurrent = createBeatmapWithoutVideo("Diff A");
+            var beatmapB = createBeatmapWithVideo("Diff B", "X.mp4", 1000);
+            var beatmapC = createBeatmapWithVideo("Diff C", "X.mp4", 2000);
+
+            var context = createContext(beatmapCurrent, [beatmapB, beatmapC]);
+
+            var issues = check.Run(context).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(2));
+            Assert.That(issues.Count(i => i.Template is CheckVideoUsage.IssueTemplateMissingVideo), Is.EqualTo(1));
+            Assert.That(issues.Count(i => i.Template is CheckVideoUsage.IssueTemplateDifferentStartTime), Is.EqualTo(1));
+        }
+
         private BeatmapVerifierContext.VerifiedBeatmap createBeatmapWithVideo(string difficultyName, string path, double startTime)
         {
             var beatmap = new Beatmap

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Edit
             new CheckBackgroundPresence(),
             new CheckBackgroundQuality(),
             new CheckVideoResolution(),
+            new CheckVideoUsage(),
 
             // Audio
             new CheckAudioPresence(),

--- a/osu.Game/Rulesets/Edit/Checks/CheckVideoUsage.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckVideoUsage.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Edit.Checks.Components;
+
+namespace osu.Game.Rulesets.Edit.Checks
+{
+    public class CheckVideoUsage : ICheck
+    {
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Resources, "Inconsistent video usage", CheckScope.BeatmapSet);
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateDifferentVideo(this),
+            new IssueTemplateDifferentStartTime(this),
+            new IssueTemplateMissingVideo(this)
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            var currentVideo = ResourcesCheckUtils.GetDifficultyVideo(context.CurrentDifficulty.Working);
+
+            // If current difficulty has no video but any other does -> problem
+            if (currentVideo == null)
+            {
+                foreach (var otherDifficulty in context.OtherDifficulties)
+                {
+                    if (ResourcesCheckUtils.GetDifficultyVideo(otherDifficulty.Working) != null)
+                    {
+                        yield return new IssueTemplateMissingVideo(this).Create(otherDifficulty.Playable.BeatmapInfo.DifficultyName);
+
+                        break;
+                    }
+                }
+
+                yield break;
+            }
+
+            string referencePath = currentVideo.Path;
+            double referenceStart = currentVideo.StartTime;
+
+            foreach (var otherDifficulty in context.OtherDifficulties)
+            {
+                var otherVideo = ResourcesCheckUtils.GetDifficultyVideo(otherDifficulty.Working);
+                string difficultyName = otherDifficulty.Playable.BeatmapInfo.DifficultyName;
+
+                // If other difficulty has no video -> problem
+                if (otherVideo == null)
+                {
+                    yield return new IssueTemplateMissingVideo(this).Create(difficultyName);
+
+                    continue;
+                }
+
+                // Different video used -> warning
+                if (!string.Equals(otherVideo.Path, referencePath, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return new IssueTemplateDifferentVideo(this).Create(difficultyName, referencePath, otherVideo.Path);
+
+                    continue;
+                }
+
+                // Same video but different start times -> problem
+                if (!referenceStart.Equals(otherVideo.StartTime))
+                {
+                    yield return new IssueTemplateDifferentStartTime(this).Create(referencePath, difficultyName, referenceStart, otherVideo.StartTime);
+                }
+            }
+        }
+
+        public class IssueTemplateDifferentVideo : IssueTemplate
+        {
+            public IssueTemplateDifferentVideo(ICheck check)
+                : base(check, IssueType.Warning, "Video file differs from current difficulty in \"{0}\" (current: \"{1}\", other: \"{2}\"). Ensure this makes sense.")
+            {
+            }
+
+            public Issue Create(string otherDifficulty, string currentPath, string otherPath)
+                => new Issue(this, otherDifficulty, currentPath, otherPath);
+        }
+
+        public class IssueTemplateDifferentStartTime : IssueTemplate
+        {
+            public IssueTemplateDifferentStartTime(ICheck check)
+                : base(check, IssueType.Problem, "Video start time differs for \"{0}\" in \"{1}\" (current: {2:0} ms, other: {3:0} ms).")
+            {
+            }
+
+            public Issue Create(string path, string otherDifficulty, double currentStartMs, double otherStartMs)
+                => new Issue(this, path, otherDifficulty, currentStartMs, otherStartMs);
+        }
+
+        public class IssueTemplateMissingVideo : IssueTemplate
+        {
+            public IssueTemplateMissingVideo(ICheck check)
+                : base(check, IssueType.Problem, "Video is missing in \"{0}\".")
+            {
+            }
+
+            public Issue Create(string otherDifficulty) => new Issue(this, otherDifficulty);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckVideoUsage.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckVideoUsage.cs
@@ -65,10 +65,10 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             // Pairwise check: for each video file used across all difficulties, ensure all start times match.
             // Build a list of all difficulties with a video present (including current).
-            var allWithVideos = new List<(string DifficultyName, string Path, double StartTime)>();
+            var allDifficultiesWithVideo = new List<(string DifficultyName, string Path, double StartTime)>();
 
             if (currentVideo != null)
-                allWithVideos.Add((context.CurrentDifficulty.Playable.BeatmapInfo.DifficultyName, currentVideo.Path, currentVideo.StartTime));
+                allDifficultiesWithVideo.Add((context.CurrentDifficulty.Playable.BeatmapInfo.DifficultyName, currentVideo.Path, currentVideo.StartTime));
 
             foreach (var other in context.OtherDifficulties)
             {
@@ -77,25 +77,25 @@ namespace osu.Game.Rulesets.Edit.Checks
                 if (video != null)
                 {
                     string name = other.Playable.BeatmapInfo.DifficultyName;
-                    allWithVideos.Add((name, video.Path, video.StartTime));
+                    allDifficultiesWithVideo.Add((name, video.Path, video.StartTime));
                 }
             }
 
             // Group by video path (case-insensitive) and compare start times pairwise within each group.
-            foreach (var group in allWithVideos.GroupBy(v => v.Path, StringComparer.OrdinalIgnoreCase))
+            foreach (var groupedByVideoPath in allDifficultiesWithVideo.GroupBy(v => v.Path, StringComparer.OrdinalIgnoreCase))
             {
-                var list = group.ToList();
+                var difficultiesWithSameVideo = groupedByVideoPath.ToList();
 
-                for (int i = 0; i < list.Count; i++)
+                for (int i = 0; i < difficultiesWithSameVideo.Count; i++)
                 {
-                    for (int j = i + 1; j < list.Count; j++)
+                    for (int j = i + 1; j < difficultiesWithSameVideo.Count; j++)
                     {
-                        if (!list[i].StartTime.Equals(list[j].StartTime))
+                        if (!difficultiesWithSameVideo[i].StartTime.Equals(difficultiesWithSameVideo[j].StartTime))
                         {
                             yield return new IssueTemplateDifferentStartTime(this).Create(
-                                group.Key,
-                                list[i].DifficultyName, list[i].StartTime,
-                                list[j].DifficultyName, list[j].StartTime);
+                                groupedByVideoPath.Key,
+                                difficultiesWithSameVideo[i].DifficultyName, difficultiesWithSameVideo[i].StartTime,
+                                difficultiesWithSameVideo[j].DifficultyName, difficultiesWithSameVideo[j].StartTime);
                         }
                     }
                 }

--- a/osu.Game/Rulesets/Edit/Checks/Components/ResourcesCheckUtils.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/ResourcesCheckUtils.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Beatmaps;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Rulesets.Edit.Checks.Components
 {
@@ -23,6 +24,27 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Retrieves the first storyboard video entry for the provided working beatmap, if any.
+        /// </summary>
+        /// <param name="workingBeatmap">The working beatmap to inspect.</param>
+        /// <returns>
+        /// The first <see cref="StoryboardVideo"/> found, or null if none exists.
+        /// </returns>
+        public static StoryboardVideo? GetDifficultyVideo(IWorkingBeatmap workingBeatmap)
+        {
+            foreach (var layer in workingBeatmap.Storyboard.Layers)
+            {
+                foreach (var element in layer.Elements)
+                {
+                    if (element is StoryboardVideo video)
+                        return video;
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/ppy/osu/issues/12091

Ports [the following check](https://github.com/Naxesss/MapsetVerifier/blob/main/src/Checks/AllModes/General/Resources/CheckMultipleVideo.cs) from MV.

I didn't really try to mimic the code from MV because of somewhat convoluted/outdated direction (i.e. the taiko exception), so I opted in for a more straightforward approach that IMO would still be useful to users.