### PR TITLE
Disable presenting beatmaps during quick play

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
     /// <summary>
     /// The main matchmaking screen which houses a custom <see cref="ScreenStack"/> through the life cycle of a single session.
     /// </summary>
-    public partial class ScreenMatchmaking : OsuScreen, IPreviewTrackOwner
+    public partial class ScreenMatchmaking : OsuScreen, IPreviewTrackOwner, IHandlePresentBeatmap
     {
         /// <summary>
         /// Padding between rows of the content.
@@ -419,6 +419,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
             beatmap.NewValue.PrepareTrackForPreview(true);
             music.EnsurePlayingSomething();
+        }
+
+        public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)
+        {
+            // Do nothing to prevent the user from potentially being kicked out
+            // of gameplay due to the screen performer's internal processes.
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/35353
Fixes https://github.com/ppy/osu/issues/35328

This is a bit of a workaround. It touches on two issues:

`PerformFromMenuRunner` will continuously try to exit the current screen. If the "are you sure you want to exit multiplayer" dialog remains open until the player loader, it will exit the player loader screen. This can be simulated with this patch: https://gist.github.com/smoogipoo/b4ed97ce99e350ed16b6ed036b299b11 (press the spectate button on an autostart room and wait until player loader before pressing cancel).

I'm not sure how to fix this yet.

The second issue is that any sort of import notification will give you a "X has been imported, click to view" button, which really shouldn't exist in quick play. This one goes deep and I'm not sure how to resolve it from every possible case of import (e.g. dragging files into the game).

By disabling beatmap presents, we effectively make both of the above operations into no-ops.