### PR TITLE
Song Select now removes/updates filters if needed when presenting a beatmap.

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapFilterControl.cs
@@ -1,10 +1,21 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Collections;
 using osu.Game.Screens.SelectV2;
+using osuTK.Input;
+using Realms;
+using CollectionDropdown = osu.Game.Screens.SelectV2.CollectionDropdown;
 
 namespace osu.Game.Tests.Visual.SongSelectV2
 {
@@ -14,6 +25,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         protected override Anchor ComponentAnchor => Anchor.TopRight;
         protected override float InitialRelativeWidth => 0.7f;
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            Dependencies.Cache(Realm);
+        }
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -34,6 +51,114 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         public void TestSearch()
         {
             AddStep("search for text", () => filterControl.Search("test search"));
+        }
+
+        [Test]
+        public void TestUpdateToIncludeBeatmapIfNotInCollection()
+        {
+            var beatmap = new BeatmapInfo();
+
+            AddStep("remove all collections", () => writeAndRefresh(r => r.RemoveAll<BeatmapCollection>()));
+
+            AddStep("add collections", () =>
+            {
+                writeAndRefresh(r => r.Add(new BeatmapCollection(name: "1")));
+                writeAndRefresh(r => r.Add(new BeatmapCollection(name: "2", [beatmap.MD5Hash])));
+            });
+
+            void testForCollection(string name)
+            {
+                AddStep("expand header", () =>
+                {
+                    InputManager.MoveMouseTo(filterControl.ChildrenOfType<CollectionDropdown.ShearedDropdownHeader>().Single());
+                    InputManager.Click(MouseButton.Left);
+                });
+
+                AddStep($"select collection {name}", () =>
+                {
+                    InputManager.MoveMouseTo(getCollectionDropdownItemFor(name));
+                    InputManager.Click(MouseButton.Left);
+                });
+
+                AddAssert($"collection {name} selected", () => filterControl.ChildrenOfType<CollectionDropdown>().Single().Current.Value.CollectionName == name);
+
+                AddStep("update filter to include beatmap", () =>
+                {
+                    filterControl.UpdateToInclude(beatmap);
+                });
+            }
+
+            testForCollection("1");
+            AddAssert("all beatmaps selected", () => filterControl.ChildrenOfType<CollectionDropdown>().Single().Current.Value is AllBeatmapsCollectionFilterMenuItem);
+
+            testForCollection("2");
+            AddAssert("collection 2 selected", () => filterControl.ChildrenOfType<CollectionDropdown>().Single().Current.Value.CollectionName == "2");
+        }
+
+        [Test]
+        public void TestUpdateToIncludeBeatmapIfNotInDifficultyRange()
+        {
+            var beatmap = new BeatmapInfo
+            {
+                StarRating = 3.141592
+            };
+
+            void testForDifficultyRange(double min, double max)
+            {
+                AddStep($"set difficulty range min to {min}", () =>
+                {
+                    filterControl.ChildrenOfType<FilterControl.DifficultyRangeSlider>().Single().LowerBound.Value = min;
+                });
+
+                AddStep($"set difficulty range max to {max}", () =>
+                {
+                    filterControl.ChildrenOfType<FilterControl.DifficultyRangeSlider>().Single().UpperBound.Value = max;
+                });
+
+                AddStep("update filter to include beatmap", () =>
+                {
+                    filterControl.UpdateToInclude(beatmap);
+                });
+            }
+
+            testForDifficultyRange(5, 10.1);
+            AddAssert("beatmap star rating in range", () =>
+            {
+                var slider = filterControl.ChildrenOfType<FilterControl.DifficultyRangeSlider>().Single();
+                return slider.LowerBound.Value <= beatmap.StarRating && slider.UpperBound.Value >= beatmap.StarRating;
+            });
+
+            testForDifficultyRange(0, 2);
+            AddAssert("beatmap star rating in range", () =>
+            {
+                var slider = filterControl.ChildrenOfType<FilterControl.DifficultyRangeSlider>().Single();
+                return slider.LowerBound.Value <= beatmap.StarRating && slider.UpperBound.Value >= beatmap.StarRating;
+            });
+
+            testForDifficultyRange(1, 8);
+            AddAssert("difficulty range didn't update", () =>
+            {
+                var slider = filterControl.ChildrenOfType<FilterControl.DifficultyRangeSlider>().Single();
+                return slider.LowerBound.Value == 1 && slider.UpperBound.Value == 8;
+            });
+
+            testForDifficultyRange(0, 10.1);
+            AddAssert("difficulty range didn't update", () =>
+            {
+                var slider = filterControl.ChildrenOfType<FilterControl.DifficultyRangeSlider>().Single();
+                return slider.LowerBound.Value == 0 && slider.UpperBound.Value == 10.1;
+            });
+        }
+
+        private void writeAndRefresh(Action<Realm> action) => Realm.Write(r =>
+        {
+            action(r);
+            r.Refresh();
+        });
+
+        private Menu.DrawableMenuItem getCollectionDropdownItemFor(string name)
+        {
+            return filterControl.ChildrenOfType<Menu.DrawableMenuItem>().Single(i => i.Item.Text.Value == name);
         }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.SelectV2
 
         public const float SPACING = 3f;
 
-        private FilterControl filterControl { get; set; } = null!;
+        private FilterControl? filterControl { get; set; }
 
         private IBindableList<BeatmapSetInfo> detachedBeatmaps = null!;
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Screens.SelectV2
 
         public const float SPACING = 3f;
 
