### PR TITLE
Fix default origin in skin editor when rotating multiple objects

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinSelectionRotationHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionRotationHandler.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             foreach (var drawableItem in objectsInRotation)
             {
-                var rotatedPosition = GeometryUtils.RotatePointAroundOrigin(originalPositions[drawableItem], actualOrigin, rotation);
+                var rotatedPosition = GeometryUtils.RotatePointAroundOrigin(originalPositions[drawableItem], ToScreenSpace(actualOrigin), rotation);
                 UpdatePosition(drawableItem, rotatedPosition);
 
                 drawableItem.Rotation = originalRotations[drawableItem] + rotation;


### PR DESCRIPTION
Resolves #35155 

SkinSelectionRotationHandler has DefaultOrigin in local space, so this is a very small pull that changes the update function for more than 1 object to convert that origin back to screenspace which fixes objects rotating around the wrong origin when 2 or more are selected.

before and after:

https://github.com/user-attachments/assets/82e5281e-3df1-4d0c-ac6c-733fd10f1e82



