### PR TITLE
'Ignore beatmap hitsounds' will now apply per beatmap

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
@@ -3,10 +3,12 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Localisation;
 using osu.Game.Screens.Play.PlayerSettings;
@@ -59,8 +61,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, false));
-            AddAssert("control shows hitsounds disabled", () => hitsoundsControl.Current.Value);
+            AddAssert("control still shows hitsounds enabled", () => hitsoundsControl.Current.Value);
         }
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
         [Test]
         public void TestBeatmapHitsoundValueChangesInBeatmap()
@@ -73,10 +78,10 @@ namespace osu.Game.Tests.Visual.Gameplay
                 hitsoundsControl.TriggerEvent(new MouseDownEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), osuTK.Input.MouseButton.Left));
             });
             AddStep("change the current value", () => hitsoundsControl.Current.Value = false);
-            AddAssert("beatmaps hitsound value is false", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOff);
+            AddAssert("beatmaps hitsound value is off", () => beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOff);
 
             AddStep("change the current value", () => hitsoundsControl.Current.Value = true);
-            AddAssert("beatmaps hitsound value is true", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOn);
+            AddAssert("beatmaps hitsound value is on", () => beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOn);
         }
 
         private void recreateControl()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
@@ -90,11 +90,11 @@ namespace osu.Game.Tests.Visual.Gameplay
                 hitsoundsControl.TriggerEvent(new MouseDownEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), osuTK.Input.MouseButton.Left));
             });
             AddStep("change the current value", () => hitsoundsControl.Current.Value = false);
-            AddAssert("beatmaps hitsound value is false", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == 2);
+            AddAssert("beatmaps hitsound value is false", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOff);
 
 
             AddStep("change the current value", () => hitsoundsControl.Current.Value = true);
-            AddAssert("beatmaps hitsound value is true", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == 1);
+            AddAssert("beatmaps hitsound value is true", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOn);
 
 
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
@@ -3,14 +3,11 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Database;
 using osu.Game.Localisation;
 using osu.Game.Screens.Play.PlayerSettings;
 
@@ -18,15 +15,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public partial class TestSceneBeatmapHitsoundsControl : OsuTestScene
     {
-
         private BeatmapHitsoundsControl hitsoundsControl = null!;
         private OsuConfigManager localConfig = null!;
-
-        [Resolved]
-        private RealmAccess realmAccess { get; set; } = null!;
-        [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
-
 
         [BackgroundDependencyLoader]
         private void load()
@@ -47,7 +37,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             recreateControl();
         }
 
-
         [Test]
         public void TestLocalConfigSyncsWithControl()
         {
@@ -58,11 +47,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
         }
 
-
         [Test]
         public void TestLocalConfigNoLongerSyncsWithControlAfterChange()
         {
-
             AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
             AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
 
@@ -73,15 +60,11 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, false));
             AddAssert("control shows hitsounds disabled", () => hitsoundsControl.Current.Value);
-
-
-
         }
 
         [Test]
         public void TestBeatmapHitsoundValueChangesInBeatmap()
         {
-
             AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
             AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
 
@@ -92,17 +75,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("change the current value", () => hitsoundsControl.Current.Value = false);
             AddAssert("beatmaps hitsound value is false", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOff);
 
-
             AddStep("change the current value", () => hitsoundsControl.Current.Value = true);
             AddAssert("beatmaps hitsound value is true", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOn);
-
-
         }
-
 
         private void recreateControl()
         {
-            AddStep("Create control", () =>
+            AddStep("create control", () =>
             {
                 Child = new PlayerSettingsGroup("Some settings")
                 {
@@ -115,6 +94,5 @@ namespace osu.Game.Tests.Visual.Gameplay
                 };
             });
         }
-
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
@@ -3,12 +3,10 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Localisation;
 using osu.Game.Screens.Play.PlayerSettings;
@@ -52,9 +50,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestLocalConfigNoLongerSyncsWithControlAfterChange()
         {
-            AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
-            AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
-
             AddStep("simulate mouse down", () =>
             {
                 hitsoundsControl.TriggerEvent(new MouseDownEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), osuTK.Input.MouseButton.Left));
@@ -62,26 +57,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, false));
             AddAssert("control still shows hitsounds enabled", () => hitsoundsControl.Current.Value);
