### PR TITLE
Adjust gameplay sample models to support custom sample sets

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Game.Audio;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Types;
@@ -53,13 +54,25 @@ namespace osu.Game.Rulesets.Catch.Objects
 
             public override IEnumerable<string> LookupNames => lookup_names;
 
-            public BananaHitSampleInfo(int volume = 100)
-                : base(string.Empty, volume: volume)
+            public BananaHitSampleInfo()
+                : this(string.Empty)
             {
             }
 
-            public sealed override HitSampleInfo With(Optional<string> newName = default, Optional<string> newBank = default, Optional<string?> newSuffix = default, Optional<int> newVolume = default, Optional<bool> newEditorAutoBank = default)
-                => new BananaHitSampleInfo(newVolume.GetOr(Volume));
+            public BananaHitSampleInfo(HitSampleInfo info)
+                : this(info.Name, info.Bank, info.Suffix, info.Volume, info.EditorAutoBank, info.UseBeatmapSamples)
+            {
+            }
+
+            private BananaHitSampleInfo(string name, string bank = SampleControlPoint.DEFAULT_BANK, string? suffix = null, int volume = 100, bool editorAutoBank = true, bool useBeatmapSamples = false)
+                : base(name, bank, suffix, volume, editorAutoBank, useBeatmapSamples)
+            {
+            }
+
+            public sealed override HitSampleInfo With(Optional<string> newName = default, Optional<string> newBank = default, Optional<string?> newSuffix = default, Optional<int> newVolume = default,
+                                                      Optional<bool> newEditorAutoBank = default, Optional<bool> newUseBeatmapSamples = default)
+                => new BananaHitSampleInfo(newName.GetOr(Name), newBank.GetOr(Bank), newSuffix.GetOr(Suffix), newVolume.GetOr(Volume),
+                    newEditorAutoBank.GetOr(EditorAutoBank), newUseBeatmapSamples.GetOr(UseBeatmapSamples));
 
             public bool Equals(BananaHitSampleInfo? other)
                 => other != null;

--- a/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Catch.Objects
                 {
                     StartTime = time,
                     BananaIndex = count,
-                    Samples = new List<HitSampleInfo> { new Banana.BananaHitSampleInfo(CreateHitSampleInfo().Volume) }
+                    Samples = new List<HitSampleInfo> { new Banana.BananaHitSampleInfo(CreateHitSampleInfo()) }
                 });
 
                 count++;

--- a/osu.Game.Rulesets.Taiko/Skinning/Argon/VolumeAwareHitSampleInfo.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Argon/VolumeAwareHitSampleInfo.cs
@@ -13,7 +13,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Argon
         public const int SAMPLE_VOLUME_THRESHOLD_MEDIUM = 60;
 
         public VolumeAwareHitSampleInfo(HitSampleInfo sampleInfo, bool isStrong = false)
-            : base(sampleInfo.Name, isStrong ? BANK_STRONG : getBank(sampleInfo.Bank, sampleInfo.Name, sampleInfo.Volume), sampleInfo.Suffix, sampleInfo.Volume)
+            : base(sampleInfo.Name, isStrong ? BANK_STRONG : getBank(sampleInfo.Bank, sampleInfo.Name, sampleInfo.Volume), sampleInfo.Suffix, sampleInfo.Volume,
+                sampleInfo.EditorAutoBank, sampleInfo.UseBeatmapSamples)
         {
         }
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         private class LegacyTaikoSampleInfo : HitSampleInfo
         {
             public LegacyTaikoSampleInfo(HitSampleInfo sampleInfo)
-                : base(sampleInfo.Name, sampleInfo.Bank, sampleInfo.Suffix, sampleInfo.Volume)
+                : base(sampleInfo.Name, sampleInfo.Bank, sampleInfo.Suffix, sampleInfo.Volume, sampleInfo.EditorAutoBank, sampleInfo.UseBeatmapSamples)
 
             {
             }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -245,14 +245,21 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 HitObjects =
                 {
                     new HitCircle { StartTime = 100, Samples = [new HitSampleInfo(HitSampleInfo.HIT_NORMAL)] },
-                    new HitCircle { StartTime = 300, Samples = [new HitSampleInfo(HitSampleInfo.HIT_NORMAL, suffix: "3")] },
+                    new HitCircle { StartTime = 200, Samples = [new HitSampleInfo(HitSampleInfo.HIT_NORMAL, useBeatmapSamples: true)] },
+                    new HitCircle { StartTime = 300, Samples = [new HitSampleInfo(HitSampleInfo.HIT_NORMAL, suffix: "3", useBeatmapSamples: true)] },
                 }
             };
 
             var decodedAfterEncode = decodeFromLegacy(encodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty))), string.Empty);
 
             Assert.That(decodedAfterEncode.beatmap.HitObjects[0].Samples[0].Suffix, Is.Null);
