### PR TITLE
Add drum touch size setting for osu!taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumTouchInputArea.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             AddStep("change scheme (kddk)", () => controlScheme.Value = TaikoTouchControlScheme.KDDK);
             AddStep("change scheme (kkdd)", () => controlScheme.Value = TaikoTouchControlScheme.KKDD);
             AddStep("change scheme (ddkk)", () => controlScheme.Value = TaikoTouchControlScheme.DDKK);
-            
+
             AddStep("set drum size (small)", () => drumSize.Value = 0.5f);
             AddStep("set drum size (normal)", () => drumSize.Value = 1.0f);
             AddStep("set drum size (large)", () => drumSize.Value = 1.5f);

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumTouchInputArea.cs
@@ -18,12 +18,14 @@ namespace osu.Game.Rulesets.Taiko.Tests
         private DrumTouchInputArea drumTouchInputArea = null!;
 
         private readonly Bindable<TaikoTouchControlScheme> controlScheme = new Bindable<TaikoTouchControlScheme>();
+        private readonly Bindable<float> drumSize = new Bindable<float>();
 
         [BackgroundDependencyLoader]
         private void load()
         {
             var config = (TaikoRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
             config.BindWith(TaikoRulesetSetting.TouchControlScheme, controlScheme);
+            config.BindWith(TaikoRulesetSetting.DrumTouchSize, drumSize);
         }
 
         private void createDrum()
@@ -57,6 +59,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
             AddStep("change scheme (kddk)", () => controlScheme.Value = TaikoTouchControlScheme.KDDK);
             AddStep("change scheme (kkdd)", () => controlScheme.Value = TaikoTouchControlScheme.KKDD);
             AddStep("change scheme (ddkk)", () => controlScheme.Value = TaikoTouchControlScheme.DDKK);
+            
+            AddStep("set drum size (small)", () => drumSize.Value = 0.5f);
+            AddStep("set drum size (normal)", () => drumSize.Value = 1.0f);
+            AddStep("set drum size (large)", () => drumSize.Value = 1.5f);
+            AddStep("set drum size (extra large)", () => drumSize.Value = 2.0f);
         }
 
         protected override Ruleset CreateRuleset() => new TaikoRuleset();

--- a/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
@@ -18,11 +18,13 @@ namespace osu.Game.Rulesets.Taiko.Configuration
             base.InitialiseDefaults();
 
             SetDefault(TaikoRulesetSetting.TouchControlScheme, TaikoTouchControlScheme.KDDK);
+            SetDefault(TaikoRulesetSetting.DrumTouchSize, 1.0f, 0.5f, 2.0f);
         }
     }
 
     public enum TaikoRulesetSetting
     {
-        TouchControlScheme
+        TouchControlScheme,
+        DrumTouchSize
     }
 }

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -30,6 +30,13 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     LabelText = RulesetSettingsStrings.TouchControlScheme,
                     Current = config.GetBindable<TaikoTouchControlScheme>(TaikoRulesetSetting.TouchControlScheme)
+                },
+                new SettingsSlider<float>
+                {
+                    LabelText = RulesetSettingsStrings.DrumTouchSize,
+                    Current = config.GetBindable<float>(TaikoRulesetSetting.DrumTouchSize),
+                    KeyboardStep = 0.1f,
+                    DisplayAsPercentage = true
                 }
             };
         }

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             config.BindWith(TaikoRulesetSetting.TouchControlScheme, configTouchControlScheme);
             config.BindWith(TaikoRulesetSetting.DrumTouchSize, configDrumTouchSize);
-            
+
             configTouchControlScheme.BindValueChanged(scheme =>
             {
                 var actions = getOrderedActionsForScheme(scheme.NewValue);
@@ -119,7 +119,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                 rightCentre.Action = actions[2];
                 rightRim.Action = actions[3];
             }, true);
-            
+
             configDrumTouchSize.BindValueChanged(size =>
             {
                 mainContent.Scale = new Vector2(size.NewValue);

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         private DrumSegment rightRim = null!;
 
         private readonly Bindable<TaikoTouchControlScheme> configTouchControlScheme = new Bindable<TaikoTouchControlScheme>();
+        private readonly Bindable<float> configDrumTouchSize = new Bindable<float>();
 
         [BackgroundDependencyLoader]
         private void load(TaikoInputManager taikoInputManager, TaikoRulesetConfigManager config)
@@ -105,6 +106,8 @@ namespace osu.Game.Rulesets.Taiko.UI
             };
 
             config.BindWith(TaikoRulesetSetting.TouchControlScheme, configTouchControlScheme);
+            config.BindWith(TaikoRulesetSetting.DrumTouchSize, configDrumTouchSize);
+            
             configTouchControlScheme.BindValueChanged(scheme =>
             {
                 var actions = getOrderedActionsForScheme(scheme.NewValue);
@@ -113,6 +116,11 @@ namespace osu.Game.Rulesets.Taiko.UI
                 leftCentre.Action = actions[1];
                 rightCentre.Action = actions[2];
                 rightRim.Action = actions[3];
+            }, true);
+            
+            configDrumTouchSize.BindValueChanged(size =>
+            {
+                mainContent.Scale = new Vector2(size.NewValue);
             }, true);
         }
 

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -68,6 +68,8 @@ namespace osu.Game.Rulesets.Taiko.UI
                     {
                         mainContent = new Container
                         {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -90,6 +90,11 @@ namespace osu.Game.Localisation
         public static LocalisableString TouchControlScheme => new TranslatableString(getKey(@"touch_control_scheme"), @"Touch control scheme");
 
         /// <summary>
+        /// "Drum touch size"
+        /// </summary>
+        public static LocalisableString DrumTouchSize => new TranslatableString(getKey(@"drum_touch_size"), @"Drum touch size");
+
+        /// <summary>
         /// "Mobile layout"
         /// </summary>
         public static LocalisableString MobileLayout => new TranslatableString(getKey(@"mobile_layout"), @"Mobile layout");


### PR DESCRIPTION
Adds a configurable drum touch size setting for osu!taiko on mobile platforms, allowing players to adjust the touch drum overlay from 50% to 200% of the default size.

## Rationale

The default drum size can be difficult to use on devices with longer screens or for players with different finger sizes and preferences. This setting improves accessibility and user experience on mobile platforms where touch input is the primary interaction method.

## Example (50% size)

![KakaoTalk_20250905_171853378](https://github.com/user-attachments/assets/ca286f59-54c6-4594-9d30-ea8275cedcc5)
![KakaoTalk_20250905_171853378_01](https://github.com/user-attachments/assets/999a966b-7a90-4209-8834-c531f5d571e0)

## Example (200% size)

![KakaoTalk_20250905_171853378_02](https://github.com/user-attachments/assets/5f15dfa3-e8a3-4bad-b58b-f16c83a59f6f)
![KakaoTalk_20250905_171853378_03](https://github.com/user-attachments/assets/e6cfd1f2-a42a-476a-8385-cac1035b8539)