-        }
-
-        [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
-
-        [Test]
-        public void TestBeatmapHitsoundValueChangesInBeatmap()
-        {
-            AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
-            AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
-
-            AddStep("simulate mouse down", () =>
-            {
-                hitsoundsControl.TriggerEvent(new MouseDownEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), osuTK.Input.MouseButton.Left));
-            });
-            AddStep("change the current value", () => hitsoundsControl.Current.Value = false);
-            AddAssert("beatmaps hitsound value is off", () => beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOff);
-
-            AddStep("change the current value", () => hitsoundsControl.Current.Value = true);
-            AddAssert("beatmaps hitsound value is on", () => beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == HitsoundsSetting.HitsoundsOn);
         }
 
         private void recreateControl()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapHitsoundsControl.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Framework.Input.States;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Database;
+using osu.Game.Localisation;
+using osu.Game.Screens.Play.PlayerSettings;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public partial class TestSceneBeatmapHitsoundsControl : OsuTestScene
+    {
+
+        private BeatmapHitsoundsControl hitsoundsControl = null!;
+        private OsuConfigManager localConfig = null!;
+
+        [Resolved]
+        private RealmAccess realmAccess { get; set; } = null!;
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Dependencies.Cache(localConfig = new OsuConfigManager(LocalStorage));
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("reset settings", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
+
+            AddStep("create working beatmap", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(Ruleset.Value);
+            });
+
+            recreateControl();
+        }
+
+
+        [Test]
+        public void TestLocalConfigSyncsWithControl()
+        {
+            AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, false));
+            AddAssert("control shows hitsounds disabled", () => !hitsoundsControl.Current.Value);
+
+            AddStep("enable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
+            AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
+        }
+
+
+        [Test]
+        public void TestLocalConfigNoLongerSyncsWithControlAfterChange()
+        {
+
+            AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
+            AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
+
+            AddStep("simulate mouse down", () =>
+            {
+                hitsoundsControl.TriggerEvent(new MouseDownEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), osuTK.Input.MouseButton.Left));
+            });
+
+            AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, false));
+            AddAssert("control shows hitsounds disabled", () => hitsoundsControl.Current.Value);
+
+
+
+        }
+
+        [Test]
+        public void TestBeatmapHitsoundValueChangesInBeatmap()
+        {
+
+            AddStep("disable beatmap hitsounds globally", () => localConfig.SetValue(OsuSetting.BeatmapHitsounds, true));
+            AddAssert("control shows hitsounds enabled", () => hitsoundsControl.Current.Value);
+
+            AddStep("simulate mouse down", () =>
+            {
+                hitsoundsControl.TriggerEvent(new MouseDownEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), osuTK.Input.MouseButton.Left));
+            });
+            AddStep("change the current value", () => hitsoundsControl.Current.Value = false);
+            AddAssert("beatmaps hitsound value is false", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == 2);
+
+
+            AddStep("change the current value", () => hitsoundsControl.Current.Value = true);
+            AddAssert("beatmaps hitsound value is true", () => Beatmap.Value.BeatmapInfo.UserSettings.Hitsounds == 1);
+
+
+        }
+
+
+        private void recreateControl()
+        {
+            AddStep("Create control", () =>
+            {
+                Child = new PlayerSettingsGroup("Some settings")
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        hitsoundsControl = new BeatmapHitsoundsControl { LabelText = SkinSettingsStrings.BeatmapHitsounds }
+                    }
+                };
+            });
+        }
+
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapUserSettings.cs
+++ b/osu.Game/Beatmaps/BeatmapUserSettings.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Game.Screens.Play.PlayerSettings;
 using Realms;
 
