### PR TITLE
Add support for pinning multiplayer rooms

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomListing.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomListing.cs
@@ -52,25 +52,25 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestBasicListChanges()
         {
-            AddStep("add rooms", () => rooms.AddRange(GenerateRooms(5, withSpotlightRooms: true)));
+            AddStep("add rooms", () => rooms.AddRange(GenerateRooms(5, withPinnedRooms: true)));
 
             AddAssert("has 5 rooms", () => container.DrawableRooms.Count == 5);
 
-            AddAssert("all spotlights at top", () => container.DrawableRooms
-                                                              .SkipWhile(r => r.Room.Category == RoomCategory.Spotlight)
-                                                              .All(r => r.Room.Category == RoomCategory.Normal));
+            AddAssert("all pinned at top", () => container.DrawableRooms
+                                                          .SkipWhile(r => r.Room.Pinned)
+                                                          .All(r => !r.Room.Pinned));
 
             AddStep("remove first room", () => rooms.RemoveAt(0));
             AddAssert("has 4 rooms", () => container.DrawableRooms.Count == 4);
             AddAssert("first room removed", () => container.DrawableRooms.All(r => r.Room.RoomID != 0));
 
             AddStep("select first room", () => container.DrawableRooms.First().TriggerClick());
-            AddAssert("first spotlight selected", () => checkRoomSelected(rooms.First(r => r.Category == RoomCategory.Spotlight)));
+            AddAssert("first pinned room selected", () => checkRoomSelected(rooms.First(r => r.Pinned)));
 
             AddStep("remove last room", () => rooms.RemoveAt(rooms.Count - 1));
-            AddAssert("first spotlight still selected", () => checkRoomSelected(rooms.First(r => r.Category == RoomCategory.Spotlight)));
+            AddAssert("first pinned room selected", () => checkRoomSelected(rooms.First(r => r.Pinned)));
 
-            AddStep("remove spotlight room", () => rooms.RemoveAll(r => r.Category == RoomCategory.Spotlight));
+            AddStep("remove pinned rooms", () => rooms.RemoveAll(r => r.Pinned));
             AddAssert("selection vacated", () => checkRoomSelected(null));
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -130,9 +130,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 };
             });
 
-            AddUntilStep("wait for panel load", () => rooms.Count == 7);
-            AddUntilStep("correct status text", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Currently playing", StringComparison.Ordinal)) == 2);
-            AddUntilStep("correct status text", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Ready to play", StringComparison.Ordinal)) == 5);
+            AddUntilStep("wait for panel load", () => rooms.Count, () => Is.EqualTo(8));
+            AddUntilStep("\"currently playing\" room count correct", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Currently playing", StringComparison.Ordinal)), () => Is.EqualTo(3));
+            AddUntilStep("\"ready to play\" room count correct", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Ready to play", StringComparison.Ordinal)), () => Is.EqualTo(4));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -149,13 +149,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for panel load", () => panel.ChildrenOfType<DrawableRoomParticipantsList>().Any());
 
-            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.CornerIcon>().Single().Alpha));
+            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.CornerIcon>().First().Alpha));
 
             AddStep("set password", () => room.Password = "password");
-            AddAssert("password icon visible", () => Precision.AlmostEquals(1, panel.ChildrenOfType<RoomPanel.CornerIcon>().Single().Alpha));
+            AddAssert("password icon visible", () => Precision.AlmostEquals(1, panel.ChildrenOfType<RoomPanel.CornerIcon>().First().Alpha));
 
             AddStep("unset password", () => room.Password = string.Empty);
-            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.CornerIcon>().Single().Alpha));
+            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.CornerIcon>().First().Alpha));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -82,6 +82,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         }),
                         createLoungeRoom(new Room
                         {
+                            Name = "Pinned room",
+                            Pinned = true,
+                            EndDate = DateTimeOffset.Now.AddDays(1),
+                            Type = MatchType.HeadToHead,
+                            Playlist = [item1],
+                            CurrentPlaylistItem = item1
+                        }),
+                        createLoungeRoom(new Room
+                        {
                             Name = "Private room",
                             Password = "*",
                             EndDate = DateTimeOffset.Now.AddDays(1),
@@ -140,13 +149,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for panel load", () => panel.ChildrenOfType<DrawableRoomParticipantsList>().Any());
 
-            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.PasswordProtectedIcon>().Single().Alpha));
+            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.CornerIcon>().Single().Alpha));
 
             AddStep("set password", () => room.Password = "password");
