### PR TITLE
Fix crash on BSS from navigating to submission settings screen

### DIFF
--- a/osu.Game/Screens/Edit/Submission/ScreenSubmissionSettings.cs
+++ b/osu.Game/Screens/Edit/Submission/ScreenSubmissionSettings.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Edit.Submission
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager configManager, OsuColour colours)
         {
-            configManager.BindWith(OsuSetting.EditorSubmissionNotifyOnDiscussionReplies, settings.NotifyOnDiscussionReplies);
+            configManager.BindWith(OsuSetting.EditorSubmissionNotifyOnDiscussionReplies, notifyOnDiscussionReplies);
             configManager.BindWith(OsuSetting.EditorSubmissionLoadInBrowserAfterSubmission, loadInBrowserAfterSubmission);
 
             Content.Add(new FillFlowContainer
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Edit.Submission
                     new FormCheckBox
                     {
                         Caption = BeatmapSubmissionStrings.NotifyOnDiscussionReplies,
-                        Current = settings.NotifyOnDiscussionReplies,
+                        Current = notifyOnDiscussionReplies,
                     },
                     new FormCheckBox
                     {


### PR DESCRIPTION
When navigating away and back towards `ScreenSubmissionSettings`, the game crashes and throws a `Unhandled exception. System.ArgumentException: An already bound bindable cannot be bound again.`

**Reproducing the bug:**

https://github.com/user-attachments/assets/ca832da0-5e47-4338-be6a-82bf7951356b


