### PR TITLE
Fix wrong beatmap shown when presenting a beatmap from results screen

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
@@ -277,7 +277,7 @@ namespace osu.Game.Tests.Visual.Navigation
         /// <summary>
         /// Note: This test was written to demonstrate the failure described at https://github.com/ppy/osu/issues/35023,
         /// but because the failure scenario there entailed a race condition, it was possible for the test to pass regardless
-        /// unless <see cref="SongSelect.SELECTION_DEBOUNCE"/> was increased.
+        /// unless <see cref="osu.Game.Screens.SelectV2.SongSelect.SELECTION_DEBOUNCE"/> was increased.
         /// </summary>
         [Test]
         public void TestPresentFromResults()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSongSelectNavigation.cs
@@ -10,10 +10,12 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens;
@@ -24,6 +26,7 @@ using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Beatmaps.IO;
+using osu.Game.Tests.Resources;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Navigation
@@ -269,6 +272,33 @@ namespace osu.Game.Tests.Visual.Navigation
             PushAndConfirm(() => new SoloSongSelect());
 
             AddUntilStep("selected beatmap is still osu! ruleset", () => Game.Beatmap.Value.BeatmapInfo, () => Is.EqualTo(selectedBeatmap));
+        }
+
+        /// <summary>
+        /// Note: This test was written to demonstrate the failure described at https://github.com/ppy/osu/issues/35023,
+        /// but because the failure scenario there entailed a race condition, it was possible for the test to pass regardless
+        /// unless <see cref="SongSelect.SELECTION_DEBOUNCE"/> was increased.
+        /// </summary>
+        [Test]
+        public void TestPresentFromResults()
+        {
+            BeatmapSetInfo beatmapToPresent = null!;
+            BeatmapSetInfo beatmapToPlay = null!;
+            AddStep("manually insert beatmap to be presented", () =>
+            {
+                Game.Realm.Write(r =>
+                {
+                    var beatmapSet = TestResources.CreateTestBeatmapSetInfo(3, [r.Find<RulesetInfo>("osu")]);
+                    r.Add(beatmapSet);
+                    beatmapToPresent = beatmapSet.Detach();
+                });
+            });
+            AddStep("import beatmap", () => beatmapToPlay = BeatmapImportHelper.LoadQuickOszIntoOsu(Game).GetResultSafely());
+            AddStep("set global beatmap", () => Game.Beatmap.Value = Game.BeatmapManager.GetWorkingBeatmap(beatmapToPlay.Beatmaps.First()));
+            playToResults();
+            AddStep("present beatmap from results", () => Game.PresentBeatmap(beatmapToPresent));
+            AddUntilStep("back at song select", () => Game.ScreenStack.CurrentScreen is SoloSongSelect);
+            AddUntilStep("presented beatmap is current", () => Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapToPresent));
         }
 
         private Func<Player> playToResults()

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -43,6 +43,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Volume;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Footer;
@@ -63,7 +64,7 @@ namespace osu.Game.Screens.SelectV2
     /// This will be gradually built upon and ultimately replace <see cref="Select.SongSelect"/> once everything is in place.
     /// </summary>
     [Cached(typeof(ISongSelect))]
-    public abstract partial class SongSelect : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, ISongSelect
+    public abstract partial class SongSelect : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, ISongSelect, IHandlePresentBeatmap
     {
         /// <summary>
         /// A debounce that governs how long after a panel is selected before the rest of song select (and the game at large)
@@ -1119,6 +1120,36 @@ namespace osu.Game.Screens.SelectV2
             Debug.Assert(Ruleset.Value.Equals(score.Ruleset));
 
             this.Push(new SoloResultsScreen(score));
+        }
+
+        #endregion
+
+        #region IHandlePresentBeatmap
+
+        void IHandlePresentBeatmap.PresentBeatmap(WorkingBeatmap workingBeatmap, RulesetInfo ruleset)
+        {
+            cancelDebounceSelection();
+
+            var beatmapInfo = workingBeatmap.BeatmapInfo;
+
+            // Don't change the local ruleset if the user is on another ruleset and is showing converted beatmaps.
+            // Eventually we probably want to check whether conversion is actually possible for the current ruleset.
+            bool requiresRulesetSwitch = !beatmapInfo.Ruleset.Equals(Ruleset.Value)
+                                         && (beatmapInfo.Ruleset.OnlineID > 0 || !showConvertedBeatmaps.Value);
+
+            if (requiresRulesetSwitch)
+            {
+                Ruleset.Value = beatmapInfo.Ruleset;
+                Beatmap.Value = workingBeatmap;
+
+                Logger.Log($"Completing {nameof(IHandlePresentBeatmap.PresentBeatmap)} with beatmap {workingBeatmap} ruleset {beatmapInfo.Ruleset}");
+            }
+            else
+            {
+                Beatmap.Value = workingBeatmap;
+
+                Logger.Log($"Completing {nameof(IHandlePresentBeatmap.PresentBeatmap)} with beatmap {workingBeatmap} (maintaining ruleset)");
+            }
         }
 
         #endregion


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/35023.
- Supersedes / closes https://github.com/ppy/osu/pull/35107.

Recommend increasing `SongSelect.SELECTION_DEBOUNCE` to like 300 when checking out the test. The test *can* fail with the default value, but generally it doesn't.