### PR TITLE
Removed some interruptions when shift-clicking a Beatmap Card to download/present it.

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -16,6 +16,7 @@ using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Localisation;
+using osuTK;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
@@ -67,6 +68,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             AddInternal(DownloadTracker);
         }
 
+        private bool shiftActivated => containingInputManager?.CurrentState.Keyboard.ShiftPressed == true;
+
+        protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => base.ReceivePositionalInputAtSubTree(screenSpacePos) && !shiftActivated;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -79,7 +84,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
             Action = () =>
             {
-                if (containingInputManager?.CurrentState.Keyboard.ShiftPressed == true)
+                if (shiftActivated)
                 {
                     switch (DownloadTracker.State.Value)
                     {

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
@@ -104,6 +104,14 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             updateState();
         }
 
+        protected override bool OnClick(ClickEvent e)
+        {
+            if (e.ShiftPressed)
+                return false;
+
+            return base.OnClick(e);
+        }
+
         private void updateState()
         {
             bool isHovered = IsHovered && Enabled.Value;

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
@@ -104,13 +104,13 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             updateState();
         }
 
-        protected override bool OnClick(ClickEvent e)
-        {
-            if (e.ShiftPressed)
-                return false;
+        // protected override bool OnClick(ClickEvent e)
+        // {
+        //     if (e.ShiftPressed)
+        //         return false;
 
-            return base.OnClick(e);
-        }
+        //     return base.OnClick(e);
+        // }
 
         private void updateState()
         {

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -85,6 +86,14 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                 progress.Value = previewTrack.CurrentTime / previewTrack.Length;
             else
                 progress.Value = 0;
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            if (e.ShiftPressed)
+                return false;
+
+            return base.OnClick(e);
         }
 
         private void updateState(ValueChangedEvent<bool> playing)

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -88,13 +88,13 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                 progress.Value = 0;
         }
 
-        protected override bool OnClick(ClickEvent e)
-        {
-            if (e.ShiftPressed)
-                return false;
+        // protected override bool OnClick(ClickEvent e)
+        // {
+        //     if (e.ShiftPressed)
+        //         return false;
 
-            return base.OnClick(e);
-        }
+        //     return base.OnClick(e);
+        // }
 
         private void updateState(ValueChangedEvent<bool> playing)
         {


### PR DESCRIPTION
Partially resolves: #35097 

Shift-clicking the play button or favorite button, no longer stops the event from propagating, and will not run the action associated with the button, allowing `BeatmapCard` to download/present the beatmap.