### PR TITLE
Fix clicking the osu! logo when in the multiplayer submenu opening solo play instead

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -390,7 +390,7 @@ namespace osu.Game.Screens.Menu
                     return false;
 
                 case ButtonSystemState.Multi:
-                    buttonsPlay.First().TriggerClick();
+                    buttonsMulti.First().TriggerClick();
                     return false;
 
                 case ButtonSystemState.Edit:


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/c74f0a74-052a-44d8-a180-9ea0d8e4c8e4

After:

https://github.com/user-attachments/assets/d7d31cef-61f8-4b59-802f-4c6d7a1bbafd