### PR TITLE
Implement Cinema Shortcut @ Song Select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -406,6 +406,147 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestAutoplayShortcutReplacesCinema()
+        {
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+            AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
+            AddAssert("beatmap selected", () => !Beatmap.IsDefault);
+
+            ChangeMods(new OsuModCinema());
+
+            AddStep("press ctrl+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("only autoplay selected", () => SongSelect.Mods.Value.Single() is ModAutoplay);
+
+            AddUntilStep("wait for return to ss", () => SongSelect.IsCurrentScreen());
+
+            AddAssert("cinema still selected", () => SongSelect.Mods.Value.Single() is ModCinema);
+        }
+
+        [Test]
+        public void TestCinemaShortcut()
+        {
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+            AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
+            AddAssert("beatmap selected", () => !Beatmap.IsDefault);
+
+            AddStep("press ctrl+shift+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("cinema selected", () => SongSelect.Mods.Value.Single() is ModCinema);
+
+            AddUntilStep("wait for return to ss", () => SongSelect.IsCurrentScreen());
+
+            AddAssert("no mods selected", () => SongSelect.Mods.Value.Count == 0);
+        }
+
+        [Test]
+        public void TestCinemaShortcutKeepsCinemaIfSelectedAlready()
+        {
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+            AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
+            AddAssert("beatmap selected", () => !Beatmap.IsDefault);
+
+            ChangeMods(new OsuModCinema());
+
+            AddStep("press ctrl+shift+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("cinema selected", () => SongSelect.Mods.Value.Single() is ModCinema);
+
+            AddUntilStep("wait for return to ss", () => SongSelect.IsCurrentScreen());
+
+            AddAssert("cinema still selected", () => SongSelect.Mods.Value.Single() is ModCinema);
+        }
+
+        [Test]
+        public void TestCinemaShortcutReturnsInitialModsOnExit()
+        {
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+            AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
+            AddAssert("beatmap selected", () => !Beatmap.IsDefault);
+
+            ChangeMods(new OsuModRelax());
+
+            AddStep("press ctrl+shift+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("only cinema selected", () => SongSelect.Mods.Value.Single() is ModCinema);
+
+            AddUntilStep("wait for return to ss", () => SongSelect.IsCurrentScreen());
+
+            AddAssert("relax returned", () => SongSelect.Mods.Value.Single() is ModRelax);
+        }
+
+        [Test]
+        public void TestCinemaShortcutReplacesAutoplay()
+        {
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+            AddStep("press right", () => InputManager.Key(Key.Right)); // press right to select in carousel, also remove.
+            AddAssert("beatmap selected", () => !Beatmap.IsDefault);
+
+            ChangeMods(new OsuModAutoplay());
+
+            AddStep("press ctrl+shift+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("only cinema selected", () => SongSelect.Mods.Value.Single() is ModCinema);
+
+            AddUntilStep("wait for return to ss", () => SongSelect.IsCurrentScreen());
+
+            AddAssert("autoplay still selected", () => SongSelect.Mods.Value.Single() is ModAutoplay);
+        }
+
+        [Test]
         public void TestModSelectCannotBeOpenedAfterConfirmingSelection()
         {
             ImportBeatmapForRuleset(0);

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -45,6 +45,11 @@ namespace osu.Game.Localisation
         public static LocalisableString NoAutoplayMod => new TranslatableString(getKey(@"no_autoplay_mod"), @"The current ruleset doesn't have an autoplay mod available!");
 
         /// <summary>
+        /// "The current ruleset doesn&#39;t have a cinema mod available!"
+        /// </summary>
+        public static LocalisableString NoCinemaMod => new TranslatableString(getKey(@"no_cinema_mod"), @"The current ruleset doesn't have a cinema mod available!");
+
+        /// <summary>
         /// "osu! doesn&#39;t seem to be able to play audio correctly.
         ///
         /// Please try changing your audio device to a working setting."

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -207,6 +207,8 @@ namespace osu.Game.Rulesets
 
         public ModAutoplay? GetAutoplayMod() => CreateMod<ModAutoplay>();
 
+        public ModCinema? GetCinemaMod() => CreateMod<ModCinema>();
+
         public ModTouchDevice? GetTouchDeviceMod() => CreateMod<ModTouchDevice>();
 
         /// <summary>

--- a/osu.Game/Screens/SelectV2/SoloSongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SoloSongSelect.cs
@@ -101,13 +101,15 @@ namespace osu.Game.Screens.SelectV2
             // Ctrl+Enter should start map with autoplay enabled.
             if (GetContainingInputManager()?.CurrentState?.Keyboard.ControlPressed == true)
             {
-                var autoInstance = getAutoplayMod();
+                // But Ctrl+Shift+Enter should start map with cinema instead
+                bool cinema = GetContainingInputManager()?.CurrentState?.Keyboard.ShiftPressed == true;
+                var autoInstance = cinema ? getCinemaMod() : getAutoplayMod();
 
                 if (autoInstance == null)
                 {
                     notifications?.Post(new SimpleNotification
                     {
-                        Text = NotificationsStrings.NoAutoplayMod
+                        Text = cinema ? NotificationsStrings.NoCinemaMod : NotificationsStrings.NoAutoplayMod
                     });
                     return;
                 }
@@ -167,6 +169,8 @@ namespace osu.Game.Screens.SelectV2
         }
 
         private ModAutoplay? getAutoplayMod() => Ruleset.Value.CreateInstance().GetAutoplayMod();
+
+        private ModCinema? getCinemaMod() => Ruleset.Value.CreateInstance().GetCinemaMod();
 
         private void revertMods()
         {


### PR DESCRIPTION
I know this has been rejected multiple times, but I believe enough people used it on stable to bring it to lazer (the existance of #9221 #9224 #11047 #30930 shows enough demand imo).
This implementation doesn't suffer from the bug that made #9224 #11047 broken.
It also features test coverage with incompatibility tests and also duplicated every autoplay shortcut test (it was to be safe, if these are unneeded feel free to edit them out).
