### PR TITLE
Fix screen event misusages in multplayer/matchmaking

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -312,11 +312,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
         public override bool OnExiting(ScreenExitEvent e)
         {
-            if (base.OnExiting(e))
-                return true;
-
             if (exitConfirmed)
             {
+                if (base.OnExiting(e))
+                {
+                    exitConfirmed = false;
+                    return true;
+                }
+
                 client.LeaveRoom().FireAndForget();
                 return false;
             }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -152,10 +152,12 @@ namespace osu.Game.Screens.OnlinePlay
             while (screenStack.CurrentScreen != null && screenStack.CurrentScreen is not LoungeSubScreen)
             {
                 var subScreen = (Screen)screenStack.CurrentScreen;
-                if (subScreen.IsLoaded && subScreen.OnExiting(e))
-                    return true;
 
                 subScreen.Exit();
+
+                // If it's still current after calling Exit(), it must have blocked OnExiting().
+                if (subScreen.IsCurrentScreen())
+                    return true;
             }
 
             waves.Hide();

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -121,6 +121,8 @@ namespace osu.Game.Screens.OnlinePlay
 
         public override void OnResuming(ScreenTransitionEvent e)
         {
+            base.OnResuming(e);
+
             this.FadeIn(250);
             this.ScaleTo(1, 250, Easing.OutSine);
 
@@ -131,8 +133,6 @@ namespace osu.Game.Screens.OnlinePlay
             // to work around this, do not proxy resume to screens that haven't loaded yet.
             if ((screenStack.CurrentScreen as Drawable)?.IsLoaded == true)
                 screenStack.CurrentScreen.OnResuming(e);
-
-            base.OnResuming(e);
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)
@@ -168,8 +168,7 @@ namespace osu.Game.Screens.OnlinePlay
 
             this.Delay(WaveContainer.DISAPPEAR_DURATION).FadeOut();
 
-            base.OnExiting(e);
-            return false;
+            return base.OnExiting(e);
         }
 
         public override bool OnBackButton()

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -106,6 +106,8 @@ namespace osu.Game.Screens.OnlinePlay
 
         public override void OnEntering(ScreenTransitionEvent e)
         {
+            base.OnEntering(e);
+
             this.FadeIn();
             waves.Show();
 
@@ -135,6 +137,8 @@ namespace osu.Game.Screens.OnlinePlay
 
         public override void OnSuspending(ScreenTransitionEvent e)
         {
+            base.OnSuspending(e);
+
             this.ScaleTo(1.1f, 250, Easing.InSine);
             this.FadeOut(250);
 


### PR DESCRIPTION
I noticed these when going through screen footer subscreen support. I don't think they're required for my changes anymore but should be applied anyway for consistency, as right now events are either being doubled (`OnExiting()`) or missed entirely (`OnEntering()`/`OnSuspending()`).

There should be no noticeable changes as a result of this.