### PR TITLE
Fix multiplayer lobby being unusable on mobile

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -148,11 +148,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 };
             });
 
-            AddUntilStep("wait for panel load", () => rooms.Count, () => Is.EqualTo(8));
+            AddUntilStep("wait for panel load", () => rooms.Count, () => Is.EqualTo(10));
             AddUntilStep("\"currently playing\" room count correct",
-                () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Currently playing", StringComparison.Ordinal)), () => Is.EqualTo(3));
+                () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Currently playing", StringComparison.Ordinal)), () => Is.EqualTo(4));
             AddUntilStep("\"ready to play\" room count correct", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Ready to play", StringComparison.Ordinal)),
-                () => Is.EqualTo(4));
+                () => Is.EqualTo(5));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -19,6 +19,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
+using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Tests.Beatmaps;
 using osuTK;
 
@@ -38,10 +39,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("create rooms", () =>
             {
-                PlaylistItem item1 = new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo)
+                PlaylistItem item1 = new PlaylistItem(new APIBeatmap
                 {
-                    BeatmapInfo = { StarRating = 2.5 }
-                }.BeatmapInfo);
+                    OnlineBeatmapSetID = 173612,
+                    OnlineID = 502132,
+                });
 
                 PlaylistItem item2 = new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo)
                 {
@@ -72,6 +74,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Spacing = new Vector2(10),
                     Children = new Drawable[]
                     {
+                        createMultiplayerPanel(new Room
+                        {
+                            Name = "Multiplayer room",
+                            EndDate = DateTimeOffset.Now.AddDays(1),
+                            Type = MatchType.HeadToHead,
+                            Playlist = [item1],
+                            CurrentPlaylistItem = item1
+                        }),
                         createLoungeRoom(new Room
                         {
                             Name = "Multiplayer room",
@@ -97,6 +107,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
                             Type = MatchType.HeadToHead,
                             Playlist = [item3],
                             CurrentPlaylistItem = item3
+                        }),
+                        createPlaylistRoomPanel(new Room
+                        {
+                            Name = "Playlist room with multiple beatmaps",
+                            Status = RoomStatus.Playing,
+                            EndDate = DateTimeOffset.Now.AddDays(1),
+                            Playlist = [item1, item2],
+                            CurrentPlaylistItem = item1
                         }),
                         createLoungeRoom(new Room
                         {
@@ -131,8 +149,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for panel load", () => rooms.Count, () => Is.EqualTo(8));
-            AddUntilStep("\"currently playing\" room count correct", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Currently playing", StringComparison.Ordinal)), () => Is.EqualTo(3));
-            AddUntilStep("\"ready to play\" room count correct", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Ready to play", StringComparison.Ordinal)), () => Is.EqualTo(4));
+            AddUntilStep("\"currently playing\" room count correct",
+                () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Currently playing", StringComparison.Ordinal)), () => Is.EqualTo(3));
+            AddUntilStep("\"ready to play\" room count correct", () => rooms.ChildrenOfType<OsuSpriteText>().Count(s => s.Text.ToString().StartsWith("Ready to play", StringComparison.Ordinal)),
+                () => Is.EqualTo(4));
         }
 
         [Test]
@@ -207,7 +227,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 {
                     new MultiplayerRoomPanel(new Room
                     {
-                        Name = "This room has a very very long title enough to make the external link button reach the participants list on the right side unless the test window is very wide, at which point I don't know, hi.",
+                        Name =
+                            "This room has a very very long title enough to make the external link button reach the participants list on the right side unless the test window is very wide, at which point I don't know, hi.",
                         QueueMode = QueueMode.HostOnly,
                         Type = MatchType.HeadToHead,
                         RoomID = 1337,
@@ -231,7 +252,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 {
                     new MultiplayerRoomPanel(room = new Room
                     {
-                        Name = "This room has a very very long title enough to make the external link button reach the participants list on the right side unless the test window is very wide, at which point I don't know, hi.",
+                        Name =
+                            "This room has a very very long title enough to make the external link button reach the participants list on the right side unless the test window is very wide, at which point I don't know, hi.",
                         QueueMode = QueueMode.HostOnly,
                         Type = MatchType.HeadToHead,
                     }),
@@ -241,6 +263,41 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("set room ID", () => room.RoomID = 1337);
             AddWaitStep("wait", 3);
             AddStep("clear room ID", () => room.RoomID = null);
+        }
+
+        private RoomPanel createPlaylistRoomPanel(Room room)
+        {
+            room.Host ??= new APIUser { Username = "peppy", Id = 2 };
+
+            if (room.RecentParticipants.Count == 0)
+            {
+                room.RecentParticipants = Enumerable.Range(0, 20).Select(i => new APIUser
+                {
+                    Id = i,
+                    Username = $"User {i}"
+                }).ToArray();
+            }
+
+            return new PlaylistsRoomPanel(room)
+            {
+                SelectedItem = new Bindable<PlaylistItem?>(room.CurrentPlaylistItem),
+            };
+        }
+
+        private RoomPanel createMultiplayerPanel(Room room)
+        {
+            room.Host ??= new APIUser { Username = "peppy", Id = 2 };
+
+            if (room.RecentParticipants.Count == 0)
+            {
+                room.RecentParticipants = Enumerable.Range(0, 20).Select(i => new APIUser
+                {
+                    Id = i,
+                    Username = $"User {i}"
+                }).ToArray();
+            }
+
+            return new MultiplayerRoomPanel(room);
         }
 
         private RoomPanel createLoungeRoom(Room room)

--- a/osu.Game/Screens/OnlinePlay/Header.cs
+++ b/osu.Game/Screens/OnlinePlay/Header.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.OnlinePlay
 {
     public partial class Header : Container
     {
-        public const float HEIGHT = 80;
+        public const float HEIGHT = 50;
 
         private readonly ScreenStack? stack;
         private readonly MultiHeaderTitle title;

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoomParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoomParticipantsList.cs
@@ -23,10 +23,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 {
     public partial class DrawableRoomParticipantsList : CompositeDrawable
     {
-        public const float SHEAR_WIDTH = 12f;
-        private const float avatar_size = 36;
-        private const float height = 60f;
-        private static readonly Vector2 shear = new Vector2(SHEAR_WIDTH / height, 0);
+        private const float avatar_size = 30;
+        private const float height = 40f;
 
         private readonly Room room;
 
@@ -54,7 +52,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     RelativeSizeAxes = Axes.Both,
                     Masking = true,
                     CornerRadius = 10,
-                    Shear = shear,
+                    Shear = OsuGame.SHEAR,
                     Child = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -71,10 +69,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                         {
                             RelativeSizeAxes = Axes.Y,
                             AutoSizeAxes = Axes.X,
-                            Spacing = new Vector2(8),
+                            Spacing = new Vector2(4),
                             Padding = new MarginPadding
                             {
-                                Left = 8,
+                                Left = 4,
                                 Right = 16
                             },
                             Children = new Drawable[]
@@ -84,7 +82,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
                                 },
-                                hostText = new LinkFlowContainer
+                                hostText = new LinkFlowContainer(s => s.Font = OsuFont.Style.Caption2)
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
@@ -103,7 +101,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                     RelativeSizeAxes = Axes.Both,
                                     Masking = true,
                                     CornerRadius = 10,
-                                    Shear = shear,
+                                    Shear = OsuGame.SHEAR,
                                     Child = new Box
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -128,12 +126,12 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
-                                            Size = new Vector2(16),
+                                            Size = new Vector2(12),
                                             Icon = FontAwesome.Solid.User,
                                         },
                                         totalCount = new OsuSpriteText
                                         {
-                                            Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                                            Font = OsuFont.Style.Caption2.With(weight: FontWeight.Bold),
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                         },

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomListing.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomListing.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         private readonly ScrollContainer<Drawable> scroll;
         private readonly FillFlowContainer<LoungeRoomPanel> roomFlow;
 
-        private const float display_scale = 0.8f;
-
         // handle deselection
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
@@ -58,7 +56,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
-                Width = display_scale,
+                Width = 0.8f,
                 ScrollbarOverlapsContent = false,
                 Padding = new MarginPadding { Right = 5 },
                 Child = new OsuContextMenuContainer
@@ -188,8 +186,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     SelectedRoom = selectedRoom,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Scale = new Vector2(display_scale),
-                    Width = 1 / display_scale,
                 };
 
                 roomFlow.Add(drawableRoom);

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
@@ -31,7 +31,6 @@ using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.Components;
 using osuTK;
-using osuTK.Graphics;
 using Container = osu.Framework.Graphics.Containers.Container;
 
 namespace osu.Game.Screens.OnlinePlay.Lounge.Components
@@ -39,7 +38,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
     public abstract partial class RoomPanel : CompositeDrawable, IHasContextMenu
     {
         protected const float CORNER_RADIUS = 10;
-        private const float height = 100;
+        private const float height = 80;
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -80,12 +79,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
             Masking = true;
             CornerRadius = CORNER_RADIUS;
-            EdgeEffect = new EdgeEffectParameters
-            {
-                Type = EdgeEffectType.Shadow,
-                Colour = Color4.Black.Opacity(40),
-                Radius = 5,
-            };
         }
 
         [BackgroundDependencyLoader]
@@ -97,6 +90,13 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 Origin = Anchor.CentreRight,
                 RelativeSizeAxes = Axes.Y,
                 AutoSizeAxes = Axes.X
+            };
+
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Shadow,
+                Colour = colourProvider.Background6.Opacity(0.4f),
+                Radius = 4,
             };
 
             InternalChildren = new Drawable[]
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                         Name = @"Room content",
                         RelativeSizeAxes = Axes.Both,
                         // This negative padding resolves 1px gaps between this background and the background above.
-                        Padding = new MarginPadding { Left = 20, Vertical = -0.5f },
+                        Padding = new MarginPadding { Left = 10, Vertical = -0.5f },
                         Child = new Container
                         {
                             RelativeSizeAxes = Axes.Both,
@@ -158,8 +158,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                                 RelativeSizeAxes = Axes.Both,
                                                 Padding = new MarginPadding
                                                 {
-                                                    Left = 20,
-                                                    Right = DrawableRoomParticipantsList.SHEAR_WIDTH,
+                                                    Left = 10,
+                                                    Right = 10,
                                                     Vertical = 5
                                                 },
                                                 Children = new Drawable[]
@@ -516,12 +516,12 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                         {
                             statusText = new OsuSpriteText
                             {
-                                Font = OsuFont.Default.With(size: 16),
+                                Font = OsuFont.Style.Caption2,
                                 Colour = colours.Lime1
                             },
                             beatmapText = new LinkFlowContainer(s =>
                             {
-                                s.Font = OsuFont.Default.With(size: 16);
+                                s.Font = OsuFont.Style.Caption2;
                                 s.Colour = colours.Lime1;
                             })
                             {
@@ -636,7 +636,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     {
                         Anchor = Anchor.BottomLeft,
                         Origin = Anchor.BottomLeft,
-                        Font = OsuFont.GetFont(size: 28),
+                        Font = OsuFont.Style.Heading2,
                     },
                     linkButton = new ExternalLinkButton
                     {

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                                         {
                                             d.Anchor = Anchor.BottomLeft;
                                             d.Origin = Anchor.BottomLeft;
-                                            d.Size = new Vector2(150, 37.5f);
+                                            d.Size = new Vector2(150, 30f);
                                             d.Action = () => Open();
                                         })),
                                         new FillFlowContainer

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                                             new AddItemButton
                                                                             {
                                                                                 RelativeSizeAxes = Axes.X,
-                                                                                Height = 40,
+                                                                                Height = 30,
                                                                                 Text = "Add item",
                                                                                 Action = () => ShowSongSelect()
                                                                             },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private MultiplayerClient client { get; set; } = null!;
 
         public ParticipantsList()
-            : base(ParticipantPanel.HEIGHT, initialPoolSize: 20)
+            : base(ParticipantPanel.HEIGHT + 1, initialPoolSize: 20)
         {
         }
 


### PR DESCRIPTION
This brings sizing down to a usable level. Note that you can actually see one current item now where you previously couldn't. This gets priority in an effort to have a minimum usability level for upcoming mobile releases.

Testing on desktop, but roughly estimating based on how things look on my iOS device.

| Before | After |
| :---: | :---: |
| <img width="2656" height="1451" alt="osu! 2025-09-01 at 10 41 18" src="https://github.com/user-attachments/assets/4db1c6ba-62fc-4cd0-8152-73fe4a61880d" /> | <img width="2656" height="1451" alt="Safari 2025-09-01 at 10 52 00" src="https://github.com/user-attachments/assets/b43499d6-8166-471e-bde1-9eb56b77e24e" /> |
| <img width="2656" height="1451" alt="osu! 2025-09-01 at 10 53 07" src="https://github.com/user-attachments/assets/78ae25e6-4b83-4a90-83e0-e4213e87f411" /> | <img width="2656" height="1451" alt="Safari 2025-09-01 at 10 52 16" src="https://github.com/user-attachments/assets/72a33016-ec68-4b84-b3c7-fb6b594ca6f2" /> |