### PR TITLE
Prevent Taiko difficulty crash if a map only contains 0-strains

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Rhythm/Data/SameRhythmHitObjectGrouping.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Rhythm/Data/SameRhythmHitObjectGrouping.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm.Data
 
         public readonly SameRhythmHitObjectGrouping? Previous;
 
-        private static readonly double snap_tolerance = IntervalGroupingUtils.MarginOfError;
+        private const double snap_tolerance = IntervalGroupingUtils.MARGIN_OF_ERROR;
 
         /// <summary>
         /// <see cref="DifficultyHitObject.StartTime"/> of the first hit object.

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -168,6 +168,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 stamina.GetCurrentStrainPeaks().ToList()
             );
 
+            if (peaks.Count == 0)
+            {
+                consistencyFactor = 0;
+                return 0;
+            }
+
             double difficulty = 0;
             double weight = 1;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -190,6 +190,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 stamina.GetObjectStrains().ToList()
             );
 
+            if (hitObjectStrainPeaks.Count == 0)
+            {
+                consistencyFactor = 0;
+                return 0;
+            }
+
             // The average of the top 5% of strain peaks from hit objects.
             double topAverageHitObjectStrain = hitObjectStrainPeaks.OrderDescending().Take(1 + hitObjectStrainPeaks.Count / 20).Average();
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes, bool isConvert, bool isClassic)
         {
-            if (estimatedUnstableRate == null)
+            if (estimatedUnstableRate == null || totalDifficultHits == 0)
                 return 0;
 
             // The estimated unstable rate for 100% accuracy, at which all rhythm difficulty has been played successfully.

--- a/osu.Game.Rulesets.Taiko/Difficulty/Utils/IntervalGroupingUtils.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Utils/IntervalGroupingUtils.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Utils
     public static class IntervalGroupingUtils
     {
         // The margin of error when comparing intervals for grouping, or snapping intervals to a common value.
-        public static double MarginOfError = 5.0;
+        public const double MARGIN_OF_ERROR = 5.0;
 
         public static List<List<T>> GroupByInterval<T>(IReadOnlyList<T> objects) where T : IHasInterval
         {
@@ -31,11 +31,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Utils
 
             for (; i < objects.Count - 1; i++)
             {
-                if (!Precision.AlmostEquals(objects[i].Interval, objects[i + 1].Interval, MarginOfError))
+                if (!Precision.AlmostEquals(objects[i].Interval, objects[i + 1].Interval, MARGIN_OF_ERROR))
                 {
                     // When an interval change occurs, include the object with the differing interval in the case it increased
                     // See https://github.com/ppy/osu/pull/31636#discussion_r1942368372 for rationale.
-                    if (objects[i + 1].Interval > objects[i].Interval + MarginOfError)
+                    if (objects[i + 1].Interval > objects[i].Interval + MARGIN_OF_ERROR)
                     {
                         groupedObjects.Add(objects[i]);
                         i++;
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Utils
 
             // Check if the last two objects in the object form a "flat" rhythm pattern within the specified margin of error.
             // If true, add the current object to the group and increment the index to process the next object.
-            if (objects.Count > 2 && i < objects.Count && Precision.AlmostEquals(objects[^1].Interval, objects[^2].Interval, MarginOfError))
+            if (objects.Count > 2 && i < objects.Count && Precision.AlmostEquals(objects[^1].Interval, objects[^2].Interval, MARGIN_OF_ERROR))
             {
                 groupedObjects.Add(objects[i]);
                 i++;


### PR DESCRIPTION
Noticed this exception when checking CI test runs on another PR. Any map that either has no strains, or only strains with 0 difficulty die because of an `.Average` LINQ call that expects elements.

Easiest fix is to return all 0s instantly.