### PR TITLE
Add long note percentage filter for mania mode

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
@@ -175,13 +175,235 @@ namespace osu.Game.Rulesets.Mania.Tests
         }
 
         [TestCase]
-        public void TestInvalidFilters()
+        public void TestInvalidKeysFilters()
         {
             var criteria = new ManiaFilterCriteria();
 
             Assert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.Equal, "some text"));
             Assert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.NotEqual, "4,some text"));
             Assert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.GreaterOrEqual, "4,5,6"));
+        }
+
+        [TestCase]
+        public void TestLnsEqualSingleValue()
+        {
+            var criteria = new ManiaFilterCriteria();
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "50");
+            BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 50
+            };
+            Assert.True(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0");
+            BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 0,
+                EndTimeObjectCount = 0
+            };
+            Assert.True(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+
+            BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 0
+            };
+            Assert.True(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "1");
+            BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 1
+            };
+            Assert.True(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "100");
+            BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 100
+            };
+            Assert.True(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0.1");
+            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 1000,
+                EndTimeObjectCount = 1
+            };
+            Assert.True(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+        }
+
+        [TestCase]
+        public void TestLnsNotEqual()
+        {
+            var criteria = new ManiaFilterCriteria();
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "50");
+            BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 50
+            };
+            Assert.False(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0");
+            BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 0,
+                EndTimeObjectCount = 0
+            };
+            Assert.False(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+
+            BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 0
+            };
+            Assert.False(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "1");
+            BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 1
+            };
+            Assert.False(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "100");
+            BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 100
+            };
+            Assert.False(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0.1");
+            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 1000,
+                EndTimeObjectCount = 1
+            };
+            Assert.False(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+        }
+
+        [TestCase]
+        public void TestLnsGreaterOrEqual()
+        {
+            var criteria = new ManiaFilterCriteria();
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "50");
+            BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 50
+            };
+            Assert.True(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0");
+            BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 0,
+                EndTimeObjectCount = 0
+            };
+            Assert.True(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+
+            BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 0
+            };
+            Assert.True(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "1");
+            BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 1
+            };
+            Assert.True(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "100");
+            BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 100
+            };
+            Assert.True(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0.1");
+            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 1000,
+                EndTimeObjectCount = 1
+            };
+            Assert.True(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+        }
+
+        [TestCase]
+        public void TestLnsGreater()
+        {
+            var criteria = new ManiaFilterCriteria();
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "49");
+            BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 50
+            };
+            Assert.True(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0");
+            BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 0,
+                EndTimeObjectCount = 0
+            };
+            Assert.False(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+
+            BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 0
+            };
+            Assert.False(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0.5");
+            BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 1
+            };
+            Assert.True(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "99");
+            BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 100
+            };
+            Assert.True(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0.01");
+            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 1000,
+                EndTimeObjectCount = 1
+            };
+            Assert.True(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+        }
+
+        [TestCase]
+        public void TestInvalidLnsFilters()
+        {
+            var criteria = new ManiaFilterCriteria();
+
+            Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "some text"));
+            Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "50,some text"));
+            Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "1some text"));
         }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         }
 
         [TestCase]
-        public void TestFilterIntersection()
+        public void TestKeysFilterIntersection()
         {
             var criteria = new ManiaFilterCriteria();
             criteria.TryParseCustomKeywordCriteria("keys", Operator.Greater, "4");
@@ -185,9 +185,13 @@ namespace osu.Game.Rulesets.Mania.Tests
         }
 
         [TestCase]
-        public void TestLnsEqualSingleValue()
+        public void TestLnsEqual()
         {
             var criteria = new ManiaFilterCriteria();
+            var filterCriteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ShortName = "mania" }
+            };
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "50");
             BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -195,7 +199,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 50
             };
-            Assert.True(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -203,14 +207,15 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 0,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo2, filterCriteria));
 
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo3, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "1");
             BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -218,7 +223,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "100");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -226,7 +231,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 100
             };
-            Assert.True(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0.1");
             BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -234,13 +239,17 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 1000,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo6, filterCriteria));
         }
 
         [TestCase]
         public void TestLnsNotEqual()
         {
             var criteria = new ManiaFilterCriteria();
+            var filterCriteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ShortName = "mania" }
+            };
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "50");
             BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -248,7 +257,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 50
             };
-            Assert.False(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -256,14 +265,15 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 0,
                 EndTimeObjectCount = 0
             };
