### PR TITLE
Fix current beatmap set being incorrectly expanded after collapsing group with current selection

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -283,5 +283,18 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             CheckHasSelection();
         }
+
+        [Test]
+        public void TestManuallyCollapsingCurrentGroupAndOpeningAnother()
+        {
+            SelectNextSet();
+            ToggleGroupCollapse();
+            SelectNextGroup();
+            AddUntilStep("no beatmap panels visible", () => GetVisiblePanels<PanelBeatmap>().Count(), () => Is.Zero);
+
+            SelectNextSet();
+            SelectNextSet();
+            AddUntilStep("no beatmap panels visible", () => GetVisiblePanels<PanelBeatmap>().Count(), () => Is.Zero);
+        }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -371,7 +371,7 @@ namespace osu.Game.Screens.SelectV2
 
                         if (userCollapsedGroup)
                         {
-                            if (grouping.BeatmapSetsGroupedTogether && CurrentGroupedBeatmap != null)
+                            if (grouping.BeatmapSetsGroupedTogether && CurrentGroupedBeatmap != null && CheckModelEquality(group, CurrentGroupedBeatmap.Group))
                                 setExpandedSet(new GroupedBeatmapSet(CurrentGroupedBeatmap.Group, CurrentGroupedBeatmap.Beatmap.BeatmapSet!));
                             userCollapsedGroup = false;
                         }


### PR DESCRIPTION
Noticed in passing. See preceding commit for failure scenario.

Regressed in https://github.com/ppy/osu/pull/35163.