### PR TITLE
Fix song select debounce not handling long (stutter) frames well

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge_DifficultyDisplay.cs
@@ -249,7 +249,7 @@ namespace osu.Game.Screens.SelectV2
                     mapperText.Text = beatmap.Value.Metadata.Author.Username;
                 }
 
-                starRatingDisplay.Current = (Bindable<StarDifficulty>)difficultyCache.GetBindableDifficulty(beatmap.Value.BeatmapInfo, cancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
+                starRatingDisplay.Current = (Bindable<StarDifficulty>)difficultyCache.GetBindableDifficulty(beatmap.Value.BeatmapInfo, cancellationSource.Token, SongSelect.DIFFICULTY_CALCULATION_DEBOUNCE);
 
                 updateCountStatistics(cancellationSource.Token);
                 updateDifficultyStatistics();

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmap = (BeatmapInfo)Item.Model;
 
-            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
+            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.DIFFICULTY_CALCULATION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(starDifficulty =>
             {
                 starRatingDisplay.Current.Value = starDifficulty.NewValue;

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -264,7 +264,7 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmap = (BeatmapInfo)Item.Model;
 
-            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.SELECTION_DEBOUNCE);
+            starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.DIFFICULTY_CALCULATION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(starDifficulty =>
             {
                 starRatingDisplay.Current.Value = starDifficulty.NewValue;

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.SelectV2
     {
         // this is intentionally slightly higher than key repeat, but low enough to not impede user experience.
         // this avoids rapid churn loading when iterating the carousel using keyboard.
-        public const int SELECTION_DEBOUNCE = 100;
+        public const int SELECTION_DEBOUNCE = 150;
 
         private const float logo_scale = 0.4f;
         private const double fade_duration = 300;

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -63,9 +63,20 @@ namespace osu.Game.Screens.SelectV2
     [Cached(typeof(ISongSelect))]
     public abstract partial class SongSelect : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, ISongSelect
     {
-        // this is intentionally slightly higher than key repeat, but low enough to not impede user experience.
-        // this avoids rapid churn loading when iterating the carousel using keyboard.
+        /// <summary>
+        /// A debounce that governs how long after a panel is selected before the rest of song select (and the game at large)
+        /// updates to show that selection.
+        ///
+        /// This is intentionally slightly higher than key repeat, but low enough to not impede user experience.
+        /// </summary>
         public const int SELECTION_DEBOUNCE = 150;
+
+        /// <summary>
+        /// A general "global" debounce to be applied to anything aggressive difficulty calculation at song select,
+        /// either after selection or after a panel comes on screen. Value should be low enough that users don't complain,
+        /// but otherwise as high as possible to reduce overheads.
+        /// </summary>
+        public const int DIFFICULTY_CALCULATION_DEBOUNCE = 150;
 
         private const float logo_scale = 0.4f;
         private const double fade_duration = 300;
@@ -1035,6 +1046,7 @@ namespace osu.Game.Screens.SelectV2
                 return;
 
             onlineLookupCancellation?.Cancel();
+            onlineLookupCancellation = null;
 
             if (beatmapSetInfo.OnlineID < 0)
             {

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -402,7 +402,7 @@ namespace osu.Game.Screens.SelectV2
             if (debounceQueuedSelection == null) return;
 
             // avoid debounce running early if there's a single long frame.
-            debounceElapsedTime += Math.Min(1000 / 60.0, Clock.ElapsedFrameTime);
+            debounceElapsedTime += Math.Min(1000 / Clock.FramesPerSecond, Clock.ElapsedFrameTime);
 
             if (debounceElapsedTime >= SELECTION_DEBOUNCE)
                 performDebounceSelection();

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -12,6 +12,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -383,7 +384,8 @@ namespace osu.Game.Screens.SelectV2
                 new Dimension(GridSizeMode.Relative, 0.5f, minSize: 500, maxSize: 700 + widescreenBonusWidth * 300),
             };
 
-            updateDebounce();
+            if (this.IsCurrentScreen())
+                updateDebounce();
         }
 
         #region Selection debounce
@@ -401,8 +403,13 @@ namespace osu.Game.Screens.SelectV2
         {
             if (debounceQueuedSelection == null) return;
 
+            double elapsed = Clock.ElapsedFrameTime;
+
             // avoid debounce running early if there's a single long frame.
-            debounceElapsedTime += Math.Min(1000 / Clock.FramesPerSecond, Clock.ElapsedFrameTime);
+            if (!DebugUtils.IsNUnitRunning && Clock.FramesPerSecond > 0)
+                elapsed = Math.Min(1000 / Clock.FramesPerSecond, elapsed);
+
+            debounceElapsedTime += elapsed;
 
             if (debounceElapsedTime >= SELECTION_DEBOUNCE)
                 performDebounceSelection();

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -400,7 +400,8 @@ namespace osu.Game.Screens.SelectV2
         {
             if (debounceQueuedSelection == null) return;
 
-            debounceElapsedTime += Clock.ElapsedFrameTime;
+            // avoid debounce running early if there's a single long frame.
+            debounceElapsedTime += Math.Min(1000 / 60.0, Clock.ElapsedFrameTime);
 
             if (debounceElapsedTime >= SELECTION_DEBOUNCE)
                 performDebounceSelection();


### PR DESCRIPTION
This fixes the edge case where a long single frame during key repeat iteration causes debounce to run immediately, instead of an expectation that it would just ignore the stutter frame and carry on.

Without this, we [runr into scenarios](https://discord.com/channels/188630481301012481/1097318920991559880/1412657191780880526) where one selection change during iteration cascades into a very bad user experience (first debounce being performed leads to further stutters, feedback loop etc.)

For what it's worth, I can reproduce this on my debug builds due to not having satori running (and something on my system causing stutters for whatever reason.

- I've also documented the debounces better, and adjusted up slightly.
- I tested adding debounce to the beatmap metadata fetch (as we're doing a *lot* of requests right now) but it doesn't work well due to being a debounce-reliant-on-another-debounce. A better approach would likely be to back-off when many selections happen over a short period, rather than delaying every request. Something for future exploration.