### PR TITLE
Fix song select not performing online lookup on re-enter

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -653,6 +653,7 @@ namespace osu.Game.Screens.SelectV2
 
             ensurePlayingSelected();
             updateBackgroundDim();
+            fetchOnlineInfo();
         }
 
         private void onLeavingScreen()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34825.

Root cause is

https://github.com/ppy/osu/blob/24ec43b3b65fa3b164b7713341cd62b1e0dacc2e/osu.Game/Screens/SelectV2/SongSelect.cs#L345-L356

not specifying `(..., true)`, therefore the fetch doesn't happen on enter if song select doesn't change the global beatmap as a side effect of the enter, which is the case on re-entering.