### PR TITLE
Add matchmaking model types required for server-side deploy

### DIFF
--- a/osu.Game.Tests/Online/Matchmaking/MatchmakingRoomStateTest.cs
+++ b/osu.Game.Tests/Online/Matchmaking/MatchmakingRoomStateTest.cs
@@ -1,0 +1,153 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+
+namespace osu.Game.Tests.Online.Matchmaking
+{
+    public class MatchmakingRoomStateTest
+    {
+        /// <summary>
+        /// The number of points awarded for each placement position (index 0 = #1, index 7 = #8).
+        /// </summary>
+        private static readonly int[] placement_points = [8, 7, 6, 5, 4, 3, 2, 1];
+
+        [Test]
+        public void Basic()
+        {
+            var state = new MatchmakingRoomState();
+
+            // 1 -> 3 -> 2
+
+            state.AdvanceRound();
+            state.RecordScores(
+            [
+                new SoloScoreInfo { UserID = 2, TotalScore = 500 },
+                new SoloScoreInfo { UserID = 1, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 3, TotalScore = 750 },
+            ], placement_points);
+
+            Assert.AreEqual(8, state.Users[1].Points);
+            Assert.AreEqual(1, state.Users[1].Placement);
+            Assert.AreEqual(1, state.Users[1].Rounds[1].Placement);
+
+            Assert.AreEqual(6, state.Users[2].Points);
+            Assert.AreEqual(3, state.Users[2].Placement);
+            Assert.AreEqual(3, state.Users[2].Rounds[1].Placement);
+
+            Assert.AreEqual(7, state.Users[3].Points);
+            Assert.AreEqual(2, state.Users[3].Placement);
+            Assert.AreEqual(2, state.Users[3].Rounds[1].Placement);
+
+            // 2 -> 1 -> 3
+
+            state.AdvanceRound();
+            state.RecordScores(
+            [
+                new SoloScoreInfo { UserID = 2, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 1, TotalScore = 750 },
+                new SoloScoreInfo { UserID = 3, TotalScore = 500 },
+            ], placement_points);
+
+            Assert.AreEqual(15, state.Users[1].Points);
+            Assert.AreEqual(1, state.Users[1].Placement);
+            Assert.AreEqual(2, state.Users[1].Rounds[2].Placement);
+
+            Assert.AreEqual(14, state.Users[2].Points);
+            Assert.AreEqual(2, state.Users[2].Placement);
+            Assert.AreEqual(1, state.Users[2].Rounds[2].Placement);
+
+            Assert.AreEqual(13, state.Users[3].Points);
+            Assert.AreEqual(3, state.Users[3].Placement);
+            Assert.AreEqual(3, state.Users[3].Rounds[2].Placement);
+        }
+
+        [Test]
+        public void MatchingScores()
+        {
+            var state = new MatchmakingRoomState();
+
+            // 1 + 2 -> 3 + 4
+
+            state.AdvanceRound();
+            state.RecordScores(
+            [
+                new SoloScoreInfo { UserID = 1, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 2, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 3, TotalScore = 500 },
+                new SoloScoreInfo { UserID = 4, TotalScore = 500 },
+            ], placement_points);
+
+            Assert.AreEqual(7, state.Users[1].Points);
+            Assert.AreEqual(1, state.Users[1].Placement);
+            Assert.AreEqual(2, state.Users[1].Rounds[1].Placement);
+
+            Assert.AreEqual(7, state.Users[2].Points);
+            Assert.AreEqual(2, state.Users[2].Placement);
+            Assert.AreEqual(2, state.Users[2].Rounds[1].Placement);
+
+            Assert.AreEqual(5, state.Users[3].Points);
+            Assert.AreEqual(3, state.Users[3].Placement);
+            Assert.AreEqual(4, state.Users[3].Rounds[1].Placement);
+
+            Assert.AreEqual(5, state.Users[4].Points);
+            Assert.AreEqual(4, state.Users[4].Placement);
+            Assert.AreEqual(4, state.Users[4].Rounds[1].Placement);
+        }
+
+        [Test]
+        public void RoundTieBreaker()
+        {
+            var state = new MatchmakingRoomState();
+
+            // 1 -> 2
+
+            state.AdvanceRound();
+            state.RecordScores(
+            [
+                new SoloScoreInfo { UserID = 1, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 2, TotalScore = 500 },
+            ], placement_points);
+
+            // 2 -> 1
+
+            state.AdvanceRound();
+            state.RecordScores(
+            [
+                new SoloScoreInfo { UserID = 1, TotalScore = 500 },
+                new SoloScoreInfo { UserID = 2, TotalScore = 1000 },
+            ], placement_points);
+
+            Assert.AreEqual(1, state.Users[1].Placement);
+            Assert.AreEqual(2, state.Users[2].Placement);
+        }
+
+        [Test]
+        public void UserIdTieBreaker()
+        {
+            var state = new MatchmakingRoomState();
+
+            // 1 + 2 + 3 + 4 + 5 + 6
+
+            state.AdvanceRound();
+            state.RecordScores(
+            [
+                new SoloScoreInfo { UserID = 4, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 6, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 2, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 3, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 1, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 5, TotalScore = 1000 },
+            ], placement_points);
+
+            Assert.AreEqual(1, state.Users[1].Placement);
+            Assert.AreEqual(2, state.Users[2].Placement);
+            Assert.AreEqual(3, state.Users[3].Placement);
+            Assert.AreEqual(4, state.Users[4].Placement);
+            Assert.AreEqual(5, state.Users[5].Placement);
+            Assert.AreEqual(6, state.Users[6].Placement);
+        }
+    }
+}

