### PR TITLE
Ignore more potentially incorrect data from BASS

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneTimingBasedNoteColouring.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneTimingBasedNoteColouring.cs
@@ -47,8 +47,6 @@ namespace osu.Game.Rulesets.Mania.Tests
                         drawableRuleset = (DrawableManiaRuleset)Ruleset.Value.CreateInstance().CreateDrawableRulesetWith(createTestBeatmap())
                     }
                 };
-
-                drawableRuleset.AllowBackwardsSeeks = true;
             });
             AddStep("retrieve config bindable", () =>
             {

--- a/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
+++ b/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
@@ -101,7 +101,6 @@ namespace osu.Game.Tests.NonVisual
             public override Container FrameStableComponents { get; }
             public override IFrameStableClock FrameStableClock { get; }
             internal override bool FrameStablePlayback { get; set; }
-            public override bool AllowBackwardsSeeks { get; set; }
             public override IReadOnlyList<Mod> Mods { get; }
 
             public override double GameplayStartTime { get; }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
@@ -131,10 +131,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void createStabilityContainer(double gameplayStartTime = double.MinValue) => AddStep("create container", () =>
         {
-            mainContainer.Child = new FrameStabilityContainer(gameplayStartTime)
-            {
-                AllowBackwardsSeeks = true,
-            }.WithChild(consumer = new ClockConsumingChild());
+            mainContainer.Child = new FrameStabilityContainer(gameplayStartTime).WithChild(consumer = new ClockConsumingChild());
         });
 
         private void seekManualTo(double time) => AddStep($"seek manual clock to {time}", () => manualClock.CurrentTime = time);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -284,7 +284,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             public override Container FrameStableComponents { get; }
             public override IFrameStableClock FrameStableClock { get; }
             internal override bool FrameStablePlayback { get; set; }
-            public override bool AllowBackwardsSeeks { get; set; }
             public override IReadOnlyList<Mod> Mods { get; }
 
             public override double GameplayStartTime { get; }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -82,17 +82,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestForwardPlaybackGuarantee()
-        {
-            hookForwardPlaybackCheck();
-
-            AddUntilStep("wait for forward playback", () => Player.GameplayClockContainer.CurrentTime > 1000);
-            AddStep("seek before gameplay", () => Player.GameplayClockContainer.Seek(-5000));
-
-            checkForwardPlayback();
-        }
-
-        [Test]
         public void TestPauseWithLargeOffset()
         {
             AddStep("force large offset", () =>

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
@@ -269,7 +269,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 drawableRuleset = (TestDrawablePoolingRuleset)ruleset.CreateDrawableRulesetWith(CreateWorkingBeatmap(beatmap).GetPlayableBeatmap(ruleset.RulesetInfo));
                 drawableRuleset.FrameStablePlayback = true;
-                drawableRuleset.AllowBackwardsSeeks = true;
                 drawableRuleset.PoolSize = poolSize;
 
                 Child = new Container

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -102,19 +102,6 @@ namespace osu.Game.Rulesets.UI
         private FrameStabilityContainer frameStabilityContainer;
         private DrawableRulesetDependencies dependencies;
 
-        private bool allowBackwardsSeeks;
-
-        public override bool AllowBackwardsSeeks
-        {
-            get => allowBackwardsSeeks;
-            set
-            {
-                allowBackwardsSeeks = value;
-                if (frameStabilityContainer != null)
-                    frameStabilityContainer.AllowBackwardsSeeks = value;
-            }
-        }
-
         private bool frameStablePlayback = true;
 
         internal override bool FrameStablePlayback
@@ -190,7 +177,6 @@ namespace osu.Game.Rulesets.UI
             InternalChild = frameStabilityContainer = new FrameStabilityContainer(GameplayStartTime)
             {
                 FrameStablePlayback = FrameStablePlayback,
-                AllowBackwardsSeeks = AllowBackwardsSeeks,
                 Children = new Drawable[]
                 {
                     FrameStableComponents,
@@ -480,12 +466,6 @@ namespace osu.Game.Rulesets.UI
         /// Whether to enable frame-stable playback.
         /// </summary>
         internal abstract bool FrameStablePlayback { get; set; }
-
-        /// <summary>
-        /// When a replay is not attached, we usually block any backwards seeks.
-        /// This will bypass the check. Should only be used for tests.
-        /// </summary>
-        public abstract bool AllowBackwardsSeeks { get; set; }
 
         /// <summary>
         /// The mods which are to be applied.

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -154,7 +154,8 @@ namespace osu.Game.Rulesets.UI
                     state = PlaybackState.NotValid;
             }
 
-            bool allowReferenceClockSeeks = hasReplayAttached || DebugUtils.IsNUnitRunning || !FrameStablePlayback;
+            // TODO: replace IsDebugBuild with a framework flag which asserts we are in a test scene, interactively or otherwise.
+            bool allowReferenceClockSeeks = hasReplayAttached || DebugUtils.IsNUnitRunning || DebugUtils.IsDebugBuild || !FrameStablePlayback;
 
             // This is a hotfix for ongoing bass issues we are trying to resolve (see https://www.un4seen.com/forum/?topic=20482.msg145474#msg145474)
             // In gameplay we should always be seeking using the

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -158,8 +158,10 @@ namespace osu.Game.Rulesets.UI
             bool allowReferenceClockSeeks = hasReplayAttached || DebugUtils.IsNUnitRunning || DebugUtils.IsDebugBuild || !FrameStablePlayback;
 
             // This is a hotfix for ongoing bass issues we are trying to resolve (see https://www.un4seen.com/forum/?topic=20482.msg145474#msg145474)
-            // In gameplay we should always be seeking using the
-            if (!allowReferenceClockSeeks && Math.Abs(proposedTime - referenceClock.CurrentTime) > 1000)
+            //
+            // In testing this triggers *very* rarely even when set to super low values (10 ms). The cases we're worried about involve multi-second jumps.
+            // A difference of more than 500 ms seems like a sane number we should never exceed.
+            if (!allowReferenceClockSeeks && Math.Abs(proposedTime - referenceClock.CurrentTime) > 500)
             {
                 if (lastBackwardsSeekLogTime == null || Math.Abs(Clock.CurrentTime - lastBackwardsSeekLogTime.Value) > 1000)
                 {

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -70,14 +70,6 @@ namespace osu.Game.Tests.Visual
 
             AddStep($"Load player for {CreatePlayerRuleset().Description}", LoadPlayer);
             AddUntilStep("player loaded", () => Player.IsLoaded && Player.Alpha == 1);
-
-            if (AllowBackwardsSeeks)
-            {
-                AddStep("allow backwards seeking", () =>
-                {
-                    Player.DrawableRuleset.AllowBackwardsSeeks = AllowBackwardsSeeks;
-                });
-            }
         }
 
         protected virtual bool AllowFail => false;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34577.
- See https://www.un4seen.com/forum/?msg=145474.

This is still a workaround but arguably it's something we could leave in place without much loss. I think this at least feels better than the previous code.

Notably, you could argue the test coverage of the fail case is lower since made it implicit that all tests will avoid the "backwards seek" detections.  But we never really had tests correctly- fail on the original so I don't see any loss of value.

Can be tested using

```diff
diff --git a/osu.Game/Screens/Play/GameplayClockContainer.cs b/osu.Game/Screens/Play/GameplayClockContainer.cs
index 2afdcfaebb..430a873e70 100644
--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -9,6 +9,7 @@
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Framework.Timing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 
 namespace osu.Game.Screens.Play
@@ -188,12 +189,20 @@ double IAdjustableClock.Rate
 
         public double Rate => GameplayClock.Rate;
 
-        public double CurrentTime => GameplayClock.CurrentTime;
+        private bool badDataFrame;
+
+        public double CurrentTime => (badDataFrame ? 10000 : 0) + GameplayClock.CurrentTime;
 
         public bool IsRunning => GameplayClock.IsRunning;
 
         #endregion
 
+        protected override void Update()
+        {
+            base.Update();
+            badDataFrame = RNG.NextDouble() > 0.999;
+        }
+
         public void ProcessFrame()
         {
             // Handled via update. Don't process here to safeguard from external usages potentially processing frames additional times.

```
