### PR TITLE
Fix song select V2 not preserving selection after an update operation

### DIFF
--- a/osu.Game/Database/RealmDetachedBeatmapStore.cs
+++ b/osu.Game/Database/RealmDetachedBeatmapStore.cs
@@ -82,6 +82,34 @@ namespace osu.Game.Database
                 return;
             }
 
+            if (changes.InsertedIndices.Length == 1 && changes.DeletedIndices.Length == 1)
+            {
+                lock (detachedBeatmapSets)
+                {
+                    var deletedSet = detachedBeatmapSets[changes.DeletedIndices[0]];
+                    var insertedSet = sender[changes.InsertedIndices[0]];
+
+                    // this handles beatmap updates using a heuristic that a beatmap update will preserve the online ID.
+                    // it relies on the fact that updates are performed by removing the old set and adding a new one, in a single transaction.
+                    // instead of removing the old set and adding a new one to the collection too, which would trigger consumers' logic related to set removals,
+                    // move the deleted set to the index occupied by the new one and then replace it in-place.
+                    // due to this, the operation can be presented to consumer in a manner that permits them to actually handle this as a replace operation
+                    // and not trigger any set removal logic that may result in selections changing or similar undesirable side effects.
+                    if (deletedSet.OnlineID == insertedSet.OnlineID)
+                    {
+                        pendingOperations.Enqueue(new OperationArgs
+                        {
+                            Type = OperationType.MoveAndReplace,
+                            BeatmapSet = insertedSet.Detach(),
+                            Index = changes.DeletedIndices[0],
+                            NewIndex = changes.InsertedIndices[0],
+                        });
+
+                        return;
+                    }
+                }
+            }
+
             foreach (int i in changes.DeletedIndices.OrderDescending())
             {
                 pendingOperations.Enqueue(new OperationArgs
@@ -138,6 +166,11 @@ namespace osu.Game.Database
                             detachedBeatmapSets.ReplaceRange(op.Index, 1, new[] { op.BeatmapSet! });
                             break;
 
+                        case OperationType.MoveAndReplace:
+                            detachedBeatmapSets.Move(op.Index, op.NewIndex!.Value);
+                            detachedBeatmapSets.ReplaceRange(op.NewIndex!.Value, 1, [op.BeatmapSet!]);
+                            break;
+
                         case OperationType.Remove:
                             detachedBeatmapSets.RemoveAt(op.Index);
                             break;
@@ -160,13 +193,15 @@ namespace osu.Game.Database
             public OperationType Type;
             public BeatmapSetInfo? BeatmapSet;
             public int Index;
+            public int? NewIndex;
         }
 
         private enum OperationType
         {
             Insert,
             Update,
-            Remove
+            Remove,
+            MoveAndReplace,
         }
     }
 }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -237,26 +237,29 @@ namespace osu.Game.Screens.Select
 
         private void beatmapSetsChanged(object? beatmaps, NotifyCollectionChangedEventArgs changed)
         {
+            IEnumerable<BeatmapSetInfo>? oldBeatmapSets = changed.OldItems?.Cast<BeatmapSetInfo>();
+            HashSet<Guid> oldBeatmapSetIDs = oldBeatmapSets?.Select(s => s.ID).ToHashSet() ?? [];
+
             IEnumerable<BeatmapSetInfo>? newBeatmapSets = changed.NewItems?.Cast<BeatmapSetInfo>();
+            HashSet<Guid> newBeatmapSetIDs = newBeatmapSets?.Select(s => s.ID).ToHashSet() ?? [];
 
             switch (changed.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    HashSet<Guid> newBeatmapSetIDs = newBeatmapSets!.Select(s => s.ID).ToHashSet();
-
                     setsRequiringRemoval.RemoveWhere(s => newBeatmapSetIDs.Contains(s.ID));
                     setsRequiringUpdate.AddRange(newBeatmapSets!);
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
-                    IEnumerable<BeatmapSetInfo> oldBeatmapSets = changed.OldItems!.Cast<BeatmapSetInfo>();
-                    HashSet<Guid> oldBeatmapSetIDs = oldBeatmapSets.Select(s => s.ID).ToHashSet();
-
                     setsRequiringUpdate.RemoveWhere(s => oldBeatmapSetIDs.Contains(s.ID));
-                    setsRequiringRemoval.AddRange(oldBeatmapSets);
+                    setsRequiringRemoval.AddRange(oldBeatmapSets!);
                     break;
 
                 case NotifyCollectionChangedAction.Replace:
+                    setsRequiringUpdate.RemoveWhere(s => oldBeatmapSetIDs.Contains(s.ID));
+                    setsRequiringRemoval.AddRange(oldBeatmapSets!);
+
+                    setsRequiringRemoval.RemoveWhere(s => newBeatmapSetIDs.Contains(s.ID));
                     setsRequiringUpdate.AddRange(newBeatmapSets!);
                     break;
 


### PR DESCRIPTION
Because the detached store exists and has a chance to actually semi-reliably intercept a beatmap update operation, I decided to try this. It still uses a bit of a heuristic in that it checks for transactions that delete and insert one beatmap each, but probably the best effort thus far?

Notably old song select that was already doing the same thing locally to itself got a bit broken by this, but with some tweaking that *looks* to be more or less harmless I managed to get it unbroken. I'm not too concerned about old song select, mind, mostly just want to keep it *vaguely* working if I can help it.

As outlined in https://github.com/ppy/osu/issues/33341#issuecomment-3360464100, I'm not too happy with this approach, but I did try to revive my first approach again today and didn't get too much further into it than I did last time. There just seemed to be too many layers failing there and that would need trudging on through to make sense.