### PR TITLE
Fix solo leaderboard sometimes not showing user position while it technically could

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     new ScoreInfo { User = new APIUser { Username = "Top", Id = 2 }, TotalScore = 900_000, Accuracy = 0.99, MaxCombo = 999 },
                     new ScoreInfo { User = new APIUser { Username = "Second", Id = 14 }, TotalScore = 800_000, Accuracy = 0.9, MaxCombo = 888 },
                     new ScoreInfo { User = friend, TotalScore = 700_000, Accuracy = 0.88, MaxCombo = 777 },
-                }, 3, null);
+                }, scoresRequested: 50, totalScores: 3, null);
             });
 
             createLeaderboard();
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     new ScoreInfo { User = new APIUser { Username = "Top", Id = 2 }, TotalScore = 900_000_000, Accuracy = 0.99, MaxCombo = 999999 },
                     new ScoreInfo { User = new APIUser { Username = "Second", Id = 14 }, TotalScore = 800_000_000, Accuracy = 0.9, MaxCombo = 888888 },
                     new ScoreInfo { User = friend, TotalScore = 700_000_000, Accuracy = 0.88, MaxCombo = 777777 },
-                }, 3, null);
+                }, scoresRequested: 50, totalScores: 3, null);
             });
 
             createLeaderboard();
@@ -170,7 +170,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     scores.Add(new ScoreInfo { User = new APIUser { Username = $"Player {i + 1}" }, TotalScore = RNG.Next(700_000, 1_000_000) });
 
                 // this is dodgy but anything less dodgy is a lot of work
-                ((Bindable<LeaderboardScores?>)leaderboardManager.Scores).Value = LeaderboardScores.Success(scores, scores.Count, null);
+                ((Bindable<LeaderboardScores?>)leaderboardManager.Scores).Value = LeaderboardScores.Success(scores, scoresRequested: 50, scores.Count, null);
                 gameplayState.ScoreProcessor.TotalScore.Value = 0;
             });
 
@@ -208,7 +208,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     new ScoreInfo { User = new APIUser { Username = "smoogipoo", Id = 1040328 }, TotalScore = 800_000, Accuracy = 0.9, MaxCombo = 888 },
                     new ScoreInfo { User = new APIUser { Username = "flyte", Id = 3103765 }, TotalScore = 700_000, Accuracy = 0.9, MaxCombo = 888 },
                     new ScoreInfo { User = new APIUser { Username = "frenzibyte", Id = 14210502 }, TotalScore = 600_000, Accuracy = 0.9, MaxCombo = 777 },
-                }, 4, null);
+                }, scoresRequested: 50, totalScores: 4, null);
             });
 
             createLeaderboard();
@@ -223,7 +223,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 ((Bindable<LeaderboardScores?>)leaderboardManager.Scores).Value = LeaderboardScores.Success(new[]
                 {
                     new ScoreInfo { User = new APIUser { Username = "Quit", Id = 3 }, TotalScore = 100_000, Accuracy = 0.99, MaxCombo = 999 },
-                }, 1, null);
+                }, scoresRequested: 50, totalScores: 1, null);
             });
 
             createLeaderboard();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSoloGameplayLeaderboardProvider.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSoloGameplayLeaderboardProvider.cs
@@ -37,7 +37,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                         TotalScore = 10_000 * (100 - i),
                         Position = i,
                     }).ToArray(),
-                    1337,
+                    scoresRequested: 100,
+                    totalScores: 100,
                     null
                 );
             });
@@ -84,7 +85,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                         TotalScore = 600_000 + 10_000 * (40 - i),
                         Position = i,
                     }).ToArray(),
-                    1337,
+                    scoresRequested: 50,
+                    totalScores: 40,
                     null
                 );
             });
@@ -131,7 +133,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                         TotalScore = 500_000 + 10_000 * (50 - i),
                         Position = i
                     }).ToArray(),
-                    1337,
+                    scoresRequested: 50,
+                    totalScores: 1337,
                     new ScoreInfo { TotalScore = 200_000 }
                 );
             });

