### PR TITLE
Use correct distance in speed evaluator

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -51,8 +51,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             if (DifficultyCalculationUtils.MillisecondsToBPM(strainTime) > min_speed_bonus)
                 speedBonus = 0.75 * Math.Pow((DifficultyCalculationUtils.BPMToMilliseconds(min_speed_bonus) - strainTime) / speed_balancing_factor, 2);
 
-            double travelDistance = osuPrevObj?.TravelDistance ?? 0;
-            double distance = travelDistance + osuCurrObj.MinimumJumpDistance;
+            double travelDistance = osuPrevObj?.LazyTravelDistance ?? 0;
+            double distance = travelDistance + osuCurrObj.LazyJumpDistance;
 
             // Cap distance at single_spacing_threshold
             distance = Math.Min(distance, single_spacing_threshold);


### PR DESCRIPTION
The current distance calculation used for distance bonus in the speed evaluator is wrong.

Currently, distance in speed evaluator is calculated as `osuCurrObj.TravelDistance` + `osuCurrObj.MinimumJumpDistance`. This was presumably done by someone who wanted to include sliders in distance calculations but did not understand the difference between the different distance variables in `OsuDifficultyHitObject`.

So what actually are these variables?
- `TravelDistance` - The "lazy" distance traveled across the slider, with a bonus multiplier given depending on the number of reverse arrows the slider has. ("lazy" distance is the distance traveled assuming the player is only going for slider ticks and ignoring the rest of the slider body)
- `MinimumJumpDistance` - A number which, at max, is the distance from the previous object's "lazy" sliderend to the start of the current object. It is less than that distance if "a more natural path is able to be taken through the previous object".

For speed, the bonus multiplier on `TravelDistance` is negligible. The missing distance on `MinimumJumpDistance` is not. Because of this, **the distance used by the speed evaluator is often less than the actual distance between two objects.**

I've changed the calculation into `osuCurrObj.LazyTravelDistance` + `osuCurrObj.LazyJumpDistance`. What does this do?
- `LazyTravelDistance` - The "lazy" distance traveled across the slider
- `LazyJumpDistance` - The distance from the previous object's "lazy" sliderend to the start of the current object.
Crucially, the sum of these numbers is the distance of a real, continuous path from the start of the previous object to the start of the current object. No distance is being cut off.

There's a handful of high profile buffs, and a couple tiny nerfs.

I believe there is also a similar issue in the aim evaluator but that's an issue for another day since the balance considerations of fixing aim are much bigger.