### PR TITLE
Move realm refetches of beatmap in song select wedges off of update thread

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -109,6 +109,8 @@ namespace osu.Game.Database
         /// </summary>
         private readonly SemaphoreSlim realmRetrievalLock = new SemaphoreSlim(1);
 
+        private readonly CountdownEvent pendingAsyncOperations = new CountdownEvent(0);
+
         /// <summary>
         /// <c>true</c> when the current thread has already entered the <see cref="realmRetrievalLock"/>.
         /// </summary>
@@ -468,6 +470,30 @@ namespace osu.Game.Database
         }
 
         /// <summary>
+        /// Run work on realm on a TPL thread, in a way that ensures that the realm isn't disposed before the work is done.
+        /// </summary>
+        public Task<T> RunAsync<T>(Func<Realm, T> action, CancellationToken token = default)
+        {
+            ObjectDisposedException.ThrowIf(isDisposed, this);
+
+            // Required to ensure the read is tracked and accounted for before disposal.
+            // Can potentially be avoided if we have a need to do so in the future.
+            if (!ThreadSafety.IsUpdateThread)
+                throw new InvalidOperationException($@"{nameof(RunAsync)} must be called from the update thread.");
+
+            // CountdownEvent will fail if already at zero.
+            if (!pendingAsyncOperations.TryAddCount())
+                pendingAsyncOperations.Reset(1);
+
+            return Task.Run(() =>
+            {
+                var result = Run(action);
+                pendingAsyncOperations.Signal();
+                return result;
+            }, token);
+        }
+
+        /// <summary>
         /// Write changes to realm.
         /// </summary>
         /// <param name="action">The work to run.</param>
@@ -507,8 +533,6 @@ namespace osu.Game.Database
             }
         }
 
-        private readonly CountdownEvent pendingAsyncWrites = new CountdownEvent(0);
-
         /// <summary>
         /// Write changes to realm asynchronously, guaranteeing order of execution.
         /// </summary>
@@ -523,8 +547,8 @@ namespace osu.Game.Database
                 throw new InvalidOperationException(@$"{nameof(WriteAsync)} must be called from the update thread.");
 
             // CountdownEvent will fail if already at zero.
-            if (!pendingAsyncWrites.TryAddCount())
-                pendingAsyncWrites.Reset(1);
+            if (!pendingAsyncOperations.TryAddCount())
+                pendingAsyncOperations.Reset(1);
 
             // Regardless of calling Realm.GetInstance or Realm.GetInstanceAsync, there is a blocking overhead on retrieval.
             // Adding a forced Task.Run resolves this.
@@ -539,7 +563,7 @@ namespace osu.Game.Database
                     // ReSharper disable once AccessToDisposedClosure (WriteAsync should be marked as [InstantHandle]).
                     await realm.WriteAsync(() => action(realm)).ConfigureAwait(false);
 
-                pendingAsyncWrites.Signal();
+                pendingAsyncOperations.Signal();
             });
 
             return writeTask;
@@ -559,8 +583,8 @@ namespace osu.Game.Database
                 throw new InvalidOperationException(@$"{nameof(WriteAsync)} must be called from the update thread.");
 
             // CountdownEvent will fail if already at zero.
-            if (!pendingAsyncWrites.TryAddCount())
-                pendingAsyncWrites.Reset(1);
+            if (!pendingAsyncOperations.TryAddCount())
+                pendingAsyncOperations.Reset(1);
 
             // Regardless of calling Realm.GetInstance or Realm.GetInstanceAsync, there is a blocking overhead on retrieval.
             // Adding a forced Task.Run resolves this.
@@ -576,7 +600,7 @@ namespace osu.Game.Database
                     // ReSharper disable once AccessToDisposedClosure (WriteAsync should be marked as [InstantHandle]).
                     result = await realm.WriteAsync(() => action(realm)).ConfigureAwait(false);
 
-                pendingAsyncWrites.Signal();
+                pendingAsyncOperations.Signal();
                 return result;
             });
 
@@ -1494,7 +1518,7 @@ namespace osu.Game.Database
 
         public void Dispose()
         {
-            if (!pendingAsyncWrites.Wait(10000))
+            if (!pendingAsyncOperations.Wait(10000))
                 Logger.Log("Realm took too long waiting on pending async writes", level: LogLevel.Error);
 
             updateRealm?.Dispose();

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -438,5 +438,12 @@ namespace osu.Game.Screens.SelectV2
                 });
             }, token);
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            userTagsCancellationSource?.Cancel();
+            userTagsCancellationSource = null;
+            base.Dispose(isDisposing);
+        }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -434,7 +434,7 @@ namespace osu.Game.Screens.SelectV2
                     }
 
                     userTags.FadeIn(transition_duration, Easing.OutQuint);