@@ -17,21 +16,17 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public double Offset { get; set; }
 
-
         /// <summary>
         /// Determines if hitsounds for beatmap are enabled, disabled, or use the global setting.
         /// </summary>
         [Ignored]
         public HitsoundsSetting Hitsounds
         {
-            get => Enum.TryParse(HitsoundsStateString, out HitsoundsSetting hitsoundsState)
-                ? hitsoundsState
-                : HitsoundsSetting.UseGlobalSetting;
-            set => HitsoundsStateString = value.ToString();
+            get => (HitsoundsSetting)HitsoundsInt;
+            set => HitsoundsInt = (int)value;
         }
 
         [MapTo(nameof(Hitsounds))]
-        public string HitsoundsStateString { get; set; } = HitsoundsSetting.UseGlobalSetting.ToString();
-
+        public int HitsoundsInt { get; set; } = (int)HitsoundsSetting.UseGlobalSetting;
     }
 }

--- a/osu.Game/Beatmaps/BeatmapUserSettings.cs
+++ b/osu.Game/Beatmaps/BeatmapUserSettings.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Game.Screens.Play.PlayerSettings;
 using Realms;
 
 namespace osu.Game.Beatmaps
@@ -19,7 +21,17 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Determines if hitsounds for beatmap are enabled, disabled, or use the global setting.
         /// </summary>
-        public int Hitsounds { get; set; }
+        [Ignored]
+        public HitsoundsSetting Hitsounds
+        {
+            get => Enum.TryParse(HitsoundsStateString, out HitsoundsSetting hitsoundsState)
+                ? hitsoundsState
+                : HitsoundsSetting.UseGlobalSetting;
+            set => HitsoundsStateString = value.ToString();
+        }
+
+        [MapTo(nameof(Hitsounds))]
+        public string HitsoundsStateString { get; set; } = HitsoundsSetting.UseGlobalSetting.ToString();
 
     }
 }

--- a/osu.Game/Beatmaps/BeatmapUserSettings.cs
+++ b/osu.Game/Beatmaps/BeatmapUserSettings.cs
@@ -14,5 +14,12 @@ namespace osu.Game.Beatmaps
         /// An audio offset that can be used for timing adjustments.
         /// </summary>
         public double Offset { get; set; }
+
+
+        /// <summary>
+        /// Determines if hitsounds for beatmap are enabled, disabled, or use the global setting.
+        /// </summary>
+        public int Hitsounds { get; set; }
+
     }
 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -101,8 +101,9 @@ namespace osu.Game.Database
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
+        /// 52   2025-10-14    Added BeatmapUserSettings.Hitsounds to disable/enable hitsounds per beatmap.
         /// </summary>
-        private const int schema_version = 51;
+        private const int schema_version = 52;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
@@ -16,14 +16,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
     {
         private Bindable<ScoreInfo> referenceScore { get; } = new Bindable<ScoreInfo>();
 
-        private readonly PlayerCheckbox beatmapHitsoundsToggle;
-
         public AudioSettings()
             : base("Audio Settings")
         {
             Children = new Drawable[]
             {
-                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = SkinSettingsStrings.BeatmapHitsounds },
+                new BeatmapHitsoundsControl { LabelText = SkinSettingsStrings.BeatmapHitsounds },
                 new BeatmapOffsetControl
                 {
                     ReferenceScore = { BindTarget = referenceScore },
@@ -34,7 +32,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, SessionStatics statics)
         {
-            beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
             statics.BindWith(Static.LastLocalUserScore, referenceScore);
         }
     }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
@@ -13,9 +13,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public partial class BeatmapHitsoundsControl : PlayerCheckbox
     {
-
         private Bindable<bool> globalHitsounds = new Bindable<bool>();
-
 
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
@@ -53,14 +51,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
             ShowsDefaultIndicator = false;
             globalHitsounds.BindValueChanged(onGlobalChanged);
             Current.BindValueChanged(onCurrentChanged);
-
         }
 
         private void onGlobalChanged(ValueChangedEvent<bool> hitsounds)
         {
             if (isFollowingGlobal) // set current based on global hitsound setting, in case the settings overlay is open when loading beatmap and changing the global setting
                 Current.Value = globalHitsounds.Value;
-
         }
 
         private void onCurrentChanged(ValueChangedEvent<bool> hitsounds)

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
@@ -85,10 +85,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 var beatmapInfo = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID);
 
                 if (beatmapInfo == null) // only the case for tests.
