### PR TITLE
Update android requirement to 9+ on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are just looking to give the game a whirl, you can grab the latest releas
 
 ### Latest release:
 
-| [Windows 10+ (x64)](https://github.com/ppy/osu/releases/latest/download/install.exe) | macOS 12+ ([Intel](https://github.com/ppy/osu/releases/latest/download/osu.app.Intel.zip), [Apple Silicon](https://github.com/ppy/osu/releases/latest/download/osu.app.Apple.Silicon.zip)) | [Linux (x64)](https://github.com/ppy/osu/releases/latest/download/osu.AppImage) | [iOS 13.4+](https://osu.ppy.sh/home/testflight) | [Android 5+](https://github.com/ppy/osu/releases/latest/download/sh.ppy.osulazer.apk) |
+| [Windows 10+ (x64)](https://github.com/ppy/osu/releases/latest/download/install.exe) | macOS 12+ ([Intel](https://github.com/ppy/osu/releases/latest/download/osu.app.Intel.zip), [Apple Silicon](https://github.com/ppy/osu/releases/latest/download/osu.app.Apple.Silicon.zip)) | [Linux (x64)](https://github.com/ppy/osu/releases/latest/download/osu.AppImage) | [iOS 13.4+](https://osu.ppy.sh/home/testflight) | [Android 9+](https://github.com/ppy/osu/releases/latest/download/sh.ppy.osulazer.apk) |
 |--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------- | ------------- | ------------- |
 
 You can also generally download a version for your current device from the [osu! site](https://osu.ppy.sh/home/download).


### PR DESCRIPTION
See issue thread in https://github.com/ppy/osu/issues/34992.

According to https://apilevels.com/, seems like we'll lose ~8% of potential users on Android, but probably fine as I've closed some issues related to old versions recently and doubt they are getting playable performance in the latest release anyway.