-            Assert.False(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo2, filterCriteria));
 
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
-            Assert.False(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo3, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "1");
             BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -271,7 +281,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 1
             };
-            Assert.False(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo4, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "100");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -279,7 +289,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 100
             };
-            Assert.False(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo5, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0.1");
             BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -287,13 +297,25 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 1000,
                 EndTimeObjectCount = 1
             };
-            Assert.False(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo6, filterCriteria));
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "50");
+            BeatmapInfo beatmapInfo7 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 0
+            };
+            Assert.True(criteria.Matches(beatmapInfo7, filterCriteria));
         }
 
         [TestCase]
         public void TestLnsGreaterOrEqual()
         {
             var criteria = new ManiaFilterCriteria();
+            var filterCriteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ShortName = "mania" }
+            };
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "50");
             BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -301,7 +323,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 50
             };
-            Assert.True(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -309,14 +331,15 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 0,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo2, filterCriteria));
 
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo3, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "1");
             BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -324,7 +347,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "100");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -332,7 +355,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 100
             };
-            Assert.True(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0.1");
             BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -340,13 +363,17 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 1000,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo6, filterCriteria));
         }
 
         [TestCase]
         public void TestLnsGreater()
         {
             var criteria = new ManiaFilterCriteria();
+            var filterCriteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ShortName = "mania" }
+            };
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "49");
             BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -354,7 +381,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 50
             };
-            Assert.True(criteria.Matches(beatmapInfo1, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -362,14 +389,15 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 0,
                 EndTimeObjectCount = 0
             };
-            Assert.False(criteria.Matches(beatmapInfo2, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo2, filterCriteria));
 
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
-            Assert.False(criteria.Matches(beatmapInfo3, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo3, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0.5");
             BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -377,7 +405,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo4, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "99");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -385,7 +413,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 100
             };
-            Assert.True(criteria.Matches(beatmapInfo5, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0.01");
             BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -393,7 +421,21 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 1000,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo6, new FilterCriteria()));
+            Assert.True(criteria.Matches(beatmapInfo6, filterCriteria));
+        }
+
+        [TestCase]
+        public void TestLnsNotManiaRuleset()
+        {
+            var criteria = new ManiaFilterCriteria();
+
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.LessOrEqual, "100");
+            BeatmapInfo beatmapInfo = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 50
+            };
+            Assert.False(criteria.Matches(beatmapInfo, new FilterCriteria()));
         }
 
         [TestCase]

--- a/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
@@ -190,30 +190,30 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
             var filterCriteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { ShortName = "mania" }
+                Ruleset = new ManiaRuleset().RulesetInfo
             };
 
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "50");
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0");
             BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 50
+                TotalObjectCount = 0,
+                EndTimeObjectCount = 0
             };
             Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
-                TotalObjectCount = 0,
+                TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
             Assert.True(criteria.Matches(beatmapInfo2, filterCriteria));
 
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0");
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "100");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
                 TotalObjectCount = 100,
-                EndTimeObjectCount = 0
+                EndTimeObjectCount = 100
             };
             Assert.True(criteria.Matches(beatmapInfo3, filterCriteria));
 
@@ -225,87 +225,13 @@ namespace osu.Game.Rulesets.Mania.Tests
             };
             Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
 
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "100");
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0.1");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 100
+                TotalObjectCount = 1000,
+                EndTimeObjectCount = 1
             };
             Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0.1");
-            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 1000,
-                EndTimeObjectCount = 1
-            };
-            Assert.True(criteria.Matches(beatmapInfo6, filterCriteria));
-        }
-
-        [TestCase]
-        public void TestLnsNotEqual()
-        {
-            var criteria = new ManiaFilterCriteria();
-            var filterCriteria = new FilterCriteria
-            {
-                Ruleset = new RulesetInfo { ShortName = "mania" }
-            };
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "50");
-            BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 50
-            };
-            Assert.False(criteria.Matches(beatmapInfo1, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0");
-            BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 0,
-                EndTimeObjectCount = 0
-            };
-            Assert.False(criteria.Matches(beatmapInfo2, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0");
-            BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 0
-            };
-            Assert.False(criteria.Matches(beatmapInfo3, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "1");
-            BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 1
-            };
-            Assert.False(criteria.Matches(beatmapInfo4, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "100");
-            BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 100
-            };
-            Assert.False(criteria.Matches(beatmapInfo5, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "0.1");
-            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 1000,
-                EndTimeObjectCount = 1
-            };
-            Assert.False(criteria.Matches(beatmapInfo6, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "50");
-            BeatmapInfo beatmapInfo7 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 0
-            };
-            Assert.True(criteria.Matches(beatmapInfo7, filterCriteria));
         }
 
         [TestCase]
@@ -314,30 +240,30 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
             var filterCriteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { ShortName = "mania" }
+                Ruleset = new ManiaRuleset().RulesetInfo
             };
 
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "50");
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0");
             BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 50
