### PR TITLE
Allow `NumberFormattingExtensions.ToStandardFormattedString()` to accept culture

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Globalization;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -53,7 +52,7 @@ namespace osu.Game.Rulesets.Catch.Mods
                 return string.Empty;
 
                 string format(string acronym, DifficultyBindable bindable)
-                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1, cultureInfo: CultureInfo.InvariantCulture)}";
+                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Globalization;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -51,7 +52,8 @@ namespace osu.Game.Rulesets.Catch.Mods
 
                 return string.Empty;
 
-                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+                string format(string acronym, DifficultyBindable bindable)
+                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1, cultureInfo: CultureInfo.InvariantCulture)}";
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Globalization;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -51,7 +52,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 return string.Empty;
 
-                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+                string format(string acronym, DifficultyBindable bindable)
+                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1, cultureInfo: CultureInfo.InvariantCulture)}";
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Globalization;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -53,7 +52,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 return string.Empty;
 
                 string format(string acronym, DifficultyBindable bindable)
-                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1, cultureInfo: CultureInfo.InvariantCulture)}";
+                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
             }
         }
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Globalization;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -34,7 +35,8 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
                 return string.Empty;
 
-                string format(string acronym, DifficultyBindable bindable, int digits) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(digits)}";
+                string format(string acronym, DifficultyBindable bindable, int digits)
+                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(digits, cultureInfo: CultureInfo.InvariantCulture)}";
             }
         }
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Globalization;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -36,7 +35,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 return string.Empty;
 
                 string format(string acronym, DifficultyBindable bindable, int digits)
-                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(digits, cultureInfo: CultureInfo.InvariantCulture)}";
+                    => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(digits)}";
             }
         }
 

--- a/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
+++ b/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Globalization;
 using NUnit.Framework;
 using osu.Game.Extensions;
 
@@ -19,7 +20,7 @@ namespace osu.Game.Tests.Extensions
         [TestCase(50, true, 0, ExpectedResult = "50%")]
         public string TestInteger(int input, bool percent, int decimalDigits)
         {
-            return input.ToStandardFormattedString(decimalDigits, percent);
+            return input.ToStandardFormattedString(decimalDigits, percent, CultureInfo.InvariantCulture);
         }
 
         [TestCase(-1, false, 0, ExpectedResult = "-1")]
@@ -41,6 +42,16 @@ namespace osu.Game.Tests.Extensions
         [TestCase(1, true, 0, ExpectedResult = "100%")]
         public string TestDouble(double input, bool percent, int decimalDigits)
         {
+            return input.ToStandardFormattedString(decimalDigits, percent, CultureInfo.InvariantCulture);
+        }
+
+        [Test]
+        [SetCulture("fr-FR")]
+        [TestCase(0.4, true, 2, ExpectedResult = "40%")]
+        [TestCase(1e-6, false, 6, ExpectedResult = "0,000001")]
+        [TestCase(0.48333, true, 4, ExpectedResult = "48,33%")]
+        public string TestCultureSensitivityWhenNoneSpecified(double input, bool percent, int decimalDigits)
+        {
             return input.ToStandardFormattedString(decimalDigits, percent);
         }
 
@@ -49,9 +60,9 @@ namespace osu.Game.Tests.Extensions
         [TestCase(0.4, true, 2, ExpectedResult = "40%")]
         [TestCase(1e-6, false, 6, ExpectedResult = "0.000001")]
         [TestCase(0.48333, true, 4, ExpectedResult = "48.33%")]
