### PR TITLE
Add Separate All Difficulties setting

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterSortingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterSortingTest.cs
@@ -139,6 +139,92 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         /// <summary>
+        /// Ensures that difficulty sorting still works and that any other sort mode will sort first by
+        /// itself then by the starrating
+        /// </summary>
+        [Test]
+        public async Task TestSeparateAllDifficultySort()
+        {
+            List<BeatmapSetInfo> beatmapSets = new List<BeatmapSetInfo>();
+            int amountOfSets = 4;
+            int amountOfBeatmaps = 2;
+
+            for (int i = 0; i < amountOfSets; i++)
+            {
+                int numberMetadata = (i - i % 2) / 2;
+                DateTimeOffset dateTimeOffset = new DateTimeOffset(2000, 1, 1, 12, 1, numberMetadata, new TimeSpan());
+
+                var set = new BeatmapSetInfo
+                {
+                    ID = Guid.NewGuid(),
+                    DateAdded = dateTimeOffset,
+                    DateRanked = dateTimeOffset,
+                    DateSubmitted = dateTimeOffset,
+                };
+
+                for (int j = 0; j < amountOfBeatmaps; j++)
+                {
+                    var metadata = new BeatmapMetadata
+                    {
+                        Artist = $"{numberMetadata}. Artist",
+                        Title = $"{numberMetadata}. beatmap",
+                        Author = { Username = $"{numberMetadata}. Guy " },
+                        Source = $"{numberMetadata}. source",
+                    };
+
+                    double starRating = 0;
+                    //Creates a stable pattern of "unsorted" starratings (0, n-1, 2, n-3, 4, n-5)
+                    if (amountOfBeatmaps % 2 == 0)
+                        starRating = j % 2 == 0 ? j : amountOfBeatmaps - j;
+                    else
+                        starRating = j % 2 == 0 ? j : amountOfBeatmaps - 1 - j;
+                    double BPM = numberMetadata * 30;
+                    double Length = numberMetadata * 20;
+
+                    BeatmapInfo beatmapInfo = new BeatmapInfo()
+                    {
+                        StarRating = starRating,
+                        ID = Guid.NewGuid(),
+                        Metadata = metadata,
+                        BeatmapSet = set,
+                        BPM = BPM,
+                        LastPlayed = dateTimeOffset,
+                        Length = numberMetadata,
+                    };
+
+                    set.Beatmaps.Add(beatmapInfo);
+                }
+
+                beatmapSets.Add(set);
+            }
+
+            foreach (var sortMode in Enum.GetValues<SortMode>())
+            {
+                if (sortMode == SortMode.Difficulty)
+                    continue;
+
+                var sortModeResults = await runSorting(sortMode, true, beatmapSets);
+
+                Assert.That(sortModeResults.Count(), Is.EqualTo(amountOfSets * amountOfBeatmaps));
+
+                for (int i = 0; i < amountOfSets * amountOfBeatmaps; ++i)
+                {
+                    Assert.That(sortModeResults.Skip(i).First().StarRating, Is.EqualTo(i % amountOfBeatmaps), () => $"{sortMode} incorrectly sorts.");
+                }
+            }
+
+            var difficultyResults = await runSorting(SortMode.Difficulty, true, beatmapSets);
+
+            Assert.That(difficultyResults.Count(), Is.EqualTo(amountOfSets * amountOfBeatmaps));
+
+            for (int i = 0; i < amountOfSets * amountOfBeatmaps; ++i)
+            {
+                double correctStarRating = (i - (i % amountOfSets)) / amountOfSets;
+                Assert.That(difficultyResults.Skip(i).First().StarRating, Is.EqualTo(correctStarRating), () => $"{SortMode.Difficulty} incorrectly sorts.");
+            }
+        }
+
+        /// <summary>
         /// Ensures stability is maintained on different sort modes for items with equal properties.
         /// </summary>
         [Test]
@@ -173,6 +259,13 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         private static async Task<IEnumerable<BeatmapInfo>> runSorting(SortMode sort, List<BeatmapSetInfo> beatmapSets)
         {
             var sorter = new BeatmapCarouselFilterSorting(() => new FilterCriteria { Sort = sort });
+            var carouselItems = await sorter.Run(beatmapSets.SelectMany(s => s.Beatmaps.Select(b => new CarouselItem(b))), CancellationToken.None);
+            return carouselItems.Select(ci => ci.Model).OfType<BeatmapInfo>();
+        }
+
+        private static async Task<IEnumerable<BeatmapInfo>> runSorting(SortMode sort, bool separateAllDifficulties, List<BeatmapSetInfo> beatmapSets)
+        {
+            var sorter = new BeatmapCarouselFilterSorting(() => new FilterCriteria { Sort = sort, SeparateAllDifficulties = separateAllDifficulties });
             var carouselItems = await sorter.Run(beatmapSets.SelectMany(s => s.Beatmaps.Select(b => new CarouselItem(b))), CancellationToken.None);
             return carouselItems.Select(ci => ci.Model).OfType<BeatmapInfo>();
         }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselFiltering.cs
