### PR TITLE
Fix external edit filename sanitising unintentionally dropping folder separators

### DIFF
--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -294,6 +294,52 @@ namespace osu.Game.Tests.Skins.IO
 
         #endregion
 
+        [Test]
+        public async Task TestExternallyMountingWithSubDirectory()
+        {
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+            {
+                try
+                {
+                    var osu = LoadOsuIntoHost(host);
+
+                    var zipStream = new MemoryStream();
+                    using var zip = ZipArchive.Create();
+                    zip.AddEntry("folder/test.png", new MemoryStream(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }));
+                    zip.SaveTo(zipStream);
+
+                    var import = await loadSkinIntoOsu(osu, new ImportTask(zipStream, "test skin.osk"));
+
+                    var skinManager = osu.Dependencies.Get<SkinManager>();
+                    var externalEdit = await skinManager.BeginExternalEditing(import.PerformRead(s => s.Detach())); // should not fail
+
+                    Assert.That(Directory.Exists(externalEdit.MountedPath));
+
+                    var directoryInfo = new DirectoryInfo(externalEdit.MountedPath);
+
+                    Assert.That(directoryInfo.GetFiles().Select(f => f.Name), Is.EquivalentTo(new[]
+                    {
+                        "skin.ini",
+                    }));
+
+                    var subDirectory = directoryInfo.GetDirectories().Single();
+                    Assert.That(subDirectory.Name, Is.EqualTo("folder"));
+                    Assert.That(subDirectory.GetFiles().Select(f => f.Name), Is.EquivalentTo(new[]
+                    {
+                        "test.png",
+                    }));
+
+                    Task finishTask = Task.CompletedTask;
+                    host.UpdateThread.Scheduler.Add(() => finishTask = externalEdit.Finish());
+                    await finishTask;
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
         /// <remarks>
         /// Note that this test passing / failing is platform / OS-specific (if it is to fail, it'll fail on windows).
         /// </remarks>

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -217,7 +217,9 @@ namespace osu.Game.Database
                 // to prevent this bricking external edit, strip invalid characters on external edit.
                 // the presumption here is that whatever produced the mangled archive is primarily at fault here, and we're just trying to trudge on locally as best as possible.
                 // if there are further troubles related to similar issues, reevaluate moving this sort of check to the import side instead (sanitising filenames on import from archive).
-                string destinationPath = Path.Join(mountedPath, realmFile.Filename.GetValidFilename());
+                string destinationPath = mountedPath;
+                foreach (string piece in realmFile.Filename.Split('/').Select(f => f.GetValidFilename()))
+                    destinationPath = Path.Combine(destinationPath, piece);
 
                 Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34929.