### PR TITLE
Refetch leaderboard when (slow) retrying a beatmap

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -283,11 +283,16 @@ namespace osu.Game.Screens.Play
             //   (as the solo gameplay leaderboard provider uses the global leaderboard manager to populate itself)
             // - the sort mode is not specified and defaults to `Score` which is good because gameplay leaderboards only support sorting by score.
             //   this may change at some point in the future, at which point specifying a sort mode should be considered.
+            refetchLeaderboard(force: false);
+        }
+
+        private void refetchLeaderboard(bool force)
+        {
             leaderboardManager?.FetchWithCriteria(new LeaderboardCriteria(
                 Beatmap.Value.BeatmapInfo,
                 Ruleset.Value,
                 leaderboardManager?.CurrentCriteria?.Scope ?? BeatmapLeaderboardScope.Global,
-                leaderboardManager?.CurrentCriteria?.ExactMods));
+                leaderboardManager?.CurrentCriteria?.ExactMods), force);
         }
 
         #region Screen handling
@@ -497,6 +502,11 @@ namespace osu.Game.Screens.Play
             QuickRestart = quickRestartRequested;
             hideOverlays = true;
             ValidForResume = true;
+            // when retrying, it is desired to refetch the global state leaderboard so that the user's previous score can show up on the leaderboard, if it needs to.
+            // that said, only do this when the user is *not* quick-retrying.
+            // this avoids the quick retry becoming longer than it needs to (because an extra API request has to complete before gameplay can start),
+            // and if the user is quick-retrying, their last score is most likely not important for global leaderboards, or the user won't care.
+            refetchLeaderboard(force: !quickRestartRequested);
         }
 
         private void contentIn(double delayBeforeSideDisplays = 0)


### PR DESCRIPTION
Probably closes https://github.com/ppy/osu/issues/34645.

Obviously this is only good if the score has managed to process online and slot into a leaderboard before the user requested a retry. I can't make miracles happen.

Notably this is not applied to quick retry, because it would make quick retry slower, and the presumption is that if the user is quick-retrying their last score is likely useless for global leaderboards anyway. (The one exception to that last part is possibly quick-retrying from results screen, which is a flow that we have, but maybe fine to ignore it...?)