### PR TITLE
Ignore `.osu` files not placed at top level of beatmap archive on import

### DIFF
--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -367,7 +367,11 @@ namespace osu.Game.Beatmaps
         {
             var beatmaps = new List<BeatmapInfo>();
 
-            foreach (var file in beatmapSet.Files.Where(f => f.Filename.EndsWith(".osu", StringComparison.OrdinalIgnoreCase)))
+            // stable appears to ignore `.osu` files which are not placed at the top level of the beatmap archive.
+            // the logic that achieves this is very difficult to make sense of, but appears to be located somewhere around
+            // https://github.com/peppy/osu-stable-reference/blob/67795dba3c308e7d0493b296149dcb073ca47ecb/osu!/GameplayElements/Beatmaps/BeatmapManager.cs#L207-L208
+            // only testing the `/` path separator character is sufficient as `RealmNamedFileUsage`s are normalised to use the front slash unix path separator convention
+            foreach (var file in beatmapSet.Files.Where(f => !f.Filename.Contains('/') && f.Filename.EndsWith(@".osu", StringComparison.OrdinalIgnoreCase)))
             {
                 using (var memoryStream = new MemoryStream(Files.Store.Get(file.File.GetStoragePath()))) // we need a memory stream so we can seek
                 {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34677.

I attempted to verify that stable does the same but honestly I am still not sure. I think that maybe possibly it does but the [stable logic I found that - I *think* - achieves this result](https://github.com/peppy/osu-stable-reference/blob/67795dba3c308e7d0493b296149dcb073ca47ecb/osu!/GameplayElements/Beatmaps/BeatmapManager.cs#L207-L208) is so obfuscated it's honestly pretty impressive.