### PR TITLE
Fix gameplay freezing on stutter frames / long load times

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -161,7 +161,9 @@ namespace osu.Game.Rulesets.UI
             //
             // In testing this triggers *very* rarely even when set to super low values (10 ms). The cases we're worried about involve multi-second jumps.
             // A difference of more than 500 ms seems like a sane number we should never exceed.
-            if (!allowReferenceClockSeeks && Math.Abs(proposedTime - referenceClock.CurrentTime) > 500)
+            //
+            // Double-checking against the parent clock ensures we don't accidentally freeze time when the game stutters due to a long running frame.
+            if (!allowReferenceClockSeeks && Math.Abs(proposedTime - referenceClock.CurrentTime) > 500 && parentGameplayClock?.ElapsedFrameTime <= 500)
             {
                 if (invalidBassTimeLogCount < 10)
                 {

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Rulesets.UI
             //
             // In testing this triggers *very* rarely even when set to super low values (10 ms). The cases we're worried about involve multi-second jumps.
             // A difference of more than 500 ms seems like a sane number we should never exceed.
-            if (!allowReferenceClockSeeks && Math.Abs(proposedTime - referenceClock.CurrentTime) > 1500)
+            if (!allowReferenceClockSeeks && Math.Abs(proposedTime - referenceClock.CurrentTime) > 500)
             {
                 if (invalidBassTimeLogCount < 10)
                 {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34732.

May hotfix for this one.

Can test using this diff:

```diff
diff --git a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
index 892f4acb78..1347787c33 100644
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -6,7 +6,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
-using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
@@ -155,7 +154,7 @@ private void updateClock()
             }
 
             // TODO: replace IsDebugBuild with a framework flag which asserts we are in a test scene, interactively or otherwise.
-            bool allowReferenceClockSeeks = hasReplayAttached || DebugUtils.IsNUnitRunning || DebugUtils.IsDebugBuild || !FrameStablePlayback;
+            bool allowReferenceClockSeeks = hasReplayAttached || !FrameStablePlayback;
 
             // This is a hotfix for ongoing bass issues we are trying to resolve (see https://www.un4seen.com/forum/?topic=20482.msg145474#msg145474)
             //
diff --git a/osu.Game/Screens/Play/Player.cs b/osu.Game/Screens/Play/Player.cs
index 22fb8a3463..36fc9f4983 100644
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -18,6 +18,7 @@
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
+using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -529,6 +530,14 @@ private Drawable createOverlayComponents()
             return container;
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            if (RNG.NextDouble() < 0.001)
+                Thread.Sleep(1600);
+        }
+
         private void onBreakTimeChanged(ValueChangedEvent<bool> isBreakTime)
         {
             updateGameplayState();

```

Can probably write a test covering this but not sure it's worth the effort.