-            Assert.That(decodedAfterEncode.beatmap.HitObjects[1].Samples[0].Suffix, Is.EqualTo("3"));
+            Assert.That(decodedAfterEncode.beatmap.HitObjects[0].Samples[0].UseBeatmapSamples, Is.False);
+
+            Assert.That(decodedAfterEncode.beatmap.HitObjects[1].Samples[0].Suffix, Is.Null);
+            Assert.That(decodedAfterEncode.beatmap.HitObjects[1].Samples[0].UseBeatmapSamples, Is.True);
+
+            Assert.That(decodedAfterEncode.beatmap.HitObjects[2].Samples[0].Suffix, Is.EqualTo("3"));
+            Assert.That(decodedAfterEncode.beatmap.HitObjects[2].Samples[0].UseBeatmapSamples, Is.True);
         }
 
         private bool areComboColoursEqual(IHasComboColours a, IHasComboColours b)

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
@@ -234,6 +235,24 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decodedSlider = (Slider)decodedAfterEncode.beatmap.HitObjects[0];
             Assert.That(decodedSlider.Path.ControlPoints.Select(p => p.Position),
                 Is.EquivalentTo(originalSlider.Path.ControlPoints.Select(p => p.Position)));
+        }
+
+        [Test]
+        public void TestEncodeCustomSampleBanks()
+        {
+            var beatmap = new Beatmap
+            {
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 100, Samples = [new HitSampleInfo(HitSampleInfo.HIT_NORMAL)] },
+                    new HitCircle { StartTime = 300, Samples = [new HitSampleInfo(HitSampleInfo.HIT_NORMAL, suffix: "3")] },
+                }
+            };
+
+            var decodedAfterEncode = decodeFromLegacy(encodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty))), string.Empty);
+
+            Assert.That(decodedAfterEncode.beatmap.HitObjects[0].Samples[0].Suffix, Is.Null);
+            Assert.That(decodedAfterEncode.beatmap.HitObjects[1].Samples[0].Suffix, Is.EqualTo("3"));
         }
 
         private bool areComboColoursEqual(IHasComboColours a, IHasComboColours b)

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -65,13 +65,19 @@ namespace osu.Game.Audio
         /// </summary>
         public bool EditorAutoBank { get; }
 
-        public HitSampleInfo(string name, string bank = SampleControlPoint.DEFAULT_BANK, string? suffix = null, int volume = 100, bool editorAutoBank = true)
+        /// <summary>
+        /// Whether the sample can be looked up from the beatmap's skin.
+        /// </summary>
+        public bool UseBeatmapSamples { get; }
+
+        public HitSampleInfo(string name, string bank = SampleControlPoint.DEFAULT_BANK, string? suffix = null, int volume = 100, bool editorAutoBank = true, bool useBeatmapSamples = false)
         {
             Name = name;
             Bank = bank;
             Suffix = suffix;
             Volume = volume;
             EditorAutoBank = editorAutoBank;
+            UseBeatmapSamples = useBeatmapSamples;
         }
 
         /// <summary>
@@ -99,16 +105,19 @@ namespace osu.Game.Audio
         /// <param name="newSuffix">An optional new lookup suffix.</param>
         /// <param name="newVolume">An optional new volume.</param>
         /// <param name="newEditorAutoBank">An optional new editor auto bank flag.</param>
+        /// <param name="newUseBeatmapSamples">An optional use beatmap samples flag.</param>
         /// <returns>The new <see cref="HitSampleInfo"/>.</returns>
-        public virtual HitSampleInfo With(Optional<string> newName = default, Optional<string> newBank = default, Optional<string?> newSuffix = default, Optional<int> newVolume = default, Optional<bool> newEditorAutoBank = default)
-            => new HitSampleInfo(newName.GetOr(Name), newBank.GetOr(Bank), newSuffix.GetOr(Suffix), newVolume.GetOr(Volume), newEditorAutoBank.GetOr(EditorAutoBank));
+        public virtual HitSampleInfo With(Optional<string> newName = default, Optional<string> newBank = default, Optional<string?> newSuffix = default, Optional<int> newVolume = default,
+                                          Optional<bool> newEditorAutoBank = default, Optional<bool> newUseBeatmapSamples = default)
+            => new HitSampleInfo(newName.GetOr(Name), newBank.GetOr(Bank), newSuffix.GetOr(Suffix), newVolume.GetOr(Volume),
+                newEditorAutoBank.GetOr(EditorAutoBank), newUseBeatmapSamples.GetOr(UseBeatmapSamples));
 
         public virtual bool Equals(HitSampleInfo? other)