@@ -119,6 +119,54 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestSeparateAllDifficulties()
+        {
+            AddStep("add single difficulty set", () =>
+            {
+                var set = TestResources.CreateTestBeatmapSetInfo(1);
+                set.Beatmaps.Clear();
+                set.Beatmaps.Add(new BeatmapInfo(new OsuRuleset().RulesetInfo, new BeatmapDifficulty(), new BeatmapMetadata())
+                {
+                    BeatmapSet = set,
+                    DifficultyName = $"Stars: 1",
+                    StarRating = 1,
+                });
+
+                BeatmapSets.Add(set);
+            });
+
+            WaitForDrawablePanels();
+
+            foreach (var sortMode in Enum.GetValues<SortMode>())
+            {
+                foreach (var groupMode in Enum.GetValues<GroupMode>())
+                {
+                    if (groupMode == GroupMode.MyMaps)
+                        continue;
+
+                    ApplyToFilterAndWaitForFilter("separate all difficulties", c =>
+                    {
+                        c.Sort = sortMode;
+                        c.Group = groupMode;
+                        c.SeparateAllDifficulties = true;
+                    });
+
+                    WaitForDrawablePanels();
+
+                    int expectedAmount = 1;
+
+                    if (groupMode != GroupMode.None)
+                        expectedAmount = 2;
+
+                    //TODO: Fix it so that it actually represents the sum of visible group panels, beatmapset panels
+                    // and beatmap panels which should be one when GroupMode is None and two when it is anything else
+                    int count = GetVisiblePanels<PanelBeatmap>().Count();
+                    Assert.IsTrue(count == expectedAmount, $"{sortMode} sort, {groupMode} group mode ({count})");
+                }
+            }
+        }
+
+        [Test]
         public void TestCarouselRemembersSelection()
         {
             Guid selectedID = Guid.Empty;

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.BeatmapLeaderboardSortMode, LeaderboardSortMode.Score);
             SetDefault(OsuSetting.BeatmapDetailModsFilter, false);
 
+            SetDefault(OsuSetting.SeparateAllDifficulties, false);
             SetDefault(OsuSetting.ShowConvertedBeatmaps, true);
             SetDefault(OsuSetting.DisplayStarsMinimum, 0.0, 0, 10, 0.1);
             SetDefault(OsuSetting.DisplayStarsMaximum, 10.1, 0, 10.1, 0.1);
@@ -486,5 +487,6 @@ namespace osu.Game.Configuration
         LastOnlineTagsPopulation,
 
         AutomaticallyAdjustBeatmapOffset,
+        SeparateAllDifficulties,
     }
 }

--- a/osu.Game/Localisation/UserInterfaceStrings.cs
+++ b/osu.Game/Localisation/UserInterfaceStrings.cs
@@ -95,6 +95,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ShowConvertedBeatmaps => new TranslatableString(getKey(@"show_converted_beatmaps"), @"Show converted beatmaps");
 
         /// <summary>
