### PR TITLE
Adjust display tag threshold to match web

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneUserTagControl.cs
@@ -71,9 +71,9 @@ namespace osu.Game.Tests.Visual.Ranking
                             var beatmapSet = CreateAPIBeatmapSet(Beatmap.Value.BeatmapInfo);
                             beatmapSet.Beatmaps.Single().TopTags =
                             [
-                                new APIBeatmapTag { TagId = 3, VoteCount = 9 },
-                                new APIBeatmapTag { TagId = 2, VoteCount = 8 },
-                                new APIBeatmapTag { TagId = 0, VoteCount = 7 },
+                                new APIBeatmapTag { TagId = 3, VoteCount = 4 },
+                                new APIBeatmapTag { TagId = 2, VoteCount = 3 },
+                                new APIBeatmapTag { TagId = 0, VoteCount = 2 },
                             ];
                             Scheduler.AddDelayed(() => getBeatmapSetRequest.TriggerSuccess(beatmapSet), 500);
                             return true;
@@ -155,14 +155,14 @@ namespace osu.Game.Tests.Visual.Ranking
                 InputManager.MoveMouseTo(getDrawableTagById(2));
                 InputManager.Click(MouseButton.Left);
             });
-            AddUntilStep("tag 2 voted for", () => getDrawableTagById(2).UserTag.VoteCount.Value, () => Is.EqualTo(9));
+            AddUntilStep("tag 2 voted for", () => getDrawableTagById(2).UserTag.VoteCount.Value, () => Is.EqualTo(4));
 
             AddStep("remove vote for tag 2", () =>
             {
                 InputManager.MoveMouseTo(getDrawableTagById(2));
                 InputManager.Click(MouseButton.Left);
             });
-            AddUntilStep("tag 2 not voted for", () => getDrawableTagById(2).UserTag.VoteCount.Value, () => Is.EqualTo(8));
+            AddUntilStep("tag 2 not voted for", () => getDrawableTagById(2).UserTag.VoteCount.Value, () => Is.EqualTo(3));
             AddAssert("tag 2 is still second", () => getTagFlow().GetLayoutPosition(getDrawableTagById(2)), () => Is.EqualTo(1));
 
             AddStep("vote for tag 2", () =>
@@ -170,7 +170,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 InputManager.MoveMouseTo(getDrawableTagById(2));
                 InputManager.Click(MouseButton.Left);
             });
-            AddUntilStep("tag 2 voted for", () => getDrawableTagById(2).UserTag.VoteCount.Value, () => Is.EqualTo(9));
+            AddUntilStep("tag 2 voted for", () => getDrawableTagById(2).UserTag.VoteCount.Value, () => Is.EqualTo(4));
             AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
             AddAssert("tag 2 reordered to first", () => getTagFlow().GetLayoutPosition(getDrawableTagById(2)), () => Is.EqualTo(0));
 

--- a/osu.Game/Screens/Ranking/UserTagControl.DrawableUserTag.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.DrawableUserTag.cs
@@ -20,6 +20,12 @@ namespace osu.Game.Screens.Ranking
     {
         public partial class DrawableUserTag : OsuAnimatedButton
         {
+            /// <summary>
+            /// Minimum count of votes required to display a tag on the beatmap's page.
+            /// Should match value specified web-side as https://github.com/ppy/osu-web/blob/cae2fdf03cfb8c30c8e332cfb142e03188ceffef/config/osu.php#L59.
+            /// </summary>
+            public const int MIN_VOTES_DISPLAY = 5;
+
             public readonly UserTag UserTag;
 
             public Action<UserTag>? OnSelected { get; set; }
@@ -154,7 +160,7 @@ namespace osu.Game.Screens.Ranking
                 {
                     voteCount.BindValueChanged(_ =>
                     {
-                        confirmed.Value = voteCount.Value >= 10;
+                        confirmed.Value = voteCount.Value >= MIN_VOTES_DISPLAY;
                     }, true);
                     voted.BindValueChanged(v =>
                     {


### PR DESCRIPTION
Follow-up to https://github.com/ppy/osu-web/pull/12381 - tags will glow green starting from 5 votes rather than 10 to match the new threshold web-side.