### PR TITLE
Refactor online lookup flows in song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardSorting.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapLeaderboardSorting.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -42,7 +43,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         private DialogOverlay dialogOverlay = null!;
 
         private LeaderboardManager leaderboardManager = null!;
-        private RealmPopulatingOnlineLookupSource lookupSource = null!;
+
+        private readonly IBindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?> onlineLookupResult = new Bindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?>();
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -52,7 +54,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
             dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, Realm, API));
             dependencies.Cache(leaderboardManager = new LeaderboardManager());
-            dependencies.Cache(lookupSource = new RealmPopulatingOnlineLookupSource());
+            dependencies.CacheAs(onlineLookupResult);
 
             Dependencies.Cache(Realm);
 
@@ -68,7 +70,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
 
             LoadComponent(leaderboardManager);
-            LoadComponent(lookupSource);
 
             Child = contentContainer = new OsuContextMenuContainer
             {

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapMetadataWedge.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Graphics;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Extensions;
 using osu.Game.Models;
-using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Screens.SelectV2;
 
@@ -18,64 +17,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 {
     public partial class TestSceneBeatmapMetadataWedge : SongSelectComponentsTestScene
     {
-        private APIBeatmapSet? currentOnlineSet;
-
         private BeatmapMetadataWedge wedge = null!;
+
+        [Cached(typeof(IBindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?>))]
+        private Bindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?> onlineLookupResult = new Bindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?>();
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            var lookupSource = new RealmPopulatingOnlineLookupSource();
-            Child = new DependencyProvidingContainer
+            Child = wedge = new BeatmapMetadataWedge
             {
-                RelativeSizeAxes = Axes.Both,
-                CachedDependencies = [(typeof(RealmPopulatingOnlineLookupSource), lookupSource)],
-                Children =
-                [
-                    lookupSource,
-                    wedge = new BeatmapMetadataWedge
-                    {
-                        State = { Value = Visibility.Visible },
-                    }
-                ]
+                State = { Value = Visibility.Visible },
             };
-        }
-
-        [SetUpSteps]
-        public override void SetUpSteps()
-        {
-            AddStep("register request handling", () =>
-            {
-                ((DummyAPIAccess)API).HandleRequest = request =>
-                {
-                    switch (request)
-                    {
-                        case GetBeatmapSetRequest set:
-                            if (set.ID == currentOnlineSet?.OnlineID)
-                            {
-                                set.TriggerSuccess(currentOnlineSet);
-                                return true;
-                            }
-
-                            return false;
-
-                        default:
-                            return false;
-                    }
-                };
-            });
         }
 
         [Test]
         public void TestShowHide()
         {
-            AddStep("all metrics", () =>
-            {
-                var (working, onlineSet) = createTestBeatmap();
-                currentOnlineSet = onlineSet;
-                Beatmap.Value = working;
-            });
+            AddStep("all metrics", () => (Beatmap.Value, onlineLookupResult.Value) = createTestBeatmap());
 
             AddStep("hide wedge", () => wedge.Hide());
             AddStep("show wedge", () => wedge.Show());
@@ -84,67 +44,63 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestVariousMetrics()
         {
-            AddStep("all metrics", () =>
-            {
-                var (working, onlineSet) = createTestBeatmap();
-                currentOnlineSet = onlineSet;
-                Beatmap.Value = working;
-            });
+            AddStep("all metrics", () => (Beatmap.Value, onlineLookupResult.Value) = createTestBeatmap());
+
             AddStep("null beatmap", () => Beatmap.SetDefault());
             AddStep("no source", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
                 working.Metadata.Source = string.Empty;
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
             AddStep("no success rate", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.Beatmaps.Single().PlayCount = 0;
-                onlineSet.Beatmaps.Single().PassCount = 0;
+                lookupResult.Online!.Beatmaps.Single().PlayCount = 0;
+                lookupResult.Online.Beatmaps.Single().PassCount = 0;
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
             AddStep("no user ratings", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.Ratings = Array.Empty<int>();
+                lookupResult.Online!.Ratings = Array.Empty<int>();
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
             AddStep("no fail times", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.Beatmaps.Single().FailTimes = null;
+                lookupResult.Online!.Beatmaps.Single().FailTimes = null;
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
             AddStep("no metrics", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.Ratings = Array.Empty<int>();
-                onlineSet.Beatmaps.Single().FailTimes = null;
+                lookupResult.Online!.Ratings = Array.Empty<int>();
+                lookupResult.Online!.Beatmaps.Single().FailTimes = null;
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
             AddStep("local beatmap", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, _) = createTestBeatmap();
 
                 working.BeatmapInfo.OnlineID = 0;
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = new RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult(null, working.BeatmapSetInfo);
                 Beatmap.Value = working;
             });
         }
@@ -154,16 +110,16 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             AddStep("long text", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
                 working.BeatmapInfo.Metadata.Author = new RealmUser { Username = "Verrrrryyyy llooonngggggg author" };
                 working.BeatmapInfo.Metadata.Source = "Verrrrryyyy llooonngggggg source";
                 working.BeatmapInfo.Metadata.Tags = string.Join(' ', Enumerable.Repeat(working.BeatmapInfo.Metadata.Tags, 3));
-                onlineSet.Genre = new BeatmapSetOnlineGenre { Id = 12, Name = "Verrrrryyyy llooonngggggg genre" };
-                onlineSet.Language = new BeatmapSetOnlineLanguage { Id = 12, Name = "Verrrrryyyy llooonngggggg language" };
-                onlineSet.Beatmaps.Single().TopTags = Enumerable.Repeat(onlineSet.Beatmaps.Single().TopTags, 3).SelectMany(t => t!).ToArray();
+                lookupResult.Online!.Genre = new BeatmapSetOnlineGenre { Id = 12, Name = "Verrrrryyyy llooonngggggg genre" };
+                lookupResult.Online.Language = new BeatmapSetOnlineLanguage { Id = 12, Name = "Verrrrryyyy llooonngggggg language" };
+                lookupResult.Online.Beatmaps.Single().TopTags = Enumerable.Repeat(lookupResult.Online.Beatmaps.Single().TopTags, 3).SelectMany(t => t!).ToArray();
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
         }
@@ -171,22 +127,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestOnlineAvailability()
         {
-            AddStep("online beatmapset", () =>
-            {
-                var (working, onlineSet) = createTestBeatmap();
+            AddStep("online beatmapset", () => (Beatmap.Value, onlineLookupResult.Value) = createTestBeatmap());
 
-                currentOnlineSet = onlineSet;
-                Beatmap.Value = working;
-            });
             AddUntilStep("rating wedge visible", () => wedge.RatingsVisible);
             AddUntilStep("fail time wedge visible", () => wedge.FailRetryVisible);
             AddStep("online beatmapset with local diff", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
                 working.BeatmapInfo.ResetOnlineInfo();
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
             AddUntilStep("rating wedge hidden", () => !wedge.RatingsVisible);
@@ -195,7 +146,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             {
                 var (working, _) = createTestBeatmap();
 
-                currentOnlineSet = null;
+                onlineLookupResult.Value = new RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult(null, working.BeatmapSetInfo);
                 Beatmap.Value = working;
             });
             AddAssert("rating wedge still hidden", () => !wedge.RatingsVisible);
@@ -205,21 +156,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestUserTags()
         {
-            AddStep("user tags", () =>
-            {
-                var (working, onlineSet) = createTestBeatmap();
+            AddStep("user tags", () => (Beatmap.Value, onlineLookupResult.Value) = createTestBeatmap());
 
-                currentOnlineSet = onlineSet;
-                Beatmap.Value = working;
-            });
             AddStep("no user tags", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.Beatmaps.Single().TopTags = null;
-                onlineSet.RelatedTags = null;
+                lookupResult.Online!.Beatmaps.Single().TopTags = null;
+                lookupResult.Online.RelatedTags = null;
+                lookupResult.Local.Beatmaps.Single().Metadata.UserTags.Clear();
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = lookupResult;
                 Beatmap.Value = working;
             });
         }
@@ -227,72 +174,60 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestLoading()
         {
-            AddStep("override request handling", () =>
-            {
-                currentOnlineSet = null;
-
-                ((DummyAPIAccess)API).HandleRequest = request =>
-                {
-                    switch (request)
-                    {
-                        case GetBeatmapSetRequest set:
-                            Scheduler.AddDelayed(() => set.TriggerSuccess(currentOnlineSet!), 500);
-                            return true;
-
-                        default:
-                            return false;
-                    }
-                };
-            });
-
             AddStep("set beatmap", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = null;
+                Scheduler.AddDelayed(() => onlineLookupResult.Value = lookupResult, 500);
                 Beatmap.Value = working;
             });
             AddWaitStep("wait", 5);
 
             AddStep("set beatmap", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.RelatedTags![0].Name = "other/tag";
-                onlineSet.RelatedTags[1].Name = "another/tag";
-                onlineSet.RelatedTags[2].Name = "some/tag";
+                lookupResult.Online!.RelatedTags![0].Name = "other/tag";
+                lookupResult.Online.RelatedTags[1].Name = "another/tag";
+                lookupResult.Online.RelatedTags[2].Name = "some/tag";
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = null;
+                Scheduler.AddDelayed(() => onlineLookupResult.Value = lookupResult, 500);
                 Beatmap.Value = working;
             });
             AddWaitStep("wait", 5);
 
             AddStep("no user tags", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.Beatmaps.Single().TopTags = null;
-                onlineSet.RelatedTags = null;
+                lookupResult.Online!.Beatmaps.Single().TopTags = null;
+                lookupResult.Online.RelatedTags = null;
+                lookupResult.Local.Beatmaps.Single().Metadata.UserTags.Clear();
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = null;
+                Scheduler.AddDelayed(() => onlineLookupResult.Value = lookupResult, 500);
                 Beatmap.Value = working;
             });
             AddWaitStep("wait", 5);
 
             AddStep("no user tags", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
-                onlineSet.Beatmaps.Single().TopTags = null;
-                onlineSet.RelatedTags = null;
+                lookupResult.Online!.Beatmaps.Single().TopTags = null;
+                lookupResult.Online.RelatedTags = null;
+                lookupResult.Local.Beatmaps.Single().Metadata.UserTags.Clear();
 
-                currentOnlineSet = onlineSet;
+                onlineLookupResult.Value = null;
+                Scheduler.AddDelayed(() => onlineLookupResult.Value = lookupResult, 500);
                 Beatmap.Value = working;
             });
             AddWaitStep("wait", 5);
         }
 
-        private (WorkingBeatmap, APIBeatmapSet) createTestBeatmap()
+        private (WorkingBeatmap, RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult) createTestBeatmap()
         {
             var working = CreateWorkingBeatmap(Ruleset.Value);
             var onlineSet = new APIBeatmapSet
@@ -346,7 +281,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             working.BeatmapSetInfo.DateSubmitted = DateTimeOffset.Now;
             working.BeatmapSetInfo.DateRanked = DateTimeOffset.Now;
-            return (working, onlineSet);
+            working.Metadata.UserTags.AddRange(onlineSet.RelatedTags.Select(t => t.Name));
+            return (working, new RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult(onlineSet, working.BeatmapSetInfo));
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
@@ -41,10 +42,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         private BeatmapTitleWedge titleWedge = null!;
         private BeatmapTitleWedge.DifficultyDisplay difficultyDisplay => titleWedge.ChildrenOfType<BeatmapTitleWedge.DifficultyDisplay>().Single();
 
-        private APIBeatmapSet? currentOnlineSet;
-
-        [Cached]
-        private RealmPopulatingOnlineLookupSource lookupSource = new RealmPopulatingOnlineLookupSource();
+        [Cached(typeof(IBindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?>))]
+        private Bindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?> onlineLookupResult = new Bindable<RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult?>();
 
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
@@ -58,7 +57,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddRange(new Drawable[]
             {
-                lookupSource,
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -142,44 +140,18 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         [Test]
         public void TestOnlineAvailability()
         {
-            AddStep("set up request handler", () =>
-            {
-                ((DummyAPIAccess)API).HandleRequest = request =>
-                {
-                    switch (request)
-                    {
-                        case GetBeatmapSetRequest set:
-                            if (set.ID == currentOnlineSet?.OnlineID)
-                            {
-                                set.TriggerSuccess(currentOnlineSet);
-                                return true;
-                            }
+            AddStep("online beatmapset", () => (Beatmap.Value, onlineLookupResult.Value) = createTestBeatmap());
 
-                            return false;
-
-                        default:
-                            return false;
-                    }
-                };
-            });
-
-            AddStep("online beatmapset", () =>
-            {
-                var (working, onlineSet) = createTestBeatmap();
-
-                currentOnlineSet = onlineSet;
-                Beatmap.Value = working;
-            });
             AddUntilStep("play count is 10000", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("10,000"));
             AddUntilStep("favourites count is 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,345"));
             AddStep("online beatmapset with local diff", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
+                var (working, lookupResult) = createTestBeatmap();
 
                 working.BeatmapInfo.ResetOnlineInfo();
 
-                currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
+                onlineLookupResult.Value = lookupResult;
             });
             AddUntilStep("play count is -", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("-"));
             AddUntilStep("favourites count is 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,345"));
@@ -187,8 +159,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             {
                 var (working, _) = createTestBeatmap();
 
-                currentOnlineSet = null;
                 Beatmap.Value = working;
+                onlineLookupResult.Value = new RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult(null, working.BeatmapSetInfo);
             });
             AddUntilStep("play count is -", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("-"));
             AddUntilStep("favourites count is -", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("-"));
@@ -205,15 +177,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 {
                     switch (request)
                     {
-                        case GetBeatmapSetRequest set:
-                            if (set.ID == currentOnlineSet?.OnlineID)
-                            {
-                                set.TriggerSuccess(currentOnlineSet);
-                                return true;
-                            }
-
-                            return false;
-
                         case PostBeatmapFavouriteRequest favourite:
                             Task.Run(() =>
                             {
@@ -228,13 +191,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 };
             });
 
-            AddStep("online beatmapset", () =>
-            {
-                var (working, onlineSet) = createTestBeatmap();
+            AddStep("online beatmapset", () => (Beatmap.Value, onlineLookupResult.Value) = createTestBeatmap());
 
-                currentOnlineSet = onlineSet;
-                Beatmap.Value = working;
-            });
             AddUntilStep("play count is 10000", () => this.ChildrenOfType<BeatmapTitleWedge.Statistic>().ElementAt(0).Text.ToString(), () => Is.EqualTo("10,000"));
             AddUntilStep("favourites count is 2345", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("2,345"));
 
@@ -251,13 +209,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("click favourite button", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().TriggerClick());
             AddStep("change to another beatmap", () =>
             {
-                var (working, onlineSet) = createTestBeatmap();
-                onlineSet.FavouriteCount = 9999;
-                onlineSet.HasFavourited = true;
-                working.BeatmapSetInfo.OnlineID = onlineSet.OnlineID = 99999;
+                var (working, lookupResult) = createTestBeatmap();
+                lookupResult.Online!.FavouriteCount = 9999;
+                lookupResult.Online.HasFavourited = true;
+                working.BeatmapSetInfo.OnlineID = lookupResult.Online.OnlineID = 99999;
 
-                currentOnlineSet = onlineSet;
                 Beatmap.Value = working;
+                onlineLookupResult.Value = lookupResult;
             });
             AddStep("allow request to complete", () => resetEvent.Set());
             AddUntilStep("favourites count is 9999", () => this.ChildrenOfType<BeatmapTitleWedge.FavouriteButton>().Single().Text.ToString(), () => Is.EqualTo("9,999"));
@@ -268,15 +226,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 {
                     switch (request)
                     {
-                        case GetBeatmapSetRequest set:
-                            if (set.ID == currentOnlineSet?.OnlineID)
-                            {
-                                set.TriggerSuccess(currentOnlineSet);
-                                return true;
-                            }
-
-                            return false;
-
                         case PostBeatmapFavouriteRequest favourite:
                             Task.Run(() =>
                             {
@@ -350,7 +299,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             });
         }
 
-        private (WorkingBeatmap, APIBeatmapSet) createTestBeatmap()
+        private (WorkingBeatmap, RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult) createTestBeatmap()
         {
             var working = CreateWorkingBeatmap(Ruleset.Value);
             var onlineSet = new APIBeatmapSet
@@ -371,7 +320,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             working.BeatmapSetInfo.DateSubmitted = DateTimeOffset.Now;
             working.BeatmapSetInfo.DateRanked = DateTimeOffset.Now;
-            return (working, onlineSet);
+            return (working, new RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult(onlineSet, working.BeatmapSetInfo));
         }
 
         private class TestHitObject : ConvertHitObject;

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -293,7 +293,7 @@ namespace osu.Game.Screens.SelectV2
                 // it also has to be handled explicitly like this because the working beatmap's `BeatmapInfo` will not receive these updates due to being detached
                 // (and because of https://github.com/ppy/osu/blob/4b73afd1957a9161e2956fc4191c8114d9958372/osu.Game/Screens/SelectV2/SongSelect.cs#L487-L488
                 // which prevents working beatmap refetches caused by changes to the realm model of perceived low importance).
-                statusPill.Status = onlineLookupResult.Value.Local.Status;
+                statusPill.Status = onlineLookupResult.Value.Local.Beatmaps.SingleOrDefault(b => b.ID == working.Value.BeatmapInfo.ID)?.Status ?? statusPill.Status;
             }
         }
     }

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_FavouriteButton.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_FavouriteButton.cs
@@ -229,7 +229,10 @@ namespace osu.Game.Screens.SelectV2
                     bool hasFavourited = favouriteRequest.Action == BeatmapFavouriteAction.Favourite;
                     beatmapSet.HasFavourited = hasFavourited;
                     beatmapSet.FavouriteCount += hasFavourited ? 1 : -1;
-                    setBeatmapSet(beatmapSet, withHeartAnimation: hasFavourited);
+
+                    // if the beatmap set reference changed under the callback, abort visual updates to avoid showing stale data
+                    if (onlineBeatmapSet == null || ReferenceEquals(beatmapSet, onlineBeatmapSet))
+                        setBeatmapSet(beatmapSet, withHeartAnimation: hasFavourited);
                 };
                 favouriteRequest.Failure += e =>
                 {
@@ -238,7 +241,10 @@ namespace osu.Game.Screens.SelectV2
                         Text = e.Message,
                         Icon = FontAwesome.Solid.Times,
                     });
