### PR TITLE
Alpha setting for `SerialisableDrawable`

### DIFF
--- a/osu.Game.Rulesets.Osu/HUD/AimErrorMeter.cs
+++ b/osu.Game.Rulesets.Osu/HUD/AimErrorMeter.cs
@@ -23,6 +23,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Statistics;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play.HUD.HitErrorMeters;
+using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 using Container = osu.Framework.Graphics.Containers.Container;
@@ -30,7 +31,7 @@ using Container = osu.Framework.Graphics.Containers.Container;
 namespace osu.Game.Rulesets.Osu.HUD
 {
     [Cached]
-    public partial class AimErrorMeter : HitErrorMeter
+    public partial class AimErrorMeter : HitErrorMeter, ISerialisableDrawable
     {
         [SettingSource(typeof(AimErrorMeterStrings), nameof(AimErrorMeterStrings.HitMarkerSize), nameof(AimErrorMeterStrings.HitMarkerSizeDescription))]
         public BindableNumber<float> HitMarkerSize { get; } = new BindableNumber<float>(7f)
@@ -56,6 +57,8 @@ namespace osu.Game.Rulesets.Osu.HUD
 
         [SettingSource(typeof(AimErrorMeterStrings), nameof(AimErrorMeterStrings.PositionDisplayStyle), nameof(AimErrorMeterStrings.PositionDisplayStyleDescription))]
         public Bindable<PositionDisplay> PositionDisplayStyle { get; } = new Bindable<PositionDisplay>();
+
+        public bool IsAlphaAdjustable => false;
 
         // used for calculate relative position.
         private Vector2? lastObjectPosition;

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -530,7 +530,7 @@ namespace osu.Game.Overlays.SkinEditor
         {
             settingsSidebar.Clear();
 
-            foreach (var component in SelectedComponents.OfType<Drawable>())
+            foreach (var component in SelectedComponents.OfType<Drawable>().Cast<ISerialisableDrawable>())
                 settingsSidebar.Add(new SkinSettingsToolbox(component));
         }
 

--- a/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Screens.Play.HUD
 
         public bool UsesFixedAnchor { get; set; }
 
+        public bool IsAlphaAdjustable => false;
+
         protected override IHasText CreateText() => new ArgonAccuracyTextComponent
         {
             WireframeOpacity = { BindTarget = WireframeOpacity },

--- a/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
@@ -12,12 +12,13 @@ using osu.Game.Configuration;
 using osu.Game.Localisation.SkinComponents;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public partial class ArgonComboCounter : ComboCounter
+    public partial class ArgonComboCounter : ComboCounter, ISerialisableDrawable
     {
         protected ArgonCounterTextComponent Text = null!;
 
@@ -35,6 +36,8 @@ namespace osu.Game.Screens.Play.HUD
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel))]
         public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
+
+        public bool IsAlphaAdjustable => false;
 
         [BackgroundDependencyLoader]
         private void load(ScoreProcessor scoreProcessor)

--- a/osu.Game/Screens/Play/HUD/ArgonPerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonPerformancePointsCounter.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel))]
         public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
+        public bool IsAlphaAdjustable => false;
+
         public override bool IsValid
         {
             get => base.IsValid;

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Screens.Play.HUD
 
         public bool UsesFixedAnchor { get; set; }
 
+        public bool IsAlphaAdjustable => false;
+
         protected override LocalisableString FormatCount(long count) => count.ToString();
 
         protected override IHasText CreateText() => scoreText = new ArgonScoreTextComponent(Anchor.TopRight, BeatmapsetsStrings.ShowScoreboardHeadersScore.ToUpper())

--- a/osu.Game/Screens/Play/HUD/ArgonUnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonUnstableRateCounter.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel))]
         public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
+        public bool IsAlphaAdjustable => false;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();

--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Screens.Play.HUD
 
         public bool UsesFixedAnchor { get; set; }
 
+        public bool IsAlphaAdjustable => false;
+
         private UpdateableRank rankDisplay = null!;
 
         private SkinnableSound rankDownSample = null!;

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -63,8 +63,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         private UprightAspectMaintainingContainer labelEarly = null!;
         private UprightAspectMaintainingContainer labelLate = null!;
 
-        private Container colourBarsEarly = null!;
-        private Container colourBarsLate = null!;
+        private BufferedContainer colourBarsEarly = null!;
+        private BufferedContainer colourBarsLate = null!;
 
         private Container judgementsContainer = null!;
 
@@ -107,7 +107,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                         RelativeSizeAxes = Axes.Y,
                         Children = new Drawable[]
                         {
-                            colourBarsEarly = new Container
+                            colourBarsEarly = new BufferedContainer(cachedFrameBuffer: true)
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.TopCentre,
@@ -117,7 +117,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                                 Height = 0.5f,
                                 Scale = new Vector2(1, -1),
                             },