--- a/osu.Game.Tests/Visual/Ranking/TestSceneSoloResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneSoloResultsScreen.cs
@@ -352,7 +352,8 @@ namespace osu.Game.Tests.Visual.Ranking
                             {
                                 Score = userBest,
                                 Position = 133_337,
-                            }
+                            },
+                            ScoresCount = 200_000,
                         });
                         return true;
                 }
@@ -406,7 +407,8 @@ namespace osu.Game.Tests.Visual.Ranking
                             {
                                 Score = userBest,
                                 Position = 133_337,
-                            }
+                            },
+                            ScoresCount = 200_000,
                         });
                         return true;
                 }
@@ -511,7 +513,8 @@ namespace osu.Game.Tests.Visual.Ranking
                             {
                                 Score = userBest,
                                 Position = 133_337,
-                            }
+                            },
+                            ScoresCount = 200_000,
                         });
                         return true;
                 }

--- a/osu.Game/Online/API/Requests/GetScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetScoresRequest.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Online.API.Requests
         public const int DEFAULT_SCORES_PER_REQUEST = 50;
         public const int MAX_SCORES_PER_REQUEST = 100;
 
+        public int ScoresRequested { get; }
+
         private readonly IBeatmapInfo beatmapInfo;
         private readonly BeatmapLeaderboardScope scope;
         private readonly IRulesetInfo ruleset;
@@ -37,6 +39,8 @@ namespace osu.Game.Online.API.Requests
             this.scope = scope;
             this.ruleset = ruleset ?? throw new ArgumentNullException(nameof(ruleset));
             this.mods = mods ?? Array.Empty<IMod>();
+
+            ScoresRequested = this.scope.RequiresSupporter(this.mods.Any()) ? MAX_SCORES_PER_REQUEST : DEFAULT_SCORES_PER_REQUEST;
         }
 
         protected override string Target => $@"beatmaps/{beatmapInfo.OnlineID}/scores";
@@ -51,7 +55,7 @@ namespace osu.Game.Online.API.Requests
             foreach (var mod in mods)
                 req.AddParameter(@"mods[]", mod.Acronym);
 
-            req.AddParameter(@"limit", (scope.RequiresSupporter(mods.Any()) ? MAX_SCORES_PER_REQUEST : DEFAULT_SCORES_PER_REQUEST).ToString(CultureInfo.InvariantCulture));
+            req.AddParameter(@"limit", ScoresRequested.ToString(CultureInfo.InvariantCulture));
             return req;
         }
 

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Screens.Ranking
             sortedScores = sortedScores.OrderByTotalScore().ToList();
 
             int delta = 0;
-            bool isPartialLeaderboard = leaderboardManager.CurrentCriteria?.Scope != BeatmapLeaderboardScope.Local && result.TopScores.Count >= 50;
+            bool isPartialLeaderboard = result.IsPartial;
 
             for (int i = 0; i < sortedScores.Count; i++)
             {

--- a/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             var globalScores = leaderboardManager?.Scores.Value;
 
-            isPartial = leaderboardManager?.CurrentCriteria?.Scope != BeatmapLeaderboardScope.Local && globalScores?.TopScores.Count >= 50;
+            isPartial = globalScores == null || globalScores.IsPartial;
 
             List<GameplayLeaderboardScore> newScores = new List<GameplayLeaderboardScore>();
 


### PR DESCRIPTION
The "partial" leaderboard logic in `SoloGameplayLeaderboardProvider` always assumed the online fetch would request 50 scores, which is no longer the case after https://github.com/ppy/osu/pull/33100.

Noticed in https://discord.com/channels/188630481301012481/188630652340404224/1430503761440149554.

The circumstances where this matters are pretty rare. You'd basically need to find an online leaderboard (friends / country / with selected mods) that has between 50 and 100 scores - if you do and then enter gameplay, the tracked score won't show a rank when it's last, even though it can. One such example I found that's usable *right now* is https://osu.ppy.sh/beatmapsets/2400092#osu/5204282, scoped to Hidden mod, which returns 63 online scores.

Because this uses the total score count as returned by web, it's probably also more accurate when a leaderboard has precisely 50 scores, but that's even more difficult to confirm, so I won't even try.