### PR TITLE
Support math operators in BeatmapAttributeText

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
@@ -115,6 +115,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [TestCase("{(-1)}", "-1")]
         [TestCase("{4(CircleSize)}", "4")]
         [TestCase("{(ApproachRate)(ApproachRate)}", "16")]
+        [TestCase("(ApproachRate-CircleSize)(Accuracy)={(ApproachRate-CircleSize)(Accuracy)}", "(ApproachRate-CircleSize)(Accuracy)=9")]
         public void TestAttributeMathDisplay(string inputText, string expectedText)
         {
             AddStep($"set text: \"{inputText}\"", () => text.Template.Value = inputText);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
@@ -89,6 +89,38 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("check correct text", getText, () => Is.EqualTo(expectedText));
         }
 
+        [TestCase("{CircleSize+1}", "2")]
+        [TestCase("{CircleSize+-1}", "0")]
+        [TestCase("{CircleSize-1}", "0")]
+        [TestCase("{-CircleSize}", "-1")]
+        [TestCase("{ {-CircleSize}", "{ -1")]
+        [TestCase("{(-CircleSize)}", "-1")]
+        [TestCase("{-(CircleSize)}", "-1")]
+        [TestCase("{(-Circleize)}", "{(-Circleize)}")]
+        [TestCase("{4+ApproachRate/4}", "5")]
+        [TestCase("{(4+ApproachRate)/4}", "2")]
+        [TestCase("{-CircleSize} {CircleSize+0} {CircleSize+}", "-1 1 {CircleSize+}")]
+        [TestCase("{-CircleSize} {CircleSize +0} {CircleSize+0}", "-1 {CircleSize +0} 1")]
+        [TestCase("{()()()()}", "{()()()()}")]
+        [TestCase("{-()()()()}", "{-()()()()}")]
+        [TestCase("{()+()+()+()}", "{()+()+()+()}")]
+        [TestCase("{(ApproachRate)(ApproachRate)(ApproachRate)(ApproachRate)}", "256")]
+        [TestCase("{(ApproachRate-(ApproachRate*ApproachRate*ApproachRate))}", "-60")]
+        [TestCase("{1/0}", "{1/0}")]
+        [TestCase("{1%0}", "{1%0}")]
+        [TestCase("{(-1)+1*1*1+(-1-1)}", "-2")]
+        [TestCase("{4%3}", "1")]
+        [TestCase("{4%1.5}", "{4%1.5}")]
+        [TestCase("{-1}", "-1")]
+        [TestCase("{(-1)}", "-1")]
+        [TestCase("{4(CircleSize)}", "4")]
+        [TestCase("{(ApproachRate)(ApproachRate)}", "16")]
+        public void TestAttributeMathDisplay(string inputText, string expectedText)
+        {
+            AddStep($"set text: \"{inputText}\"", () => text.Template.Value = inputText);
+            AddAssert("check correct text", getText, () => Is.EqualTo(expectedText));
+        }
+
         [Test]
         public void TestChangeBeatmap()
         {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
@@ -83,6 +83,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [TestCase("{4%1.5}", "1")]
         [TestCase("{-1}", "-1")]
         [TestCase("{(-1)}", "-1")]
+        [TestCase("{(CircleSize+)(CircleSize)}", "-1")]
         [TestCase("{4(CircleSize)}", "4")]
         [TestCase("{(ApproachRate)(ApproachRate)}", "16")]
         [TestCase("(ApproachRate-CircleSize)(Accuracy)={(ApproachRate-CircleSize)(Accuracy)}", "(ApproachRate-CircleSize)(Accuracy)=9")]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
@@ -1,27 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
 using NUnit.Framework;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
 using osu.Game.Models;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Difficulty;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
-using osu.Game.Rulesets.Difficulty.Skills;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.UI;
-using osu.Game.Scoring;
 using osu.Game.Skinning.Components;
 using osu.Game.Tests.Beatmaps;
 
@@ -30,6 +17,7 @@ namespace osu.Game.Tests.Visual.UserInterface
     public partial class TestSceneBeatmapAttributeTextMath : OsuTestScene
     {
         private readonly BeatmapAttributeText text;
+
         public TestSceneBeatmapAttributeTextMath()
         {
             Child = text = new BeatmapAttributeText
@@ -105,74 +93,5 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         private string getText() => text.ChildrenOfType<SpriteText>().Single().Text.ToString();
-        private class TestRuleset : Ruleset
-        {
-            public override IEnumerable<Mod> GetModsFor(ModType type) => new[]
-            {
-                new TestMod()
-            };
-
-            public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap)
-                => new OsuRuleset().CreateBeatmapConverter(beatmap);
-
-            public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap)
-                => new TestDifficultyCalculator(new TestRuleset().RulesetInfo, beatmap);
-
-            public override PerformanceCalculator CreatePerformanceCalculator()
-                => new TestPerformanceCalculator(new TestRuleset());
-
-            public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod>? mods = null)
-                => null!;
-
-            public override string Description => string.Empty;
-            public override string ShortName => string.Empty;
-        }
-
-        private class TestDifficultyCalculator : DifficultyCalculator
-        {
-            public TestDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
-                : base(ruleset, beatmap)
-            {
-            }
-
-            protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate)
-                => new DifficultyAttributes(mods, mods.OfType<TestMod>().SingleOrDefault()?.Difficulty.Value ?? 0);
-
-            protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)
-                => Array.Empty<DifficultyHitObject>();
-
-            protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
-                => Array.Empty<Skill>();
-        }
-
-        private class TestPerformanceCalculator : PerformanceCalculator
-        {
-            public TestPerformanceCalculator(Ruleset ruleset)
-                : base(ruleset)
-            {
-            }
-
-            protected override PerformanceAttributes CreatePerformanceAttributes(ScoreInfo score, DifficultyAttributes attributes)
-                => new PerformanceAttributes { Total = score.Mods.OfType<TestMod>().SingleOrDefault()?.Performance.Value ?? 0 };
-        }
-
-        private class TestMod : Mod
-        {
-            [SettingSource("difficulty")]
-            public BindableDouble Difficulty { get; } = new BindableDouble(0);
-
-            [SettingSource("performance")]
-            public BindableDouble Performance { get; } = new BindableDouble(0);
-
-            [JsonConstructor]
-            public TestMod()
-            {
-            }
-
-            public override string Name => string.Empty;
-            public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1.0;
-            public override string Acronym => "Test";
-        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
@@ -20,7 +20,6 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Skinning.Components;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [TestCase("{1%0}", "{1%0}")]
         [TestCase("{(-1)+1*1*1+(-1-1)}", "-2")]
         [TestCase("{4%3}", "1")]
-        [TestCase("{4%1.5}", "{4%1.5}")]
+        [TestCase("{4%1.5}", "1")]
         [TestCase("{-1}", "-1")]
         [TestCase("{(-1)}", "-1")]
         [TestCase("{4(CircleSize)}", "4")]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeTextMath.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [TestCase("{4%1.5}", "1")]
         [TestCase("{-1}", "-1")]
         [TestCase("{(-1)}", "-1")]
-        [TestCase("{(CircleSize+)(CircleSize)}", "-1")]
+        [TestCase("{(CircleSize+)(CircleSize)}", "{(CircleSize+)(CircleSize)}")]
         [TestCase("{4(CircleSize)}", "4")]
         [TestCase("{(ApproachRate)(ApproachRate)}", "16")]
         [TestCase("(ApproachRate-CircleSize)(Accuracy)={(ApproachRate-CircleSize)(Accuracy)}", "(ApproachRate-CircleSize)(Accuracy)=9")]

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -490,7 +490,8 @@ namespace osu.Game.Skinning.Components
         private void addImpliedMultiplication(ref string input, int start, int end)
         {
             string numbers = "1234567890";
-            input = input.Replace(")(", ")*(");
+            string insideBracket = input.Substring(start + 1, end - start - 1).Replace(")(", ")*(");
+            input = string.Concat(input.Substring(0, start + 1), insideBracket, input.Substring(end, input.Length - end));
             for (int i = start; i < end; ++i)
             {
                 end = input.IndexOf('}', start);

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -654,10 +654,12 @@ namespace osu.Game.Skinning.Components
                 bool canBeParsed = true;
 
                 string noNumbers = variableTexts[i];
+
                 for (int j = 0; j < numbers.Length; ++j)
                 {
                     noNumbers = noNumbers.Replace(numbers[j].ToString(), "");
                 }
+
                 noNumbers = noNumbers.Replace(".", "");
                 if (noNumbers.Length > 0)
                     canBeParsed = false;

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -133,6 +133,7 @@ namespace osu.Game.Skinning.Components
             if (anyBracketsContainOperations(numberedTemplate))
             {
                 int[] bracketStartPositions = getOperatorContainingBracketPos(numberedTemplate);
+
                 for (int i = 0; i < bracketStartPositions.Length; i++)
                 {
                     string calculatedTemplate = numberedTemplate;
@@ -142,17 +143,20 @@ namespace osu.Game.Skinning.Components
                     if (!checkOperatorCorrectness(calculatedTemplate, bracketStartPositions[i], bracketEndPosition)
                         || !checkRoundBracketCorrectness(calculatedTemplate, bracketStartPositions[i], bracketEndPosition))
                         continue;
+
                     replaceMinus(ref calculatedTemplate, bracketStartPositions[i], bracketEndPosition);
                     addImpliedMultiplication(ref calculatedTemplate, bracketStartPositions[i], bracketEndPosition);
                     //Recalculate endPosition since both of the above function add new characters,
                     //therefore offsetting things.
                     bracketEndPosition = calculatedTemplate.IndexOf('}', bracketStartPositions[i]);
                     int operatorCount = 0;
+
                     for (int j = bracketStartPositions[i]; j < bracketEndPosition; j++)
                     {
                         if (mathOperators.Contains(calculatedTemplate[j]))
                             operatorCount++;
                     }
+
                     string[] variableTexts = new string[operatorCount + 1];
                     string[] operatorSymbols = new string[operatorCount];
                     int[] operatorPriority = new int[operatorCount];
@@ -164,6 +168,7 @@ namespace osu.Game.Skinning.Components
                     double result = doConversionCalculation(variableTexts, operatorSymbols, operatorPriority);
                     if (double.IsNaN(result))
                         continue;
+
                     values.Add(result.ToLocalisableString(@"0.##"));
                     //Set endposition again to ensure that it replaces the right substring.
                     bracketEndPosition = numberedTemplate.IndexOf('}', bracketStartPositions[i]);
@@ -174,6 +179,7 @@ namespace osu.Game.Skinning.Components
                     changeInLength -= numberedTemplate.Length;
                     if (i == bracketStartPositions.Length - 1)
                         continue;
+
                     for (int j = i + 1; j < bracketStartPositions.Length; ++j)
                     {
                         bracketStartPositions[j] -= changeInLength;
@@ -293,7 +299,8 @@ namespace osu.Game.Skinning.Components
             }
         }
 
-        private string mathOperators = "+-*/%";
+        private const string mathOperators = "+-*/%";
+
         private bool anyBracketsContainOperations(string input)
         {
             for (int i = 0; i < input.Length; ++i)
@@ -304,12 +311,15 @@ namespace osu.Game.Skinning.Components
                 int openingBracketPos = input.IndexOf('{', i);
                 if (openingBracketPos == -1)
                     return false;
+
                 int closingBracketPos = input.IndexOf('}', openingBracketPos);
                 if (closingBracketPos == -1)
                     return false;
+
                 int openingResult = input.IndexOf('{', openingBracketPos);
                 if (openingResult == -1)
                     return false;
+
                 //For consistent behaviour we only calculate the most inside brackets
                 //For example: if you write { {CircleSize} } then the other ones remain
                 //intact. This while loop looks for such openings.
@@ -319,20 +329,24 @@ namespace osu.Game.Skinning.Components
                     if (openingResult != -1 && openingResult < closingBracketPos)
                         openingBracketPos = openingResult;
                 }
+
                 //We only check the insides of brackets, not the outside.
                 string bracketInside = input.Substring(openingBracketPos, closingBracketPos - openingBracketPos - 1);
                 i = closingBracketPos;
+
                 for (int j = 0; j < mathOperators.Length; ++j)
                 {
                     if (bracketInside.Contains(mathOperators[j]))
                         return true;
                 }
+
                 //Due to implied multiplication, brackets can be "valid" operators
                 //though only if there is anything besides these brackets
                 if ((bracketInside.Contains('(') || bracketInside.Contains(')'))
                     && bracketInside.Replace("(", "").Replace(")", "").Length > 0)
                     return true;
             }
+
             return false;
         }
 
@@ -344,6 +358,7 @@ namespace osu.Game.Skinning.Components
         private int[] getOperatorContainingBracketPos(string input)
         {
             List<int> openingBracketPositions = new List<int>();
+
             for (int i = 0; i < input.Length; ++i)
             {
                 //If there are brackets inside of brackets then only the most inside
@@ -352,12 +367,15 @@ namespace osu.Game.Skinning.Components
                 int openingBracketPos = input.IndexOf('{', i);
                 if (openingBracketPos == -1)
                     break;
+
                 int closingBracketPos = input.IndexOf('}', openingBracketPos);
                 if (closingBracketPos == -1)
                     break;
+
                 int openingResult = input.IndexOf('{', openingBracketPos);
                 if (openingResult == -1)
                     break;
+
                 //For consistent behaviour we only calculate the most inside brackets
                 //For example: if you write { {CircleSize} } then the other ones remain
                 //intact. This while loop looks for such openings.
@@ -367,9 +385,11 @@ namespace osu.Game.Skinning.Components
                     if (openingResult != -1 && openingResult < closingBracketPos)
                         openingBracketPos = openingResult;
                 }
+
                 //We only check the insides of brackets to not get false positives
                 string bracketInside = input.Substring(openingBracketPos, closingBracketPos - openingBracketPos - 1);
                 i = closingBracketPos;
+
                 for (int j = 0; j < mathOperators.Length; ++j)
                 {
                     if (bracketInside.Contains(mathOperators[j]))
@@ -378,10 +398,12 @@ namespace osu.Game.Skinning.Components
                         break;
                     }
                 }
+
                 if ((bracketInside.Contains('(') || bracketInside.Contains(')'))
                     && !openingBracketPositions.Contains(openingBracketPos))
                     openingBracketPositions.Add(openingBracketPos);
             }
+
             return openingBracketPositions.ToArray();
         }
 
