### PR TITLE
Fix `HealthProcessor` potentially incorrectly reverting failed state

### DIFF
--- a/osu.Game/Rulesets/Scoring/HealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/HealthProcessor.cs
@@ -59,11 +59,7 @@ namespace osu.Game.Rulesets.Scoring
 
         protected override void RevertResultInternal(JudgementResult result)
         {
-            // TODO: this is rudimentary as to make rewinding failed replays work,
-            // but it also acts up (sometimes rewinding a replay several times around the fail boundary moves the point of fail forward).
-            // needs further investigation.
-            if (result.FailedAtJudgement)
-                HasFailed = false;
+            HasFailed = result.FailedAtJudgement;
 
             if (HasFailed)
                 return;


### PR DESCRIPTION
This stems from me looking into `TestSceneFailAnimation` failures (https://github.com/ppy/osu/runs/48663953318). As it turns out, I should not have been mad by CI, and rather should have been mad at myself for failing to read.

`FailedAtJudgement` in fact does not mean "this judgement, and only this judgement, triggered failure". If any further judgements occur post-fail, they will also have `FailedAtJudgement` set to true. It is essentially a *dump* of the state of `HealthProcessor.Failed` prior to applying the judgement.

https://github.com/ppy/osu/blob/ec21685c2531af3b243f7f0833ffbb340bf3c044/osu.Game/Rulesets/Scoring/HealthProcessor.cs#L49-L57

Because of this, reverting several judgements which occur post-fail could lead to failed state reverting earlier than intended, and thus potentially trigger a second fail, thus tripping the `Player` assertion.

Appears to stop the test failures on a sample size of N=1 run.