### PR TITLE
Make quick play redownload locally modified beatmaps

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -644,7 +644,7 @@ namespace osu.Game.Beatmaps
 
         public override bool IsAvailableLocally(BeatmapSetInfo model) => Realm.Run(realm => realm.All<BeatmapSetInfo>().Any(s => s.OnlineID == model.OnlineID && !s.DeletePending));
 
-        public bool IsAvailableLocally(BeatmapInfo model)
+        public bool IsAvailableLocally(IBeatmapInfo model)
         {
             return Realm.Run(r => r.All<BeatmapInfo>()
                                    .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -644,6 +644,14 @@ namespace osu.Game.Beatmaps
 
         public override bool IsAvailableLocally(BeatmapSetInfo model) => Realm.Run(realm => realm.All<BeatmapSetInfo>().Any(s => s.OnlineID == model.OnlineID && !s.DeletePending));
 
+        public bool IsAvailableLocally(BeatmapInfo model)
+        {
+            return Realm.Run(r => r.All<BeatmapInfo>()
+                                   .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")
+                                   .Filter($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", model.OnlineID)
+                                   .Any());
+        }
+
         #endregion
 
         #region Implementation of IPostImports<out BeatmapSetInfo>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
             downloadCheckCancellation?.Cancel();
 
-            if (beatmapManager.IsAvailableLocally(new BeatmapInfo { OnlineID = item.BeatmapID }))
+            if (beatmapManager.IsAvailableLocally(new APIBeatmap { OnlineID = item.BeatmapID }))
                 return;
 
             // In a perfect world we'd use BeatmapAvailability, but there's no event-driven flow for when a selection changes.

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -17,6 +17,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online;
@@ -74,6 +75,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
         [Resolved]
         private AudioManager audio { get; set; } = null!;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
 
         private readonly MultiplayerRoom room;
 
@@ -290,7 +294,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                     if (beatmapSet == null)
                         return;
 
-                    beatmapDownloader.Download(beatmapSet);
+                    beatmapDownloader.Download(beatmapSet, config.Get<bool>(OsuSetting.PreferNoVideo));
                 }));
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -20,6 +20,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking.Events;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -275,18 +276,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
             downloadCheckCancellation?.Cancel();
 
+            if (beatmapManager.IsAvailableLocally(new BeatmapInfo { OnlineID = item.BeatmapID }))
+                return;
+
             // In a perfect world we'd use BeatmapAvailability, but there's no event-driven flow for when a selection changes.
             // ie. if selection changes from "not downloaded" to another "not downloaded" we wouldn't get a value changed raised.
             beatmapLookupCache
                 .GetBeatmapAsync(item.BeatmapID, (downloadCheckCancellation = new CancellationTokenSource()).Token)
                 .ContinueWith(resolved => Schedule(() =>
                 {
-                    var beatmapSet = resolved.GetResultSafely()?.BeatmapSet;
+                    APIBeatmapSet? beatmapSet = resolved.GetResultSafely()?.BeatmapSet;
 
                     if (beatmapSet == null)
-                        return;
-
-                    if (beatmapManager.IsAvailableLocally(new BeatmapSetInfo { OnlineID = beatmapSet.OnlineID }))
                         return;
 
                     beatmapDownloader.Download(beatmapSet);


### PR DESCRIPTION
`IsLocallyAvailable` returns `true` if the beatmap set exists even if the beatmap we'll use was modified. The new `BeatmapInfo` overload added in this PR uses the same condition as in other places to test for beatmap availability:

https://github.com/ppy/osu/blob/47b95de06de78151875322f68f3b87a8766d6999/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs#L612

https://github.com/ppy/osu/blob/47b95de06de78151875322f68f3b87a8766d6999/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L655

https://github.com/ppy/osu/blob/47b95de06de78151875322f68f3b87a8766d6999/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs#L493

https://github.com/ppy/osu/blob/47b95de06de78151875322f68f3b87a8766d6999/osu.Game/Screens/OnlinePlay/OnlinePlayBeatmapAvailabilityTracker.cs#L156-L157

For the time being, this PR only updates quick play to use this new method. Before going further and updating other usages, I'd first like confirmation that this is the correct way of going about things.