### PR TITLE
Reading bonus hotfix for Traceable mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -214,7 +214,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.3 + (totalHits * (0.0016 / (1 + 2 * effectiveMissCount)) * Math.Pow(accuracy, 16)) * (1 - 0.003 * attributes.DrainRate * attributes.DrainRate);
             else if (score.Mods.Any(m => m is OsuModTraceable))
             {
-                aimValue *= 1.0 + OsuRatingCalculator.CalculateVisibilityBonus(score.Mods, approachRate, attributes.SliderFactor);
+                aimValue *= 1.0 + OsuRatingCalculator.CalculateVisibilityBonus(score.Mods, approachRate, sliderFactor: attributes.SliderFactor);
             }
 
             aimValue *= accuracy;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -187,7 +187,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             bool isAlwaysPartiallyVisible = mods.OfType<OsuModHidden>().Any(m => m.OnlyFadeApproachCircles.Value) || mods.OfType<OsuModTraceable>().Any();
 
             // Start from normal curve, rewarding lower AR up to AR7
-            double readingBonus = 0.04 * (12.0 - Math.Max(approachRate, 7));
+            // TC forcefully requires a lower reading bonus for now as it's post-applied in PP which makes it multiplicative with the regular AR bonuses
+            // This means it has an advantage over HD, so we decrease the multiplier to compensate
+            // This should be removed once we're able to apply TC bonuses in SR (depends on real-time difficulty calculations being possible)
+            double readingBonus = (isAlwaysPartiallyVisible ? 0.025 : 0.04) * (12.0 - Math.Max(approachRate, 7));
 
             readingBonus *= visibilityFactor;
 
@@ -196,11 +199,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // For AR up to 0 - reduce reward for very low ARs when object is visible
             if (approachRate < 7)
-                readingBonus += (isAlwaysPartiallyVisible ? 0.03 : 0.045) * (7.0 - Math.Max(approachRate, 0)) * sliderVisibilityFactor;
+                readingBonus += (isAlwaysPartiallyVisible ? 0.02 : 0.045) * (7.0 - Math.Max(approachRate, 0)) * sliderVisibilityFactor;
 
             // Starting from AR0 - cap values so they won't grow to infinity
             if (approachRate < 0)
-                readingBonus += (isAlwaysPartiallyVisible ? 0.075 : 0.1) * (1 - Math.Pow(1.5, approachRate)) * sliderVisibilityFactor;
+                readingBonus += (isAlwaysPartiallyVisible ? 0.01 : 0.1) * (1 - Math.Pow(1.5, approachRate)) * sliderVisibilityFactor;
 
             return readingBonus;
         }


### PR DESCRIPTION
2 fixes:

- `CalculateVisibilityBonus` takes 2 default params and aim was incorrectly passing the slider factor into the wrong parameter for Traceable. This meant some slider-heavy maps were evading nerfs (placing a ~100pp advantage over HD in the most extreme cases)
- Traceable's visibility bonus is applied post-difficulty unlike HD, meaning the result it has on aim is multiplicative in nature so we need to decrease its bonus globally in order to keep values somewhat around expectations. This does unfortunately mean a slight TC nerf globally but this is the only option for now

This should only be a temporary measure. Once we have real time calculations, TC bonuses can & should be moved into difficulty calculations and we can revert these nerfs entirely.

This is **required** for the in-progress Q3 deploy.