### PR TITLE
Always use audio from maximised player if there is one in multiplayer spectator

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public Facade MaximisedFacade { get; }
 
+        /// <summary>
+        /// The currently-maximised cell.
+        /// </summary>
+        public Cell? MaximisedCell { get; private set; }
+
         private readonly Container paddingContainer;
         private readonly FillFlowContainer<Facade> facadeContainer;
         private readonly Container<Cell> cellContainer;
@@ -99,7 +104,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private void toggleMaximisationState(Cell target)
         {
             // in the case the target is the already maximised cell (or there is only one cell), no cell should be maximised.
-            bool hasMaximised = !target.IsMaximised && cellContainer.Count > 1;
+            bool hasMaximised = target != MaximisedCell && cellContainer.Count > 1;
+            MaximisedCell = hasMaximised ? target : null;
 
             // Iterate through all cells to ensure only one is maximised at any time.
             foreach (var cell in cellContainer.ToList())

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// A cell of the grid. Contains the content and tracks to the linked facade.
         /// </summary>
-        private partial class Cell : CompositeDrawable
+        public partial class Cell : CompositeDrawable
         {
             /// <summary>
             /// The index of the original facade of this cell.
@@ -32,11 +32,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             /// An action that toggles the maximisation state of this cell.
             /// </summary>
             public Action<Cell>? ToggleMaximisationState;
-
-            /// <summary>
-            /// Whether this cell is currently maximised.
-            /// </summary>
-            public bool IsMaximised { get; private set; }
 
             private Facade facade;
 
@@ -83,7 +78,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             public void SetFacade(Facade newFacade, bool isMaximised)
             {
                 facade = newFacade;
-                IsMaximised = isMaximised;
                 isAnimating = true;
 
                 TweenEdgeEffectTo(new EdgeEffectParameters


### PR DESCRIPTION
- closes https://github.com/ppy/osu/issues/31767
- supersedes https://github.com/ppy/osu/pull/34632

I can try adjusting the test to work headless if it is deemed required but given that the other one is already marked `[FlakyTest]` I dunno that it's a very productive use of time.