### PR TITLE
Exclude all beatmap audios from the hitsounds format check

### DIFF
--- a/osu.Game/Rulesets/Edit/Checks/CheckHitsoundsFormat.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckHitsoundsFormat.cs
@@ -3,10 +3,12 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using ManagedBass;
 using osu.Framework.Audio.Callbacks;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
+using osu.Game.Models;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
@@ -24,13 +26,22 @@ namespace osu.Game.Rulesets.Edit.Checks
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
             var beatmapSet = context.CurrentDifficulty.Playable.BeatmapInfo.BeatmapSet;
-            var audioFile = beatmapSet?.GetFile(context.CurrentDifficulty.Playable.Metadata.AudioFile);
 
             if (beatmapSet == null) yield break;
 
+            // Collect all audio files from all difficulties to exclude them from the check, as they aren't hitsounds.
+            var audioFiles = new HashSet<RealmNamedFileUsage>();
+
+            foreach (var difficulty in context.AllDifficulties)
+            {
+                var audioFile = beatmapSet.GetFile(difficulty.Playable.Metadata.AudioFile);
+                if (audioFile != null)
+                    audioFiles.Add(audioFile);
+            }
+
             foreach (var file in beatmapSet.Files)
             {
-                if (audioFile != null && ReferenceEquals(file.File, audioFile.File)) continue;
+                if (audioFiles.Any(audioFile => ReferenceEquals(file.File, audioFile.File))) continue;
 
                 using (Stream data = context.CurrentDifficulty.Working.GetStream(file.File.GetStoragePath()))
                 {

--- a/osu.Game/Rulesets/Edit/Checks/CheckHitsoundsFormat.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckHitsoundsFormat.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using ManagedBass;
 using osu.Framework.Audio.Callbacks;
 using osu.Game.Beatmaps;
@@ -30,7 +29,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (beatmapSet == null) yield break;
 
             // Collect all audio files from all difficulties to exclude them from the check, as they aren't hitsounds.
-            var audioFiles = new HashSet<RealmNamedFileUsage>();
+            var audioFiles = new HashSet<RealmNamedFileUsage>(ReferenceEqualityComparer.Instance);
 
             foreach (var difficulty in context.AllDifficulties)
             {
@@ -41,7 +40,7 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             foreach (var file in beatmapSet.Files)
             {
-                if (audioFiles.Any(audioFile => ReferenceEquals(file.File, audioFile.File))) continue;
+                if (audioFiles.Contains(file)) continue;
 
                 using (Stream data = context.CurrentDifficulty.Working.GetStream(file.File.GetStoragePath()))
                 {


### PR DESCRIPTION
Right now only the current difficulty's audio is excluded from the check. This PR prevents false positives on maps with multiple audios, which will be handled via #34666 instead.