### PR TITLE
Fix `rank-up` and `rank-down` sounds playing too often in some scenarios

### DIFF
--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -33,11 +33,11 @@ namespace osu.Game.Screens.Play.HUD
         private SkinnableSound rankUpSample = null!;
 
         private Bindable<double?> lastSamplePlayback = null!;
-        private double lastRankUpdate;
+        private double timeSinceChange;
 
-        private ScoreRank displayedRank;
+        private ScoreRank? displayedRank;
 
-        private const int minimum_update_rate = 3000;
+        private const int time_before_commit = 1500;
 
         public DefaultRankDisplay()
         {
@@ -69,13 +69,14 @@ namespace osu.Game.Screens.Play.HUD
 
             var currentRank = scoreProcessor.Rank.Value;
 
-            if (currentRank != displayedRank)
+            if (currentRank == displayedRank)
             {
-                bool enoughTimeElapsed = Time.Current - lastRankUpdate >= minimum_update_rate;
-
-                if (enoughTimeElapsed || currentRank == ScoreRank.F)
-                    updateRank(currentRank);
+                timeSinceChange = 0;
+                return;
             }
+
+            if ((timeSinceChange += Time.Elapsed) >= time_before_commit || scoreProcessor.HasCompleted.Value)
+                updateRank(currentRank);
         }
 
         private void updateRank(ScoreRank rank)
@@ -86,7 +87,7 @@ namespace osu.Game.Screens.Play.HUD
             bool enoughSampleTimeElapsed = !lastSamplePlayback.Value.HasValue || Time.Current - lastSamplePlayback.Value >= OsuGameBase.SAMPLE_DEBOUNCE_TIME;
 
             // Also don't play rank-down sfx on quit/retry/initial update.
-            if (rank != displayedRank && rank > ScoreRank.F && PlaySamples.Value && enoughSampleTimeElapsed && lastRankUpdate > 0)
+            if (rank != displayedRank && rank > ScoreRank.F && PlaySamples.Value && enoughSampleTimeElapsed && displayedRank != null)
             {
                 if (rank > displayedRank)
                     rankUpSample.Play();
@@ -97,7 +98,7 @@ namespace osu.Game.Screens.Play.HUD
             }
 
             displayedRank = rank;
-            lastRankUpdate = Time.Current;
+            timeSinceChange = 0;
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Play.HUD
             {
                 rankDownSample = new SkinnableSound(new SampleInfo("Gameplay/rank-down")),
                 rankUpSample = new SkinnableSound(new SampleInfo("Gameplay/rank-up")),
-                rankDisplay = new UpdateableRank(ScoreRank.X)
+                rankDisplay = new UpdateableRank
                 {
                     RelativeSizeAxes = Axes.Both
                 },

--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -63,6 +63,13 @@ namespace osu.Game.Screens.Play.HUD
             lastSamplePlayback = statics.GetBindable<double?>(Static.LastRankChangeSamplePlaybackTime);
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            updateRank(scoreProcessor.Rank.Value);
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -75,7 +82,7 @@ namespace osu.Game.Screens.Play.HUD
                 return;
             }
 
-            if ((timeSinceChange += Time.Elapsed) >= time_before_commit || scoreProcessor.HasCompleted.Value)
+            if ((timeSinceChange += Time.Elapsed) >= time_before_commit || scoreProcessor.HasCompleted.Value || currentRank == ScoreRank.F)
                 updateRank(currentRank);
         }
 
@@ -87,7 +94,7 @@ namespace osu.Game.Screens.Play.HUD
             bool enoughSampleTimeElapsed = !lastSamplePlayback.Value.HasValue || Time.Current - lastSamplePlayback.Value >= OsuGameBase.SAMPLE_DEBOUNCE_TIME;
 
             // Also don't play rank-down sfx on quit/retry/initial update.
-            if (rank != displayedRank && rank > ScoreRank.F && PlaySamples.Value && enoughSampleTimeElapsed && displayedRank != null)
+            if (displayedRank != null && rank > ScoreRank.F && PlaySamples.Value && enoughSampleTimeElapsed)
             {
                 if (rank > displayedRank)
                     rankUpSample.Play();

--- a/osu.Game/Skinning/LegacyRankDisplay.cs
+++ b/osu.Game/Skinning/LegacyRankDisplay.cs
@@ -67,6 +67,13 @@ namespace osu.Game.Skinning
             lastSamplePlayback = statics.GetBindable<double?>(Static.LastRankChangeSamplePlaybackTime);
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            updateRank(scoreProcessor.Rank.Value);
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -79,7 +86,7 @@ namespace osu.Game.Skinning
                 return;
             }
 
-            if ((timeSinceChange += Time.Elapsed) >= time_before_commit || scoreProcessor.HasCompleted.Value)
+            if ((timeSinceChange += Time.Elapsed) >= time_before_commit || scoreProcessor.HasCompleted.Value || currentRank == ScoreRank.F)
                 updateRank(currentRank);
         }
 
@@ -89,7 +96,7 @@ namespace osu.Game.Skinning
 
             rankDisplay.Texture = texture;
 
-            if (texture != null)
+            if (texture != null && displayedRank != null)
             {
                 var transientRank = new Sprite
                 {
@@ -111,7 +118,7 @@ namespace osu.Game.Skinning
             bool enoughSampleTimeElapsed = !lastSamplePlayback.Value.HasValue || Time.Current - lastSamplePlayback.Value >= OsuGameBase.SAMPLE_DEBOUNCE_TIME;
 
             // Also don't play rank-down sfx on quit/retry/initial update.
-            if (rank != displayedRank && rank > ScoreRank.F && PlaySamples.Value && enoughSampleTimeElapsed && displayedRank != null)
+            if (displayedRank != null && rank > ScoreRank.F && PlaySamples.Value && enoughSampleTimeElapsed)
             {
                 if (rank > displayedRank)
                     rankUpSample.Play();


### PR DESCRIPTION
resolve #34754 

~~- DRY for `LegacyRankDisplay` and `DefaultRankDisplay`~~
- Added delay between rank updates (3 seconds; 1 second still feels fast)

### Preview

https://github.com/user-attachments/assets/2e7b1842-c483-425b-8671-0d46fe9eb21a

