### PR TITLE
Fix argon judgement counter looking misaligned with wireframe off

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonJudgementCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonJudgementCounter.cs
@@ -183,6 +183,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("Show all judgements", () => counterDisplay.Mode.Value = ArgonJudgementCounterDisplay.DisplayMode.All);
             AddWaitStep("wait some", 2);
             AddAssert("Check all visible", () => counterDisplay.CounterFlow.ChildrenOfType<ArgonJudgementCounter>().Last().Alpha == 1);
+            AddToggleStep("toggle wireframe display", t => counterDisplay.WireframeOpacity.Value = t ? 0.3f : 0);
+            AddStep("Set direction vertical", () => counterDisplay.FlowDirection.Value = Direction.Vertical);
+            AddStep("Set direction horizontal", () => counterDisplay.FlowDirection.Value = Direction.Horizontal);
         }
 
         private int hiddenCount()

--- a/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
@@ -74,13 +74,13 @@ namespace osu.Game.Screens.Play.HUD
                     {
                         wireframesPart = new ArgonCounterSpriteText(wireframesLookup)
                         {
-                            Anchor = anchor,
-                            Origin = anchor,
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
                         },
                         textPart = new ArgonCounterSpriteText(textLookup)
                         {
-                            Anchor = anchor,
-                            Origin = anchor,
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
                         },
                     }
                 }

--- a/osu.Game/Skinning/Components/ArgonJudgementCounter.cs
+++ b/osu.Game/Skinning/Components/ArgonJudgementCounter.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Skinning.Components
             Result = result;
 
             AutoSizeAxes = Axes.Both;
-            AddInternal(textComponent = new ArgonCounterTextComponent(Anchor.TopRight, result.DisplayName.ToUpper()));
+            AddInternal(textComponent = new ArgonCounterTextComponent(Anchor.TopLeft, result.DisplayName.ToUpper()));
         }
 
         private void updateWireframe()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34959.

`ArgonCounterTextComponent` is pretty terrible and prevents being able to fix the issue easily. The core issue is that this is the first instance of the component's usage where the label text can be longer than the counter in the X dimension, so the total width of any counter is equal to max(label width, counter width), and the label will be aligned to the left of that width, while the counter will be aligned to the right of that width.

The fix sort of relies on the fact that I don't expect *any* consumer of `ArgonCounterTextComponent` that meaningfully uses the wireframe digits to want the non-wireframe digits to be aligned to the *left* of the wireframe rather than the right. It's not how I'd expect any segmented display to work. (There are usages that specify `TopLeft` anchor, but they usually display the same number of wireframe and non-wireframe digits, so for them it doesn't really matter if the digits are left-aligned to the wireframes or not.)