-            AddAssert("password icon visible", () => Precision.AlmostEquals(1, panel.ChildrenOfType<RoomPanel.PasswordProtectedIcon>().Single().Alpha));
+            AddAssert("password icon visible", () => Precision.AlmostEquals(1, panel.ChildrenOfType<RoomPanel.CornerIcon>().Single().Alpha));
 
             AddStep("unset password", () => room.Password = string.Empty);
-            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.PasswordProtectedIcon>().Single().Alpha));
+            AddAssert("password icon hidden", () => Precision.AlmostEquals(0, panel.ChildrenOfType<RoomPanel.CornerIcon>().Single().Alpha));
         }
 
         [Test]

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -263,6 +263,12 @@ namespace osu.Game.Online.Rooms
             set => SetField(ref availability, value);
         }
 
+        public bool Pinned
+        {
+            get => pinned;
+            set => SetField(ref pinned, value);
+        }
+
         [JsonProperty("id")]
         private long? roomId;
 
@@ -338,6 +344,9 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("status")]
         [JsonConverter(typeof(SnakeCaseStringEnumConverter))]
         private RoomStatus status;
+
+        [JsonProperty("pinned")]
+        private bool pinned;
 
         // Not yet serialised (not implemented).
         private RoomAvailability availability;

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomListing.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomListing.cs
@@ -194,8 +194,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
                 roomFlow.Add(drawableRoom);
 
-                // Always show spotlight playlists at the top of the listing.
-                roomFlow.SetLayoutPosition(drawableRoom, room.Category > RoomCategory.Normal ? float.MinValue : -(room.RoomID ?? 0));
+                roomFlow.SetLayoutPosition(drawableRoom, room.Pinned ? float.MinValue : -(room.RoomID ?? 0));
             }
 
             applyFilterCriteria(Filter.Value);

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
@@ -59,7 +59,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         private DrawableRoomParticipantsList? drawableRoomParticipantsList;
         private RoomSpecialCategoryPill? specialCategoryPill;
-        private PasswordProtectedIcon? passwordIcon;
+        private CornerIcon? passwordIcon;
+        private CornerIcon? pinnedIcon;
         private EndDateInfo? endDateInfo;
         private RoomNameLine? roomName;
         private DelayedLoadWrapper wrapper = null!;
@@ -88,7 +89,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colours)
+        private void load(OverlayColourProvider colourProvider, OsuColour colours)
         {
             ButtonsContainer = new Container
             {
@@ -104,7 +105,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.Background5,
+                    Colour = colourProvider.Background5,
                 },
                 CreateBackground().With(d =>
                 {
@@ -128,7 +129,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                 new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = colours.Background5,
+                                    Colour = colourProvider.Background5,
                                     Width = 0.2f,
                                 },
                                 new Box
@@ -136,7 +137,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                     Anchor = Anchor.TopRight,
                                     Origin = Anchor.TopRight,
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f)),
+                                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background5, colourProvider.Background5.Opacity(0.3f)),
                                     Width = 0.8f,
                                 },
                                 new GridContainer
@@ -254,7 +255,28 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                         }
                                     }
                                 },
-                                passwordIcon = new PasswordProtectedIcon { Alpha = 0 }
+                                passwordIcon = new CornerIcon
+                                {
+                                    Alpha = 0,
+                                    Background = { Colour = colours.Gray8, },
+                                    Icon =
+                                    {
+                                        Icon = FontAwesome.Solid.Lock,
+                                        Colour = colours.Gray3,
+                                        Rotation = 45,
+                                    },
+                                },
+                                pinnedIcon = new CornerIcon
+                                {
+                                    Alpha = 0,
+                                    Background = { Colour = colours.Orange2 },
+                                    Icon =
+                                    {
+                                        Icon = FontAwesome.Solid.Thumbtack,
+                                        Colour = colours.Gray3,
+                                        Rotation = 45,
+                                    },
+                                }
                             },
                         },
                     }, 0)
@@ -283,6 +305,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 updateRoomCategory();
                 updateRoomType();
                 updateRoomHasPassword();
+                updateRoomPinned();
             };
 
             SelectedItem.BindValueChanged(onSelectedItemChanged, true);
@@ -310,6 +333,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
                 case nameof(Room.HasPassword):
                     updateRoomHasPassword();
+                    break;
+
+                case nameof(Room.Pinned):
+                    updateRoomPinned();
                     break;
             }
         }
