### PR TITLE
Adjust extended OD limits for mania difficulty change mod to reflect HR and EZ values

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
@@ -12,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             Precision = 0.1f,
             MinValue = 0,
             MaxValue = 10,
+            // Use larger extended limits for mania to include OD values that occur with EZ or HR enabled
             ExtendedMaxValue = 15,
             ExtendedMinValue = -15,
             ReadCurrentFromDifficulty = diff => diff.OverallDifficulty,

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Rulesets.Mania.Mods
             Precision = 0.1f,
             MinValue = 0,
             MaxValue = 10,
-            ExtendedMaxValue = 13.61f,
-            ExtendedMinValue = -14.93f,
+            ExtendedMaxValue = 15,
+            ExtendedMinValue = -15,
             ReadCurrentFromDifficulty = diff => diff.OverallDifficulty,
         };
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
@@ -7,5 +7,14 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModDifficultyAdjust : ModDifficultyAdjust
     {
+        public override DifficultyBindable OverallDifficulty { get; } = new DifficultyBindable
+        {
+            Precision = 0.1f,
+            MinValue = 0,
+            MaxValue = 10,
+            ExtendedMaxValue = 13.61f,
+            ExtendedMinValue = -14.93f,
+            ReadCurrentFromDifficulty = diff => diff.OverallDifficulty,
+        };
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Mods
         };
 
         [SettingSource("Accuracy", "Override a beatmap's set OD.", LAST_SETTING_ORDER, SettingControlType = typeof(DifficultyAdjustSettingsControl))]
-        public DifficultyBindable OverallDifficulty { get; } = new DifficultyBindable
+        public virtual DifficultyBindable OverallDifficulty { get; } = new DifficultyBindable
         {
             Precision = 0.1f,
             MinValue = 0,


### PR DESCRIPTION
Resolves #35186 

This change sets the OD bindable in ModDifficultyAdjust to virtual and the mania specific difficulty adjust mod is changed to override the bindable and set extended OD limits to their EZ minimum and HR maximum. 

<img width="431" height="246" alt="image" src="https://github.com/user-attachments/assets/62acd83d-cf3f-4e12-a2d4-4ce3bcace09b" />
<img width="488" height="264" alt="image" src="https://github.com/user-attachments/assets/748996a3-5d84-4240-b28f-d2e36b4694cf" />