--- a/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+
+namespace osu.Game.Online.Matchmaking
+{
+    public interface IMatchmakingClient : IStatefulUserHubClient
+    {
+        /// <summary>
+        /// Signals that the local user was placed in the matchmaking queue.
+        /// </summary>
+        Task MatchmakingQueueJoined();
+
+        /// <summary>
+        /// Signals that the local user was removed from the matchmaking queue.
+        /// </summary>
+        Task MatchmakingQueueLeft();
+
+        /// <summary>
+        /// Signals that a match has been found and the local user is invited to it.
+        /// The invitation may be <see cref="IMatchmakingServer.MatchmakingAcceptInvitation">accepted</see>,
+        /// <see cref="IMatchmakingServer.MatchmakingDeclineInvitation">declined</see>,
+        /// or ignored - in which case it will automatically be declined after a short timeout period.
+        /// </summary>
+        Task MatchmakingRoomInvited();
+
+        /// <summary>
+        /// Signals that the matchmaking room is ready to be opened.
+        /// </summary>
+        Task MatchmakingRoomReady(long roomId, string password);
+
+        /// <summary>
+        /// The matchmaking lobby status has changed.
+        /// </summary>
+        Task MatchmakingLobbyStatusChanged(MatchmakingLobbyStatus status);
+
+        /// <summary>
+        /// The matchmaking status of the current user has changed.
+        /// </summary>
+        Task MatchmakingQueueStatusChanged(MatchmakingQueueStatus status);
+
+        /// <summary>
+        /// The user has raised a candidate playlist item to be played.
+        /// </summary>
+        Task MatchmakingItemSelected(int userId, long playlistItemId);
+
+        /// <summary>
+        /// The user has removed a candidate playlist item.
+        /// </summary>
+        Task MatchmakingItemDeselected(int userId, long playlistItemId);
+    }
+}

