### PR TITLE
Implement "favourites" grouping mode

### DIFF
--- a/osu.Game.Tests/Online/BeatmapFavouritingTest.cs
+++ b/osu.Game.Tests/Online/BeatmapFavouritingTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Online.API;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Online
+{
+    [TestFixture]
+    public class BeatmapFavouritingTest
+    {
+        /// <summary>
+        /// Tests whether <see cref="APIExtensions.GetFavouriteState"/> correctly handles beatmaps which were not favourited at first.
+        /// </summary>
+        [Test]
+        public void TestNormalBeatmap()
+        {
+            var beatmapSet = OsuTestScene.CreateAPIBeatmapSet(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo);
+
+            // beatmap not favourited initially
+            beatmapSet.HasFavourited = false;
+            beatmapSet.FavouriteCount = 1336;
+
+            var api = new DummyAPIAccess();
+
+            Assert.That(api.GetFavouriteState(beatmapSet), Is.EqualTo(new BeatmapSetFavouriteState(false, 1336)));
+
+            api.AddToFavourites(beatmapSet);
+
+            Assert.That(api.GetFavouriteState(beatmapSet), Is.EqualTo(new BeatmapSetFavouriteState(true, 1337)));
+
+            api.RemoveFromFavourites(beatmapSet);
+
+            Assert.That(api.GetFavouriteState(beatmapSet), Is.EqualTo(new BeatmapSetFavouriteState(false, 1336)));
+        }
+
+        /// <summary>
+        /// Tests whether <see cref="APIExtensions.GetFavouriteState"/> correctly handles beatmaps which were favourited at first.
+        /// </summary>
+        [Test]
+        public void TestFavouritedBeatmap()
+        {
+            var beatmapSet = OsuTestScene.CreateAPIBeatmapSet(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo);
+
+            // beatmap favourited initially
+            beatmapSet.HasFavourited = true;
+            beatmapSet.FavouriteCount = 1337;
+
+            var api = new DummyAPIAccess();
+            api.AddToFavourites(beatmapSet);
+
+            Assert.That(api.GetFavouriteState(beatmapSet), Is.EqualTo(new BeatmapSetFavouriteState(true, 1337)));
+
+            api.RemoveFromFavourites(beatmapSet);
+
+            Assert.That(api.GetFavouriteState(beatmapSet), Is.EqualTo(new BeatmapSetFavouriteState(false, 1336)));
+
+            api.AddToFavourites(beatmapSet);
+
+            Assert.That(api.GetFavouriteState(beatmapSet), Is.EqualTo(new BeatmapSetFavouriteState(true, 1337)));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
@@ -75,11 +75,8 @@ namespace osu.Game.Tests.Visual.Beatmaps
             undownloadable.LastUpdated = DateTimeOffset.Now.AddYears(-1);
 
             var someDifficulties = getManyDifficultiesBeatmapSet(11);
-            someDifficulties.Title = someDifficulties.TitleUnicode = "favourited";
             someDifficulties.Title = someDifficulties.TitleUnicode = "some difficulties";
             someDifficulties.Status = BeatmapOnlineStatus.Qualified;
-            someDifficulties.HasFavourited = true;
-            someDifficulties.FavouriteCount = 1;
             someDifficulties.NominationStatus = new BeatmapSetNominationStatus
             {
                 Current = 2,
@@ -93,20 +90,33 @@ namespace osu.Game.Tests.Visual.Beatmaps
             var manyDifficulties = getManyDifficultiesBeatmapSet(100);
             manyDifficulties.Status = BeatmapOnlineStatus.Pending;
 
+            var favourited = getManyDifficultiesBeatmapSet(11);
+            favourited.Title = favourited.TitleUnicode = "favourited";
+            favourited.Status = BeatmapOnlineStatus.Qualified;
+            favourited.NominationStatus = new BeatmapSetNominationStatus
+            {
+                Current = 2,
+                RequiredMeta =
+                {
+                    MainRuleset = 2,
+                    NonMainRuleset = 1,
+                }
+            };
+
             var explicitMap = CreateAPIBeatmapSet(Ruleset.Value);
-            explicitMap.Title = someDifficulties.TitleUnicode = "explicit beatmap";
+            explicitMap.Title = explicitMap.TitleUnicode = "explicit beatmap";
             explicitMap.HasExplicitContent = true;
 
             var spotlightMap = CreateAPIBeatmapSet(Ruleset.Value);
-            spotlightMap.Title = someDifficulties.TitleUnicode = "spotlight beatmap";
+            spotlightMap.Title = spotlightMap.TitleUnicode = "spotlight beatmap";
             spotlightMap.FeaturedInSpotlight = true;
 
             var featuredMap = CreateAPIBeatmapSet(Ruleset.Value);
-            featuredMap.Title = someDifficulties.TitleUnicode = "featured artist beatmap";
+            featuredMap.Title = featuredMap.TitleUnicode = "featured artist beatmap";
             featuredMap.TrackId = 1;
 
             var allBadgesMap = CreateAPIBeatmapSet(Ruleset.Value);
-            allBadgesMap.Title = someDifficulties.TitleUnicode = "all-badges beatmap";
+            allBadgesMap.Title = allBadgesMap.TitleUnicode = "all-badges beatmap";
             allBadgesMap.HasExplicitContent = true;
             allBadgesMap.FeaturedInSpotlight = true;
             allBadgesMap.TrackId = 2;
@@ -126,6 +136,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 undownloadable,
                 someDifficulties,
                 manyDifficulties,
+                favourited,
                 explicitMap,
                 spotlightMap,
                 featuredMap,
@@ -135,6 +146,9 @@ namespace osu.Game.Tests.Visual.Beatmaps
 
             foreach (var testCase in testCases)
                 testCase.OnlineID = online_id;
+
+            favourited.OnlineID = 1; // assign favourited a unique online ID so it's the only one marked as favourited.
+            API.AddToFavourites(favourited);
         }
 
         private APIBeatmapSet getUndownloadableBeatmapSet() => new APIBeatmapSet

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardFavouriteButton.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardFavouriteButton.cs
@@ -35,7 +35,11 @@ namespace osu.Game.Tests.Visual.Beatmaps
             AddStep("create beatmap set", () =>
             {
                 beatmapSetInfo = CreateAPIBeatmapSet(Ruleset.Value);
-                beatmapSetInfo.HasFavourited = favourited;
+
+                if (favourited)
+                    API.AddToFavourites(beatmapSetInfo);
+                else
+                    API.RemoveFromFavourites(beatmapSetInfo);
             });
             AddStep("create button", () => Child = button = new FavouriteButton(beatmapSetInfo)
             {

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
@@ -11,6 +11,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.Carousel;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
@@ -368,7 +369,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             var groupingFilter = new BeatmapCarouselFilterGrouping(
                 () => new FilterCriteria { Group = group },
                 () => new List<BeatmapCollection>(),
-                _ => new Dictionary<Guid, ScoreRank>());
+                _ => new Dictionary<Guid, ScoreRank>(),
+                () => new List<APIBeatmapSet>());
 
             return await groupingFilter.Run(beatmapSets.SelectMany(s => s.Beatmaps.Select(b => new CarouselItem(b))).ToList(), CancellationToken.None);
         }

--- a/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/SongSelectTestScene.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             int beatmapsCount = 0;
 
-            AddStep($"import test map for ruleset {rulesetIds}", () =>
+            AddStep($"import test map for ruleset {string.Join(", ", rulesetIds)}", () =>
             {
                 beatmapsCount = SongSelect.IsNull() ? 0 : Carousel.Filters.OfType<BeatmapCarouselFilterGrouping>().Single().SetItems.Count;
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapTitleWedge.cs
@@ -254,6 +254,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 var (working, onlineSet) = createTestBeatmap();
                 onlineSet.FavouriteCount = 9999;
                 onlineSet.HasFavourited = true;
+                API.AddToFavourites(onlineSet);
                 working.BeatmapSetInfo.OnlineID = onlineSet.OnlineID = 99999;
 
                 currentOnlineSet = onlineSet;

--- a/osu.Game/Online/API/APIExtensions.cs
+++ b/osu.Game/Online/API/APIExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Online.API
+{
+    public static class APIExtensions
+    {
+        /// <summary>
+        /// Returns the current favourite state of the given beatmap.
+        /// This should be called whenever a change in <see cref="IAPIProvider.BeatmapFavourites"/> has occurred.
+        /// </summary>
+        // todo: this should eventually be moved to a separate component, away from IAPIProvider / APIAccess.
+        public static BeatmapSetFavouriteState GetFavouriteState(this IAPIProvider api, APIBeatmapSet beatmapSet)
+        {
+            bool favourited = api.BeatmapFavourites.Any(s => s.OnlineID == beatmapSet.OnlineID);
+            int favouriteCount = beatmapSet.FavouriteCount;
+
+            if (beatmapSet.HasFavourited != favourited)
+                favouriteCount += favourited ? 1 : -1;
+
+            return new BeatmapSetFavouriteState(favourited, favouriteCount);
+        }
+    }
+}

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Online.API
 
         public BindableList<APIRelation> Friends { get; } = new BindableList<APIRelation>();
         public BindableList<APIRelation> Blocks { get; } = new BindableList<APIRelation>();
+        public IBindableList<APIBeatmapSet> BeatmapFavourites => beatmapFavourites;
+
+        private readonly BindableList<APIBeatmapSet> beatmapFavourites = new BindableList<APIBeatmapSet>();
 
         public DummyNotificationsClient NotificationsClient { get; } = new DummyNotificationsClient();
         INotificationsClient IAPIProvider.NotificationsClient => NotificationsClient;
@@ -183,6 +186,22 @@ namespace osu.Game.Online.API
 
         public void UpdateLocalBlocks()
         {
+        }
+
+        public PostBeatmapFavouriteRequest AddToFavourites(APIBeatmapSet beatmapSet)
+        {
+            var req = new PostBeatmapFavouriteRequest(beatmapSet.OnlineID, BeatmapFavouriteAction.Favourite);
+            Perform(req);
+            beatmapFavourites.Add(beatmapSet);
+            return req;
+        }
+
+        public PostBeatmapFavouriteRequest RemoveFromFavourites(APIBeatmapSet beatmapSet)
+        {
+            var req = new PostBeatmapFavouriteRequest(beatmapSet.OnlineID, BeatmapFavouriteAction.UnFavourite);
+            Perform(req);
+            beatmapFavourites.RemoveAll(s => s.OnlineID == beatmapSet.OnlineID);
+            return req;
         }
 
         public IHubClientConnector? GetHubConnector(string clientName, string endpoint) => null;

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Game.Localisation;
+using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Online.Notifications.WebSocket;
@@ -27,6 +28,11 @@ namespace osu.Game.Online.API
         /// The users blocked by the local user.
         /// </summary>
         IBindableList<APIRelation> Blocks { get; }
+
+        /// <summary>
+        /// The beatmaps favourited by the user.
+        /// </summary>
+        IBindableList<APIBeatmapSet> BeatmapFavourites { get; }
 
         /// <summary>
         /// The language supplied by this provider to API requests.
@@ -118,6 +124,8 @@ namespace osu.Game.Online.API
         /// </summary>
         void Logout();
 
+        // todo: all of these friends/blocks/favourites methods should eventually be moved to a separate component, away from IAPIProvider / APIAccess.
+
         /// <summary>
         /// Update the friends status of the current user.
         /// </summary>
@@ -127,6 +135,18 @@ namespace osu.Game.Online.API
         /// Update the list of users blocked by the current user.
         /// </summary>
         void UpdateLocalBlocks();
+
+        /// <summary>
+        /// Adds the given beatmap set to the favourited list.
+        /// </summary>
+        /// <returns>An API request sent to the server for performing this operation.</returns>
+        PostBeatmapFavouriteRequest AddToFavourites(APIBeatmapSet beatmapSet);
+
+        /// <summary>
+        /// Removes the given beatmap from the favourited list.
+        /// </summary>
+        /// <returns>An API request sent to the server for performing this operation.</returns>
+        PostBeatmapFavouriteRequest RemoveFromFavourites(APIBeatmapSet beatmapSet);
 
         /// <summary>
         /// Schedule a callback to run on the update thread.

--- a/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
@@ -13,7 +13,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Overlays.Notifications;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using APIUser = osu.Game.Online.API.Requests.Responses.APIUser;
@@ -68,7 +67,10 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
 
                 request?.Cancel();
 
-                request = new PostBeatmapFavouriteRequest(BeatmapSet.Value.OnlineID, favourited.Value ? BeatmapFavouriteAction.UnFavourite : BeatmapFavouriteAction.Favourite);
+                if (!favourited.Value)
+                    request = api.AddToFavourites(BeatmapSet.Value);
+                else
+                    request = api.RemoveFromFavourites(BeatmapSet.Value);
 
                 request.Success += () =>
                 {
@@ -76,16 +78,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
                     loading.Hide();
                 };
 
-                request.Failure += e =>
-                {
-                    notifications?.Post(new SimpleNotification
-                    {
-                        Text = e.Message,
-                        Icon = FontAwesome.Solid.Times,
-                    });
-
-                    loading.Hide();
-                };
+                request.Failure += _ => loading.Hide();
 
                 api.Queue(request);
             };

--- a/osu.Game/Screens/Select/Filter/GroupMode.cs
+++ b/osu.Game/Screens/Select/Filter/GroupMode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
@@ -32,8 +32,8 @@ namespace osu.Game.Screens.Select.Filter
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Difficulty))]
         Difficulty,
 
-        // [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Favourites))]
-        // Favourites,
+        [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Favourites))]
+        Favourites,
 
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.LastPlayed))]
         LastPlayed,

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -25,6 +25,8 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Models;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select;
@@ -102,7 +104,7 @@ namespace osu.Game.Screens.SelectV2
             {
                 new BeatmapCarouselFilterMatching(() => Criteria!),
                 new BeatmapCarouselFilterSorting(() => Criteria!),
-                grouping = new BeatmapCarouselFilterGrouping(() => Criteria!, getDetachedCollections, getTopRanksMapping)
+                grouping = new BeatmapCarouselFilterGrouping(() => Criteria!, getDetachedCollections, getTopRanksMapping, getFavourites)
             };
 
             AddInternal(loading = new LoadingLayer());
