### PR TITLE
Add a CircleSizeSelector to the FilterControl

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -29,6 +29,11 @@ namespace osu.Game.Rulesets.Mania
             bool keyCountMatch = includedKeyCounts.Contains(keyCount);
             bool longNotePercentageMatch = !longNotePercentage.HasFilter || (!isConvertedBeatmap(beatmapInfo) && longNotePercentage.IsInRange(calculateLongNotePercentage(beatmapInfo)));
 
+            if (criteria.DiscreteCircleSizeValues?.Any() == true)
+            {
+                keyCountMatch = criteria.DiscreteCircleSizeValues.Contains(keyCount);
+            }
+
             return keyCountMatch && longNotePercentageMatch;
         }
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
@@ -22,6 +23,7 @@ using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.Select.Leaderboards;
+using osu.Game.Screens.SelectV2;
 using osu.Game.Skinning;
 using osu.Game.Users;
 
@@ -51,6 +53,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.SongSelectGroupMode, GroupMode.None);
             SetDefault(OsuSetting.SongSelectSortingMode, SortMode.Title);
+            SetDefault(OsuSetting.SongSelectCircleSizeMode, CsItemIds.ALL.First().Id);
 
             SetDefault(OsuSetting.RandomSelectAlgorithm, RandomSelectAlgorithm.RandomPermutation);
             SetDefault(OsuSetting.ModSelectHotkeyStyle, ModSelectHotkeyStyle.Sequential);
@@ -399,6 +402,7 @@ namespace osu.Game.Configuration
         DisplayStarsMaximum,
         SongSelectGroupMode,
         SongSelectSortingMode,
+        SongSelectCircleSizeMode,
         RandomSelectAlgorithm,
         ModSelectHotkeyStyle,
         ShowFpsDisplay,

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -116,6 +116,8 @@ namespace osu.Game.Screens.Select
         /// </summary>
         public IEnumerable<string>? CollectionBeatmapMD5Hashes { get; set; }
 
+        public List<float>? DiscreteCircleSizeValues { get; set; }
+
         public IRulesetFilterCriteria? RulesetCriteria { get; set; }
 
         /// <summary>