@@ -369,6 +396,12 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         {
             if (passwordIcon != null)
                 passwordIcon.Alpha = Room.HasPassword ? 1 : 0;
+        }
+
+        private void updateRoomPinned()
+        {
+            if (pinnedIcon != null)
+                pinnedIcon.Alpha = Room.Pinned ? 1 : 0;
         }
 
         private int numberOfAvatars = 7;
@@ -534,10 +567,12 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
             }
         }
 
-        public partial class PasswordProtectedIcon : CompositeDrawable
+        public partial class CornerIcon : CompositeDrawable
         {
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            public SpriteIcon Icon { get; }
+            public Box Background { get; }
+
+            public CornerIcon()
             {
                 Anchor = Anchor.TopRight;
                 Origin = Anchor.TopRight;
@@ -546,20 +581,19 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
                 InternalChildren = new Drawable[]
                 {
-                    new Box
+                    Background = new Box
                     {
                         Anchor = Anchor.TopRight,
                         Origin = Anchor.TopCentre,
-                        Colour = colours.Gray5,
                         Rotation = 45,
                         RelativeSizeAxes = Axes.Both,
                         Width = 2,
                     },
-                    new SpriteIcon
+                    Icon = new SpriteIcon
                     {
-                        Icon = FontAwesome.Solid.Lock,
                         Anchor = Anchor.TopRight,
-                        Origin = Anchor.TopRight,
+                        Origin = Anchor.Centre,
+                        Position = new Vector2(-13, 13),
                         Margin = new MarginPadding(6),
                         Size = new Vector2(14),
                     }

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         /// </remarks>
         protected virtual OnlinePlayTestSceneDependencies CreateOnlinePlayDependencies() => new OnlinePlayTestSceneDependencies();
 
-        protected Room[] GenerateRooms(int count, RulesetInfo? ruleset = null, bool withPassword = false, bool withSpotlightRooms = false)
+        protected Room[] GenerateRooms(int count, RulesetInfo? ruleset = null, bool withPassword = false, bool withPinnedRooms = false)
         {
             Room[] rooms = new Room[count];
 
@@ -110,10 +110,10 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                     Name = $@"Room {currentRoomId}",
                     Host = new APIUser { Username = @"Host" },
                     Duration = TimeSpan.FromSeconds(10),
-                    Category = withSpotlightRooms && i % 2 == 0 ? RoomCategory.Spotlight : RoomCategory.Normal,
                     Password = withPassword ? @"password" : null,
                     PlaylistItemStats = new Room.RoomPlaylistItemStats { RulesetIDs = [ruleset.OnlineID] },
-                    Playlist = [new PlaylistItem(new BeatmapInfo { Metadata = new BeatmapMetadata() }) { RulesetID = ruleset.OnlineID }]
+                    Playlist = [new PlaylistItem(new BeatmapInfo { Metadata = new BeatmapMetadata() }) { RulesetID = ruleset.OnlineID }],
+                    Pinned = withPinnedRooms && i % 2 == 0,
                 };
             }
 


### PR DESCRIPTION
Pinned rooms will be used for special events such as spotlights or other ongoing featured contests and tournaments. They will be indicated by a yellow pin marker in the upper right corner of the room panel:

<img width="1902" height="421" alt="Screenshot 2025-08-22 at 10 17 08" src="https://github.com/user-attachments/assets/a26efa36-f01f-48f6-ba34-743d16b77035" />

and shown at the top of the room listing.

---

- Closes https://github.com/ppy/osu/issues/34537
- [x] Depends on https://github.com/ppy/osu-web/pull/12362

As mentioned in the web-side pull, I expect that all spotlights & featured artist rooms will also be implicitly pinned. They were not until now, which meant that in a worst-case scenario that probably never happened, the client-side hack for pinning those that was used in `RoomListing` up until now could fail if the rooms were not returned in the first page by osu-web (which was not guaranteed until now).

Notably there's also the part wherein the game does deficient polling because it never attempts to retrieve more than the first page of active rooms, but that probably requires a significant restructuring of how the lounge screens work that I am not doing without getting explicit buy-in first.

I've already seen someone report [last week](https://discord.com/channels/188630481301012481/1097318920991559880/1405977204239765556) that they're not able to see their friends' multiplayer rooms that *could possibly* be caused by that. As far as I can tell the problem is currently masked unless there are more than 250 active rooms / playlists at any point in time.

Visual adjustments to the private room marker made at @peppy's behest.