### PR TITLE
Add structure and support for jumping in quick play rooms

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Matchmaking.Events;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
@@ -90,6 +91,12 @@ namespace osu.Game.Tests.Visual.Matchmaking
                     }
                 }
             }).WaitSafely());
+        }
+
+        [Test]
+        public void TestJump()
+        {
+            AddStep("jump", () => MultiplayerClient.SendUserMatchRequest(1, new MatchmakingAvatarActionRequest { Action = MatchmakingAvatarAction.Jump }).WaitSafely());
         }
     }
 }

--- a/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarAction.cs
+++ b/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarAction.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Online.Matchmaking.Events
+{
+    /// <summary>
+    /// An action performed on a user's avatar in a matchmaking room.
+    /// </summary>
+    public enum MatchmakingAvatarAction
+    {
+    }
+}

--- a/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarAction.cs
+++ b/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarAction.cs
@@ -8,5 +8,6 @@ namespace osu.Game.Online.Matchmaking.Events
     /// </summary>
     public enum MatchmakingAvatarAction
     {
+        Jump
     }
 }

--- a/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarActionEvent.cs
+++ b/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarActionEvent.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+using osu.Game.Online.Multiplayer;
+
+namespace osu.Game.Online.Matchmaking.Events
+{
+    /// <summary>
+    /// An action performed by a user in a matchmaking room.
+    /// </summary>
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingAvatarActionEvent : MatchServerEvent
+    {
+        /// <summary>
+        /// The user performing the action.
+        /// </summary>
+        [Key(0)]
+        public int UserId { get; set; }
+
+        /// <summary>
+        /// The action.
+        /// </summary>
+        [Key(1)]
+        public MatchmakingAvatarAction Action { get; set; }
+    }
+}

