### PR TITLE
Add half-height-of-selected-panel adjustment to carousel scroll target

### DIFF
--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -761,10 +761,10 @@ namespace osu.Game.Graphics.Carousel
                 updateItemYPosition(item, ref lastVisible, ref yPos);
 
                 if (CheckModelEquality(item.Model, currentKeyboardSelection.Model!))
-                    currentKeyboardSelection = new Selection(currentKeyboardSelection.Model, item, item.CarouselYPosition, i);
+                    currentKeyboardSelection = new Selection(currentKeyboardSelection.Model, item, item.CarouselYPosition + item.DrawHeight / 2, i);
 
                 if (CheckModelEquality(item.Model, currentSelection.Model!))
-                    currentSelection = new Selection(currentSelection.Model, item, item.CarouselYPosition, i);
+                    currentSelection = new Selection(currentSelection.Model, item, item.CarouselYPosition + item.DrawHeight / 2, i);
             }
 
             // Update the total height of all items (to make the scroll container scrollable through the full height even though


### PR DESCRIPTION
| | sets together | sets split apart |
| :-: | :-: | :-: |
| before | ![osu_2025-09-30_12-46-06](https://github.com/user-attachments/assets/3a70f417-7619-4e95-8160-6d47081263f8) | ![osu_2025-09-30_12-46-10](https://github.com/user-attachments/assets/174ba18e-fce5-4028-91cf-cdb09863fab6) |
| after | ![osu_2025-09-30_12-46-42](https://github.com/user-attachments/assets/3ae55ec9-2970-4cfc-a6d0-dc57b938418c) | ![osu_2025-09-30_12-46-47](https://github.com/user-attachments/assets/56967711-ae5e-483f-8c89-557f208fd9c0) |

---

Intended to address https://github.com/ppy/osu/issues/35147, maybe?

The old carousel would target the vertical center of the active panel when scrolling:

https://github.com/ppy/osu/blob/b9e1b6969e78dfa798bb4afed8afae55e9e4adb1/osu.Game/Screens/Select/BeatmapCarousel.cs#L948

This was not in place in the new carousel, weirdly, which was targeting the top-left corner of the selected panel.