### PR TITLE
Fix beatmap carousel triggering full filters more often than it needs to

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -23,7 +23,9 @@ using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Screens.SelectV2;
+using osu.Game.Tests.Resources;
 using osuTK.Input;
+using BeatmapCarousel = osu.Game.Screens.SelectV2.BeatmapCarousel;
 using FooterButtonMods = osu.Game.Screens.SelectV2.FooterButtonMods;
 using FooterButtonOptions = osu.Game.Screens.SelectV2.FooterButtonOptions;
 using FooterButtonRandom = osu.Game.Screens.SelectV2.FooterButtonRandom;
@@ -300,6 +302,28 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 InputManager.Key(Key.Down);
                 InputManager.ReleaseKey(Key.ControlLeft);
             });
+        }
+
+        /// <summary>
+        /// Last played and rank achieved may have changed, so we want to make sure filtering runs on resume to song select.
+        /// </summary>
+        [Test]
+        public void TestFilteringRunsAfterReturningFromGameplay()
+        {
+            AddStep("import actual beatmap", () => Beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()));
+            LoadSongSelect();
+
+            AddUntilStep("wait for filtered", () => SongSelect.ChildrenOfType<BeatmapCarousel>().Single().FilterCount, () => Is.EqualTo(1));
+
+            AddStep("enter gameplay", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is Player);
+            AddUntilStep("wait for fail", () => ((Player)Stack.CurrentScreen).GameplayState.HasFailed);
+
+            AddStep("exit gameplay", () => InputManager.Key(Key.Escape));
+            AddStep("exit gameplay", () => InputManager.Key(Key.Escape));
+
+            AddUntilStep("wait for filtered", () => SongSelect.ChildrenOfType<BeatmapCarousel>().Single().FilterCount, () => Is.EqualTo(2));
         }
 
         [Test]

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Graphics.Carousel
         /// <summary>
         /// The number of times filter operations have been triggered.
         /// </summary>
-        internal int FilterCount { get; private set; }
+        public int FilterCount { get; private set; }
 
         /// <summary>
         /// The number of displayable items currently being tracked (before filtering).

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -211,6 +212,12 @@ namespace osu.Game.Graphics.Carousel
         }
 
         /// <summary>
+        /// Called when <see cref="Items"/> changes in any way.
+        /// </summary>
+        /// <returns>Whether a re-filter is required.</returns>
+        protected virtual bool HandleItemsChanged(NotifyCollectionChangedEventArgs args) => true;
+
+        /// <summary>
         /// Fired after a filter operation completed.
         /// </summary>
         protected virtual void HandleFilterCompleted()
@@ -301,7 +308,11 @@ namespace osu.Game.Graphics.Carousel
                 RelativeSizeAxes = Axes.Both,
             };
 
-            Items.BindCollectionChanged((_, _) => filterAfterItemsChanged.Invalidate());
+            Items.BindCollectionChanged((_, args) =>
+            {
+                if (HandleItemsChanged(args))
+                    filterAfterItemsChanged.Invalidate();
+            });
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -143,6 +143,9 @@ namespace osu.Game.Screens.SelectV2
             switch (changed.Action)
             {
                 case NotifyCollectionChangedAction.Add:
+                    if (!newItems!.Any())
+                        return;
+
                     Items.AddRange(newItems!.SelectMany(s => s.Beatmaps));
                     break;
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -392,7 +392,9 @@ namespace osu.Game.Screens.SelectV2
                             // displayed on panel
                             oldBeatmap.DifficultyName == newBeatmap.DifficultyName &&
                             // hidden changed, needs re-filter
-                            oldBeatmap.Hidden == newBeatmap.Hidden;
+                            oldBeatmap.Hidden == newBeatmap.Hidden &&
+                            // might be used for grouping, returning from gameplay
+                            oldBeatmap.LastPlayed == newBeatmap.LastPlayed;
 
                         if (equalForDisplayPurposes)
                             return false;

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -356,6 +356,52 @@ namespace osu.Game.Screens.SelectV2
             }
         }
 
