### PR TITLE
Colour Rank Achieved panels to the related rank

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelGroup.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelGroup.cs
@@ -3,12 +3,14 @@
 
 using System;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Cursor;
+using osu.Game.Scoring;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Visual.UserInterface;
 using osuTK;
@@ -75,6 +77,64 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                     new PanelGroupStarDifficulty
                                     {
                                         Item = new CarouselItem(new StarDifficultyGroupDefinition(3, $"{star} Star(s)", new StarDifficulty(star, 0))),
+                                        Expanded = { Value = true },
+                                        KeyboardSelected = { Value = true },
+                                    },
+                                },
+                            }
+                        }
+                    };
+                });
+            }
+        }
+
+        [Test]
+        public void TestRanks()
+        {
+            for (int i = -1; i <= 7; i++)
+            {
+                ScoreRank rank = (ScoreRank)i;
+
+                AddStep($"display rank {rank}", () =>
+                {
+                    ContentContainer.Child = new DependencyProvidingContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        CachedDependencies = new (Type, object)[]
+                        {
+                            (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Aquamarine))
+                        },
+                        Child = new OsuContextMenuContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Child = new FillFlowContainer
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Width = 0.5f,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(0f, 5f),
+                                Children = new[]
+                                {
+                                    new PanelGroupRankDisplay
+                                    {
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(0, $"{rank.GetDescription()}", rank))
+                                    },
+                                    new PanelGroupRankDisplay
+                                    {
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(1, $"{rank.GetDescription()}", rank)),
+                                        KeyboardSelected = { Value = true },
+                                    },
+                                    new PanelGroupRankDisplay
+                                    {
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(2, $"{rank.GetDescription()}", rank)),
+                                        Expanded = { Value = true },
+                                    },
+                                    new PanelGroupRankDisplay
+                                    {
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(3, $"{rank.GetDescription()}", rank)),
                                         Expanded = { Value = true },
                                         KeyboardSelected = { Value = true },
                                     },

--- a/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelGroup.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestScenePanelGroup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using NUnit.Framework;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
@@ -120,21 +119,21 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                                 {
                                     new PanelGroupRankDisplay
                                     {
-                                        Item = new CarouselItem(new RankDisplayGroupDefinition(0, $"{rank.GetDescription()}", rank))
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(rank))
                                     },
                                     new PanelGroupRankDisplay
                                     {
-                                        Item = new CarouselItem(new RankDisplayGroupDefinition(1, $"{rank.GetDescription()}", rank)),
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(rank)),
                                         KeyboardSelected = { Value = true },
                                     },
                                     new PanelGroupRankDisplay
                                     {
-                                        Item = new CarouselItem(new RankDisplayGroupDefinition(2, $"{rank.GetDescription()}", rank)),
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(rank)),
                                         Expanded = { Value = true },
                                     },
                                     new PanelGroupRankDisplay
                                     {
-                                        Item = new CarouselItem(new RankDisplayGroupDefinition(3, $"{rank.GetDescription()}", rank)),
+                                        Item = new CarouselItem(new RankDisplayGroupDefinition(rank)),
                                         Expanded = { Value = true },
                                         KeyboardSelected = { Value = true },
                                     },

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -789,7 +789,7 @@ namespace osu.Game.Screens.SelectV2
         private readonly DrawablePool<PanelBeatmapSet> setPanelPool = new DrawablePool<PanelBeatmapSet>(100);
         private readonly DrawablePool<PanelGroup> groupPanelPool = new DrawablePool<PanelGroup>(100);
         private readonly DrawablePool<PanelGroupStarDifficulty> starsGroupPanelPool = new DrawablePool<PanelGroupStarDifficulty>(11);
