### PR TITLE
Update mod icons

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override string Acronym => "FF";
         public override LocalisableString Description => "The fruits are... floating?";
         public override double ScoreMultiplier => 1;
-        public override IconUsage? Icon => FontAwesome.Solid.Cloud;
+        public override IconUsage? Icon => OsuIcon.ModFloatingFruits;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)
         {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModMovingFast.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModMovingFast.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Mods;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override LocalisableString Description => "Dashing by default, slow down!";
         public override ModType Type => ModType.Fun;
         public override double ScoreMultiplier => 1;
-        public override IconUsage? Icon => FontAwesome.Solid.Running;
+        public override IconUsage? Icon => OsuIcon.ModMovingFast;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax) };
 
         private DrawableCatchRuleset drawableRuleset = null!;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => "No more tricky speed changes!";
 
-        public override IconUsage? Icon => FontAwesome.Solid.Equals;
+        public override IconUsage? Icon => OsuIcon.ModConstantSpeed;
 
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
@@ -14,6 +16,7 @@ namespace osu.Game.Rulesets.Mania.Mods
     {
         public override string Name => "Cover";
         public override string Acronym => "CO";
+        public override IconUsage? Icon => OsuIcon.ModCover;
 
         public override LocalisableString Description => @"Decrease the playfield's viewing area.";
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDualStages.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDualStages.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
@@ -13,6 +15,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Dual Stages";
         public override string Acronym => "DS";
         public override LocalisableString Description => @"Double the stages, double the fun!";
+        public override IconUsage? Icon => OsuIcon.ModDualStages;
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
@@ -12,6 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
     {
         public override string Name => "Fade In";
         public override string Acronym => "FI";
+        public override IconUsage? Icon => OsuIcon.ModFadeIn;
         public override LocalisableString Description => @"Keys appear out of nowhere!";
         public override double ScoreMultiplier => 1;
         public override bool ValidForFreestyleAsRequiredMod => false;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHoldOff.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHoldOff.cs
@@ -9,6 +9,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Framework.Graphics.Sprites;
 using System.Collections.Generic;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Beatmaps;
 
 namespace osu.Game.Rulesets.Mania.Mods
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => @"Replaces all hold notes with normal notes.";
 
-        public override IconUsage? Icon => FontAwesome.Solid.DotCircle;
+        public override IconUsage? Icon => OsuIcon.ModHoldOff;
 
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mods;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => "Hold the keys. To the beat.";
 
-        public override IconUsage? Icon => FontAwesome.Solid.YinYang;
+        public override IconUsage? Icon => OsuIcon.ModInvert;
 
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 1;
         public override string Name => "One Key";
         public override string Acronym => "1K";
+        public override IconUsage? Icon => OsuIcon.ModOneKey;
         public override LocalisableString Description => @"Play with one key.";
         public override bool Ranked => false;
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 10;
         public override string Name => "Ten Keys";
         public override string Acronym => "10K";
+        public override IconUsage? Icon => OsuIcon.ModTenKeys;
         public override LocalisableString Description => @"Play with ten keys.";
         public override bool Ranked => false;
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 2;
         public override string Name => "Two Keys";
         public override string Acronym => "2K";
+        public override IconUsage? Icon => OsuIcon.ModTwoKeys;
         public override LocalisableString Description => @"Play with two keys.";
         public override bool Ranked => false;
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 3;
         public override string Name => "Three Keys";
         public override string Acronym => "3K";
+        public override IconUsage? Icon => OsuIcon.ModThreeKeys;
         public override LocalisableString Description => @"Play with three keys.";
         public override bool Ranked => false;
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey4.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey4.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 4;
         public override string Name => "Four Keys";
         public override string Acronym => "4K";
+        public override IconUsage? Icon => OsuIcon.ModFourKeys;
         public override LocalisableString Description => @"Play with four keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey5.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey5.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 5;
         public override string Name => "Five Keys";
         public override string Acronym => "5K";
+        public override IconUsage? Icon => OsuIcon.ModFiveKeys;
         public override LocalisableString Description => @"Play with five keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey6.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey6.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 6;
         public override string Name => "Six Keys";
         public override string Acronym => "6K";
+        public override IconUsage? Icon => OsuIcon.ModSixKeys;
         public override LocalisableString Description => @"Play with six keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey7.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey7.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 7;
         public override string Name => "Seven Keys";
         public override string Acronym => "7K";
+        public override IconUsage? Icon => OsuIcon.ModSevenKeys;
         public override LocalisableString Description => @"Play with seven keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey8.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey8.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 8;
         public override string Name => "Eight Keys";
         public override string Acronym => "8K";
+        public override IconUsage? Icon => OsuIcon.ModEightKeys;
         public override LocalisableString Description => @"Play with eight keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey9.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey9.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 9;
         public override string Name => "Nine Keys";
         public override string Acronym => "9K";
+        public override IconUsage? Icon => OsuIcon.ModNineKeys;
         public override LocalisableString Description => @"Play with nine keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Linq;
 using System.Threading;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
@@ -25,6 +27,8 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override LocalisableString Description => "No more timing the end of hold notes.";
 
         public override double ScoreMultiplier => 0.9;
+
+        public override IconUsage? Icon => OsuIcon.ModNoRelease;
 
         public override ModType Type => ModType.DifficultyReduction;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Name => @"Alternate";
         public override string Acronym => @"AL";
         public override LocalisableString Description => @"Don't use the same key twice in a row!";
-        public override IconUsage? Icon => FontAwesome.Solid.Keyboard;
+        public override IconUsage? Icon => OsuIcon.ModAlternate;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModSingleTap) }).ToArray();
 
         protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction != action;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Acronym => "AD";
         public override LocalisableString Description => "Never trust the approach circles...";
         public override double ScoreMultiplier => 1;
