### PR TITLE
feat: Add an accuracy filter to the beatmaps carousel search bar

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -813,7 +813,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.True(filterCriteria.Accuracy.IsLowerInclusive);
             Assert.IsNull(filterCriteria.Accuracy.Max);
         }
-        
+
         [TestCase("0.9097")]
         [TestCase("90.97%")]
         [TestCase("90.97")]

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -787,5 +787,44 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.That(filterCriteria.UserTags[1].SearchTerm, Is.EqualTo("clean"));
             Assert.That(filterCriteria.UserTags[1].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
         }
+
+        [TestCase("acc")]
+        [TestCase("accuracy")]
+        public void TestApplyAccuracyQueries(string variant)
+        {
+            string query = $"{variant}<90 easy";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("easy", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            Assert.IsNotNull(filterCriteria.Accuracy.Max);
+            Assert.AreEqual(filterCriteria.Accuracy.Max, 0.90d);
+            Assert.IsNull(filterCriteria.Accuracy.Min);
+        }
+
+        [TestCase("acc")]
+        [TestCase("accuracy")]
+        public void TestAccuracyQueriesInclusive(string variant)
+        {
+            string query = $"{variant}>=90.97";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual(filterCriteria.Accuracy.Min, 0.9097d);
+            Assert.True(filterCriteria.Accuracy.IsLowerInclusive);
+            Assert.IsNull(filterCriteria.Accuracy.Max);
+        }
+        
+        [TestCase("0.9097")]
+        [TestCase("90.97%")]
+        [TestCase("90.97")]
+        public void TestParseAccuracyQueriesFormatVariants(string parameter)
+        {
+            string query = $"acc>={parameter}";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual(filterCriteria.Accuracy.Min, 0.9097d);
+            Assert.True(filterCriteria.Accuracy.IsLowerInclusive);
+            Assert.IsNull(filterCriteria.Accuracy.Max);
+        }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -454,6 +454,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             public Func<List<BeatmapCollection>> AllCollections { get; set; } = () => [];
             public Func<FilterCriteria, Dictionary<Guid, ScoreRank>> BeatmapInfoGuidToTopRankMapping { get; set; } = _ => new Dictionary<Guid, ScoreRank>();
+            public Func<FilterCriteria, Dictionary<Guid, double>> BeatmapInfoGuidToTopRankAccuracyMapping { get; set; } = _ => new Dictionary<Guid, double>();
 
             public TestBeatmapCarousel()
             {
@@ -479,6 +480,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             protected override List<BeatmapCollection> GetAllCollections() => AllCollections.Invoke();
             protected override Dictionary<Guid, ScoreRank> GetBeatmapInfoGuidToTopRankMapping(FilterCriteria criteria) => BeatmapInfoGuidToTopRankMapping.Invoke(criteria);
+            protected override Dictionary<Guid, double> GetBeatmapInfoGuidToTopRankAccuracyMapping(FilterCriteria criteria) => BeatmapInfoGuidToTopRankAccuracyMapping.Invoke(criteria);
         }
     }
 }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
+using osu.Game.Scoring;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Utils;
 
@@ -62,6 +64,14 @@ namespace osu.Game.Screens.Select.Carousel
 
             match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(BeatmapInfo.StarRating.FloorToDecimalDigits(2));
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(BeatmapInfo.Difficulty.ApproachRate);
+            match &= !criteria.Accuracy.HasFilter || (criteria.Accuracy.IsInRange(90d));
+
+            Logger.Log($"Passing on the beatmap [{BeatmapInfo.GetDisplayTitle()}]");
+            if (BeatmapInfo.Scores.Any())
+            {
+                Logger.Log($"Applying Beatmap Carousel Filter matching : max acc found for map : {BeatmapInfo.GetDisplayTitle()} is {BeatmapInfo.Scores.Max(info => info.Accuracy)}");
+            }
+
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(BeatmapInfo.Difficulty.DrainRate);
             match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(BeatmapInfo.Difficulty.CircleSize);
             match &= !criteria.OverallDifficulty.HasFilter || criteria.OverallDifficulty.IsInRange(BeatmapInfo.Difficulty.OverallDifficulty);

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Screens.Select.Carousel
 
             match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(BeatmapInfo.StarRating.FloorToDecimalDigits(2));
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(BeatmapInfo.Difficulty.ApproachRate);
-
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(BeatmapInfo.Difficulty.DrainRate);
             match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(BeatmapInfo.Difficulty.CircleSize);
             match &= !criteria.OverallDifficulty.HasFilter || criteria.OverallDifficulty.IsInRange(BeatmapInfo.Difficulty.OverallDifficulty);

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
-using osu.Game.Scoring;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Utils;
 
