### PR TITLE
Make `ScreenFooter` support subscreens

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -213,7 +213,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("mods selected", () => SelectedMods.Value, () => Has.Count.EqualTo(1));
             AddStep("right click mod button", () =>
             {
-                InputManager.MoveMouseTo(Footer.ChildrenOfType<FooterButtonMods>().Single());
+                InputManager.MoveMouseTo(ScreenFooter.ChildrenOfType<FooterButtonMods>().Single());
                 InputManager.Click(MouseButton.Right);
             });
             AddAssert("not mods selected", () => SelectedMods.Value, () => Has.Count.EqualTo(0));
@@ -620,7 +620,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddAssert("previous random invoked", () => previousRandomCalled && !nextRandomCalled);
         }
 
-        private FooterButtonRandom randomButton => Footer.ChildrenOfType<FooterButtonRandom>().Single();
+        private FooterButtonRandom randomButton => ScreenFooter.ChildrenOfType<FooterButtonRandom>().Single();
 
         [Test]
         public void TestFooterOptions()

--- a/osu.Game/Screens/Footer/ScreenStackFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenStackFooter.cs
@@ -1,0 +1,220 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Screens;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Footer
+{
+    public partial class ScreenStackFooter : CompositeDrawable
+    {
+        /// <summary>
+        /// Called when logo tracking begins, intended to bring the osu! logo to the frontmost visually.
+        /// </summary>
+        public Action<bool>? RequestLogoInFront { private get; init; }
+
+        /// <summary>
+        /// The back button was pressed.
+        /// </summary>
+        public Action? BackButtonPressed { private get; init; }
+
+        /// <summary>
+        /// The (legacy) back button.
+        /// </summary>
+        public readonly BackButton BackButton;
+
+        /// <summary>
+        /// The footer.
+        /// </summary>
+        public readonly ScreenFooter Footer;
+
+        /// <summary>
+        /// Whether the legacy back button is currently displayed.
+        /// </summary>
+        private readonly IBindable<bool> backButtonVisibility = new BindableBool();
+
+        private readonly ScreenStackTracker screenTracker;
+
+        public ScreenStackFooter(ScreenStack screenStack, ScreenFooter.BackReceptor? backReceptor = null)
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                BackButton = new BackButton(backReceptor)
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Action = () => BackButtonPressed?.Invoke(),
+                },
+                Footer = new ScreenFooter(backReceptor)
+                {
+                    RequestLogoInFront = v => RequestLogoInFront?.Invoke(v),
+                    BackButtonPressed = () => BackButtonPressed?.Invoke()
+                }
+            };
+
+            screenTracker = new ScreenStackTracker(screenStack);
+            screenTracker.ScreenChanged += onScreenChanged;
+
+            backButtonVisibility.ValueChanged += onBackButtonVisibilityChanged;
+        }
+
+        private void onScreenChanged(IScreen lastScreen, IScreen newScreen)
+        {
+            unbindScreen(lastScreen);
+            bindScreen(newScreen);
+        }
+
+        private void onBackButtonVisibilityChanged(ValueChangedEvent<bool> visible)
+        {
+            if (visible.NewValue)
+                BackButton.Show();
+            else
+                BackButton.Hide();
+        }
+
+        private void unbindScreen(IScreen screen)
+        {
+            if (screen is not OsuScreen osuScreen)
+                return;
+
+            backButtonVisibility.UnbindFrom(osuScreen.BackButtonVisibility);
+        }
+
+        private void bindScreen(IScreen screen)
+        {
+            if (screen is not OsuScreen osuScreen)
+            {
+                ((BindableBool)backButtonVisibility).Value = true;
+
+                Footer.SetButtons([]);
+                Footer.Hide();
+                return;
+            }
+
+            if (osuScreen.ShowFooter)
+            {
+                // the legacy back button should never display while the new footer is in use, as it
+                // contains its own local back button.
+                ((BindableBool)backButtonVisibility).Value = false;
+
+                Footer.Show();
+
+                if (osuScreen.IsLoaded)
+                    updateFooterButtons();
+                else
+                {
+                    // ensure the current buttons are immediately disabled on screen change (so they can't be pressed).
+                    Footer.SetButtons([]);
+
+                    osuScreen.OnLoadComplete += _ => updateFooterButtons();
+                }
+
+                void updateFooterButtons()
+                {
+                    var buttons = osuScreen.CreateFooterButtons();
+
+                    osuScreen.LoadComponentsAgainstScreenDependencies(buttons);
+
+                    Footer.SetButtons(buttons);
+                    Footer.Show();
+                }
+            }
+            else
+            {
+                backButtonVisibility.BindTo(osuScreen.BackButtonVisibility);
+
+                Footer.SetButtons([]);
+                Footer.Hide();
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            screenTracker.Dispose();
+        }
+
+        /// <summary>
+        /// Recursively represents a single screen stack and any nested subscreen stack.
+        /// </summary>
+        private class ScreenStackTracker : IDisposable
+        {
+            /// <summary>
+            /// Invoked when the leading screen changes.
+            /// </summary>
+            /// <remarks>
+            /// This differs from <see cref="ScreenStack.ScreenPushed"/> and <see cref="ScreenStack.ScreenExited"/>
+            /// because <c>lastScreen</c> and <c>newScreen</c> may be subscreens of the current screen stack.
+            /// <br />
+            /// As such, no assumptions may be made as to the relation of screens to this entry's <see cref="ScreenStack"/>.
+            /// </remarks>
+            public event ScreenChangedDelegate? ScreenChanged;
+
+            /// <summary>
+            /// The screen stack tracked by this entry.
+            /// </summary>
+            private readonly ScreenStack stack;
+
+            /// <summary>
+            /// An entry corresponding to the subscreen stack of the current screen, if any.
+            /// </summary>
+            private ScreenStackTracker? subScreenTracker;
+
+            /// <summary>
+            /// The screen which should be bound to the screen footer - the most nested subscreen.
+            /// </summary>
+            private IScreen leadingScreen => subScreenTracker?.leadingScreen ?? stack.CurrentScreen;
+
+            public ScreenStackTracker(ScreenStack stack)
+            {
+                this.stack = stack;
+
+                stack.ScreenPushed += onParentScreenChanged;
+                stack.ScreenExited += onParentScreenChanged;
+            }
+
+            private void onParentScreenChanged(IScreen lastScreen, IScreen newScreen)
+            {
+                // The screen which we will be UNBINDING from the screen footer later on.
+                IScreen lastLeadingScreen = subScreenTracker?.leadingScreen ?? lastScreen;
+
+                // Subscreens are attached to a parent screen, so when the parent changes the subscreen must also.
+                subScreenTracker?.Dispose();
+                subScreenTracker = null;
+
+                // Check if we've switched to a screen that has a subscreen.
+                if (newScreen is IHasSubScreenStack newStack)
+                {
+                    subScreenTracker = new ScreenStackTracker(newStack.SubScreenStack);
+                    subScreenTracker.ScreenChanged += onSubScreenScreenChanged;
+                }
+
+                ScreenChanged?.Invoke(lastLeadingScreen, leadingScreen);
+            }
+
+            private void onSubScreenScreenChanged(IScreen lastScreen, IScreen newScreen)
+            {
+                ScreenChanged?.Invoke(lastScreen, newScreen);
+            }
+
+            public void Dispose()
+            {
+                stack.ScreenPushed -= onParentScreenChanged;
+                stack.ScreenExited -= onParentScreenChanged;
+
+                if (subScreenTracker != null)
+                {
+                    subScreenTracker.ScreenChanged -= onSubScreenScreenChanged;
+                    subScreenTracker.Dispose();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Intro

In https://github.com/ppy/osu/pull/35117 I included changes to `OsuGame` which allowed the footer to be displayed in subscreens for use in the playlist song selection. The change is fragile as evidenced by the [failing tests](https://github.com/ppy/osu/pull/35117/checks?check_run_id=51198918830), so I set out to do this more properly.

This is the culmination of about 6 attempts at this, because the footer is extremely complicated. There are many edge cases to consider, such as:
- We still have a legacy back button, the state of which is controlled by both `OsuScreen.BackButtonVisibility` _and_ whether the `ScreenFooter` itself is visible.
- Some screens [selectively](https://github.com/ppy/osu/blob/159349a64bef93f0230113cbc792e81fae82763c/osu.Game/Screens/SelectV2/SongSelect.cs#L980) show or hide the footer.
- Some screens [selectively](https://github.com/ppy/osu/blob/159349a64bef93f0230113cbc792e81fae82763c/osu.Game/Screens/Play/PlayerLoader.cs#L518) show or hide the legacy back button.
- Some screens work with the footer in [other ways](https://github.com/ppy/osu/blob/159349a64bef93f0230113cbc792e81fae82763c/osu.Game/Screens/Footer/ScreenFooter.cs#L149-L164), which I'm not sure how to handle more universally at this point.
- Footer buttons are expected to be [single use](https://github.com/ppy/osu/blob/159349a64bef93f0230113cbc792e81fae82763c/osu.Game/Screens/Footer/ScreenFooter.cs#L219-L220), and disposed/expired when changing screens. In practice this means buttons must be recreated all the time.
- Footer buttons are expected to be cleared/disabled [as soon as](https://github.com/ppy/osu/blob/159349a64bef93f0230113cbc792e81fae82763c/osu.Game/OsuGame.cs#L1759-L1764) the screen is pushed or exited. In practice this means putting related code in `OnEntering()`/`OnExiting()` produces slightly different behaviour.

Therefore I've tried to keep the changes somewhat simple for this attempt but I still foresee this going through several refactoring efforts.

## Outline

I've tried to imagine somewhat complicated scenarios here, and reduced it to tracking what I call the "leading screen" which is the most-nested 'current screen'. For example:
```
Parent -> Parent
          ^^^^^^

Parent -> [ Child -> Child ]
                     ^^^^^

Parent -> [ Child -> Child ] -> Parent
                                ^^^^^^

Parent -> [ Child -> [ Child -> Child ] ]
                                ^^^^^
```

This is done by the new class `ScreenStackFooter` which handles both the footer and the legacy back button almost exactly as `OsuGame` already does it, except with the above leading screen detail included.

## Testing

 Besides the new included tests, I've also tested this works with https://github.com/ppy/osu/pull/35117.