--- a/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+
+namespace osu.Game.Online.Matchmaking
+{
+    public interface IMatchmakingServer
+    {
+        /// <summary>
+        /// Joins the matchmaking lobby, allowing the local user to receive status updates.
+        /// </summary>
+        Task MatchmakingJoinLobby();
+
+        /// <summary>
+        /// Leaves the matchmaking lobby.
+        /// </summary>
+        Task MatchmakingLeaveLobby();
+
+        /// <summary>
+        /// Joins the matchmaking queue, allowing the local user to get matched up with others.
+        /// </summary>
+        Task MatchmakingJoinQueue(MatchmakingSettings settings);
+
+        /// <summary>
+        /// Leaves the matchmaking queue.
+        /// </summary>
+        Task MatchmakingLeaveQueue();
+
+        /// <summary>
+        /// Accepts a matchmaking room invitation.
+        /// </summary>
+        Task MatchmakingAcceptInvitation();
+
+        /// <summary>
+        /// Declines a matchmaking room invitation.
+        /// </summary>
+        Task MatchmakingDeclineInvitation();
+
+        /// <summary>
+        /// Raise a candidate playlist item to be played in the current round.
+        /// </summary>
+        /// <param name="playlistItemId">The playlist item.</param>
+        Task MatchmakingToggleSelection(long playlistItemId);
+
+        /// <summary>
+        /// Debug only - skips to the next stage of the matchmaking room.
+        /// </summary>
+        Task MatchmakingSkipToNextStage();
+    }
+}

--- a/osu.Game/Online/Matchmaking/MatchmakingLobbyStatus.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingLobbyStatus.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking
+{
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingLobbyStatus
+    {
+        [Key(0)]
+        public int[] UsersInQueue { get; set; } = [];
+    }
+}

--- a/osu.Game/Online/Matchmaking/MatchmakingQueueStatus.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingQueueStatus.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking
+{
+    [Serializable]
+    [MessagePackObject]
+    [Union(0, typeof(Searching))] // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
+    [Union(1, typeof(MatchFound))]
+    [Union(2, typeof(JoiningMatch))]
+    public abstract class MatchmakingQueueStatus
+    {
+        [Serializable]
+        [MessagePackObject]
+        public class Searching : MatchmakingQueueStatus
+        {
+        }
+
+        [Serializable]
+        [MessagePackObject]
+        public class MatchFound : MatchmakingQueueStatus
+        {
+        }
+
+        [Serializable]
+        [MessagePackObject]
+        public class JoiningMatch : MatchmakingQueueStatus
+        {
+        }
+    }
+}

--- a/osu.Game/Online/Matchmaking/MatchmakingSettings.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingSettings.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingSettings : IEquatable<MatchmakingSettings>
+    {
+        [Key(0)]
+        public int RulesetId { get; set; }
+
+        public bool Equals(MatchmakingSettings? other)
+            => other != null && RulesetId == other.RulesetId;
+
+        public override bool Equals(object? obj)
+            => obj is MatchmakingSettings other && Equals(other);
+
+        [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
+        public override int GetHashCode()
+        {
+            return RulesetId;
+        }
+    }
+}

--- a/osu.Game/Online/Matchmaking/MatchmakingSettings.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingSettings.cs
@@ -14,16 +14,18 @@ namespace osu.Game.Online.Matchmaking
         [Key(0)]
         public int RulesetId { get; set; }
 
+        [Key(1)]
+        public int Variant { get; set; }
+
         public bool Equals(MatchmakingSettings? other)
-            => other != null && RulesetId == other.RulesetId;
+            => other != null
+               && RulesetId == other.RulesetId
+               && Variant == other.Variant;
 
         public override bool Equals(object? obj)
             => obj is MatchmakingSettings other && Equals(other);
 
         [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
-        public override int GetHashCode()
-        {
-            return RulesetId;
-        }
+        public override int GetHashCode() => HashCode.Combine(RulesetId, Variant);
     }
 }

