### PR TITLE
Fix beatmap panels locally handling mod and ruleset changes unnecessarily

### DIFF
--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -205,11 +205,7 @@ namespace osu.Game.Screens.SelectV2
                 updateKeyCount();
             });
 
-            mods.BindValueChanged(_ =>
-            {
-                computeStarRating();
-                updateKeyCount();
-            }, true);
+            mods.BindValueChanged(_ => updateKeyCount(), true);
         }
 
         protected override void PrepareForUse()

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -199,12 +199,7 @@ namespace osu.Game.Screens.SelectV2
         {
             base.LoadComplete();
 
-            ruleset.BindValueChanged(_ =>
-            {
-                computeStarRating();
-                updateKeyCount();
-            });
-
+            ruleset.BindValueChanged(_ => updateKeyCount());
             mods.BindValueChanged(_ => updateKeyCount(), true);
         }
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -209,17 +209,8 @@ namespace osu.Game.Screens.SelectV2
         {
             base.LoadComplete();
 
-            ruleset.BindValueChanged(_ =>
-            {
-                computeStarRating();
-                updateKeyCount();
-            });
-
-            mods.BindValueChanged(_ =>
-            {
-                computeStarRating();
-                updateKeyCount();
-            }, true);
+            ruleset.BindValueChanged(_ => updateKeyCount());
+            mods.BindValueChanged(_ => updateKeyCount(), true);
 
             Selected.BindValueChanged(s => Expanded.Value = s.NewValue, true);
         }


### PR DESCRIPTION
The `BeatmapDifficultyCache` [handles mod changes](https://github.com/ppy/osu/blob/6500be3f2deb1c1acf1db8f74b657c435ccfb61c/osu.Game/Beatmaps/BeatmapDifficultyCache.cs#L82-L87), so handling locally is unnecessary. By handling locally, it creates a visual issue when adjusting mods often. Test using Ctrl +/- at song select and observing that without this change, the star rating will flicker back to the default due to the local re-fetch.

Before:

https://github.com/user-attachments/assets/fc0d5783-dfba-4b1b-a22f-b68cb1181b0d

After:

https://github.com/user-attachments/assets/c99a90ee-a5ea-45fe-9d73-5593cdcb1ab4

