### PR TITLE
Fix missing tiny droplets not changing catcher animation state to fail

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestTinyDropletMissPreservesCatcherState()
+        public void TestTinyDropletMissChangesCatcherState()
         {
             AddStep("catch hyper kiai fruit", () => attemptCatch(new TestKiaiFruit
             {
@@ -165,8 +165,8 @@ namespace osu.Game.Rulesets.Catch.Tests
             }));
             AddStep("catch tiny droplet", () => attemptCatch(new TinyDroplet()));
             AddStep("miss tiny droplet", () => attemptCatch(new TinyDroplet { X = 100 }));
-            // catcher state and hyper dash state is preserved
-            checkState(CatcherAnimationState.Kiai);
+            // catcher state is changed but hyper dash state is preserved
+            checkState(CatcherAnimationState.Fail);
             checkHyperDash(true);
         }
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -224,7 +224,20 @@ namespace osu.Game.Rulesets.Catch.UI
                     addLighting(result, drawableObject.AccentColour.Value, positionInStack.X);
             }
 
-            // droplet doesn't affect the catcher state
+            if (result.IsHit)
+                CurrentState = hitObject.Kiai ? CatcherAnimationState.Kiai : CatcherAnimationState.Idle;
+            else if (hitObject is not Banana)
+                CurrentState = CatcherAnimationState.Fail;
+
+            if (palpableObject.HitObject.LastInCombo)
+            {
+                if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
+                    Explode();
+                else
+                    Drop();
+            }
+
+            // droplet doesn't affect hyperdash state
             if (hitObject is TinyDroplet) return;
 
             // if a hyper fruit was already handled this frame, just go where it says to go.
@@ -243,19 +256,6 @@ namespace osu.Game.Rulesets.Catch.UI
                 }
                 else
                     SetHyperDashState();
-            }
-
-            if (result.IsHit)
-                CurrentState = hitObject.Kiai ? CatcherAnimationState.Kiai : CatcherAnimationState.Idle;
-            else if (!(hitObject is Banana))
-                CurrentState = CatcherAnimationState.Fail;
-
-            if (palpableObject.HitObject.LastInCombo)
-            {
-                if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
-                    Explode();
-                else
-                    Drop();
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/35182.

The source as it is would have you believe that this is correct and intentional but I'm not so sure about that. For one thing, I cross-checked stable, and sure, missing tiny droplets does change the state to fail over there. For another, the guard in master at

https://github.com/ppy/osu/blob/5e642cbce72862b29b117829e7ec90d6d6b0ce1e/osu.Game.Rulesets.Catch/UI/Catcher.cs#L250

is very suspicious, given that it is dead in cause of tiny droplets because of a preceding guard:

https://github.com/ppy/osu/blob/5e642cbce72862b29b117829e7ec90d6d6b0ce1e/osu.Game.Rulesets.Catch/UI/Catcher.cs#L227-L228

Looking into blame, the tiny droplet guard originates at https://github.com/ppy/osu/commit/e7f1f0f38b50946a147828699265e35c6ad9ccaa, wherein it looks to have been aimed at handling *hyperdash* state specifically. Later, the logic has been moved around and around like five times; at https://github.com/ppy/osu/commit/7069cef9ce6a92cfddf6cb8a25d2cb2dbf48e9b8, the catcher animation logic was added *below* the hyperdash-aimed guard without the comment being updated in any way; https://github.com/ppy/osu/commit/5a5c956cedfda99b3280c9d7bb7933f267fea821 moved the logic from `CatcherArea` to `Catcher`, while simultaneously changing the inline comment to no longer mention hyperdashing; and finally, https://github.com/ppy/osu/commit/1d669cf65ed5c9ee5e398a3cac7e5bc386b5f49a added specific testing of tiny droplets not changing catcher animation state, which I wager to be back-engineered from the implementation as-it-was rather than supported by any actual ground truth.

For additional reference:

- [catcher animation logic in stable](https://github.com/peppy/osu-stable-reference/blob/67795dba3c308e7d0493b296149dcb073ca47ecb/osu!/GameModes/Play/Rulesets/Fruits/RulesetFruits.cs#L411-L463)
- [hyperdash application logic in stable](https://github.com/peppy/osu-stable-reference/blob/67795dba3c308e7d0493b296149dcb073ca47ecb/osu!/GameModes/Play/Rulesets/Fruits/RulesetFruits.cs#L165-L171)