-        public override IconUsage? Icon { get; } = FontAwesome.Regular.Circle;
+        public override IconUsage? Icon => OsuIcon.ModApproachDifferent;
 
         public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles), typeof(OsuModFreezeFrame) };
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => "Play with blinds on your screen.";
         public override string Acronym => "BL";
 
-        public override IconUsage? Icon => FontAwesome.Solid.Adjust;
+        public override IconUsage? Icon => OsuIcon.ModBlinds;
         public override ModType Type => ModType.DifficultyIncrease;
 
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
@@ -3,9 +3,11 @@
 
 using System;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mods;
@@ -21,6 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Bloom";
         public override string Acronym => "BM";
+        public override IconUsage? Icon => OsuIcon.ModBloom;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "The cursor blooms into.. a larger cursor!";
         public override double ScoreMultiplier => 1;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
@@ -11,7 +11,9 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -33,6 +35,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => "Don't let their popping distract you!";
 
         public override double ScoreMultiplier => 1;
+
+        public override IconUsage? Icon => OsuIcon.ModBubbles;
 
         public override ModType Type => ModType.Fun;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDeflate.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDeflate.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override string Acronym => "DF";
 
-        public override IconUsage? Icon => FontAwesome.Solid.CompressArrowsAlt;
+        public override IconUsage? Icon => OsuIcon.ModDeflate;
 
         public override LocalisableString Description => "Hit them at the right size!";
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Depth";
         public override string Acronym => "DP";
-        public override IconUsage? Icon => FontAwesome.Solid.Cube;
+        public override IconUsage? Icon => OsuIcon.ModDepth;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "3D. Almost.";
         public override double ScoreMultiplier => 1;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Linq;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -18,6 +20,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Name => "Freeze Frame";
 
         public override string Acronym => "FR";
+
+        public override IconUsage? Icon => OsuIcon.ModFreezeFrame;
 
         public override double ScoreMultiplier => 1;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override string Acronym => "GR";
 
-        public override IconUsage? Icon => FontAwesome.Solid.ArrowsAltV;
+        public override IconUsage? Icon => OsuIcon.ModGrow;
 
         public override LocalisableString Description => "Hit them at the right size!";
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -9,6 +9,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Magnetised";
         public override string Acronym => "MG";
-        public override IconUsage? Icon => FontAwesome.Solid.Magnet;
+        public override IconUsage? Icon => OsuIcon.ModMagnetised;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "No need to chase the circles – your cursor is a magnet!";
         public override double ScoreMultiplier => 0.5;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -4,10 +4,12 @@
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -23,6 +25,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Repel";
         public override string Acronym => "RP";
+        public override IconUsage? Icon => OsuIcon.ModRepel;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Hit objects run away!";
         public override double ScoreMultiplier => 1;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -11,6 +13,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => @"Single Tap";
         public override string Acronym => @"SG";
+        public override IconUsage? Icon => OsuIcon.ModSingleTap;
         public override LocalisableString Description => @"You must only use one key!";
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAlternate) }).ToArray();
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Spin In";
         public override string Acronym => "SI";
-        public override IconUsage? Icon => FontAwesome.Solid.Undo;
+        public override IconUsage? Icon => OsuIcon.ModSpinIn;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Circles spin in. No approach circles.";
         public override double ScoreMultiplier => 1;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Linq;
 using System.Threading;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -24,6 +26,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => @"Strict Tracking";
         public override string Acronym => @"ST";
+        public override IconUsage? Icon => OsuIcon.ModStrictTracking;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => @"Once you start a slider, follow precisely or get a miss.";
         public override double ScoreMultiplier => 1.0;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Name => "Target Practice";
         public override string Acronym => "TP";
         public override ModType Type => ModType.Conversion;
