### PR TITLE
Add osu!stream skin

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -130,6 +130,7 @@ namespace osu.Game.Overlays.Settings.Sections
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.ARGON_PRO_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.TRIANGLES_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.CLASSIC_SKIN).ToLive(realm));
+            dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.STREAM_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.RETRO_SKIN).ToLive(realm));
 
             dropdownItems.Add(random_skin_info);

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Skinning
         internal static readonly Guid ARGON_PRO_SKIN = new Guid("9FC9CF5D-0F16-4C71-8256-98868321AC43");
         internal static readonly Guid CLASSIC_SKIN = new Guid("81F02CD3-EEC6-4865-AC23-FAE26A386187");
         internal static readonly Guid RETRO_SKIN = new Guid("0555C76A-CC6B-4BB4-9548-DF76BA72EF25");
+        internal static readonly Guid STREAM_SKIN = new Guid("E8D8675A-CD82-4E34-84FA-2FD7AE0C270C");
         internal static readonly Guid RANDOM_SKIN = new Guid("D39DFEFB-477C-4372-B1EA-2BCEA5FB8908");
 
         [PrimaryKey]

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -66,6 +66,8 @@ namespace osu.Game.Skinning
 
         private Skin retroSkin { get; }
 
+        private Skin streamSkin { get; }
+
         public override bool PauseImports
         {
             get => base.PauseImports;
@@ -94,6 +96,7 @@ namespace osu.Game.Skinning
             var defaultSkins = new[]
             {
                 retroSkin = new RetroSkin(this),
+                streamSkin = new StreamSkin(this),
                 DefaultClassicSkin = new DefaultLegacySkin(this),
                 trianglesSkin = new TrianglesSkin(this),
                 argonSkin = new ArgonSkin(this),
@@ -375,6 +378,9 @@ namespace osu.Game.Skinning
 
                 if (guid == SkinInfo.RETRO_SKIN)
                     skinInfo = retroSkin.SkinInfo;
+
+                if (guid == SkinInfo.STREAM_SKIN)
+                    skinInfo = streamSkin.SkinInfo;
             }
 
             CurrentSkinInfo.Value = skinInfo ?? trianglesSkin.SkinInfo;

--- a/osu.Game/Skinning/StreamSkin.cs
+++ b/osu.Game/Skinning/StreamSkin.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using JetBrains.Annotations;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Game.Extensions;
+using osu.Game.IO;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// The skin from osu!stream.
+    /// </summary>
+    /// <remarks>
+    /// The assets were taken from the osu!stream github repo https://github.com/ppy/osu-stream
+    /// </remarks>
+    public class StreamSkin : LegacySkin
+    {
+        public static SkinInfo CreateInfo() => new SkinInfo
+        {
+            ID = Skinning.SkinInfo.STREAM_SKIN,
+            Name = "osu! \"stream\" (2011)",
+            Creator = "team osu!",
+            Protected = true,
+            InstantiationInfo = typeof(StreamSkin).GetInvariantInstantiationInfo(),
+        };
+
+        public StreamSkin(IStorageResourceProvider resources)
+            : this(CreateInfo(), resources)
+        {
+        }
+
+        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
+        public StreamSkin(SkinInfo skin, IStorageResourceProvider resources)
+            : base(
+                skin,
+                resources,
+                new NamespacedResourceStore<byte[]>(resources.Resources, "Skins/Stream")
+            )
+        {
+        }
+
+        public override Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
+        {
+            return base.GetTexture(componentName, wrapModeS, wrapModeT);
+        }
+    }
+}

--- a/osu.Game/Skinning/StreamSkin.cs
+++ b/osu.Game/Skinning/StreamSkin.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using JetBrains.Annotations;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Game.Extensions;
 using osu.Game.IO;
@@ -14,7 +12,7 @@ namespace osu.Game.Skinning
     /// The skin from osu!stream.
     /// </summary>
     /// <remarks>
-    /// The assets were taken from the osu!stream github repo https://github.com/ppy/osu-stream
+    /// The assets were taken from the osu!stream GitHub repository: https://github.com/ppy/osu-stream/tree/master/Artwork, https://github.com/ppy/osu-stream/tree/master/osu!stream/Skins/Default
     /// </remarks>
     public class StreamSkin : LegacySkin
     {

--- a/osu.Game/Skinning/StreamSkin.cs
+++ b/osu.Game/Skinning/StreamSkin.cs
@@ -41,10 +41,5 @@ namespace osu.Game.Skinning
             )
         {
         }
-
-        public override Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
-        {
-            return base.GetTexture(componentName, wrapModeS, wrapModeT);
-        }
     }
 }


### PR DESCRIPTION
This PR adds the osu!stream skin to osu!lazer.

It requires the following PR on `osu-resources`: https://github.com/ppy/osu-resources/pull/389

Some images required re-exporting in 2x from the .psd files in order to look good on high quality displays but all other files are from https://github.com/ppy/osu-stream

Created a [feature request](https://github.com/ppy/osu/discussions/23356) 2 years ago but never got around to actually doing it. Saw that the 2008 skin was added so I decided to try and make it