### PR TITLE
Fix aim error meter applying incorrect scaling constant in normalised mode

### DIFF
--- a/osu.Game.Rulesets.Osu/HUD/AimErrorMeter.cs
+++ b/osu.Game.Rulesets.Osu/HUD/AimErrorMeter.cs
@@ -323,7 +323,7 @@ namespace osu.Game.Rulesets.Osu.HUD
             if (PositionDisplayStyle.Value == PositionDisplay.Normalised && lastObjectPosition != null)
             {
                 hitPosition = AccuracyHeatmap.FindRelativeHitPosition(lastObjectPosition.Value, ((OsuHitObject)circleJudgement.HitObject).StackedEndPosition,
-                    circleJudgement.CursorPositionAtHit.Value, objectRadius, 45) * 0.5f;
+                    circleJudgement.CursorPositionAtHit.Value, objectRadius, 45) * (inner_portion / 2);
             }
             else
             {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34769

Visible (and easiest to check) in test scene.