--- a/osu.Game/Screens/SelectV2/CircleSizeFilter.cs
+++ b/osu.Game/Screens/SelectV2/CircleSizeFilter.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public class CsItemInfo
+    {
+        public required string Id { get; set; }
+        public required string DisplayName { get; set; }
+        public float? CsValue { get; set; }
+        public bool IsDefault { get; set; }
+    }
+
+    public static class CsItemIds
+    {
+        private const int mania_ruleset_id = 3;
+
+        public static readonly List<CsItemInfo> ALL = new List<CsItemInfo>
+        {
+            new CsItemInfo { Id = "All", DisplayName = "All", IsDefault = true },
+            new CsItemInfo { Id = "CS1", DisplayName = "1", CsValue = 1 },
+            new CsItemInfo { Id = "CS2", DisplayName = "2", CsValue = 2 },
+            new CsItemInfo { Id = "CS3", DisplayName = "3", CsValue = 3 },
+            new CsItemInfo { Id = "CS4", DisplayName = "4", CsValue = 4 },
+            new CsItemInfo { Id = "CS5", DisplayName = "5", CsValue = 5 },
+            new CsItemInfo { Id = "CS6", DisplayName = "6", CsValue = 6 },
+            new CsItemInfo { Id = "CS7", DisplayName = "7", CsValue = 7 },
+            new CsItemInfo { Id = "CS8", DisplayName = "8", CsValue = 8 },
+            new CsItemInfo { Id = "CS9", DisplayName = "9", CsValue = 9 },
+            new CsItemInfo { Id = "CS10", DisplayName = "10", CsValue = 10 },
+            new CsItemInfo { Id = "CS12", DisplayName = "12", CsValue = 12 },
+            new CsItemInfo { Id = "CS14", DisplayName = "14", CsValue = 14 },
+            new CsItemInfo { Id = "CS16", DisplayName = "16", CsValue = 16 },
+            new CsItemInfo { Id = "CS18", DisplayName = "18", CsValue = 18 },
+        };
+
+        public static List<CsItemInfo> GetModesForRuleset(int rulesetId)
+        {
+            if (rulesetId == mania_ruleset_id)
+                return ALL.Where(m => m.CsValue == null || m.CsValue >= 4).ToList();
+
+            return ALL.Where(m => m.CsValue == null || m.CsValue <= 10).ToList();
+        }
+
+        public static CsItemInfo? GetById(string id) => ALL.FirstOrDefault(m => m.Id == id);
+    }
+
+    public class CircleSizeFilter
+    {
+        public HashSet<string> SelectedModeIds { get; } = new HashSet<string> { "All" };
+
+        public event Action? SelectionChanged;
+
+        public void SetSelection(HashSet<string> modeIds)
+        {
+            var newSet = new HashSet<string>();
+            if (modeIds.Count == 0 || modeIds.Contains("All"))
+                newSet.Add("All");
+            else
+                newSet.UnionWith(modeIds);
+
+            SelectedModeIds.Clear();
+            SelectedModeIds.UnionWith(newSet);
+            SelectionChanged?.Invoke();
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/FilterControl_CircleSizeSelector.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl_CircleSizeSelector.cs
@@ -1,0 +1,401 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osuTK;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class CircleSizeSelector : CompositeDrawable
+    {
+        private readonly Bindable<string> keyModeId = new Bindable<string>("All");
+        private readonly BindableBool isMultiSelectMode = new BindableBool();
+        private readonly Dictionary<int, HashSet<string>> modeSelections = new Dictionary<int, HashSet<string>>();
+
+        private ShearedCsModeTabControl tabControl = null!;
+        private ShearedToggleButton multiSelectButton = null!;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        public IBindable<string> Current => tabControl.Current;
+
+        public CircleSizeFilter CircleSizeFilter { get; } = new CircleSizeFilter();
+
+        public CircleSizeSelector()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            CornerRadius = 8;
+            Masking = true;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Shear = -OsuGame.SHEAR,
+                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute),
+                        new Dimension(GridSizeMode.AutoSize),
+                    },
+                    Content = new[]
+                    {
+                        new[]
+                        {
+                            tabControl = new ShearedCsModeTabControl
+                            {
+                                RelativeSizeAxes = Axes.X,
+                            },
+                            Empty(),
+                            multiSelectButton = new ShearedToggleButton
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Text = "Multi",
+                                Height = 30f,
+                            }
+                        }
+                    }
+                }
+            };
+
+            multiSelectButton.Active.BindTo(isMultiSelectMode);
+
+            keyModeId.BindTo(config.GetBindable<string>(OsuSetting.SongSelectCircleSizeMode));
+            keyModeId.BindValueChanged(onSelectorChanged, true);
+
+            isMultiSelectMode.BindValueChanged(_ => updateValue(), true);
+            ruleset.BindValueChanged(onRulesetChanged, true);
+            CircleSizeFilter.SelectionChanged += updateValue;
+
+            tabControl.Current.BindTarget = keyModeId;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            CircleSizeFilter.SelectionChanged -= updateValue;
+        }
+
+        private void onRulesetChanged(ValueChangedEvent<RulesetInfo> e)
+        {
+            tabControl.UpdateForRuleset(e.NewValue.OnlineID);
+            updateValue();
+        }
+
+        private void onSelectorChanged(ValueChangedEvent<string> e)
+        {
+            var modes = parseModeIds(e.NewValue);
+            CircleSizeFilter.SetSelection(modes);
+            tabControl.UpdateTabItemUI(modes);
+        }
+
+        private void updateValue()
+        {
+            int currentRulesetId = ruleset.Value.OnlineID;
+
+            if (!modeSelections.ContainsKey(currentRulesetId))
+                modeSelections[currentRulesetId] = new HashSet<string> { "All" };
+
+            HashSet<string> selectedModes;
+
+            if (isMultiSelectMode.Value)
+            {
+                selectedModes = CircleSizeFilter.SelectedModeIds;
+                keyModeId.Value = string.Join(",", selectedModes.OrderBy(x => x));
+            }
+            else
+            {
+                selectedModes = CircleSizeFilter.SelectedModeIds;
+                keyModeId.Value = selectedModes.Count > 0 ? selectedModes.First() : "All";
+            }
+
+            modeSelections[currentRulesetId] = selectedModes;
+            tabControl.UpdateForRuleset(currentRulesetId);
+            tabControl.UpdateTabItemUI(selectedModes);
+            tabControl.IsMultiSelectMode = isMultiSelectMode.Value;
+        }
+
+        private HashSet<string> parseModeIds(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return new HashSet<string> { "All" };
+
+            return new HashSet<string>(value.Split(','));
+        }
+
+        public partial class ShearedCsModeTabControl : OsuTabControl<string>
+        {
+            private readonly Box labelBox;
+            private readonly OsuSpriteText labelText;
+            private HashSet<string> currentSelection = new HashSet<string> { "All" };
+            private int currentRulesetId = -1;
+
+            public Container LabelContainer;
+            public bool IsMultiSelectMode { get; set; }
+            public float TabHeight { get; set; } = 30f;
+
+            public Action<HashSet<string>>? SetCurrentSelections;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            public ShearedCsModeTabControl()
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+                Shear = OsuGame.SHEAR;
+                CornerRadius = ShearedButton.CORNER_RADIUS;
+                Masking = true;
+                LabelContainer = new Container
+                {
+                    Depth = float.MaxValue,
+                    CornerRadius = ShearedButton.CORNER_RADIUS,
+                    Masking = true,
+                    AutoSizeAxes = Axes.Y,
+                    Width = 50,
+                    Children = new Drawable[]
+                    {
+                        labelBox = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        labelText = new OsuSpriteText
+                        {
+                            Text = "Keys",
+                            Margin = new MarginPadding
+                                { Horizontal = 8f, Vertical = 7f },
+                            Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
+                            Shear = -OsuGame.SHEAR,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                    }
+                };
+                AddInternal(LabelContainer);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                labelBox.Colour = colourProvider.Background3;
+
+                TabContainer.Anchor = Anchor.CentreLeft;
+                TabContainer.Origin = Anchor.CentreLeft;
+                TabContainer.Shear = -OsuGame.SHEAR;
+                TabContainer.RelativeSizeAxes = Axes.X;
+                TabContainer.AutoSizeAxes = Axes.Y;
+                TabContainer.Spacing = new Vector2(0f);
+                TabContainer.Margin = new MarginPadding
+                {
+                    Left = LabelContainer.DrawWidth + 8,
+                };
+            }
+
+            public void UpdateForRuleset(int rulesetId)
+            {
+                if (currentRulesetId == rulesetId && Items.Any())
+                    return;
+
+                currentRulesetId = rulesetId;
+
+                var keyModes = CsItemIds.GetModesForRuleset(rulesetId)
+                                        .OrderBy(m => m.Id == "All" ? -1 : m.CsValue ?? 0)
+                                        .Select(m => m.Id)
+                                        .ToList();
+
+                TabContainer.Clear();
+                Items = keyModes;
+                labelText.Text = rulesetId == 3 ? "Keys" : "CS";
+
+                UpdateTabItemUI(currentSelection);
+            }
+
+            public void UpdateTabItemUI(HashSet<string> selectedModes)
+            {
+                currentSelection = new HashSet<string>(selectedModes);
+
+                foreach (var tabItem in TabContainer.Children.Cast<ShearedCsModeTabItem>())
+                {
+                    bool isSelected = selectedModes.Contains(tabItem.Value);
+                    tabItem.UpdateButton(isSelected);
+                }
+            }
+
+            protected override Dropdown<string> CreateDropdown() => null!;
+            // protected override bool AddEnumEntriesAutomatically => false;
+
+            protected override TabItem<string> CreateTabItem(string value)
+            {
+                var tabItem = new ShearedCsModeTabItem(value);
+                tabItem.Clicked += onTabItemClicked;
+                return tabItem;
+            }
+
+            private void onTabItemClicked(string mode)
+            {
+                var newSelection = new HashSet<string>(currentSelection);
+
+                if (mode == "All" || newSelection.Count == 0)
+                {
+                    newSelection.Clear();
+                    newSelection.Add("All");
+                }
+                else if (newSelection.Contains("All"))
+                {
+                    newSelection.Clear();
+                    newSelection.Add(mode);
+                }
+                else if (!newSelection.Add(mode))
+                {
+                    newSelection.Remove(mode);
+                }
+                else
+                {
+                    if (IsMultiSelectMode)
+                    {
+                        newSelection.Add(mode);
+                    }
+                    else
+                    {
+                        newSelection.Clear();
+                        newSelection.Add(mode);
+                    }
+                }
+
+                currentSelection = newSelection;
+                Current.Value = string.Join(",", newSelection.OrderBy(x => x));
+                UpdateTabItemUI(newSelection);
+
+                SetCurrentSelections?.Invoke(newSelection);
+            }
+
+            public partial class ShearedCsModeTabItem : TabItem<string>
+            {
+                private readonly OsuSpriteText text;
+                private readonly Box background;
+                private OverlayColourProvider colourProvider = null!;
+
+                public event Action<string>? Clicked;
+
+                public ShearedCsModeTabItem(string value)
+                    : base(value)
+                {
+                    Shear = OsuGame.SHEAR;
+                    CornerRadius = ShearedButton.CORNER_RADIUS;
+                    Masking = true;
+                    AutoSizeAxes = Axes.Both;
+                    Margin = new MarginPadding { Left = 4 };
+
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    };
+
+                    var modeInfo = CsItemIds.GetById(value);
+                    text = new OsuSpriteText
+                    {
+                        Text = modeInfo?.DisplayName ?? value,
+                        Margin = new MarginPadding
+                            { Horizontal = 10f, Vertical = 7f },
+                        Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Shear = -OsuGame.SHEAR,
+                        Colour = Colour4.White,
+                    };
+
+                    AddInternal(background);
+                    AddInternal(text);
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider colourProvider)
+                {
+                    this.colourProvider = colourProvider;
+                    background.Colour = colourProvider.Background5;
+                }
+
+                public void UpdateButton(bool isSelected)
+                {
+                    if (Active.Value != isSelected)
+                    {
+                        Active.Value = isSelected;
+                        Schedule(updateColours);
+                    }
+                }
+
+                private void updateColours()
+                {
+                    using (BeginDelayedSequence(0))
+                    {
+                        if (Active.Value)
+                        {
+                            background.FadeColour(colourProvider.Light4, 150, Easing.OutQuint);
+                            text.FadeColour(Colour4.Black, 150, Easing.OutQuint);
+                        }
+                        else if (IsHovered)
+                        {
+                            background.FadeColour(colourProvider.Background4, 150, Easing.OutQuint);
+                            text.FadeColour(Colour4.White, 150, Easing.OutQuint);
+                        }
+                        else
+                        {
+                            background.FadeColour(colourProvider.Background5, 150, Easing.OutQuint);
+                            text.FadeColour(Colour4.White, 150, Easing.OutQuint);
+                        }
+                    }
+                }
+
+                protected override void OnActivated() => Schedule(updateColours);
+                protected override void OnDeactivated() => Schedule(updateColours);
+
+                protected override bool OnHover(HoverEvent e)
+                {
+                    Schedule(updateColours);
+                    return base.OnHover(e);
+                }
+
+                protected override void OnHoverLost(HoverLostEvent e)
+                {
+                    Schedule(updateColours);
+                    base.OnHoverLost(e);
+                }
+
+                protected override bool OnClick(ClickEvent e)
+                {
+                    Clicked?.Invoke(Value);
+                    return true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a CS selection filter in the song selection interface, which supports single selection/multiple selection;
With multi-select switch button. Single-click to select it, click here to uncheck. Return to All when the election is empty.

<img width="917" height="549" alt="Snipaste_2025-08-30_23-49-20" src="https://github.com/user-attachments/assets/be463846-8dfc-4ad5-b2c3-eae6f2613fb2" />
For mania mode, you can accurately multi-select, such as 4k + 7K, instead of 4~7K;
<img width="887" height="313" alt="Snipaste_2025-08-30_23-49-52" src="https://github.com/user-attachments/assets/e304e28d-f2eb-4252-b75f-0969b3430171" />

For non-mania mode, in the multi-select state, it is filtered by the maximum/minimum value of the selection (I didn't find a good place to apply precise filtering in non-mania mode)
When selecting, filter according to the variable ± 0.5, I think this will be more intuitive, such as selecting CS4, the filter result is 3.5
<img width="993" height="552" alt="Snipaste_2025-08-30_23-52-10" src="https://github.com/user-attachments/assets/4c1844d9-7c1e-477d-822a-30e3801cc637" />
