### PR TITLE
Fix rotation & scale popovers crashing on dismissal via keyboard when simultaneously dragging sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/PreciseMovementPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseMovementPopover.cs
@@ -176,6 +176,11 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void applyPosition()
         {
+            // can happen if popover disabled by a keyboard key press while dragging UI controls
+            // it doesn't cause a crash, but it looks wrong
+            if (!editorBeatmap.TransactionActive)
+                return;
+
             editorBeatmap.PerformOnSelection(ho =>
             {
                 if (!initialPositions.TryGetValue(ho, out var initialPosition))

--- a/osu.Game.Rulesets.Osu/Edit/PreciseMovementPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseMovementPopover.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void applyPosition()
         {
-            // can happen if popover disabled by a keyboard key press while dragging UI controls
+            // can happen if popover is dismissed by a keyboard key press while dragging UI controls
             // it doesn't cause a crash, but it looks wrong
             if (!editorBeatmap.TransactionActive)
                 return;

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -97,7 +97,11 @@ namespace osu.Game.Rulesets.Osu.Edit
             base.LoadComplete();
 
             ScheduleAfterChildren(() => angleInput.TakeFocus());
-            angleInput.Current.BindValueChanged(angle => rotationInfo.Value = rotationInfo.Value with { Degrees = angle.NewValue });
+            angleInput.Current.BindValueChanged(angle =>
+            {
+                if (rotationHandler.OperationInProgress.Value)
+                    rotationInfo.Value = rotationInfo.Value with { Degrees = angle.NewValue };
+            });
 
             rotationHandler.CanRotateAroundSelectionOrigin.BindValueChanged(e =>
             {

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -97,11 +97,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             base.LoadComplete();
 
             ScheduleAfterChildren(() => angleInput.TakeFocus());
-            angleInput.Current.BindValueChanged(angle =>
-            {
-                if (rotationHandler.OperationInProgress.Value)
-                    rotationInfo.Value = rotationInfo.Value with { Degrees = angle.NewValue };
-            });
+            angleInput.Current.BindValueChanged(angle => rotationInfo.Value = rotationInfo.Value with { Degrees = angle.NewValue });
 
             rotationHandler.CanRotateAroundSelectionOrigin.BindValueChanged(e =>
             {
@@ -161,6 +157,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             rotationInfo.BindValueChanged(rotation =>
             {
+                // can happen if the popover is dismessed by a keyboard key press while dragging UI controls
+                if (!rotationHandler.OperationInProgress.Value)
+                    return;
+
                 rotationHandler.Update(rotation.NewValue.Degrees, getOriginPosition(rotation.NewValue));
             });
         }

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             rotationInfo.BindValueChanged(rotation =>
             {
-                // can happen if the popover is dismessed by a keyboard key press while dragging UI controls
+                // can happen if the popover is dismissed by a keyboard key press while dragging UI controls
                 if (!rotationHandler.OperationInProgress.Value)
                     return;
 

--- a/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
@@ -140,7 +140,11 @@ namespace osu.Game.Rulesets.Osu.Edit
             base.LoadComplete();
 
             ScheduleAfterChildren(() => scaleInput.TakeFocus());
-            scaleInput.Current.BindValueChanged(scale => scaleInfo.Value = scaleInfo.Value with { Scale = scale.NewValue });
+            scaleInput.Current.BindValueChanged(scale =>
+            {
+                if (scaleHandler.OperationInProgress.Value)
+                    scaleInfo.Value = scaleInfo.Value with { Scale = scale.NewValue };
+            });
 
             xCheckBox.Current.BindValueChanged(_ =>
             {

--- a/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
@@ -140,11 +140,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             base.LoadComplete();
 
             ScheduleAfterChildren(() => scaleInput.TakeFocus());
-            scaleInput.Current.BindValueChanged(scale =>
-            {
-                if (scaleHandler.OperationInProgress.Value)
-                    scaleInfo.Value = scaleInfo.Value with { Scale = scale.NewValue };
-            });
+            scaleInput.Current.BindValueChanged(scale => scaleInfo.Value = scaleInfo.Value with { Scale = scale.NewValue });
 
             xCheckBox.Current.BindValueChanged(_ =>
             {
@@ -224,6 +220,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             scaleInfo.BindValueChanged(scale =>
             {
+                // can happen if the popover is dismissed by a keyboard key press while dragging UI controls
+                if (!scaleHandler.OperationInProgress.Value)
+                    return;
+
                 var newScale = new Vector2(scale.NewValue.Scale, scale.NewValue.Scale);
                 scaleHandler.Update(newScale, getOriginPosition(scale.NewValue), getAdjustAxis(scale.NewValue), getRotation(scale.NewValue));
             });


### PR DESCRIPTION
resolve #34738 

Pressing space closes the Popover, which calls `Commit`. However, value could still be changed via slider while the`OperationInProgress` is already false, which causes an exception.

Now fixed