@@ -401,11 +423,13 @@ namespace osu.Game.Skinning.Components
                     j = input.IndexOf(mathOperators[i], j);
                     if (j == -1 || j >= end)
                         break;
+
                     if (j != 0)
                         //Check if operator is next to a {
                         if ((input[j - 1] == '{'
                             || mathOperators.Contains(input[j - 1])) && input[j] != '-')
                             return false;
+
                     if (j != input.Length - 1)
                         //Check if operator is next to a }
                         if ((input[j + 1] == '}'
@@ -413,6 +437,7 @@ namespace osu.Game.Skinning.Components
                             return false;
                 }
             }
+
             return true;
         }
 
@@ -432,6 +457,7 @@ namespace osu.Game.Skinning.Components
             int closingBracketPos = start;
             if (input.Contains("()"))
                 return false;
+
             while (openingBracketPos != -1 || closingBracketPos != -1)
             {
                 if (openingBracketPos != -1 && openingBracketPos < end)
@@ -444,6 +470,7 @@ namespace osu.Game.Skinning.Components
                 if (openingBracketPos > closingBracketPos)
                     return false;
             }
+
             return true;
         }
 
@@ -455,27 +482,22 @@ namespace osu.Game.Skinning.Components
         /// <param name="end">The closing bracket's index (exclusive)</param>
         private void replaceMinus(ref string input, int start, int end)
         {
-            string numbers = "1234567890";
+            const string numbers = "1234567890";
+
             for (int i = start; i < end; ++i)
             {
                 end = input.IndexOf('}', start);
                 i = input.IndexOf('-', i);
                 if (i == -1 || i >= end)
                     break;
+
                 if (i != 0 && i != input.Length)
                 {
-                    //The first check (!numbers.Contains(input[i - 1]) && (mathOperators.Contains(input[i - 1])
-                    //                  || input[i - 1] == '{' || input[i - 1] == '(') && numbers.Contains(input[i + 1])))
-                    //handles all cases where a number receives the minus sign
-                    //The second check (((mathOperators.Contains(input[i - 1]) || input[i - 1] == '{'
-                    //    || input[i - 1] == '(')
-                    //    && (!numbers.Contains(input[i + 1]) && !mathOperators.Contains(input[i + 1])))
-                    //handles all cases where a variable receives the minus sign
-                    if ((!numbers.Contains(input[i - 1]) && (mathOperators.Contains(input[i - 1])
-                        || input[i - 1] == '{' || input[i - 1] == '(') && numbers.Contains(input[i + 1]))
-                        || ((mathOperators.Contains(input[i - 1]) || input[i - 1] == '{'
-                        || input[i - 1] == '(')
-                        && (!numbers.Contains(input[i + 1]) && !mathOperators.Contains(input[i + 1]))))
+                    bool isAfterNumber = numbers.Contains(input[i - 1]);
+                    bool isAfterMathSymbol = mathOperators.Contains(input[i - 1]) || input[i - 1] == '{' || input[i - 1] == '(';
+                    bool isBeforeNumber = numbers.Contains(input[i + 1]);
+                    bool isBeforeMathOperator = mathOperators.Contains(input[i + 1]);
+                    if ((!isAfterNumber && isAfterMathSymbol && isBeforeNumber) || (isAfterMathSymbol && !isBeforeNumber && !isBeforeMathOperator))
                         input = string.Concat(input.Substring(0, i), "_", input.Substring(i + 1, input.Length - i - 1));
                 }
             }
@@ -489,15 +511,17 @@ namespace osu.Game.Skinning.Components
         /// <param name="end">The closing bracket's index (exclusive)</param>
         private void addImpliedMultiplication(ref string input, int start, int end)
         {
-            string numbers = "1234567890";
+            const string numbers = "1234567890";
             string insideBracket = input.Substring(start + 1, end - start - 1).Replace(")(", ")*(");
             input = string.Concat(input.Substring(0, start + 1), insideBracket, input.Substring(end, input.Length - end));
+
             for (int i = start; i < end; ++i)
             {
                 end = input.IndexOf('}', start);
                 i = input.IndexOf('(', i);
                 if (i == -1 || i >= end)
                     break;
+
                 if (i != 0)
                 {
                     if (numbers.Contains(input[i - 1]))
@@ -518,6 +542,7 @@ namespace osu.Game.Skinning.Components
             //so it would be better to skip the ones which aren't used
             //Note: This is future proofing for when more are added
             bool[] skipOperator = new bool[mathOperators.Length];
+
             for (int i = 0; i < mathOperators.Length; ++i)
             {
                 skipOperator[i] = !variableTexts[0].Contains(mathOperators[i]);
@@ -527,11 +552,13 @@ namespace osu.Game.Skinning.Components
             {
                 if (skipOperator[mathOperatorIndex])
                     continue;
+
                 for (int splitTextIndex = 0; splitTextIndex < trueLength; ++splitTextIndex)
                 {
                     string[] split = variableTexts[splitTextIndex].Split(mathOperators[mathOperatorIndex]);
                     if (split.Length < 2)
                         continue;
+
                     //We first move out of the way the already stored variables
                     //It starts from the last index and store items at split length minus one lower
                     //So if 7 is the last index and it was split between 3 then the stored
@@ -541,6 +568,7 @@ namespace osu.Game.Skinning.Components
                     {
                         int movedFromIndex = movedToIndex - split.Length + 1;
                         variableTexts[movedToIndex] = variableTexts[movedFromIndex];
+
                         //operator related arrays' length is one less than variableTexts' length
                         if (movedToIndex != variableTexts.Length - 1)
                         {
@@ -548,16 +576,19 @@ namespace osu.Game.Skinning.Components
                             operatorPriority[movedToIndex] = operatorPriority[movedFromIndex];
                         }
                     }
+
                     //Then add the splits to the created empty places
                     for (int k = 0; k < split.Length; ++k)
                     {
                         variableTexts[splitTextIndex + k] = split[k];
+
                         if (k != split.Length - 1)
                         {
                             operatorSymbols[splitTextIndex + k] = mathOperators[mathOperatorIndex].ToString();
                             operatorPriority[splitTextIndex + k] = mathOperatorIndex;
                         }
                     }
+
                     //The split values don't gonna contain the operator
                     //they were split by so we can skip them.
                     trueLength += split.Length - 1;
@@ -566,6 +597,7 @@ namespace osu.Game.Skinning.Components
             }
 
             int giveHigherPriority = 0;
+
             for (int i = 0; i < operatorSymbols.Length; ++i)
             {
                 //priority is given to operators which are inside ()
@@ -584,11 +616,13 @@ namespace osu.Game.Skinning.Components
         {
             double[] variableValues = new double[variableTexts.Length];
             BeatmapAttribute[] beatmapAttributes = Enum.GetValues<BeatmapAttribute>();
+
             for (int i = 0; i < variableTexts.Length; ++i)
             {
                 bool isValueNegative = variableTexts[i].Trim('(')[0] == '_';
                 bool isBeatmapAttribute = false;
                 variableTexts[i] = variableTexts[i].Trim('(', ')', '_');
+
                 for (int j = 0; j < beatmapAttributes.Length; ++j)
                 {
                     if (beatmapAttributes[j].ToString() == variableTexts[i])
@@ -599,6 +633,7 @@ namespace osu.Game.Skinning.Components
                             variableValues[i] *= -1;
                         break;
                     }
+
                     if (variableTexts[i] == "Value")
                     {
                         variableValues[i] = getLabelValue(Attribute.Value);
@@ -608,8 +643,10 @@ namespace osu.Game.Skinning.Components
                         break;
                     }
                 }
+
                 if (isBeatmapAttribute)
                     continue;
+
                 if (!double.TryParse(variableTexts[i], out variableValues[i]))
                 {
                     variableValues[i] = double.NaN;
@@ -624,27 +661,33 @@ namespace osu.Game.Skinning.Components
             //Ordering priorities so that everything calculated in expected order
             List<int> decreasingPriorities = new List<int>();
             int previousMaxPriority = int.MaxValue;
+
             for (int i = 0; i < operatorPriority.Length; ++i)
             {
                 int maxPriority = 0;
+
                 for (int j = 0; j < operatorPriority.Length; ++j)
                 {
                     if (operatorPriority[j] > maxPriority && operatorPriority[j] < previousMaxPriority)
                         maxPriority = operatorPriority[j];
                 }
+
                 previousMaxPriority = maxPriority;
                 decreasingPriorities.Add(maxPriority);
             }
 
             int prioritiesTrueLength = operatorPriority.Length;
+
             for (int i = 0; i < decreasingPriorities.Count; ++i)
             {
                 for (int j = 0; j < prioritiesTrueLength; ++j)
                 {
                     if (operatorPriority[j] != decreasingPriorities[i])
                         continue;
+
                     variableValues[j] = doMathOperation(operatorSymbols[j], variableValues[j], variableValues[j + 1]);
                     prioritiesTrueLength--;
+
                     //Overwrite already used variable, calculated operator
                     for (int k = j; k < prioritiesTrueLength; ++k)
                     {
@@ -652,9 +695,11 @@ namespace osu.Game.Skinning.Components
                         operatorPriority[k] = operatorPriority[k + 1];
                         variableValues[k + 1] = variableValues[k + 2];
                     }
+
                     --j;
                 }
             }
+
             return variableValues[0];
         }
 
@@ -664,17 +709,23 @@ namespace osu.Game.Skinning.Components
             {
                 case "+":
                     return value1 + value2;
+
                 case "-":
                     return value1 - value2;
+
                 case "*":
                     return value1 * value2;
+
                 case "/":
                     if (value2 == 0)
                         return double.NaN;
+
                     return value1 / value2;
+
                 case "%":
                     return value1 % value2;
             }
+
             return double.NaN;
         }
 

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -425,16 +425,18 @@ namespace osu.Game.Skinning.Components
                         break;
 
                     if (j != 0)
+                    {
                         //Check if operator is next to a {
-                        if ((input[j - 1] == '{'
-                            || mathoperators.Contains(input[j - 1])) && input[j] != '-')
+                        if ((input[j - 1] == '{' || mathoperators.Contains(input[j - 1])) && input[j] != '-')
                             return false;
+                    }
 
                     if (j != input.Length - 1)
+                    {
                         //Check if operator is next to a }
-                        if ((input[j + 1] == '}'
-                            || mathoperators.Contains(input[j + 1])) && input[j + 1] != '-')
+                        if ((input[j + 1] == '}' || mathoperators.Contains(input[j + 1])) && input[j + 1] != '-')
                             return false;
+                    }
                 }
             }
 

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -431,15 +431,15 @@ namespace osu.Game.Skinning.Components
 
                     if (j != 0)
                     {
-                        //Check if operator is next to a {
-                        if ((input[j - 1] == '{' || mathoperators.Contains(input[j - 1])) && input[j] != '-')
+                        //Check if operator is next to a { or (
+                        if ((input[j - 1] == '{' || input[j - 1] == '(' || mathoperators.Contains(input[j - 1])) && input[j] != '-')
                             return false;
                     }
 
                     if (j != input.Length - 1)
                     {
-                        //Check if operator is next to a }
-                        if ((input[j + 1] == '}' || mathoperators.Contains(input[j + 1])) && input[j + 1] != '-')
+                        //Check if operator is next to a } or )
+                        if ((input[j + 1] == '}' || input[j + 1] == ')' || mathoperators.Contains(input[j + 1])) && input[j + 1] != '-')
                             return false;
                     }
                 }

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Skinning.Components
 
                     for (int j = bracketStartPositions[i]; j < bracketEndPosition; j++)
                     {
-                        if (mathOperators.Contains(calculatedTemplate[j]))
+                        if (mathoperators.Contains(calculatedTemplate[j]))
                             operatorCount++;
                     }
 
@@ -299,7 +299,7 @@ namespace osu.Game.Skinning.Components
             }
         }
 
-        private const string mathOperators = "+-*/%";
+        private const string mathoperators = "+-*/%";
 
         private bool anyBracketsContainOperations(string input)
         {
@@ -334,9 +334,9 @@ namespace osu.Game.Skinning.Components
                 string bracketInside = input.Substring(openingBracketPos, closingBracketPos - openingBracketPos - 1);
                 i = closingBracketPos;
 
-                for (int j = 0; j < mathOperators.Length; ++j)
+                for (int j = 0; j < mathoperators.Length; ++j)
                 {
-                    if (bracketInside.Contains(mathOperators[j]))
+                    if (bracketInside.Contains(mathoperators[j]))
                         return true;
                 }
 
@@ -390,9 +390,9 @@ namespace osu.Game.Skinning.Components
                 string bracketInside = input.Substring(openingBracketPos, closingBracketPos - openingBracketPos - 1);
                 i = closingBracketPos;
 
-                for (int j = 0; j < mathOperators.Length; ++j)
+                for (int j = 0; j < mathoperators.Length; ++j)
                 {
-                    if (bracketInside.Contains(mathOperators[j]))
+                    if (bracketInside.Contains(mathoperators[j]))
                     {
                         openingBracketPositions.Add(openingBracketPos);
                         break;
@@ -416,24 +416,24 @@ namespace osu.Game.Skinning.Components
         /// <returns>Returns true if every operator has a value inbetween them.</returns>
         private bool checkOperatorCorrectness(string input, int start, int end)
         {
-            for (int i = 0; i < mathOperators.Length; ++i)
+            for (int i = 0; i < mathoperators.Length; ++i)
             {
                 for (int j = start; j < end; ++j)
                 {
-                    j = input.IndexOf(mathOperators[i], j);
+                    j = input.IndexOf(mathoperators[i], j);
                     if (j == -1 || j >= end)
                         break;
 
                     if (j != 0)
                         //Check if operator is next to a {
                         if ((input[j - 1] == '{'
-                            || mathOperators.Contains(input[j - 1])) && input[j] != '-')
+                            || mathoperators.Contains(input[j - 1])) && input[j] != '-')
                             return false;
 
                     if (j != input.Length - 1)
                         //Check if operator is next to a }
                         if ((input[j + 1] == '}'
-                            || mathOperators.Contains(input[j + 1])) && input[j + 1] != '-')
+                            || mathoperators.Contains(input[j + 1])) && input[j + 1] != '-')
                             return false;
                 }
             }
@@ -494,9 +494,9 @@ namespace osu.Game.Skinning.Components
                 if (i != 0 && i != input.Length)
                 {
                     bool isAfterNumber = numbers.Contains(input[i - 1]);
-                    bool isAfterMathSymbol = mathOperators.Contains(input[i - 1]) || input[i - 1] == '{' || input[i - 1] == '(';
+                    bool isAfterMathSymbol = mathoperators.Contains(input[i - 1]) || input[i - 1] == '{' || input[i - 1] == '(';
                     bool isBeforeNumber = numbers.Contains(input[i + 1]);
-                    bool isBeforeMathOperator = mathOperators.Contains(input[i + 1]);
+                    bool isBeforeMathOperator = mathoperators.Contains(input[i + 1]);
                     if ((!isAfterNumber && isAfterMathSymbol && isBeforeNumber) || (isAfterMathSymbol && !isBeforeNumber && !isBeforeMathOperator))
                         input = string.Concat(input.Substring(0, i), "_", input.Substring(i + 1, input.Length - i - 1));
                 }
@@ -541,21 +541,21 @@ namespace osu.Game.Skinning.Components
             //A lot of the time only one or two operators will be used
             //so it would be better to skip the ones which aren't used
             //Note: This is future proofing for when more are added
-            bool[] skipOperator = new bool[mathOperators.Length];
+            bool[] skipOperator = new bool[mathoperators.Length];
 
-            for (int i = 0; i < mathOperators.Length; ++i)
+            for (int i = 0; i < mathoperators.Length; ++i)
             {
-                skipOperator[i] = !variableTexts[0].Contains(mathOperators[i]);
+                skipOperator[i] = !variableTexts[0].Contains(mathoperators[i]);
             }
 
-            for (int mathOperatorIndex = 0; mathOperatorIndex < mathOperators.Length; ++mathOperatorIndex)
+            for (int mathOperatorIndex = 0; mathOperatorIndex < mathoperators.Length; ++mathOperatorIndex)
             {
                 if (skipOperator[mathOperatorIndex])
                     continue;
 
                 for (int splitTextIndex = 0; splitTextIndex < trueLength; ++splitTextIndex)
                 {
-                    string[] split = variableTexts[splitTextIndex].Split(mathOperators[mathOperatorIndex]);
+                    string[] split = variableTexts[splitTextIndex].Split(mathoperators[mathOperatorIndex]);
                     if (split.Length < 2)
                         continue;
 
@@ -584,7 +584,7 @@ namespace osu.Game.Skinning.Components
 
                         if (k != split.Length - 1)
                         {
-                            operatorSymbols[splitTextIndex + k] = mathOperators[mathOperatorIndex].ToString();
+                            operatorSymbols[splitTextIndex + k] = mathoperators[mathOperatorIndex].ToString();
                             operatorPriority[splitTextIndex + k] = mathOperatorIndex;
                         }
                     }
@@ -605,9 +605,9 @@ namespace osu.Game.Skinning.Components
                 //the length of mathOperators multiplied by the amount of brackets
                 //it is in
                 if (variableTexts[i].Length - variableTexts[i].TrimStart('(').Length > 0)
-                    giveHigherPriority += mathOperators.Length * (variableTexts[i].Length - variableTexts[i].TrimStart('(').Length);
+                    giveHigherPriority += mathoperators.Length * (variableTexts[i].Length - variableTexts[i].TrimStart('(').Length);
                 if (variableTexts[i].Length - variableTexts[i].TrimEnd(')').Length > 0)
-                    giveHigherPriority -= mathOperators.Length * (variableTexts[i].Length - variableTexts[i].TrimEnd(')').Length);
+                    giveHigherPriority -= mathoperators.Length * (variableTexts[i].Length - variableTexts[i].TrimEnd(')').Length);
                 operatorPriority[i] += giveHigherPriority;
             }
         }


### PR DESCRIPTION
- Answers https://github.com/ppy/osu/discussions/31901

https://github.com/user-attachments/assets/b7d5cc68-c2a0-4fc9-aad8-83dde7da637c

Adds support for:

- addition (+)
- subtraction (-)
- minus (-) (subtraction: x-y, minus: x+-y)
- multiplication (*)
- division (/)
- remainder (%)
- round brackets (())
- implied multiplication ((x+1)(x-1))

Title, Artist, DifficultyName, Creator, and Source usage will result the calculation not be calculated. Any error or typo will result in the calculation not happening.

In a follow up PR I plan to add function (abs(), sqrt(), root(), pow(), floor(), etc.) support. And no, I am not gonna add support for the use of | as absolute because then one third or more of this PR's line changes would have been about this operator.