### PR TITLE
Attempt to fix intermittent tests

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
@@ -191,6 +191,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         }
 
         [Test]
+        [FlakyTest]
         public void TestRewind()
         {
             AddStep("set manual clock", () => manualClock = new ManualClock

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneCollectionDropdown.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneCollectionDropdown.cs
@@ -86,11 +86,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "2"))));
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "3"))));
 
-            AddAssert("check count 5", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(5));
+            AddUntilStep("check count 5", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(5));
 
             AddStep("delete all collections", () => writeAndRefresh(r => r.RemoveAll<BeatmapCollection>()));
 
-            AddAssert("check count 2", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(2));
+            AddUntilStep("check count 2", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(2));
         }
 
         [Test]
@@ -185,11 +185,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection contains beatmap", () => getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
+            AddUntilStep("collection contains beatmap", () => getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             assertFirstButtonIs(FontAwesome.Solid.MinusSquare);
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection does not contain beatmap", () => !getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
+            AddUntilStep("collection does not contain beatmap", () => !getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
         }
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneCollectionDropdown.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneCollectionDropdown.cs
@@ -87,11 +87,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "2"))));
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "3"))));
 
-            AddAssert("check count 5", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(5));
+            AddUntilStep("check count 5", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(5));
 
             AddStep("delete all collections", () => writeAndRefresh(r => r.RemoveAll<BeatmapCollection>()));
 
-            AddAssert("check count 2", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(2));
+            AddUntilStep("check count 2", () => dropdown.ChildrenOfType<CollectionDropdown>().Single().ChildrenOfType<Menu.DrawableMenuItem>().Count(), () => Is.EqualTo(2));
         }
 
         [Test]
@@ -186,11 +186,11 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection contains beatmap", () => getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
+            AddUntilStep("collection contains beatmap", () => getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             assertFirstButtonIs(FontAwesome.Solid.MinusSquare);
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection does not contain beatmap", () => !getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
+            AddUntilStep("collection does not contain beatmap", () => !getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
         }
 

--- a/osu.Game/Tests/Visual/EditorSavingTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorSavingTestScene.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual
             SoloSongSelect songSelect = null;
 
             PushAndConfirm(() => songSelect = new SoloSongSelect());
-            AddUntilStep("wait for carousel load", () => songSelect.CarouselItemsPresented);
+            AddUntilStep("wait for carousel load", () => songSelect.CarouselItemsPresented && !songSelect.IsFiltering);
 
             AddStep("Present same beatmap", () => Game.PresentBeatmap(Game.BeatmapManager.QueryBeatmapSet(set => set.ID == beatmapSetGuid)!.Value, beatmap => beatmap.ID == beatmapGuid));
             AddUntilStep("Wait for beatmap selected", () => Game.Beatmap.Value.BeatmapInfo.ID == beatmapGuid);


### PR DESCRIPTION
These tests have been failing for a while now...


## `TestLocallyModifyingOnlineBeatmap`

See: https://github.com/ppy/osu/actions/runs/17935223169/job/51001961529

This is a shot in the dark as I don't know what's going on here. A trimmed log:

```
2025-09-23 03:56:22 [verbose]: Beginning PresentBeatmap with beatmap Soleily - Renatus (Deif)
2025-09-23 03:56:22 [verbose]: Game-wide working beatmap updated to Soleily - Renatus (Deif) [Platter]
2025-09-23 03:56:22 [verbose]: Completing PresentBeatmap with beatmap Soleily - Renatus (Deif) ruleset osu!catch
2025-09-23 03:56:22 [verbose]: 🔸 Step #22 Wait for beatmap selected
2025-09-23 03:56:22 [verbose]: Game-wide working beatmap updated to Soleily - Renatus (Gamu) [Hard]
2025-09-23 03:56:22 [verbose]: Carousel[op 1775353] 0 ms: Filter operation queued, waiting for 100 ms debounce
2025-09-23 03:56:22 [verbose]: 🔸 Step #23 Open editor
```

My only clue is the filter op happening around the same time the beatmap gets updated to the unexpected `[Hard]` difficulty.

## `TestRewind`

See: https://github.com/ppy/osu/actions/runs/17937346737/job/51008396007

## Collection dropdown

See: https://github.com/smoogipoo/osu/actions/runs/17937291613/job/51008242333