### PR TITLE
Fix crash when trying to test map in the editor

### DIFF
--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -60,15 +60,16 @@ namespace osu.Game.Screens.Edit.GameplayTest
             base.LoadAsyncComplete();
 
             if (DrawableRuleset != null)
-            {
                 preventMissOnPreviousHitObjects();
-                markPreviousObjectsHit();
-            }
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            // this will notify components such as the skin's combo counter, which needs to happen on the update thread
+            // and therefore can't happen alongside `preventMissOnPreviousHitObjects()` in `LoadAsyncComplete()`
+            markPreviousObjectsHit();
 
             ScoreProcessor.HasCompleted.BindValueChanged(completed =>
             {

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -124,27 +124,28 @@ namespace osu.Game.Screens.Edit.GameplayTest
         {
             void preventMiss(HitObject hitObject)
             {
-                if (hitObject.StartTime > editorState.Time)
-                    return;
-
                 var drawableObject = DrawableRuleset.Playfield.HitObjectContainer
                                                     .AliveObjects
                                                     .LastOrDefault(it => it.HitObject == hitObject);
 
-                preventMissOnDrawable(drawableObject);
+                if (drawableObject != null)
+                    preventMissOnDrawable(drawableObject);
             }
 
-            void preventMissOnDrawable(DrawableHitObject? drawableObject)
+            void preventMissOnDrawable(DrawableHitObject drawableObject)
             {
-                if (drawableObject?.Entry == null)
+                if (drawableObject.Entry == null)
                     return;
-
-                var result = drawableObject.CreateResult(drawableObject.HitObject.Judgement);
-                result.Type = result.Judgement.MaxResult;
-                drawableObject.Entry.Result = result;
 
                 foreach (var nested in drawableObject.NestedHitObjects)
                     preventMissOnDrawable(nested);
+
+                if (drawableObject.HitObject.GetEndTime() < editorState.Time)
+                {
+                    var result = drawableObject.CreateResult(drawableObject.HitObject.Judgement);
+                    result.Type = result.Judgement.MaxResult;
+                    drawableObject.Entry.Result = result;
+                }
             }
 
             void removeListener()

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -14,6 +14,7 @@ using osu.Game.Overlays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
@@ -127,12 +128,20 @@ namespace osu.Game.Screens.Edit.GameplayTest
                                                     .AliveObjects
                                                     .LastOrDefault(it => it.HitObject == hitObject);
 
+                preventMissOnDrawable(drawableObject);
+            }
+
+            void preventMissOnDrawable(DrawableHitObject? drawableObject)
+            {
                 if (drawableObject?.Entry == null)
                     return;
 
                 var result = drawableObject.CreateResult(drawableObject.HitObject.Judgement);
                 result.Type = result.Judgement.MaxResult;
                 drawableObject.Entry.Result = result;
+
+                foreach (var nested in drawableObject.NestedHitObjects)
+                    preventMissOnDrawable(nested);
             }
 
             void removeListener()

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -134,13 +134,10 @@ namespace osu.Game.Screens.Edit.GameplayTest
 
             void preventMissOnDrawable(DrawableHitObject drawableObject)
             {
-                if (drawableObject.Entry == null)
-                    return;
-
                 foreach (var nested in drawableObject.NestedHitObjects)
                     preventMissOnDrawable(nested);
 
-                if (drawableObject.HitObject.GetEndTime() < editorState.Time)
+                if (drawableObject.Entry != null && drawableObject.HitObject.GetEndTime() < editorState.Time)
                 {
                     var result = drawableObject.CreateResult(drawableObject.HitObject.Judgement);
                     result.Type = result.Judgement.MaxResult;

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -59,8 +59,11 @@ namespace osu.Game.Screens.Edit.GameplayTest
         {
             base.LoadAsyncComplete();
 
-            preventMissOnPreviousHitObjects();
-            markPreviousObjectsHit();
+            if (DrawableRuleset != null)
+            {
+                preventMissOnPreviousHitObjects();
+                markPreviousObjectsHit();
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
             {
                 var drawableObject = DrawableRuleset.Playfield.HitObjectContainer
                                                     .AliveObjects
-                                                    .LastOrDefault(it => it.HitObject == hitObject);
+                                                    .SingleOrDefault(it => it.HitObject == hitObject);
 
                 if (drawableObject != null)
                     preventMissOnDrawable(drawableObject);

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -60,13 +60,12 @@ namespace osu.Game.Screens.Edit.GameplayTest
             base.LoadAsyncComplete();
 
             preventMissOnPreviousHitObjects();
+            markPreviousObjectsHit();
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            markPreviousObjectsHit();
 
             ScoreProcessor.HasCompleted.BindValueChanged(completed =>
             {

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -59,6 +59,8 @@ namespace osu.Game.Screens.Edit.GameplayTest
         {
             base.LoadAsyncComplete();
 
+            // `preventMissOnPreviousHitObjects()` needs to be called to install its hooks before drawable hit objects get the chance to run update logic,
+            // because it will not work otherwise due to being too late (various effects of the objects getting missed will have already taken place).
             if (DrawableRuleset != null)
                 preventMissOnPreviousHitObjects();
         }

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -59,10 +59,12 @@ namespace osu.Game.Screens.Edit.GameplayTest
         {
             base.LoadAsyncComplete();
 
-            // `preventMissOnPreviousHitObjects()` needs to be called to install its hooks before drawable hit objects get the chance to run update logic,
+            if (!LoadedBeatmapSuccessfully)
+                return;
+
+            // This hack needs to be called to install its hooks before drawable hit objects get the chance to run update logic,
             // because it will not work otherwise due to being too late (various effects of the objects getting missed will have already taken place).
-            if (DrawableRuleset != null)
-                preventMissOnPreviousHitObjects();
+            preventMissOnPreviousHitObjects();
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Closes #34846 

Turns out the editor player was relying on the 1-frame delay before hitobject drawables would become alive prior to #34830.
Issue here was that with hitobjects becoming alive immediately, they already had a chance to update their state to "miss" before the player can manually set their result now.
This lead to a null pointer exception in the playfield's update look due to `JudgementResult.RawTime` being null.

Assigning a time to the result did fix the crash but the logic of marking the objectse was still broken, so tried to hook things up to update before the hitobject has a chance to update it's own state. Not 100% confident in this fix quality wise though so maybe reverting #34830 is a better option.
