### PR TITLE
Refresh realm before performing song select refetches following an online metadata lookup

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -440,6 +440,7 @@ namespace osu.Game.Screens.SelectV2
             string[] tags = realm.Run(r =>
             {
                 // need to refetch because `beatmap.Value.BeatmapInfo` is not going to have the latest tags
+                r.Refresh();
                 var refetchedBeatmap = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID);
                 return refetchedBeatmap?.Metadata.UserTags.ToArray() ?? [];
             });

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -332,6 +332,7 @@ namespace osu.Game.Screens.SelectV2
                 // which prevents working beatmap refetches caused by changes to the realm model of perceived low importance).
                 var status = realm.Run(r =>
                 {
+                    r.Refresh();
                     var refetchedBeatmap = r.Find<BeatmapInfo>(working.Value.BeatmapInfo.ID);
                     return refetchedBeatmap?.Status;
                 });


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34716
- Alternative to / closes https://github.com/ppy/osu/pull/34737

Can't see any other cause, can reproduce the issue on master using manual db modifications via realm studio and it is not a consistent reproduction, so seems like an open-and-shut lack of refresh.