### PR TITLE
Refactor gameplay conclusion to be more centralised

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -175,9 +175,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             ScoreProcessor.FailScore(Score.ScoreInfo);
         }
 
-        protected override void ConcludeFailedScore(Score score)
-            => throw new NotSupportedException($"{nameof(MultiplayerPlayer)} should never be calling {nameof(ConcludeFailedScore)}. Failing in multiplayer only marks the score with F rank.");
-
         private void failAndBail(string? message = null)
         {
             if (!string.IsNullOrEmpty(message))

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -90,8 +89,5 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             // see also: `MultiplayerPlayer.PerformFail()`
             ScoreProcessor.FailScore(Score.ScoreInfo);
         }
-
-        protected override void ConcludeFailedScore(Score score)
-            => throw new NotSupportedException($"{nameof(MultiSpectatorPlayer)} should never be calling {nameof(ConcludeFailedScore)}. Failing in multiplayer only marks the score with F rank.");
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -813,6 +813,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             GameplayState.HasPassed = true;
+            ConcludeGameplay();
 
             // Setting this early in the process means that even if something were to go wrong in the order of events following, there
             // is no chance that a user could return to the (already completed) Player instance from a child screen.
@@ -981,19 +982,12 @@ namespace osu.Game.Screens.Play
             // finalise the score as "failed".
             Schedule(() =>
             {
-                ConcludeFailedScore(Score);
+                ScoreProcessor.FailScore(Score.ScoreInfo);
+                ConcludeGameplay();
 
                 if (restartOnFail)
                     Restart(true);
             });
-        }
-
-        /// <summary>
-        /// Performs last operations on the supplied <paramref name="score"/> before this <see cref="Player"/> is definitively exited due to failing.
-        /// </summary>
-        protected virtual void ConcludeFailedScore(Score score)
-        {
-            ScoreProcessor.FailScore(score.ScoreInfo);
         }
 
         /// <summary>
@@ -1156,6 +1150,13 @@ namespace osu.Game.Screens.Play
                 skipIntroOverlay.SkipWhenReady();
         }
 
+        /// <summary>
+        /// Performs any final operations prior to gameplay concluding either as a result of a successful completion, a fail, or exiting the screen.
+        /// </summary>
+        protected virtual void ConcludeGameplay()
+        {
+        }
+
         public override void OnSuspending(ScreenTransitionEvent e)
         {
             screenSuspension?.RemoveAndDisposeImmediately();
@@ -1181,6 +1182,8 @@ namespace osu.Game.Screens.Play
 
                 if (DrawableRuleset.ReplayScore == null)
                     ScoreProcessor.FailScore(Score.ScoreInfo);
+
+                ConcludeGameplay();
             }
 
             // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.


### PR DESCRIPTION
This follows on from https://github.com/ppy/osu/pull/34628, further centralising all gameplay conclusion processes via `ConcludeGameplay()`.

Part of the fix involves moving the `spectatorClient.EndPlaying()` invocation back to the update thread, addressing the `TestSceneScreenNavigation` test failures in https://github.com/ppy/osu/actions/runs/17598682704/job/49998218911:

```
❌ TestLastScoreNotNullAfterExitingPlayer
	System.AggregateException : One or more errors occurred. (Cannot invoke BeginPlaying when already playing)
	  ----> System.InvalidOperationException : Cannot invoke BeginPlaying when already playing
```

The failures can be reproed in practice with:

```diff
diff --git a/osu.Game/Screens/Play/SubmittingPlayer.cs b/osu.Game/Screens/Play/SubmittingPlayer.cs
index 06f1a9c530..1c668ce755 100644
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -269,6 +269,7 @@ private void submitFromFailOrQuit(Score score)
 
                 Task.Run(async () =>
                 {
+                    await Task.Delay(5000).ConfigureAwait(false);
                     await submitScore(scoreCopy).ConfigureAwait(false);
                     spectatorClient.EndPlaying(GameplayState);
                 }).FireAndForget();

```

... and can affect/crash the game in practice if the task takes too long to complete before quick-retry.

Relying on practical testing + `TestScenePlayerScoreSubmission` to cover any edge cases.