### PR TITLE
feat: favorite beatmaps collection

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneCollectionDropdown.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneCollectionDropdown.cs
@@ -87,11 +87,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "2"))));
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "3"))));
 
-            AddAssert("check count 5", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(5));
+            AddAssert("check count 6", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(6));
 
             AddStep("delete all collections", () => writeAndRefresh(r => r.RemoveAll<BeatmapCollection>()));
 
-            AddAssert("check count 2", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(2));
+            AddAssert("check count 3", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(3));
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         {
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "1"))));
             assertCollectionDropdownContains("1");
-            AddStep("select collection", () => dropdown.Current.Value = dropdown.ItemSource.ElementAt(1));
+            AddStep("select collection", () => dropdown.Current.Value = dropdown.ItemSource.ElementAt(2));
 
             addExpandHeaderStep();
 
@@ -136,8 +136,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             addExpandHeaderStep();
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "1"))));
             assertCollectionDropdownContains("1");
-            AddStep("hover collection", () => InputManager.MoveMouseTo(getAddOrRemoveButton(1)));
-            AddAssert("collection has add button", () => getAddOrRemoveButton(1).IsPresent);
+            AddStep("hover collection", () => InputManager.MoveMouseTo(getAddOrRemoveButton(2)));
+            AddAssert("collection has add button", () => getAddOrRemoveButton(2).IsPresent);
         }
 
         [Test]
@@ -149,10 +149,10 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             assertCollectionDropdownContains("1");
 
             AddStep("select available beatmap", () => Beatmap.Value = beatmapManager.GetWorkingBeatmap(beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0]));
-            AddAssert("button enabled", () => getAddOrRemoveButton(1).Enabled.Value);
+            AddAssert("button enabled", () => getAddOrRemoveButton(2).Enabled.Value);
 
             AddStep("set dummy beatmap", () => Beatmap.SetDefault());
-            AddAssert("button disabled", () => !getAddOrRemoveButton(1).Enabled.Value);
+            AddAssert("button disabled", () => !getAddOrRemoveButton(2).Enabled.Value);
         }
 
         [Test]
@@ -185,11 +185,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             assertCollectionDropdownContains("1");
             assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
 
-            addClickAddOrRemoveButtonStep(1);
+            addClickAddOrRemoveButtonStep(2);
             AddAssert("collection contains beatmap", () => getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             assertFirstButtonIs(FontAwesome.Solid.MinusSquare);
 
-            addClickAddOrRemoveButtonStep(1);
+            addClickAddOrRemoveButtonStep(2);
             AddAssert("collection does not contain beatmap", () => !getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
         }
@@ -204,7 +204,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddStep("select collection", () =>
             {
-                InputManager.MoveMouseTo(getCollectionDropdownItemAt(1));
+                InputManager.MoveMouseTo(getCollectionDropdownItemAt(2));
                 InputManager.Click(MouseButton.Left);
             });
 
@@ -232,7 +232,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             => AddUntilStep($"collection dropdown header displays '{collectionName}'",
                 () => shouldDisplay == dropdown.ChildrenOfType<CollectionDropdown.ShearedDropdownHeader>().Any(h => h.ChildrenOfType<SpriteText>().Any(t => t.Text == collectionName)));
 
-        private void assertFirstButtonIs(IconUsage icon) => AddUntilStep($"button is {icon.Icon.ToString()}", () => getAddOrRemoveButton(1).Icon.Equals(icon));
+        private void assertFirstButtonIs(IconUsage icon) => AddUntilStep($"button is {icon.Icon.ToString()}", () => getAddOrRemoveButton(2).Icon.Equals(icon));
 
         private void assertCollectionDropdownContains(LocalisableString collectionName, bool shouldContain = true) =>
             AddUntilStep($"collection dropdown {(shouldContain ? "contains" : "does not contain")} '{collectionName}'",

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
@@ -19,7 +19,6 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Resources;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.SongSelectV2
 {
@@ -45,6 +44,17 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             Dependencies.Cache(localUserPlayInfo);
 
             beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("reset API state", () =>
+            {
+                dummyAPI.HandleRequest = null;
+                dummyAPI.Logout();
+                localUserPlayInfo.PlayingState.Value = LocalUserPlayingState.NotPlaying;
+            });
         }
 
         [SetUp]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                     return false;
                 };
             });