-                    userTags.Tags = (tags, t => songSelect?.Search($@"tag=""{t}""!"));
+                    userTags.Tags = (tags, tag => songSelect?.Search($@"tag=""{tag}""!"));
                 });
             }, token);
         }

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -415,6 +415,9 @@ namespace osu.Game.Screens.SelectV2
 
             Task.Run(() =>
             {
+                if (token.IsCancellationRequested)
+                    return;
+
                 string[] tags = realm.Run(r =>
                 {
                     // need to refetch because `beatmap.Value.BeatmapInfo` is not going to have the latest tags

--- a/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapMetadataWedge.cs
@@ -418,7 +418,6 @@ namespace osu.Game.Screens.SelectV2
                 string[] tags = realm.Run(r =>
                 {
                     // need to refetch because `beatmap.Value.BeatmapInfo` is not going to have the latest tags
-                    r.Refresh();
                     var refetchedBeatmap = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID);
                     return refetchedBeatmap?.Metadata.UserTags.ToArray() ?? [];
                 });

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -326,5 +326,12 @@ namespace osu.Game.Screens.SelectV2
                 }, token);
             }
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            onlineDisplayCancellationSource?.Dispose();
+            onlineDisplayCancellationSource = null;
+            base.Dispose(isDisposing);
+        }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -309,7 +309,6 @@ namespace osu.Game.Screens.SelectV2
                     // which prevents working beatmap refetches caused by changes to the realm model of perceived low importance).
                     var status = realm.Run(r =>
                     {
-                        r.Refresh();
                         var refetchedBeatmap = r.Find<BeatmapInfo>(working.Value.BeatmapInfo.ID);
                         return refetchedBeatmap?.Status;
                     });

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -301,6 +301,9 @@ namespace osu.Game.Screens.SelectV2
 
                 Task.Run(() =>
                 {
+                    if (token.IsCancellationRequested)
+                        return;
+
                     // the online fetch may have also updated the beatmap's status.
                     // this needs to be checked against the *local* beatmap model rather than the online one, because it's not known here whether the status change has occurred or not
                     // (think scenarios like the beatmap being locally modified).

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.cs
@@ -278,8 +278,13 @@ namespace osu.Game.Screens.SelectV2
             }, token);
         }
 
+        private CancellationTokenSource? onlineDisplayCancellationSource;
+
         private void updateOnlineDisplay()
         {
+            onlineDisplayCancellationSource?.Cancel();
+            onlineDisplayCancellationSource = null;
+
             if (onlineLookupResult.Value?.Status != SongSelect.BeatmapSetLookupStatus.Completed)
             {
                 playCount.Value = null;
@@ -291,20 +296,35 @@ namespace osu.Game.Screens.SelectV2
                 playCount.Value = new StatisticPlayCount.Data(onlineBeatmap?.PlayCount ?? -1, onlineBeatmap?.UserPlayCount ?? -1);
                 favouriteButton.SetBeatmapSet(onlineLookupResult.Value.Result);
 
-                // the online fetch may have also updated the beatmap's status.
-                // this needs to be checked against the *local* beatmap model rather than the online one, because it's not known here whether the status change has occurred or not
-                // (think scenarios like the beatmap being locally modified).
-                // it also has to be handled explicitly like this because the working beatmap's `BeatmapInfo` will not receive these updates due to being detached
-                // (and because of https://github.com/ppy/osu/blob/4b73afd1957a9161e2956fc4191c8114d9958372/osu.Game/Screens/SelectV2/SongSelect.cs#L487-L488
-                // which prevents working beatmap refetches caused by changes to the realm model of perceived low importance).
-                var status = realm.Run(r =>
+                onlineDisplayCancellationSource = new CancellationTokenSource();
+                var token = onlineDisplayCancellationSource.Token;
+
+                Task.Run(() =>
                 {
-                    r.Refresh();
-                    var refetchedBeatmap = r.Find<BeatmapInfo>(working.Value.BeatmapInfo.ID);
-                    return refetchedBeatmap?.Status;
-                });
-                if (status != null)
-                    statusPill.Status = status.Value;
+                    // the online fetch may have also updated the beatmap's status.
+                    // this needs to be checked against the *local* beatmap model rather than the online one, because it's not known here whether the status change has occurred or not
+                    // (think scenarios like the beatmap being locally modified).
+                    // it also has to be handled explicitly like this because the working beatmap's `BeatmapInfo` will not receive these updates due to being detached
+                    // (and because of https://github.com/ppy/osu/blob/4b73afd1957a9161e2956fc4191c8114d9958372/osu.Game/Screens/SelectV2/SongSelect.cs#L487-L488
+                    // which prevents working beatmap refetches caused by changes to the realm model of perceived low importance).
+                    var status = realm.Run(r =>
+                    {
+                        r.Refresh();
+                        var refetchedBeatmap = r.Find<BeatmapInfo>(working.Value.BeatmapInfo.ID);
+                        return refetchedBeatmap?.Status;
+                    });
+
+                    if (status != null)
+                    {
+                        Schedule(() =>
+                        {
+                            if (token.IsCancellationRequested)
+                                return;
+
+                            statusPill.Status = status.Value;
+                        });
+                    }
+                }, token);
             }
         }
     }


### PR DESCRIPTION
From local testing on release build (such that online beatmaps are accessible) with a large database it seems that maybe this'll help with recurrent complaints of 'stutters'.