+        private FilterControl filterControl { get; set; } = null!;
+
         private IBindableList<BeatmapSetInfo> detachedBeatmaps = null!;
 
         private readonly LoadingLayer loading;
@@ -332,6 +334,9 @@ namespace osu.Game.Screens.SelectV2
 
                 if (CurrentGroupedBeatmap != null && value.Equals(CurrentGroupedBeatmap.Beatmap))
                     return;
+
+                filterControl ??= Dependencies.Get<FilterControl>();
+                filterControl?.UpdateToInclude(value);
 
                 // it is not universally guaranteed that the carousel items will be materialised at the time this is set.
                 // therefore, in cases where it is known that they will not be, default to a null group.

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -304,17 +304,17 @@ namespace osu.Game.Screens.SelectV2
         {
             if (beatmap == null) return;
 
-            if (!currentCriteria.CollectionBeatmapMD5Hashes?.Contains(beatmap.MD5Hash) ?? false)
+            if (!currentCriteria?.CollectionBeatmapMD5Hashes?.Contains(beatmap.MD5Hash) ?? false)
             {
                 collectionDropdown.Current.Value = collectionDropdown.Items.OfType<AllBeatmapsCollectionFilterMenuItem>().First();
             }
 
-            if (beatmap.StarRating < currentCriteria.UserStarDifficulty.Min)
+            if (beatmap.StarRating < currentCriteria?.UserStarDifficulty.Min)
             {
                 double precision = difficultyRangeSlider.LowerBound is BindableNumberWithCurrent<double> n ? n.Precision : 0.1;
                 difficultyRangeSlider.LowerBound.Value = Math.Floor(beatmap.StarRating / precision) * precision;
             }
-            else if (beatmap.StarRating > currentCriteria.UserStarDifficulty.Max)
+            else if (beatmap.StarRating > currentCriteria?.UserStarDifficulty.Max)
             {
                 double precision = difficultyRangeSlider.UpperBound is BindableNumberWithCurrent<double> n ? n.Precision : 0.1;
                 difficultyRangeSlider.UpperBound.Value = Math.Ceiling(beatmap.StarRating / precision) * precision;

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -302,7 +302,7 @@ namespace osu.Game.Screens.SelectV2
         ///
         public void UpdateToInclude(BeatmapInfo? beatmap)
         {
-            if (beatmap == null || currentCriteria == null) return;
+            if (beatmap == null) return;
 
             if (!currentCriteria.CollectionBeatmapMD5Hashes?.Contains(beatmap.MD5Hash) ?? false)
             {

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Database;
@@ -292,6 +293,34 @@ namespace osu.Game.Screens.SelectV2
         public void Search(string query)
         {
             searchTextBox.Current.Value = query;
+        }
+
+        /// <summary>
+        /// Updates the needed filters to include the specified beatmap.
+        /// </summary>
+        /// <param name="beatmap"></param>
+        ///
+        public void UpdateToInclude(BeatmapInfo? beatmap)
+        {
+            if (beatmap == null || currentCriteria == null) return;
+
+            if (!currentCriteria.CollectionBeatmapMD5Hashes?.Contains(beatmap.MD5Hash) ?? false)
+            {
+                collectionDropdown.Current.Value = collectionDropdown.Items.OfType<AllBeatmapsCollectionFilterMenuItem>().First();
+            }
+
+            if (beatmap.StarRating < currentCriteria.UserStarDifficulty.Min)
+            {
+                double precision = difficultyRangeSlider.LowerBound is BindableNumberWithCurrent<double> n ? n.Precision : 0.1;
+                difficultyRangeSlider.LowerBound.Value = Math.Floor(beatmap.StarRating / precision) * precision;
+            }
+            else if (beatmap.StarRating > currentCriteria.UserStarDifficulty.Max)
+            {
+                double precision = difficultyRangeSlider.UpperBound is BindableNumberWithCurrent<double> n ? n.Precision : 0.1;
+                difficultyRangeSlider.UpperBound.Value = Math.Ceiling(beatmap.StarRating / precision) * precision;
+            }
+
+            // TODO: Check if it needs to remove the search query too.
         }
 
         protected override void PopIn()

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -156,6 +156,8 @@ namespace osu.Game.Screens.SelectV2
 
         private Bindable<bool> configBackgroundBlur = null!;
 
+        private DependencyContainer dependencies = null!;
+
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, OsuConfigManager config)
         {
@@ -294,6 +296,8 @@ namespace osu.Game.Screens.SelectV2
                 modSelectOverlay,
             });
 
+            dependencies.Cache(filterControl);
+
             configBackgroundBlur = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur);
             configBackgroundBlur.BindValueChanged(e =>
             {
@@ -303,6 +307,9 @@ namespace osu.Game.Screens.SelectV2
                 updateBackgroundDim();
             });
         }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>
+            dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
         private void requestRecommendedSelection(IEnumerable<GroupedBeatmap> groupedBeatmaps)
         {


### PR DESCRIPTION
Resolves: #35058

Adds an `UpdateToInclude` method in the `FilterControl` class. Which is called every time you present a beatmap.

The `UpdateToInculde` method will remove any filters that filter out the specified beatmap. (e.g. If a beatmap is not in a collection but the song select is currently filtering by a collection, it will remove the collection filter and show all beatmaps.)

I've only implemented the collection and star rating filters for now. Eventually, we should probably also make it remove any search queries too, if they are filtering out the beatmap.

https://github.com/user-attachments/assets/dae8741b-e22a-4099-b396-c23caf1600bb