-                {
-                    beatmap.Value.BeatmapInfo.UserSettings.Hitsounds = Current.Value ? HitsoundsSetting.HitsoundsOn : HitsoundsSetting.HitsoundsOff;
                     return;
-                }
 
                 beatmapInfo.UserSettings.Hitsounds = Current.Value ? HitsoundsSetting.HitsoundsOn : HitsoundsSetting.HitsoundsOff;
                 // once value is changed (to On/Off) it will never return to global (same as osu!stable)

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapHitsoundsControl.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Database;
+
+namespace osu.Game.Screens.Play.PlayerSettings
+{
+    public partial class BeatmapHitsoundsControl : PlayerCheckbox
+    {
+
+        private Bindable<bool> globalHitsounds = new Bindable<bool>();
+
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        private IDisposable? beatmapHitsoundsSubscription;
+        private Task? realmWriteTask;
+        private bool isFollowingGlobal { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            globalHitsounds = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            var info = realm.Realm.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID)
+                ?? beatmap.Value.BeatmapInfo; // use in-memory beatmap for tests
+            int val = info.UserSettings.Hitsounds;
+
+            if (val == 0) // 0 == global
+            {
+                Current.Value = globalHitsounds.Value;
+                isFollowingGlobal = true;
+            }
+            else
+            {
+                Current.Value = val == 1; // 1 == On; 2 == Off
+                isFollowingGlobal = false;
+            }
+
+
+            Current.Disabled = false;
+            ShowsDefaultIndicator = false;
+            globalHitsounds.BindValueChanged(onGlobalChanged);
+            Current.BindValueChanged(onCurrentChanged);
+
+        }
+
+        private void onGlobalChanged(ValueChangedEvent<bool> hitsounds)
+        {
+            if (isFollowingGlobal) // set current based on global hitsound setting, in case the settings overlay is open when loading beatmap and changing the global setting
+                Current.Value = globalHitsounds.Value;
+
+        }
+
+
+
+        private void onCurrentChanged(ValueChangedEvent<bool> hitsounds)
+        {
+            if (!isFollowingGlobal)
+                writeHitsoundsToBeatmap();
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            isFollowingGlobal = false;
+            return base.OnMouseDown(e);
+        }
+
+        private void writeHitsoundsToBeatmap()
+        {
+            // ensure the previous write has completed. ignoring performance concerns, if we don't do this, the async writes could be out of sequence.
+            if (realmWriteTask?.IsCompleted == false)
+            {
+                Scheduler.AddOnce(writeHitsoundsToBeatmap);
+                return;
+            }
+
+            realmWriteTask = realm.WriteAsync(r =>
+            {
+                var setInfo = r.Find<BeatmapSetInfo>(beatmap.Value.BeatmapSetInfo.ID);
+
+                if (setInfo == null) // only the case for tests.
+                {
+                    beatmap.Value.BeatmapInfo.UserSettings.Hitsounds = Current.Value ? 1 : 2;
+                    return;
+                }
+
+                // Apply to all difficulties in a beatmap set if they have the same audio
+                // (they generally always share hitsounds).
+                foreach (var b in setInfo.Beatmaps)
+                {
+                    BeatmapUserSettings userSettings = b.UserSettings;
+                    int val = Current.Value ? 1 : 2; // 1 == On; 2 == Off
+
+                    if (userSettings.Hitsounds != val && b.AudioEquals(beatmap.Value.BeatmapInfo))
+                    {
+                        userSettings.Hitsounds = val; // once value is changed (to On/Off) it will never return to global (same as osu!stable)
+                    }
+                }
+            });
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            beatmapHitsoundsSubscription?.Dispose();
+        }
+    }
+}

