### PR TITLE
Fix even more issues with replay fail indicator

### DIFF
--- a/osu.Game/Screens/Play/ReplayFailIndicator.cs
+++ b/osu.Game/Screens/Play/ReplayFailIndicator.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Screens.Play
         private SkinnableSound failSample = null!;
         private AudioFilter failLowPassFilter = null!;
         private AudioFilter failHighPassFilter = null!;
+        private Container content = null!;
 
         private double? failTime;
 
@@ -44,7 +45,6 @@ namespace osu.Game.Screens.Play
 
         public ReplayFailIndicator(GameplayClockContainer gameplayClockContainer)
         {
-            AlwaysPresent = true;
             Clock = this.gameplayClockContainer = gameplayClockContainer;
         }
 
@@ -54,7 +54,6 @@ namespace osu.Game.Screens.Play
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             AutoSizeAxes = Axes.Both;
-            Alpha = 0;
 
             track = beatmap.Value.Track;
 
@@ -65,13 +64,14 @@ namespace osu.Game.Screens.Play
                 failSample = new SkinnableSound(new SampleInfo(@"Gameplay/failsound")),
                 failLowPassFilter = new AudioFilter(audio.TrackMixer),
                 failHighPassFilter = new AudioFilter(audio.TrackMixer, BQFType.HighPass),
-                new Container
+                content = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     AutoSizeAxes = Axes.Both,
                     Masking = true,
                     CornerRadius = 20,
+                    Alpha = 0,
                     Children = new Drawable[]
                     {
                         new Box
@@ -132,7 +132,7 @@ namespace osu.Game.Screens.Play
                 // intentionally shorter than the actual fail animation
                 const double audio_sweep_duration = 1000;
 
-                this.FadeInFromZero(200, Easing.OutQuint);
+                content.FadeInFromZero(200, Easing.OutQuint);
                 this.ScaleTo(1.1f, audio_sweep_duration, Easing.OutElasticHalf);
                 this.TransformBindableTo(trackFreq, 0, audio_sweep_duration);
                 this.TransformBindableTo(volumeAdjustment, 0.5);

--- a/osu.Game/Screens/Play/ReplayFailIndicator.cs
+++ b/osu.Game/Screens/Play/ReplayFailIndicator.cs
@@ -155,8 +155,11 @@ namespace osu.Game.Screens.Play
                 failSample.Play();
             }
 
-            if (Time.Current < failTime)
+            if (Time.Current < failTime && failSamplePlaybackInitiated)
+            {
                 failSamplePlaybackInitiated = false;
+                failSample.Stop();
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -197,8 +197,7 @@ namespace osu.Game.Screens.Play
 
         public override void OnSuspending(ScreenTransitionEvent e)
         {
-            // safety against filters or samples from the indicator playing long after the screen is exited
-            failIndicator.RemoveAndDisposeImmediately();
+            stopAllAudioEffects();
             base.OnSuspending(e);
         }
 
@@ -207,6 +206,18 @@ namespace osu.Game.Screens.Play
             // safety against filters or samples from the indicator playing long after the screen is exited
             failIndicator.RemoveAndDisposeImmediately();
             return base.OnExiting(e);
+        }
+
+        private void stopAllAudioEffects()
+        {
+            // safety against filters or samples from the indicator playing long after the screen is exited
+            failIndicator.RemoveAndDisposeImmediately();
+
+            if (GameplayClockContainer is MasterGameplayClockContainer master)
+            {
+                playbackSettings.UserPlaybackRate.UnbindFrom(master.UserPlaybackRate);
+                master.UserPlaybackRate.SetDefault();
+            }
         }
     }
 }


### PR DESCRIPTION
## [Fix replay fail indicator "go to results" button being clickable while invisible](https://github.com/ppy/osu/commit/5b1b22cb6611fe3efcb156fea3ce2856882a1612)

closes https://github.com/ppy/osu/issues/34685

## [Stop fail sample when rewinding to before it in replay](https://github.com/ppy/osu/commit/39baf6e9b3efd3403e3a932ec2c24d09ae5c9e33)

closes https://github.com/ppy/osu/issues/34688

I originally wrote it this way semi-intentionally because I thought cutting out the sample was worse than letting it play out, but I also forgot that people use like seventy hour long fail samples in skins for whatever reason.

## [Unapply replay playback speed when going to results](https://github.com/ppy/osu/commit/d26f31b71d7fda2fc6e8b90431db3f61b67d8bc5)

closes https://github.com/ppy/osu/issues/34700