### PR TITLE
Fix wrong beatmap opened when navigating from results screen

### DIFF
--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -396,11 +396,13 @@ namespace osu.Game.Screens.SelectV2
         #region Selection debounce
 
         private BeatmapInfo? debounceQueuedSelection;
+        private BeatmapInfo? selectedBeatmapWhenQueueStarted;
         private double debounceElapsedTime;
 
         private void debounceQueueSelection(BeatmapInfo beatmap)
         {
             debounceQueuedSelection = beatmap;
+            selectedBeatmapWhenQueueStarted = Beatmap.Value.BeatmapInfo;
             debounceElapsedTime = 0;
         }
 
@@ -433,6 +435,13 @@ namespace osu.Game.Screens.SelectV2
                 if (Beatmap.Value.BeatmapInfo.Equals(debounceQueuedSelection))
                     return;
 
+                // If the currently selected beatmap is different than the value at the time the debounced selection was first queued,
+                // then that means a non-debounced selection was made since.
+                // We don't want to overwrite that value with our older selection.
+                // Just cancel the debounced selection if this is the case.
+                if (!Beatmap.Value.BeatmapInfo.Equals(selectedBeatmapWhenQueueStarted))
+                    return;
+
                 Beatmap.Value = beatmaps.GetWorkingBeatmap(debounceQueuedSelection);
             }
             finally
@@ -444,6 +453,7 @@ namespace osu.Game.Screens.SelectV2
         private void cancelDebounceSelection()
         {
             debounceQueuedSelection = null;
+            selectedBeatmapWhenQueueStarted = null;
             debounceElapsedTime = 0;
         }
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/35023. Copying the relevant details from that issue here:

**Reproduction steps:**
1. Play map X and end up at the results screen.
2. Without hitting escape back to song select, use ctrl-B to download a new map/navigate to an already-downloaded map.
3. Instead of bringing you to the selected map in song select, map X is selected.

This bug was not present prior to 2025.912.0

**Root cause:**

Running git bisect, the issue was introduced in https://github.com/ppy/osu/pull/34903. 

This is an existing race condition unrelated to the change in debounce logic. Rather, the change from 100ms -> 150ms makes the timing just right to reproduce consistently on my machine.

Adding logs, the following order of events are happening to trigger the bug:
1. Navigating to a downloaded map enters `OsuGame:PresentBeatmap`.
2. `PerformFromScreen` does the screen switch before invoking the supplied action.
3. The screen switch causes `SongSelect:debounceQueueSelection` to be triggered with another beatmap which will queued and selected in ~150ms.
4. `OsuGame:PresentBeatmap` hits the `Beatmap.Value = ...` line
5. 150ms elapses and `SongSelect.performDebounceSelection` executes its  `Beatmap.Value = ...` line.

With 100ms, the last two lines are swapped.

**Fix:**
Before applying the debounced selection, check if the currently selected beatmap is different than the value at the time the debounced selection was first queued. If so, then that means a non-debounced selection was made since.

In this scenario, we don't want to overwrite that value with our older selection. Just cancel the debounced selection instead.