### PR TITLE
Allow beatmaps to show up multiple times in the carousel if grouping criteria requires it

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -325,7 +325,7 @@ namespace osu.Game.Tests.Visual.Background
         private void setupUserSettings()
         {
             AddUntilStep("Song select is current", () => songSelect.IsCurrentScreen());
-            AddUntilStep("Song select has selection", () => songSelect.Carousel?.CurrentSelection != null);
+            AddUntilStep("Song select has selection", () => songSelect.Carousel?.CurrentGroupedBeatmap != null);
             AddStep("Set default user settings", () =>
             {
                 SelectedMods.Value = new[] { new OsuModNoFail() };

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             var results = await runGrouping(GroupMode.None, beatmapSets);
             Assert.That(results.Select(r => r.Model).OfType<GroupedBeatmapSet>().Select(groupedSet => groupedSet.BeatmapSet), Is.EquivalentTo(beatmapSets));
-            Assert.That(results.Select(r => r.Model).OfType<BeatmapInfo>(), Is.EquivalentTo(allBeatmaps));
+            Assert.That(results.Select(r => r.Model).OfType<GroupedBeatmap>().Select(groupedBeatmap => groupedBeatmap.Beatmap), Is.EquivalentTo(allBeatmaps));
             assertTotal(results, beatmapSets.Count + allBeatmaps.Length);
         }
 
@@ -391,7 +391,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             var groupModel = (GroupDefinition)groupItem.Model;
 
             Assert.That(groupModel.Title, Is.EqualTo(expectedTitle));
-            Assert.That(itemsInGroup.Select(i => i.Model).OfType<BeatmapInfo>(), Is.EquivalentTo(expectedBeatmaps));
+            Assert.That(itemsInGroup.Select(i => i.Model).OfType<GroupedBeatmap>().Select(gb => gb.Beatmap), Is.EquivalentTo(expectedBeatmaps));
 
             totalItems += itemsInGroup.Count() + 1;
         }

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -283,8 +283,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 // offset by one because the group itself is included in the items list.
                 CarouselItem item = groupingFilter.GroupItems[groupDefinition].ElementAt(panel + 1);
 
-                return (Carousel.CurrentSelection as BeatmapInfo)?
-                    .Equals(item.Model as BeatmapInfo) == true;
+                return (Carousel.CurrentSelection as GroupedBeatmap)?
+                    .Equals(item.Model as GroupedBeatmap) == true;
             });
         }
 
@@ -293,7 +293,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             if (diff != null)
             {
                 AddUntilStep($"selected is set{set} diff{diff.Value}",
-                    () => (Carousel.CurrentSelection as BeatmapInfo),
+                    () => (Carousel.CurrentSelection as GroupedBeatmap)?.Beatmap,
                     () => Is.EqualTo(BeatmapSets[set].Beatmaps[diff.Value]));
             }
             else
@@ -466,7 +466,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 if (FilterDelay != 0)
                     await Task.Delay(FilterDelay).ConfigureAwait(true);
 
-                PostFilterBeatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
+                PostFilterBeatmaps = items.Select(i => i.Model).OfType<GroupedBeatmap>().Select(i => i.Beatmap);
                 return items;
             }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -117,13 +117,15 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                     NewItemsPresented = _ => NewItemsPresentedInvocationCount++,
                                     RequestSelection = b =>
                                     {
-                                        BeatmapRequestedSelections.Push(b);
+                                        BeatmapRequestedSelections.Push(b.Beatmap);
                                         Carousel.CurrentSelection = b;
                                     },
-                                    RequestRecommendedSelection = beatmaps =>
+                                    RequestRecommendedSelection = groupedBeatmaps =>
                                     {
-                                        BeatmapSetRequestedSelections.Push(beatmaps.First().BeatmapSet!);
-                                        Carousel.CurrentSelection = BeatmapRecommendationFunction?.Invoke(beatmaps) ?? beatmaps.First();
+                                        var recommendedBeatmap = BeatmapRecommendationFunction?.Invoke(groupedBeatmaps.Select(gb => gb.Beatmap)) ?? groupedBeatmaps.First().Beatmap;
+                                        var recommendedGroupedBeatmap = groupedBeatmaps.First(gb => gb.Beatmap.Equals(recommendedBeatmap));
+                                        BeatmapSetRequestedSelections.Push(recommendedBeatmap.BeatmapSet!);
+                                        Carousel.CurrentSelection = recommendedGroupedBeatmap;
                                     },
                                     BleedTop = 50,
                                     BleedBottom = 50,
@@ -439,7 +441,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             public IEnumerable<BeatmapInfo> PostFilterBeatmaps = null!;
 
-            public BeatmapInfo? SelectedBeatmapInfo => CurrentSelection as BeatmapInfo;
+            public BeatmapInfo? SelectedBeatmapInfo => (CurrentSelection as GroupedBeatmap)?.Beatmap;
             public BeatmapSetInfo? SelectedBeatmapSet => SelectedBeatmapInfo?.BeatmapSet;
 
             public new GroupedBeatmapSet? ExpandedBeatmapSet => base.ExpandedBeatmapSet;

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -118,14 +118,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                     RequestSelection = b =>
                                     {
                                         BeatmapRequestedSelections.Push(b.Beatmap);
-                                        Carousel.CurrentSelection = b;
+                                        Carousel.CurrentGroupedBeatmap = b;
                                     },
                                     RequestRecommendedSelection = groupedBeatmaps =>
                                     {
                                         var recommendedBeatmap = BeatmapRecommendationFunction?.Invoke(groupedBeatmaps.Select(gb => gb.Beatmap)) ?? groupedBeatmaps.First().Beatmap;
                                         var recommendedGroupedBeatmap = groupedBeatmaps.First(gb => gb.Beatmap.Equals(recommendedBeatmap));
                                         BeatmapSetRequestedSelections.Push(recommendedBeatmap.BeatmapSet!);
-                                        Carousel.CurrentSelection = recommendedGroupedBeatmap;
+                                        Carousel.CurrentGroupedBeatmap = recommendedGroupedBeatmap;
                                     },
                                     BleedTop = 50,
                                     BleedBottom = 50,
@@ -219,8 +219,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         protected void Select() => AddStep("select", () => InputManager.Key(Key.Enter));
 
-        protected void CheckNoSelection() => AddAssert("has no selection", () => Carousel.CurrentSelection, () => Is.Null);
-        protected void CheckHasSelection() => AddAssert("has selection", () => Carousel.CurrentSelection, () => Is.Not.Null);
+        protected void CheckNoSelection() => AddAssert("has no selection", () => Carousel.CurrentGroupedBeatmap, () => Is.Null);
+        protected void CheckHasSelection() => AddAssert("has selection", () => Carousel.CurrentGroupedBeatmap, () => Is.Not.Null);
 
         protected void CheckRequestPresentCount(int expected) =>
             AddAssert($"check present count is {expected}", () => Carousel.RequestPresentBeatmapCount, () => Is.EqualTo(expected));
@@ -285,8 +285,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 // offset by one because the group itself is included in the items list.
                 CarouselItem item = groupingFilter.GroupItems[groupDefinition].ElementAt(panel + 1);
 
-                return (Carousel.CurrentSelection as GroupedBeatmap)?
-                    .Equals(item.Model as GroupedBeatmap) == true;
+                return Carousel.CurrentGroupedBeatmap?.Equals(item.Model as GroupedBeatmap) == true;
             });
         }
 