--- a/osu.Game/Screens/Play/PlayerSettings/HitsoundsSetting.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/HitsoundsSetting.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.Screens.Play.PlayerSettings
+{
+    public enum HitsoundsSetting
+    {
+        [Description("Global")]
+        UseGlobalSetting,
+        [Description("On")]
+        HitsoundsOn,
+        [Description("Off")]
+        HitsoundsOff,
+    }
+}

--- a/osu.Game/Screens/Play/PlayerSettings/HitsoundsSetting.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/HitsoundsSetting.cs
@@ -8,10 +8,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
     public enum HitsoundsSetting
     {
         [Description("Global")]
-        UseGlobalSetting,
+        UseGlobalSetting = 0,
+
         [Description("On")]
-        HitsoundsOn,
+        HitsoundsOn = 1,
+
         [Description("Off")]
-        HitsoundsOff,
+        HitsoundsOff = 2,
     }
 }

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -62,6 +62,7 @@ namespace osu.Game.Skinning
 
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
         private HitsoundsSetting beatmapHitsoundsState;
 
         protected override bool AllowSampleLookup(ISampleInfo sampleInfo)
@@ -76,9 +77,11 @@ namespace osu.Game.Skinning
                 case HitsoundsSetting.HitsoundsOn:
                     useHitsounds = true;
                     break;
+
                 case HitsoundsSetting.HitsoundsOff:
                     useHitsounds = false;
                     break;
+
                 case HitsoundsSetting.UseGlobalSetting:
                 default:
                     useHitsounds = beatmapHitsounds.Value;
@@ -113,6 +116,7 @@ namespace osu.Game.Skinning
 
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
+
         private IDisposable? beatmapHitsoundsSubscription;
 
         [BackgroundDependencyLoader]
@@ -124,12 +128,10 @@ namespace osu.Game.Skinning
 
             beatmapHitsoundsSubscription = realm.SubscribeToPropertyChanged(
                 r => r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID)?.UserSettings,
-                settings => settings.HitsoundsStateString,
+                settings => settings.HitsoundsInt,
                 val =>
                 {
-                    beatmapHitsoundsState = Enum.TryParse(val, out HitsoundsSetting parsed)
-                        ? parsed
-                        : HitsoundsSetting.UseGlobalSetting;
+                    beatmapHitsoundsState = (HitsoundsSetting)val;
                     TriggerSourceChanged();
                 });
 

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -70,25 +70,25 @@ namespace osu.Game.Skinning
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
-            bool useHitsounds;
+            bool useBeatmapHitsounds;
 
             switch (beatmapHitsoundsState)
             {
                 case HitsoundsSetting.HitsoundsOn:
-                    useHitsounds = true;
+                    useBeatmapHitsounds = true;
                     break;
 
                 case HitsoundsSetting.HitsoundsOff:
-                    useHitsounds = false;
+                    useBeatmapHitsounds = false;
                     break;
 
                 case HitsoundsSetting.UseGlobalSetting:
                 default:
-                    useHitsounds = beatmapHitsounds.Value;
+                    useBeatmapHitsounds = beatmapHitsounds.Value;
                     break;
             }
 
-            return sampleInfo is StoryboardSampleInfo || useHitsounds;
+            return sampleInfo is StoryboardSampleInfo || useBeatmapHitsounds;
         }
 
         private readonly ISkin skin;


### PR DESCRIPTION
This PR intends to close #33397

Previously when loading into beatmap, toggling the 'ignore beatmap hitsounds' would change the setting globally. This PR restores the behaviour from osu!stable, where this setting by default follows the global setting, however on toggling it becomes local to the specific beatmap that's loaded.