+        /// "Separate all difficulties"
+        /// </summary>
+        public static LocalisableString SeparateAllDifficulties => new TranslatableString(getKey(@"separate_all_difficulties"), @"Separate all difficulties");
+
+        /// <summary>
         /// "Display beatmaps from"
         /// </summary>
         public static LocalisableString StarsMinimum => new TranslatableString(getKey(@"stars_minimum"), @"Display beatmaps from");

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -21,6 +21,12 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
             {
                 new SettingsCheckbox
                 {
+                    LabelText = UserInterfaceStrings.SeparateAllDifficulties,
+                    Current = config.GetBindable<bool>(OsuSetting.SeparateAllDifficulties),
+                    Keywords = new[] { "separate" }
+                },
+                new SettingsCheckbox
+                {
                     LabelText = UserInterfaceStrings.ShowConvertedBeatmaps,
                     Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
                     Keywords = new[] { "converts", "converted" }

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -52,6 +52,7 @@ namespace osu.Game.Screens.Select
         public RulesetInfo? Ruleset;
         public IReadOnlyList<Mod>? Mods;
         public bool AllowConvertedBeatmaps;
+        public bool SeparateAllDifficulties;
         public int? BeatmapSetId;
 
         public bool? HasOnlineID;

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -162,8 +162,8 @@ namespace osu.Game.Screens.SelectV2
             if (criteria.Group == GroupMode.RankAchieved)
                 return false;
 
-            // In the majority case we group sets together for display.
-            return true;
+            // In the majority case we group sets together based on the user's preference.
+            return !criteria.SeparateAllDifficulties;
         }
 
         private List<GroupMapping> getGroups(List<CarouselItem> items, FilterCriteria criteria)

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterSorting.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterSorting.cs
@@ -126,6 +126,11 @@ namespace osu.Game.Screens.SelectV2
             if (comparison == 0)
                 comparison = b.BeatmapSet!.ID.CompareTo(a.BeatmapSet!.ID);
 
+            // If the user's preference is to separate all difficulties then there are way more cases where
+            // the initial sort could not differentiate which results in undesirable ordering
+            if (comparison == 0 && !aggregate)
+                comparison = a.StarRating.CompareTo(b.StarRating);
+
             return comparison;
         }
 

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Screens.SelectV2
         private ShearedDropdown<SortMode> sortDropdown = null!;
         private ShearedDropdown<GroupMode> groupDropdown = null!;
         private CollectionDropdown collectionDropdown = null!;
+        private BindableBool separateAllDifficulties = null!;
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
@@ -73,6 +74,8 @@ namespace osu.Game.Screens.SelectV2
         [BackgroundDependencyLoader]
         private void load(IAPIProvider api)
         {
+            separateAllDifficulties = new BindableBool();
+
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
@@ -197,6 +200,7 @@ namespace osu.Game.Screens.SelectV2
             config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmapsButton.Active);
             config.BindWith(OsuSetting.SongSelectSortingMode, sortDropdown.Current);
             config.BindWith(OsuSetting.SongSelectGroupMode, groupDropdown.Current);
+            config.BindWith(OsuSetting.SeparateAllDifficulties, separateAllDifficulties);
 
             ruleset.BindValueChanged(_ => updateCriteria());
             mods.BindValueChanged(m =>
@@ -219,6 +223,7 @@ namespace osu.Game.Screens.SelectV2
             difficultyRangeSlider.LowerBound.BindValueChanged(_ => updateCriteria());
             difficultyRangeSlider.UpperBound.BindValueChanged(_ => updateCriteria());
             showConvertedBeatmapsButton.Active.BindValueChanged(_ => updateCriteria());
+            separateAllDifficulties.BindValueChanged(_ => updateCriteria());
             sortDropdown.Current.BindValueChanged(_ => updateCriteria());
             groupDropdown.Current.BindValueChanged(_ => updateCriteria());
             collectionDropdown.Current.BindValueChanged(v =>
@@ -260,6 +265,7 @@ namespace osu.Game.Screens.SelectV2
                 Sort = sortDropdown.Current.Value,
                 Group = groupDropdown.Current.Value,
                 AllowConvertedBeatmaps = showConvertedBeatmapsButton.Active.Value,
+                SeparateAllDifficulties = separateAllDifficulties.Value,
                 Ruleset = ruleset.Value,
                 Mods = mods.Value,
                 CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToImmutableHashSet(),


### PR DESCRIPTION
This PR implements the Separate Alll Difficulties setting for song select. (Based on this [video](https://www.youtube.com/watch?v=H_a5Cqv7Tok&t=96s))

Showcase:

https://github.com/user-attachments/assets/ececa113-2f2b-48eb-b5e4-db18c6fee61d

I also made it so that when this setting is enabled and you select a sort where the data (Title, Author, Source, etc.) is the same across beatmaps it try to sort using that and then sort by difficulty.

Without:
<img width="740" height="585" alt="image" src="https://github.com/user-attachments/assets/77b90405-2251-44c9-922f-ad30dc6db34b" />

With:
<img width="767" height="569" alt="image" src="https://github.com/user-attachments/assets/2dad6882-be88-411f-81d2-41e364c6e734" />

Do note that one test case isn't working right now (TestSeparateAllDifficulties in TestSceneBeatmapCarouselFiltering) and I require assistence in fixing it. TL;DR: it would test if the setting actually makes every sort and group combination have all difficulties separated, but I can't seem to get it to work. And I want to check this by whether a beatmapsetpanel appears or not.

The other test ensures that Same titled beatmapsets keep separate and the difficulty sorting is done correctly and is working.