@@ -64,13 +62,6 @@ namespace osu.Game.Screens.Select.Carousel
 
             match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(BeatmapInfo.StarRating.FloorToDecimalDigits(2));
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(BeatmapInfo.Difficulty.ApproachRate);
-            match &= !criteria.Accuracy.HasFilter || (criteria.Accuracy.IsInRange(90d));
-
-            Logger.Log($"Passing on the beatmap [{BeatmapInfo.GetDisplayTitle()}]");
-            if (BeatmapInfo.Scores.Any())
-            {
-                Logger.Log($"Applying Beatmap Carousel Filter matching : max acc found for map : {BeatmapInfo.GetDisplayTitle()} is {BeatmapInfo.Scores.Max(info => info.Accuracy)}");
-            }
 
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(BeatmapInfo.Difficulty.DrainRate);
             match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(BeatmapInfo.Difficulty.CircleSize);

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Screens.Select
         public BeatmapSetInfo? SelectedBeatmapSet;
 
         public OptionalRange<double> StarDifficulty;
+        public OptionalRange<double> Accuracy;
         public OptionalRange<float> ApproachRate;
         public OptionalRange<float> DrainRate;
         public OptionalRange<float> CircleSize;

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -43,6 +43,9 @@ namespace osu.Game.Screens.Select
                 case "sr":
                     return TryUpdateCriteriaRange(ref criteria.StarDifficulty, op, value, 0);
 
+
+                case "acc":
+                    return TryUpdateCriteriaRange(ref criteria.Accuracy, op, value);
                 case "ar":
                     return TryUpdateCriteriaRange(ref criteria.ApproachRate, op, value);
 

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -43,9 +43,21 @@ namespace osu.Game.Screens.Select
                 case "sr":
                     return TryUpdateCriteriaRange(ref criteria.StarDifficulty, op, value, 0);
 
-
                 case "acc":
