### PR TITLE
Fix hitobject drawables becoming visible 1 frame too late

### DIFF
--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -160,8 +160,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
             if (!IsPresent)
                 return false;
 
-            bool aliveChanged = base.CheckChildrenLife();
-            aliveChanged |= lifetimeManager.Update(Time.Current - PastLifetimeExtension, Time.Current + FutureLifetimeExtension);
+            bool aliveChanged = lifetimeManager.Update(Time.Current - PastLifetimeExtension, Time.Current + FutureLifetimeExtension);
+            aliveChanged |= base.CheckChildrenLife();
             return aliveChanged;
         }
     }


### PR DESCRIPTION
Trying to find the cause of this has been haunting me for well over a year now but I finally figured it out: Turns out `PooledDrawableWithLifetimeContainer.CheckChildrenLife()` is doing things in the wrong order.

Currently, the container first updates its children's alive-status and then updates the lifetime manager, which will add all drawables that should become visible on the current frame. The alive-status of the newly added drawables remains unchanged however and they have to wait until the next update loop for the container to re-run step 1 to become visible.

By reversing the order of those 2 operations the new drawables will get made alive immediately, and will appear on the same frame.

In practice this has very little impact. It's only really noticeable in the editor, and even there a bunch of conditions need to be met to actually notice it:
- two overlapping hitobjects need to be removed and inserted on the same frame. The overlap is needed so the flicker is actually noticeable 
- if the game runs it's update loop faster than v-sync there's a decent chance the frame this is happening on will be skipped

That being said, those conditions can be met reliably by converting a slider to a stream with the game running in single-threaded mode and with v-sync enabled. I'm also pretty sure it's what caused the flickering in the polygon tool prior to #30214 (see video on the pr).

While the impact is negligible I do think that the current implementation is incorrect and this is worth fixing.

### Before

https://github.com/user-attachments/assets/28e44940-0181-412d-ba61-764141740cc7

### After

https://github.com/user-attachments/assets/0766da2d-6740-4a5d-a926-7f5db52905d4

