### PR TITLE
Fix quick play "view beatmap" not showing beatmap overlay

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
@@ -23,10 +24,17 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             BeatmapSelectPanel? panel = null;
 
-            AddStep("add panel", () => Child = panel = new BeatmapSelectPanel(new MultiplayerPlaylistItem())
+            AddStep("add panel", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
+                Child = new OsuContextMenuContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = panel = new BeatmapSelectPanel(new MultiplayerPlaylistItem())
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                };
             });
 
             AddStep("add maarvin", () => panel!.AddUser(new APIUser

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -19,6 +20,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
@@ -315,7 +317,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
         {
             get
             {
-                var items = base.ContextMenuItems.ToList();
+                List<MenuItem> items = [new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, DefaultAction)];
 
                 foreach (var button in buttonContainer.Buttons)
                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectPanel.cs
@@ -157,16 +157,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
         protected override void OnHoverLost(HoverLostEvent e)
         {
             base.OnHoverLost(e);
+
             lighting.FadeOut(200);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             if (AllowSelection && e.Button == MouseButton.Left)
-            {
                 scaleContainer.ScaleTo(0.95f, 400, Easing.OutExpo);
-                return true;
-            }
 
             return base.OnMouseDown(e);
         }
@@ -174,6 +172,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
         protected override void OnMouseUp(MouseUpEvent e)
         {
             base.OnMouseUp(e);
+
             if (e.Button == MouseButton.Left)
                 scaleContainer.ScaleTo(1f, 500, Easing.OutElasticHalf);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectPanel.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 
         private BeatmapCardMatchmaking? card;
 
-        public override bool PropagatePositionalInputSubTree => AllowSelection;
-
         public BeatmapSelectPanel(MultiplayerPlaylistItem item)
         {
             Item = item;
@@ -119,7 +117,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 mainContent.Add(card = new BeatmapCardMatchmaking(beatmap)
                 {
                     Depth = float.MaxValue,
-                    Action = () => Action?.Invoke(Item),
+                    Action = () =>
+                    {
+                        if (AllowSelection)
+                            Action?.Invoke(Item);
+                    },
                 });
 
                 foreach (var user in users)
@@ -141,23 +143,26 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 
         protected override bool OnHover(HoverEvent e)
         {
-            lighting.FadeTo(0.2f, 50)
-                    .Then()
-                    .FadeTo(0.1f, 300);
+            if (AllowSelection)
+            {
+                lighting.FadeTo(0.2f, 50)
+                        .Then()
+                        .FadeTo(0.1f, 300);
+                return true;
+            }
 
-            return true;
+            return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
             base.OnHoverLost(e);
-
             lighting.FadeOut(200);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (e.Button == MouseButton.Left)
+            if (AllowSelection && e.Button == MouseButton.Left)
             {
                 scaleContainer.ScaleTo(0.95f, 400, Easing.OutExpo);
                 return true;
@@ -169,18 +174,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
         protected override void OnMouseUp(MouseUpEvent e)
         {
             base.OnMouseUp(e);
-
             if (e.Button == MouseButton.Left)
-            {
                 scaleContainer.ScaleTo(1f, 500, Easing.OutElasticHalf);
-            }
         }
 
         protected override bool OnClick(ClickEvent e)
         {
-            lighting.FadeTo(0.5f, 50)
-                    .Then()
-                    .FadeTo(0.1f, 400);
+            if (AllowSelection)
+            {
+                lighting.FadeTo(0.5f, 50)
+                        .Then()
+                        .FadeTo(0.1f, 400);
+            }
 
             // pass through to let the beatmap card handle actual click.
             return false;


### PR DESCRIPTION
Partially resolves https://github.com/ppy/osu/issues/35329
Tangentially fixes https://github.com/ppy/osu/issues/35327

Minimal effort because this structure is extremely confusing to work with. (Hoping to get a redesign of these cards and reimplement completely)

In this case, `base.ContextMenuItems` only contains the single "view beatmap" item anyway so this is only changes its routing from `Action` to `DefaultAction`.