-                    return TryUpdateCriteriaRange(ref criteria.Accuracy, op, value);
+                case "accuracy":
+                    // Allowed accuracy formats are :
+                    // - 90%
+                    // - 0.90
+                    // - 90
+                    // So users can write `acc>90`, `acc>0.90` and `acc>90%` and the same goes for other comparison operators.
+                    if (value.EndsWith('%'))
+                        value = value.TrimEnd('%');
+
+                    if (double.TryParse(value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out double parsedAcc) && parsedAcc > 1)
+                        parsedAcc /= 100;
+
+                    return TryUpdateCriteriaRange(ref criteria.Accuracy, op, parsedAcc.ToString(CultureInfo.InvariantCulture), 0);
+
                 case "ar":
                     return TryUpdateCriteriaRange(ref criteria.ApproachRate, op, value);
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -832,7 +832,7 @@ namespace osu.Game.Screens.SelectV2
 
         protected virtual Dictionary<Guid, double> GetBeatmapInfoGuidToTopRankAccuracyMapping(FilterCriteria criteria) => realm.Run(r =>
         {
-            var topRankMapping = new Dictionary<Guid, double>();
+            var topRankAccuracyMapping = new Dictionary<Guid, double>();
 
             var allLocalScores = r.GetAllLocalScoresForUser(criteria.LocalUserId)
                                   .Filter($@"{nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $0", criteria.Ruleset?.ShortName)
@@ -843,13 +843,13 @@ namespace osu.Game.Screens.SelectV2
             {
                 Debug.Assert(score.BeatmapInfo != null);
 
-                if (topRankMapping.ContainsKey(score.BeatmapInfo.ID))
+                if (topRankAccuracyMapping.ContainsKey(score.BeatmapInfo.ID))
                     continue;
 
-                topRankMapping[score.BeatmapInfo.ID] = score.Accuracy;
+                topRankAccuracyMapping[score.BeatmapInfo.ID] = score.Accuracy;
             }
 
-            return topRankMapping;
+            return topRankAccuracyMapping;
         });
 
         #endregion

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Screens.Select;
@@ -17,12 +16,14 @@ namespace osu.Game.Screens.SelectV2
     public class BeatmapCarouselFilterMatching : ICarouselFilter
     {
         private readonly Func<FilterCriteria> getCriteria;
+        private readonly Func<FilterCriteria, IReadOnlyDictionary<Guid, double>> getLocalUserTopRanksAccuracy;
 
         public int BeatmapItemsCount { get; private set; }
 
-        public BeatmapCarouselFilterMatching(Func<FilterCriteria> getCriteria)
+        public BeatmapCarouselFilterMatching(Func<FilterCriteria> getCriteria, Func<FilterCriteria, IReadOnlyDictionary<Guid, double>> getLocalUserTopRanksAccuracy)
         {
             this.getCriteria = getCriteria;
+            this.getLocalUserTopRanksAccuracy = getLocalUserTopRanksAccuracy;
         }
 
         public async Task<List<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken) => await Task.Run(() =>
@@ -34,6 +35,8 @@ namespace osu.Game.Screens.SelectV2
 
         private IEnumerable<CarouselItem> matchItems(IEnumerable<CarouselItem> items, FilterCriteria criteria)
         {
+            // Load every map top scores before iterating over the beatmaps
+            IReadOnlyDictionary<Guid, double> beatmapsIdsToTopRanksAccuracies = getLocalUserTopRanksAccuracy(criteria);
             int countMatching = 0;
 
             foreach (var item in items)
@@ -43,7 +46,7 @@ namespace osu.Game.Screens.SelectV2
                 if (beatmap.Hidden)
                     continue;
 
-                if (!checkCriteriaMatch(beatmap, criteria))
+                if (!checkCriteriaMatch(beatmap, criteria, beatmapsIdsToTopRanksAccuracies))
                     continue;
 
                 countMatching++;
@@ -53,7 +56,7 @@ namespace osu.Game.Screens.SelectV2
             BeatmapItemsCount = countMatching;
         }
 
-        private static bool checkCriteriaMatch(BeatmapInfo beatmap, FilterCriteria criteria)
+        private static bool checkCriteriaMatch(BeatmapInfo beatmap, FilterCriteria criteria, IReadOnlyDictionary<Guid, double> beatmapsIdsToTopRanksAccuracies)
         {
             bool match = criteria.Ruleset == null || beatmap.AllowGameplayWithRuleset(criteria.Ruleset!, criteria.AllowConvertedBeatmaps);
 
@@ -82,10 +85,10 @@ namespace osu.Game.Screens.SelectV2
 
             match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(beatmap.StarRating.FloorToDecimalDigits(2));
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(beatmap.Difficulty.ApproachRate);
-            match &= !criteria.Accuracy.HasFilter || (criteria.Accuracy.IsInRange(90f));
 
-            Logger.Log($"Passing on the beatmap [{beatmap.GetDisplayTitle()}]");
-            if (beatmap.Scores.Any()) Logger.Log($"Applying Beatmap Carousel Filter matching : max acc found for map : {beatmap.GetDisplayTitle()} is {beatmap.Scores.Max(info => info.Accuracy)}");
+            // If a user searches for acc > X, we only want maps they already played.
+            // If a user searches for acc < X, we accept maps with less than X accuracy and maps they didn't play yet.
+            match &= !criteria.Accuracy.HasFilter || criteria.Accuracy.IsInRange(beatmapsIdsToTopRanksAccuracies.GetValueOrDefault(beatmap.ID, 0d));
 
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(beatmap.Difficulty.DrainRate);
             match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(beatmap.Difficulty.CircleSize);

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Screens.Select;
@@ -81,11 +82,17 @@ namespace osu.Game.Screens.SelectV2
 
             match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(beatmap.StarRating.FloorToDecimalDigits(2));
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(beatmap.Difficulty.ApproachRate);
+            match &= !criteria.Accuracy.HasFilter || (criteria.Accuracy.IsInRange(90f));
+
+            Logger.Log($"Passing on the beatmap [{beatmap.GetDisplayTitle()}]");
+            if (beatmap.Scores.Any()) Logger.Log($"Applying Beatmap Carousel Filter matching : max acc found for map : {beatmap.GetDisplayTitle()} is {beatmap.Scores.Max(info => info.Accuracy)}");
+
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(beatmap.Difficulty.DrainRate);
             match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(beatmap.Difficulty.CircleSize);
             match &= !criteria.OverallDifficulty.HasFilter || criteria.OverallDifficulty.IsInRange(beatmap.Difficulty.OverallDifficulty);
             match &= !criteria.Length.HasFilter || criteria.Length.IsInRange(beatmap.Length);
             match &= !criteria.LastPlayed.HasFilter || criteria.LastPlayed.IsInRange(beatmap.LastPlayed ?? DateTimeOffset.MinValue);
+
             match &= !criteria.DateRanked.HasFilter || (beatmap.BeatmapSet?.DateRanked != null && criteria.DateRanked.IsInRange(beatmap.BeatmapSet.DateRanked.Value));
             match &= !criteria.DateSubmitted.HasFilter || (beatmap.BeatmapSet?.DateSubmitted != null && criteria.DateSubmitted.IsInRange(beatmap.BeatmapSet.DateSubmitted.Value));
             match &= !criteria.BPM.HasFilter || criteria.BPM.IsInRange(beatmap.BPM);


### PR DESCRIPTION
This PR adds an accuracy filter on the beatmaps carousel search bar.

This filter allows players to filter the beatmaps based on the accuracy they've achieved during their best score.

This filter recognizes the keywords `acc` and `accuracy`, and the value can be described in several formats : 

- `acc>=90.97` corresponds to `90.97%` accuracy
- `accuracy<=95.84%` corresponds to `95.84%` accuracy
- `acc>0.90` corresponds to `90%` accuracy

Beatmaps that have not yet been played are considered to have an accuracy of 0%, so a player searching for `acc<x` or `acc<=x` will still see unplayed maps.

The best scores achieved by the offline ("Guest") player are taken into account when filtering.

# Example

![osu_2025-10-16_10-53-41](https://github.com/user-attachments/assets/61b91b05-21a3-409d-84d3-e0471ef0450c)

---

With a filter of `acc>96%`, we obtain the only beatmap where the accuracy of the best score is greater than “96%”:

![osu_2025-10-16_10-54-02](https://github.com/user-attachments/assets/dedfe2c3-b410-48b7-b687-ae1acef89c99)

---
With a filter `acc>91`, we only get the two beatmaps where the user has an accuracy greater than 91%: 

![osu_2025-10-16_13-49-01](https://github.com/user-attachments/assets/71e591ba-d8d3-4b19-8cdd-b5b9b70e0c70)

![osu_2025-10-16_13-47-16](https://github.com/user-attachments/assets/5bcc8bfd-bf71-408e-a30b-59d75c372efa)

---
Same goes for `accuracy>0.9`, since it's only the value format that changes : 

![osu_2025-10-16_10-54-45](https://github.com/user-attachments/assets/f6076a6e-4c7a-42da-8b23-70b5c3d2e6fe)

---
With a "less than" filter, such as `accuracy<91`, we only get beatmaps with a maximum accuracy of less than 91%, as well as beatmaps that have not yet been played :

![osu_2025-10-16_11-02-31](https://github.com/user-attachments/assets/3ac2acbe-faf7-484a-a8c4-17b950750467)

![osu_2025-10-16_10-55-35](https://github.com/user-attachments/assets/9dff4ddf-a135-47c3-874f-d5543c69b9a3)