### PR TITLE
Play gameplay start sample in matchmaking

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
@@ -4,6 +4,8 @@
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
@@ -67,8 +69,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         [Resolved]
         private IDialogOverlay dialogOverlay { get; set; } = null!;
 
+        [Resolved]
+        private AudioManager audio { get; set; } = null!;
+
         private readonly MultiplayerRoom room;
 
+        private Sample? sampleStart;
         private CancellationTokenSource? downloadCheckCancellation;
         private int? lastDownloadCheckedBeatmapId;
 
@@ -83,6 +89,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         [BackgroundDependencyLoader]
         private void load()
         {
+            sampleStart = audio.Samples.Get(@"SongSelect/confirm-selection");
+
             InternalChild = new OsuContextMenuContainer
             {
                 RelativeSizeAxes = Axes.Both,
@@ -248,6 +256,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         private void onLoadRequested() => Scheduler.Add(() =>
         {
             updateGameplayState();
+
+            if (Beatmap.IsDefault)
+            {
+                Logger.Log("Aborting gameplay start - beatmap not downloaded.");
+                return;
+            }
+
+            sampleStart?.Play();
+
             this.Push(new MultiplayerPlayerLoader(() => new MatchmakingPlayer(new Room(room), new PlaylistItem(client.Room!.CurrentPlaylistItem), room.Users.ToArray())));
         });
 


### PR DESCRIPTION
As brought up internally https://discord.com/channels/90072389919997952/1327149041511043134/1419630219655905290

Follows the same implementation as multiplayer: 

https://github.com/ppy/osu/blob/1840363713d5cdeb3aba446e5a742422b8e00297/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L564-L594