### PR TITLE
Ensure all mod types are `public`

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
@@ -7,7 +7,7 @@ using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModGrow : OsuModObjectScaleTween
+    public class OsuModGrow : OsuModObjectScaleTween
     {
         public override string Name => "Grow";
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -19,7 +19,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModRepel : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
+    public class OsuModRepel : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
     {
         public override string Name => "Repel";
         public override string Acronym => "RP";

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
@@ -14,7 +14,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModTransform : ModWithVisibilityAdjustment
+    public class OsuModTransform : ModWithVisibilityAdjustment
     {
         public override string Name => "Transform";
         public override string Acronym => "TR";

--- a/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModWiggle : ModWithVisibilityAdjustment
+    public class OsuModWiggle : ModWithVisibilityAdjustment
     {
         public override string Name => "Wiggle";
         public override string Acronym => "WG";


### PR DESCRIPTION
For reference: https://discord.com/channels/188630481301012481/188630652340404224/1405902132242022530

For use cases where Lazer is used as a nuget-package to access certain features (decoders, difficulty calculation, ...), and for the sake of consistency, it'd be useful to have all mods `public`. Right now, these 4 mods are the only ones that happen to end up `internal`.