### PR TITLE
Allow snapping slider control points to nearby objects in the editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -471,7 +471,13 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             {
                 Vector2 newControlPointPosition = Parent!.ToScreenSpace(e.MousePosition);
 
-                var result = positionSnapProvider?.TrySnapToNearbyObjects(newControlPointPosition, oldStartTime);
+                // Snapping inherited B-spline control points to nearby objects would be unintuitive, because snapping them does not equate to snapping the interpolated slider path.
+                bool shouldSnapToNearbyObjects = dragPathTypes[draggedControlPointIndex] is not null ||
+                                                 dragPathTypes[..draggedControlPointIndex].LastOrDefault(t => t is not null)?.Type != SplineType.BSpline;
+
+                SnapResult result = null;
+                if (shouldSnapToNearbyObjects)
+                    result = positionSnapProvider?.TrySnapToNearbyObjects(newControlPointPosition, oldStartTime);
                 if (positionSnapProvider?.TrySnapToPositionGrid(result?.ScreenSpacePosition ?? newControlPointPosition, result?.Time ?? oldStartTime) is SnapResult gridSnapResult)
                     result = gridSnapResult;
                 result ??= new SnapResult(newControlPointPosition, oldStartTime);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -440,21 +440,26 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             Vector2 oldPosition = hitObject.Position;
             double oldStartTime = hitObject.StartTime;
 
+            SnapResult snapControlPoint(Vector2 newScreenSpacePosition, bool trySnapToDistanceGrid)
+            {
+                var result = positionSnapProvider?.TrySnapToNearbyObjects(newScreenSpacePosition, oldStartTime);
+                if (trySnapToDistanceGrid)
+                    result ??= positionSnapProvider?.TrySnapToDistanceGrid(newScreenSpacePosition, limitedDistanceSnap.Value ? oldStartTime : null);
+                if (positionSnapProvider?.TrySnapToPositionGrid(result?.ScreenSpacePosition ?? newScreenSpacePosition, result?.Time ?? oldStartTime) is SnapResult gridSnapResult)
+                    result = gridSnapResult;
+                result ??= new SnapResult(newScreenSpacePosition, oldStartTime);
+                return result;
+            }
+
             if (selectedControlPoints.Contains(hitObject.Path.ControlPoints[0]))
             {
                 // Special handling for selections containing head control point - the position of the hit object changes which means the snapped position and time have to be taken into account
                 Vector2 newHeadPosition = Parent!.ToScreenSpace(e.MousePosition + (dragStartPositions[0] - dragStartPositions[draggedControlPointIndex]));
-
-                var result = positionSnapProvider?.TrySnapToNearbyObjects(newHeadPosition, oldStartTime);
-                result ??= positionSnapProvider?.TrySnapToDistanceGrid(newHeadPosition, limitedDistanceSnap.Value ? oldStartTime : null);
-                if (positionSnapProvider?.TrySnapToPositionGrid(result?.ScreenSpacePosition ?? newHeadPosition, result?.Time ?? oldStartTime) is SnapResult gridSnapResult)
-                    result = gridSnapResult;
-                result ??= new SnapResult(newHeadPosition, oldStartTime);
-
-                Vector2 movementDelta = Parent!.ToLocalSpace(result.ScreenSpacePosition) - hitObject.Position;
+                var snapResult = snapControlPoint(newHeadPosition, true);
+                Vector2 movementDelta = Parent!.ToLocalSpace(snapResult.ScreenSpacePosition) - hitObject.Position;
 
                 hitObject.Position += movementDelta;
-                hitObject.StartTime = result.Time ?? hitObject.StartTime;
+                hitObject.StartTime = snapResult.Time ?? hitObject.StartTime;
 
                 for (int i = 1; i < hitObject.Path.ControlPoints.Count; i++)
                 {
@@ -469,9 +474,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             }
             else
             {
-                SnapResult result = positionSnapProvider?.TrySnapToPositionGrid(Parent!.ToScreenSpace(e.MousePosition));
-
-                Vector2 movementDelta = Parent!.ToLocalSpace(result?.ScreenSpacePosition ?? Parent!.ToScreenSpace(e.MousePosition)) - dragStartPositions[draggedControlPointIndex] - hitObject.Position;
+                Vector2 newControlPointPosition = Parent!.ToScreenSpace(e.MousePosition);
+                var snapResult = snapControlPoint(newControlPointPosition, false);
+                Vector2 movementDelta = Parent!.ToLocalSpace(snapResult.ScreenSpacePosition) - dragStartPositions[draggedControlPointIndex] - hitObject.Position;
 
                 for (int i = 0; i < controlPoints.Count; ++i)
                 {


### PR DESCRIPTION
This feature is like an extension of #20385, I'd like to have this because this makes it easy to make sliders that align with existing geometry of the map. For instance making a sliderend that overlaps with another sliderend exactly like in the image below. Also I don't see a reason why it doesn't allow this already.
In the future I'd also like to add the inverse ability, to allow snapping other objects to (uninherited) slider anchors, but I think this is a good start.

<img width="293" height="284" alt="image" src="https://github.com/user-attachments/assets/b7177216-b6e0-444b-9bde-d0c9159e0f81" />

For the code I copied the logic for snapping the slider head control point which already allowed snapping to nearby objects, then refactored it to a local function to avoid code duplication.