### PR TITLE
Ensure submission progress sample is stopped when transitioning into a final state

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneSubmissionStageProgress.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneSubmissionStageProgress.cs
@@ -68,6 +68,25 @@ namespace osu.Game.Tests.Visual.Editing
                         progress.SetInProgress(incrementingProgress += RNG.NextSingle(0.08f));
                 }, 0, true);
             });
+            AddStep("increase progress slowly then fail", () =>
+            {
+                incrementingProgress = 0;
+
+                ScheduledDelegate? task = null;
+
+                task = Scheduler.AddDelayed(() =>
+                {
+                    if (incrementingProgress >= 1)
+                    {
+                        progress.SetFailed("nope");
+                        // ReSharper disable once AccessToModifiedClosure
+                        task?.Cancel();
+                        return;
+                    }
+
+                    progress.SetInProgress(incrementingProgress += RNG.NextSingle(0.001f));
+                }, 0, true);
+            });
 
             AddUntilStep("wait for completed", () => incrementingProgress >= 1);
             AddStep("completed", () => progress.SetCompleted());

--- a/osu.Game/Screens/Edit/Submission/SubmissionStageProgress.cs
+++ b/osu.Game/Screens/Edit/Submission/SubmissionStageProgress.cs
@@ -263,6 +263,7 @@ namespace osu.Game.Screens.Edit.Submission
                     iconContainer.Colour = colours.Red1;
                     iconContainer.FlashColour(Colour4.White, 1000, Easing.OutQuint);
                     errorSample?.Play();
+                    progressSampleChannel?.Stop();
                     break;
 
                 case StageStatusType.Canceled:
@@ -274,6 +275,7 @@ namespace osu.Game.Screens.Edit.Submission
                     iconContainer.Colour = colours.Gray8;
                     iconContainer.FlashColour(Colour4.White, 1000, Easing.OutQuint);
                     cancelSample?.Play();
+                    progressSampleChannel?.Stop();
                     break;
             }
         }


### PR DESCRIPTION
Probably closes https://github.com/ppy/osu/issues/35138. I'm not sure. I only got the issue to reproduce once, on dev, using a very large archive that was uploading really slowly, and then never again. The test here somewhat resembles that failure scenario that I saw, except that _it doesn't fail_ in the same way, at least to my ears.

The working theory is that basically handling of `progressSampleChannel` is quite dodgy and it could possibly, in circumstances unknown, be allowed to play forevermore after transitioning to failed / canceled state. Success state does not get this treatment because it has special logic to set progress to 1.