### PR TITLE
Rescale Relax Ok and Meh count to increase stability

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -128,11 +128,18 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 // https://www.desmos.com/calculator/vspzsop6td
                 // we use OD13.3 as maximum since it's the value at which great hitwidow becomes 0
                 // this is well beyond currently maximum achievable OD which is 12.17 (DTx2 + DA with OD11)
-                double okMultiplier = 0.75 * Math.Max(0.0, overallDifficulty > 0.0 ? 1 - overallDifficulty / 13.33 : 1.0);
+                double okMultiplier = 0.8 * Math.Max(0.0, overallDifficulty > 0.0 ? 1 - overallDifficulty / 13.33 : 1.0);
                 double mehMultiplier = Math.Max(0.0, overallDifficulty > 0.0 ? 1 - Math.Pow(overallDifficulty / 13.33, 5) : 1.0);
 
+                // Sum weighted into total count to make rescale consistent (otherwise 100 Oks and 100 Mehs would be worth less than 200 Mehs).
+                double weightedInaccuracyCount = countOk + countMeh * mehMultiplier / Math.Max(okMultiplier, 1e-17);
+
+                // We would want to rescale inaccuracies into logarithmic scale to make sure that increasing length of the map would never lead to pp decrease.
+                // Cap with Min to make sure that Oks and Mehs aren't penalized more than misses. This makes it reduce inaccuracy count starting from 11 Oks equivalent.
+                double rescaledInnacuracyCount = Math.Min(weightedInaccuracyCount, 10 * Math.Log(weightedInaccuracyCount + 1));
+
                 // As we're adding Oks and Mehs to an approximated number of combo breaks the result can be higher than total hits in specific scenarios (which breaks some calculations) so we need to clamp it.
-                effectiveMissCount = Math.Min(effectiveMissCount + countOk * okMultiplier + countMeh * mehMultiplier, totalHits);
+                effectiveMissCount = Math.Min(effectiveMissCount + rescaledInnacuracyCount * okMultiplier, totalHits);
             }
 
             speedDeviation = calculateSpeedDeviation(osuAttributes);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 // Cap with Min to make sure that Oks and Mehs aren't penalized more than misses. This makes it reduce inaccuracy count starting from 11 Oks equivalent.
                 double rescaledInnacuracyCount = Math.Min(weightedInaccuracyCount, 10 * Math.Log(weightedInaccuracyCount + 1));
 
-                // As we're adding Oks and Mehs to an approximated number of combo breaks the result can be higher than total hits in specific scenarios (which breaks some calculations) so we need to clamp it.
+                // As we're adding rescaled inaccuracies to an approximated number of combo breaks the result can be higher than total hits in specific scenarios (which breaks some calculations) so we need to clamp it.
                 effectiveMissCount = Math.Min(effectiveMissCount + rescaledInnacuracyCount * okMultiplier, totalHits);
             }
 


### PR DESCRIPTION
Currently with relax long maps are heavily disadvantaged because at some point you just start losing significant amount of pp for every 100 without gaining much pp from length.

The reason for this is not relax-related - it's a flaw in miss count formula (that's using Log for difficult strain count). In normal pp at some point keeping the same amount of misses per object will make you continuously lose pp. However - in relax this problem is much more vital because 100s and 50s count as partial misses, so this problem occurs much sooner.
This PR is partially fixing the problem for relax by rescaling 100s and 50s to save long maps from being heavily underweight in relax. The overall 100s penalty was slightly increased to compensate for this.

Those are tests for Horrible Kids [Cataclysm] +DTRX for 99% accuracy, 4x100 for 1 repeat (original version):
N times repeated: Master pp => PR pp
1 times: 270.28pp => 269.61pp
2 times: 314.13pp => 312.75pp
5 times: 375.46pp => 372.06pp
10 times: 415.29pp => 416.20pp
25 times: 393.08pp => 491.00pp
100 times: 245.74pp => 578.46pp
1000 times: 54.49pp => 714.70pp