### PR TITLE
Preserve pre-post notification completion target

### DIFF
--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Overlays
             notification.Closed += () => notificationClosed(notification);
 
             if (notification is IHasCompletionTarget hasCompletionTarget)
-                hasCompletionTarget.CompletionTarget = Post;
+                hasCompletionTarget.CompletionTarget ??= Post;
 
             playDebouncedSample(notification.PopInSampleName);
 


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/34815

I ran into this twice in recent time, when chaining notifications. If the completion target is set before the `Post()` scheduled delegate runs, it will override the completion target.