### PR TITLE
Use consistent ordering of update button on carousel beatmap panels

### DIFF
--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -134,12 +134,6 @@ namespace osu.Game.Screens.SelectV2
                             Margin = new MarginPadding { Top = 4f },
                             Children = new Drawable[]
                             {
-                                updateButton = new PanelUpdateBeatmapButton
-                                {
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.CentreLeft,
-                                    Margin = new MarginPadding { Right = 5f, Top = -2f },
-                                },
                                 statusPill = new BeatmapSetOnlineStatusPill
                                 {
                                     Origin = Anchor.CentreLeft,
@@ -147,6 +141,12 @@ namespace osu.Game.Screens.SelectV2
                                     TextSize = OsuFont.Style.Caption2.Size,
                                     Margin = new MarginPadding { Right = 5f },
                                     Animated = false,
+                                },
+                                updateButton = new PanelUpdateBeatmapButton
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Margin = new MarginPadding { Right = 5f, Top = -2f },
                                 },
                                 difficultiesDisplay = new DifficultySpectrumDisplay
                                 {


### PR DESCRIPTION
| | set panel | standalone beatmap panel |
| :-: | :-: | :-: |
| before | <img alt="Screenshot 2025-10-01 at 13 43 59" src="https://github.com/user-attachments/assets/a5be5b5e-1d19-4b04-a4ff-a8a7be110efd" /> | <img alt="Screenshot 2025-10-01 at 13 44 13" src="https://github.com/user-attachments/assets/910d46f3-27c8-41b9-b16e-7688e5dcfda8" /> |
| after | <img alt="Screenshot 2025-10-01 at 13 44 43" src="https://github.com/user-attachments/assets/8dfd7d1f-954b-4054-abd9-2abef4665818" /> | <img alt="Screenshot 2025-10-01 at 13 44 48" src="https://github.com/user-attachments/assets/c917bc43-219f-4f99-abc9-a60876209d66" /> |

---

Closes https://github.com/ppy/osu/issues/34810.

The reason why I touched it in this direction and not the other is only because the standalone panel positioning of the button was touched last in 92ed9646277d14b469a7d8f18ad3ad78f613a8fb, thus I changed the set panel to match that.