-            AddStep("select favorites", () => selectFavoritesFilter());
+            AddStep("select favorites", selectFavoritesFilter);
             AddAssert("API request was made", () => lastQueuedRequest is GetUserBeatmapsRequest);
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
@@ -1,0 +1,264 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Collections;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.SelectV2;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    public partial class TestSceneFavoriteBeatmapsFilter : OsuManualInputManagerTestScene
+    {
+        private BeatmapManager beatmapManager = null!;
+        private FilterControl filterControl = null!;
+        private CollectionDropdown collectionDropdown = null!;
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
+
+        [Cached]
+        private readonly LocalUserPlayInfo localUserPlayInfo = new LocalUserPlayInfo();
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            Dependencies.Cache(new RealmRulesetStore(Realm));
+            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, null, Audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
+            Dependencies.Cache(localUserPlayInfo);
+
+            beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
+        }
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    filterControl = new FilterControl
+                    {
+                        State = { Value = Visibility.Visible },
+                        RelativeSizeAxes = Axes.X,
+                        Height = 200,
+                    },
+                    collectionDropdown = new CollectionDropdown
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Y = 220,
+                        Height = 40,
+                    }
+                }
+            };
+        });
+
+        [Test]
+        public void TestFavoritesOptionNotVisibleWhenLoggedOut()
+        {
+            AddStep("log out", () => dummyAPI.Logout());
+            AddStep("open dropdown", () => collectionDropdown.Show());
+            AddAssert("no favorites option", () =>
+                collectionDropdown.ChildrenOfType<CollectionDropdown.ShearedCollectionDropdownMenu>()
+                    .First()
+                    .ChildrenOfType<Dropdown<CollectionFilterMenuItem>.DropdownItem>()
+                    .All(item => !(item.Value is FavoriteBeatmapsCollectionFilterMenuItem)));
+        }
+
+        [Test]
+        public void TestFavoritesOptionVisibleWhenLoggedIn()
+        {
+            AddStep("log in", () => dummyAPI.Login("test", "test"));
+            AddStep("open dropdown", () => collectionDropdown.Show());
+            AddAssert("favorites option exists", () =>
+                collectionDropdown.ChildrenOfType<CollectionDropdown.ShearedCollectionDropdownMenu>()
+                    .First()
+                    .ChildrenOfType<Dropdown<CollectionFilterMenuItem>.DropdownItem>()
+                    .Any(item => item.Value is FavoriteBeatmapsCollectionFilterMenuItem));
+        }
+
+        [Test]
+        public void TestFavoritesFilterWithNoCache()
+        {
+            AddStep("log in", () => dummyAPI.Login("test", "test"));
+            AddStep("select favorites", () => selectFavoritesFilter());
+            AddAssert("API request was made", () => dummyAPI.LastQueuedRequest is GetUserBeatmapsRequest);
+        }
+
+        [Test]
+        public void TestFavoritesFilterWithCache()
+        {
+            GetUserBeatmapsRequest? lastRequest = null;
+
+            AddStep("log in", () => dummyAPI.Login("test", "test"));
+            AddStep("mock API response", () =>
+            {
+                dummyAPI.HandleRequest = req =>
+                {
+                    if (req is GetUserBeatmapsRequest getUserBeatmapsRequest)
+                    {
+                        lastRequest = getUserBeatmapsRequest;
+                        getUserBeatmapsRequest.TriggerSuccess(new APIBeatmapSet[]
+                        {
+                            new APIBeatmapSet { OnlineID = 1 },
+                            new APIBeatmapSet { OnlineID = 2 }
+                        });
+                        return true;
+                    }
+                    return false;
+                };
+            });
+
+            AddStep("select favorites", () => selectFavoritesFilter());
+            AddAssert("API request was made", () => lastRequest != null);
+
+            AddStep("reset request tracking", () => lastRequest = null);
+            AddStep("select all beatmaps", () => selectAllBeatmapsFilter());
+            AddStep("select favorites again", () => selectFavoritesFilter());
+            AddAssert("no new API request", () => lastRequest == null);
+        }
+
+        [Test]
+        public void TestFavoriteStatusChangeUpdatesFilter()
+        {
+            AddStep("log in", () => dummyAPI.Login("test", "test"));
+            AddStep("mock API responses", () => setupMockAPI());
+            AddStep("select favorites filter", () => selectFavoritesFilter());
+
+            AddStep("trigger favorite change event", () =>
+                PostBeatmapFavouriteRequest.FavouriteChanged?.Invoke(123, true));
+            AddAssert("filter criteria updated", () => filterControl.CreateCriteria().CollectionBeatmapMD5Hashes != null);
+        }
+
+        [Test]
+        public void TestPeriodicRefreshOnlyWhenNotPlaying()
+        {
+            AddStep("log in", () => dummyAPI.Login("test", "test"));
+            AddStep("set playing state", () => localUserPlayInfo.PlayingState.Value = LocalUserPlayingState.Playing);
+            AddStep("mock API responses", () => setupMockAPI());
+            AddStep("select favorites filter", () => selectFavoritesFilter());
+            AddAssert("playing state is respected", () => localUserPlayInfo.PlayingState.Value == LocalUserPlayingState.Playing);
+
+            AddStep("set not playing state", () => localUserPlayInfo.PlayingState.Value = LocalUserPlayingState.NotPlaying);
+            AddAssert("not playing state is set", () => localUserPlayInfo.PlayingState.Value == LocalUserPlayingState.NotPlaying);
+        }
+
+        [Test]
+        public void TestCacheClearsOnUserChange()
+        {
+            AddStep("log in as user 1", () => dummyAPI.Login("user1", "test"));
+            AddStep("mock API responses", () => setupMockAPI());
+            AddStep("select favorites filter", () => selectFavoritesFilter());
+            AddAssert("cache populated", () => filterControl.CreateCriteria().CollectionBeatmapMD5Hashes != null);
+
+            AddStep("log in as user 2", () => dummyAPI.Login("user2", "test"));
+            AddStep("select favorites filter", () => selectFavoritesFilter());
+            AddAssert("new API request for new user", () => dummyAPI.LastQueuedRequest is GetUserBeatmapsRequest);
+        }
+
+        [Test]
+        public void TestFavoritesFilterShowsCorrectBeatmaps()
+        {
+            AddStep("log in", () => dummyAPI.Login("test", "test"));
+            AddStep("mock API with known beatmap", () =>
+            {
+                var importedBeatmap = beatmapManager.GetAllUsableBeatmapSets().First();
+
+                dummyAPI.HandleRequest = req =>
+                {
+                    if (req is GetUserBeatmapsRequest getUserBeatmapsRequest)
+                    {
+                        getUserBeatmapsRequest.TriggerSuccess(new APIBeatmapSet[]
+                        {
+                            new APIBeatmapSet { OnlineID = importedBeatmap.OnlineID }
+                        });
+                        return true;
+                    }
+                    return false;
+                };
+            });
+
+            AddStep("select favorites filter", () => selectFavoritesFilter());
+            AddAssert("filter includes imported beatmap hashes", () =>
+            {
+                var criteria = filterControl.CreateCriteria();
+                var importedBeatmap = beatmapManager.GetAllUsableBeatmapSets().First();
+                var importedHashes = importedBeatmap.Beatmaps.Select(b => b.MD5Hash).ToHashSet();
+                return criteria.CollectionBeatmapMD5Hashes?.Intersect(importedHashes).Any() == true;
+            });
+        }
+
+        private void selectFavoritesFilter()
+        {
+            AddStep("open dropdown", () => collectionDropdown.Show());
+            AddStep("click favorites option", () =>
+            {
+                var favoritesItem = collectionDropdown
+                    .ChildrenOfType<CollectionDropdown.ShearedCollectionDropdownMenu>()
+                    .First()
+                    .ChildrenOfType<Dropdown<CollectionFilterMenuItem>.DropdownItem>()
+                    .First(item => item.Value is FavoriteBeatmapsCollectionFilterMenuItem);
+
+                InputManager.MoveMouseTo(favoritesItem);
+                InputManager.Click(MouseButton.Left);
+            });
+        }
+
+        private void selectAllBeatmapsFilter()
+        {
+            AddStep("open dropdown", () => collectionDropdown.Show());
+            AddStep("click all beatmaps option", () =>
+            {
+                var allBeatmapsItem = collectionDropdown
+                    .ChildrenOfType<CollectionDropdown.ShearedCollectionDropdownMenu>()
+                    .First()
+                    .ChildrenOfType<Dropdown<CollectionFilterMenuItem>.DropdownItem>()
+                    .First(item => item.Value is AllBeatmapsCollectionFilterMenuItem);
+
+                InputManager.MoveMouseTo(allBeatmapsItem);
+                InputManager.Click(MouseButton.Left);
+            });
+        }
+
+        private void setupMockAPI()
+        {
+            dummyAPI.HandleRequest = req =>
+            {
+                if (req is GetUserBeatmapsRequest getUserBeatmapsRequest)
+                {
+                    getUserBeatmapsRequest.TriggerSuccess(new APIBeatmapSet[]
+                    {
+                        new APIBeatmapSet { OnlineID = 1 },
+                        new APIBeatmapSet { OnlineID = 2 }
+                    });
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        private partial class LocalUserPlayInfo : ILocalUserPlayInfo
+        {
+            public Bindable<LocalUserPlayingState> PlayingState { get; } = new Bindable<LocalUserPlayingState>();
+
+            IBindable<LocalUserPlayingState> ILocalUserPlayInfo.PlayingState => PlayingState;
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneFavoriteBeatmapsFilter.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -14,7 +13,6 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using CollectionDropdown = osu.Game.Screens.SelectV2.CollectionDropdown;
-using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;

--- a/osu.Game/Collections/CollectionFilterMenuItem.cs
+++ b/osu.Game/Collections/CollectionFilterMenuItem.cs
@@ -64,6 +64,18 @@ namespace osu.Game.Collections
         public override int GetHashCode() => 1;
     }
 
+    public class FavoriteBeatmapsCollectionFilterMenuItem : CollectionFilterMenuItem
+    {
+        public FavoriteBeatmapsCollectionFilterMenuItem()
+            : base(CollectionsStrings.FavoriteBeatmaps)
+        {
+        }
+
+        public override bool Equals(CollectionFilterMenuItem? other) => other is FavoriteBeatmapsCollectionFilterMenuItem;
+
+        public override int GetHashCode() => 3;
+    }
+
     public class ManageCollectionsFilterMenuItem : CollectionFilterMenuItem
     {
         public ManageCollectionsFilterMenuItem()

--- a/osu.Game/Localisation/CollectionsStrings.cs
+++ b/osu.Game/Localisation/CollectionsStrings.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Localisation
         public static LocalisableString AllBeatmaps => new TranslatableString(getKey(@"all_beatmaps"), @"All beatmaps");
 
         /// <summary>
+        /// "Favorite beatmaps"
+        /// </summary>
+        public static LocalisableString FavoriteBeatmaps => new TranslatableString(getKey(@"favorite_beatmaps"), @"Favorite beatmaps");
+
+        /// <summary>
         /// "Manage collections..."
         /// </summary>
         public static LocalisableString ManageCollections => new TranslatableString(getKey(@"manage_collections"), @"Manage collections...");

--- a/osu.Game/Online/API/Requests/PostBeatmapFavouriteRequest.cs
+++ b/osu.Game/Online/API/Requests/PostBeatmapFavouriteRequest.cs
@@ -2,12 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.IO.Network;
+using System;
 using System.Net.Http;
 
 namespace osu.Game.Online.API.Requests
 {
     public class PostBeatmapFavouriteRequest : APIRequest
     {
+        /// <summary>
+        /// Fired when any beatmap favorite status changes successfully.
+        /// Provides the beatmap set ID and whether it was favorited (true) or unfavorited (false).
+        /// </summary>
+        public static event Action<int, bool>? FavouriteChanged;
+
         public readonly BeatmapFavouriteAction Action;
 
         private readonly int id;
@@ -16,6 +23,13 @@ namespace osu.Game.Online.API.Requests
         {
             this.id = id;
             Action = action;
+
+            // Hook into the success event to fire the global event
+            Success += () =>
+            {
+                bool favourited = Action == BeatmapFavouriteAction.Favourite;
+                FavouriteChanged?.Invoke(id, favourited);
+            };
         }
 
         protected override WebRequest CreateWebRequest()

--- a/osu.Game/Screens/SelectV2/CollectionDropdown.cs
+++ b/osu.Game/Screens/SelectV2/CollectionDropdown.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Screens.SelectV2
         private void userChanged(ValueChangedEvent<APIUser> user)
         {
             // If user logged out and favorites is selected, switch to all beatmaps
-            if (user.NewValue?.Id <= 1 && Current.Value is FavoriteBeatmapsCollectionFilterMenuItem)
+            if (user.NewValue.Id <= 1 && Current.Value is FavoriteBeatmapsCollectionFilterMenuItem)
                 Current.Value = allBeatmapsItem;
 
             updateItems();

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.SelectV2
         /// <summary>
         /// Interval for periodic favorites cache refresh in milliseconds (5 minutes).
         /// </summary>
-        private const double PERIODIC_REFRESH_INTERVAL = 300000;
+        private const double PeriodicRefreshInterval = 300000;
 
         public LocalisableString StatusText
         {
@@ -495,7 +495,7 @@ namespace osu.Game.Screens.SelectV2
             base.Update();
 
             // Check for periodic favorites refresh
-            if (Time.Current - lastPeriodicCheck >= PERIODIC_REFRESH_INTERVAL)
+            if (Time.Current - lastPeriodicCheck >= PeriodicRefreshInterval)
             {
                 lastPeriodicCheck = Time.Current;
                 periodicFavoritesRefresh();

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -279,9 +279,9 @@ namespace osu.Game.Screens.SelectV2
                     lastFetchedUserId = user.NewValue?.Id;
                     cacheTime = null;
                 }
+
                 updateCriteria();
             });
-
 
             updateCriteria();
 
@@ -361,7 +361,7 @@ namespace osu.Game.Screens.SelectV2
 
             isFetchingFavorites = true;
 
-            var userId = api.LocalUser.Value!.Id;
+            int userId = api.LocalUser.Value!.Id;
             var request = new GetUserBeatmapsRequest(userId, BeatmapSetType.Favourite, new PaginationParameters(0, 200));
 
             request.Success += response =>
@@ -372,7 +372,7 @@ namespace osu.Game.Screens.SelectV2
                     {
                         var favoriteMD5Hashes = new HashSet<string>();
 
-                        if (response?.Count > 0)
+                        if (response.Count > 0)
                         {
                             var favoriteOnlineIds = response.Select(set => set.OnlineID).Where(id => id > 0).ToHashSet();
 
@@ -441,6 +441,7 @@ namespace osu.Game.Screens.SelectV2
                 return;
             }
 
+
             // Update cache directly with the changed beatmap set
             updateCacheForBeatmapSet(beatmapSetId, favourited);
 
@@ -462,9 +463,9 @@ namespace osu.Game.Screens.SelectV2
 
             // Get all MD5 hashes for this beatmap set
             var setMD5Hashes = matchingSet.Beatmaps
-                .Where(beatmap => !string.IsNullOrEmpty(beatmap.MD5Hash))
-                .Select(beatmap => beatmap.MD5Hash)
-                .ToHashSet();
+                                          .Where(beatmap => !string.IsNullOrEmpty(beatmap.MD5Hash))
+                                          .Select(beatmap => beatmap.MD5Hash)
+                                          .ToHashSet();
 
             if (setMD5Hashes.Count == 0)
                 return;
@@ -475,13 +476,13 @@ namespace osu.Game.Screens.SelectV2
             if (favourited)
             {
                 // Add hashes to favorites
-                foreach (var hash in setMD5Hashes)
+                foreach (string hash in setMD5Hashes)
                     currentHashes.Add(hash);
             }
             else
             {
                 // Remove hashes from favorites
-                foreach (var hash in setMD5Hashes)
+                foreach (string hash in setMD5Hashes)
                     currentHashes.Remove(hash);
             }
 

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -317,7 +317,7 @@ namespace osu.Game.Screens.SelectV2
                 AllowConvertedBeatmaps = showConvertedBeatmapsButton.Active.Value,
                 Ruleset = ruleset.Value,
                 Mods = mods.Value,
-                CollectionBeatmapMD5Hashes = GetCollectionHashes(collectionDropdown.Current.Value),
+                CollectionBeatmapMD5Hashes = getCollectionHashes(collectionDropdown.Current.Value),
                 LocalUserId = isValidUser ? localUser.Value.Id : null,
                 LocalUserUsername = isValidUser ? localUser.Value.Username : null,
             };
@@ -334,7 +334,7 @@ namespace osu.Game.Screens.SelectV2
             return criteria;
         }
 
-        private ImmutableHashSet<string>? GetCollectionHashes(CollectionFilterMenuItem? item)
+        private ImmutableHashSet<string>? getCollectionHashes(CollectionFilterMenuItem? item)
         {
             if (item is FavoriteBeatmapsCollectionFilterMenuItem)
             {

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.SelectV2
         /// <summary>
         /// Interval for periodic favorites cache refresh in milliseconds (5 minutes).
         /// </summary>
-        private const double PeriodicRefreshInterval = 300000;
+        private const double periodic_refresh_interval = 300000;
 
         public LocalisableString StatusText
         {
@@ -338,13 +338,13 @@ namespace osu.Game.Screens.SelectV2
         {
             if (item is FavoriteBeatmapsCollectionFilterMenuItem)
             {
-                return GetFavoriteBeatmapHashes();
+                return getFavoriteBeatmapHashes();
             }
 
             return item?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToImmutableHashSet();
         }
 
-        private ImmutableHashSet<string>? GetFavoriteBeatmapHashes()
+        private ImmutableHashSet<string>? getFavoriteBeatmapHashes()
         {
             // Check if user is logged in and API is available
             if (api.LocalUser.Value?.Id <= 1 || api.State.Value != APIState.Online)
@@ -495,7 +495,7 @@ namespace osu.Game.Screens.SelectV2
             base.Update();
 
             // Check for periodic favorites refresh
-            if (Time.Current - lastPeriodicCheck >= PeriodicRefreshInterval)
+            if (Time.Current - lastPeriodicCheck >= periodic_refresh_interval)
             {
                 lastPeriodicCheck = Time.Current;
                 periodicFavoritesRefresh();

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -361,7 +361,7 @@ namespace osu.Game.Screens.SelectV2
 
             isFetchingFavorites = true;
 
-            var userId = api.LocalUser.Value.Id;
+            var userId = api.LocalUser.Value!.Id;
             var request = new GetUserBeatmapsRequest(userId, BeatmapSetType.Favourite, new PaginationParameters(0, 200));
 
             request.Success += response =>


### PR DESCRIPTION
> [!NOTE]
> After doing this I found #34744, but since my outcome differs I opened this anyway—up to whoever.

https://github.com/user-attachments/assets/1f3a914f-44ba-43f6-ac0d-d1c3b43e2415

Adds a **Favorite beatmaps** collection for logged-in users.

Closes #34494

Uses `GetUserBeatmapsRequest` with `BeatmapSetType.Favourite` on load and listens to `PostBeatmapFavouriteRequest.FavouriteChanged` events for real-time updates.

Refreshes every 5 minutes (menu only, not during gameplay) to sync with external changes. Collection is removed when logged out.

Added ``TestSceneFavoriteBeatmapsFilter.cs`` but I wasn't able to run the test locally due to *some* test runner issues I ran into (150K+ resolution errors even on clean master).