### PR TITLE
Add option to change timeline objects opacity in the editor

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorDim, 0.25f, 0f, 0.75f, 0.25f);
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f, 0f, 1f, 0.25f);
-            SetDefault(OsuSetting.EditorTimelineObjectsOpacity, 1.0f, 0f, 1f, 0.25f);
+            SetDefault(OsuSetting.EditorTimelineObjectsOpacity, 1.0f, 0.25f, 1f, 0.25f);
             SetDefault(OsuSetting.EditorShowHitMarkers, true);
             SetDefault(OsuSetting.EditorAutoSeekOnPlacement, true);
             SetDefault(OsuSetting.EditorLimitedDistanceSnap, false);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -199,6 +199,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorDim, 0.25f, 0f, 0.75f, 0.25f);
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f, 0f, 1f, 0.25f);
+            SetDefault(OsuSetting.EditorTimelineObjectsOpacity, 1.0f, 0f, 1f, 0.25f);
             SetDefault(OsuSetting.EditorShowHitMarkers, true);
             SetDefault(OsuSetting.EditorAutoSeekOnPlacement, true);
             SetDefault(OsuSetting.EditorLimitedDistanceSnap, false);
@@ -437,6 +438,7 @@ namespace osu.Game.Configuration
         GameplayDisableWinKey,
         SeasonalBackgroundMode,
         EditorWaveformOpacity,
+        EditorTimelineObjectsOpacity,
         EditorShowHitMarkers,
         EditorAutoSeekOnPlacement,
         DiscordRichPresence,

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Localisation
         public static LocalisableString WaveformOpacity => new TranslatableString(getKey(@"waveform_opacity"), @"Waveform opacity");
 
         /// <summary>
+        /// "Timeline objects opacity"
+        /// </summary>
+        public static LocalisableString TimelineObjectsOpacity => new TranslatableString(getKey(@"timeline_objects_opacity"), @"Timeline objects opacity");
+
+        /// <summary>
         /// "Show hit markers"
         /// </summary>
         public static LocalisableString ShowHitMarkers => new TranslatableString(getKey(@"show_hit_markers"), @"Show hit markers");

--- a/osu.Game/Screens/Edit/BackgroundDimMenuItem.cs
+++ b/osu.Game/Screens/Edit/BackgroundDimMenuItem.cs
@@ -1,46 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
-    internal class BackgroundDimMenuItem : MenuItem
+    internal class BackgroundDimMenuItem : GenericChangeOpacityMenuItem
     {
-        private readonly Bindable<float> backgroundDim;
-
-        private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
-
         public BackgroundDimMenuItem(Bindable<float> backgroundDim)
-            : base(GameplaySettingsStrings.BackgroundDim)
+            : base(backgroundDim, GameplaySettingsStrings.BackgroundDim, [0f, 0.25f, 0.5f, 0.75f])
         {
-            Items = new[]
-            {
-                createMenuItem(0f),
-                createMenuItem(0.25f),
-                createMenuItem(0.5f),
-                createMenuItem(0.75f),
-            };
-
-            this.backgroundDim = backgroundDim;
-            backgroundDim.BindValueChanged(dim =>
-            {
-                foreach (var kvp in menuItemLookup)
-                    kvp.Value.State.Value = kvp.Key == dim.NewValue ? TernaryState.True : TernaryState.False;
-            }, true);
         }
-
-        private TernaryStateRadioMenuItem createMenuItem(float dim)
-        {
-            var item = new TernaryStateRadioMenuItem($"{dim * 100}%", MenuItemType.Standard, _ => updateOpacity(dim));
-            menuItemLookup[dim] = item;
-            return item;
-        }
-
-        private void updateOpacity(float dim) => backgroundDim.Value = dim;
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -84,6 +84,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private TimelineTimingChangeDisplay controlPoints = null!;
 
         private Bindable<float> waveformOpacity = null!;
+        private Bindable<float> objectsOpacity = null!;
+
         private Bindable<bool> controlPointsVisible = null!;
         private Bindable<bool> ticksVisible = null!;
 
@@ -155,6 +157,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             });
 
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
+            objectsOpacity = config.GetBindable<float>(OsuSetting.EditorTimelineObjectsOpacity);
+
             controlPointsVisible = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTimingChanges);
             ticksVisible = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTicks);
 
@@ -189,6 +193,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             base.LoadComplete();
 
             waveformOpacity.BindValueChanged(_ => updateWaveformOpacity(), true);
+            objectsOpacity.BindValueChanged(_ => updateObjectsOpacity(), true);
 
             ticksVisible.BindValueChanged(visible => ticks.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint), true);
 
@@ -203,6 +208,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void updateWaveformOpacity() =>
             waveform.FadeTo(waveformOpacity.Value, 200, Easing.OutQuint);