@@ -627,10 +629,13 @@ namespace osu.Game.Screens.SelectV2
 
         #endregion
 
-        #region Database fetches for grouping support
+        #region Database/API fetches for grouping support
 
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
 
         private List<BeatmapCollection> getDetachedCollections() => realm.Run(r => r.All<BeatmapCollection>().AsEnumerable().Detach());
 
@@ -658,6 +663,8 @@ namespace osu.Game.Screens.SelectV2
 
             return topRankMapping;
         });
+
+        private IReadOnlyList<APIBeatmapSet> getFavourites() => api.BeatmapFavourites;
 
         #endregion
 

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Screens.SelectV2
         private RealmAccess realm { get; set; } = null!;
 
         private IBindable<APIUser> localUser = null!;
+        private IBindableList<APIBeatmapSet> beatmapFavourites = null!;
 
         public LocalisableString StatusText
         {
@@ -186,6 +187,9 @@ namespace osu.Game.Screens.SelectV2
             };
 
             localUser = api.LocalUser.GetBoundCopy();
+
+            beatmapFavourites = new BindableList<APIBeatmapSet>();
+            beatmapFavourites.BindTo(api.BeatmapFavourites);
         }
 
         protected override void LoadComplete()
@@ -237,6 +241,12 @@ namespace osu.Game.Screens.SelectV2
             });
 
             localUser.BindValueChanged(_ => updateCriteria());
+
+            beatmapFavourites.BindCollectionChanged((_, _) =>
+            {
+                if (groupDropdown.Current.Value == GroupMode.Favourites)
+                    updateCriteria();
+            });
 
             updateCriteria();
         }

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -1004,6 +1004,7 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Drawables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Failable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=favourited/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=favouriting/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gamefield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameplay/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Geki/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Closes #34494 

RFC. This was an involved one as the favourite state can be mutated from different places in the client. I've approached this by having a centralised place for managing beatmap favourites, with an event listened to by song select (as well as all favourite buttons) to refresh states.

It was discussed to pick `APIAccess` as the centralised place for favourites management temporarily until it's refactored out (alongside friends and blocks) into a separate "local user state" component. I've added TODO comments to highlight that part.

Preview of grouping, as well as the cross-interaction between all possible places of favouriting a beatmap:

https://github.com/user-attachments/assets/293e15c4-d41c-4844-afd1-3847d4b44700

