### PR TITLE
Update difficulty calculation tests for osu ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -15,22 +15,22 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Osu.Tests";
 
-        [TestCase(6.7331304290522747d, 239, "diffcalc-test")]
-        [TestCase(1.4595591215544095d, 54, "zero-length-sliders")]
-        [TestCase(0.4339253366122357d, 4, "very-fast-slider")]
-        [TestCase(0.14143808967817237d, 2, "nan-slider")]
+        [TestCase(6.6232533278125061d, 239, "diffcalc-test")]
+        [TestCase(1.5045783545699611d, 54, "zero-length-sliders")]
+        [TestCase(0.43333836671191595d, 4, "very-fast-slider")]
+        [TestCase(0.13841532030395723d, 2, "nan-slider")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(9.6779397290273756d, 239, "diffcalc-test")]
-        [TestCase(1.7680515258663754d, 54, "zero-length-sliders")]
-        [TestCase(0.56174427678665129d, 4, "very-fast-slider")]
+        [TestCase(9.6491691624112761d, 239, "diffcalc-test")]
+        [TestCase(1.756936832498702d, 54, "zero-length-sliders")]
+        [TestCase(0.57771197086735004d, 4, "very-fast-slider")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModDoubleTime());
 
-        [TestCase(6.7331304290522747d, 239, "diffcalc-test")]
-        [TestCase(1.4595591215544095d, 54, "zero-length-sliders")]
-        [TestCase(0.4339253366122357d, 4, "very-fast-slider")]
+        [TestCase(6.6232533278125061d, 239, "diffcalc-test")]
+        [TestCase(1.5045783545699611d, 54, "zero-length-sliders")]
+        [TestCase(0.43333836671191595d, 4, "very-fast-slider")]
         public void TestClassicMod(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModClassic());
 


### PR DESCRIPTION
We're done making changes now so best time to update the tests ready for PR.

Will follow up with taiko once they're also done making changes.

catch & mania require no changes as they don't have any difficulty changes.