+
+        private void updateObjectsOpacity() =>
+            userContent.FadeTo(objectsOpacity.Value, 200, Easing.OutQuint);
 
         protected override void Update()
         {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -408,6 +408,7 @@ namespace osu.Game.Screens.Edit
                                                 Items =
                                                 [
                                                     new WaveformOpacityMenuItem(config.GetBindable<float>(OsuSetting.EditorWaveformOpacity)),
+                                                    new TimelineObjectsOpacityMenuItem(config.GetBindable<float>(OsuSetting.EditorTimelineObjectsOpacity)),
                                                     new ToggleMenuItem(EditorStrings.TimelineShowTimingChanges)
                                                     {
                                                         State = { BindTarget = editorTimelineShowTimingChanges }

--- a/osu.Game/Screens/Edit/GenericChangeOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/GenericChangeOpacityMenuItem.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Edit
+{
+    internal class GenericChangeOpacityMenuItem : MenuItem
+    {
+        private readonly Bindable<float> opacity;
+
+        private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
+
+        public GenericChangeOpacityMenuItem(Bindable<float> opacity, LocalisableString text, IEnumerable<float> availableOptions)
+            : base(text)
+        {
+            Items = availableOptions.Select(createMenuItem).ToList().AsReadOnly();
+
+            this.opacity = opacity;
+            opacity.BindValueChanged(opacity =>
+            {
+                foreach (var kvp in menuItemLookup)
+                    kvp.Value.State.Value = kvp.Key == opacity.NewValue ? TernaryState.True : TernaryState.False;
+            }, true);
+        }
+
+        private TernaryStateRadioMenuItem createMenuItem(float opacity)
+        {
+            var item = new TernaryStateRadioMenuItem($"{opacity * 100}%", MenuItemType.Standard, _ => updateOpacity(opacity));
+            menuItemLookup[opacity] = item;
+            return item;
+        }
+
+        private void updateOpacity(float opacity) => this.opacity.Value = opacity;
+    }
+}

--- a/osu.Game/Screens/Edit/GenericChangeOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/GenericChangeOpacityMenuItem.cs
@@ -12,17 +12,17 @@ namespace osu.Game.Screens.Edit
 {
     internal class GenericChangeOpacityMenuItem : MenuItem
     {
-        private readonly Bindable<float> opacity;
+        private readonly Bindable<float> bindableOpacity;
 
         private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
 
-        public GenericChangeOpacityMenuItem(Bindable<float> opacity, LocalisableString text, IEnumerable<float> availableOptions)
+        public GenericChangeOpacityMenuItem(Bindable<float> bindableOpacity, LocalisableString text, IEnumerable<float> availableOptions)
             : base(text)
         {
             Items = availableOptions.Select(createMenuItem).ToList().AsReadOnly();
 
-            this.opacity = opacity;
-            opacity.BindValueChanged(opacity =>
+            this.bindableOpacity = bindableOpacity;
+            bindableOpacity.BindValueChanged(opacity =>
             {
                 foreach (var kvp in menuItemLookup)
                     kvp.Value.State.Value = kvp.Key == opacity.NewValue ? TernaryState.True : TernaryState.False;
@@ -36,6 +36,6 @@ namespace osu.Game.Screens.Edit
             return item;
         }
 
-        private void updateOpacity(float opacity) => this.opacity.Value = opacity;
+        private void updateOpacity(float opacity) => bindableOpacity.Value = opacity;
     }
 }

--- a/osu.Game/Screens/Edit/TimelineObjectsOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/TimelineObjectsOpacityMenuItem.cs
@@ -1,47 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
-    internal class TimelineObjectsOpacityMenuItem : MenuItem
+    internal class TimelineObjectsOpacityMenuItem : GenericChangeOpacityMenuItem
     {
-        private readonly Bindable<float> timelineObjectsOpacity;
-
-        private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
-
         public TimelineObjectsOpacityMenuItem(Bindable<float> timelineObjectsOpacity)
-            : base(EditorStrings.TimelineObjectsOpacity)
+            : base(timelineObjectsOpacity, EditorStrings.TimelineObjectsOpacity, [0.25f, 0.5f, 0.75f, 1f])
         {
-            Items = new[]
-            {
-                createMenuItem(0f),
-                createMenuItem(0.25f),
-                createMenuItem(0.5f),
-                createMenuItem(0.75f),
-                createMenuItem(1f),
-            };
-
-            this.timelineObjectsOpacity = timelineObjectsOpacity;
-            timelineObjectsOpacity.BindValueChanged(opacity =>
-            {
-                foreach (var kvp in menuItemLookup)
-                    kvp.Value.State.Value = kvp.Key == opacity.NewValue ? TernaryState.True : TernaryState.False;
-            }, true);
         }
-
-        private TernaryStateRadioMenuItem createMenuItem(float opacity)
-        {
-            var item = new TernaryStateRadioMenuItem($"{opacity * 100}%", MenuItemType.Standard, _ => updateOpacity(opacity));
-            menuItemLookup[opacity] = item;
-            return item;
-        }
-
-        private void updateOpacity(float opacity) => timelineObjectsOpacity.Value = opacity;
     }
 }

--- a/osu.Game/Screens/Edit/TimelineObjectsOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/TimelineObjectsOpacityMenuItem.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
+
+namespace osu.Game.Screens.Edit
+{
+    internal class TimelineObjectsOpacityMenuItem : MenuItem
+    {
+        private readonly Bindable<float> timelineObjectsOpacity;
+
+        private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
+
+        public TimelineObjectsOpacityMenuItem(Bindable<float> timelineObjectsOpacity)
+            : base(EditorStrings.TimelineObjectsOpacity)
+        {
+            Items = new[]
+            {
+                createMenuItem(0f),
+                createMenuItem(0.25f),
+                createMenuItem(0.5f),
+                createMenuItem(0.75f),
+                createMenuItem(1f),
+            };
+
+            this.timelineObjectsOpacity = timelineObjectsOpacity;
+            timelineObjectsOpacity.BindValueChanged(opacity =>
+            {
+                foreach (var kvp in menuItemLookup)
+                    kvp.Value.State.Value = kvp.Key == opacity.NewValue ? TernaryState.True : TernaryState.False;
+            }, true);
+        }
+
+        private TernaryStateRadioMenuItem createMenuItem(float opacity)
+        {
+            var item = new TernaryStateRadioMenuItem($"{opacity * 100}%", MenuItemType.Standard, _ => updateOpacity(opacity));
+            menuItemLookup[opacity] = item;
+            return item;
+        }
+
+        private void updateOpacity(float opacity) => timelineObjectsOpacity.Value = opacity;
+    }
+}

--- a/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
@@ -1,47 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
-    internal class WaveformOpacityMenuItem : MenuItem
+    internal class WaveformOpacityMenuItem : GenericChangeOpacityMenuItem
     {
-        private readonly Bindable<float> waveformOpacity;
-
-        private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
-
         public WaveformOpacityMenuItem(Bindable<float> waveformOpacity)
-            : base(EditorStrings.WaveformOpacity)
+            : base(waveformOpacity, EditorStrings.WaveformOpacity, [0f, 0.25f, 0.5f, 0.75f, 1f])
         {
-            Items = new[]
-            {
-                createMenuItem(0f),
-                createMenuItem(0.25f),
-                createMenuItem(0.5f),
-                createMenuItem(0.75f),
-                createMenuItem(1f),
-            };
-
-            this.waveformOpacity = waveformOpacity;
-            waveformOpacity.BindValueChanged(opacity =>
-            {
-                foreach (var kvp in menuItemLookup)
-                    kvp.Value.State.Value = kvp.Key == opacity.NewValue ? TernaryState.True : TernaryState.False;
-            }, true);
         }
-
-        private TernaryStateRadioMenuItem createMenuItem(float opacity)
-        {
-            var item = new TernaryStateRadioMenuItem($"{opacity * 100}%", MenuItemType.Standard, _ => updateOpacity(opacity));
-            menuItemLookup[opacity] = item;
-            return item;
-        }
-
-        private void updateOpacity(float opacity) => waveformOpacity.Value = opacity;
     }
 }


### PR DESCRIPTION
## Motivation

### Problem
Currently, when you edit a map, you can not see most of the waveform that is behind an object on the timeline (e.g. circle or slider), since objects have 100% opacity (see example below).

<details>
<summary>Screenshot</summary>

<img width="381" height="162" alt="image" src="https://github.com/user-attachments/assets/88497d24-0c5d-42e6-8d8e-df483e0f9348" />

</details>

This is inconvenient, since waveform is a useful tool to check if map is timed correctly (although stable does not have waveform, and many mappers rely on audio instead of the waveform, but still).

### Proposed solution
I would like to have an option for changing objects opacity, so that I could see both the object and the waveform behind it. See example of how it looks below.

<details>
<summary>Screenshot</summary>

<img width="380" height="161" alt="image" src="https://github.com/user-attachments/assets/5f62a646-2ea5-4b0e-9d6e-a8c81eed9696" />

</details>

Now I can better see that the timing is wrong and can adjust it properly.

## Implementation details

There is already a menu for changing waveform opacity, so it is very easy to add another menu for changing timeline objects opacity.

There are also currently two menus that use very similar code: background dim select and waveform opacity select. So we can reduce code duplication by creating a common class, and use it for timeline objects opacity as well.

By default, the opacity is 100%, same as it was before. So this is completely optional for mappers, and they can choose to use this feature or not.

This is how the menu would look:

<details>
<summary>Screenshot</summary>

<img width="1805" height="536" alt="image" src="https://github.com/user-attachments/assets/0f0f7b90-437a-4266-913a-de1249bee01c" />

</details>

## Notes

There are some workarounds currently, for example you can move the object on the timeline to see behind it, or delete it and then press Ctrl+Z. This is still less convenient than it could be, in my opinion.

Localization will be needed for a string `timeline_objects_opacity`.

It would be nice if this PR was merged, I think it would help other mappers as well, not only myself.
