### PR TITLE
Fix mangled initial undo state on fresh skins

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -391,10 +391,10 @@ namespace osu.Game.Overlays.SkinEditor
                 return;
             }
 
-            if (skinComponentsContainer.IsLoaded)
+            if (skinComponentsContainer.ComponentsLoaded)
                 bindChangeHandler(skinComponentsContainer);
             else
-                skinComponentsContainer.OnLoadComplete += d => Schedule(() => bindChangeHandler((SkinnableContainer)d));
+                skinComponentsContainer.OnComponentsLoaded += onComponentsLoaded;
 
             content.Child = new SkinBlueprintContainer(skinComponentsContainer);
 
@@ -427,6 +427,13 @@ namespace osu.Game.Overlays.SkinEditor
             {
                 RequestPlacement = requestPlacement
             });
+
+            void onComponentsLoaded(Drawable d)
+            {
+                SkinnableContainer container = (SkinnableContainer)d;
+                container.OnComponentsLoaded -= onComponentsLoaded;
+                Schedule(() => bindChangeHandler(container));
+            }
 
             void requestPlacement(Type type)
             {

--- a/osu.Game/Skinning/SkinnableContainer.cs
+++ b/osu.Game/Skinning/SkinnableContainer.cs
@@ -21,6 +21,11 @@ namespace osu.Game.Skinning
     /// </remarks>
     public partial class SkinnableContainer : SkinReloadableDrawable, ISerialisableDrawableContainer
     {
+        /// <summary>
+        /// Invoked when the skinnable components of this container finish loading.
+        /// </summary>
+        public event Action<Drawable>? OnComponentsLoaded;
+
         private Container? content;
 
         /// <summary>
@@ -67,6 +72,7 @@ namespace osu.Game.Skinning
                 AddInternal(wrapper);
                 components.AddRange(wrapper.Children.OfType<ISerialisableDrawable>());
                 ComponentsLoaded = true;
+                OnComponentsLoaded?.Invoke(this);
             }, (cancellationSource = new CancellationTokenSource()).Token);
         }
 
@@ -105,6 +111,13 @@ namespace osu.Game.Skinning
             base.SkinChanged(skin);
 
             Reload();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            OnComponentsLoaded = null;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/34479

In retrospect the cause is somewhat simple - when opening the skin editor, if the current skin is one of the defaults then a new one is created and swapped to, reloading all `SkinnableContainers` concurrently (asynchronously) whilst saving the initial editor state.
Thus if the load takes too long (such as with the patch in the issue thread, such as in CI runs) the initial undo state can be of a half-loaded state.

I'm actually not sure where the "new skin is created and swapped to" code path lies, but it's irrelevant to the fix. Just mentioning this as difficulty in understanding the flow.

The fix is to delay binding the change handler until components are fully loaded. I've added multiple safety guards too because I've also noticed that the `OnLoadComplete` bind would get leaked.