### PR TITLE
Fix a bunch of issues with replay fail indicator

### DIFF
--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -194,6 +194,13 @@ namespace osu.Game.Screens.Play
             failIndicator.Display();
         }
 
+        public override void OnSuspending(ScreenTransitionEvent e)
+        {
+            // safety against filters or samples from the indicator playing long after the screen is exited
+            failIndicator.RemoveAndDisposeImmediately();
+            base.OnSuspending(e);
+        }
+
         public override bool OnExiting(ScreenExitEvent e)
         {
             // safety against filters or samples from the indicator playing long after the screen is exited

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Play
                 playbackSettings.UserPlaybackRate.BindTo(master.UserPlaybackRate);
 
             HUDOverlay.PlayerSettingsOverlay.AddAtStart(playbackSettings);
-            HUDOverlay.Add(failIndicator = new ReplayFailIndicator(GameplayClockContainer)
+            AddInternal(failIndicator = new ReplayFailIndicator(GameplayClockContainer)
             {
                 GoToResults = () =>
                 {

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -191,6 +191,7 @@ namespace osu.Game.Screens.Play
         protected override void PerformFail()
         {
             // base logic intentionally suppressed - we have our own custom fail interaction
+            ScoreProcessor.FailScore(Score.ScoreInfo);
             failIndicator.Display();
         }
 


### PR DESCRIPTION
## [Fix frequency not returning to normal when proceeding to results screen of a failed replay](https://github.com/ppy/osu/commit/78a3a1b721888afbcf27d779fce695a2ef1471f2)

closes https://github.com/ppy/osu/issues/34674

## [Fix fail indicator being hideable by toggling HUD off](https://github.com/ppy/osu/commit/8dfe72c7e10456654c44292d0dc2a5efd2484461)

closes https://github.com/ppy/osu/issues/34675

## [Fix score rank not being F on fail in replays](https://github.com/ppy/osu/commit/fd13e94c6fdd91d7c2d9b8dbb44ce0c0090ce474)

closes https://github.com/ppy/osu/issues/34673

This is a bit half-baked because the next thing someone is going to report is that when rewinding with a rank display present in the user's skin, the rank doesn't revert from F anymore after rewinding from the point of fail. That is because of

https://github.com/ppy/osu/blob/237de1ef72a06babd9e3dbd582d5c29faca171b9/osu.Game/Rulesets/Scoring/ScoreProcessor.cs#L392-L394

which I'm not willing to touch on short notice (has implications for multiplayer at the least).