### PR TITLE
Fix carousel sometimes crashing when attempting to select next random set

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -1012,13 +1012,13 @@ namespace osu.Game.Screens.SelectV2
 
         private bool nextRandomSet()
         {
-            ICollection<GroupedBeatmapSet> visibleGroupedSets = ExpandedGroup != null
+            ICollection<GroupedBeatmapSet> visibleGroupedSets = ExpandedGroup != null && grouping.GroupItems.TryGetValue(ExpandedGroup, out var groupItems)
                 // In the case of grouping, users expect random to only operate on the expanded group.
                 // This is going to incur some overhead as we don't have a group-beatmapset mapping currently.
                 //
                 // If this becomes an issue, we could either store a mapping, or run the random algorithm many times
                 // using the `SetItems` method until we get a group HIT.
-                ? grouping.GroupItems[ExpandedGroup].Select(i => i.Model).OfType<GroupedBeatmapSet>().ToArray()
+                ? groupItems.Select(i => i.Model).OfType<GroupedBeatmapSet>().ToArray()
                 // This is the fastest way to retrieve sets for randomisation.
                 : grouping.SetItems.Keys;
 


### PR DESCRIPTION
I'm not exactly sure on the reproduction scenario here, but I have had switching ruleset with converts disabled hard-crash on me a few times today. It appears to happen sometimes when after the switch the expanded group no longer exists in the set mapping, because a filter just ran and removed that group from set of possible groups because there'd be no beatmaps under it.

I tried to manufacture a quick test but it's not a quick one to test because filtering intereference is required to reproduce, I think. I will try again on request but I mostly just want to get this fix out ASAP before I finish up for the day.