### PR TITLE
Fix tags popover search functionality not always working

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_MetadataDisplay.cs
@@ -165,8 +165,8 @@ namespace osu.Game.Screens.SelectV2
             {
                 clear();
 
-                contentTags.Tags = tags;
                 contentTags.PerformSearch = searchAction;
+                contentTags.Tags = tags;
             }
 
             private void setLoading()

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.SelectV2
 
                 public float LineBaseHeight => text.LineBaseHeight;
 
-                public Action<string>? PerformSearch { get; set; }
+                public Action<string>? PerformSearch { get; init; }
 
                 public TagsOverflowButton(string[] tags)
                 {

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Screens.SelectV2
                 Add(overflowButton = new TagsOverflowButton(tags)
                 {
                     Alpha = 0f,
-                    PerformSearch = PerformSearch,
+                    PerformSearch = s => PerformSearch?.Invoke(s),
                 });
 
                 drawSizeLayout.Invalidate();


### PR DESCRIPTION
5 minute prospective fix for https://github.com/ppy/osu/discussions/34636.

This is super haphazard in the first place but I'm going to look past that for now.

Basically, due to the order of operation, the tags could be initialised via `updateTags()` before the perform search action was initialised, leading to clicks doing nothing.

If it makes it any more clear, here's an alternative fix (which I'd also be happy with if it's preferred):

```diff
diff --git a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
index 7c5f203cc8..e48b4f20da 100644
--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge_TagsLine.cs
@@ -117,7 +117,7 @@ private void updateTags()
                 Add(overflowButton = new TagsOverflowButton(tags)
                 {
                     Alpha = 0f,
-                    PerformSearch = PerformSearch,
+                    PerformSearch = s => PerformSearch?.Invoke(s),
                 });
 
                 drawSizeLayout.Invalidate();

```
