### PR TITLE
FIX: Discord RPC is now working when Discord is installed using Flatpak (and osu!lazer isn't containerized)

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Runtime.InteropServices;
 using System.Text;
 using DiscordRPC;
 using DiscordRPC.Message;
 using Newtonsoft.Json;
+using osu.Desktop.Linux;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -70,6 +72,11 @@ namespace osu.Desktop
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, SessionStatics session)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                DiscordFlatpak.TryCreateLinuxDiscordFlatpakSymlink();
+            }
+
             privacyMode = config.GetBindable<DiscordRichPresenceMode>(OsuSetting.DiscordRichPresence);
             userStatus = config.GetBindable<UserStatus>(OsuSetting.UserOnlineStatus);
             userActivity = session.GetBindable<UserActivity?>(Static.UserOnlineActivity);

--- a/osu.Desktop/Linux/DiscordFlatpak.cs
+++ b/osu.Desktop/Linux/DiscordFlatpak.cs
@@ -1,10 +1,126 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.Versioning;
+using osu.Framework.Logging;
+
 namespace osu.Desktop.Linux
 {
-    public class DiscordFlatpak
+    [SupportedOSPlatform("linux")]
+    public static class DiscordFlatpak
     {
-        
+        /// <summary>
+        /// Discord Flatpak packages names
+        /// Examples: com.discordapp.Discord, com.discordapp.DiscordCanary
+        /// </summary>
+        private static readonly string[] discord_package_names =
+        {
+            "com.discordapp.Discord", "com.discordapp.DiscordCanary"
+        };
+
+        /// <summary>
+        /// Get Discord IPC Path for Flatpak installation.
+        /// </summary>
+        private static string? getDiscordFlatpakIpcPath()
+        {
+            string xdgRuntimeDir = XdgUtils.GetXdgRuntimeDir();
+
+            foreach (string discordPackageName in discord_package_names)
+            {
+                string discordDirectory = Path.Combine(xdgRuntimeDir, ".flatpak/" + discordPackageName + "/xdg-run");
+
+                if (!Path.Exists(discordDirectory))
+                {
+                    continue;
+                }
+
+                for (int socketNum = 0; socketNum < 10; socketNum++)
+                {
+                    string socketPath = Path.Combine(discordDirectory, $"discord-ipc-{socketNum}");
+                    if (File.Exists(socketPath))
+                    {
+                        return socketPath;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static void TryCreateLinuxSymlink(string filePath, string targetPath)
+        {
+            Process symlinkProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "ln",
+                    Arguments = $"-s \"{targetPath}\" \"{filePath}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+
+            try
+            {
+                symlinkProcess.Start();
+                symlinkProcess.WaitForExit();
+
+                if (symlinkProcess.ExitCode != 0)
+                {
+                    string error = symlinkProcess.StandardError.ReadToEnd();
+                    Logger.Error(new ArgumentException(), $"Unable to create symbolic link: {error}");
+                    return;
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, $"Unable to create symbolic link: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Creates symlink for Discord's socket from Discord's Flatpak installation.
+        /// </summary>
+        public static void TryCreateLinuxDiscordFlatpakSymlink()
+        {
+            // When Discord is installed as Flatpak,
+            // it usually creates the UNIX socket file in
+            // `/run/user/{uid}/.flatpak/com.discordapp.Discord/xdg-run/discord-ipc-{number}`
+
+            string xdgRuntimeDir = XdgUtils.GetXdgRuntimeDir();
+            string defaultDiscordIpcPath = Path.Combine(xdgRuntimeDir, "discord-ipc-0");
+
+            if (Path.Exists(defaultDiscordIpcPath))
+            {
+                var linkInfo = new FileInfo(defaultDiscordIpcPath);
+
+                if (linkInfo.Attributes.HasFlag(FileAttributes.ReparsePoint) && Path.Exists(linkInfo.LinkTarget))
+                {
+                    File.Delete(defaultDiscordIpcPath);
+                }
+                else
+                {
+                    Logger.Log(@"Discord IPC already exists, skipping");
+                    return;
+                }
+            }
+
+            string? discordFlatpakIpcPath = getDiscordFlatpakIpcPath();
+            Logger.LogPrint($"Got Discord Flatpak IPC Path: {discordFlatpakIpcPath}");
+
+            if (discordFlatpakIpcPath == null)
+            {
+                Logger.LogPrint(@"Could not find Discord Flatpak IPC Socket.");
+                return;
+            }
+
+            Logger.LogPrint($"Trying to create a symlink: {defaultDiscordIpcPath} -> {discordFlatpakIpcPath}");
+            TryCreateLinuxSymlink(defaultDiscordIpcPath, discordFlatpakIpcPath);
+        }
     }
 }

--- a/osu.Desktop/Linux/DiscordFlatpak.cs
+++ b/osu.Desktop/Linux/DiscordFlatpak.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Desktop.Linux
+{
+    public class DiscordFlatpak
+    {
+        
+    }
+}

--- a/osu.Desktop/Linux/DiscordFlatpak.cs
+++ b/osu.Desktop/Linux/DiscordFlatpak.cs
@@ -50,7 +50,7 @@ namespace osu.Desktop.Linux
             return null;
         }
 
-        private static void TryCreateLinuxSymlink(string filePath, string targetPath)
+        private static void tryCreateLinuxSymlink(string filePath, string targetPath)
         {
             Process symlinkProcess = new Process
             {
@@ -120,7 +120,7 @@ namespace osu.Desktop.Linux
             }
 
             Logger.LogPrint($"Trying to create a symlink: {defaultDiscordIpcPath} -> {discordFlatpakIpcPath}");
-            TryCreateLinuxSymlink(defaultDiscordIpcPath, discordFlatpakIpcPath);
+            tryCreateLinuxSymlink(defaultDiscordIpcPath, discordFlatpakIpcPath);
         }
     }
 }

--- a/osu.Desktop/Linux/XdgUtils.cs
+++ b/osu.Desktop/Linux/XdgUtils.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.Versioning;
+using System.Runtime.InteropServices;
+using osu.Framework.Logging;
+
+namespace osu.Desktop.Linux
+{
+    [SupportedOSPlatform("linux")]
+    public static class XDGUtils
+    {
+        [DllImport("libc", SetLastError = true)]
+        private static extern uint getuid();
+
+        public static uint GetUserID()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Exception notSupportedException = new PlatformNotSupportedException();
+                Logger.Error(notSupportedException, "You're not running this code on Linux!");
+                throw notSupportedException;
+            }
+
+            return getuid();
+        }
+
+        public static string GetXdg
+    }
+}

--- a/osu.Desktop/Linux/XdgUtils.cs
+++ b/osu.Desktop/Linux/XdgUtils.cs
@@ -4,28 +4,31 @@
 using System;
 using System.Runtime.Versioning;
 using System.Runtime.InteropServices;
-using osu.Framework.Logging;
 
 namespace osu.Desktop.Linux
 {
     [SupportedOSPlatform("linux")]
-    public static class XDGUtils
+    public static class XdgUtils
     {
         [DllImport("libc", SetLastError = true)]
         private static extern uint getuid();
 
+        /// <summary>
+        /// Get current Linux user ID.
+        /// </summary>
         public static uint GetUserID()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Exception notSupportedException = new PlatformNotSupportedException();
-                Logger.Error(notSupportedException, "You're not running this code on Linux!");
-                throw notSupportedException;
-            }
-
             return getuid();
         }
 
-        public static string GetXdg
+        /// <summary>
+        /// Get XDG Runtime Directory.
+        /// </summary>
+        public static string GetXdgRuntimeDir()
+        {
+            string? runtimeDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+
+            return runtimeDir ?? $"/run/user/{GetUserID()}";
+        }
     }
 }


### PR DESCRIPTION
I noticed that Discord RPC didn't care about my Discord installed in Flatpak. So, because of this, I've decided to do some shady stuff to bring it to a working state. 

The workaround? I created a symlink to the `/run/user/1000/.flatpak/com.discordapp.Discord/xdg-run/discord-ipc-0` socket in `/run/user/1000/discord-ipc-0`, and now I can get it working. 

❗️**THIS IS A VERY BAD CROUCH.** I didn't fully understand the codebase myself, so there's may be a better way to implement this.

Also, this is my first ever commit to the big project like this, so you're welcome to give me some further advices.

Tested on Arch Linux (rolling), with Discord 0.0.111 (Flatpak) and osu!lazer (both latest commit and latest lazer update).