### PR TITLE
feat: add ability to adjust slider velocity according to distance

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                             {
                                 AutoSizeAxes = Axes.Y,
                                 RelativeSizeAxes = Axes.X,
-                                Text = "Hold shift while dragging the end of an object to adjust velocity while snapping."
+                                Text = "Hold shift while dragging the end of an object to adjust velocity while snapping.\nDouble-clicking the end point of an object with a path to adjust velocity to make it land on the intended position."
                             },
                             new SliderVelocityInspector(sliderVelocitySlider.Current),
                         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -474,6 +474,29 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 changeHandler?.EndChange();
                 OnDragHandled?.Invoke(null);
             }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                base.OnClick(e);
+
+                // Handle the click event here first for the double-click handler to be invoked.
+                return true;
+            }
+
+            protected override bool OnDoubleClick(DoubleClickEvent e)
+            {
+                base.OnDoubleClick(e);
+
+                if (hitObject is IHasPath hasPath && hitObject is IHasSliderVelocity hasSliderVelocity)
+                {
+                    // Adjust the velocity to match the actual distance of the path with the expected distance.
+                    hasSliderVelocity.SliderVelocityMultiplier *= hasPath.Path.CalculatedDistance / hasPath.Path.Distance;
+                    hasPath.Path.ExpectedDistance.Value = hasPath.Path.CalculatedDistance;
+                    beatmap.Update(hitObject);
+                }
+
+                return true;
+            }
         }
 
         public partial class Border : ExtendableCircle


### PR DESCRIPTION
This pull request adds ability to adjust slider velocity exactly match the path's position by double-clicking on the end of a slider in the timeline.

https://github.com/user-attachments/assets/49908b54-4979-4b68-9dc2-48d8371ca23a

It can be useful when creating beatmaps that strictly follow grid snapping.
