### PR TITLE
Attempt to improve performance of beatmap carousel when not grouped by sets

### DIFF
--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -761,13 +761,26 @@ namespace osu.Game.Graphics.Carousel
             {
                 var item = carouselItems[i];
 
+                bool isKeyboardSelection = CheckModelEquality(item.Model, currentKeyboardSelection.Model!);
+                bool isSelection = CheckModelEquality(item.Model, currentSelection.Model!);
+
+                // while we don't know the Y position of the item yet, as it's about to be updated,
+                // consumers (specifically `BeatmapCarousel.GetSpacingBetweenPanels()`) benefit from `CurrentSelectionItem` already pointing
+                // at the correct item to avoid redundant local equality checks.
+                // the Y positions will be filled in after they're computed.
+                if (isKeyboardSelection)
+                    currentKeyboardSelection = new Selection(currentKeyboardSelection.Model, item, null, i);
+
+                if (isSelection)
+                    currentSelection = new Selection(currentSelection.Model, item, null, i);
+
                 updateItemYPosition(item, ref lastVisible, ref yPos);
 
-                if (CheckModelEquality(item.Model, currentKeyboardSelection.Model!))
-                    currentKeyboardSelection = new Selection(currentKeyboardSelection.Model, item, item.CarouselYPosition + item.DrawHeight / 2, i);
+                if (isKeyboardSelection)
+                    currentKeyboardSelection = currentKeyboardSelection with { YPosition = item.CarouselYPosition + item.DrawHeight / 2 };
 
-                if (CheckModelEquality(item.Model, currentSelection.Model!))
-                    currentSelection = new Selection(currentSelection.Model, item, item.CarouselYPosition + item.DrawHeight / 2, i);
+                if (isSelection)
+                    currentSelection = currentSelection with { YPosition = item.CarouselYPosition + item.DrawHeight / 2 };
             }
 
             // Update the total height of all items (to make the scroll container scrollable through the full height even though

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -86,8 +86,7 @@ namespace osu.Game.Screens.SelectV2
             }
             else
             {
-                // `CurrentSelectionItem` cannot be used here because it may not be correctly set yet.
-                if (CurrentSelection != null && (CheckModelEquality(top.Model, CurrentSelection) || CheckModelEquality(bottom.Model, CurrentSelection)))
+                if (CurrentSelection != null && (top == CurrentSelectionItem || bottom == CurrentSelectionItem))
                     return SPACING * 2;
             }
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Collections;
@@ -38,6 +39,7 @@ namespace osu.Game.Screens.SelectV2
 
         private Box chevronBackground = null!;
         private PanelSetBackground setBackground = null!;
+        private ScheduledDelegate? scheduledBackgroundRetrieval;
 
         private OsuSpriteText titleText = null!;
         private OsuSpriteText artistText = null!;
@@ -191,7 +193,7 @@ namespace osu.Game.Screens.SelectV2
             var beatmapSet = groupedBeatmapSet.BeatmapSet;
 
             // Choice of background image matches BSS implementation (always uses the lowest `beatmap_id` from the set).
-            setBackground.Beatmap = beatmaps.GetWorkingBeatmap(beatmapSet.Beatmaps.MinBy(b => b.OnlineID));
+            scheduledBackgroundRetrieval = Scheduler.AddDelayed(s => setBackground.Beatmap = beatmaps.GetWorkingBeatmap(s.Beatmaps.MinBy(b => b.OnlineID)), beatmapSet, 50);
 
             titleText.Text = new RomanisableString(beatmapSet.Metadata.TitleUnicode, beatmapSet.Metadata.Title);
             artistText.Text = new RomanisableString(beatmapSet.Metadata.ArtistUnicode, beatmapSet.Metadata.Artist);
