### PR TITLE
Fix players positioning on next matchmaking round

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/PlayerPanelList.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/PlayerPanelList.cs
@@ -244,8 +244,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
             public void ReleasePanels()
             {
-                foreach (var panel in Children)
-                    panel.ReleasePanel();
+                // Matches the schedule in AcquirePanels.
+                ScheduleAfterChildren(() =>
+                {
+                    foreach (var panel in Children)
+                        panel.ReleasePanel();
+                });
             }
         }
 


### PR DESCRIPTION
Fixes this on master:

https://github.com/user-attachments/assets/f6bada3f-4bd7-4755-859d-e77e4f050497

The problem here is that two screens are being entered/exited simultaneously - the pick screen with the split panels, and the idle screen with the grid panels.

I really don't like these schedules but this will do for now...