### PR TITLE
Change hitobject undimming function to be approach rate dependent

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -115,8 +115,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private void applyDim(Drawable piece)
         {
             piece.FadeColour(new Color4(195, 195, 195, 255));
-            using (piece.BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
-                piece.FadeColour(Color4.White, 100);
+            piece.FadeColour(Color4.White, Math.Max(0, InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW), Easing.InQuint);
         }
 
         private void applyDimToDrawableHitObject(DrawableHitObject dho, ArmedState _) => applyDim(dho);


### PR DESCRIPTION
Mostly fixes #31193

This changes the undimming from a constant 100ms duration at exact preempt-400ms timing (which equals to AR10.33) to a quint fade in from preempt to preempt-400ms which makes abusing extreme contrast settings to get everything dimmed invisible and everything undimmed visible much harder. Practically this means that undimming is now tied to approach rate and any non-software-dependant quantizing of brightness can only reduce the difficulty of density reading slightly.

Quint easing was chosen to preserve the "snap" of sudden opacity change at the 400ms timing to keep the gameplay feel similar to before.

## Comparisons
### AR 0 Before
https://github.com/user-attachments/assets/a0c2ecec-58c5-4384-aede-e9c78f13ec5d 

### AR 0 After
https://github.com/user-attachments/assets/d2a77d53-8084-4d65-a96b-a3cd489d3da0

### AR 5 Before
https://github.com/user-attachments/assets/6ce855b2-47fe-42e9-8cf6-e98137add015

### AR 5 After
https://github.com/user-attachments/assets/0fab780b-a8fb-477a-be78-76940ad4b8fd

### AR 9 Before
https://github.com/user-attachments/assets/356548b5-3502-4f7d-bfc1-18cb75a81744

### AR 9 After
https://github.com/user-attachments/assets/3e487c02-029d-453a-a802-5abaf4360e77

### AR -10 Before with gamma and contrast abuse
https://github.com/user-attachments/assets/5fb256f3-316a-48fa-ad4c-b956dbf876a5

### AR -10 After with gamma and contrast abuse
https://github.com/user-attachments/assets/35f93515-0c0f-41d3-860a-3ca90d3fd1ba

Approach rates above 10.33 are completely unchanged since the original undimming happens at a timing that's before preempt even starts.