+                TotalObjectCount = 0,
+                EndTimeObjectCount = 0
             };
             Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
-                TotalObjectCount = 0,
+                TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
             Assert.True(criteria.Matches(beatmapInfo2, filterCriteria));
 
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0");
+            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "100");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
                 TotalObjectCount = 100,
-                EndTimeObjectCount = 0
+                EndTimeObjectCount = 100
             };
             Assert.True(criteria.Matches(beatmapInfo3, filterCriteria));
 
@@ -349,93 +275,31 @@ namespace osu.Game.Rulesets.Mania.Tests
             };
             Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
 
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "100");
-            BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 100
-            };
-            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
-
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0.1");
-            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 1000,
-                EndTimeObjectCount = 1
-            };
-            Assert.True(criteria.Matches(beatmapInfo6, filterCriteria));
-        }
-
-        [TestCase]
-        public void TestLnsGreater()
-        {
-            var criteria = new ManiaFilterCriteria();
-            var filterCriteria = new FilterCriteria
-            {
-                Ruleset = new RulesetInfo { ShortName = "mania" }
-            };
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "49");
-            BeatmapInfo beatmapInfo1 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 50
-            };
-            Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0");
-            BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 0,
-                EndTimeObjectCount = 0
-            };
-            Assert.False(criteria.Matches(beatmapInfo2, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0");
-            BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 0
-            };
-            Assert.False(criteria.Matches(beatmapInfo3, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0.5");
-            BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 1
-            };
-            Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "99");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
             {
-                TotalObjectCount = 100,
-                EndTimeObjectCount = 100
-            };
-            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
-
-            criteria.TryParseCustomKeywordCriteria("lns", Operator.Greater, "0.01");
-            BeatmapInfo beatmapInfo6 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
-            {
                 TotalObjectCount = 1000,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo6, filterCriteria));
+            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
         }
 
         [TestCase]
         public void TestLnsNotManiaRuleset()
         {
             var criteria = new ManiaFilterCriteria();
+            var filterCriteria = new FilterCriteria
+            {
+                Ruleset = new ManiaRuleset().RulesetInfo
+            };
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.LessOrEqual, "100");
-            BeatmapInfo beatmapInfo = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
+            BeatmapInfo beatmapInfo = new BeatmapInfo
             {
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 50
             };
-            Assert.False(criteria.Matches(beatmapInfo, new FilterCriteria()));
+            Assert.False(criteria.Matches(beatmapInfo, filterCriteria));
         }
 
         [TestCase]
@@ -444,7 +308,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
 
             Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "some text"));
-            Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.NotEqual, "50,some text"));
             Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "1some text"));
         }
     }

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Mania
             int keyCount = ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), criteria.Mods);
 
             bool keyCountMatch = includedKeyCounts.Contains(keyCount);
-            bool longNoteRatioMatch = !longNoteRatio.HasFilter || longNoteRatio.IsInRange(calculatelongNoteRatio(beatmapInfo));
+            bool longNoteRatioMatch = !longNoteRatio.HasFilter || (!isConvertedBeatMap(beatmapInfo, criteria) && longNoteRatio.IsInRange(calculateLongNoteRatio(beatmapInfo)));
 
             return keyCountMatch && longNoteRatioMatch;
         }
@@ -98,15 +98,6 @@ namespace osu.Game.Rulesets.Mania
             return false;
         }
 
-        private static float calculatelongNoteRatio(BeatmapInfo beatmapInfo)
-        {
-            int holdNotes = beatmapInfo.EndTimeObjectCount;
-            int totalNotes = beatmapInfo.TotalObjectCount;
-            int sum = Math.Max(1, totalNotes);
-
-            return holdNotes / (float)sum * 100;
-        }
-
         public bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
             if (includedKeyCounts.Count != LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT)
@@ -120,6 +111,20 @@ namespace osu.Game.Rulesets.Mania
             }
 
             return false;