-                            colourBarsLate = new Container
+                            colourBarsLate = new BufferedContainer(cachedFrameBuffer: true)
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.TopCentre,

--- a/osu.Game/Screens/Play/HUD/SongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgress.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Timing;
@@ -92,9 +93,9 @@ namespace osu.Game.Screens.Play.HUD
             }
         }
 
-        protected override void PopIn() => this.FadeIn(500, Easing.OutQuint);
+        protected override void PopIn() => Content.Children.ForEach(d => d.FadeIn(500, Easing.OutQuint));
 
-        protected override void PopOut() => this.FadeOut(100);
+        protected override void PopOut() => Content.Children.ForEach(d => d.FadeOut(100));
 
         protected override void Update()
         {

--- a/osu.Game/Skinning/ISerialisableDrawable.cs
+++ b/osu.Game/Skinning/ISerialisableDrawable.cs
@@ -34,6 +34,11 @@ namespace osu.Game.Skinning
         /// </summary>
         bool UsesFixedAnchor { get; set; }
 
+        /// <summary>
+        /// Whether this component should have <see cref="Drawable.Alpha"/> editing by an end user
+        /// </summary>
+        bool IsAlphaAdjustable => true;
+
         void CopyAdjustedSetting(IBindable target, object source)
         {
             if (source is IBindable sourceBindable)

--- a/osu.Game/Skinning/LegacySongProgress.cs
+++ b/osu.Game/Skinning/LegacySongProgress.cs
@@ -11,7 +11,7 @@ using osuTK;
 
 namespace osu.Game.Skinning
 {
-    public partial class LegacySongProgress : SongProgress
+    public partial class LegacySongProgress : SongProgress, ISerialisableDrawable
     {
         private CircularProgress circularProgress = null!;
 
@@ -25,6 +25,8 @@ namespace osu.Game.Skinning
             // handle stretched cases well.
             AutoSizeAxes = Axes.Both;
         }
+
+        public bool IsAlphaAdjustable => false;
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Skinning/SerialisableDrawableExtensions.cs
+++ b/osu.Game/Skinning/SerialisableDrawableExtensions.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Skinning
             component.Scale = drawableInfo.Scale;
             component.Anchor = drawableInfo.Anchor;
             component.Origin = drawableInfo.Origin;
+            component.Alpha = drawableInfo.Alpha;
 
             if (component is ISerialisableDrawable serialisableDrawable)
             {

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Skinning
 
         public Vector2 Scale { get; set; } = Vector2.One;
 
+        public float Alpha { get; set; } = 1f;
+
         public float? Width { get; set; }
 
         public float? Height { get; set; }
@@ -66,6 +68,7 @@ namespace osu.Game.Skinning
             Position = component.Position;
             Rotation = component.Rotation;
             Scale = component.Scale;
+            Alpha = component.Alpha;
 
             if ((component as CompositeDrawable)?.AutoSizeAxes.HasFlag(Axes.X) != true)
                 Width = component.Width;


### PR DESCRIPTION
It was allowed in #22475, but not implemented yet.

---
## Preview
https://github.com/user-attachments/assets/460dce8e-9a0a-4243-800c-3e7c2feabe62

- [x] Can adjust alpha
- [x] Can save it
- [x]  Works for all skin HUD components

## Issues

### Composite drawables
> Of note though, some components will not look good with alpha applied (unless buffered) due to alpha being applied individually to each layer.

Some components looks bad with low alpha value. At this moment fixed only `BarHitErrorMeter` just using `BufferedContainer` for some static inner layers, but i have no idea how to fix other, because it's create problems with colors and updating.

##### Argon score counters
<img width="1087" height="308" alt="All Argon Counters" src="https://github.com/user-attachments/assets/edde3af9-492a-4a08-8003-c7f815a9ac0f" />

##### Some other composite drawables
<img width="508" height="525" alt="AimHitErrorMeter" src="https://github.com/user-attachments/assets/a155cb1d-a7db-43d8-a2d7-d3b63af49fb8" />

If acceptable it can be be left as is.

### `SongProgress` animations
They related with the `Alpha` changing, and adjusting value of this doesn't work after reload. (Also alpha setting value on sidebar have broken initialization with `SongProgress` objects) 

[SongProgress.cs](https://github.com/ppy/osu/blob/master/osu.Game/Screens/Play/HUD/SongProgress.cs#L95)
```csharp
        protected override void PopIn() => this.FadeIn(500, Easing.OutQuint);

        protected override void PopOut() => this.FadeOut(100);
```
I'm not sure i can just delete them. So i want to know what to do about it, because it's objective problem.

----

_First PR. I read contributing guidelines but can't run `CodeInspect.sh` (i cannot install dotnet 6.0 in my OS for `CodeFileSanity`, and in some reason it's all can't get assembly references)... but i hope i didn't break anything really important, because tests in visual browser and game itself works fine._