@@ -204,6 +206,8 @@ namespace osu.Game.Screens.SelectV2
         {
             base.FreeAfterUse();
 
+            scheduledBackgroundRetrieval?.Cancel();
+            scheduledBackgroundRetrieval = null;
             setBackground.Beatmap = null;
             updateButton.BeatmapSet = null;
             difficultiesDisplay.BeatmapSet = null;

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
@@ -55,6 +56,7 @@ namespace osu.Game.Screens.SelectV2
         private CancellationTokenSource? starDifficultyCancellationSource;
 
         private PanelSetBackground beatmapBackground = null!;
+        private ScheduledDelegate? scheduledBackgroundRetrieval;
 
         private OsuSpriteText titleText = null!;
         private OsuSpriteText artistText = null!;
@@ -222,7 +224,7 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmapSet = beatmap.BeatmapSet!;
 
-            beatmapBackground.Beatmap = beatmaps.GetWorkingBeatmap(beatmap);
+            scheduledBackgroundRetrieval = Scheduler.AddDelayed(b => beatmapBackground.Beatmap = beatmaps.GetWorkingBeatmap(b), beatmap, 50);
 
             titleText.Text = new RomanisableString(beatmapSet.Metadata.TitleUnicode, beatmapSet.Metadata.Title);
             artistText.Text = new RomanisableString(beatmapSet.Metadata.ArtistUnicode, beatmapSet.Metadata.Artist);
@@ -244,6 +246,8 @@ namespace osu.Game.Screens.SelectV2
         {
             base.FreeAfterUse();
 
+            scheduledBackgroundRetrieval?.Cancel();
+            scheduledBackgroundRetrieval = null;
             beatmapBackground.Beatmap = null;
             updateButton.BeatmapSet = null;
             localRank.Beatmap = null;

--- a/osu.Game/Screens/SelectV2/PanelSetBackground.cs
+++ b/osu.Game/Screens/SelectV2/PanelSetBackground.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Screens.SelectV2
                 // - By using a slightly customised formula to decide when to start the load, we can coerce the loading of backgrounds into an order that
                 //   prioritises panels which are closest to the centre of the screen. Basically, we want to load backgrounds "outwards" from the visual
                 //   centre to give the user the best experience possible.
-                float timeUpdatingBeforeLoad = 50 + Math.Abs(containingSsdq.Centre.Y - ScreenSpaceDrawQuad.Centre.Y) / containingSsdq.Height * 100;
+                float timeUpdatingBeforeLoad = Math.Abs(containingSsdq.Centre.Y - ScreenSpaceDrawQuad.Centre.Y) / containingSsdq.Height * 100;
 
                 timeSinceUnpool += Time.Elapsed;
 


### PR DESCRIPTION
RFC. Maybe addresses some of https://github.com/ppy/osu/issues/34843.

## [Slightly delay retrieval of working beatmaps in song select panels](https://github.com/ppy/osu/commit/4ebd97b8040cdc1124f648e1cb849e079722bf20)

Beatmap panels can be visible for very brief instants. `PanelSetBackground` has a backstop to prevent expensive background loads which is based on the position of the panel relative to centre of screen.

However, retrieving the working beatmap - which is done *only* for the purposes of displaying the backgrounds, and that *precedes* any of that expensive background load logic - is *also* expensive because realm detaches are expensive due to deep cloning via automapper, and *always* runs even if a panel is visible on screen for only a brief second. Therefore, by moving some of that background load delay towards delaying retrieving the working beatmap, we can save on doing even more work, which has beneficial implications for performance.

There's no great way to show profiling results for this, as the hopeful result is the decreased *count* of calls to `GetWorkingBeatmap()`, which is a bit tricky to demonstrate when spamming F2 because how many retrievals happen depends on pure chance.

This doesn't specifically impact standalone panels, which is why the commit also touches set panels, but is more noticeable on standalone panels because there are *more* panels with backgrounds in these cases.

## [Fix performance overhead when computing spacing between standalone panels](https://github.com/ppy/osu/commit/c34b2ffc052e918855478d062bb72bee8efd066c) 

The equality check that was supposed to replace the read of `CurrentSelectionItem` (see https://github.com/ppy/osu/commit/a3db764008798aa8500266a95f960ed15a6ae28b) showed up as a hotspot in profiling.

The selection updating code looks a little stupid after this, but all in the name of performance...

| before | after |
| :-: | :-: |
| <img width="1231" height="645" alt="Screenshot 2025-10-22 at 12 00 55" src="https://github.com/user-attachments/assets/54d6c23a-e795-4f97-b32b-c637e51036f1" /> | <img width="1220" height="659" alt="Screenshot 2025-10-22 at 12 01 28" src="https://github.com/user-attachments/assets/643fdb35-dafd-4f56-8501-ed3c850782da" /> |