-            => other != null && Name == other.Name && Bank == other.Bank && Suffix == other.Suffix;
+            => other != null && Name == other.Name && Bank == other.Bank && Suffix == other.Suffix && UseBeatmapSamples == other.UseBeatmapSamples;
 
         public override bool Equals(object? obj)
             => obj is HitSampleInfo other && Equals(other);
 
-        public override int GetHashCode() => HashCode.Combine(Name, Bank, Suffix);
+        public override int GetHashCode() => HashCode.Combine(Name, Bank, Suffix, UseBeatmapSamples);
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -321,9 +321,21 @@ namespace osu.Game.Beatmaps.Formats
                     int volume = samples.Max(o => o.Volume);
                     string bank = samples.Where(s => s.Name == HitSampleInfo.HIT_NORMAL).Select(s => s.Bank).FirstOrDefault()
                                   ?? samples.Select(s => s.Bank).First();
-                    int customIndex = samples.Any(o => o is ConvertHitObjectParser.LegacyHitSampleInfo)
-                        ? samples.OfType<ConvertHitObjectParser.LegacyHitSampleInfo>().Max(o => o.CustomSampleBank)
-                        : -1;
+
+                    int customIndex = samples.Max(s =>
+                    {
+                        switch (s)
+                        {
+                            case ConvertHitObjectParser.LegacyHitSampleInfo legacy:
+                                return legacy.CustomSampleBank;
+
+                            default:
+                                if (int.TryParse(s.Suffix, out int index))
+                                    return index;
+
+                                return s.UseBeatmapSamples ? 1 : -1;
+                        }
+                    });
 
                     return new LegacyBeatmapDecoder.LegacySampleControlPoint { Time = time, SampleVolume = volume, SampleBank = bank, CustomSampleBank = customIndex };
                 }

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -11,7 +11,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Database;
 using osu.Game.IO;
-using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK.Graphics;
 
@@ -90,11 +89,8 @@ namespace osu.Game.Skinning
 
         public override ISample? GetSample(ISampleInfo sampleInfo)
         {
-            if (sampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacy && legacy.CustomSampleBank == 0)
-            {
-                // When no custom sample bank is provided, always fall-back to the default samples.
+            if (sampleInfo is HitSampleInfo hitSampleInfo && !hitSampleInfo.UseBeatmapSamples)
                 return null;
-            }
 
             return base.GetSample(sampleInfo);
         }


### PR DESCRIPTION
RFC. First real step towards https://github.com/ppy/osu/issues/35370.

This is a set of model changes which is supposed to facilitate support for custom sample sets to the beatmap editor that is on par with stable.

It is the minimal set of changes. Because of this, it can probably be considered "ugly" or however else you want to put it - but before you say that, I want to try and pre-empt that criticism by explaining where the problems lie.

Problem 1: duality in sample models
---

There is currently a weird duality of what a `HitObject`'s samples will be.

- If an object has just been placed in the editor, and not saved / decoded yet, it will use `HitSampleInfo`.
- If an object has already been encoded to the beatmap at least once, it will use `ConvertHitObjectParser.LegacyHitSampleInfo`.

As long as that state of affairs remains, `HitSampleInfo` must be able to represent anything that `LegacyHitSampleInfo` can, if feature parity is to be achieved.

Problem 2: The 0 & 1 sample banks
---

Custom sample banks of 2 and above are a pretty clean affair. They map to a suffix on the sample filename, and said samples are allowed to be looked up from the beatmap skin. `Suffix` already exists in `HitSampleInfo`.

However, the 1 custom sample bank is evil. It uses *non-suffixed* samples, and *allows lookups from the beatmap skins*, contrary to no bank / bank 0, which *also* uses non-suffixed samples, but *doesn't* allow them to be looked up from the beatmap skin.

This is why `HitSampleInfo.UseBeatmapSamples` has been called to existence - without it there is no way to represent the ability of using or not using the beatmap skin assets.

As has been stated previously in discussions about this feature, it's both a *mapping* and a *skinning* concern.

There are many things you could do about either of these problems, but I am pretty sure tackling either one is going to take *many* more lines of code than this commit does. Which is why this is the starting point of negotiation.