### PR TITLE
Fixed interruptions when shift-clicking a Beatmap Card to download/present it.

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -16,6 +16,7 @@ using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Localisation;
+using osuTK;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
@@ -81,9 +82,13 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 throw new InvalidOperationException($"An action should be assigned to this {nameof(BeatmapCard)}. To use the default, assign {nameof(DefaultAction)}.");
         }
 
+        private bool shiftActivated => containingInputManager?.CurrentState.Keyboard.ShiftPressed == true;
+
+        protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => base.ReceivePositionalInputAtSubTree(screenSpacePos) && !shiftActivated;
+
         protected void DefaultAction()
         {
-            if (containingInputManager?.CurrentState.Keyboard.ShiftPressed == true)
+            if (shiftActivated)
             {
                 switch (DownloadTracker.State.Value)
                 {


### PR DESCRIPTION
Resolves: #35097 

Overrode `ReceivePositionalInputAtSubTree` in `BeatmapCard` making it not propagate input to sub-tree when shift is held.

<sub>Using `PropagatePositionalInputSubTree` will not send positional input to `BeatmapCard` when false, that's why I used `ReceivePositionalInputAtSubTree`.</sub>