### PR TITLE
Fix potential loss of room events during join

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -172,6 +172,8 @@ namespace osu.Game.Online.Multiplayer
 
         protected Room? APIRoom { get; private set; }
 
+        private readonly Queue<Action> pendingRequests = new Queue<Action>();
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -266,6 +268,9 @@ namespace osu.Game.Online.Multiplayer
 
                 updateLocalRoomSettings(joinedRoom.Settings);
 
+                while (pendingRequests.TryDequeue(out Action? action))
+                    action();
+
                 postServerShuttingDownNotification();
 
                 OnRoomJoined();
@@ -300,10 +305,23 @@ namespace osu.Game.Online.Multiplayer
                 RoomUpdated?.Invoke();
             });
 
-            return joinOrLeaveTaskChain.Add(async () =>
+            return Task.Run(async () =>
             {
-                await scheduledReset.ConfigureAwait(false);
-                await LeaveRoomInternal().ConfigureAwait(false);
+                try
+                {
+                    await joinOrLeaveTaskChain.Add(async () =>
+                    {
+                        await scheduledReset.ConfigureAwait(false);
+                        await LeaveRoomInternal().ConfigureAwait(false);
+                    });
+                }
+                finally
+                {
+                    await runOnUpdateThreadAsync(() =>
+                    {
+                        pendingRequests.Clear();
+                    });
+                }
             });
         }
 
@@ -449,11 +467,9 @@ namespace osu.Game.Online.Multiplayer
 
         Task IMultiplayerClient.RoomStateChanged(MultiplayerRoomState state)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 Debug.Assert(APIRoom != null);
 
                 Room.State = state;
@@ -476,7 +492,7 @@ namespace osu.Game.Online.Multiplayer
                 }
 
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
@@ -485,10 +501,9 @@ namespace osu.Game.Online.Multiplayer
         {
             await PopulateUsers([user]).ConfigureAwait(false);
 
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
+                Debug.Assert(Room != null);
 
                 // for sanity, ensure that there can be no duplicate users in the room user list.
                 if (Room.Users.Any(existing => existing.UserID == user.UserID))
@@ -500,18 +515,18 @@ namespace osu.Game.Online.Multiplayer
 
                 UserJoined?.Invoke(user);
                 RoomUpdated?.Invoke();
-            }, false);
+            });
         }
 
         Task IMultiplayerClient.UserLeft(MultiplayerRoomUser user)
         {
-            Scheduler.Add(() => handleUserLeft(user, UserLeft), false);
+            handleRoomRequest(() => handleUserLeft(user, UserLeft));
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.UserKicked(MultiplayerRoomUser user)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
                 if (LocalUser == null)
                     return;
@@ -520,7 +535,7 @@ namespace osu.Game.Online.Multiplayer
                     LeaveRoom();
 
                 handleUserLeft(user, UserKicked);
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
@@ -528,9 +543,7 @@ namespace osu.Game.Online.Multiplayer
         private void handleUserLeft(MultiplayerRoomUser user, Action<MultiplayerRoomUser>? callback)
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
-
-            if (Room == null)
-                return;
+            Debug.Assert(Room != null);
 
             Room.Users.Remove(user);
             PlayingUserIds.Remove(user.UserID);
@@ -587,11 +600,9 @@ namespace osu.Game.Online.Multiplayer
 
         Task IMultiplayerClient.HostChanged(int userId)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 Debug.Assert(APIRoom != null);
 
                 var user = Room.Users.FirstOrDefault(u => u.UserID == userId);
@@ -601,22 +612,24 @@ namespace osu.Game.Online.Multiplayer
 
                 HostChanged?.Invoke(user);
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.SettingsChanged(MultiplayerRoomSettings newSettings)
         {
-            Scheduler.Add(() => updateLocalRoomSettings(newSettings));
+            handleRoomRequest(() => updateLocalRoomSettings(newSettings));
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
+                Debug.Assert(Room != null);
+
+                var user = Room.Users.SingleOrDefault(u => u.UserID == userId);
 
                 // TODO: user should NEVER be null here, see https://github.com/ppy/osu/issues/17713.
                 if (user == null)
@@ -626,16 +639,18 @@ namespace osu.Game.Online.Multiplayer
                 updateUserPlayingState(userId, state);
 
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.MatchUserStateChanged(int userId, MatchUserState state)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
+                Debug.Assert(Room != null);
+
+                var user = Room.Users.SingleOrDefault(u => u.UserID == userId);
 
                 // TODO: user should NEVER be null here, see https://github.com/ppy/osu/issues/17713.
                 if (user == null)
@@ -643,31 +658,29 @@ namespace osu.Game.Online.Multiplayer
 
                 user.MatchState = state;
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.MatchRoomStateChanged(MatchRoomState state)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
+                Debug.Assert(Room != null);
 
                 Room.MatchState = state;
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         public Task MatchEvent(MatchServerEvent e)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
+                Debug.Assert(Room != null);
 
                 switch (e)
                 {
@@ -691,7 +704,7 @@ namespace osu.Game.Online.Multiplayer
                 }
 
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
@@ -708,9 +721,11 @@ namespace osu.Game.Online.Multiplayer
 
         Task IMultiplayerClient.UserBeatmapAvailabilityChanged(int userId, BeatmapAvailability beatmapAvailability)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
+                Debug.Assert(Room != null);
+
+                var user = Room.Users.SingleOrDefault(u => u.UserID == userId);
 
                 // errors here are not critical - beatmap availability state is mostly for display.
                 if (user == null)
@@ -719,16 +734,18 @@ namespace osu.Game.Online.Multiplayer
                 user.BeatmapAvailability = beatmapAvailability;
 
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.UserStyleChanged(int userId, int? beatmapId, int? rulesetId)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
+                Debug.Assert(Room != null);
+
+                var user = Room.Users.SingleOrDefault(u => u.UserID == userId);
 
                 // errors here are not critical - user style is mostly for display.
                 if (user == null)
@@ -739,16 +756,18 @@ namespace osu.Game.Online.Multiplayer
 
                 UserStyleChanged?.Invoke(user);
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.UserModsChanged(int userId, IEnumerable<APIMod> mods)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
+                Debug.Assert(Room != null);
+
+                var user = Room.Users.SingleOrDefault(u => u.UserID == userId);
 
                 // errors here are not critical - user mods are mostly for display.
                 if (user == null)
@@ -758,70 +777,60 @@ namespace osu.Game.Online.Multiplayer
 
                 UserModsChanged?.Invoke(user);
                 RoomUpdated?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.LoadRequested()
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 LoadRequested?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.GameplayAborted(GameplayAbortReason reason)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 GameplayAborted?.Invoke(reason);
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.GameplayStarted()
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 GameplayStarted?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         Task IMultiplayerClient.ResultsReady()
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 ResultsReady?.Invoke();
-            }, false);
+            });
 
             return Task.CompletedTask;
         }
 
         public Task PlaylistItemAdded(MultiplayerPlaylistItem item)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 Debug.Assert(APIRoom != null);
 
                 Room.Playlist.Add(item);