--- a/osu.Game/Online/Matchmaking/MatchmakingStageCountdown.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingStageCountdown.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MessagePack;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+
+namespace osu.Game.Online.Matchmaking
+{
+    [MessagePackObject]
+    public class MatchmakingStageCountdown : MultiplayerCountdown
+    {
+        [Key(2)]
+        public MatchmakingStage Stage { get; set; }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchRoomState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using MessagePack;
+using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 
 namespace osu.Game.Online.Multiplayer
@@ -14,6 +15,7 @@ namespace osu.Game.Online.Multiplayer
     [Serializable]
     [MessagePackObject]
     [Union(0, typeof(TeamVersusRoomState))] // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
+    [Union(1, typeof(MatchmakingRoomState))]
     public abstract class MatchRoomState
     {
     }

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRoomState.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using MessagePack;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
+{
+    /// <summary>
+    /// Describes the state of a matchmaking room.
+    /// </summary>
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingRoomState : MatchRoomState
+    {
+        /// <summary>
+        /// The current room status.
+        /// </summary>
+        [Key(0)]
+        public MatchmakingStage Stage { get; set; }
+
+        /// <summary>
+        /// The current round number (1-based).
+        /// </summary>
+        [Key(1)]
+        public int CurrentRound { get; set; }
+
+        /// <summary>
+        /// The playlist items that were picked as gameplay candidates.
+        /// </summary>
+        [Key(2)]
+        public long[] CandidateItems { get; set; } = [];
+
+        /// <summary>
+        /// The final gameplay candidate.
+        /// </summary>
+        [Key(3)]
+        public long CandidateItem { get; set; }
+
+        /// <summary>
+        /// The users in the room.
+        /// </summary>
+        [Key(4)]
+        public MatchmakingUserList Users { get; set; } = new MatchmakingUserList();
+
+        /// <summary>
+        /// Advances to the next round.
+        /// </summary>
+        public void AdvanceRound()
+        {
+            CurrentRound++;
+        }
+
+        /// <summary>
+        /// Sets scores for the current round, applying points and adjusting user placements.
+        /// </summary>
+        /// <remarks>
+        /// When applying points:
+        /// <list type="bullet">
+        ///   <item>Matching scores are considered to be placed in the lower-equal (e.g. two equal top scores are considered "equal-second").</item>
+        ///   <item>Failed scores are considered to have passed the map.</item>
+        ///   <item>Missing scores are not considered.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="scores">The scores to apply.</param>
+        /// <param name="placementPoints">The number of points to award for each placement position (0-indexed). Must be at least of equal length to <paramref name="scores"/>.</param>
+        public void RecordScores(SoloScoreInfo[] scores, int[] placementPoints)
+        {
+            if (placementPoints.Length < scores.Length)
+                throw new ArgumentException($"{nameof(placementPoints)} must be at least of equal length to {nameof(scores)}.");
+
+            SoloScoreInfo[] orderedScores = scores.OrderByDescending(s => s.TotalScore).ToArray();
+
+            int placement = 0;
+
+            foreach (var scoreGroup in orderedScores.GroupBy(s => s.TotalScore))
+            {
+                placement += scoreGroup.Count();
+
+                foreach (var score in scoreGroup)
+                {
+                    MatchmakingUser mmUser = Users[score.UserID];
+                    mmUser.Points += placementPoints[placement - 1];
+
+                    MatchmakingRound mmRound = mmUser.Rounds[CurrentRound];
+                    mmRound.Placement = placement;
+                    mmRound.TotalScore = score.TotalScore;
+                    mmRound.Accuracy = score.Accuracy;
+                    mmRound.MaxCombo = score.MaxCombo;
+                    mmRound.Statistics = score.Statistics;
+                }
+            }
+
+            int i = 1;
+            foreach (var user in Users.Order(new MatchmakingUserComparer(CurrentRound)))
+                user.Placement = i++;
+        }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRound.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRound.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using MessagePack;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
+{
+    /// <summary>
+    /// Describes a user's score for a round of a matchmaking room.
+    /// </summary>
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingRound
+    {
+        /// <summary>
+        /// The round.
+        /// </summary>
+        [Key(0)]
+        public required int Round { get; set; }
+
+        /// <summary>
+        /// The user's placement in this round (1-based).
+        /// </summary>
+        [Key(1)]
+        public int Placement { get; set; }
+
+        /// <summary>
+        /// The achieved total score.
+        /// </summary>
+        [Key(2)]
+        public long TotalScore { get; set; }
+
+        /// <summary>
+        /// The achieved accuracy.
+        /// </summary>
+        [Key(3)]
+        public double Accuracy { get; set; }
+
+        /// <summary>
+        /// The achieved maximum combo.
+        /// </summary>
+        [Key(4)]
+        public int MaxCombo { get; set; }
+
+        /// <summary>
+        /// The achieved score statistics.
+        /// </summary>
+        [Key(5)]
+        public IDictionary<HitResult, int> Statistics { get; set; } = new Dictionary<HitResult, int>();
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRoundList.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRoundList.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
+{
+    /// <summary>
+    /// Describes the per-round scores of a matchmaking room.
+    /// </summary>
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingRoundList : IEnumerable<MatchmakingRound>
+    {
+        /// <summary>
+        /// A key-value-pair mapping of rounds to scores.
+        /// </summary>
+        [Key(0)]
+        public IDictionary<int, MatchmakingRound> RoundsDictionary { get; set; } = new Dictionary<int, MatchmakingRound>();
+
+        /// <summary>
+        /// Creates or retrieves the score for the given round.
+        /// </summary>
+        /// <param name="round">The round.</param>
+        public MatchmakingRound this[int round]
+        {
+            get
+            {
+                if (RoundsDictionary.TryGetValue(round, out MatchmakingRound? score))
+                    return score;
+
+                return RoundsDictionary[round] = new MatchmakingRound { Round = round };
+            }
+        }
+
+        /// <summary>
+        /// The total number of rounds.
+        /// </summary>
+        [IgnoreMember]
+        public int Count => RoundsDictionary.Count;
+
+        public IEnumerator<MatchmakingRound> GetEnumerator() => RoundsDictionary.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingStage.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingStage.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
+{
+    /// <summary>
+    /// Describes the current status of a matchmaking room.
+    /// </summary>
+    [Serializable]
+    public enum MatchmakingStage
+    {
+        /// <summary>
+        /// The initial state of a room. Users are still joining.
+        /// </summary>
+        WaitingForClientsJoin,
+
+        /// <summary>
+        /// A short delay before the round begins.
+        /// </summary>
+        RoundWarmupTime,
+
+        /// <summary>
+        /// Users are given a chance to lock in their beatmap picks.
+        /// </summary>
+        UserBeatmapSelect,
+
+        /// <summary>
+        /// Clients have sent their picks, and the server has responded with the finalised beatmap.
+        /// </summary>
+        ServerBeatmapFinalised,
+
+        /// <summary>
+        /// Clients are given an opportunity to download the beatmap.
+        /// </summary>
+        WaitingForClientsBeatmapDownload,
+
+        /// <summary>
+        /// A short delay before gameplay starts.
+        /// </summary>
+        GameplayWarmupTime,
+
+        /// <summary>
+        /// Gameplay is ongoing.
+        /// </summary>
+        Gameplay,
+
+        /// <summary>
+        /// Gameplay has finished, results are being displayed.
+        /// </summary>
+        ResultsDisplaying,
+
+        /// <summary>
+        /// All rounds have completed. Users may still be chatting.
+        /// </summary>
+        Ended
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUser.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUser.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
+{
+    /// <summary>
+    /// Describes a user of a matchmaking room.
+    /// </summary>
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingUser
+    {
+        /// <summary>
+        /// The user's ID.
+        /// </summary>
+        [Key(0)]
+        public required int UserId { get; set; }
+
+        /// <summary>
+        /// The aggregate room placement (1-based).
+        /// </summary>
+        [Key(1)]
+        public int Placement { get; set; }
+
+        /// <summary>
+        /// The aggregate points.
+        /// </summary>
+        [Key(2)]
+        public int Points { get; set; }
+
+        /// <summary>
+        /// The scores set.
+        /// </summary>
+        [Key(3)]
+        public MatchmakingRoundList Rounds { get; set; } = new MatchmakingRoundList();
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUserComparer.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUserComparer.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
+{
+    /// <summary>
+    /// Orders <see cref="MatchmakingUser"/> in order of placement.
+    /// </summary>
+    public class MatchmakingUserComparer : Comparer<MatchmakingUser>
+    {
+        private readonly int rounds;
+
+        public MatchmakingUserComparer(int rounds)
+        {
+            this.rounds = rounds;
+        }
+
+        public override int Compare(MatchmakingUser? x, MatchmakingUser? y)
+        {
+            ArgumentNullException.ThrowIfNull(x);
+            ArgumentNullException.ThrowIfNull(y);
+
+            // X appears earlier in the list if it has more points.
+            if (x.Points > y.Points)
+                return -1;
+
+            // Y appears earlier in the list if it has more points.
+            if (y.Points > x.Points)
+                return 1;
+
+            // Tiebreaker 1 (likely): From each user's point-of-view, their earliest and best placement.
+            for (int r = 1; r <= rounds; r++)
+            {
+                MatchmakingRound? xRound;
+                x.Rounds.RoundsDictionary.TryGetValue(r, out xRound);
+
+                MatchmakingRound? yRound;
+                y.Rounds.RoundsDictionary.TryGetValue(r, out yRound);
+
+                // Nothing to do if both players haven't played this round.
+                if (xRound == null && yRound == null)
+                    continue;
+
+                // X appears later in the list if it hasn't played this round.
+                if (xRound == null)
+                    return 1;
+
+                // Y appears later in the list if it hasn't played this round.
+                if (yRound == null)
+                    return -1;
+
+                // X appears earlier in the list if it has a better placement in the round.
+                int compare = xRound.Placement.CompareTo(yRound.Placement);
+                if (compare != 0)
+                    return compare;
+            }
+
+            // Tiebreaker 2 (unlikely): User ID.
+            return x.UserId.CompareTo(y.UserId);
+        }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUserList.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUserList.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
+{
+    /// <summary>
+    /// Describes the users of a matchmaking room.
+    /// </summary>
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingUserList : IEnumerable<MatchmakingUser>
+    {
+        /// <summary>
+        /// A key-value-pair mapping of ids to users.
+        /// </summary>
+        [Key(0)]
+        public IDictionary<int, MatchmakingUser> UserDictionary { get; set; } = new Dictionary<int, MatchmakingUser>();
+
+        /// <summary>
+        /// Creates or retrieves the user for the given id.
+        /// </summary>
+        /// <param name="userId">The user id.</param>
+        public MatchmakingUser this[int userId]
+        {
+            get
+            {
+                if (UserDictionary.TryGetValue(userId, out MatchmakingUser? user))
+                    return user;
+
+                return UserDictionary[userId] = new MatchmakingUser { UserId = userId };
+            }
+        }
+
+        /// <summary>
+        /// The total number of users.
+        /// </summary>
+        [IgnoreMember]
+        public int Count => UserDictionary.Count;
+
+        public IEnumerator<MatchmakingUser> GetEnumerator() => UserDictionary.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerCountdown.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerCountdown.cs
@@ -3,6 +3,7 @@
 
 using System;
 using MessagePack;
+using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer.Countdown;
 
 namespace osu.Game.Online.Multiplayer
@@ -14,6 +15,7 @@ namespace osu.Game.Online.Multiplayer
     [Union(0, typeof(MatchStartCountdown))] // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
     [Union(1, typeof(ForceGameplayStartCountdown))]
     [Union(2, typeof(ServerShuttingDownCountdown))]
+    [Union(3, typeof(MatchmakingStageCountdown))]
     public abstract class MultiplayerCountdown
     {
         /// <summary>

--- a/osu.Game/Online/Rooms/MatchType.cs
+++ b/osu.Game/Online/Rooms/MatchType.cs
@@ -17,5 +17,7 @@ namespace osu.Game.Online.Rooms
 
         [LocalisableDescription(typeof(MatchesStrings), nameof(MatchesStrings.MatchTeamTypesTeamVersus))]
         TeamVersus,
+
+        Matchmaking
     }
 }

--- a/osu.Game/Online/Rooms/MultiplayerPlaylistItem.cs
+++ b/osu.Game/Online/Rooms/MultiplayerPlaylistItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using MessagePack;
 using osu.Game.Online.API;
@@ -13,7 +14,7 @@ namespace osu.Game.Online.Rooms
 {
     [Serializable]
     [MessagePackObject]
-    public class MultiplayerPlaylistItem
+    public class MultiplayerPlaylistItem : IEquatable<MultiplayerPlaylistItem>
     {
         [Key(0)]
         public long ID { get; set; }
@@ -117,6 +118,43 @@ namespace osu.Game.Online.Rooms
             clone.RequiredMods = RequiredMods.ToArray();
             clone.AllowedMods = AllowedMods.ToArray();
             return clone;
+        }
+
+        public bool Equals(MultiplayerPlaylistItem? other)
+            => other != null
+               && ID == other.ID
+               && OwnerID == other.OwnerID
+               && BeatmapID == other.BeatmapID
+               && BeatmapChecksum == other.BeatmapChecksum
+               && RulesetID == other.RulesetID
+               && RequiredMods.SequenceEqual(other.RequiredMods)
+               && AllowedMods.SequenceEqual(other.AllowedMods)
+               && Expired == other.Expired
+               && PlaylistOrder == other.PlaylistOrder
+               && PlayedAt == other.PlayedAt
+               && StarRating == other.StarRating
+               && Freestyle == other.Freestyle;
+
+        public override bool Equals(object? obj)
+            => obj is MultiplayerPlaylistItem other && Equals(other);
+
+        [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(ID);
+            hashCode.Add(OwnerID);
+            hashCode.Add(BeatmapID);
+            hashCode.Add(BeatmapChecksum);
+            hashCode.Add(RulesetID);
+            hashCode.Add(RequiredMods);
+            hashCode.Add(AllowedMods);
+            hashCode.Add(Expired);
+            hashCode.Add(PlaylistOrder);
+            hashCode.Add(PlayedAt);
+            hashCode.Add(StarRating);
+            hashCode.Add(Freestyle);
+            return hashCode.ToHashCode();
         }
     }
 }

--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.Countdown;
+using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Users;
 
@@ -45,6 +47,13 @@ namespace osu.Game.Online
             (typeof(UserActivity.TestingBeatmap), typeof(UserActivity)),
             (typeof(UserActivity.InDailyChallengeLobby), typeof(UserActivity)),
             (typeof(UserActivity.PlayingDailyChallenge), typeof(UserActivity)),
+
+            // matchmaking
+            (typeof(MatchmakingQueueStatus.Searching), typeof(MatchmakingQueueStatus)),
+            (typeof(MatchmakingQueueStatus.MatchFound), typeof(MatchmakingQueueStatus)),
+            (typeof(MatchmakingQueueStatus.JoiningMatch), typeof(MatchmakingQueueStatus)),
+            (typeof(MatchmakingRoomState), typeof(MatchRoomState)),
+            (typeof(MatchmakingStageCountdown), typeof(MultiplayerCountdown))
         };
     }
 }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -508,7 +508,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             if (item == null)
                 throw new InvalidOperationException("Item does not exist in the room.");
 
-            if (item == currentItem)
+            if (item.Equals(currentItem))
                 throw new InvalidOperationException("The room's current item cannot be removed.");
 
             if (item.OwnerID != userId)


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/34815 to get server-side things deployed.

Should be a clean diff against `matchmaking` main branch with no surprises.