### PR TITLE
SongSelectV2: Fix rewind triggering on right-clicking and dragging away from random button

### DIFF
--- a/osu.Game/Screens/SelectV2/FooterButtonRandom.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonRandom.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.SelectV2
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
-            if (e.Button == MouseButton.Right)
+            if (e.Button == MouseButton.Right && IsHovered)
             {
                 rewindSearch = true;
                 TriggerClick();


### PR DESCRIPTION
I don't think it was an intentional change, but during the switch to Song Select V2 this check got removed from the Random button code, meaning that releasing a right click started on the random button elsewhere would always trigger rewind. This simply copies the condition over from the [Song Select V1 button](https://github.com/ppy/osu/blob/4fe50f98ef7d62938ef7f4214bd985a16b02d181/osu.Game/Screens/Select/FooterButtonRandom.cs#L130), making it functionally match how clicks in general work elsewhere.
Before:

https://github.com/user-attachments/assets/c5eb1753-0135-4ce6-b861-4e40ab9f3645

After:

https://github.com/user-attachments/assets/c9a9c5a1-9e6c-4dec-9389-f7e1f2bed61e

