### PR TITLE
Fix flashlight not always matching gameplay scaling

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
-        public override float DefaultFlashlightSize => 325;
+        public override float DefaultFlashlightSize => 203.125f;
 
         protected override Flashlight CreateFlashlight() => new CatchFlashlight(this, playfield);
 

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -33,26 +33,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         public void TestComboBasedSize([Values] bool comboBasedSize) => CreateModTest(new ModTestData { Mod = new OsuModFlashlight { ComboBasedSize = { Value = comboBasedSize } }, PassCondition = () => true });
 
         [Test]
-        public void TestPlayfieldBasedSize()
-        {
-            OsuModFlashlight flashlight;
-            CreateModTest(new ModTestData
-            {
-                Mods = [flashlight = new OsuModFlashlight(), new OsuModBarrelRoll()],
-                PassCondition = () =>
-                {
-                    var flashlightOverlay = Player.DrawableRuleset.Overlays
-                                                  .ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>()
-                                                  .First();
-
-                    // the combo check is here because the flashlight radius decreases for the first time at 100 combo
-                    // and hardcoding it here eliminates the need to meddle in flashlight internals further by e.g. exposing `GetComboScaleFor()`
-                    return flashlightOverlay.GetSize() < flashlight.DefaultFlashlightSize && Player.GameplayState.ScoreProcessor.Combo.Value < 100;
-                }
-            });
-        }
-
-        [Test]
         public void TestSliderDimsOnlyAfterStartTime()
         {
             bool sliderDimmedBeforeStartTime = false;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
-        public override float DefaultFlashlightSize => 200;
+        public override float DefaultFlashlightSize => 125;
 
         private OsuFlashlight flashlight = null!;
 

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModFlashlight.cs
@@ -3,7 +3,10 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Rulesets.Taiko.UI;
 using osuTK;
@@ -12,6 +15,34 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
 {
     public partial class TestSceneTaikoModFlashlight : TaikoModTestScene
     {
+        [Test]
+        public void TestAspectRatios([Values] bool withClassicMod)
+        {
+            if (withClassicMod)
+                CreateModTest(new ModTestData { Mods = new Mod[] { new TaikoModFlashlight(), new TaikoModClassic() }, PassCondition = () => true });
+            else
+                CreateModTest(new ModTestData { Mod = new TaikoModFlashlight(), PassCondition = () => true });
+
+            AddStep("clear dim", () => LocalConfig.SetValue(OsuSetting.DimLevel, 0.0));
+
+            AddStep("reset", () => Stack.FillMode = FillMode.Stretch);
+            AddStep("set to 16:9", () =>
+            {
+                Stack.FillAspectRatio = 16 / 9f;
+                Stack.FillMode = FillMode.Fit;
+            });
+            AddStep("set to 4:3", () =>
+            {
+                Stack.FillAspectRatio = 4 / 3f;
+                Stack.FillMode = FillMode.Fit;
+            });
+            AddSliderStep("aspect ratio", 0.01f, 5f, 1f, v =>
+            {
+                Stack.FillAspectRatio = v;
+                Stack.FillMode = FillMode.Fit;
+            });
+        }
+
         [TestCase(1f)]
         [TestCase(0.5f)]
         [TestCase(1.25f)]

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -47,28 +47,15 @@ namespace osu.Game.Rulesets.Taiko.Mods
             {
                 this.taikoPlayfield = taikoPlayfield;
 
-                FlashlightSize = adjustSizeForPlayfieldAspectRatio(GetSize());
+                FlashlightSize = new Vector2(0, GetSize());
                 FlashlightSmoothness = 1.4f;
 
                 AddLayout(flashlightProperties);
             }
 
-            /// <summary>
-            /// Returns the aspect ratio-adjusted size of the flashlight.
-            /// This ensures that the size of the flashlight remains independent of taiko-specific aspect ratio adjustments.
-            /// </summary>
-            /// <param name="size">
-            /// The size of the flashlight.
-            /// The value provided here should always come from <see cref="ModFlashlight{T}.Flashlight.GetSize"/>.
-            /// </param>
-            private Vector2 adjustSizeForPlayfieldAspectRatio(float size)
-            {
-                return new Vector2(0, size * taikoPlayfield.Parent!.Scale.Y);
-            }
-
             protected override void UpdateFlashlightSize(float size)
             {
-                this.TransformTo(nameof(FlashlightSize), adjustSizeForPlayfieldAspectRatio(size), FLASHLIGHT_FADE_DURATION);
+                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), FLASHLIGHT_FADE_DURATION);
             }
 
             protected override string FragmentShader => "CircularFlashlight";
@@ -82,7 +69,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     FlashlightPosition = ToLocalSpace(taikoPlayfield.HitTarget.ScreenSpaceDrawQuad.Centre);
 
                     ClearTransforms(targetMember: nameof(FlashlightSize));
-                    FlashlightSize = adjustSizeForPlayfieldAspectRatio(GetSize());
+                    FlashlightSize = new Vector2(0, GetSize());
 
                     flashlightProperties.Validate();
                 }

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -325,8 +325,9 @@ namespace osu.Game.Rulesets.Mods
         }
 
         /// <summary>
