### PR TITLE
Suppress warning about scores not being submitted on online maps with local changes

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -99,6 +99,8 @@ namespace osu.Game.Screens.Play
 
         public Action<bool> PrepareLoaderForRestart;
 
+        protected static bool IsQuickRestart { get; private set; }
+
         private bool isRestarting;
         private bool skipExitTransition;
 
@@ -754,6 +756,7 @@ namespace osu.Game.Screens.Play
                 return false;
 
             isRestarting = true;
+            IsQuickRestart = quickRestart;
 
             // at the point of restarting the track should either already be paused or the volume should be zero.
             // stopping here is to ensure music doesn't become audible after exiting back to PlayerLoader.
@@ -1139,6 +1142,9 @@ namespace osu.Game.Screens.Play
 
             StartGameplay();
             OnGameplayStarted?.Invoke();
+
+            if (!isRestarting)
+                IsQuickRestart = false;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -154,7 +154,8 @@ namespace osu.Game.Screens.Play
                                 break;
 
                             case @"invalid or missing beatmap_hash":
-                                Logger.Log($"This beatmap does not match the online version. Please update or redownload it.\n\n{whatWillHappen}", level: LogLevel.Important);
+                                if (!IsQuickRestart)
+                                    Logger.Log($"This beatmap does not match the online version. Please update or redownload it.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;
 
                             case @"expired token":


### PR DESCRIPTION
## Problem
Quick restarting on an online map with local changes spams the notification feed on every reload with the same message.

## Proposed Solution
Suppress the warning for quick restarts, but keep them for normal retries and loading the map from song select.

https://github.com/user-attachments/assets/6d1cf817-f1ed-470a-9d29-781bacca1366