-                    setBeatmapSet(beatmapSet, withHeartAnimation: false);
+
+                    // if the beatmap set reference changed under the callback, abort visual updates to avoid showing stale data
+                    if (onlineBeatmapSet == null || ReferenceEquals(beatmapSet, onlineBeatmapSet))
+                        setBeatmapSet(beatmapSet, withHeartAnimation: false);
                 };
                 api.Queue(favouriteRequest);
                 setLoading();

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -977,17 +977,17 @@ namespace osu.Game.Screens.SelectV2
 
             onlineLookupCancellation = new CancellationTokenSource();
             currentOnlineLookup = onlineLookupSource.LookupOnlineAsync(beatmapSetInfo);
-            currentOnlineLookup.ContinueWith(t => Schedule(() =>
+            currentOnlineLookup.ContinueWith(t =>
             {
                 if (t.IsCompletedSuccessfully)
-                    lastLookupResult.Value = t.GetResultSafely();
+                    Schedule(() => lastLookupResult.Value = t.GetResultSafely());
 
                 if (t.Exception != null)
                 {
                     Logger.Log($"Error when fetching online beatmap set: {t.Exception}", LoggingTarget.Network);
-                    lastLookupResult.Value = new RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult(null, Beatmap.Value.BeatmapSetInfo);
+                    Schedule(() => lastLookupResult.Value = new RealmPopulatingOnlineLookupSource.BeatmapSetLookupResult(null, Beatmap.Value.BeatmapSetInfo));
                 }
-            }));
+            });
         }
 
         #endregion


### PR DESCRIPTION
RFC

## [Refactor realm populating online beatmap set lookup to not require explicit realm refetch](https://github.com/ppy/osu/commit/bd215ca670ef65d99a63fd6da8df634598c1b17f)

- Alternative to / closes https://github.com/ppy/osu/pull/34723
- Closes https://github.com/ppy/osu/issues/34716

Implements idea from https://github.com/ppy/osu/pull/34723#discussion_r2282247507 wherein the "realm populating lookup component" also returns the state of the local beatmap set model after it's done touching it to avoid a realm refresh.

## [Pull up online lookup to song select level to avoid two components doing the same fetch independently](https://github.com/ppy/osu/commit/f4db2632982757f7bab48f814853becb17184d70)

This is not required for anything but it was annoying me for long enough that when I was touching the same areas anyway I figured I might as well try and get rid. Can drop this from the PR if deemed incorrect direction.

## [Fix song select favourite button potentially showing stale data from (un)favourite request callback](https://github.com/ppy/osu/commit/60b16c7c6909a1bce89710dfa7ac4a70cf5fed19)

Noticed in test failures after previous commit.