### PR TITLE
Remove databasing of `MechanicalDifficulty` and `ReadingDifficulty` attributes

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// The difficulty corresponding to the mechanical skills in osu!taiko.
         /// This includes colour and stamina combined.
         /// </summary>
-        [JsonProperty("mechanical_difficulty")]
         public double MechanicalDifficulty { get; set; }
 
         /// <summary>
@@ -26,7 +25,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// <summary>
         /// The difficulty corresponding to the reading skill.
         /// </summary>
-        [JsonProperty("reading_difficulty")]
         public double ReadingDifficulty { get; set; }
 
         /// <summary>
@@ -59,9 +57,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 yield return v;
 
             yield return (ATTRIB_ID_DIFFICULTY, StarRating);
-            yield return (ATTRIB_ID_MECHANICAL_DIFFICULTY, MechanicalDifficulty);
             yield return (ATTRIB_ID_RHYTHM_DIFFICULTY, RhythmDifficulty);
-            yield return (ATTRIB_ID_READING_DIFFICULTY, ReadingDifficulty);
             yield return (ATTRIB_ID_MONO_STAMINA_FACTOR, MonoStaminaFactor);
             yield return (ATTRIB_ID_CONSISTENCY_FACTOR, ConsistencyFactor);
         }
@@ -71,9 +67,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             base.FromDatabaseAttributes(values, onlineInfo);
 
             StarRating = values[ATTRIB_ID_DIFFICULTY];
-            MechanicalDifficulty = values[ATTRIB_ID_MECHANICAL_DIFFICULTY];
             RhythmDifficulty = values[ATTRIB_ID_RHYTHM_DIFFICULTY];
-            ReadingDifficulty = values[ATTRIB_ID_READING_DIFFICULTY];
             MonoStaminaFactor = values[ATTRIB_ID_MONO_STAMINA_FACTOR];
             ConsistencyFactor = values[ATTRIB_ID_CONSISTENCY_FACTOR];
         }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Rulesets.Difficulty
         protected const int ATTRIB_ID_NESTED_SCORE_PER_OBJECT = 37;
         protected const int ATTRIB_ID_LEGACY_SCORE_BASE_MULTIPLIER = 39;
         protected const int ATTRIB_ID_MAXIMUM_LEGACY_COMBO_SCORE = 41;
-        protected const int ATTRIB_ID_RHYTHM_DIFFICULTY = 45;
-        protected const int ATTRIB_ID_CONSISTENCY_FACTOR = 49;
+        protected const int ATTRIB_ID_RHYTHM_DIFFICULTY = 43;
+        protected const int ATTRIB_ID_CONSISTENCY_FACTOR = 45;
 
         /// <summary>
         /// The mods which were applied to the beatmap.

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -31,9 +31,7 @@ namespace osu.Game.Rulesets.Difficulty
         protected const int ATTRIB_ID_NESTED_SCORE_PER_OBJECT = 37;
         protected const int ATTRIB_ID_LEGACY_SCORE_BASE_MULTIPLIER = 39;
         protected const int ATTRIB_ID_MAXIMUM_LEGACY_COMBO_SCORE = 41;
-        protected const int ATTRIB_ID_MECHANICAL_DIFFICULTY = 43;
         protected const int ATTRIB_ID_RHYTHM_DIFFICULTY = 45;
-        protected const int ATTRIB_ID_READING_DIFFICULTY = 47;
         protected const int ATTRIB_ID_CONSISTENCY_FACTOR = 49;
 
         /// <summary>


### PR DESCRIPTION
These are unused in performance calculations currently so there's no point databasing them.