### PR TITLE
More matchmaking SFX work

### DIFF
--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -8,7 +8,6 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Scoring;
-using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osu.Game.Users;
@@ -29,7 +28,6 @@ namespace osu.Game.Configuration
             SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null);
             SetDefault(Static.LastModSelectPanelSamplePlaybackTime, (double?)null);
             SetDefault(Static.LastRankChangeSamplePlaybackTime, (double?)null);
-            SetDefault(Static.LastMatchmakingCloudSamplePlaybackTime, (double?)null);
             SetDefault<APISeasonalBackgrounds?>(Static.SeasonalBackgrounds, null);
             SetDefault(Static.TouchInputActive, RuntimeInfo.IsMobile);
             SetDefault<ScoreInfo?>(Static.LastLocalUserScore, null);
@@ -82,12 +80,6 @@ namespace osu.Game.Configuration
         /// Used to debounce rank change sounds game-wide to avoid potential volume saturation from multiple simultaneous playback.
         /// </summary>
         LastRankChangeSamplePlaybackTime,
-
-        /// <summary>
-        /// The last playback time in milliseconds for the 'user appear' sample in <see cref="MatchmakingCloud"/>.
-        /// Used to debounce sample playback to avoid volume saturation from multiple simultaneous playback.
-        /// </summary>
-        LastMatchmakingCloudSamplePlaybackTime,
 
         /// <summary>
         /// Whether the last positional input received was a touch input.

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Pick/BeatmapSelectionGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Pick/BeatmapSelectionGrid.cs
@@ -45,8 +45,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Pick
 
         private bool allowSelection = true;
 
-        private readonly Sample[] rouletteSamples = new Sample[8];
-        private Sample? rouletteResultSample;
+        private readonly Sample?[] spinSamples = new Sample?[5];
+        private static readonly int[] spin_sample_sequence = [0, 1, 2, 3, 4, 2, 3, 4];
+        private Sample? resultSample;
         private Sample? swooshSample;
         private double? lastSamplePlayback;
 
@@ -77,15 +78,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Pick
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            rouletteSamples[0] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-0");
-            rouletteSamples[1] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-1");
-            rouletteSamples[2] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-2");
-            rouletteSamples[3] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-3");
-            rouletteSamples[4] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-4");
-            rouletteSamples[5] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-2");
-            rouletteSamples[6] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-3");
-            rouletteSamples[7] = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-4");
-            rouletteResultSample = audio.Samples.Get(@"Multiplayer/Matchmaking/roulette-result");
+            for (int i = 0; i < spinSamples.Length; i++)
+                spinSamples[i] = audio.Samples.Get($@"Multiplayer/Matchmaking/Selection/roulette-{i}");
+
+            resultSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Selection/roulette-result");
             swooshSample = audio.Samples.Get(@"SongSelect/options-pop-out");
         }
 
@@ -306,8 +302,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Pick
 
                     if (lastSamplePlayback == null || Time.Current - lastSamplePlayback > OsuGameBase.SAMPLE_DEBOUNCE_TIME)
                     {
-                        int sampleIdx = ii % (rouletteSamples.Length);
-                        rouletteSamples[sampleIdx].Play();
+                        int sequenceIdx = ii % spin_sample_sequence.Length;
+                        spinSamples[spin_sample_sequence[sequenceIdx]]?.Play();
                         lastSamplePlayback = Time.Current;
                     }
 
@@ -338,7 +334,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Pick
                     panel.MoveTo(Vector2.Zero, 1000, Easing.OutExpo)
                          .ScaleTo(1.5f, 1000, Easing.OutExpo);
 
-                    rouletteResultSample?.Play();
+                    resultSample?.Play();
                 });
             }
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/StageBubble.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/StageBubble.cs
@@ -3,6 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -31,6 +33,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         private DateTimeOffset countdownStartTime;
         private DateTimeOffset countdownEndTime;
 
+        private Sample? stageProgressSample;
+        private double? lastSamplePlayback;
+
         public StageBubble(MatchmakingStage stage, LocalisableString displayText)
         {
             this.stage = stage;
@@ -40,7 +45,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             InternalChild = new CircularContainer
             {
@@ -68,6 +73,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                     }
                 }
             };
+
+            stageProgressSample = audio.Samples.Get(@"Multiplayer/countdown-tick");
         }
 
         protected override void LoadComplete()
@@ -98,6 +105,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
             {
                 TimeSpan elapsed = DateTimeOffset.Now - countdownStartTime;
                 progressBar.Width = (float)(elapsed.TotalMilliseconds / duration.TotalMilliseconds);
+
+                bool enoughTimeElapsed = lastSamplePlayback == null || Time.Current - lastSamplePlayback >= 1000f;
+                if (elapsed.TotalMilliseconds < 1000f || !enoughTimeElapsed || elapsed.TotalMilliseconds >= duration.TotalMilliseconds)
+                    return;
+
+                stageProgressSample?.Play();
+                lastSamplePlayback = Time.Current;
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/StageText.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/StageText.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,13 +22,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         private OsuSpriteText text = null!;
 
+        private Sample? textChangedSample;
+        private double? lastSamplePlayback;
+
         public StageText()
         {
             AutoSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             InternalChild = text = new OsuSpriteText
             {
@@ -34,6 +39,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                 Font = OsuFont.Default,
                 AlwaysPresent = true,
             };
+
+            textChangedSample = audio.Samples.Get(@"Multiplayer/Matchmaking/stage-message");
         }
 
         protected override void LoadComplete()
@@ -50,6 +57,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                 return;
 
             text.Text = getTextForStatus(matchmakingState.Stage);
+
+            if (text.Text == string.Empty || (lastSamplePlayback != null && Time.Current - lastSamplePlayback < OsuGameBase.SAMPLE_DEBOUNCE_TIME))
+                return;
+
+            textChangedSample?.Play();
+            lastSamplePlayback = Time.Current;
         });
 
         private LocalisableString getTextForStatus(MatchmakingStage status)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.908.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.911.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.913.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
- Replaced placeholder `MatchmakingCloud` SFX with something new (might be a bit much, but we'll see...)

https://github.com/user-attachments/assets/0da554d0-9eb5-43a2-bfb5-64e2cd123291

- Added placeholder-y SFX for stage progression feedback

https://github.com/user-attachments/assets/133e11ec-622a-4011-b6f7-259a89e0de06

- Refactoring of roulette SFX logic that was not great

---

- [x] depends on ppy/osu-resources#387