+        protected override bool HandleItemsChanged(NotifyCollectionChangedEventArgs args)
+        {
+            switch (args.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                case NotifyCollectionChangedAction.Remove:
+                case NotifyCollectionChangedAction.Move:
+                case NotifyCollectionChangedAction.Reset:
+                    return true;
+
+                case NotifyCollectionChangedAction.Replace:
+                    var oldBeatmaps = args.OldItems!.OfType<BeatmapInfo>().ToList();
+                    var newBeatmaps = args.NewItems!.OfType<BeatmapInfo>().ToList();
+
+                    for (int i = 0; i < oldBeatmaps.Count; i++)
+                    {
+                        var oldBeatmap = oldBeatmaps[i];
+                        var newBeatmap = newBeatmaps[i];
+
+                        // Ignore changes which don't concern us.
+                        //
+                        // Here are some examples of things that can go wrong:
+                        // - Background difficulty calculation runs and causes a realm update.
+                        //   We use `BeatmapDifficultyCache` and don't want to know about these.
+                        // - Background user tag population runs and causes a realm update.
+                        //   We don't display user tags so want to ignore this.
+                        if (
+                            // covers metadata changes
+                            oldBeatmap.Hash == newBeatmap.Hash &&
+                            // displayed
+                            oldBeatmap.Status == newBeatmap.Status &&
+                            // displayed
+                            oldBeatmap.DifficultyName == newBeatmap.DifficultyName &&
+                            // sanity
+                            oldBeatmap.OnlineID == newBeatmap.OnlineID
+                        )
+                            return false;
+                    }
+
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         protected override void HandleFilterCompleted()
         {
             base.HandleFilterCompleted();

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -382,16 +382,19 @@ namespace osu.Game.Screens.SelectV2
                         //   We use `BeatmapDifficultyCache` and don't want to know about these.
                         // - Background user tag population runs and causes a realm update.
                         //   We don't display user tags so want to ignore this.
-                        if (
+                        bool equalForDisplayPurposes =
                             // covers metadata changes
                             oldBeatmap.Hash == newBeatmap.Hash &&
-                            // displayed
+                            // sanity check
+                            oldBeatmap.OnlineID == newBeatmap.OnlineID &&
+                            // displayed on panel
                             oldBeatmap.Status == newBeatmap.Status &&
-                            // displayed
+                            // displayed on panel
                             oldBeatmap.DifficultyName == newBeatmap.DifficultyName &&
-                            // sanity
-                            oldBeatmap.OnlineID == newBeatmap.OnlineID
-                        )
+                            // hidden changed, needs re-filter
+                            oldBeatmap.Hidden == newBeatmap.Hidden;
+
+                        if (equalForDisplayPurposes)
                             return false;
                     }
 


### PR DESCRIPTION
Maybe not 100% what we discussed, but works and doesn't feel too bad?

- Closes https://github.com/ppy/osu/issues/34578
- (Probably) closes https://github.com/ppy/osu/issues/34583
- (Should) closes https://github.com/ppy/osu/issues/34580

The latter two were tested using the same setup for difficulty changes, which I think should be ample as it follows the same pathway (sitting in editor to make sure it doesn't pause due to gameplay).

Test setup:

```diff
diff --git a/osu.Game/Database/BackgroundDataStoreProcessor.cs b/osu.Game/Database/BackgroundDataStoreProcessor.cs
index f8d1b9ae51..2daffff212 100644
--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -157,7 +157,7 @@ private void populateMissingStarRatings()
 
             realmAccess.Run(r =>
             {
-                foreach (var b in r.All<BeatmapInfo>().Where(b => b.StarRating < 0 && b.BeatmapSet != null))
+                foreach (var b in r.All<BeatmapInfo>())
                     beatmapIds.Add(b.ID);
             });
 
@@ -181,42 +181,45 @@ Ruleset getRuleset(RulesetInfo rulesetInfo)
                 return ruleset;
             }
 
-            foreach (Guid id in beatmapIds)
+            while (true)
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
+                foreach (Guid id in beatmapIds)
+                {
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
 
-                updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+                    updateNotificationProgress(notification, processedCount, beatmapIds.Count);
 
-                sleepIfRequired();
+                    sleepIfRequired();
 
-                var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
+                    var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
 
-                if (beatmap == null)
-                    return;
+                    if (beatmap == null)
+                        return;
 
-                try
-                {
-                    var working = beatmapManager.GetWorkingBeatmap(beatmap);
-                    var ruleset = getRuleset(working.BeatmapInfo.Ruleset);
+                    try
+                    {
+                        var working = beatmapManager.GetWorkingBeatmap(beatmap);
+                        var ruleset = getRuleset(working.BeatmapInfo.Ruleset);
 
-                    Debug.Assert(ruleset != null);
+                        Debug.Assert(ruleset != null);
 
-                    var calculator = ruleset.CreateDifficultyCalculator(working);
+                        var calculator = ruleset.CreateDifficultyCalculator(working);
 
-                    double starRating = calculator.Calculate().StarRating;
-                    realmAccess.Write(r =>
+                        double starRating = calculator.Calculate().StarRating;
+                        realmAccess.Write(r =>
+                        {
+                            if (r.Find<BeatmapInfo>(id) is BeatmapInfo liveBeatmapInfo)
+                                liveBeatmapInfo.StarRating = starRating;
+                        });
+                        ((IWorkingBeatmapCache)beatmapManager).Invalidate(beatmap);
+                        ++processedCount;
+                    }
+                    catch (Exception e)
                     {
-                        if (r.Find<BeatmapInfo>(id) is BeatmapInfo liveBeatmapInfo)
-                            liveBeatmapInfo.StarRating = starRating;
-                    });
-                    ((IWorkingBeatmapCache)beatmapManager).Invalidate(beatmap);
-                    ++processedCount;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log($"Background processing failed on {beatmap}: {e}");
-                    ++failedCount;
+                        Logger.Log($"Background processing failed on {beatmap}: {e}");
+                        ++failedCount;
+                    }
                 }
             }
 

```
