### PR TITLE
Make DrawableDate formatting localizable

### DIFF
--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
@@ -264,7 +265,7 @@ namespace osu.Game.Tournament.Screens.Schedule
             {
             }
 
-            protected override string Format() => Date < DateTimeOffset.Now
+            protected override LocalisableString Format() => Date < DateTimeOffset.Now
                 ? $"Started {base.Format()}"
                 : $"Starting {base.Format()}";
         }

--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -266,8 +266,8 @@ namespace osu.Game.Tournament.Screens.Schedule
             }
 
             protected override LocalisableString Format() => Date < DateTimeOffset.Now
-                ? $"Started {base.Format()}"
-                : $"Starting {base.Format()}";
+                ? LocalisableString.Interpolate($"Started {base.Format()}")
+                : LocalisableString.Interpolate($"Starting {base.Format()}");
         }
 
         public partial class ScheduleContainer : Container

--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -97,8 +97,7 @@ namespace osu.Game.Graphics
 
             public string GetLocalised(LocalisationParameters parameters) => HumanizerUtils.Humanize(Date);
 
-            // Override for default string interpolations
-            public override string ToString() => HumanizerUtils.Humanize(Date);
+            public override string ToString() => GetLocalised(LocalisationParameters.DEFAULT);
         }
     }
 }

--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Utils;
 
@@ -71,7 +72,7 @@ namespace osu.Game.Graphics
             Scheduler.AddDelayed(updateTimeWithReschedule, timeUntilNextUpdate);
         }
 
-        protected virtual string Format() => HumanizerUtils.Humanize(Date);
+        protected virtual LocalisableString Format() => HumanizerUtils.Humanize(Date);
 
         private void updateTime() => Text = Format();
 

--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -72,12 +72,33 @@ namespace osu.Game.Graphics
             Scheduler.AddDelayed(updateTimeWithReschedule, timeUntilNextUpdate);
         }
 
-        protected virtual LocalisableString Format() => HumanizerUtils.Humanize(Date);
+        protected virtual LocalisableString Format() => new LocalisableString(new HumanisedLocalisableDate(Date));
 
         private void updateTime() => Text = Format();
 
         public ITooltip<DateTimeOffset> GetCustomTooltip() => new DateTooltip();
 
         public DateTimeOffset TooltipContent => Date;
+
+        private class HumanisedLocalisableDate : IEquatable<HumanisedLocalisableDate>, ILocalisableStringData
+        {
+            public readonly DateTimeOffset Date;
+
+            public HumanisedLocalisableDate(DateTimeOffset date)
+            {
+                Date = date;
+            }
+
+            public bool Equals(HumanisedLocalisableDate? other)
+                => other?.Date != null && Date.Equals(other.Date);
+
+            public bool Equals(ILocalisableStringData? other)
+                => other is HumanisedLocalisableDate otherDate && Equals(otherDate);
+
+            public string GetLocalised(LocalisationParameters parameters) => HumanizerUtils.Humanize(Date);
+
+            // Override for default string interpolations
+            public override string ToString() => HumanizerUtils.Humanize(Date);
+        }
     }
 }

--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Graphics
             Scheduler.AddDelayed(updateTimeWithReschedule, timeUntilNextUpdate);
         }
 
-        protected virtual LocalisableString Format() => new LocalisableString(new HumanisedLocalisableDate(Date));
+        protected virtual LocalisableString Format() => new LocalisableString(new HumanisedDate(Date));
 
         private void updateTime() => Text = Format();
 
@@ -80,20 +80,20 @@ namespace osu.Game.Graphics
 
         public DateTimeOffset TooltipContent => Date;
 
-        private class HumanisedLocalisableDate : IEquatable<HumanisedLocalisableDate>, ILocalisableStringData
+        private class HumanisedDate : IEquatable<HumanisedDate>, ILocalisableStringData
         {
             public readonly DateTimeOffset Date;
 
-            public HumanisedLocalisableDate(DateTimeOffset date)
+            public HumanisedDate(DateTimeOffset date)
             {
                 Date = date;
             }
 
-            public bool Equals(HumanisedLocalisableDate? other)
+            public bool Equals(HumanisedDate? other)
                 => other?.Date != null && Date.Equals(other.Date);
 
             public bool Equals(ILocalisableStringData? other)
-                => other is HumanisedLocalisableDate otherDate && Equals(otherDate);
+                => other is HumanisedDate otherDate && Equals(otherDate);
 
             public string GetLocalised(LocalisationParameters parameters) => HumanizerUtils.Humanize(Date);
 

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -429,7 +429,7 @@ namespace osu.Game.Online.Leaderboards
                 Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold);
             }
 
-            protected override string Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));
+            protected override LocalisableString Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));
         }
 
         public class LeaderboardScoreStatistic

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreboardTime.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreboardTime.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Localisation;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 
@@ -14,7 +15,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         {
         }
 
-        protected override string Format()
+        protected override LocalisableString Format()
             => Date.ToShortRelativeTime(TimeSpan.FromHours(1));
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/EndDateInfo.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/EndDateInfo.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Online.Rooms;
 
@@ -62,7 +63,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 Date = room.EndDate ?? DateTimeOffset.Now.AddYears(1);
             }
 
-            protected override string Format()
+            protected override LocalisableString Format()
             {
                 if (room.EndDate == null)
                     return string.Empty;

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/EndDateInfo.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/EndDateInfo.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 var diffToNow = Date.Subtract(DateTimeOffset.Now);
 
                 if (diffToNow.TotalSeconds < -5)
-                    return $"Closed {base.Format()}";
+                    return LocalisableString.Interpolate($"Closed {base.Format()}");
 
                 if (diffToNow.TotalSeconds < 0)
                     return "Closed";
@@ -79,7 +79,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 if (diffToNow.TotalSeconds < 5)
                     return "Closing soon";
 
-                return $"Closing {base.Format()}";
+                return LocalisableString.Interpolate($"Closing {base.Format()}");
             }
 
             protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -652,7 +652,7 @@ namespace osu.Game.Screens.SelectV2
                 Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold);
             }
 
-            protected override string Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));
+            protected override LocalisableString Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));
         }
 
         private partial class ScoreComponentLabel : Container


### PR DESCRIPTION
The demand comes from the localisation of schedule screen, where it uses `DrawableDate.Format()` to render dates. To support the use of LocalisableString, change of the return type is needed.

https://github.com/ppy/osu/blob/23d10ccdeb2cedeb9b1222a5f8b150c14aec0745/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs#L267-L269
