### PR TITLE
Fix osu!mania legacy skin WidthForNoteHeightScale not being used

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyNotePiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyNotePiece.cs
@@ -1,6 +1,5 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -22,7 +21,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         private Drawable noteAnimation = null!;
 
-        private float? minimumColumnWidth;
+        private float? widthForNoteHeightScale;
 
         public LegacyNotePiece()
         {
@@ -33,7 +32,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin, IScrollingInfo scrollingInfo)
         {
-            minimumColumnWidth = skin.GetConfig<ManiaSkinConfigurationLookup, float>(new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.MinimumColumnWidth))?.Value;
+            widthForNoteHeightScale = skin.GetConfig<ManiaSkinConfigurationLookup, float>(new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.WidthForNoteHeightScale))?.Value;
 
             InternalChild = directionContainer = new Container
             {
@@ -60,9 +59,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
             if (texture != null)
             {
-                // The height is scaled to the minimum column width, if provided.
-                float minimumWidth = minimumColumnWidth ?? DrawWidth;
-                noteAnimation.Scale = Vector2.Divide(new Vector2(DrawWidth, minimumWidth), texture.DisplayWidth);
+                float noteHeight = widthForNoteHeightScale ?? DrawWidth;
+                noteAnimation.Scale = Vector2.Divide(new Vector2(DrawWidth, noteHeight), texture.DisplayWidth);
             }
         }
 

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyNotePiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyNotePiece.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
+
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -145,8 +145,8 @@ namespace osu.Game.Skinning
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnWidth[maniaLookup.ColumnIndex.Value]));
 
                 case LegacyManiaSkinConfigurationLookups.WidthForNoteHeightScale:
-                    Debug.Assert(maniaLookup.ColumnIndex != null);
-                    return SkinUtils.As<TValue>(new Bindable<float>(existing.WidthForNoteHeightScale));
+                    var bindable = new Bindable<Single>(existing.WidthForNoteHeightScale);
+                    return bindable.Value == 0 ? null : SkinUtils.As<TValue>(bindable);
 
                 case LegacyManiaSkinConfigurationLookups.HitPosition:
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.HitPosition));

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -145,8 +145,10 @@ namespace osu.Game.Skinning
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnWidth[maniaLookup.ColumnIndex.Value]));
 
                 case LegacyManiaSkinConfigurationLookups.WidthForNoteHeightScale:
-                    var bindable = new Bindable<Single>(existing.WidthForNoteHeightScale);
-                    return bindable.Value == 0 ? null : SkinUtils.As<TValue>(bindable);
+                    float width = existing.WidthForNoteHeightScale;
+                    if (width <= 0)
+                        width = existing.MinimumColumnWidth;
+                    return SkinUtils.As<TValue>(new Bindable<float>(width));
 
                 case LegacyManiaSkinConfigurationLookups.HitPosition:
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.HitPosition));


### PR DESCRIPTION
Fixes #24664

Lazer (fixed)/Lazer/Stable
<img width="5760" height="1081" alt="lazer fixed" src="https://github.com/user-attachments/assets/60f8ba75-34f1-46eb-bfe6-dc7978ade537" />

