### PR TITLE
Fix a few issues regarding incorrect treatment of locally-modified beatmaps

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -316,6 +316,26 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);
         }
 
+        [Test]
+        public void TestNoSubmissionOnLocallyModifiedBeatmapWithOnlineId()
+        {
+            prepareTestAPI(true);
+
+            createPlayerTest(false, r =>
+            {
+                var beatmap = createTestBeatmap(r);
+                beatmap.BeatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
+                return beatmap;
+            });
+
+            AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            addFakeHit();
+
+            AddStep("exit", () => Player.Exit());
+            AddAssert("ensure no submission", () => Player.SubmittedScore == null);
+        }
+
         [TestCase(null)]
         [TestCase(10)]
         public void TestNoSubmissionOnCustomRuleset(int? rulesetId)

--- a/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
+using osu.Game.Beatmaps;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
@@ -33,6 +34,9 @@ namespace osu.Game.Screens.Play
             int rulesetId = Ruleset.Value.OnlineID;
 
             if (beatmapId <= 0)
+                return null;
+
+            if (Beatmap.Value.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified)
                 return null;
 
             if (!Ruleset.Value.IsLegacyRuleset())

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -42,6 +42,9 @@ namespace osu.Game.Screens.Play
             if (beatmapId <= 0)
                 return null;
 
+            if (Beatmap.Value.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified)
+                return null;
+
             if (!Ruleset.Value.IsLegacyRuleset())
                 return null;
 

--- a/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
+++ b/osu.Game/Screens/SelectV2/RealmPopulatingOnlineLookupSource.cs
@@ -82,7 +82,9 @@ namespace osu.Game.Screens.SelectV2
                 // unfortunately in terms of subscriptions realm treats *every* write to any realm object as a modification,
                 // even if the write was redundant and had no observable effect.
 
-                if (dbBeatmapSet.Status != onlineBeatmapSet.Status)
+                // notably, `LocallyModified` status is preserved on the set until the user performs an explicit action to get rid of it
+                // (be it updating the set or deciding to discard their changes, removing the set and re-downloading it, etc.)
+                if (dbBeatmapSet.Status != onlineBeatmapSet.Status && dbBeatmapSet.Status != BeatmapOnlineStatus.LocallyModified)
                     dbBeatmapSet.Status = onlineBeatmapSet.Status;
 
                 foreach (var dbBeatmap in dbBeatmapSet.Beatmaps)


### PR DESCRIPTION
## [Do not overwrite "locally modified" beatmap set status when performing online lookups in song select](https://github.com/ppy/osu/commit/365cdfd40ec6710b0d588ccbbcc3004e32f682ca)

A relatively recent regression. It's maybe not a huge one, in that it probably doesn't matter all that much, but it is somewhat important to keep the "locally modified" status of the set for as long as possible.

One reason for that is that keeping the "locally modified" status will pull up a dialog when the user attempts to update the beatmap, warning them that they will lose their local changes - this dialog will not show if the online lookup flow is allowed to overwrite the map status with something else.

## [Do not attempt to retrieve score submission tokens for locally-modified beatmaps](https://github.com/ppy/osu/commit/2a85f7b7c8cd850cc81d364c137077d6e73ce013)

Because it is 99% sure that doing so will fail and spam the user with "this beatmap doesn't match the online version" notifications, and because the map status is "locally modified", they should be pretty aware of that already. This fixes the primary mode of the failure that https://github.com/ppy/osu/pull/35173 was attempting to hack around.

This will have regressed somewhere around the time that BSS went live, because at that point [the editor stopped resetting online IDs for beatmaps that got locally modified](https://github.com/ppy/osu/pull/31747), making the `beatmapId <= 0` guards no longer prevent attempts of submission.