### PR TITLE
Fix excess requests leading to queueing / delays of updating metadata at song select

### DIFF
--- a/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
+++ b/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Screens.SelectV2
             var request = new GetBeatmapSetRequest(id);
             var tcs = new TaskCompletionSource<APIBeatmapSet?>();
 
+            token.Register(() => request.Cancel());
+
             // async request success callback is a bit of a dangerous game, but there's some reasoning for it.
             // - don't really want to use `IAPIAccess.PerformAsync()` because we still want to respect request queueing & online status checks
             // - we want the realm write here to be async because it is known to be slow for some users with large beatmap collections

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -1011,7 +1011,7 @@ namespace osu.Game.Screens.SelectV2
 
             lastLookupResult.Value = BeatmapSetLookupResult.InProgress();
             onlineLookupCancellation = new CancellationTokenSource();
-            currentOnlineLookup = onlineLookupSource.GetBeatmapSetAsync(beatmapSetInfo.OnlineID);
+            currentOnlineLookup = onlineLookupSource.GetBeatmapSetAsync(beatmapSetInfo.OnlineID, onlineLookupCancellation.Token);
             currentOnlineLookup.ContinueWith(t =>
             {
                 if (t.IsCompletedSuccessfully)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34848

Can test with:

```diff
diff --git a/osu.Game/Screens/SelectV2/SongSelect.cs b/osu.Game/Screens/SelectV2/SongSelect.cs
index a97f0fbca0..334da8dd35 100644
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -65,7 +65,7 @@ public abstract partial class SongSelect : ScreenWithBeatmapBackground, IKeyBind
     {
         // this is intentionally slightly higher than key repeat, but low enough to not impede user experience.
         // this avoids rapid churn loading when iterating the carousel using keyboard.
-        public const int SELECTION_DEBOUNCE = 100;
+        public const int SELECTION_DEBOUNCE = 0;
 
         private const float logo_scale = 0.4f;
         private const double fade_duration = 300;

```