@@ -295,12 +294,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             if (diff != null)
             {
                 AddUntilStep($"selected is set{set} diff{diff.Value}",
-                    () => (Carousel.CurrentSelection as GroupedBeatmap)?.Beatmap,
+                    () => Carousel.CurrentBeatmap,
                     () => Is.EqualTo(BeatmapSets[set].Beatmaps[diff.Value]));
             }
             else
             {
-                AddUntilStep($"selected is set{set}", () => BeatmapSets[set].Beatmaps.Contains(((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap));
+                AddUntilStep($"selected is set{set}", () => BeatmapSets[set].Beatmaps.Contains(Carousel.CurrentBeatmap!));
             }
         }
 
@@ -419,7 +418,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                 tracked: {Carousel.ItemsTracked}
                                 displayable: {Carousel.DisplayableItems}
                                 displayed: {Carousel.VisibleItems}
-                                selected: {Carousel.CurrentSelection}
+                                selected: {Carousel.CurrentGroupedBeatmap}
                                 """);
 
             void createHeader(string text)

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -300,7 +300,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             }
             else
             {
-                AddUntilStep($"selected is set{set}", () => BeatmapSets[set].Beatmaps.Contains(Carousel.CurrentSelection));
+                AddUntilStep($"selected is set{set}", () => BeatmapSets[set].Beatmaps.Contains(((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap));
             }
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -16,11 +16,13 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Collections;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
+using osu.Game.Scoring;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
@@ -443,6 +445,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             public new GroupedBeatmapSet? ExpandedBeatmapSet => base.ExpandedBeatmapSet;
             public new GroupDefinition? ExpandedGroup => base.ExpandedGroup;
 
+            public Func<List<BeatmapCollection>> AllCollections { get; set; } = () => [];
+            public Func<FilterCriteria, Dictionary<Guid, ScoreRank>> BeatmapInfoGuidToTopRankMapping { get; set; } = _ => new Dictionary<Guid, ScoreRank>();
+
             public TestBeatmapCarousel()
             {
                 RequestPresentBeatmap = _ => RequestPresentBeatmapCount++;
@@ -464,6 +469,9 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 PostFilterBeatmaps = items.Select(i => i.Model).OfType<BeatmapInfo>();
                 return items;
             }
+
+            protected override List<BeatmapCollection> GetAllCollections() => AllCollections.Invoke();
+            protected override Dictionary<Guid, ScoreRank> GetBeatmapInfoGuidToTopRankMapping(FilterCriteria criteria) => BeatmapInfoGuidToTopRankMapping.Invoke(criteria);
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
@@ -92,7 +91,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckHasSelection();
             AddAssert("no drawable selection", GetSelectedPanel, () => Is.Null);
 
-            AddStep("add previous selection", () => BeatmapSets.Add(((BeatmapInfo)selection!).BeatmapSet!));
+            AddStep("add previous selection", () => BeatmapSets.Add(((GroupedBeatmap)selection!).Beatmap.BeatmapSet!));
 
             AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
             AddUntilStep("drawable selection restored", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));
@@ -132,7 +131,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForBeatmapSelection(0, 1);
             // Expanding a group will move keyboard selection to the selected beatmap if contained.
             AddAssert("keyboard selected panel is expanded", () => groupPanel?.Expanded.Value, () => Is.True);
-            AddAssert("keyboard selected panel is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, Is.TypeOf<BeatmapInfo>);
+            AddAssert("keyboard selected panel is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, Is.TypeOf<GroupedBeatmap>);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckHasSelection();
             AddAssert("drawable selection non-null", () => selection, () => Is.Not.Null);
-            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentGroupedBeatmap));
 
             RemoveAllBeatmaps();
             AddUntilStep("no drawable selection", GetSelectedPanel, () => Is.Null);
@@ -93,7 +93,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("add previous selection", () => BeatmapSets.Add(((GroupedBeatmap)selection!).Beatmap.BeatmapSet!));
 
-            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentGroupedBeatmap));
             AddUntilStep("drawable selection restored", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));
             AddAssert("carousel item is visible", () => GetSelectedPanel()?.Item?.IsVisible, () => Is.True);
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselCollectionGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselCollectionGrouping.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Collections;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    [TestFixture]
+    public partial class TestSceneBeatmapCarouselCollectionGrouping : BeatmapCarouselTestScene
+    {
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            RemoveAllBeatmaps();
+            CreateCarousel();
+
+            AddBeatmaps(10, 3);
+
+            AddStep("set up collections", () =>
+            {
+                List<BeatmapCollection> collections =
+                [
+                    new BeatmapCollection("collection one", [
+                        ..BeatmapSets[0].Beatmaps.Select(b => b.MD5Hash),
+                        ..BeatmapSets[1].Beatmaps.Select(b => b.MD5Hash),
+                        ..BeatmapSets[2].Beatmaps.Select(b => b.MD5Hash),
+                        BeatmapSets[5].Beatmaps[1].MD5Hash,
+                        BeatmapSets[8].Beatmaps[0].MD5Hash,
+                    ]),
+                    new BeatmapCollection("collection two", [
+                        BeatmapSets[0].Beatmaps[0].MD5Hash,
+                        ..BeatmapSets[1].Beatmaps.Select(b => b.MD5Hash),
+                        ..BeatmapSets[2].Beatmaps.Select(b => b.MD5Hash),
+                        BeatmapSets[6].Beatmaps[2].MD5Hash,
+                        BeatmapSets[8].Beatmaps[2].MD5Hash,
+                    ]),
+                    new BeatmapCollection("collection one copy", [
+                        ..BeatmapSets[0].Beatmaps.Select(b => b.MD5Hash),
+                        ..BeatmapSets[1].Beatmaps.Select(b => b.MD5Hash),
+                        ..BeatmapSets[2].Beatmaps.Select(b => b.MD5Hash),
+                        BeatmapSets[5].Beatmaps[1].MD5Hash,
+                        BeatmapSets[8].Beatmaps[0].MD5Hash,
+                    ]),
+                ];
+                Carousel.AllCollections = () => collections;
+            });
+
+            SortAndGroupBy(SortMode.Title, GroupMode.Collections);
+            WaitForDrawablePanels();
+        }
+
+        [Test]
+        public void TestMultipleCopiesOfBeatmapsPresent()
+        {
+            CheckDisplayedGroupsCount(4); // one for each collection, plus no collections
+            // all three collections have beatmaps from 5 beatmap sets
+            // 7 beatmap sets have beatmaps which belong to no collection
+            CheckDisplayedBeatmapSetsCount(5 + 5 + 5 + 7);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
@@ -82,7 +81,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckHasSelection();
             AddAssert("no drawable selection", GetSelectedPanel, () => Is.Null);
 
-            AddStep("add previous selection", () => BeatmapSets.Add(((BeatmapInfo)selection!).BeatmapSet!));
+            AddStep("add previous selection", () => BeatmapSets.Add(((GroupedBeatmap)selection!).Beatmap.BeatmapSet!));
 
             AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
             AddUntilStep("drawable selection restored", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));
@@ -121,7 +120,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             WaitForBeatmapSelection(0, 0);
             // Expanding a group will move keyboard selection to the selected beatmap if contained.
             AddAssert("keyboard selected panel is expanded", () => groupPanel?.Expanded.Value, () => Is.True);
-            AddAssert("keyboard selected panel is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, Is.TypeOf<BeatmapInfo>);
+            AddAssert("keyboard selected panel is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, Is.TypeOf<GroupedBeatmap>);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselDifficultyGrouping.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckHasSelection();
             AddAssert("drawable selection non-null", () => selection, () => Is.Not.Null);
-            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentGroupedBeatmap));
 
             RemoveAllBeatmaps();
             AddUntilStep("no drawable selection", GetSelectedPanel, () => Is.Null);
@@ -83,7 +83,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("add previous selection", () => BeatmapSets.Add(((GroupedBeatmap)selection!).Beatmap.BeatmapSet!));
 
-            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentGroupedBeatmap));
             AddUntilStep("drawable selection restored", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));
             AddAssert("carousel item is visible", () => GetSelectedPanel()?.Item?.IsVisible, () => Is.True);
 
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         private void checkBeatmapIsKeyboardSelected() =>
-            AddUntilStep("check keyboard selected group is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddUntilStep("check keyboard selected group is beatmap", () => GetKeyboardSelectedPanel()?.Item?.Model, () => Is.EqualTo(Carousel.CurrentGroupedBeatmap));
 
         private void checkGroupKeyboardSelected(int index) => AddUntilStep($"check keyboard selected group is {index}", () => GetKeyboardSelectedPanel()?.Item?.Model, () =>
         {

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -130,14 +130,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextPanel();
             Select();
 
-            AddStep("record selection", () => selectedID = ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID);
+            AddStep("record selection", () => selectedID = Carousel.CurrentBeatmap!.ID);
 
             for (int i = 0; i < 5; i++)
             {
                 ApplyToFilterAndWaitForFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
-                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
+                AddAssert("selection not changed", () => Carousel.CurrentBeatmap!.ID == selectedID);
                 ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
-                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
+                AddAssert("selection not changed", () => Carousel.CurrentBeatmap!.ID == selectedID);
             }
         }
 
@@ -177,14 +177,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             SelectNextSet();
 
-            AddStep("record selection", () => selectedID = ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID);
+            AddStep("record selection", () => selectedID = Carousel.CurrentBeatmap!.ID);
 
             for (int i = 0; i < 5; i++)
             {
                 ApplyToFilterAndWaitForFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
-                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
+                AddAssert("selection not changed", () => Carousel.CurrentBeatmap!.ID == selectedID);
                 ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
-                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
+                AddAssert("selection not changed", () => Carousel.CurrentBeatmap!.ID == selectedID);
             }
         }
 
@@ -200,14 +200,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             {
                 int diff = i;
 
-                AddStep($"select diff {diff}", () => Carousel.CurrentSelection = chosenBeatmap = BeatmapSets[20].Beatmaps[diff]);
-                AddUntilStep("selection changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(chosenBeatmap));
+                AddStep($"select diff {diff}", () => Carousel.CurrentBeatmap = chosenBeatmap = BeatmapSets[20].Beatmaps[diff]);
+                AddUntilStep("selection changed", () => Carousel.CurrentBeatmap, () => Is.EqualTo(chosenBeatmap));
 
                 SortBy(SortMode.Difficulty);
-                AddAssert("selection retained", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(chosenBeatmap));
+                AddAssert("selection retained", () => Carousel.CurrentBeatmap, () => Is.EqualTo(chosenBeatmap));
 
                 SortBy(SortMode.Title);
-                AddAssert("selection retained", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(chosenBeatmap));
+                AddAssert("selection retained", () => Carousel.CurrentBeatmap, () => Is.EqualTo(chosenBeatmap));
             }
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -130,14 +130,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextPanel();
             Select();
 
-            AddStep("record selection", () => selectedID = ((BeatmapInfo)Carousel.CurrentSelection!).ID);
+            AddStep("record selection", () => selectedID = ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID);
 
             for (int i = 0; i < 5; i++)
             {
                 ApplyToFilterAndWaitForFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
-                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
                 ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
-                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
             }
         }
 
@@ -177,14 +177,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             SelectNextSet();
 
-            AddStep("record selection", () => selectedID = ((BeatmapInfo)Carousel.CurrentSelection!).ID);
+            AddStep("record selection", () => selectedID = ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID);
 
             for (int i = 0; i < 5; i++)
             {
                 ApplyToFilterAndWaitForFilter("filter all", c => c.SearchText = Guid.NewGuid().ToString());
-                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
                 ApplyToFilterAndWaitForFilter("remove filter", c => c.SearchText = string.Empty);
-                AddAssert("selection not changed", () => ((BeatmapInfo)Carousel.CurrentSelection!).ID == selectedID);
+                AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap.ID == selectedID);
             }
         }
 
@@ -239,7 +239,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 var visibleBeatmapPanels = GetVisiblePanels<PanelBeatmap>();
 
                 return visibleBeatmapPanels.Count() == 1
-                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 0) == 1;
+                       && visibleBeatmapPanels.Count(p => ((GroupedBeatmap)p.Item!.Model).Beatmap.Ruleset.OnlineID == 0) == 1;
             });
 
             ApplyToFilterAndWaitForFilter("filter to taiko", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(1));
@@ -249,8 +249,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 var visibleBeatmapPanels = GetVisiblePanels<PanelBeatmap>();
 
                 return visibleBeatmapPanels.Count() == 2
-                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 0) == 1
-                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 1) == 1;
+                       && visibleBeatmapPanels.Count(p => ((GroupedBeatmap)p.Item!.Model).Beatmap.Ruleset.OnlineID == 0) == 1
+                       && visibleBeatmapPanels.Count(p => ((GroupedBeatmap)p.Item!.Model).Beatmap.Ruleset.OnlineID == 1) == 1;
             });
 
             ApplyToFilterAndWaitForFilter("filter to catch", c => c.Ruleset = rulesets.AvailableRulesets.ElementAt(2));
@@ -260,8 +260,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 var visibleBeatmapPanels = GetVisiblePanels<PanelBeatmap>();
 
                 return visibleBeatmapPanels.Count() == 2
-                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 0) == 1
-                       && visibleBeatmapPanels.Count(p => ((BeatmapInfo)p.Item!.Model).Ruleset.OnlineID == 2) == 1;
+                       && visibleBeatmapPanels.Count(p => ((GroupedBeatmap)p.Item!.Model).Beatmap.Ruleset.OnlineID == 0) == 1
+                       && visibleBeatmapPanels.Count(p => ((GroupedBeatmap)p.Item!.Model).Beatmap.Ruleset.OnlineID == 2) == 1;
             });
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -201,13 +201,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 int diff = i;
 
                 AddStep($"select diff {diff}", () => Carousel.CurrentSelection = chosenBeatmap = BeatmapSets[20].Beatmaps[diff]);
-                AddUntilStep("selection changed", () => Carousel.CurrentSelection, () => Is.EqualTo(chosenBeatmap));
+                AddUntilStep("selection changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(chosenBeatmap));
 
                 SortBy(SortMode.Difficulty);
-                AddAssert("selection retained", () => Carousel.CurrentSelection, () => Is.EqualTo(chosenBeatmap));
+                AddAssert("selection retained", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(chosenBeatmap));
 
                 SortBy(SortMode.Title);
-                AddAssert("selection retained", () => Carousel.CurrentSelection, () => Is.EqualTo(chosenBeatmap));
+                AddAssert("selection retained", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(chosenBeatmap));
             }
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckHasSelection();
             AddAssert("drawable selection non-null", () => selection, () => Is.Not.Null);
-            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddAssert("drawable selection matches carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentGroupedBeatmap));
 
             RemoveAllBeatmaps();
             AddUntilStep("no drawable selection", GetSelectedPanel, () => Is.Null);
@@ -102,7 +102,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("add previous selection", () => BeatmapSets.Add(((GroupedBeatmap)selection!).Beatmap.BeatmapSet!));
 
-            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
+            AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentGroupedBeatmap));
             AddUntilStep("drawable selection restored", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));
             AddAssert("carousel item is visible", () => GetSelectedPanel()?.Item?.IsVisible, () => Is.True);
         }
@@ -389,15 +389,15 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         private void checkSelectionIterating(bool isIterating)
         {
-            object? selection = null;
+            GroupedBeatmap? selection = null;
 
             for (int i = 0; i < 3; i++)
             {
-                AddStep("store selection", () => selection = Carousel.CurrentSelection);
+                AddStep("store selection", () => selection = Carousel.CurrentGroupedBeatmap);
                 if (isIterating)
-                    AddUntilStep("selection changed", () => Carousel.CurrentSelection != selection);
+                    AddUntilStep("selection changed", () => Carousel.CurrentGroupedBeatmap != selection);
                 else
-                    AddUntilStep("selection not changed", () => Carousel.CurrentSelection == selection);
+                    AddUntilStep("selection not changed", () => Carousel.CurrentGroupedBeatmap == selection);
             }
         }
     }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselNoGrouping.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
 using osuTK;
@@ -101,7 +100,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             CheckHasSelection();
             AddAssert("no drawable selection", GetSelectedPanel, () => Is.Null);
 
-            AddStep("add previous selection", () => BeatmapSets.Add(((BeatmapInfo)selection!).BeatmapSet!));
+            AddStep("add previous selection", () => BeatmapSets.Add(((GroupedBeatmap)selection!).Beatmap.BeatmapSet!));
 
             AddAssert("selection matches original carousel selection", () => selection, () => Is.EqualTo(Carousel.CurrentSelection));
             AddUntilStep("drawable selection restored", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(selection));

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -248,6 +248,30 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestRewindOverGroupingModeChange()
+        {
+            const int local_set_count = 3;
+
+            SortAndGroupBy(SortMode.Artist, GroupMode.Artist);
+            AddBeatmaps(local_set_count, 3);
+            WaitForDrawablePanels();
+
+            SelectNextSet();
+
+            for (int i = 0; i < local_set_count; i++)
+                nextRandom();
+
+            SortAndGroupBy(SortMode.Title, GroupMode.LastPlayed);
+            WaitForDrawablePanels();
+
+            for (int i = 0; i < local_set_count; i++)
+            {
+                prevRandomSet();
+                checkRewindCorrectSet();
+            }
+        }
+
+        [Test]
         public void TestRandomThenRewindSameFrame()
         {
             AddBeatmaps(10, 3, true);

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -50,12 +50,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             nextRandom();
             ensureRandomDidNotRepeat();
 
-            AddStep("store selection", () => originalSelected = (BeatmapInfo)Carousel.CurrentSelection!);
+            AddStep("store selection", () => originalSelected = ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap);
 
             SortAndGroupBy(SortMode.Artist, GroupMode.Difficulty);
             WaitForFiltering();
 
-            AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(originalSelected));
+            AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(originalSelected));
 
             storeExpandedGroup();
 
@@ -253,12 +253,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(10, 3, true);
             WaitForDrawablePanels();
 
-            BeatmapInfo? originalSelected = null;
+            GroupedBeatmap? originalSelected = null;
 
             nextRandom();
 
             CheckHasSelection();
-            AddStep("store selection", () => originalSelected = (BeatmapInfo)Carousel.CurrentSelection!);
+            AddStep("store selection", () => originalSelected = ((GroupedBeatmap)Carousel.CurrentSelection!));
 
             AddStep("random then rewind", () =>
             {
@@ -275,20 +275,20 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddBeatmaps(10, 3, true);
             WaitForDrawablePanels();
 
-            BeatmapInfo? originalSelected = null;
-            BeatmapInfo? postRandomSelection = null;
+            GroupedBeatmap? originalSelected = null;
+            GroupedBeatmap? postRandomSelection = null;
 
             nextRandom();
 
             CheckHasSelection();
-            AddStep("store selection", () => originalSelected = (BeatmapInfo)Carousel.CurrentSelection!);
+            AddStep("store selection", () => originalSelected = (GroupedBeatmap)Carousel.CurrentSelection!);
 
             nextRandom();
-            AddStep("store selection", () => postRandomSelection = (BeatmapInfo)Carousel.CurrentSelection!);
+            AddStep("store selection", () => postRandomSelection = (GroupedBeatmap)Carousel.CurrentSelection!);
 
             AddAssert("selection changed", () => originalSelected, () => Is.Not.SameAs(postRandomSelection));
 
-            AddStep("delete previous selection beatmaps", () => BeatmapSets.Remove(originalSelected!.BeatmapSet!));
+            AddStep("delete previous selection beatmaps", () => BeatmapSets.Remove(originalSelected!.Beatmap.BeatmapSet!));
             WaitForFiltering();
 
             AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(postRandomSelection));

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselRandom.cs
@@ -50,12 +50,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             nextRandom();
             ensureRandomDidNotRepeat();
 
-            AddStep("store selection", () => originalSelected = ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap);
+            AddStep("store selection", () => originalSelected = Carousel.CurrentBeatmap!);
 
             SortAndGroupBy(SortMode.Artist, GroupMode.Difficulty);
             WaitForFiltering();
 
-            AddAssert("selection not changed", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(originalSelected));
+            AddAssert("selection not changed", () => Carousel.CurrentBeatmap, () => Is.EqualTo(originalSelected));
 
             storeExpandedGroup();
 
@@ -282,7 +282,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             nextRandom();
 
             CheckHasSelection();
-            AddStep("store selection", () => originalSelected = ((GroupedBeatmap)Carousel.CurrentSelection!));
+            AddStep("store selection", () => originalSelected = Carousel.CurrentGroupedBeatmap!);
 
             AddStep("random then rewind", () =>
             {
@@ -290,7 +290,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 Carousel.PreviousRandom();
             });
 
-            AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(originalSelected));
+            AddAssert("selection not changed", () => Carousel.CurrentGroupedBeatmap, () => Is.EqualTo(originalSelected));
         }
 
         [Test]
@@ -305,20 +305,20 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             nextRandom();
 
             CheckHasSelection();
-            AddStep("store selection", () => originalSelected = (GroupedBeatmap)Carousel.CurrentSelection!);
+            AddStep("store selection", () => originalSelected = Carousel.CurrentGroupedBeatmap!);
 
             nextRandom();
-            AddStep("store selection", () => postRandomSelection = (GroupedBeatmap)Carousel.CurrentSelection!);
+            AddStep("store selection", () => postRandomSelection = Carousel.CurrentGroupedBeatmap!);
 
             AddAssert("selection changed", () => originalSelected, () => Is.Not.SameAs(postRandomSelection));
 
             AddStep("delete previous selection beatmaps", () => BeatmapSets.Remove(originalSelected!.Beatmap.BeatmapSet!));
             WaitForFiltering();
 
-            AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(postRandomSelection));
+            AddAssert("selection not changed", () => Carousel.CurrentGroupedBeatmap, () => Is.EqualTo(postRandomSelection));
 
             prevRandomSet();
-            AddAssert("selection not changed", () => Carousel.CurrentSelection, () => Is.EqualTo(postRandomSelection));
+            AddAssert("selection not changed", () => Carousel.CurrentGroupedBeatmap, () => Is.EqualTo(postRandomSelection));
         }
 
         private void nextRandom() =>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select middle beatmap", () => Carousel.CurrentSelection = BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First());
+            AddStep("select middle beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First()));
 
             WaitForScrolling();
 
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select middle beatmap", () => Carousel.CurrentSelection = BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First());
+            AddStep("select middle beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First()));
             WaitForScrolling();
 
             AddStep("override scroll with user scroll", () =>
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("scroll to end", () => Scroll.ScrollToEnd(false));
 
-            AddStep("select last beatmap", () => Carousel.CurrentSelection = BeatmapSets.Last().Beatmaps.Last());
+            AddStep("select last beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.Last().Beatmaps.Last()));
 
             WaitForScrolling();
 
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select first beatmap", () => Carousel.CurrentSelection = BeatmapSets.First().Beatmaps.First());
+            AddStep("select first beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.First().Beatmaps.First()));
 
             WaitForScrolling();
 
@@ -108,7 +108,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select first beatmap", () => Carousel.CurrentSelection = BeatmapSets.First().Beatmaps.First());
+            AddStep("select first beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.First().Beatmaps.First()));
             WaitForScrolling();
 
             AddStep("override scroll with user scroll", () =>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselScrolling.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select middle beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First()));
+            AddStep("select middle beatmap", () => Carousel.CurrentGroupedBeatmap = new GroupedBeatmap(null, BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First()));
 
             WaitForScrolling();
 
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select middle beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First()));
+            AddStep("select middle beatmap", () => Carousel.CurrentGroupedBeatmap = new GroupedBeatmap(null, BeatmapSets.ElementAt(BeatmapSets.Count - 2).Beatmaps.First()));
             WaitForScrolling();
 
             AddStep("override scroll with user scroll", () =>
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("scroll to end", () => Scroll.ScrollToEnd(false));
 
-            AddStep("select last beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.Last().Beatmaps.Last()));
+            AddStep("select last beatmap", () => Carousel.CurrentGroupedBeatmap = new GroupedBeatmap(null, BeatmapSets.Last().Beatmaps.Last()));
 
             WaitForScrolling();
 
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select first beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.First().Beatmaps.First()));
+            AddStep("select first beatmap", () => Carousel.CurrentGroupedBeatmap = new GroupedBeatmap(null, BeatmapSets.First().Beatmaps.First()));
 
             WaitForScrolling();
 
@@ -108,7 +108,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             Quad positionBefore = default;
 
-            AddStep("select first beatmap", () => Carousel.CurrentSelection = new GroupedBeatmap(null, BeatmapSets.First().Beatmaps.First()));
+            AddStep("select first beatmap", () => Carousel.CurrentGroupedBeatmap = new GroupedBeatmap(null, BeatmapSets.First().Beatmaps.First()));
             WaitForScrolling();
 
             AddStep("override scroll with user scroll", () =>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b =>
@@ -195,7 +195,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
@@ -205,14 +205,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b => b.DifficultyName = "new name");
             assertDidFilter();
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
@@ -222,14 +222,14 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b => b.OnlineID = b.OnlineID + 1);
             assertDidFilter();
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
@@ -239,7 +239,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             // Add another difficulty with same online ID.
@@ -252,7 +252,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
@@ -262,7 +262,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             // Remove original selected difficulty, and add two difficulties with same name as selection.
@@ -284,7 +284,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => Carousel.CurrentBeatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
             AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselUpdateHandling.cs
@@ -179,8 +179,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b =>
             {
@@ -195,8 +195,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
         [Test] // Checks that we keep selection based on online ID where possible.
@@ -205,15 +205,15 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b => b.DifficultyName = "new name");
             assertDidFilter();
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
         [Test] // Checks that we fallback to keeping selection based on difficulty name.
@@ -222,15 +222,15 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             updateBeatmap(b => b.OnlineID = b.OnlineID + 1);
             assertDidFilter();
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
         [Test] // Checks that we don't crash if there exists a difficulty with the same online ID as the selected difficulty.
@@ -239,8 +239,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             // Add another difficulty with same online ID.
             updateBeatmap(null, bs =>
@@ -252,8 +252,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
         [Test] // Checks that we don't crash if there exists a difficulty with the same name as the selected difficulty.
@@ -262,8 +262,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
 
             WaitForSetSelection(1, 0);
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
 
             // Remove original selected difficulty, and add two difficulties with same name as selection.
             updateBeatmap(null, bs =>
@@ -284,8 +284,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             WaitForFiltering();
 
-            AddAssert("selection is updateable beatmap", () => Carousel.CurrentSelection, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
-            AddAssert("visible panel is updateable beatmap", () => GetSelectedPanel()?.Item?.Model, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("selection is updateable beatmap", () => ((GroupedBeatmap)Carousel.CurrentSelection!).Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
+            AddAssert("visible panel is updateable beatmap", () => (GetSelectedPanel()?.Item?.Model as GroupedBeatmap)?.Beatmap, () => Is.EqualTo(baseTestBeatmap.Beatmaps[0]));
         }
 
         /// <summary>

--- a/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmap.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmap.cs
@@ -104,21 +104,21 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     {
                         new PanelBeatmap
                         {
-                            Item = new CarouselItem(beatmap)
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap))
                         },
                         new PanelBeatmap
                         {
-                            Item = new CarouselItem(beatmap),
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap)),
                             KeyboardSelected = { Value = true }
                         },
                         new PanelBeatmap
                         {
-                            Item = new CarouselItem(beatmap),
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap)),
                             Selected = { Value = true }
                         },
                         new PanelBeatmap
                         {
-                            Item = new CarouselItem(beatmap),
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap)),
                             KeyboardSelected = { Value = true },
                             Selected = { Value = true }
                         },

--- a/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmapStandalone.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelBeatmapStandalone.cs
@@ -104,21 +104,21 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     {
                         new PanelBeatmapStandalone
                         {
-                            Item = new CarouselItem(beatmap)
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap))
                         },
                         new PanelBeatmapStandalone
                         {
-                            Item = new CarouselItem(beatmap),
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap)),
                             KeyboardSelected = { Value = true }
                         },
                         new PanelBeatmapStandalone
                         {
-                            Item = new CarouselItem(beatmap),
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap)),
                             Selected = { Value = true }
                         },
                         new PanelBeatmapStandalone
                         {
-                            Item = new CarouselItem(beatmap),
+                            Item = new CarouselItem(new GroupedBeatmap(null, beatmap)),
                             KeyboardSelected = { Value = true },
                             Selected = { Value = true }
                         },

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
     /// </summary>
     public partial class TestSceneSongSelectCurrentSelectionInvalidated : SongSelectTestScene
     {
-        private BeatmapInfo? selectedBeatmap => (BeatmapInfo?)Carousel.CurrentSelection;
+        private BeatmapInfo? selectedBeatmap => (Carousel.CurrentSelection as GroupedBeatmap)?.Beatmap;
         private BeatmapSetInfo? selectedBeatmapSet => selectedBeatmap?.BeatmapSet;
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectCurrentSelectionInvalidated.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
     /// </summary>
     public partial class TestSceneSongSelectCurrentSelectionInvalidated : SongSelectTestScene
     {
-        private BeatmapInfo? selectedBeatmap => (Carousel.CurrentSelection as GroupedBeatmap)?.Beatmap;
+        private BeatmapInfo? selectedBeatmap => Carousel.CurrentBeatmap;
         private BeatmapSetInfo? selectedBeatmapSet => selectedBeatmap?.BeatmapSet;
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectGrouping.cs
@@ -317,7 +317,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert($"\"{name}\" present", () =>
             {
                 var group = grouping.GroupItems.Single(g => g.Key.Title == name);
-                var actualBeatmaps = group.Value.Select(i => i.Model).OfType<BeatmapInfo>().OrderBy(b => b.ID);
+                var actualBeatmaps = group.Value.Select(i => i.Model).OfType<GroupedBeatmap>().Select(gb => gb.Beatmap).OrderBy(b => b.ID);
                 var expectedBeatmaps = getBeatmaps().SelectMany(s => s.Beatmaps).OrderBy(b => b.ID);
                 return actualBeatmaps.SequenceEqual(expectedBeatmaps);
             });

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Graphics.Carousel
         /// The selection is never reset due to not existing. It can be set to anything.
         /// If no matching carousel item exists, there will be no visually selected item while waiting for potential new item which matches.
         /// </remarks>
-        public object? CurrentSelection
+        public virtual object? CurrentSelection
         {
             get => currentSelection.Model;
             set

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Graphics.Carousel
         /// The selection is never reset due to not existing. It can be set to anything.
         /// If no matching carousel item exists, there will be no visually selected item while waiting for potential new item which matches.
         /// </remarks>
-        public virtual object? CurrentSelection
+        protected object? CurrentSelection
         {
             get => currentSelection.Model;
             set

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -103,14 +103,14 @@ namespace osu.Game.Screens.SelectV2
             {
                 new BeatmapCarouselFilterMatching(() => Criteria!),
                 new BeatmapCarouselFilterSorting(() => Criteria!),
-                grouping = new BeatmapCarouselFilterGrouping(() => Criteria!, getDetachedCollections, getTopRanksMapping)
+                grouping = new BeatmapCarouselFilterGrouping(() => Criteria!, GetAllCollections, GetBeatmapInfoGuidToTopRankMapping)
             };
 
             AddInternal(loading = new LoadingLayer());
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapStore beatmapStore, RealmAccess realm, AudioManager audio, OsuConfigManager config, CancellationToken? cancellationToken)
+        private void load(BeatmapStore beatmapStore, AudioManager audio, OsuConfigManager config, CancellationToken? cancellationToken)
         {
             setupPools();
             detachedBeatmaps = beatmapStore.GetBeatmapSets(cancellationToken);
@@ -687,9 +687,9 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        private List<BeatmapCollection> getDetachedCollections() => realm.Run(r => r.All<BeatmapCollection>().AsEnumerable().Detach());
+        protected virtual List<BeatmapCollection> GetAllCollections() => realm.Run(r => r.All<BeatmapCollection>().AsEnumerable().Detach());
 
-        private Dictionary<Guid, ScoreRank> getTopRanksMapping(FilterCriteria criteria) => realm.Run(r =>
+        protected virtual Dictionary<Guid, ScoreRank> GetBeatmapInfoGuidToTopRankMapping(FilterCriteria criteria) => realm.Run(r =>
         {
             var topRankMapping = new Dictionary<Guid, ScoreRank>();
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -418,9 +418,21 @@ namespace osu.Game.Screens.SelectV2
             // Store selected group before handling selection (it may implicitly change the expanded group).
             var groupForReselection = ExpandedGroup;
 
-            // Ensure correct post-selection logic is handled on the new items list.
-            // This will update the visual state of the selected item.
-            HandleItemSelected(CurrentSelection);
+            var currentGroupedBeatmap = CurrentSelection as GroupedBeatmap;
+
+            // The filter might have changed the set of available groups, which means that the current selection may point to a stale group.
+            // Check whether the current selection's group still exists.
+            if (currentGroupedBeatmap?.Group != null && grouping.GroupItems.ContainsKey(currentGroupedBeatmap.Group))
+            {
+                // If the group still exists, then only update the visual state of the selected item.
+                HandleItemSelected(currentGroupedBeatmap);
+            }
+            else if (currentGroupedBeatmap != null)
+            {
+                // If the group no longer exists, grab an arbitrary other instance of the beatmap under the first group encountered.
+                var newSelection = GetCarouselItems()?.Select(i => i.Model).OfType<GroupedBeatmap>().FirstOrDefault(gb => gb.Beatmap.Equals(currentGroupedBeatmap.Beatmap));
+                CurrentSelection = newSelection;
+            }
 
             // If a group was selected that is not the one containing the selection, attempt to reselect it.
             // If the original group was not found, ExpandedGroup will already have been updated to a valid value in `HandleItemSelected` above.

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -295,6 +295,26 @@ namespace osu.Game.Screens.SelectV2
         protected override bool ShouldActivateOnKeyboardSelection(CarouselItem item) =>
             grouping.BeatmapSetsGroupedTogether && item.Model is GroupedBeatmap;
 
+        public override object? CurrentSelection
+        {
+            get => base.CurrentSelection;
+            set
+            {
+                // this is a special pathway for external consumers who only care about showing some particular copy of a beatmap
+                // (there could be multiple panels for one beatmap due to grouping).
+                // in this pathway we basically figure out what group to use internally, and continue working with `GroupedBeatmap` all the way after that.
+                if (value is BeatmapInfo beatmapInfo)
+                {
+                    if (CurrentSelection is GroupedBeatmap groupedBeatmap && beatmapInfo.Equals(groupedBeatmap.Beatmap))
+                        return;
+
+                    value = GetCarouselItems()?.Select(item => item.Model).OfType<GroupedBeatmap>().FirstOrDefault(gb => gb.Beatmap.Equals(beatmapInfo));
+                }
+
+                base.CurrentSelection = value;
+            }
+        }
+
         protected override void HandleItemActivated(CarouselItem item)
         {
             try

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -308,7 +308,12 @@ namespace osu.Game.Screens.SelectV2
                     if (CurrentSelection is GroupedBeatmap groupedBeatmap && beatmapInfo.Equals(groupedBeatmap.Beatmap))
                         return;
 
-                    value = GetCarouselItems()?.Select(item => item.Model).OfType<GroupedBeatmap>().FirstOrDefault(gb => gb.Beatmap.Equals(beatmapInfo));
+                    // it is not universally guaranteed that the carousel items will be materialised at the time this is set.
+                    // therefore, in cases where it is known that they will not be, default to a null group.
+                    // even if grouping is active, this will be rectified to a correct group on the next invocation of `HandleFilterCompleted()`.
+                    value = IsLoaded && !IsFiltering
+                        ? GetCarouselItems()?.Select(item => item.Model).OfType<GroupedBeatmap>().FirstOrDefault(gb => gb.Beatmap.Equals(beatmapInfo))
+                        : new GroupedBeatmap(null, beatmapInfo);
                 }
 
                 base.CurrentSelection = value;

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -441,10 +441,13 @@ namespace osu.Game.Screens.SelectV2
             var currentGroupedBeatmap = CurrentSelection as GroupedBeatmap;
 
             // The filter might have changed the set of available groups, which means that the current selection may point to a stale group.
-            // Check whether the current selection's group still exists.
-            if (currentGroupedBeatmap?.Group != null && grouping.GroupItems.ContainsKey(currentGroupedBeatmap.Group))
+            // Check whether that is the case.
+            bool groupingRemainsOff = currentGroupedBeatmap?.Group == null && grouping.GroupItems.Count == 0;
+            bool groupStillExists = currentGroupedBeatmap?.Group != null && grouping.GroupItems.ContainsKey(currentGroupedBeatmap.Group);
+
+            if (groupingRemainsOff || groupStillExists)
             {
-                // If the group still exists, then only update the visual state of the selected item.
+                // Only update the visual state of the selected item.
                 HandleItemSelected(currentGroupedBeatmap);
             }
             else if (currentGroupedBeatmap != null)

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -987,7 +987,11 @@ namespace osu.Game.Screens.SelectV2
                 var previousBeatmap = randomHistory[^1];
                 randomHistory.RemoveAt(randomHistory.Count - 1);
 
-                var previousBeatmapItem = carouselItems.FirstOrDefault(i => i.Model is GroupedBeatmap gb && gb.Equals(previousBeatmap));
+                // when going back through rewind history, we may no longer be in the same grouping mode.
+                // the user wants to go back to the beatmap first and foremost, so the most important thing is to find a panel that corresponds to the beatmap.
+                // going back to the same group is a nice-to-have, but a secondary concern.
+                var previousBeatmapItem = carouselItems.Where(i => i.Model is GroupedBeatmap gb && gb.Beatmap.Equals(previousBeatmap.Beatmap))
+                                                       .MaxBy(i => ((GroupedBeatmap)i.Model).Group == previousBeatmap.Group);
 
                 if (previousBeatmapItem == null)
                     return false;
@@ -1003,7 +1007,7 @@ namespace osu.Game.Screens.SelectV2
                         playSpinSample(visiblePanelCountBetweenItems(previousBeatmapItem, CurrentSelectionItem));
                 }
 
-                RequestSelection(previousBeatmap);
+                RequestSelection((GroupedBeatmap)previousBeatmapItem.Model);
                 return true;
             }
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -451,7 +451,10 @@ namespace osu.Game.Screens.SelectV2
             {
                 // If the group no longer exists, grab an arbitrary other instance of the beatmap under the first group encountered.
                 var newSelection = GetCarouselItems()?.Select(i => i.Model).OfType<GroupedBeatmap>().FirstOrDefault(gb => gb.Beatmap.Equals(currentGroupedBeatmap.Beatmap));
-                CurrentSelection = newSelection;
+                // Only change the selection if we actually got a positive hit.
+                // This is necessary so that selection isn't lost if the panel reappears later due to e.g. unapplying some filter criteria that made it disappear in the first place.
+                if (newSelection != null)
+                    CurrentSelection = newSelection;
             }
 
             // If a group was selected that is not the one containing the selection, attempt to reselect it.

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.Carousel;
@@ -124,7 +125,7 @@ namespace osu.Game.Screens.SelectV2
                             item.DrawHeight = PanelBeatmapStandalone.HEIGHT;
                         }
 
-                        addItem(item);
+                        addItem(new CarouselItem(new GroupedBeatmap(group, beatmap)));
                         lastBeatmap = beatmap;
                         displayedBeatmapsCount++;
                     }
@@ -192,7 +193,7 @@ namespace osu.Game.Screens.SelectV2
                         var date = b.LastPlayed;
 
                         if (date == null || date == DateTimeOffset.MinValue)
-                            return new GroupDefinition(int.MaxValue, "Never");
+                            return new GroupDefinition(int.MaxValue, "Never").Yield();
 
                         return defineGroupByDate(date.Value);
                     }, items);
@@ -236,184 +237,204 @@ namespace osu.Game.Screens.SelectV2
             }
         }
 
-        private List<GroupMapping> getGroupsBy(Func<BeatmapInfo, GroupDefinition?> getGroup, List<CarouselItem> items)
+        private List<GroupMapping> getGroupsBy(Func<BeatmapInfo, IEnumerable<GroupDefinition>> defineGroups, List<CarouselItem> items)
         {
-            return items.GroupBy(i => getGroup((BeatmapInfo)i.Model))
-                        .Where(g => g.Key != null)
-                        .OrderBy(g => g.Key!.Order)
-                        .ThenBy(g => g.Key!.Title)
-                        .Select(g => new GroupMapping(g.Key, g.ToList()))
-                        .ToList();
+            var groups = new Dictionary<GroupDefinition, GroupMapping>();
+
+            foreach (var item in items)
+            {
+                foreach (var groupDefinition in defineGroups((BeatmapInfo)item.Model))
+                {
+                    if (!groups.TryGetValue(groupDefinition, out var group))
+                        group = groups[groupDefinition] = new GroupMapping(groupDefinition, []);
+
+                    group.ItemsInGroup.Add(item);
+                }
+            }
+
+            return groups.Values
+                         .OrderBy(g => g.Group!.Order)
+                         .ThenBy(g => g.Group!.Title)
+                         .ToList();
         }
 
-        private GroupDefinition defineGroupAlphabetically(string name)
+        private IEnumerable<GroupDefinition> defineGroupAlphabetically(string name)
         {
             char firstChar = name.FirstOrDefault();
 
             if (char.IsAsciiDigit(firstChar))
-                return new GroupDefinition(int.MinValue, "0-9");
+                return new GroupDefinition(int.MinValue, "0-9").Yield();
 
             if (char.IsAsciiLetter(firstChar))
-                return new GroupDefinition(char.ToUpperInvariant(firstChar) - 'A', char.ToUpperInvariant(firstChar).ToString());
+                return new GroupDefinition(char.ToUpperInvariant(firstChar) - 'A', char.ToUpperInvariant(firstChar).ToString()).Yield();
 
-            return new GroupDefinition(int.MaxValue, "Other");
+            return new GroupDefinition(int.MaxValue, "Other").Yield();
         }
 
-        private GroupDefinition defineGroupByDate(DateTimeOffset date)
+        private IEnumerable<GroupDefinition> defineGroupByDate(DateTimeOffset date)
         {
             var now = DateTimeOffset.Now;
             var elapsed = now - date;
 
             if (elapsed.TotalDays < 1)
-                return new GroupDefinition(0, "Today");
+                return new GroupDefinition(0, "Today").Yield();
 
             if (elapsed.TotalDays < 2)
-                return new GroupDefinition(1, "Yesterday");
+                return new GroupDefinition(1, "Yesterday").Yield();
 
             if (elapsed.TotalDays < 7)
-                return new GroupDefinition(2, "Last week");
+                return new GroupDefinition(2, "Last week").Yield();
 
             if (elapsed.TotalDays < 30)
-                return new GroupDefinition(3, "Last month");
+                return new GroupDefinition(3, "Last month").Yield();
 
             if (elapsed.TotalDays < 60)
-                return new GroupDefinition(4, "1 month ago");
+                return new GroupDefinition(4, "1 month ago").Yield();
 
             for (int i = 90; i <= 150; i += 30)
             {
                 if (elapsed.TotalDays < i)
-                    return new GroupDefinition(i, $"{i / 30 - 1} months ago");
+                    return new GroupDefinition(i, $"{i / 30 - 1} months ago").Yield();
             }
 
-            return new GroupDefinition(151, "Over 5 months ago");
+            return new GroupDefinition(151, "Over 5 months ago").Yield();
         }
 
-        private GroupDefinition defineGroupByRankedDate(DateTimeOffset? date)
+        private IEnumerable<GroupDefinition> defineGroupByRankedDate(DateTimeOffset? date)
         {
             if (date == null)
-                return new GroupDefinition(0, "Unranked");
+                return new GroupDefinition(0, "Unranked").Yield();
 
-            return new GroupDefinition(-date.Value.Year, $"{date.Value.Year}");
+            return new GroupDefinition(-date.Value.Year, $"{date.Value.Year}").Yield();
         }
 
-        private GroupDefinition defineGroupByStatus(BeatmapOnlineStatus status)
+        private IEnumerable<GroupDefinition> defineGroupByStatus(BeatmapOnlineStatus status)
         {
             switch (status)
             {
                 case BeatmapOnlineStatus.Ranked:
                 case BeatmapOnlineStatus.Approved:
-                    return new GroupDefinition(0, BeatmapOnlineStatus.Ranked.GetDescription());
+                    return new GroupDefinition(0, BeatmapOnlineStatus.Ranked.GetDescription()).Yield();
 
                 case BeatmapOnlineStatus.Qualified:
-                    return new GroupDefinition(1, status.GetDescription());
+                    return new GroupDefinition(1, status.GetDescription()).Yield();
 
                 case BeatmapOnlineStatus.WIP:
-                    return new GroupDefinition(2, status.GetDescription());
+                    return new GroupDefinition(2, status.GetDescription()).Yield();
 
                 case BeatmapOnlineStatus.Pending:
-                    return new GroupDefinition(3, status.GetDescription());
+                    return new GroupDefinition(3, status.GetDescription()).Yield();
 
                 case BeatmapOnlineStatus.Graveyard:
-                    return new GroupDefinition(4, status.GetDescription());
+                    return new GroupDefinition(4, status.GetDescription()).Yield();
 
                 case BeatmapOnlineStatus.LocallyModified:
-                    return new GroupDefinition(5, status.GetDescription());
+                    return new GroupDefinition(5, status.GetDescription()).Yield();
 
                 case BeatmapOnlineStatus.None:
-                    return new GroupDefinition(6, status.GetDescription());
+                    return new GroupDefinition(6, status.GetDescription()).Yield();
 
                 case BeatmapOnlineStatus.Loved:
-                    return new GroupDefinition(7, status.GetDescription());
+                    return new GroupDefinition(7, status.GetDescription()).Yield();
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(status), status, null);
             }
         }
 
-        private GroupDefinition defineGroupByBPM(double bpm)
+        private IEnumerable<GroupDefinition> defineGroupByBPM(double bpm)
         {
             if (bpm < 60)
-                return new GroupDefinition(60, "Under 60 BPM");
+                return new GroupDefinition(60, "Under 60 BPM").Yield();
 
             for (int i = 70; i <= 300; i += 10)
             {
                 if (bpm < i)
-                    return new GroupDefinition(i, $"{i - 10} - {i} BPM");
+                    return new GroupDefinition(i, $"{i - 10} - {i} BPM").Yield();
             }
 
-            return new GroupDefinition(301, "Over 300 BPM");
+            return new GroupDefinition(301, "Over 300 BPM").Yield();
         }
 
-        private GroupDefinition defineGroupByStars(double stars)
+        private IEnumerable<GroupDefinition> defineGroupByStars(double stars)
         {
             // truncation is intentional - compare `FormatUtils.FormatStarRating()`
             int starInt = (int)stars;
             var starDifficulty = new StarDifficulty(starInt, 0);
 
             if (starInt == 0)
-                return new StarDifficultyGroupDefinition(0, "Below 1 Star", starDifficulty);
+                return new StarDifficultyGroupDefinition(0, "Below 1 Star", starDifficulty).Yield();
 
             if (starInt == 1)
-                return new StarDifficultyGroupDefinition(1, "1 Star", starDifficulty);
+                return new StarDifficultyGroupDefinition(1, "1 Star", starDifficulty).Yield();
 
-            return new StarDifficultyGroupDefinition(starInt, $"{starInt} Stars", starDifficulty);
+            return new StarDifficultyGroupDefinition(starInt, $"{starInt} Stars", starDifficulty).Yield();
         }
 
-        private GroupDefinition defineGroupByLength(double length)
+        private IEnumerable<GroupDefinition> defineGroupByLength(double length)
         {
             for (int i = 1; i < 6; i++)
             {
                 if (length <= i * 60_000)
                 {
                     if (i == 1)
-                        return new GroupDefinition(1, "1 minute or less");
+                        return new GroupDefinition(1, "1 minute or less").Yield();
 
-                    return new GroupDefinition(i, $"{i} minutes or less");
+                    return new GroupDefinition(i, $"{i} minutes or less").Yield();
                 }
             }
 
             if (length <= 10 * 60_000)
-                return new GroupDefinition(10, "10 minutes or less");
+                return new GroupDefinition(10, "10 minutes or less").Yield();
 
-            return new GroupDefinition(11, "Over 10 minutes");
+            return new GroupDefinition(11, "Over 10 minutes").Yield();
         }
 
-        private GroupDefinition defineGroupBySource(string source)
+        private IEnumerable<GroupDefinition> defineGroupBySource(string source)
         {
             if (string.IsNullOrEmpty(source))
-                return new GroupDefinition(1, "Unsourced");
+                return new GroupDefinition(1, "Unsourced").Yield();
 
-            return new GroupDefinition(0, source);
+            return new GroupDefinition(0, source).Yield();
         }
 
-        private GroupDefinition defineGroupByCollection(BeatmapInfo beatmap, IEnumerable<BeatmapCollection> collections)
+        private IEnumerable<GroupDefinition> defineGroupByCollection(BeatmapInfo beatmap, IEnumerable<BeatmapCollection> collections)
         {
+            bool anyCollections = false;
+
             foreach (var collection in collections)
             {
                 if (collection.BeatmapMD5Hashes.Contains(beatmap.MD5Hash))
-                    return new GroupDefinition(0, collection.Name);
+                {
+                    yield return new GroupDefinition(0, collection.Name);
+
+                    anyCollections = true;
+                }
             }
 
-            return new GroupDefinition(1, "Not in collection");
+            if (anyCollections)
+                yield break;
+
+            yield return new GroupDefinition(1, "Not in collection");
         }
 
-        private GroupDefinition? defineGroupByOwnMaps(BeatmapInfo beatmap, int? localUserId, string? localUserUsername)
+        private IEnumerable<GroupDefinition> defineGroupByOwnMaps(BeatmapInfo beatmap, int? localUserId, string? localUserUsername)
         {
             var author = beatmap.BeatmapSet!.Metadata.Author;
 
             if (author.OnlineID == localUserId || (author.OnlineID <= 1 && author.Username == localUserUsername))
-                return new GroupDefinition(0, "My maps");
+                return new GroupDefinition(0, "My maps").Yield();
 
             // discard beatmaps not owned by the user.
-            return null;
+            return [];
         }
 
-        private GroupDefinition defineGroupByRankAchieved(BeatmapInfo beatmap, IReadOnlyDictionary<Guid, ScoreRank> topRankMapping)
+        private IEnumerable<GroupDefinition> defineGroupByRankAchieved(BeatmapInfo beatmap, IReadOnlyDictionary<Guid, ScoreRank> topRankMapping)
         {
             if (topRankMapping.TryGetValue(beatmap.ID, out var rank))
-                return new GroupDefinition(-(int)rank, rank.GetDescription());
+                return new GroupDefinition(-(int)rank, rank.GetDescription()).Yield();
 
-            return new GroupDefinition(int.MaxValue, "Unplayed");
+            return new GroupDefinition(int.MaxValue, "Unplayed").Yield();
         }
 
         private record GroupMapping(GroupDefinition? Group, List<CarouselItem> ItemsInGroup);

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -121,11 +121,12 @@ namespace osu.Game.Screens.SelectV2
                         {
                             if (groupItem != null)
                                 groupItem.NestedItemCount++;
-
-                            item.DrawHeight = PanelBeatmapStandalone.HEIGHT;
                         }
 
-                        addItem(new CarouselItem(new GroupedBeatmap(group, beatmap)));
+                        addItem(new CarouselItem(new GroupedBeatmap(group, beatmap))
+                        {
+                            DrawHeight = BeatmapSetsGroupedTogether ? PanelBeatmap.HEIGHT : PanelBeatmapStandalone.HEIGHT,
+                        });
                         lastBeatmap = beatmap;
                         displayedBeatmapsCount++;
                     }

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -72,14 +71,7 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private ISongSelect? songSelect { get; set; }
 
-        private GroupedBeatmap groupedBeatmap
-        {
-            get
-            {
-                Debug.Assert(Item != null);
-                return (GroupedBeatmap)Item!.Model;
-            }
-        }
+        private BeatmapInfo beatmap => ((GroupedBeatmap)Item!.Model).Beatmap;
 
         public PanelBeatmap()
         {
@@ -216,8 +208,6 @@ namespace osu.Game.Screens.SelectV2
         {
             base.PrepareForUse();
 
-            var beatmap = groupedBeatmap.Beatmap;
-
             difficultyIcon.Icon = getRulesetIcon(beatmap.Ruleset);
 
             localRank.Beatmap = beatmap;
@@ -255,8 +245,6 @@ namespace osu.Game.Screens.SelectV2
 
             if (Item == null)
                 return;
-
-            var beatmap = groupedBeatmap.Beatmap;
 
             starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(starDifficulty =>
@@ -301,8 +289,6 @@ namespace osu.Game.Screens.SelectV2
             if (Item == null)
                 return;
 
-            var beatmap = groupedBeatmap.Beatmap;
-
             if (ruleset.Value.OnlineID == 3)
             {
                 // Account for mania differences locally for now.
@@ -327,7 +313,7 @@ namespace osu.Game.Screens.SelectV2
                 List<MenuItem> items = new List<MenuItem>();
 
                 if (songSelect != null)
-                    items.AddRange(songSelect.GetForwardActions(groupedBeatmap.Beatmap));
+                    items.AddRange(songSelect.GetForwardActions(beatmap));
 
                 return items.ToArray();
             }

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -72,6 +72,15 @@ namespace osu.Game.Screens.SelectV2
         [Resolved]
         private ISongSelect? songSelect { get; set; }
 
+        private GroupedBeatmap groupedBeatmap
+        {
+            get
+            {
+                Debug.Assert(Item != null);
+                return (GroupedBeatmap)Item!.Model;
+            }
+        }
+
         public PanelBeatmap()
         {
             PanelXOffset = 60;
@@ -207,8 +216,7 @@ namespace osu.Game.Screens.SelectV2
         {
             base.PrepareForUse();
 
-            Debug.Assert(Item != null);
-            var beatmap = (BeatmapInfo)Item.Model;
+            var beatmap = groupedBeatmap.Beatmap;
 
             difficultyIcon.Icon = getRulesetIcon(beatmap.Ruleset);
 
@@ -248,7 +256,7 @@ namespace osu.Game.Screens.SelectV2
             if (Item == null)
                 return;
 
-            var beatmap = (BeatmapInfo)Item.Model;
+            var beatmap = groupedBeatmap.Beatmap;
 
             starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(starDifficulty =>
@@ -293,7 +301,7 @@ namespace osu.Game.Screens.SelectV2
             if (Item == null)
                 return;
 
-            var beatmap = (BeatmapInfo)Item.Model;
+            var beatmap = groupedBeatmap.Beatmap;
 
             if (ruleset.Value.OnlineID == 3)
             {
@@ -319,7 +327,7 @@ namespace osu.Game.Screens.SelectV2
                 List<MenuItem> items = new List<MenuItem>();
 
                 if (songSelect != null)
-                    items.AddRange(songSelect.GetForwardActions((BeatmapInfo)Item.Model));
+                    items.AddRange(songSelect.GetForwardActions(groupedBeatmap.Beatmap));
 
                 return items.ToArray();
             }

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -73,6 +73,15 @@ namespace osu.Game.Screens.SelectV2
 
         private Box backgroundBorder = null!;
 
+        private GroupedBeatmap groupedBeatmap
+        {
+            get
+            {
+                Debug.Assert(Item != null);
+                return (GroupedBeatmap)Item!.Model;
+            }
+        }
+
         public PanelBeatmapStandalone()
         {
             PanelXOffset = 20;
@@ -219,9 +228,7 @@ namespace osu.Game.Screens.SelectV2
         {
             base.PrepareForUse();
 
-            Debug.Assert(Item != null);
-
-            var beatmap = (BeatmapInfo)Item.Model;
+            var beatmap = groupedBeatmap.Beatmap;
             var beatmapSet = beatmap.BeatmapSet!;
 
             beatmapBackground.Beatmap = beatmaps.GetWorkingBeatmap(beatmap);
@@ -262,7 +269,7 @@ namespace osu.Game.Screens.SelectV2
             if (Item == null)
                 return;
 
-            var beatmap = (BeatmapInfo)Item.Model;
+            var beatmap = groupedBeatmap.Beatmap;
 
             starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(starDifficulty =>
@@ -300,7 +307,7 @@ namespace osu.Game.Screens.SelectV2
             if (Item == null)
                 return;
 
-            var beatmap = (BeatmapInfo)Item.Model;
+            var beatmap = groupedBeatmap.Beatmap;
 
             if (ruleset.Value.OnlineID == 3)
             {
@@ -326,7 +333,7 @@ namespace osu.Game.Screens.SelectV2
                 List<MenuItem> items = new List<MenuItem>();
 
                 if (songSelect != null)
-                    items.AddRange(songSelect.GetForwardActions((BeatmapInfo)Item.Model));
+                    items.AddRange(songSelect.GetForwardActions(groupedBeatmap.Beatmap));
 
                 return items.ToArray();
             }

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -73,14 +72,7 @@ namespace osu.Game.Screens.SelectV2
 
         private Box backgroundBorder = null!;
 
-        private GroupedBeatmap groupedBeatmap
-        {
-            get
-            {
-                Debug.Assert(Item != null);
-                return (GroupedBeatmap)Item!.Model;
-            }
-        }
+        private BeatmapInfo beatmap => ((GroupedBeatmap)Item!.Model).Beatmap;
 
         public PanelBeatmapStandalone()
         {
@@ -228,7 +220,6 @@ namespace osu.Game.Screens.SelectV2
         {
             base.PrepareForUse();
 
-            var beatmap = groupedBeatmap.Beatmap;
             var beatmapSet = beatmap.BeatmapSet!;
 
             beatmapBackground.Beatmap = beatmaps.GetWorkingBeatmap(beatmap);
@@ -269,8 +260,6 @@ namespace osu.Game.Screens.SelectV2
             if (Item == null)
                 return;
 
-            var beatmap = groupedBeatmap.Beatmap;
-
             starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(starDifficulty =>
             {
@@ -307,8 +296,6 @@ namespace osu.Game.Screens.SelectV2
             if (Item == null)
                 return;
 
-            var beatmap = groupedBeatmap.Beatmap;
-
             if (ruleset.Value.OnlineID == 3)
             {
                 // Account for mania differences locally for now.
@@ -333,7 +320,7 @@ namespace osu.Game.Screens.SelectV2
                 List<MenuItem> items = new List<MenuItem>();
 
                 if (songSelect != null)
-                    items.AddRange(songSelect.GetForwardActions(groupedBeatmap.Beatmap));
+                    items.AddRange(songSelect.GetForwardActions(beatmap));
 
                 return items.ToArray();
             }

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -535,8 +535,7 @@ namespace osu.Game.Screens.SelectV2
 
                 if (validBeatmaps.Any())
                 {
-                    // TODO: this needs a primitive that tells the carousel "I need this beatmap to be selected, you figure out the grouping".
-                    //requestRecommendedSelection(validBeatmaps);
+                    carousel.CurrentSelection = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
                     return true;
                 }
             }

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -479,7 +479,7 @@ namespace osu.Game.Screens.SelectV2
             if (!this.IsCurrentScreen())
                 return;
 
-            carousel.CurrentSelection = groupedBeatmap;
+            carousel.CurrentGroupedBeatmap = groupedBeatmap;
 
             // Debounce consideration is to avoid beatmap churn on key repeat selection.
             selectionDebounce?.Cancel();
@@ -512,7 +512,7 @@ namespace osu.Game.Screens.SelectV2
 
             if (validSelection)
             {
-                carousel.CurrentSelection = currentBeatmap.BeatmapInfo;
+                carousel.CurrentBeatmap = currentBeatmap.BeatmapInfo;
                 return true;
             }
 
@@ -535,7 +535,7 @@ namespace osu.Game.Screens.SelectV2
 
                 if (validBeatmaps.Any())
                 {
-                    carousel.CurrentSelection = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
+                    carousel.CurrentBeatmap = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
                     return true;
                 }
             }


### PR DESCRIPTION
https://github.com/user-attachments/assets/23dfe2bf-b3f4-4045-acb1-021a72e7f49e

The only current case where this kicks in is the collections grouping mode, as individual beatmap difficulties can be in multiple collections at once.

---

RFC. Closes https://github.com/ppy/osu/issues/34286.

I'm not really super sure what to type here. This is likely going to be a rough review. I don't know that this can be remedied. I've attempted to do my best with splitting commits, adding messages to individual commits, and also inline comments, but we'll see how well that went.

The general idea is the continuation of https://github.com/ppy/osu/pull/34822, except now it's `GroupedBeatmap` that replaces `BeatmapInfo`. The first few commits here are rather menial and probably What You Would Expect To See, generally. The later ones are where Stuff Starts.

The Stuff Starts because some flows, some of which go all the way up to song select, expect to be able to Just Select A Map Period, or to Just Keep The Current Map Selected Period. With grouping being allowed to spawn duplicates of a map this is no longer that trivial of an operation. Therefore some borderline-hacks such as https://github.com/ppy/osu/commit/107e103825cc64c7ebc66fa65e415f93639a9c33, https://github.com/ppy/osu/commit/dfed564bda7408ec4fd1c82ab15f90f410cdd444, or https://github.com/ppy/osu/pull/34842/commits/4ffc262073804e5fdad0e62a86832e81618635a4 get spawned.

If there are performance implications of this I've not looked into them. My immediate goal was to make this somehow work and see how much everyone hates the end result. If the answer is "not that much" or better, I could look into performance concerns.