### PR TITLE
Refactor notification avatar to remove `OnUpdate`

### DIFF
--- a/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
+++ b/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
@@ -26,26 +26,20 @@ namespace osu.Game.Overlays.Notifications
         [BackgroundDependencyLoader]
         private void load()
         {
-            Avatar = new DrawableAvatar(user)
+            IconContent.Masking = true;
+            IconContent.CornerRadius = CORNER_RADIUS;
+            IconContent.ChangeChildDepth(IconDrawable, float.MinValue);
+
+            LoadComponentAsync(Avatar = new DrawableAvatar(user)
             {
                 FillMode = FillMode.Fill,
-            };
-
-            if (user != null)
-            {
-                IconContent.Masking = true;
-                IconContent.CornerRadius = CORNER_RADIUS;
-                IconContent.ChangeChildDepth(IconDrawable, float.MinValue);
-                LoadComponentAsync(Avatar, IconContent.Add);
-            }
+            }, IconContent.Add);
         }
 
         protected override void Update()
         {
             base.Update();
-
-            if (user != null)
-                IconContent.Width = IconContent.DrawHeight;
+            IconContent.Width = IconContent.DrawHeight;
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
+++ b/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
@@ -31,13 +31,20 @@ namespace osu.Game.Overlays.Notifications
                 IconContent.Masking = true;
                 IconContent.CornerRadius = CORNER_RADIUS;
                 IconContent.ChangeChildDepth(IconDrawable, float.MinValue);
-                IconContent.OnUpdate += _ => IconContent.Width = IconContent.BoundingBox.Height;
 
                 LoadComponentAsync(Avatar = new DrawableAvatar(user)
                 {
                     FillMode = FillMode.Fill,
                 }, IconContent.Add);
             }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (user != null)
+                IconContent.Width = IconContent.DrawHeight;
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
+++ b/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
@@ -26,16 +26,17 @@ namespace osu.Game.Overlays.Notifications
         [BackgroundDependencyLoader]
         private void load()
         {
+            Avatar = new DrawableAvatar(user)
+            {
+                FillMode = FillMode.Fill,
+            };
+
             if (user != null)
             {
                 IconContent.Masking = true;
                 IconContent.CornerRadius = CORNER_RADIUS;
                 IconContent.ChangeChildDepth(IconDrawable, float.MinValue);
-
-                LoadComponentAsync(Avatar = new DrawableAvatar(user)
-                {
-                    FillMode = FillMode.Fill,
-                }, IconContent.Add);
+                LoadComponentAsync(Avatar, IconContent.Add);
             }
         }
 


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/pull/34533#discussion_r2278748709.

Bundled another change in here, which is to make `Avatar` (expected to be non-null in all external usages) truly non-null (as far as we expect from o!f).