### PR TITLE
Allow snapping to nearby visible slider control points in the editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -644,18 +644,15 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 var controlPoint = DrawableObject.HitObject.Path.ControlPoints[i];
 
+                if (controlPoint.Type is not null)
+                    currentPathType = controlPoint.Type;
+
                 // Skip the first control point because it is already covered by the slider head
                 if (i == 0)
-                {
-                    currentPathType = controlPoint.Type;
                     continue;
-                }
 
                 if (controlPoint.Type is null && currentPathType != PathType.LINEAR)
                     continue;
-
-                if (controlPoint.Type is not null)
-                    currentPathType = controlPoint.Type;
 
                 var screenSpacePosition = DrawableObject.SliderBody.ToScreenSpace(DrawableObject.SliderBody.PathOffset + controlPoint.Position);
                 yield return screenSpacePosition;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -637,12 +637,20 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (DrawableObject.SliderBody == null)
                 yield break;
 
-            PathType? currentPathType = DrawableObject.HitObject.Path.ControlPoints.FirstOrDefault()?.Type;
+            PathType? currentPathType = null;
 
-            // Skip the first control point because it is already covered by the slider head
             // Skip the last control point because its always either not on the slider path or exactly on the slider end
-            foreach (var controlPoint in DrawableObject.HitObject.Path.ControlPoints.Skip(1).SkipLast(1))
+            for (int i = 0; i < DrawableObject.HitObject.Path.ControlPoints.Count - 1; i++)
             {
+                var controlPoint = DrawableObject.HitObject.Path.ControlPoints[i];
+
+                // Skip the first control point because it is already covered by the slider head
+                if (i == 0)
+                {
+                    currentPathType = controlPoint.Type;
+                    continue;
+                }
+
                 if (controlPoint.Type is null && currentPathType != PathType.LINEAR)
                     continue;
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -632,16 +632,15 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private IEnumerable<Vector2> getScreenSpaceControlPointNodes()
         {
-            // Return all control point positions which are noticeable on the slider body
-            // This excludes inherited control points which don't sit on the slider body: Bezier and B-Spline
-            // And inherited control points which are smooth: Perfect and Catmull
+            // Returns the positions of control points that produce visible kinks on the slider's path
+            // This excludes inherited control points from Bezier, B-Spline, Perfect, and Catmull curves
             if (DrawableObject.SliderBody == null)
                 yield break;
 
             PathType? currentPathType = DrawableObject.HitObject.Path.ControlPoints.FirstOrDefault()?.Type;
 
             // Skip the first control point because it is already covered by the slider head
-            // Skip the last control point because its always either not on the slider body or exactly on the slider end
+            // Skip the last control point because its always either not on the slider path or exactly on the slider end
             foreach (var controlPoint in DrawableObject.HitObject.Path.ControlPoints.Skip(1).SkipLast(1))
             {
                 if (controlPoint.Type is null && currentPathType != PathType.LINEAR)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -642,7 +642,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             // Skip the first control point because it is already covered by the slider head
             // Skip the last control point because its always either not on the slider body or exactly on the slider end
-            foreach (var controlPoint in DrawableObject.HitObject.Path.ControlPoints.Skip(0).SkipLast(1))
+            foreach (var controlPoint in DrawableObject.HitObject.Path.ControlPoints.Skip(1).SkipLast(1))
             {
                 if (controlPoint.Type is null && currentPathType != PathType.LINEAR)
                     continue;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -626,10 +626,34 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         public override Vector2 ScreenSpaceSelectionPoint => DrawableObject.SliderBody?.ToScreenSpace(DrawableObject.SliderBody.PathOffset)
                                                              ?? BodyPiece.ToScreenSpace(BodyPiece.PathStartLocation);
 
-        protected override Vector2[] ScreenSpaceAdditionalNodes => new[]
-        {
+        protected override Vector2[] ScreenSpaceAdditionalNodes => getScreenSpaceControlPointNodes().Prepend(
             DrawableObject.SliderBody?.ToScreenSpace(DrawableObject.SliderBody.PathEndOffset) ?? BodyPiece.ToScreenSpace(BodyPiece.PathEndLocation)
-        };
+        ).ToArray();
+
+        private IEnumerable<Vector2> getScreenSpaceControlPointNodes()
+        {
+            // Return all control point positions which are noticeable on the slider body
+            // This excludes inherited control points which don't sit on the slider body: Bezier and B-Spline
+            // And inherited control points which are smooth: Perfect and Catmull
+            if (DrawableObject.SliderBody == null)
+                yield break;
+
+            PathType? currentPathType = DrawableObject.HitObject.Path.ControlPoints.FirstOrDefault()?.Type;
+
+            // Skip the first control point because it is already covered by the slider head
+            // Skip the last control point because its always either not on the slider body or exactly on the slider end
+            foreach (var controlPoint in DrawableObject.HitObject.Path.ControlPoints.Skip(0).SkipLast(1))
+            {
+                if (controlPoint.Type is null && currentPathType != PathType.LINEAR)
+                    continue;
+
+                if (controlPoint.Type is not null)
+                    currentPathType = controlPoint.Type;
+
+                var screenSpacePosition = DrawableObject.SliderBody.ToScreenSpace(DrawableObject.SliderBody.PathOffset + controlPoint.Position);
+                yield return screenSpacePosition;
+            }
+        }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
         {


### PR DESCRIPTION
Like mentioned in https://github.com/ppy/osu/pull/35056
Extends the `TrySnapToNearbyObjects` functionality to include slider control point positions that are noticeable on the slider body. This excludes control points which are not exactly on the slider path or are smooth, ensuring the snap position is a clearly defined geometric feature on the slider body.

Seems most of the ground work for this feature was already laid with `ScreenSpaceAdditionalNodes` so implementation is pretty simple, just adding more items to this array.