@@ -836,11 +845,9 @@ namespace osu.Game.Online.Multiplayer
 
         public Task PlaylistItemRemoved(long playlistItemId)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 Debug.Assert(APIRoom != null);
 
                 Room.Playlist.Remove(Room.Playlist.Single(existing => existing.ID == playlistItemId));
@@ -857,11 +864,9 @@ namespace osu.Game.Online.Multiplayer
 
         public Task PlaylistItemChanged(MultiplayerPlaylistItem item)
         {
-            Scheduler.Add(() =>
+            handleRoomRequest(() =>
             {
-                if (Room == null)
-                    return;
-
+                Debug.Assert(Room != null);
                 Debug.Assert(APIRoom != null);
 
                 Room.Playlist[Room.Playlist.IndexOf(Room.Playlist.Single(existing => existing.ID == item.ID))] = item;
@@ -908,9 +913,7 @@ namespace osu.Game.Online.Multiplayer
         /// <param name="settings">The new <see cref="MultiplayerRoomSettings"/> to update from.</param>
         private void updateLocalRoomSettings(MultiplayerRoomSettings settings)
         {
-            if (Room == null)
-                return;
-
+            Debug.Assert(Room != null);
             Debug.Assert(APIRoom != null);
 
             // Update a few properties of the room instantaneously.
@@ -970,6 +973,20 @@ namespace osu.Game.Online.Multiplayer
             });
 
             return tcs.Task;
+        }
+
+        private void handleRoomRequest(Action request)
+        {
+            Scheduler.Add(() =>
+            {
+                if (Room == null)
+                {
+                    pendingRequests.Enqueue(request);
+                    return;
+                }
+
+                request();
+            });
         }
 
         Task IStatefulUserHubClient.DisconnectRequested()

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -313,14 +313,14 @@ namespace osu.Game.Online.Multiplayer
                     {
                         await scheduledReset.ConfigureAwait(false);
                         await LeaveRoomInternal().ConfigureAwait(false);
-                    });
+                    }).ConfigureAwait(false);
                 }
                 finally
                 {
                     await runOnUpdateThreadAsync(() =>
                     {
                         pendingRequests.Clear();
-                    });
+                    }).ConfigureAwait(false);
                 }
             });
         }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -202,6 +202,7 @@ namespace osu.Game.Online.Multiplayer
 
             await joinOrLeaveTaskChain.Add(async () =>
             {
+                await runOnUpdateThreadAsync(() => pendingRequests.Clear(), cancellationSource.Token).ConfigureAwait(false);
                 var multiplayerRoom = await CreateRoomInternal(new MultiplayerRoom(room)).ConfigureAwait(false);
                 await setupJoinedRoom(room, multiplayerRoom, cancellationSource.Token).ConfigureAwait(false);
             }, cancellationSource.Token).ConfigureAwait(false);
@@ -225,6 +226,7 @@ namespace osu.Game.Online.Multiplayer
 
             await joinOrLeaveTaskChain.Add(async () =>
             {
+                await runOnUpdateThreadAsync(() => pendingRequests.Clear(), cancellationSource.Token).ConfigureAwait(false);
                 var multiplayerRoom = await JoinRoomInternal(room.RoomID.Value, password ?? room.Password).ConfigureAwait(false);
                 await setupJoinedRoom(room, multiplayerRoom, cancellationSource.Token).ConfigureAwait(false);
             }, cancellationSource.Token).ConfigureAwait(false);


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/34815

As I mentioned internally, during `JoinRoom` there's a small window where events could be coming in and fail the `Room != null` check because we're busy doing a few more operations, such as looking up online users.

This turns out to be more of a problem with matchmaking because all users are joined to the room simultaneously, but it can also happen in a standard multiplayer match and lead a desynchronised state.

The change here can only be classified as a hacky workaround. We'll need to do this better in the future, likely by reworking the room join process in the first place.