### PR TITLE
Fix errors on exiting from editor if there are no more beatmaps remaining for the ruleset active in song select

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -251,6 +251,11 @@ namespace osu.Game.Screens.SelectV2
                             newSetBeatmaps.FirstOrDefault(b => b.OnlineID > 0 && b.OnlineID == beatmap.OnlineID) ??
                             newSetBeatmaps.FirstOrDefault(b => b.DifficultyName == beatmap.DifficultyName && b.Ruleset.Equals(beatmap.Ruleset));
 
+                        // The matching beatmap may have been deleted or invalidated in some way since this event was fired.
+                        // Let's make sure we have the most up-to-date realm state.
+                        if (matchingNewBeatmap?.ID is Guid matchingID)
+                            matchingNewBeatmap = realm.Run(r => r.FindWithRefresh<BeatmapInfo>(matchingID)?.Detach());
+
                         if (matchingNewBeatmap != null)
                         {
                             // TODO: should this exist in song select instead of here?

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -260,12 +260,10 @@ namespace osu.Game.Screens.SelectV2
                         {
                             // TODO: should this exist in song select instead of here?
                             // we need to ensure the global beatmap is also updated alongside changes.
-                            if (CurrentSelection is GroupedBeatmap currentBeatmapUnderGrouping)
-                            {
-                                var candidateSelection = currentBeatmapUnderGrouping with { Beatmap = beatmap };
-                                if (CheckModelEquality(candidateSelection, CurrentSelection))
-                                    RequestSelection(candidateSelection);
-                            }
+                            if (CurrentBeatmap != null && beatmap.Equals(CurrentBeatmap))
+                                // we don't know in which group the matching new beatmap is, but that's fine - we can leave it null for now.
+                                // we are about to modify `Items`, which will trigger a re-filter, which will pick a correct group - if one is present - via `HandleFilterCompleted()`.
+                                RequestSelection(new GroupedBeatmap(null, matchingNewBeatmap));
 
                             Items.ReplaceRange(previousIndex, 1, [matchingNewBeatmap]);
                             newSetBeatmaps.Remove(matchingNewBeatmap);


### PR DESCRIPTION
## [Ensure that matching beatmap still exists when performing replace operation in the carousel](https://github.com/ppy/osu/commit/6e5bf57fe7918d1a12b63f9ff5da6598db823661)

Closes https://github.com/ppy/osu/issues/34826. Idea "borrowed" from https://github.com/ppy/osu/issues/34826#issuecomment-3244462921, with an extra detach to stop it blowing up.

## [Fix test failing because of new realm check](https://github.com/ppy/osu/commit/bae288859b49d25a6903fd036dad9893add4c5f3)

Given that realm is now directly involved in the replace beatmap callback, it needs to also be involved in the relevant test as well. A little haphazard but kinda works...

## [Fix broken reselection logic](https://github.com/ppy/osu/commit/134f854d7ba18e7a2ee82c51f99c49154c711422)

Relevant because this change triggered me to go fix the relevant test which led me to finding a regression.

https://github.com/ppy/osu/commit/d4b357dfa0133d24083aa08372644f86c799a14b contains a sneaky regression. The previous code read:

```csharp
if (CurrentSelection != null && CheckModelEquality(beatmap, CurrentSelection))
	RequestSelection(matchingNewBeatmap);
```

and the new one reads:

```csharp
if (CurrentSelection is GroupedBeatmap currentBeatmapUnderGrouping)
{
	var candidateSelection = currentBeatmapUnderGrouping with { Beatmap = beatmap };
	if (CheckModelEquality(candidateSelection, CurrentSelection))
		RequestSelection(candidateSelection);
}
```

The point there was that we want to reselect `matchingNewBeatmap` here, not the old selection. The `CheckModelEquality()` check's purpose is to check whether *the current selection needs updating*.

I'm not sure why tests just wonderfully passed despite this, but my suspicion is that it was because of accidental copying of realm guids in the relevant test that obscured this problem.