--- a/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarActionRequest.cs
+++ b/osu.Game/Online/Matchmaking/Events/MatchmakingAvatarActionRequest.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+using osu.Game.Online.Multiplayer;
+
+namespace osu.Game.Online.Matchmaking.Events
+{
+    /// <summary>
+    /// Requests to perform an action on a user's avatar in a matchmaking room.
+    /// </summary>
+    [Serializable]
+    [MessagePackObject]
+    public class MatchmakingAvatarActionRequest : MatchUserRequest
+    {
+        /// <summary>
+        /// The action.
+        /// </summary>
+        [Key(0)]
+        public MatchmakingAvatarAction Action { get; set; }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchServerEvent.cs
+++ b/osu.Game/Online/Multiplayer/MatchServerEvent.cs
@@ -3,6 +3,7 @@
 
 using System;
 using MessagePack;
+using osu.Game.Online.Matchmaking.Events;
 using osu.Game.Online.Multiplayer.Countdown;
 
 namespace osu.Game.Online.Multiplayer
@@ -15,6 +16,7 @@ namespace osu.Game.Online.Multiplayer
     // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
     [Union(0, typeof(CountdownStartedEvent))]
     [Union(1, typeof(CountdownStoppedEvent))]
+    [Union(2, typeof(MatchmakingAvatarActionEvent))]
     public abstract class MatchServerEvent
     {
     }

--- a/osu.Game/Online/Multiplayer/MatchUserRequest.cs
+++ b/osu.Game/Online/Multiplayer/MatchUserRequest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using MessagePack;
+using osu.Game.Online.Matchmaking.Events;
 using osu.Game.Online.Multiplayer.Countdown;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 
@@ -17,6 +18,7 @@ namespace osu.Game.Online.Multiplayer
     [Union(0, typeof(ChangeTeamRequest))]
     [Union(1, typeof(StartMatchCountdownRequest))]
     [Union(2, typeof(StopCountdownRequest))]
+    [Union(3, typeof(MatchmakingAvatarActionRequest))]
     public abstract class MatchUserRequest
     {
     }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -117,6 +117,8 @@ namespace osu.Game.Online.Multiplayer
 
         public event Action<MultiplayerCountdown>? CountdownStopped;
 
+        public event Action<MatchServerEvent>? MatchEvent;
+
         public event Action<MultiplayerRoomUser, MultiplayerUserState>? UserStateChanged;
 
         public event Action? MatchmakingQueueJoined;
@@ -704,7 +706,7 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
-        public Task MatchEvent(MatchServerEvent e)
+        Task IMultiplayerClient.MatchEvent(MatchServerEvent e)
         {
             handleRoomRequest(() =>
             {
@@ -737,6 +739,7 @@ namespace osu.Game.Online.Multiplayer
                         break;
                 }
 
+                MatchEvent?.Invoke(e);
                 RoomUpdated?.Invoke();
             });
 

--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Game.Online.Matchmaking;
+using osu.Game.Online.Matchmaking.Events;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.Countdown;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
@@ -53,7 +54,9 @@ namespace osu.Game.Online
             (typeof(MatchmakingQueueStatus.MatchFound), typeof(MatchmakingQueueStatus)),
             (typeof(MatchmakingQueueStatus.JoiningMatch), typeof(MatchmakingQueueStatus)),
             (typeof(MatchmakingRoomState), typeof(MatchRoomState)),
-            (typeof(MatchmakingStageCountdown), typeof(MultiplayerCountdown))
+            (typeof(MatchmakingStageCountdown), typeof(MultiplayerCountdown)),
+            (typeof(MatchmakingAvatarActionRequest), typeof(MatchUserRequest)),
+            (typeof(MatchmakingAvatarActionEvent), typeof(MatchServerEvent)),
         };
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingChatDisplay.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Input;
+using osu.Game.Input.Bindings;
+using osu.Game.Online.Rooms;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Screens.OnlinePlay.Match.Components;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
+{
+    public partial class MatchmakingChatDisplay : MatchChatDisplay, IKeyBindingHandler<GlobalAction>
+    {
+        protected new ChatTextBox TextBox => base.TextBox!;
+
+        public MatchmakingChatDisplay(Room room, bool leaveChannelOnDispose = true)
+            : base(room, leaveChannelOnDispose)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(RealmKeyBindingStore keyBindingStore)
+        {
+            resetPlaceholderText();
+
+            TextBox.HoldFocus = false;
+            TextBox.ReleaseFocusOnCommit = true;
+            TextBox.Focus = () => TextBox.PlaceholderText = ChatStrings.InputPlaceholder;
+            TextBox.FocusLost = resetPlaceholderText;
+
+            void resetPlaceholderText() => TextBox.PlaceholderText = Localisation.ChatStrings.InGameInputPlaceholder(keyBindingStore.GetBindingsStringFor(GlobalAction.ToggleChatFocus));
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            switch (e.Action)
+            {
+                case GlobalAction.Back:
+                    if (TextBox.HasFocus)
+                    {
+                        Schedule(() => TextBox.KillFocus());
+                        return true;
+                    }
+
+                    break;
+
+                case GlobalAction.ToggleChatFocus:
+                    if (TextBox.HasFocus)
+                    {
+                        Schedule(() => TextBox.KillFocus());
+                    }
+                    else
+                    {
+                        Schedule(() => TextBox.TakeFocus());
+                    }
+
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -13,12 +13,14 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online;
+using osu.Game.Online.Matchmaking.Events;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -28,6 +30,7 @@ using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.Gameplay;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Users;
+using osuTK.Input;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 {
@@ -288,6 +291,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
                     beatmapDownloader.Download(beatmapSet);
                 }));
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            switch (e.Key)
+            {
+                case Key.Space:
+                    if (e.Repeat)
+                        return true;
+
+                    client.SendMatchRequest(new MatchmakingAvatarActionRequest { Action = MatchmakingAvatarAction.Jump }).FireAndForget();
+                    return true;
+            }
+
+            return false;
         }
 
         private bool exitConfirmed;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                                         Width = 700,
                                         Height = 130,
                                         Padding = new MarginPadding { Bottom = row_padding },
-                                        Child = chat = new MatchChatDisplay(new Room(room))
+                                        Child = chat = new MatchmakingChatDisplay(new Room(room))
                                         {
                                             RelativeSizeAxes = Axes.Both,
                                         }


### PR DESCRIPTION
## [Make quick play chat not hold focus](https://github.com/ppy/osu/commit/96c44fa32799b4a973d2ade9ab892bbdbc2a3d56)

This changes the chat to not hold focus, and act like the in-gameplay chat (`press {Enter} to chat`). Otherwise pressing space will input a whitespace into the chat.

I figure this will be required regardless if we want to add more actions to the avatars.

## [Add avatar action request/event models](https://github.com/ppy/osu/pull/35154/commits/3ebb72a20af1cf0ad65b7ca26beae54cc4844863)

This adds the models for server-side use and can be PR'd separately if requested. Using the regular match request/event structure seems to be enough.

## [Add ability to jump in quick play](https://github.com/ppy/osu/commit/bf5dcabbe5fd3d698f59aec7cd24880220286ac0)

This adds the jump ability. Whether this goes in is up to @peppy, and the commit can be dropped if requested.

https://github.com/user-attachments/assets/af90867a-ba18-49b6-adac-4024681f0ab5

The user panel masking is kind of unfortunate but maybe it doesn't look too bad... This component probably shouldn't inherit from `UserPanel`, but that would be a separate change.