### PR TITLE
Various improvements to matchmaking testability

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneIdleScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneIdleScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Screens;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Idle;
 using osu.Game.Tests.Visual.Multiplayer;
 using osuTK;
@@ -26,7 +27,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             AddStep("add list", () =>

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreen.cs
@@ -35,8 +35,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
 
             AddStep("join room", () =>
             {
-                var room = CreateDefaultRoom();
-                room.Type = MatchType.Matchmaking;
+                var room = CreateDefaultRoom(MatchType.Matchmaking);
                 room.Playlist = Enumerable.Range(1, 50).Select(i => new PlaylistItem(new MultiplayerPlaylistItem
                 {
                     ID = i,

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreen.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
                 changeStage(MatchmakingStage.UserBeatmapSelect);
                 changeStage(MatchmakingStage.ServerBeatmapFinalised, state =>
                 {
-                    MultiplayerPlaylistItem[] beatmaps = Enumerable.Range(1, 50).Select(i => new MultiplayerPlaylistItem
+                    MultiplayerPlaylistItem[] beatmaps = Enumerable.Range(1, 8).Select(i => new MultiplayerPlaylistItem
                     {
                         ID = i,
                         BeatmapID = i,

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreen.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Screens;
-using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -19,10 +17,7 @@ using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
-using osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Pick;
 using osu.Game.Tests.Visual.Multiplayer;
-using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
@@ -41,6 +36,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
             AddStep("join room", () =>
             {
                 var room = CreateDefaultRoom();
+                room.Type = MatchType.Matchmaking;
                 room.Playlist = Enumerable.Range(1, 50).Select(i => new PlaylistItem(new MultiplayerPlaylistItem
                 {
                     ID = i,
@@ -97,104 +93,47 @@ namespace osu.Game.Tests.Visual.Matchmaking
         [Test]
         public void TestGameplayFlow()
         {
-            // Initial "ready" status of the room".
-            AddWaitStep("wait", 5);
-
-            AddStep("round start", () => MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState
+            for (int round = 1; round <= 2; round++)
             {
-                Stage = MatchmakingStage.RoundWarmupTime
-            }).WaitSafely());
+                AddLabel($"Round {round}");
 
-            // Next round starts with picks.
-            AddWaitStep("wait", 5);
-
-            AddStep("pick", () => MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState
-            {
-                Stage = MatchmakingStage.UserBeatmapSelect
-            }).WaitSafely());
-
-            // Make some selections
-            AddWaitStep("wait", 5);
-
-            for (int i = 0; i < 3; i++)
-            {
-                int j = i * 2;
-                AddStep("click a beatmap", () =>
+                int r = round;
+                changeStage(MatchmakingStage.RoundWarmupTime, state => state.CurrentRound = r);
+                changeStage(MatchmakingStage.UserBeatmapSelect);
+                changeStage(MatchmakingStage.ServerBeatmapFinalised, state =>
                 {
-                    Quad panelQuad = this.ChildrenOfType<BeatmapPanel>().ElementAt(j).ScreenSpaceDrawQuad;
+                    MultiplayerPlaylistItem[] beatmaps = Enumerable.Range(1, 50).Select(i => new MultiplayerPlaylistItem
+                    {
+                        ID = i,
+                        BeatmapID = i,
+                        StarRating = i / 10.0,
+                    }).ToArray();
 
-                    InputManager.MoveMouseTo(new Vector2(panelQuad.Centre.X, panelQuad.TopLeft.Y + 5));
-                    InputManager.Click(MouseButton.Left);
-                });
+                    state.CandidateItems = beatmaps.Select(b => b.ID).ToArray();
+                    state.CandidateItem = beatmaps[0].ID;
+                }, waitTime: 35);
 
-                AddWaitStep("wait", 2);
+                changeStage(MatchmakingStage.WaitingForClientsBeatmapDownload);
+                changeStage(MatchmakingStage.GameplayWarmupTime);
+                changeStage(MatchmakingStage.Gameplay);
+                changeStage(MatchmakingStage.ResultsDisplaying);
             }
 
-            // Lock in the gameplay beatmap
-
-            AddStep("selection", () =>
+            changeStage(MatchmakingStage.Ended, state =>
             {
-                MultiplayerPlaylistItem[] beatmaps = Enumerable.Range(1, 50).Select(i => new MultiplayerPlaylistItem
-                {
-                    ID = i,
-                    BeatmapID = i,
-                    StarRating = i / 10.0,
-                }).ToArray();
-
-                MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState
-                {
-                    Stage = MatchmakingStage.ServerBeatmapFinalised,
-                    CandidateItems = beatmaps.Select(b => b.ID).ToArray(),
-                    CandidateItem = beatmaps[0].ID
-                }).WaitSafely();
-            });
-
-            // Prepare gameplay.
-            AddWaitStep("wait", 25);
-
-            AddStep("prepare gameplay", () => MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState
-            {
-                Stage = MatchmakingStage.GameplayWarmupTime
-            }).WaitSafely());
-
-            // Start gameplay.
-            AddWaitStep("wait", 5);
-
-            AddStep("gameplay", () => MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState
-            {
-                Stage = MatchmakingStage.Gameplay
-            }).WaitSafely());
-
-            AddStep("start gameplay", () => MultiplayerClient.StartMatch().WaitSafely());
-            // AddUntilStep("wait for player", () => (Stack.CurrentScreen as Player)?.IsLoaded == true);
-
-            // Finish gameplay.
-            AddWaitStep("wait", 5);
-
-            AddStep("round end", () => MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState
-            {
-                Stage = MatchmakingStage.ResultsDisplaying
-            }).WaitSafely());
-
-            AddWaitStep("wait", 10);
-
-            AddStep("room end", () =>
-            {
-                MatchmakingRoomState state = new MatchmakingRoomState
-                {
-                    CurrentRound = 1,
-                    Stage = MatchmakingStage.Ended
-                };
-
                 int localUserId = API.LocalUser.Value.OnlineID;
 
                 state.Users[localUserId].Placement = 1;
                 state.Users[localUserId].Rounds[1].Placement = 1;
                 state.Users[localUserId].Rounds[1].TotalScore = 1;
                 state.Users[localUserId].Rounds[1].Statistics[HitResult.LargeBonus] = 1;
-
-                MultiplayerClient.ChangeMatchRoomState(state).WaitSafely();
             });
+        }
+
+        private void changeStage(MatchmakingStage stage, Action<MatchmakingRoomState>? prepare = null, int waitTime = 5)
+        {
+            AddStep($"stage: {stage}", () => MultiplayerClient.MatchmakingChangeStage(stage, prepare).WaitSafely());
+            AddWaitStep("wait", waitTime);
         }
 
         private void setupRequestHandler()

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreenStack.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreenStack.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
                 changeStage(MatchmakingStage.UserBeatmapSelect);
                 changeStage(MatchmakingStage.ServerBeatmapFinalised, state =>
                 {
-                    MultiplayerPlaylistItem[] beatmaps = Enumerable.Range(1, 50).Select(i => new MultiplayerPlaylistItem
+                    MultiplayerPlaylistItem[] beatmaps = Enumerable.Range(1, 8).Select(i => new MultiplayerPlaylistItem
                     {
                         ID = i,
                         BeatmapID = i,

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreenStack.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreenStack.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
 
             AddStep("join room", () =>
             {
-                var room = CreateDefaultRoom();
+                var room = CreateDefaultRoom(MatchType.Matchmaking);
                 room.Playlist = Enumerable.Range(1, 50).Select(i => new PlaylistItem(new MultiplayerPlaylistItem
                 {
                     ID = i,

--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePickScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePickScreen.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
 
             AddStep("join room", () =>
             {
-                var room = CreateDefaultRoom();
+                var room = CreateDefaultRoom(MatchType.Matchmaking);
                 room.Playlist = items;
 
                 JoinRoom(room);

--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osu.Game.Tests.Visual.Multiplayer;
 using osu.Game.Users;
@@ -21,7 +22,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             AddStep("add panel", () => Child = panel = new PlayerPanel(new MultiplayerRoomUser(1)

--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanelList.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanelList.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osu.Game.Tests.Visual.Multiplayer;
 using osuTK;
@@ -24,7 +25,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             AddStep("add list", () => Child = new Container

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
@@ -8,6 +8,7 @@ using osu.Framework.Screens;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Results;
 using osu.Game.Tests.Visual.Multiplayer;
@@ -23,7 +24,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             AddStep("add results screen", () =>

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneRoundResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneRoundResultsScreen.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             setupRequestHandler();

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneStageBubble.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneStageBubble.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osu.Game.Tests.Visual.Multiplayer;
 
@@ -19,7 +20,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             AddStep("add bubble", () => Child = new StageBubble(MatchmakingStage.RoundWarmupTime, "Next Round")

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneStageDisplay.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneStageDisplay.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osu.Game.Tests.Visual.Multiplayer;
 
@@ -17,7 +18,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             AddStep("add bubble", () => Child = new StageDisplay

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneStageDisplay.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneStageDisplay.cs
@@ -5,7 +5,6 @@ using System;
 using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
-using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osu.Game.Tests.Visual.Multiplayer;
@@ -31,24 +30,11 @@ namespace osu.Game.Tests.Visual.Matchmaking
         }
 
         [Test]
-        public void TestStartCountdown()
+        public void TestChangeStage()
         {
-            foreach (var status in Enum.GetValues<MatchmakingStage>())
+            foreach (var stage in Enum.GetValues<MatchmakingStage>())
             {
-                AddStep($"{status}", () =>
-                {
-                    MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState
-                    {
-                        Stage = status
-                    }).WaitSafely();
-
-                    MultiplayerClient.StartCountdown(new MatchmakingStageCountdown
-                    {
-                        Stage = status,
-                        TimeRemaining = TimeSpan.FromSeconds(5)
-                    }).WaitSafely();
-                });
-
+                AddStep($"{stage}", () => MultiplayerClient.MatchmakingChangeStage(stage).WaitSafely());
                 AddWaitStep("wait a bit", 10);
             }
         }

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneStageText.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneStageText.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
@@ -26,18 +27,14 @@ namespace osu.Game.Tests.Visual.Matchmaking
             });
         }
 
-        [TestCase(MatchmakingStage.WaitingForClientsJoin)]
-        [TestCase(MatchmakingStage.RoundWarmupTime)]
-        [TestCase(MatchmakingStage.UserBeatmapSelect)]
-        [TestCase(MatchmakingStage.ServerBeatmapFinalised)]
-        [TestCase(MatchmakingStage.WaitingForClientsBeatmapDownload)]
-        [TestCase(MatchmakingStage.GameplayWarmupTime)]
-        [TestCase(MatchmakingStage.Gameplay)]
-        [TestCase(MatchmakingStage.ResultsDisplaying)]
-        [TestCase(MatchmakingStage.Ended)]
-        public void TestStatus(MatchmakingStage status)
+        [Test]
+        public void TestChangeStage()
         {
-            AddStep("set status", () => MultiplayerClient.ChangeMatchRoomState(new MatchmakingRoomState { Stage = status }).WaitSafely());
+            foreach (var stage in Enum.GetValues<MatchmakingStage>())
+            {
+                AddStep($"{stage}", () => MultiplayerClient.MatchmakingChangeStage(stage).WaitSafely());
+                AddWaitStep("wait a bit", 10);
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneStageText.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneStageText.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osu.Game.Tests.Visual.Multiplayer;
 
@@ -17,7 +18,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("join room", () => JoinRoom(CreateDefaultRoom()));
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
             WaitForJoined();
 
             AddStep("create display", () => Child = new StageText

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -24,12 +24,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public bool RoomJoined => MultiplayerClient.RoomJoined;
 
-        protected Room CreateDefaultRoom()
+        protected Room CreateDefaultRoom(MatchType type = MatchType.HeadToHead)
         {
             return new Room
             {
                 Name = "test name",
-                Type = MatchType.HeadToHead,
+                Type = type,
                 Playlist =
                 [
                     new PlaylistItem(new TestBeatmap(Ruleset.Value).BeatmapInfo)

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -824,6 +824,25 @@ namespace osu.Game.Tests.Visual.Multiplayer
             await ((IMatchmakingClient)this).MatchmakingItemSelected(clone(userId), clone(playlistItemId)).ConfigureAwait(false);
         }
 
+        public async Task MatchmakingChangeStage(MatchmakingStage stage, Action<MatchmakingRoomState>? prepare = null)
+        {
+            MatchmakingRoomState state = clone((MatchmakingRoomState)ServerRoom!.MatchState!);
+
+            state.Stage = stage;
+
+            if (stage == MatchmakingStage.RoundWarmupTime)
+                state.CurrentRound++;
+
+            prepare?.Invoke(state);
+
+            await ChangeMatchRoomState(state).ConfigureAwait(false);
+            await StartCountdown(new MatchmakingStageCountdown
+            {
+                Stage = stage,
+                TimeRemaining = TimeSpan.FromSeconds(10)
+            }).ConfigureAwait(false);
+        }
+
         #region API Room Handling
 
         public IReadOnlyList<Room> ServerSideRooms

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -17,6 +17,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.Countdown;
+using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Mods;
@@ -248,6 +249,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Host = localUser
             };
 
+            await changeMatchType(ServerRoom.Settings.MatchType).ConfigureAwait(false);
             await updatePlaylistOrder(ServerRoom).ConfigureAwait(false);
             await updateCurrentItem(ServerRoom, false).ConfigureAwait(false);
 
@@ -260,10 +262,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         protected override void OnRoomJoined()
         {
             Debug.Assert(ServerRoom != null);
-
-            // emulate the server sending this after the join room. scheduler required to make sure the join room event is fired first (in Join).
-            changeMatchType(ServerRoom.Settings.MatchType).WaitSafely();
-
             RoomJoined = true;
         }
 
@@ -589,6 +587,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     foreach (var user in ServerRoom.Users)
                     {
                         user.MatchState = new TeamVersusUserState();
+                        await ((IMultiplayerClient)this).MatchUserStateChanged(clone(user.UserID), clone(user.MatchState)).ConfigureAwait(false);
+                    }
+
+                    break;
+
+                case MatchType.Matchmaking:
+                    ServerRoom.MatchState = new MatchmakingRoomState();
+                    await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
+
+                    foreach (var user in ServerRoom.Users)
+                    {
+                        user.MatchState = null;
                         await ((IMultiplayerClient)this).MatchUserStateChanged(clone(user.UserID), clone(user.MatchState)).ConfigureAwait(false);
                     }
 


### PR DESCRIPTION
Maybe this will help a bit?

Most of matchmaking is intended to be tested via `TestMultiplayerClient.ChangeMatchRoomState()` and designing the appropriate state to test your objects with.  
This change primarily adds `TestMultiplayerClient.MatchmakingChangeStage()` which acts as a helper for components that just need the current stage + the countdown for it. The biggest changes are to `TestSceneMatchmakingScreen` and `TestSceneMatchmakingScreenStack`.

Interspersed are a few more minor changes including https://github.com/ppy/osu/commit/597a06ac38ba3d859d383e2bed4f35c7681f817a + https://github.com/ppy/osu/commit/83dafb4ef99abd0f12d8525a113be3e78bb8b4f5 which together help to bring the room into a correct initial state, and https://github.com/ppy/osu/commit/3556d6c8c882bac84246ef805fa499d656711597 which reduces the number of picks shown in test scenes to a more realistic value (8 users per room, not 50).