### PR TITLE
Fix test failures during individual runs

### DIFF
--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -32,9 +32,6 @@ namespace osu.Game.Tests.Visual.OnlinePlay
 
         protected override Container<Drawable> Content => content;
 
-        [Resolved]
-        private RulesetStore rulesets { get; set; } = null!;
-
         private readonly Container content;
         private readonly Container drawableDependenciesContainer;
         private DelegatedDependencyContainer dependencies = null!;
@@ -100,7 +97,11 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             Room[] rooms = new Room[count];
 
             // Can't reference Osu ruleset project here.
-            ruleset ??= rulesets.GetRuleset(0)!;
+            if (ruleset == null)
+            {
+                using var assemblyRulesetStore = new AssemblyRulesetStore();
+                ruleset = assemblyRulesetStore.GetRuleset(0)!;
+            }
 
             for (int i = 0; i < count; i++)
             {


### PR DESCRIPTION
Running `TestSceneMultiplayerLoungeSubScreen.TestPopoverHidesOnBackButton` individually fails with:

```
System.NullReferenceException : Object reference not set to an instance of an object.
```

This is because it uses the method inside the test invocation prior to DI members being resolved, rather than inside a step. There's a few tests that do this, but I think the most sane method is to use `AssemblyRulesetStore`?