-        private readonly DrawablePool<PanelGroupRankDisplay> ranksGroupPanelPool = new DrawablePool<PanelGroupRankDisplay>(11);
+        private readonly DrawablePool<PanelGroupRankDisplay> ranksGroupPanelPool = new DrawablePool<PanelGroupRankDisplay>(9);
 
         private void setupPools()
         {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -788,9 +788,11 @@ namespace osu.Game.Screens.SelectV2
         private readonly DrawablePool<PanelBeatmapSet> setPanelPool = new DrawablePool<PanelBeatmapSet>(100);
         private readonly DrawablePool<PanelGroup> groupPanelPool = new DrawablePool<PanelGroup>(100);
         private readonly DrawablePool<PanelGroupStarDifficulty> starsGroupPanelPool = new DrawablePool<PanelGroupStarDifficulty>(11);
+        private readonly DrawablePool<PanelGroupRankDisplay> ranksGroupPanelPool = new DrawablePool<PanelGroupRankDisplay>(11);
 
         private void setupPools()
         {
+            AddInternal(ranksGroupPanelPool);
             AddInternal(starsGroupPanelPool);
             AddInternal(groupPanelPool);
             AddInternal(beatmapPanelPool);
@@ -828,6 +830,9 @@ namespace osu.Game.Screens.SelectV2
             {
                 case StarDifficultyGroupDefinition:
                     return starsGroupPanelPool.Get();
+
+                case RankDisplayGroupDefinition:
+                    return ranksGroupPanelPool.Get();
 
                 case GroupDefinition:
                     return groupPanelPool.Get();
@@ -1084,6 +1089,11 @@ namespace osu.Game.Screens.SelectV2
     /// Defines a grouping header for a set of carousel items grouped by star difficulty.
     /// </summary>
     public record StarDifficultyGroupDefinition(int Order, string Title, StarDifficulty Difficulty) : GroupDefinition(Order, Title);
+
+    /// <summary>
+    /// Defines a grouping header for a set of carousel items grouped by achieved rank.
+    /// </summary>
+    public record RankDisplayGroupDefinition(int Order, string Title, ScoreRank Rank) : GroupDefinition(Order, Title);
 
     /// <summary>
     /// Used to represent a portion of a <see cref="BeatmapSetInfo"/> under a <see cref="GroupDefinition"/>.

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -13,6 +13,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
@@ -1093,7 +1094,7 @@ namespace osu.Game.Screens.SelectV2
     /// <summary>
     /// Defines a grouping header for a set of carousel items grouped by achieved rank.
     /// </summary>
-    public record RankDisplayGroupDefinition(int Order, string Title, ScoreRank Rank) : GroupDefinition(Order, Title);
+    public record RankDisplayGroupDefinition(ScoreRank Rank) : GroupDefinition(-(int)Rank, Rank.GetDescription());
 
     /// <summary>
     /// Used to represent a portion of a <see cref="BeatmapSetInfo"/> under a <see cref="GroupDefinition"/>.

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -433,7 +433,7 @@ namespace osu.Game.Screens.SelectV2
         private IEnumerable<GroupDefinition> defineGroupByRankAchieved(BeatmapInfo beatmap, IReadOnlyDictionary<Guid, ScoreRank> topRankMapping)
         {
             if (topRankMapping.TryGetValue(beatmap.ID, out var rank))
-                return new RankDisplayGroupDefinition(-(int)rank, rank.GetDescription(), rank).Yield();
+                return new RankDisplayGroupDefinition(rank).Yield();
 
             return new GroupDefinition(int.MaxValue, "Unplayed").Yield();
         }

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -433,7 +433,7 @@ namespace osu.Game.Screens.SelectV2
         private IEnumerable<GroupDefinition> defineGroupByRankAchieved(BeatmapInfo beatmap, IReadOnlyDictionary<Guid, ScoreRank> topRankMapping)
         {
             if (topRankMapping.TryGetValue(beatmap.ID, out var rank))
-                return new GroupDefinition(-(int)rank, rank.GetDescription()).Yield();
+                return new RankDisplayGroupDefinition(-(int)rank, rank.GetDescription(), rank).Yield();
 
             return new GroupDefinition(int.MaxValue, "Unplayed").Yield();
         }

--- a/osu.Game/Screens/SelectV2/PanelGroupRankDisplay.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroupRankDisplay.cs
@@ -1,0 +1,225 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Backgrounds;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Scoring;
+using osuTK;
+using osuTK.Graphics;
+using WebCommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class PanelGroupRankDisplay : Panel
+    {
+        public const float HEIGHT = PanelGroup.HEIGHT;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private Drawable iconContainer = null!;
+        private Box backgroundBorder = null!;
+        private Box contentBackground = null!;
+        private OsuSpriteText starRatingText = null!;
+        private CircularContainer countPill = null!;
+        private OsuSpriteText countText = null!;
+        private TrianglesV2 triangles = null!;
+        private Box glow = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Height = PanelGroup.HEIGHT;
+
+            Icon = iconContainer = new Container
+            {
+                AlwaysPresent = true,
+                RelativeSizeAxes = Axes.Y,
+                Alpha = 0f,
+                Child = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.Solid.ChevronDown,
+                    Size = new Vector2(12),
+                },
+            };
+
+            Background = backgroundBorder = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = colourProvider.Highlight1,
+            };
+
+            AccentColour = colourProvider.Highlight1;
+            Content.Children = new Drawable[]
+            {
+                contentBackground = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                triangles = new TrianglesV2
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Thickness = 0.02f,
+                    SpawnRatio = 0.6f,
+                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
+                },
+                glow = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Width = 0.5f,
+                    Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                },
+                new FillFlowContainer
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    AutoSizeAxes = Axes.Both,
+                    Spacing = new Vector2(10f, 0f),
+                    Margin = new MarginPadding { Left = 10f },
+                    Children = new Drawable[]
+                    {
+                        starRatingText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            UseFullGlyphHeight = false,
+                            Font = OsuFont.Style.Heading2,
+                        }
+                    }
+                },
+                countPill = new CircularContainer
+                {
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    Size = new Vector2(50f, 14f),
+                    Margin = new MarginPadding { Right = 30f },
+                    Masking = true,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Black.Opacity(0.7f),
+                        },
+                        countText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                            UseFullGlyphHeight = false,
+                        }
+                    },
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Expanded.BindValueChanged(_ => onExpanded(), true);
+        }
+
+        private Color4 rankColour;
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+
+            Debug.Assert(Item != null);
+
+            var group = (RankDisplayGroupDefinition)Item.Model;
+            ScoreRank rank = group.Rank;
+
+            rankColour = OsuColour.ForRank(rank);
+
+            AccentColour = rankColour;
+            backgroundBorder.Colour = rankColour;
+            contentBackground.Colour = rankColour.Darken(1f);
+            glow.Colour = ColourInfo.GradientHorizontal(rankColour, rankColour.Opacity(0f));
+
+            switch (rank)
+            {
+                case ScoreRank.SH:
+                case ScoreRank.XH:
+                    starRatingText.Colour = ColourInfo.GradientVertical(Color4.White, Color4Extensions.FromHex("afdff0"));
+                    iconContainer.Colour = colourProvider.Background5;
+                    break;
+
+                case ScoreRank.X:
+                case ScoreRank.S:
+                    starRatingText.Colour = ColourInfo.GradientVertical(Color4Extensions.FromHex(@"ffe7a8"), Color4Extensions.FromHex(@"ffb800"));
+                    iconContainer.Colour = colourProvider.Background5;
+                    break;
+
+                case ScoreRank.F:
+                    starRatingText.Colour = Color4Extensions.FromHex(@"CC3333");
+                    iconContainer.Colour = colourProvider.Content1;
+                    break;
+
+                default:
+                    starRatingText.Colour = Color4.White;
+                    iconContainer.Colour = colourProvider.Background5;
+                    break;
+            }
+
+            starRatingText.Text = group.Title;
+
+            ColourInfo colour = ColourInfo.GradientHorizontal(rankColour.Darken(0.6f), rankColour.Darken(0.8f));
+
+            triangles.Colour = colour;
+
+            countText.Text = Item.NestedItemCount.ToLocalisableString(@"N0");
+
+            onExpanded();
+        }
+
+        private void onExpanded()
+        {
+            const float duration = 500;
+
+            iconContainer.ResizeWidthTo(Expanded.Value ? 20f : 5f, duration, Easing.OutQuint);
+            iconContainer.FadeTo(Expanded.Value ? 1f : 0f, duration, Easing.OutQuint);
+
+            glow.FadeTo(Expanded.Value ? 0.4f : 0, duration, Easing.OutQuint);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // Move the count pill in the opposite direction to keep it pinned to the screen regardless of the X position of TopLevelContent.
+            countPill.X = -TopLevelContent.X;
+        }
+
+        public override MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                if (Item == null)
+                    return Array.Empty<MenuItem>();
+
+                return new MenuItem[]
+                {
+                    new OsuMenuItem(Expanded.Value ? WebCommonStrings.ButtonsCollapse.ToSentence() : WebCommonStrings.ButtonsExpand.ToSentence(), MenuItemType.Highlighted, () => TriggerClick())
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/PanelGroupRankDisplay.cs
+++ b/osu.Game/Screens/SelectV2/PanelGroupRankDisplay.cs
@@ -16,6 +16,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Scoring;
 using osuTK;
@@ -158,18 +159,18 @@ namespace osu.Game.Screens.SelectV2
             {
                 case ScoreRank.SH:
                 case ScoreRank.XH:
-                    starRatingText.Colour = ColourInfo.GradientVertical(Color4.White, Color4Extensions.FromHex("afdff0"));
+                    starRatingText.Colour = DrawableRank.GetRankNameColour(rank);
                     iconContainer.Colour = colourProvider.Background5;
                     break;
 
                 case ScoreRank.X:
                 case ScoreRank.S:
-                    starRatingText.Colour = ColourInfo.GradientVertical(Color4Extensions.FromHex(@"ffe7a8"), Color4Extensions.FromHex(@"ffb800"));
+                    starRatingText.Colour = DrawableRank.GetRankNameColour(rank);
                     iconContainer.Colour = colourProvider.Background5;
                     break;
 
                 case ScoreRank.F:
-                    starRatingText.Colour = Color4Extensions.FromHex(@"CC3333");
+                    starRatingText.Colour = DrawableRank.GetRankNameColour(rank);
                     iconContainer.Colour = colourProvider.Content1;
                     break;
 


### PR DESCRIPTION
As I said in https://github.com/ppy/osu/pull/35139#issuecomment-3344187534, previous PR (#35139) was outdated, so this one should be based on the most modern master branch. I'm genuinely sorry for not checking that before. I want to thank everybody leaving their reaction under previous PR, those were heartwarming and I'll try to check my repository next time, to not raise a conflicts like these.

This PR was (re)opened after I felt like that I got enough upvotes and reactions under #35075. I think it would be nice addition to coloured Difficulty panels, plus it took me only a single night to develop this, based on sorting by difficulty code. 

I wasn't sure about how important should that be, but I've decided to add related tests as well (Difficulty pannels had their own separate test, but I haven't made one for Ranks, since I thought that would be excessive (Can be added upon request)).

All of the colours were based on my discussion post.

Comparison:
|[`master`](https://github.com/ppy/osu/tree/master)|[`this PR`](https://github.com/tadatomix/osu/tree/song-select/coloured-group-ranks)|
|---|---|
|<img width="770" height="699" alt="изображение" src="https://github.com/user-attachments/assets/f2c4183c-449e-4d83-87d9-34cb644d2c27" />|<img width="768" height="701" alt="изображение" src="https://github.com/user-attachments/assets/1e5f2b1d-4102-4fe5-8115-3381e36f7714" />|

>[!NOTE]
>Since Joehuu has made their PR #35126, that changes the text on those panels, I'll update my code, when their PR will be merged