+        }
+
+        private static bool isConvertedBeatMap(BeatmapInfo beatmapInfo, FilterCriteria criteria)
+        {
+            return criteria.Ruleset == null || beatmapInfo.Ruleset.ShortName != criteria.Ruleset!.ShortName;
+        }
+
+        private static float calculateLongNoteRatio(BeatmapInfo beatmapInfo)
+        {
+            int holdNotes = beatmapInfo.EndTimeObjectCount;
+            int totalNotes = beatmapInfo.TotalObjectCount;
+            int sum = Math.Max(1, totalNotes);
+
+            return holdNotes / (float)sum * 100;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -20,16 +20,16 @@ namespace osu.Game.Rulesets.Mania
     public class ManiaFilterCriteria : IRulesetFilterCriteria
     {
         private readonly HashSet<int> includedKeyCounts = Enumerable.Range(1, LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT).ToHashSet();
-        private FilterCriteria.OptionalRange<float> longNoteRatio;
+        private FilterCriteria.OptionalRange<float> longNotePercentage;
 
         public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria)
         {
             int keyCount = ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), criteria.Mods);
 
             bool keyCountMatch = includedKeyCounts.Contains(keyCount);
-            bool longNoteRatioMatch = !longNoteRatio.HasFilter || (!isConvertedBeatMap(beatmapInfo, criteria) && longNoteRatio.IsInRange(calculateLongNoteRatio(beatmapInfo)));
+            bool longNotePercentageMatch = !longNotePercentage.HasFilter || (!isConvertedBeatmap(beatmapInfo) && longNotePercentage.IsInRange(calculateLongNotePercentage(beatmapInfo)));
 
-            return keyCountMatch && longNoteRatioMatch;
+            return keyCountMatch && longNotePercentageMatch;
         }
 
         public bool TryParseCustomKeywordCriteria(string key, Operator op, string strValues)
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Mania
 
                 case "ln":
                 case "lns":
-                    return FilterQueryParser.TryUpdateCriteriaRange(ref longNoteRatio, op, strValues);
+                    return FilterQueryParser.TryUpdateCriteriaRange(ref longNotePercentage, op, strValues);
             }
 
             return false;
@@ -113,18 +113,17 @@ namespace osu.Game.Rulesets.Mania
             return false;
         }
 
-        private static bool isConvertedBeatMap(BeatmapInfo beatmapInfo, FilterCriteria criteria)
+        private static bool isConvertedBeatmap(BeatmapInfo beatmapInfo)
         {
-            return criteria.Ruleset == null || beatmapInfo.Ruleset.ShortName != criteria.Ruleset!.ShortName;
+            return !beatmapInfo.Ruleset.Equals(new ManiaRuleset().RulesetInfo);
         }
 
-        private static float calculateLongNoteRatio(BeatmapInfo beatmapInfo)
+        private static float calculateLongNotePercentage(BeatmapInfo beatmapInfo)
         {
             int holdNotes = beatmapInfo.EndTimeObjectCount;
-            int totalNotes = beatmapInfo.TotalObjectCount;
-            int sum = Math.Max(1, totalNotes);
+            int totalNotes = Math.Max(1, beatmapInfo.TotalObjectCount);
 
-            return holdNotes / (float)sum * 100;
+            return holdNotes / (float)totalNotes * 100;
         }
     }
 }


### PR DESCRIPTION
Long notes are a huge part of mania gameplay, especially with all the o2jam-style maps out there. But finding LN-heavy maps is kind of a pain since beatmap tags are often missing or wrong, and some players just want to avoid LNs entirely.

The another rhythm game *Quaver* has this neat LN percentage filter, so I figured why not add it to osu!mania too? Now you can filter maps by how much of them are actually long notes.

https://github.com/user-attachments/assets/198fc805-fc07-43c4-ae7f-b3724ce343ef

## What's new

- Added `ln`/`lns` keywords to search - works with all the usual operators (`=`, `!=`, `>=`, `>`, `<=`, `<`)
- Uses percentages (0-100) because that's way more intuitive than decimals
- Examples:
    - `ln=0` - maps with no long notes
    - `ln>=50` - maps with 50% or more long notes
    - `ln<10` - maps with less than 10% long notes
- Added tests

## Known Issues

This might not work perfectly on converted beatmaps since I'm using `EndTimeObjectCount` instead of actually parsing the `HitObjects` from the `Beatmap` class. But honestly, if you're hunting for LN maps you're probably not looking at converts anyway, so it should be fine for what people actually want to do.