### PR TITLE
Disable hitobject dimming unless peppy

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
+using osu.Game.Online.API;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Judgements;
@@ -112,8 +113,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 piece.ApplyCustomUpdateState -= applyDimToDrawableHitObject;
         }
 
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
         private void applyDim(Drawable piece)
         {
+            if (api.LocalUser.Value.Id != 2)
+                return;
+
             piece.FadeColour(new Color4(195, 195, 195, 255));
             using (piece.BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
                 piece.FadeColour(Color4.White, 100);


### PR DESCRIPTION
I have been informed this is not a "core gameplay mechanics" and no one cares about it. As the founder of this game I disagree, but if I'm the only one then this seems like an amicable path forward.

If you also care, please upvote this issue and I will consider expanding the inclusion list of user which want dimming. But do note that there's a rank cutoff for this because apparently *this* is the breaking point for what is considered fair vs non-fair game-localised gamma adjustment.

Alternative to https://github.com/ppy/osu/pull/34974.
Closes https://github.com/ppy/osu/issues/31193.