### PR TITLE
Fix sheared dropdown click sound area

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/ShearedDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ShearedDropdown.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 osuHeader.Dropdown = this;
                 osuHeader.LeftSideLabel = label;
             }
-
-            AddInternal(new HoverClickSounds());
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
@@ -192,6 +190,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
                         }
                     },
                 };
+
+                AddInternal(new HoverClickSounds());
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
Also matches `OsuDropdown`. Seems like items not having click sounds were intentional before, see https://github.com/ppy/osu/commit/d462394635c67dbf24238fdccfb38916474f134a (audio feedback seems to be relying on the closing sound).

| Before | After | `OsuDropdown` |
| --- | --- | --- |
| <img width="468" height="327" alt="Screenshot 2025-09-07 at 10 51 22 AM" src="https://github.com/user-attachments/assets/2e031226-e453-487c-8856-4891d7677c3f" /> | <img width="520" height="358" alt="Screenshot 2025-09-07 at 10 48 09 AM" src="https://github.com/user-attachments/assets/e49cbf0a-9f7c-4ab0-a176-0ef6b227eaf0" /> | <img width="628" height="395" alt="Screenshot 2025-09-07 at 10 52 25 AM" src="https://github.com/user-attachments/assets/a0999f82-19a4-468f-a236-34fcd5b8e6bf" /> |