### PR TITLE
Fix applause audio clashing with preview audio

### DIFF
--- a/osu.Game/Audio/PreviewTrackManager.cs
+++ b/osu.Game/Audio/PreviewTrackManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
@@ -21,6 +22,9 @@ namespace osu.Game.Audio
         private ITrackStore trackStore = null!;
 
         protected TrackManagerPreviewTrack? CurrentTrack;
+
+        public event Action? PreviewTrackStarted;
+        public event Action? PreviewTrackStopped;
 
         public PreviewTrackManager(IAdjustableAudioComponent mainTrackAdjustments)
         {
@@ -47,6 +51,7 @@ namespace osu.Game.Audio
                 CurrentTrack?.Stop();
                 CurrentTrack = track;
                 mainTrackAdjustments.AddAdjustment(AdjustableProperty.Volume, muteBindable);
+                PreviewTrackStarted?.Invoke();
             });
 
             track.Stopped += () => Schedule(() =>
@@ -56,6 +61,7 @@ namespace osu.Game.Audio
 
                 CurrentTrack = null;
                 mainTrackAdjustments.RemoveAdjustment(AdjustableProperty.Volume, muteBindable);
+                PreviewTrackStopped?.Invoke();
             });
 
             return track;

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Screens.Ranking
         public bool IsLocalPlay { get; init; }
 
         private Sample? popInSample;
+        [Resolved]
+        private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
@@ -102,6 +104,8 @@ namespace osu.Game.Screens.Ranking
             FillFlowContainer buttons;
 
             popInSample = audio.Samples.Get(@"UI/overlay-pop-in");
+            previewTrackManager.PreviewTrackStarted += stopApplause;
+            previewTrackManager.PreviewTrackStopped += resumeApplause;
 
             InternalChild = new PopoverContainer
             {
@@ -214,6 +218,7 @@ namespace osu.Game.Screens.Ranking
                 allowHotkeyRetry = true;
             }
 
+
             if (allowHotkeyRetry)
             {
                 AddInternal(new HotkeyRetryOverlay
@@ -233,6 +238,16 @@ namespace osu.Game.Screens.Ranking
 
             if (Score?.BeatmapInfo?.BeatmapSet != null && Score.BeatmapInfo.BeatmapSet.OnlineID > 0)
                 buttons.Add(new FavouriteButton(Score.BeatmapInfo.BeatmapSet));
+        }
+        protected override void Dispose(bool isDisposing)
+        {
+            if (previewTrackManager != null)
+            {
+                previewTrackManager.PreviewTrackStarted -= stopApplause;
+                previewTrackManager.PreviewTrackStopped -= resumeApplause;
+            }
+
+            base.Dispose(isDisposing);
         }
 
         protected override void LoadComplete()
@@ -310,6 +325,15 @@ namespace osu.Game.Screens.Ranking
                 rankApplauseSound.VolumeTo(applause_volume);
                 rankApplauseSound.Play();
             });
+        }
+        private void stopApplause()
+        {
+            rankApplauseSound?.Stop();
+        }
+
+        private void resumeApplause()
+        {
+            rankApplauseSound?.Play();
         }
 
         #endregion

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -85,6 +85,7 @@ namespace osu.Game.Screens.Ranking
         public bool IsLocalPlay { get; init; }
 
         private Sample? popInSample;
+
         [Resolved]
         private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
@@ -218,7 +219,6 @@ namespace osu.Game.Screens.Ranking
                 allowHotkeyRetry = true;
             }
 
-
             if (allowHotkeyRetry)
             {
                 AddInternal(new HotkeyRetryOverlay
@@ -239,14 +239,11 @@ namespace osu.Game.Screens.Ranking
             if (Score?.BeatmapInfo?.BeatmapSet != null && Score.BeatmapInfo.BeatmapSet.OnlineID > 0)
                 buttons.Add(new FavouriteButton(Score.BeatmapInfo.BeatmapSet));
         }
+
         protected override void Dispose(bool isDisposing)
         {
-            if (previewTrackManager != null)
-            {
-                previewTrackManager.PreviewTrackStarted -= stopApplause;
-                previewTrackManager.PreviewTrackStopped -= resumeApplause;
-            }
-
+            previewTrackManager.PreviewTrackStarted -= stopApplause;
+            previewTrackManager.PreviewTrackStopped -= resumeApplause;
             base.Dispose(isDisposing);
         }
 
@@ -326,6 +323,7 @@ namespace osu.Game.Screens.Ranking
                 rankApplauseSound.Play();
             });
         }
+
         private void stopApplause()
         {
             rankApplauseSound?.Stop();


### PR DESCRIPTION
To recreate the bug:
- Finish playing through a beatmap/watching a replay. The applause audio will start playing on the results screen. 
- Quickly click a user's profile and preview the audio of any of their favorite beatmaps. 
- Both the audio of the applause and the preview audio will play at the same time. 

Now only one of them can play at a time. 