### PR TITLE
Show leaderboard in solo spectator

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
@@ -9,6 +9,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
+using osu.Game.Screens.Select.Leaderboards;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 {
@@ -24,6 +25,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         private readonly AudioAdjustments clockAdjustmentsFromMods = new AudioAdjustments();
         private readonly SpectatorPlayerClock spectatorPlayerClock;
+
+        // purposefully cached as empty - the multi spectator screen already has one leaderboard, on the left of all the player instances
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private readonly EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
 
         /// <summary>
         /// Creates a new <see cref="MultiSpectatorPlayer"/>.

--- a/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Screens;
 using osu.Game.Online.Spectator;
 using osu.Game.Scoring;
+using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Play
@@ -14,10 +15,13 @@ namespace osu.Game.Screens.Play
     {
         private readonly Score score;
 
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private SoloGameplayLeaderboardProvider leaderboardProvider = new SoloGameplayLeaderboardProvider();
+
         protected override UserActivity InitialActivity => new UserActivity.SpectatingUser(Score.ScoreInfo);
 
         public SoloSpectatorPlayer(Score score)
-            : base(score, new PlayerConfiguration { AllowUserInteraction = false })
+            : base(score, new PlayerConfiguration { AllowUserInteraction = false, ShowLeaderboard = true })
         {
             this.score = score;
         }
@@ -26,6 +30,8 @@ namespace osu.Game.Screens.Play
         private void load()
         {
             SpectatorClient.OnUserBeganPlaying += userBeganPlaying;
+
+            AddInternal(leaderboardProvider);
         }
 
         public override bool OnExiting(ScreenExitEvent e)

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -13,17 +13,11 @@ using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
-using osu.Game.Screens.Select.Leaderboards;
 
 namespace osu.Game.Screens.Play
 {
     public abstract partial class SpectatorPlayer : Player
     {
-        // TODO: maybe consider giving this proper scores.
-        // `SoloGameplayLeaderboardProvider` doesn't immediately work because there's no guarantee that `LeaderboardManager` global state matches the currently spectated beatmap.
-        [Cached(typeof(IGameplayLeaderboardProvider))]
-        private readonly EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
-
         [Resolved]
         protected SpectatorClient SpectatorClient { get; private set; } = null!;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35293.

The removed comment here says that "there's no guarantee" that `LeaderboardManager` has the correct scores:

https://github.com/ppy/osu/blob/a060ddb5439412e8b503800f4e6e8d80df40cacf/osu.Game/Screens/Play/SpectatorPlayer.cs#L22-L25

but at least now, that's not correct because this is ensured via

https://github.com/ppy/osu/blob/a060ddb5439412e8b503800f4e6e8d80df40cacf/osu.Game/Screens/Play/PlayerLoader.cs#L280-L286

through which the solo spectator player is pushed:

https://github.com/ppy/osu/blob/a060ddb5439412e8b503800f4e6e8d80df40cacf/osu.Game/Screens/Play/SoloSpectatorScreen.cs#L239

The empty leaderboard provider is still valid however in the case of multiplayer spectator, because there we don't really ever want to be showing any leaderboards on the individual player instances.