-        public string TestCultureInsensitivity(double input, bool percent, int decimalDigits)
+        public string TestCultureInsensitivityWhenInvariantSpecified(double input, bool percent, int decimalDigits)
         {
-            return input.ToStandardFormattedString(decimalDigits, percent);
+            return input.ToStandardFormattedString(decimalDigits, percent, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
+++ b/osu.Game.Tests/Extensions/NumberFormattingExtensionsTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Globalization;
 using NUnit.Framework;
 using osu.Game.Extensions;
 
@@ -18,9 +17,10 @@ namespace osu.Game.Tests.Extensions
         [TestCase(0, true, 0, ExpectedResult = "0%")]
         [TestCase(1, true, 0, ExpectedResult = "1%")]
         [TestCase(50, true, 0, ExpectedResult = "50%")]
+        [SetCulture("")] // invariant culture
         public string TestInteger(int input, bool percent, int decimalDigits)
         {
-            return input.ToStandardFormattedString(decimalDigits, percent, CultureInfo.InvariantCulture);
+            return input.ToStandardFormattedString(decimalDigits, percent);
         }
 
         [TestCase(-1, false, 0, ExpectedResult = "-1")]
@@ -40,17 +40,8 @@ namespace osu.Game.Tests.Extensions
         [TestCase(0.48333, true, 2, ExpectedResult = "48%")]
         [TestCase(0.48333, true, 4, ExpectedResult = "48.33%")]
         [TestCase(1, true, 0, ExpectedResult = "100%")]
+        [SetCulture("")] // invariant culture
         public string TestDouble(double input, bool percent, int decimalDigits)
-        {
-            return input.ToStandardFormattedString(decimalDigits, percent, CultureInfo.InvariantCulture);
-        }
-
-        [Test]
-        [SetCulture("fr-FR")]
-        [TestCase(0.4, true, 2, ExpectedResult = "40%")]
-        [TestCase(1e-6, false, 6, ExpectedResult = "0,000001")]
-        [TestCase(0.48333, true, 4, ExpectedResult = "48,33%")]
-        public string TestCultureSensitivityWhenNoneSpecified(double input, bool percent, int decimalDigits)
         {
             return input.ToStandardFormattedString(decimalDigits, percent);
         }
@@ -58,11 +49,11 @@ namespace osu.Game.Tests.Extensions
         [Test]
         [SetCulture("fr-FR")]
         [TestCase(0.4, true, 2, ExpectedResult = "40%")]
-        [TestCase(1e-6, false, 6, ExpectedResult = "0.000001")]
-        [TestCase(0.48333, true, 4, ExpectedResult = "48.33%")]
-        public string TestCultureInsensitivityWhenInvariantSpecified(double input, bool percent, int decimalDigits)
+        [TestCase(1e-6, false, 6, ExpectedResult = "0,000001")]
+        [TestCase(0.48333, true, 4, ExpectedResult = "48,33%")]
+        public string TestCultureSensitivity(double input, bool percent, int decimalDigits)
         {
-            return input.ToStandardFormattedString(decimalDigits, percent, CultureInfo.InvariantCulture);
+            return input.ToStandardFormattedString(decimalDigits, percent);
         }
     }
 }

--- a/osu.Game/Extensions/NumberFormattingExtensions.cs
+++ b/osu.Game/Extensions/NumberFormattingExtensions.cs
@@ -16,9 +16,12 @@ namespace osu.Game.Extensions
         /// <param name="value">The numeric value.</param>
         /// <param name="maxDecimalDigits">The maximum number of decimals to be considered in the original value.</param>
         /// <param name="asPercentage">Whether the output should be a percentage. For integer types, 0-100 is mapped to 0-100%; for other types 0-1 is mapped to 0-100%.</param>
+        /// <param name="cultureInfo">The culture to use when formatting the value. Defaults to <see cref="CultureInfo.CurrentCulture"/> if not specified.</param>
         /// <returns>The formatted output.</returns>
-        public static string ToStandardFormattedString<T>(this T value, int maxDecimalDigits, bool asPercentage = false) where T : struct, INumber<T>, IMinMaxValue<T>
+        public static string ToStandardFormattedString<T>(this T value, int maxDecimalDigits, bool asPercentage = false, CultureInfo? cultureInfo = null) where T : struct, INumber<T>, IMinMaxValue<T>
         {
+            cultureInfo ??= CultureInfo.CurrentCulture;
+
             double floatValue = double.CreateTruncating(value);
 
             decimal decimalPrecision = normalise(decimal.CreateTruncating(value), maxDecimalDigits);
@@ -31,12 +34,12 @@ namespace osu.Game.Extensions
                 if (value is int)
                     floatValue /= 100;
 
-                return floatValue.ToString($@"0.{new string('0', Math.Max(0, significantDigits - 2))}%", CultureInfo.InvariantCulture);
+                return floatValue.ToString($@"0.{new string('0', Math.Max(0, significantDigits - 2))}%", cultureInfo);
             }
 
             string negativeSign = Math.Round(floatValue, significantDigits) < 0 ? "-" : string.Empty;
 
-            return $"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}", CultureInfo.InvariantCulture)}";
+            return $"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}", cultureInfo)}";
         }
 
         /// <summary>

