### PR TITLE
Allow editing offline Guest username on results screen

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneOfflineUsernameInput.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneOfflineUsernameInput.cs
@@ -1,0 +1,231 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Framework.Extensions;
+using osu.Framework.Platform;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osu.Game.Screens;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Ranking;
+using osu.Game.Tests.Resources;
+using osu.Game.Graphics.UserInterface;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Ranking
+{
+    public partial class TestSceneOfflineUsernameInput : OsuManualInputManagerTestScene
+    {
+        private ScoreManager scoreManager = null!;
+        private RulesetStore rulesetStore = null!;
+        private BeatmapManager beatmapManager = null!;
+
+        private BeatmapInfo importedBeatmap = null!;
+
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            dependencies.Cache(rulesetStore = new RealmRulesetStore(Realm));
+            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
+            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, Realm, API));
+
+            Dependencies.Cache(Realm);
+
+            return dependencies;
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("import beatmap", () =>
+            {
+                beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
+                importedBeatmap = beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps.First();
+            });
+            AddStep("clear all scores", () => Realm.Write(r => r.RemoveAll<ScoreInfo>()));
+            AddStep("set API offline", () => dummyAPI.SetState(APIState.Offline));
+        }
+
+        [Test]
+        public void TestVisibleForOfflineGuestAndCommitOnEnter()
+        {
+            TestResultsScreen screen = null!;
+            Guid dbScoreId = Guid.Empty;
+
+            AddStep("create and import guest score", () =>
+            {
+                var score = TestResources.CreateTestScoreInfo(importedBeatmap);
+                score.User = new GuestUser();
+                var live = scoreManager.Import(score)!;
+                dbScoreId = live.Value.ID;
+            });
+            AddStep("show results", () => loadResults(sc => screen = sc, Realm.Run(r => r.Find<ScoreInfo>(dbScoreId)!).Detach()));
+            AddUntilStep("results loaded", () => screen.IsLoaded);
+
+            OsuTextBox textBox = null!;
+            AddUntilStep("input visible", () => this.ChildrenOfType<OfflineUsernameInput>().Single().Alpha, () => Is.EqualTo(1));
+            AddStep("get username textbox", () => textBox = this.ChildrenOfType<OfflineUsernameInput>().Single().ChildrenOfType<OsuTextBox>().Single());
+
+            AddStep("focus textbox", () => ((IFocusManager)InputManager).ChangeFocus(textBox));
+            AddStep("type new name", () => textBox.Text = "NewName");
+            AddStep("commit", () => InputManager.Key(Key.Enter));
+
+            AddStep("exit results", () => this.ChildrenOfType<OsuScreenStack>().Single().CurrentScreen.Exit());
+
+            AddUntilStep("username updated in realm (User)", () => Realm.Run(r => r.Find<ScoreInfo>(dbScoreId)!.User.Username) == "NewName");
+            AddUntilStep("username updated in realm (RealmUser)", () => Realm.Run(r => r.Find<ScoreInfo>(dbScoreId)!.RealmUser.Username) == "NewName");
+        }
+
+        [Test]
+        public void TestCommitOnExitWithoutExplicitEnter()
+        {
+            TestResultsScreen screen = null!;
+            Guid dbScoreId = Guid.Empty;
+
+            AddStep("create and import guest score", () =>
+            {
+                var score = TestResources.CreateTestScoreInfo(importedBeatmap);
+                score.User = new GuestUser();
+                var live = scoreManager.Import(score)!;
+                dbScoreId = live.Value.ID;
+            });
+            AddStep("show results", () => loadResults(sc => screen = sc, Realm.Run(r => r.Find<ScoreInfo>(dbScoreId)!).Detach()));
+            AddUntilStep("results loaded", () => screen.IsLoaded);
+
+            OsuTextBox textBox = null!;
+            AddStep("get username textbox", () => textBox = this.ChildrenOfType<OfflineUsernameInput>().Single().ChildrenOfType<OsuTextBox>().Single());
+
+            AddStep("set text without committing", () => textBox.Text = "my cool new username");
+            AddStep("exit results", () => this.ChildrenOfType<OsuScreenStack>().Single().CurrentScreen.Exit());
+
+            AddUntilStep("username updated on dispose", () => Realm.Run(r => r.Find<ScoreInfo>(dbScoreId)!.User.Username) == "my cool new username");
+            AddUntilStep("realm user updated on dispose", () => Realm.Run(r => r.Find<ScoreInfo>(dbScoreId)!.RealmUser.Username) == "my cool new username");
+        }
+
+        [Test]
+        public void TestVisibilityTogglesWithAPIState()
+        {
+            TestResultsScreen screen = null!;
+            Guid dbScoreId = Guid.Empty;
+
+            AddStep("create and import guest score", () =>
+            {
+                var score = TestResources.CreateTestScoreInfo(importedBeatmap);
+                score.User = new GuestUser();
+                var live = scoreManager.Import(score)!;
+                dbScoreId = live.Value.ID;
+            });
+            AddStep("show results", () => loadResults(sc => screen = sc, Realm.Run(r => r.Find<ScoreInfo>(dbScoreId)!).Detach()));
+            AddUntilStep("results loaded", () => screen.IsLoaded);
+
+            AddUntilStep("visible when offline", () => this.ChildrenOfType<OfflineUsernameInput>().Single().Alpha, () => Is.EqualTo(1));
+
+            AddStep("go online", () => dummyAPI.SetState(APIState.Online));
+            AddUntilStep("hidden when online", () => this.ChildrenOfType<OfflineUsernameInput>().Single().Alpha, () => Is.Zero);
+
+            AddStep("go offline again", () => dummyAPI.SetState(APIState.Offline));
+            AddUntilStep("visible when offline again", () => this.ChildrenOfType<OfflineUsernameInput>().Single().Alpha, () => Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestLastUsernamePrefillsNextScreen()
+        {
+            TestResultsScreen screen = null!;
+            Guid firstScoreId = Guid.Empty;
+            Guid secondScoreId = Guid.Empty;
+
+            AddStep("create and import first guest score", () =>
+            {
+                var score = TestResources.CreateTestScoreInfo(importedBeatmap);
+                score.User = new GuestUser();
+                var live = scoreManager.Import(score)!;
+                firstScoreId = live.Value.ID;
+            });
+            AddStep("show first results", () => loadResults(sc => screen = sc, Realm.Run(r => r.Find<ScoreInfo>(firstScoreId)!).Detach()));
+            AddUntilStep("first loaded", () => screen.IsLoaded);
+
+            OsuTextBox textBox = null!;
+            AddStep("get textbox", () => textBox = this.ChildrenOfType<OfflineUsernameInput>().Single().ChildrenOfType<OsuTextBox>().Single());
+            AddStep("focus textbox", () => ((IFocusManager)InputManager).ChangeFocus(textBox));
+            AddStep("type Alice and commit", () => textBox.Text = "Alice");
+            AddStep("commit", () => InputManager.Key(Key.Enter));
+            AddStep("exit first results", () => this.ChildrenOfType<OsuScreenStack>().Single().CurrentScreen.Exit());
+
+            AddStep("create and import second guest score", () =>
+            {
+                var score = TestResources.CreateTestScoreInfo(importedBeatmap);
+                score.User = new GuestUser();
+                var live = scoreManager.Import(score)!;
+                secondScoreId = live.Value.ID;
+            });
+            AddStep("show second results", () => loadResults(sc => screen = sc, Realm.Run(r => r.Find<ScoreInfo>(secondScoreId)!).Detach()));
+            AddUntilStep("second loaded", () => screen.IsLoaded);
+
+            OsuTextBox secondTextBox = null!;
+            AddStep("get second textbox", () => secondTextBox = this.ChildrenOfType<OfflineUsernameInput>().Single().ChildrenOfType<OsuTextBox>().Single());
+            AddAssert("prefilled with last username", () => secondTextBox.Text == "Alice");
+        }
+
+        private void loadResults(Action<TestResultsScreen> onCreated, ScoreInfo score)
+        {
+            TestResultsScreen results;
+            Child = new TestResultsContainer(results = new TestResultsScreen(score));
+            onCreated(results);
+        }
+
+        private partial class TestResultsContainer : Container
+        {
+            [Cached(typeof(Player))]
+            private readonly Player player = new TestPlayer();
+
+            public TestResultsContainer(IScreen screen)
+            {
+                RelativeSizeAxes = Axes.Both;
+                OsuScreenStack stack;
+
+                InternalChild = stack = new OsuScreenStack
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+
+                stack.Push(screen);
+            }
+        }
+
+        private partial class TestResultsScreen : SoloResultsScreen
+        {
+            public TestResultsScreen(ScoreInfo score)
+                : base(score)
+            {
+                AllowRetry = true;
+                IsLocalPlay = true;
+            }
+
+            protected override Task<ScoreInfo[]> FetchScores()
+            {
+                // keep it simple; a small list ensures score panels appear and screen is interactive
+                var scores = new ScoreInfo[3];
+                for (int i = 0; i < scores.Length; i++)
+                    scores[i] = TestResources.CreateTestScoreInfo();
+                return Task.FromResult(scores);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/OfflineUsernameInput.cs
+++ b/osu.Game/Screens/Ranking/OfflineUsernameInput.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Ranking
     {
         public readonly Bindable<ScoreInfo?> Score = new Bindable<ScoreInfo?>();
         public ScoreInfo? AchievedScore { get; init; }
-
+        public readonly Bindable<string> Username = new Bindable<string>(lastOfflineUsername);
         private OsuTextBox? usernameTextBox;
         private Container? container;
 
@@ -92,6 +92,7 @@ namespace osu.Game.Screens.Ranking
                 if (usernameTextBox.Text != text)
                     usernameTextBox.Text = text;
 
+                Username.Value = text;
                 updateScoreUsername(text);
                 lastOfflineUsername = text;
             };
@@ -111,21 +112,21 @@ namespace osu.Game.Screens.Ranking
             bool shouldBeVisible = AchievedScore != null &&
                                    api != null &&
                                    api.State.Value == APIState.Offline &&
-                                   AchievedScore.User.Username == "Guest" &&
                                    AchievedScore.UserID == APIUser.SYSTEM_USER_ID;
             Alpha = shouldBeVisible ? 1 : 0;
         }
 
         private void commitIfPending()
         {
-            if (realm == null || AchievedScore == null) return;
+            if (api == null || realm == null || AchievedScore == null) return;
 
-            if (AchievedScore.User.Username == "Guest" && AchievedScore.UserID == APIUser.SYSTEM_USER_ID)
+            if (api.State.Value == APIState.Offline && AchievedScore.UserID == APIUser.SYSTEM_USER_ID)
             {
                 string text = string.IsNullOrWhiteSpace(usernameTextBox?.Text) ? "Guest" : usernameTextBox.Text;
 
                 if (text != "Guest")
                 {
+                    Username.Value = text;
                     updateScoreUsername(text);
                     lastOfflineUsername = text;
                 }

--- a/osu.Game/Screens/Ranking/OfflineUsernameInput.cs
+++ b/osu.Game/Screens/Ranking/OfflineUsernameInput.cs
@@ -1,0 +1,174 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.Database;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Scoring;
+using osuTK;
+
+namespace osu.Game.Screens.Ranking
+{
+    public partial class OfflineUsernameInput : CompositeDrawable
+    {
+        public readonly Bindable<ScoreInfo?> Score = new Bindable<ScoreInfo?>();
+        public ScoreInfo? AchievedScore { get; init; }
+
+        private OsuTextBox? usernameTextBox;
+        private Container? container;
+
+        private static string lastOfflineUsername = "Guest";
+
+        [Resolved]
+        private IAPIProvider? api { get; set; }
+
+        [Resolved]
+        private RealmAccess? realm { get; set; }
+
+        public OfflineUsernameInput() => AutoSizeAxes = Axes.Both;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            updateVisibility();
+
+            InternalChild = container = new Container
+            {
+                AutoSizeAxes = Axes.Both,
+                Children =
+                [
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.Gray1.Opacity(0.8f),
+                        Alpha = 0.8f
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(10, 0),
+                        Padding = new MarginPadding(15),
+                        Children =
+                        [
+                            new OsuSpriteText
+                            {
+                                Text = "Offline Username:",
+                                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Medium),
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                            },
+                            usernameTextBox = new OsuTextBox
+                            {
+                                Width = 200,
+                                Height = 30,
+                                Text = lastOfflineUsername,
+                                PlaceholderText = "Enter username",
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            container.CornerRadius = 8;
+            container.Masking = true;
+
+            usernameTextBox.OnCommit += (sender, newText) =>
+            {
+                string text = string.IsNullOrWhiteSpace(usernameTextBox.Text) ? "Guest" : usernameTextBox.Text;
+
+                if (usernameTextBox.Text != text)
+                    usernameTextBox.Text = text;
+
+                updateScoreUsername(text);
+                lastOfflineUsername = text;
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            api?.State.BindValueChanged(_ => updateVisibility());
+
+            updateVisibility();
+        }
+
+        private void updateVisibility()
+        {
+            bool shouldBeVisible = AchievedScore != null &&
+                                   api != null &&
+                                   api.State.Value == APIState.Offline &&
+                                   AchievedScore.User.Username == "Guest" &&
+                                   AchievedScore.UserID == APIUser.SYSTEM_USER_ID;
+            Alpha = shouldBeVisible ? 1 : 0;
+        }
+
+        private void commitIfPending()
+        {
+            if (realm == null || AchievedScore == null) return;
+
+            if (AchievedScore.User.Username == "Guest" && AchievedScore.UserID == APIUser.SYSTEM_USER_ID)
+            {
+                string text = string.IsNullOrWhiteSpace(usernameTextBox?.Text) ? "Guest" : usernameTextBox.Text;
+
+                if (text != "Guest")
+                {
+                    updateScoreUsername(text);
+                    lastOfflineUsername = text;
+                }
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+                commitIfPending();
+            base.Dispose(isDisposing);
+        }
+
+        private void updateScoreUsername(string newUsername)
+        {
+            if (realm == null || AchievedScore == null) return;
+
+            if (string.IsNullOrWhiteSpace(newUsername))
+                newUsername = "Guest";
+
+            realm.Write(r =>
+            {
+                ScoreInfo? databaseScore = r.Find<ScoreInfo>(AchievedScore.ID);
+
+                if (databaseScore != null)
+                {
+                    databaseScore.User.Username = newUsername;
+                    databaseScore.RealmUser.Username = newUsername;
+                }
+            });
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            container.FadeColour(Colour4.White, 200);
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            if (usernameTextBox?.HasFocus != true)
+                container.FadeColour(Colour4.White.Opacity(0.5f), 200);
+            base.OnHoverLost(e);
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -86,6 +86,8 @@ namespace osu.Game.Screens.Ranking
 
         private Sample? popInSample;
 
+        private OfflineUsernameInput? offlineUsernameInput;
+
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
 
@@ -139,7 +141,7 @@ namespace osu.Game.Screens.Ranking
                                         {
                                             RelativeSizeAxes = Axes.Both
                                         },
-                                        new OfflineUsernameInput
+                                        offlineUsernameInput = new OfflineUsernameInput
                                         {
                                             Score = { BindTarget = SelectedScore },
                                             AchievedScore = IsLocalPlay && Score != null ? Score : null,
@@ -193,6 +195,15 @@ namespace osu.Game.Screens.Ranking
                 bool shouldFlair = player != null && !Score.User.IsBot;
 
                 ScorePanelList.AddScore(Score, shouldFlair);
+                offlineUsernameInput?.Username.BindValueChanged(v =>
+                {
+                    if (Score == null) return;
+
+                    Score.User.Username = v.NewValue;
+                    Score.RealmUser.Username = v.NewValue;
+                    ScorePanel panel = ScorePanelList.GetPanelForScore(Score);
+                    panel.Refresh();
+                });
                 // this is mostly for medal display.
                 // we don't want the medal animation to trample on the results screen animation, so we (ab)use `OverlayActivationMode`
                 // to give the results screen enough time to play the animation out before the medals can be shown.

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -139,6 +139,14 @@ namespace osu.Game.Screens.Ranking
                                         {
                                             RelativeSizeAxes = Axes.Both
                                         },
+                                        new OfflineUsernameInput
+                                        {
+                                            Score = { BindTarget = SelectedScore },
+                                            AchievedScore = IsLocalPlay && Score != null ? Score : null,
+                                            Anchor = Anchor.TopRight,
+                                            Origin = Anchor.TopRight,
+                                            Margin = new MarginPadding { Top = 20, Right = 20 },
+                                        },
                                     }
                                 }
                             },

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -301,6 +301,13 @@ namespace osu.Game.Screens.Ranking
             }
         }
 
+        public void Refresh()
+        {
+            if (!IsLoaded) return;
+
+            updateState();
+        }
+
         public override Vector2 Size
         {
             get => base.Size;


### PR DESCRIPTION
![Image of Offline Username textbox after setting a new score offline](https://github.com/user-attachments/assets/4c801a2e-df92-4f1c-943d-777421dfe922)

This PR lets players who set scores while offline change the username on those local scores from "Guest" to any name they choose via a textbox shown on the top right of the results screen, which closes https://github.com/ppy/osu/issues/12407

This textbox is only visible when:
- The player is offline
- The shown score is the locally-achieved score
- The score’s user ID is `SYSTEM_USER_ID`

## Example

https://github.com/user-attachments/assets/db5c4f48-ffa8-492d-8cb5-fffae1d438fa

P.S. I'm open to any changes on the positing of the textbox element, as I can see how just sticking it on the top right of the results screen at all times may be undesirable.