### PR TITLE
Fix song select background being stuck in revealed state

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -850,7 +850,7 @@ namespace osu.Game.Screens.SelectV2
             // For simplicity, disable this functionality on mobile.
             bool isTouchInput = e.CurrentState.Mouse.LastSource is ISourcedFromTouch;
 
-            if (!carousel.AbsoluteScrolling && !isTouchInput && mouseDownPriority)
+            if (!carousel.AbsoluteScrolling && !isTouchInput && mouseDownPriority && revealingBackground == null)
             {
                 revealingBackground = Scheduler.AddDelayed(() =>
                 {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34731.

The failure scenario here is as follows:

- User holds down left mouse button for >200ms to reveal the background.
- User presses down another mouse button and releases it in <200ms.
- User releases left mouse button. Song select does not return.

The timing here is key because what is happening here is that the second mouse button press is overwriting the `revealingBackground` scheduled delegate. Releasing that same mouse button within 200ms leads to that scheduled delegate being cancelled and cleared, and thus the release of left mouse wrongly decides there is nothing left to do.

One thing I'm not entirely sure about is the release behaviour even with this change; as things stand, the first release of any mouse button will bring song select back, even if it was not the button that was initially held down to reveal the background. That's probably easily fixed if deemed required, but I'm most interested in fixing the bad breakage.