### PR TITLE
`StarRatingDisplay` will now indicate if the star rating was adjusted by mods.

### DIFF
--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -22,12 +23,13 @@ namespace osu.Game.Beatmaps.Drawables
     /// <summary>
     /// A pill that displays the star rating of a beatmap.
     /// </summary>
-    public partial class StarRatingDisplay : CompositeDrawable, IHasCurrentValue<StarDifficulty>
+    public partial class StarRatingDisplay : CompositeDrawable, IHasCurrentValue<StarDifficulty>, IHasCustomTooltip<StarDifficulty>
     {
         private readonly bool animated;
         private readonly Box background;
         private readonly SpriteIcon starIcon;
         private readonly OsuSpriteText starsText;
+        private readonly SpriteIcon valueIcon;
 
         private readonly BindableWithCurrent<StarDifficulty> current = new BindableWithCurrent<StarDifficulty>();
 
@@ -109,6 +111,8 @@ namespace osu.Game.Beatmaps.Drawables
                             new Dimension(GridSizeMode.AutoSize),
                             new Dimension(GridSizeMode.Absolute, 3f),
                             new Dimension(GridSizeMode.AutoSize, minSize: 25f),
+                            new Dimension(GridSizeMode.Absolute, 2f),
+                            new Dimension(GridSizeMode.AutoSize),
                         },
                         RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
                         Content = new[]
@@ -131,6 +135,17 @@ namespace osu.Game.Beatmaps.Drawables
                                     Spacing = new Vector2(-1.4f),
                                     Font = OsuFont.Torus.With(size: 14.4f, weight: FontWeight.Bold, fixedWidth: true),
                                     Shadow = false,
+                                },
+                                Empty(),
+                                valueIcon = new SpriteIcon
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Margin = new MarginPadding
+                                    {
+                                        Top = -1f,
+                                    },
+                                    Size = new Vector2(8),
                                 },
                             }
                         }
@@ -162,8 +177,32 @@ namespace osu.Game.Beatmaps.Drawables
 
                 starIcon.Colour = s.NewValue >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : colourProvider?.Background5 ?? Color4Extensions.FromHex("303d47");
                 starsText.Colour = s.NewValue >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : colourProvider?.Background5 ?? Color4.Black.Opacity(0.75f);
+
+                updateDisplay();
             }, true);
+            updateDisplay();
         }
+
+        private void updateDisplay()
+        {
+            if (Current.Value.Stars == Current.Value.NoModStars)
+            {
+                valueIcon.ScaleTo(0, 300, Easing.OutQuint).OnComplete(_ =>
+                {
+                    valueIcon.Hide();
+                });
+            }
+            else
+            {
+                valueIcon.Colour = starIcon.Colour;
+                valueIcon.Icon = Current.Value.Stars > Current.Value.NoModStars ? FontAwesome.Solid.SortUp : FontAwesome.Solid.SortDown;
+                valueIcon.ScaleTo(1, 300, Easing.OutQuint);
+                valueIcon.Show();
+            }
+        }
+
+        public ITooltip<StarDifficulty> GetCustomTooltip() => new StarRatingDisplayTooltip();
+        public StarDifficulty TooltipContent => Current.Value;
     }
 
     public enum StarRatingDisplaySize

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplayTooltip.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplayTooltip.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Beatmaps.Drawables
+{
+    public partial class StarRatingDisplayTooltip : VisibilityContainer, ITooltip<StarDifficulty>
+    {
+        private readonly OverlayColourProvider? colourProvider;
+
+        private Container content = null!;
+
+        private StarDifficulty starDifficulty;
+        private OsuSpriteText adjustedByModsText = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public StarRatingDisplayTooltip(OverlayColourProvider? colourProvider = null)
+        {
+            this.colourProvider = colourProvider;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            Masking = true;
+            CornerRadius = 5;
+
+            InternalChildren = new Drawable[]
+            {
+                content = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colourProvider?.Background4 ?? colours.Gray3,
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Vertical = 10, Horizontal = 15 },
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(10),
+                            Children = new Drawable[]
+                            {
+                                adjustedByModsText = new OsuSpriteText
+                                {
+                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                                },
+                            }
+                        },
+                    }
+                },
+            };
+
+            updateDisplay();
+        }
+
+        private void updateDisplay()
+        {
+            if (!Precision.AlmostEquals(starDifficulty.Stars, starDifficulty.NoModStars))
+            {
+                adjustedByModsText.Text = $"This value is being adjusted by mods ({starDifficulty.NoModStars:0.0#} → {starDifficulty.Stars:0.0#}).";
+                content.Show();
+            }
+            else
+                content.Hide();
+        }
+
+        public void SetContent(StarDifficulty starDifficulty)
+        {
+            this.starDifficulty = starDifficulty;
+            updateDisplay();
+        }
+
+        protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
+        protected override void PopOut() => this.FadeOut(200, Easing.OutQuint);
+
+        public void Move(Vector2 pos) => Position = pos;
+    }
+}

--- a/osu.Game/Beatmaps/StarDifficulty.cs
+++ b/osu.Game/Beatmaps/StarDifficulty.cs
@@ -14,6 +14,11 @@ namespace osu.Game.Beatmaps
         public readonly double Stars;
 
         /// <summary>
+        /// The star difficulty rating for the given beatmap without any mods applied.
+        /// </summary>
+        public readonly double NoModStars;
+
+        /// <summary>
         /// The maximum combo achievable on the given beatmap.
         /// </summary>
         public readonly int MaxCombo;
@@ -33,9 +38,10 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Creates a <see cref="StarDifficulty"/> structure.
         /// </summary>
-        public StarDifficulty(DifficultyAttributes difficulty, PerformanceAttributes performance)
+        public StarDifficulty(DifficultyAttributes difficulty, PerformanceAttributes performance, DifficultyAttributes noModDifficulty)
         {
             Stars = double.IsFinite(difficulty.StarRating) ? difficulty.StarRating : 0;
+            NoModStars = double.IsFinite(noModDifficulty.StarRating) ? noModDifficulty.StarRating : 0;
             MaxCombo = difficulty.MaxCombo;
             DifficultyAttributes = difficulty;
             PerformanceAttributes = performance;
@@ -49,6 +55,7 @@ namespace osu.Game.Beatmaps
         public StarDifficulty(double starDifficulty, int maxCombo)
         {
             Stars = double.IsFinite(starDifficulty) ? starDifficulty : 0;
+            NoModStars = Stars;
             MaxCombo = maxCombo;
         }
 


### PR DESCRIPTION
`StarRatingDisplay` will indicate that it has been adjusted by mods with a little arrow, and a tooltip showing the original star rating, just like how the `BeatmapTitleWedge.StatisticDifficulty` works.

This should resolve: https://github.com/ppy/osu/issues/34961

Preview:

https://github.com/user-attachments/assets/ea06611d-7a59-4568-95f0-bbf34ad51695