--- a/osu.Game/Extensions/NumberFormattingExtensions.cs
+++ b/osu.Game/Extensions/NumberFormattingExtensions.cs
@@ -13,15 +13,15 @@ namespace osu.Game.Extensions
         /// <summary>
         /// For a given numeric type, return a formatted string in the standard format we use for display everywhere.
         /// </summary>
+        /// <remarks>
+        /// Number formatting will abide by <see cref="CultureInfo.CurrentCulture"/>.
+        /// </remarks>
         /// <param name="value">The numeric value.</param>
         /// <param name="maxDecimalDigits">The maximum number of decimals to be considered in the original value.</param>
         /// <param name="asPercentage">Whether the output should be a percentage. For integer types, 0-100 is mapped to 0-100%; for other types 0-1 is mapped to 0-100%.</param>
-        /// <param name="cultureInfo">The culture to use when formatting the value. Defaults to <see cref="CultureInfo.CurrentCulture"/> if not specified.</param>
         /// <returns>The formatted output.</returns>
-        public static string ToStandardFormattedString<T>(this T value, int maxDecimalDigits, bool asPercentage = false, CultureInfo? cultureInfo = null) where T : struct, INumber<T>, IMinMaxValue<T>
+        public static string ToStandardFormattedString<T>(this T value, int maxDecimalDigits, bool asPercentage = false) where T : struct, INumber<T>, IMinMaxValue<T>
         {
-            cultureInfo ??= CultureInfo.CurrentCulture;
-
             double floatValue = double.CreateTruncating(value);
 
             decimal decimalPrecision = normalise(decimal.CreateTruncating(value), maxDecimalDigits);
@@ -34,12 +34,12 @@ namespace osu.Game.Extensions
                 if (value is int)
                     floatValue /= 100;
 
-                return floatValue.ToString($@"0.{new string('0', Math.Max(0, significantDigits - 2))}%", cultureInfo);
+                return floatValue.ToString($@"0.{new string('0', Math.Max(0, significantDigits - 2))}%", CultureInfo.CurrentCulture);
             }
 
             string negativeSign = Math.Round(floatValue, significantDigits) < 0 ? "-" : string.Empty;
 
-            return $"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}", cultureInfo)}";
+            return $"{negativeSign}{Math.Abs(floatValue).ToString($"N{significantDigits}", CultureInfo.CurrentCulture)}";
         }
 
         /// <summary>

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 else
                 {
                     applySuggestion.Enabled.Value = true;
-                    hintText.Text = AudioSettingsStrings.SuggestedOffsetValueReceived(averageHitErrorHistory.Count, SuggestedOffset.Value.Value.ToStandardFormattedString(0, false));
+                    hintText.Text = AudioSettingsStrings.SuggestedOffsetValueReceived(averageHitErrorHistory.Count, SuggestedOffset.Value.Value.ToStandardFormattedString(0));
                 }
             }
 

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -82,7 +81,7 @@ namespace osu.Game.Rulesets.Mods
 
                 return string.Empty;
 
-                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1, cultureInfo: CultureInfo.InvariantCulture)}";
+                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
             }
         }
 

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -81,7 +82,7 @@ namespace osu.Game.Rulesets.Mods
 
                 return string.Empty;
 
-                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1, cultureInfo: CultureInfo.InvariantCulture)}";
             }
         }
 


### PR DESCRIPTION
I had previously made it invariant in https://github.com/ppy/osu/pull/32837, and in another instance of past me being an asshole, I can't actually find the reasoning for this at this time.

That said, you'd be excused for thinking "why does this matter"? Well, this will fix https://github.com/ppy/osu/issues/35381, because that failure only occurs when the user's culture is set to one that doesn't use a decimal point (`.`) but rather a decimal comma (`,`). This messes with framework, [which uses the *current* culture to check for decimal separator rather than invariant](https://github.com/ppy/osu-framework/blob/d3226a7842487de43a0d989e1bb59a9ebbc479af/osu.Framework/Graphics/UserInterface/TextBox.cs#L106-L111) and therefore strips the decimal point, leading to the breakage.

I debated whether the default should be current culture or invariant, but ended up using current culture to be consistent with .NET's default behaviour.

An alternative would be to change framework instead to always accept the invariant decimal separator.

God I hate this culture crap.