### PR TITLE
Fix quick play player panels being hard to see against bright user backgrounds

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
                     Id = 2,
                     Colour = "99EB47",
                     CountryCode = CountryCode.AU,
-                    CoverUrl = @"https://assets.ppy.sh/user-profile-covers/8195163/4a8e2ad5a02a2642b631438cfa6c6bd7e2f9db289be881cb27df18331f64144c.jpeg",
+                    CoverUrl = @"https://assets.ppy.sh/user-profile-covers/2/baba245ef60834b769694178f8f6d4f6166c5188c740de084656ad2b80f1eea7.jpeg",
                     Statistics = new UserStatistics { GlobalRank = null, CountryRank = null }
                 }
             })

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
@@ -67,13 +67,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
         private IDialogOverlay? dialogOverlay { get; set; }
 
         [Resolved]
-        protected OverlayColourProvider? ColourProvider { get; private set; }
+        private OverlayColourProvider? colourProvider { get; set; }
 
         [Resolved]
         private IPerformFromScreenRunner? performer { get; set; }
 
         [Resolved]
-        protected OsuColour Colours { get; private set; } = null!;
+        private OsuColour colours { get; set; } = null!;
 
         [Resolved]
         private MultiplayerClient? multiplayerClient { get; set; }
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             Add(SolidBackgroundLayer = new Box
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = ColourProvider?.Background5 ?? Colours.Gray1
+                Colour = colourProvider?.Background5 ?? colours.Gray1
             });
 
             Background = new UserCoverBackground
@@ -141,6 +141,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
+                Colour = colours.Gray7,
                 User = User
             };
             if (Background != null)
@@ -303,7 +304,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
                     this.ResizeTo(horizontal ? size_horizontal : size_vertical, duration, Easing.OutPow10);
 
-                    rankText.MoveTo(horizontal ? new Vector2(-40, -10) : new Vector2(-70, 0), duration, Easing.OutPow10);
+                    rankText.MoveTo(horizontal ? new Vector2(-40, -20) : new Vector2(-70, 0), duration, Easing.OutPow10);
                     username.MoveTo(horizontal ? new Vector2(0, -46) : new Vector2(0, -86), duration, Easing.OutPow10);
                     scoreText.MoveTo(horizontal ? new Vector2(0, -16) : new Vector2(0, -56), duration, Easing.OutPow10);
                     break;


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| <img width="662" height="374" alt="2025-10-18 23 20 57@2x" src="https://github.com/user-attachments/assets/eef17402-764c-438e-8fd2-6157a7fa517b" /> | <img width="662" height="374" alt="2025-10-18 23 20 14@2x" src="https://github.com/user-attachments/assets/f9e70ae2-cbe7-4882-b0fa-5d4c0560fc40" /> |