-        public override IconUsage? Icon => OsuIcon.ModTarget;
+        public override IconUsage? Icon => OsuIcon.ModTargetPractice;
         public override LocalisableString Description => @"Practice keeping up with the beat of the song.";
         public override double ScoreMultiplier => 0.1;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -4,7 +4,9 @@
 using System;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -18,6 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Traceable";
         public override string Acronym => "TC";
+        public override IconUsage? Icon => OsuIcon.ModTraceable;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Put your faith in the approach circles...";
         public override double ScoreMultiplier => 1;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Transform";
         public override string Acronym => "TR";
-        public override IconUsage? Icon => FontAwesome.Solid.ArrowsAlt;
+        public override IconUsage? Icon => OsuIcon.ModTransform;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Everything rotates. EVERYTHING.";
         public override double ScoreMultiplier => 1;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Wiggle";
         public override string Acronym => "WG";
-        public override IconUsage? Icon => FontAwesome.Solid.Certificate;
+        public override IconUsage? Icon => OsuIcon.ModWiggle;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "They just won't stay still...";
         public override double ScoreMultiplier => 1;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModConstantSpeed.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModConstantSpeed.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.Mods;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override string Acronym => "CS";
         public override double ScoreMultiplier => 0.9;
         public override LocalisableString Description => "No more tricky speed changes!";
-        public override IconUsage? Icon => FontAwesome.Solid.Equals;
+        public override IconUsage? Icon => OsuIcon.ModConstantSpeed;
         public override ModType Type => ModType.Conversion;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -21,6 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override string Acronym => "SR";
         public override double ScoreMultiplier => 0.6;
         public override LocalisableString Description => "Simplify tricky rhythms!";
+        public override IconUsage? Icon => OsuIcon.ModSimplifiedRhythm;
         public override ModType Type => ModType.DifficultyReduction;
 
         [SettingSource("1/3 to 1/2 conversion", "Converts 1/3 patterns to 1/2 rhythm.")]

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -6,9 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -24,6 +26,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override string Name => @"Single Tap";
         public override string Acronym => @"SG";
+        public override IconUsage? Icon => OsuIcon.ModSingleTap;
         public override LocalisableString Description => @"One key for dons, one key for kats.";
 
         public override double ScoreMultiplier => 1.0;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -16,6 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override string Name => "Swap";
         public override string Acronym => "SW";
         public override LocalisableString Description => @"Dons become kats, kats become dons";
