### PR TITLE
Accuracy to pause 

### DIFF
--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -23,7 +23,6 @@ using osuTK;
 using osuTK.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Utils;
-using osu.Game.Localisation.HUD;
 
 namespace osu.Game.Screens.Play
 {
@@ -233,10 +232,12 @@ namespace osu.Game.Screens.Play
                 playInfoText.AddText(GameplayMenuOverlayStrings.SongProgress);
                 playInfoText.AddText($"{progress}%", cp => cp.Font = cp.Font.With(weight: FontWeight.Bold));
             }
+
             if (gameplayState != null)
             {
                 playInfoText.NewLine();
-                playInfoText.AddText("Accuracy: ");
+                playInfoText.AddText(SongSelectStrings.Accuracy);
+                playInfoText.AddText(": ");
                 playInfoText.AddText(gameplayState!.ScoreProcessor.Accuracy.Value.FormatAccuracy(), cp => cp.Font = cp.Font.With(weight: FontWeight.Bold));
             }
         }

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -22,6 +22,8 @@ using osu.Game.Input.Bindings;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Localisation;
+using osu.Game.Utils;
+using osu.Game.Localisation.HUD;
 
 namespace osu.Game.Screens.Play
 {
@@ -230,6 +232,12 @@ namespace osu.Game.Screens.Play
                 playInfoText.NewLine();
                 playInfoText.AddText(GameplayMenuOverlayStrings.SongProgress);
                 playInfoText.AddText($"{progress}%", cp => cp.Font = cp.Font.With(weight: FontWeight.Bold));
+            }
+            if (gameplayState != null)
+            {
+                playInfoText.NewLine();
+                playInfoText.AddText("Accuracy: ");
+                playInfoText.AddText(gameplayState!.ScoreProcessor.Accuracy.Value.FormatAccuracy(), cp => cp.Font = cp.Font.With(weight: FontWeight.Bold));
             }
         }
 


### PR DESCRIPTION
### **I like, really want to have accuracy in the pause and fail menus**

I chose not to have accuracy active in gameplay in my skin, so I removed it. But now if I fail, I can't see it. Then I came up with an idea! Make it into the game!

So! I made it, it works, but has no localization. With this people without accuracy in their skins can see it when paused or failed.

oh yeah, it also works on all game modes as it should