-        /// The purpose of this component is to track any changes to <see cref="Playfield.DrawInfo"/> (technically its parent),
-        /// in order for the flashlight to invalidate its draw node and read any changes in the playfield's scaling.
+        /// The purpose of this component is to track any changes to <c>Playfield.Parent.DrawInfo</c>
+        /// (by being added to the content of <see cref="PlayfieldAdjustmentContainer"/>).
+        /// All in order for the flashlight to invalidate its draw node and read any changes in the playfield's scaling.
         /// </summary>
         internal partial class PlayfieldDrawInfoTracker : Component
         {


### PR DESCRIPTION
- Closes #34703 

This fix essentially expands on https://github.com/ppy/osu/pull/33910 by extracting scale directly from the playfield rather than just reading `PlayfieldAdjustmentContainer.Scale` (which does not cover any scaling factor applied in nested containers between the playfield adjustment container and the playfield itself).

This also required size adjustments in osu! and catch, as well as a minor change in taiko flashlight:
 - In osu!, because I'm now scaling the flashlight based on the playfield, there's a constant 1.6x factor applied directly by `OsuPlayfieldAdjustmentContainer.ScalingContainer`. To keep the flashlight size from visually getting 1.6x larger, I've adjusted the default flashlight size to counter that. Applied in https://github.com/ppy/osu/commit/29b2a7167ecbd1db4b97e2510006b47180a582f4.
 - In osu!catch, same as osu!, there's a 1.6x factor applied by `CatchPlayfieldAdjustmentContainer.ScalingContainer`. Also applied in https://github.com/ppy/osu/commit/29b2a7167ecbd1db4b97e2510006b47180a582f4.
 - In osu!taiko, since https://github.com/ppy/osu/pull/33910 was merged, the flashlight size became scaled twice by the playfield, once in:

   https://github.com/ppy/osu/blob/30f7da8f716a48f0c3ebbea3b1f95a50405cc75a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs#L66 and again in:
  https://github.com/ppy/osu/blob/30f7da8f716a48f0c3ebbea3b1f95a50405cc75a/osu.Game/Rulesets/Mods/ModFlashlight.cs#L159-L166

   This made the flashlight grow its view as the playfield widens:

   https://github.com/user-attachments/assets/e4da4e24-f656-4e13-af23-19e26cc35eea

   This is fixed in https://github.com/ppy/osu/commit/5a84c076fcc271c0c6f401435249498175638fd6 by removing the local logic in favour of the main scaling logic added by this PR in the flashlight draw node. PR:

   

   https://github.com/user-attachments/assets/6a5f47f4-5c1a-4b3e-82db-2241359c8420

   For comparison, this is how the flashlight size is with just the changes in https://github.com/ppy/osu/pull/33910 reverted (point is to show that it matches what I have in this PR, i.e. the correct behaviour):

   https://github.com/user-attachments/assets/17d0877a-3132-4f56-9606-b1c9ab0889ee

 - In osu!mania, no direct changes were made, but it seems this PR fixes an issue with flashlight that has existed since mobile mania was improved. Before:


   https://github.com/user-attachments/assets/970ffbc8-034c-4800-8039-bd77152d8561

   After:

   https://github.com/user-attachments/assets/82a54c44-e301-46e8-85ad-4ce02b46c656