+        public override IconUsage? Icon => OsuIcon.ModSwap;
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModRandom)).ToArray();

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
@@ -4,11 +4,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
@@ -21,6 +23,9 @@ namespace osu.Game.Tests.Visual.UserInterface
     {
         private FillFlowContainer spreadOutFlow = null!;
         private ModDisplay modDisplay = null!;
+
+        [Resolved]
+        private RulesetStore rulesetStore { get; set; } = null!;
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -70,9 +75,26 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestShowAllMods()
         {
-            AddStep("create mod icons", () =>
+            createModIconsForRuleset(0);
+            createModIconsForRuleset(1);
+            createModIconsForRuleset(2);
+            createModIconsForRuleset(3);
+
+            AddStep("toggle selected", () =>
             {
-                addRange(Ruleset.Value.CreateInstance().CreateAllMods().Select(m =>
+                foreach (var icon in this.ChildrenOfType<ModIcon>())
+                    icon.Selected.Toggle();
+            });
+        }
+
+        private void createModIconsForRuleset(int rulesetId)
+        {
+            AddStep($"create mod icons for ruleset {rulesetId}", () =>
+            {
+                spreadOutFlow.Clear();
+                modDisplay.Current.Value = [];
+
+                addRange(rulesetStore.GetRuleset(rulesetId)!.CreateInstance().CreateAllMods().Select(m =>
                 {
                     if (m is OsuModFlashlight fl)
                         fl.FollowDelay.Value = 1245;
@@ -88,12 +110,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
                     return m;
                 }));
-            });
-
-            AddStep("toggle selected", () =>
-            {
-                foreach (var icon in this.ChildrenOfType<ModIcon>())
-                    icon.Selected.Toggle();
             });
         }
 

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -81,27 +81,6 @@ namespace osu.Game.Graphics
         public static IconUsage InsaneMania => get(0xe027);
         public static IconUsage ExpertMania => get(0xe028);
 
-        // mod icons
-        public static IconUsage ModPerfect => get(0xe049);
-        public static IconUsage ModAutopilot => get(0xe03a);
-        public static IconUsage ModAuto => get(0xe03b);
-        public static IconUsage ModCinema => get(0xe03c);
-        public static IconUsage ModDoubleTime => get(0xe03d);
-        public static IconUsage ModEasy => get(0xe03e);
-        public static IconUsage ModFlashlight => get(0xe03f);
-        public static IconUsage ModHalftime => get(0xe040);
-        public static IconUsage ModHardRock => get(0xe041);
-        public static IconUsage ModHidden => get(0xe042);
-        public static IconUsage ModNightcore => get(0xe043);
-        public static IconUsage ModNoFail => get(0xe044);
-        public static IconUsage ModRelax => get(0xe045);
-        public static IconUsage ModSpunOut => get(0xe046);
-        public static IconUsage ModSuddenDeath => get(0xe047);
-        public static IconUsage ModTarget => get(0xe048);
-
-        // Use "Icons/BeatmapDetails/mod-icon" instead
-        // public static IconUsage ModBg => Get(0xe04a);
-
         #endregion
 
         #region New single-file-based icons
@@ -180,6 +159,88 @@ namespace osu.Game.Graphics
         public static IconUsage EditorWhistle => get(OsuIconMapping.EditorWhistle);
         public static IconUsage Tortoise => get(OsuIconMapping.Tortoise);
         public static IconUsage Hare => get(OsuIconMapping.Hare);
+
+        // mod icons
+
+        public static IconUsage ModNoMod => get(OsuIconMapping.ModNoMod);
+
+        /*
+         can be regenerated semi-automatically using osu-web's mod database via
+
+         $ jq -r '.[].Mods[].Name' mods.json | sort | uniq | \
+           sed 's/ //g' | \
+           awk '{print "public static IconUsage Mod" $0 " => get(OsuIconMapping.Mod" $0 ");"}' | pbcopy
+         */
+
+        public static IconUsage ModAccuracyChallenge => get(OsuIconMapping.ModAccuracyChallenge);
+        public static IconUsage ModAdaptiveSpeed => get(OsuIconMapping.ModAdaptiveSpeed);
+        public static IconUsage ModAlternate => get(OsuIconMapping.ModAlternate);
+        public static IconUsage ModApproachDifferent => get(OsuIconMapping.ModApproachDifferent);
+        public static IconUsage ModAutopilot => get(OsuIconMapping.ModAutopilot);
+        public static IconUsage ModAutoplay => get(OsuIconMapping.ModAutoplay);
+        public static IconUsage ModBarrelRoll => get(OsuIconMapping.ModBarrelRoll);
+        public static IconUsage ModBlinds => get(OsuIconMapping.ModBlinds);
+        public static IconUsage ModBloom => get(OsuIconMapping.ModBloom);
+        public static IconUsage ModBubbles => get(OsuIconMapping.ModBubbles);
+        public static IconUsage ModCinema => get(OsuIconMapping.ModCinema);
+        public static IconUsage ModClassic => get(OsuIconMapping.ModClassic);
+        public static IconUsage ModConstantSpeed => get(OsuIconMapping.ModConstantSpeed);
+        public static IconUsage ModCover => get(OsuIconMapping.ModCover);
+        public static IconUsage ModDaycore => get(OsuIconMapping.ModDaycore);
+        public static IconUsage ModDeflate => get(OsuIconMapping.ModDeflate);
+        public static IconUsage ModDepth => get(OsuIconMapping.ModDepth);
+        public static IconUsage ModDifficultyAdjust => get(OsuIconMapping.ModDifficultyAdjust);
+        public static IconUsage ModDoubleTime => get(OsuIconMapping.ModDoubleTime);
+        public static IconUsage ModDualStages => get(OsuIconMapping.ModDualStages);
+        public static IconUsage ModEasy => get(OsuIconMapping.ModEasy);
+        public static IconUsage ModEightKeys => get(OsuIconMapping.ModEightKeys);
+        public static IconUsage ModFadeIn => get(OsuIconMapping.ModFadeIn);
+        public static IconUsage ModFiveKeys => get(OsuIconMapping.ModFiveKeys);
+        public static IconUsage ModFlashlight => get(OsuIconMapping.ModFlashlight);
+        public static IconUsage ModFloatingFruits => get(OsuIconMapping.ModFloatingFruits);
+        public static IconUsage ModFourKeys => get(OsuIconMapping.ModFourKeys);
+        public static IconUsage ModFreezeFrame => get(OsuIconMapping.ModFreezeFrame);
+        public static IconUsage ModGrow => get(OsuIconMapping.ModGrow);
+        public static IconUsage ModHalfTime => get(OsuIconMapping.ModHalfTime);
+        public static IconUsage ModHardRock => get(OsuIconMapping.ModHardRock);
+        public static IconUsage ModHidden => get(OsuIconMapping.ModHidden);
+        public static IconUsage ModHoldOff => get(OsuIconMapping.ModHoldOff);
+        public static IconUsage ModInvert => get(OsuIconMapping.ModInvert);
+        public static IconUsage ModMagnetised => get(OsuIconMapping.ModMagnetised);
+        public static IconUsage ModMirror => get(OsuIconMapping.ModMirror);
+        public static IconUsage ModMovingFast => get(OsuIconMapping.ModMovingFast);
+        public static IconUsage ModMuted => get(OsuIconMapping.ModMuted);
+        public static IconUsage ModNightcore => get(OsuIconMapping.ModNightcore);
+        public static IconUsage ModNineKeys => get(OsuIconMapping.ModNineKeys);
+        public static IconUsage ModNoFail => get(OsuIconMapping.ModNoFail);
+        public static IconUsage ModNoRelease => get(OsuIconMapping.ModNoRelease);
+        public static IconUsage ModNoScope => get(OsuIconMapping.ModNoScope);
+        public static IconUsage ModOneKey => get(OsuIconMapping.ModOneKey);
+        public static IconUsage ModPerfect => get(OsuIconMapping.ModPerfect);
+        public static IconUsage ModRandom => get(OsuIconMapping.ModRandom);
+        public static IconUsage ModRelax => get(OsuIconMapping.ModRelax);
+        public static IconUsage ModRepel => get(OsuIconMapping.ModRepel);
+        public static IconUsage ModScoreV2 => get(OsuIconMapping.ModScoreV2);
+        public static IconUsage ModSevenKeys => get(OsuIconMapping.ModSevenKeys);
+        public static IconUsage ModSimplifiedRhythm => get(OsuIconMapping.ModSimplifiedRhythm);
+        public static IconUsage ModSingleTap => get(OsuIconMapping.ModSingleTap);
+        public static IconUsage ModSixKeys => get(OsuIconMapping.ModSixKeys);
+        public static IconUsage ModSpinIn => get(OsuIconMapping.ModSpinIn);
+        public static IconUsage ModSpunOut => get(OsuIconMapping.ModSpunOut);
+        public static IconUsage ModStrictTracking => get(OsuIconMapping.ModStrictTracking);
+        public static IconUsage ModSuddenDeath => get(OsuIconMapping.ModSuddenDeath);
+        public static IconUsage ModSwap => get(OsuIconMapping.ModSwap);
+        public static IconUsage ModSynesthesia => get(OsuIconMapping.ModSynesthesia);
+        public static IconUsage ModTargetPractice => get(OsuIconMapping.ModTargetPractice);
+        public static IconUsage ModTenKeys => get(OsuIconMapping.ModTenKeys);
+        public static IconUsage ModThreeKeys => get(OsuIconMapping.ModThreeKeys);
+        public static IconUsage ModTouchDevice => get(OsuIconMapping.ModTouchDevice);
+        public static IconUsage ModTraceable => get(OsuIconMapping.ModTraceable);
+        public static IconUsage ModTransform => get(OsuIconMapping.ModTransform);
+        public static IconUsage ModTwoKeys => get(OsuIconMapping.ModTwoKeys);
+        public static IconUsage ModWiggle => get(OsuIconMapping.ModWiggle);
+        public static IconUsage ModWindDown => get(OsuIconMapping.ModWindDown);
+        public static IconUsage ModWindUp => get(OsuIconMapping.ModWindUp);
 
         private static IconUsage get(OsuIconMapping glyph) => new IconUsage((char)glyph, FONT_NAME);
 
@@ -400,6 +461,224 @@ namespace osu.Game.Graphics
 
             [Description(@"hare")]
             Hare,
+
+            // mod icons
+
+            [Description(@"Mods/mod-no-mod")]
+            ModNoMod,
+
+            /*
+             rest can be regenerated semi-automatically using osu-web's mod database via
+             $ jq -r '.[].Mods[].Name' mods.json | sort | uniq | \
+               awk '{kebab = $0; gsub(" ", "-", kebab); pascal = $0; gsub(" ", "", pascal); print "[Description(@\"Mods/mod-" tolower(kebab) "\")]\nMod" pascal ",\n" }' | pbcopy
+             */
+
+            [Description(@"Mods/mod-accuracy-challenge")]
+            ModAccuracyChallenge,
+
+            [Description(@"Mods/mod-adaptive-speed")]
+            ModAdaptiveSpeed,
+
+            [Description(@"Mods/mod-alternate")]
+            ModAlternate,
+
+            [Description(@"Mods/mod-approach-different")]
+            ModApproachDifferent,
+
+            [Description(@"Mods/mod-autopilot")]
+            ModAutopilot,
+
+            [Description(@"Mods/mod-autoplay")]
+            ModAutoplay,
+
+            [Description(@"Mods/mod-barrel-roll")]
+            ModBarrelRoll,
+
+            [Description(@"Mods/mod-blinds")]
+            ModBlinds,
+
+            [Description(@"Mods/mod-bloom")]
+            ModBloom,
+
+            [Description(@"Mods/mod-bubbles")]
+            ModBubbles,
+
+            [Description(@"Mods/mod-cinema")]
+            ModCinema,
+
+            [Description(@"Mods/mod-classic")]
+            ModClassic,
+
+            [Description(@"Mods/mod-constant-speed")]
+            ModConstantSpeed,
+
+            [Description(@"Mods/mod-cover")]
+            ModCover,
+
+            [Description(@"Mods/mod-daycore")]
+            ModDaycore,
+
+            [Description(@"Mods/mod-deflate")]
+            ModDeflate,
+
+            [Description(@"Mods/mod-depth")]
+            ModDepth,
+
+            [Description(@"Mods/mod-difficulty-adjust")]
+            ModDifficultyAdjust,
+
+            [Description(@"Mods/mod-double-time")]
+            ModDoubleTime,
+
+            [Description(@"Mods/mod-dual-stages")]
+            ModDualStages,
+
+            [Description(@"Mods/mod-easy")]
+            ModEasy,
+
+            [Description(@"Mods/mod-eight-keys")]
+            ModEightKeys,
+
+            [Description(@"Mods/mod-fade-in")]
+            ModFadeIn,
+
+            [Description(@"Mods/mod-five-keys")]
+            ModFiveKeys,
+
+            [Description(@"Mods/mod-flashlight")]
+            ModFlashlight,
+
+            [Description(@"Mods/mod-floating-fruits")]
+            ModFloatingFruits,
+
+            [Description(@"Mods/mod-four-keys")]
+            ModFourKeys,
+
+            [Description(@"Mods/mod-freeze-frame")]
+            ModFreezeFrame,
+
+            [Description(@"Mods/mod-grow")]
+            ModGrow,
+
+            [Description(@"Mods/mod-half-time")]
+            ModHalfTime,
+
+            [Description(@"Mods/mod-hard-rock")]
+            ModHardRock,
+
+            [Description(@"Mods/mod-hidden")]
+            ModHidden,
+
+            [Description(@"Mods/mod-hold-off")]
+            ModHoldOff,
+
+            [Description(@"Mods/mod-invert")]
+            ModInvert,
+
+            [Description(@"Mods/mod-magnetised")]
+            ModMagnetised,
+
+            [Description(@"Mods/mod-mirror")]
+            ModMirror,
+
+            [Description(@"Mods/mod-moving-fast")]
+            ModMovingFast,
+
+            [Description(@"Mods/mod-muted")]
+            ModMuted,
+
+            [Description(@"Mods/mod-nightcore")]
+            ModNightcore,
+
+            [Description(@"Mods/mod-nine-keys")]
+            ModNineKeys,
+
+            [Description(@"Mods/mod-no-fail")]
+            ModNoFail,
+
+            [Description(@"Mods/mod-no-release")]
+            ModNoRelease,
+
+            [Description(@"Mods/mod-no-scope")]
+            ModNoScope,
+
+            [Description(@"Mods/mod-one-key")]
+            ModOneKey,
+
+            [Description(@"Mods/mod-perfect")]
+            ModPerfect,
+
+            [Description(@"Mods/mod-random")]
+            ModRandom,
+
+            [Description(@"Mods/mod-relax")]
+            ModRelax,
+
+            [Description(@"Mods/mod-repel")]
+            ModRepel,
+
+            [Description(@"Mods/mod-score-v2")]
+            ModScoreV2,
+
+            [Description(@"Mods/mod-seven-keys")]
+            ModSevenKeys,
+
+            [Description(@"Mods/mod-simplified-rhythm")]
+            ModSimplifiedRhythm,
+
+            [Description(@"Mods/mod-single-tap")]
+            ModSingleTap,
+
+            [Description(@"Mods/mod-six-keys")]
+            ModSixKeys,
+
+            [Description(@"Mods/mod-spin-in")]
+            ModSpinIn,
+
+            [Description(@"Mods/mod-spun-out")]
+            ModSpunOut,
+
+            [Description(@"Mods/mod-strict-tracking")]
+            ModStrictTracking,
+
+            [Description(@"Mods/mod-sudden-death")]
+            ModSuddenDeath,
+
+            [Description(@"Mods/mod-swap")]
+            ModSwap,
+
+            [Description(@"Mods/mod-synesthesia")]
+            ModSynesthesia,
+
+            [Description(@"Mods/mod-target-practice")]
+            ModTargetPractice,
+
+            [Description(@"Mods/mod-ten-keys")]
+            ModTenKeys,
+
+            [Description(@"Mods/mod-three-keys")]
+            ModThreeKeys,
+
+            [Description(@"Mods/mod-touch-device")]
+            ModTouchDevice,
+
+            [Description(@"Mods/mod-traceable")]
+            ModTraceable,
+
+            [Description(@"Mods/mod-transform")]
+            ModTransform,
+
+            [Description(@"Mods/mod-two-keys")]
+            ModTwoKeys,
+
+            [Description(@"Mods/mod-wiggle")]
+            ModWiggle,
+
+            [Description(@"Mods/mod-wind-down")]
+            ModWindDown,
+
+            [Description(@"Mods/mod-wind-up")]
+            ModWindUp,
         }
 
         public class OsuIconStore : ITextureStore, ITexturedGlyphLookupStore

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Localisation.HUD;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
@@ -23,6 +25,8 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "AC";
 
         public override LocalisableString Description => "Fail if your accuracy drops too low!";
+
+        public override IconUsage? Icon => OsuIcon.ModAccuracyChallenge;
 
         public override ModType Type => ModType.DifficultyIncrease;
 

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
@@ -26,6 +28,8 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "AS";
 
         public override LocalisableString Description => "Let track speed adapt to you.";
+
+        public override IconUsage? Icon => OsuIcon.ModAdaptiveSpeed;
 
         public override ModType Type => ModType.Fun;
 

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Autoplay";
         public override string Acronym => "AT";
-        public override IconUsage? Icon => OsuIcon.ModAuto;
+        public override IconUsage? Icon => OsuIcon.ModAutoplay;
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => "Watch a perfect automated play through the song.";
         public override double ScoreMultiplier => 1;

--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -36,6 +38,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override string Name => "Barrel Roll";
         public override string Acronym => "BR";
+        public override IconUsage? Icon => OsuIcon.ModBarrelRoll;
         public override LocalisableString Description => "The whole playfield is on a wheel!";
         public override double ScoreMultiplier => 1;
 

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override double ScoreMultiplier => 0.96;
 
-        public override IconUsage? Icon => FontAwesome.Solid.History;
+        public override IconUsage? Icon => OsuIcon.ModClassic;
 
         public override LocalisableString Description => "Feeling nostalgic?";
 

--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Mods
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Daycore";
         public override string Acronym => "DC";
-        public override IconUsage? Icon => null;
+        public override IconUsage? Icon => OsuIcon.ModDaycore;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Whoaaaaa...";
         public override bool Ranked => UsesDefaultConfiguration;

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -9,6 +9,7 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.Conversion;
 
-        public override IconUsage? Icon => FontAwesome.Solid.Hammer;
+        public override IconUsage? Icon => OsuIcon.ModDifficultyAdjust;
 
         public override double ScoreMultiplier => 0.5;
 

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Half Time";
         public override string Acronym => "HT";
-        public override IconUsage? Icon => OsuIcon.ModHalftime;
+        public override IconUsage? Icon => OsuIcon.ModHalfTime;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Less zoom...";
         public override bool Ranked => SpeedChange.IsDefault;

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -1,12 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+
 namespace osu.Game.Rulesets.Mods
 {
     public abstract class ModMirror : Mod
     {
         public override string Name => "Mirror";
         public override string Acronym => "MR";
+        public override IconUsage? Icon => OsuIcon.ModMirror;
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1;
     }

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Objects;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Muted";
         public override string Acronym => "MU";
-        public override IconUsage? Icon => FontAwesome.Solid.VolumeMute;
+        public override IconUsage? Icon => OsuIcon.ModMuted;
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
         public override double ScoreMultiplier => 1;

--- a/osu.Game/Rulesets/Mods/ModNoMod.cs
+++ b/osu.Game/Rulesets/Mods/ModNoMod.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "NM";
         public override LocalisableString Description => "No mods applied.";
         public override double ScoreMultiplier => 1;
-        public override IconUsage? Icon => FontAwesome.Solid.Ban;
+        public override IconUsage? Icon => OsuIcon.ModNoMod;
         public override ModType Type => ModType.System;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "No Scope";
         public override string Acronym => "NS";
         public override ModType Type => ModType.Fun;
-        public override IconUsage? Icon => FontAwesome.Solid.EyeSlash;
+        public override IconUsage? Icon => OsuIcon.ModNoScope;
         public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
 

--- a/osu.Game/Rulesets/Mods/ModRandom.cs
+++ b/osu.Game/Rulesets/Mods/ModRandom.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Random";
         public override string Acronym => "RD";
         public override ModType Type => ModType.Conversion;
-        public override IconUsage? Icon => OsuIcon.Dice;
+        public override IconUsage? Icon => OsuIcon.ModRandom;
         public override double ScoreMultiplier => 1;
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]

--- a/osu.Game/Rulesets/Mods/ModScoreV2.cs
+++ b/osu.Game/Rulesets/Mods/ModScoreV2.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -13,6 +15,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Score V2";
         public override string Acronym => @"SV2";
+        public override IconUsage? Icon => OsuIcon.ModScoreV2;
         public override ModType Type => ModType.System;
         public override LocalisableString Description => "Score set on earlier osu! versions with the V2 scoring algorithm active.";
         public override double ScoreMultiplier => 1;

--- a/osu.Game/Rulesets/Mods/ModSynesthesia.cs
+++ b/osu.Game/Rulesets/Mods/ModSynesthesia.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -14,6 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "SY";
         public override LocalisableString Description => "Colours hit objects based on the rhythm.";
         public override double ScoreMultiplier => 0.8;
+        public override IconUsage? Icon => OsuIcon.ModSynesthesia;
         public override ModType Type => ModType.Fun;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModTouchDevice.cs
+++ b/osu.Game/Rulesets/Mods/ModTouchDevice.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public sealed override string Name => "Touch Device";
         public sealed override string Acronym => "TD";
-        public sealed override IconUsage? Icon => OsuIcon.PlayStyleTouch;
+        public sealed override IconUsage? Icon => OsuIcon.ModTouchDevice;
         public sealed override LocalisableString Description => "Automatically applied to plays on devices with a touchscreen.";
         public sealed override double ScoreMultiplier => 1;
         public sealed override ModType Type => ModType.System;

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Wind Down";
         public override string Acronym => "WD";
         public override LocalisableString Description => "Sloooow doooown...";
-        public override IconUsage? Icon => FontAwesome.Solid.ChevronCircleDown;
+        public override IconUsage? Icon => OsuIcon.ModWindDown;
 
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1)
         {

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Wind Up";
         public override string Acronym => "WU";
         public override LocalisableString Description => "Can you keep up?";
-        public override IconUsage? Icon => FontAwesome.Solid.ChevronCircleUp;
+        public override IconUsage? Icon => OsuIcon.ModWindUp;
 
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1)
         {

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -167,7 +167,13 @@ namespace osu.Game.Rulesets.UI
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                            Size = new Vector2(45),
+                            RelativeSizeAxes = Axes.Both,
+                            // the mod icon assets in `osu-resources` are sized such that they are flush with the hexagonal background with no shadow baked in.
+                            // the `Icons/BeatmapDetails/mod-icon` asset (of size 135x100) has a shadow and some extra transparent pixels baked in.
+                            // the hexagonal background on that asset, excluding its shadow and the transparent pixels, is 131px wide and 92px high.
+                            // height is divided by 135 rather than by 100, because this entire component is square-sized.
+                            Width = 131 / 135f,
+                            Height = 92 / 135f,
                             Icon = FontAwesome.Solid.Question
                         },
                         adjustmentMarker = new Container

--- a/osu.Game/Rulesets/UI/ModSwitchSmall.cs
+++ b/osu.Game/Rulesets/UI/ModSwitchSmall.cs
@@ -61,7 +61,6 @@ namespace osu.Game.Rulesets.UI
                     AutoSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Spacing = new Vector2(0, 4),
                     Direction = FillDirection.Vertical,
                     Child = tinySwitch = new ModSwitchTiny(mod)
                     {
@@ -79,7 +78,9 @@ namespace osu.Game.Rulesets.UI
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    Size = new Vector2(21),
+                    Size = new Vector2(37, 26),
+                    // arbitrary adjustment for better vertical alignment
+                    Margin = new MarginPadding { Top = -1 },
                     Icon = mod.Icon.Value
                 });
                 tinySwitch.Scale = new Vector2(0.3f);

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.808.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.819.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.821.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
| | icon | mod select switch |
| :-: | :-: | :-: |
| osu! | <img width="2031" height="269" alt="Screenshot 2025-08-21 at 09 12 35" src="https://github.com/user-attachments/assets/442fed22-52cd-4f73-a74a-5538b2ffbea5" /> | <img width="1551" height="485" alt="Screenshot 2025-08-21 at 09 16 24" src="https://github.com/user-attachments/assets/fa8174c6-e277-48b3-82f7-37b06857efde" /> |
| taiko | <img width="1999" height="180" alt="Screenshot 2025-08-21 at 09 12 47" src="https://github.com/user-attachments/assets/a3ef4579-c692-4ddd-9f5e-390ce776dcaa" /> | <img width="630" height="485" alt="Screenshot 2025-08-21 at 09 16 34" src="https://github.com/user-attachments/assets/cd33d24e-536c-4c33-8483-2ac4b75062fe" /> |
| catch | <img width="2000" height="182" alt="Screenshot 2025-08-21 at 09 12 57" src="https://github.com/user-attachments/assets/05ab05f6-aa9e-4779-90c3-9191b25b16e1" /> | <img width="629" height="485" alt="Screenshot 2025-08-21 at 09 16 45" src="https://github.com/user-attachments/assets/ab13a3e3-ba5a-4a91-9dc7-a5a5a5f95216" /> |
| mania | <img width="1997" height="182" alt="Screenshot 2025-08-21 at 09 13 06" src="https://github.com/user-attachments/assets/709ab3c4-778a-4772-93e3-e77e98e1ad09" /> | <img width="1398" height="483" alt="Screenshot 2025-08-21 at 09 16 55" src="https://github.com/user-attachments/assets/8a873aea-a1b5-4ef9-92a3-c0e4700161fa" /> |

---

- See https://github.com/ppy/osu/issues/34248
- [x] Depends on https://github.com/ppy/osu-resources/pull/379
- Supersedes / closes https://github.com/ppy/osu/pull/22175