### PR TITLE
Change debounce method in rank display to allow more immediate updates

### DIFF
--- a/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultRankDisplay.cs
@@ -33,11 +33,11 @@ namespace osu.Game.Screens.Play.HUD
         private SkinnableSound rankUpSample = null!;
 
         private Bindable<double?> lastSamplePlayback = null!;
-        private double timeSinceChange;
+        private double lastChangeTime;
 
         private ScoreRank? displayedRank;
 
-        private const int time_before_commit = 1500;
+        private const int time_between_changes = 1500;
 
         public DefaultRankDisplay()
         {
@@ -77,12 +77,9 @@ namespace osu.Game.Screens.Play.HUD
             var currentRank = scoreProcessor.Rank.Value;
 
             if (currentRank == displayedRank)
-            {
-                timeSinceChange = 0;
                 return;
-            }
 
-            if ((timeSinceChange += Time.Elapsed) >= time_before_commit || scoreProcessor.HasCompleted.Value || currentRank == ScoreRank.F)
+            if (Time.Current - lastChangeTime >= time_between_changes || scoreProcessor.HasCompleted.Value || currentRank == ScoreRank.F)
                 updateRank(currentRank);
         }
 
@@ -105,7 +102,7 @@ namespace osu.Game.Screens.Play.HUD
             }
 
             displayedRank = rank;
-            timeSinceChange = 0;
+            lastChangeTime = Time.Current;
         }
     }
 }

--- a/osu.Game/Skinning/LegacyRankDisplay.cs
+++ b/osu.Game/Skinning/LegacyRankDisplay.cs
@@ -35,11 +35,11 @@ namespace osu.Game.Skinning
         private SkinnableSound rankUpSample = null!;
 
         private Bindable<double?> lastSamplePlayback = null!;
-        private double timeSinceChange;
+        private double lastChangeTime;
 
         private ScoreRank? displayedRank;
 
-        private const int time_before_commit = 1500;
+        private const int time_between_changes = 1500;
 
         public LegacyRankDisplay()
         {
@@ -81,12 +81,9 @@ namespace osu.Game.Skinning
             var currentRank = scoreProcessor.Rank.Value;
 
             if (currentRank == displayedRank)
-            {
-                timeSinceChange = 0;
                 return;
-            }
 
-            if ((timeSinceChange += Time.Elapsed) >= time_before_commit || scoreProcessor.HasCompleted.Value || currentRank == ScoreRank.F)
+            if (Time.Current - lastChangeTime >= time_between_changes || scoreProcessor.HasCompleted.Value || currentRank == ScoreRank.F)
                 updateRank(currentRank);
         }
 
@@ -129,7 +126,7 @@ namespace osu.Game.Skinning
             }
 
             displayedRank = rank;
-            timeSinceChange = 0;
+            lastChangeTime = Time.Current;
         }
     }
 }


### PR DESCRIPTION
This basically restores the originally proposed method in the [recent change](https://github.com/ppy/osu/pull/34905) based on [overwhelming user feedback](https://osu.ppy.sh/home/changelog/tachyon/2025.905.0) that the method I preferred is not what people want. 🤷 

