### PR TITLE
Fix daily challenge / playlist leaderboard sometimes showing incorrect default state

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/PlaylistsGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/PlaylistsGameplayLeaderboardProvider.cs
@@ -65,8 +65,12 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             // touching the public bindable must happen on the update thread for general thread safety,
             // since we may have external subscribers bound already
-            Schedule(() => scores.AddRange(scoresToShow));
-            Scheduler.AddDelayed(sort, 1000, true);
+            Schedule(() =>
+            {
+                scores.AddRange(scoresToShow);
+                sort();
+                Scheduler.AddDelayed(sort, 1000, true);
+            });
         }
 
         // logic shared with SoloGameplayLeaderboardProvider

--- a/osu.Game/Screens/Select/Leaderboards/PlaylistsGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/PlaylistsGameplayLeaderboardProvider.cs
@@ -37,7 +37,11 @@ namespace osu.Game.Screens.Select.Leaderboards
             var scoresToShow = new List<GameplayLeaderboardScore>();
 
             var scoresRequest = new IndexPlaylistScoresRequest(room.RoomID!.Value, playlistItem.ID);
-            scoresRequest.Success += response =>
+            api.Perform(scoresRequest);
+
+            var response = scoresRequest.Response;
+
+            if (response != null)
             {
                 isPartial = response.Scores.Count < response.TotalScores;
 
@@ -50,8 +54,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
                 if (response.UserScore != null && response.Scores.All(s => s.ID != response.UserScore.ID))
                     scoresToShow.Add(new GameplayLeaderboardScore(response.UserScore, tracked: false, GameplayLeaderboardScore.ComboDisplayMode.Highest));
-            };
-            api.Perform(scoresRequest);
+            }
 
             if (gameplayState != null)
             {


### PR DESCRIPTION
Noticed while investigating https://github.com/ppy/osu/issues/34641. Likely doesn't resolve that issue, but does resolve another.

The sort in 3f179e3 just feels right to have there. Avoids some edge case where it takes 1 second to show correct state on initial display.