### PR TITLE
Implement grouping by favourites

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselFilterGroupingTest.cs
@@ -368,10 +368,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
         private static async Task<List<CarouselItem>> runGrouping(GroupMode group, List<BeatmapSetInfo> beatmapSets)
         {
-            var groupingFilter = new BeatmapCarouselFilterGrouping(
-                () => new FilterCriteria { Group = group },
-                () => new List<BeatmapCollection>(),
-                _ => new Dictionary<Guid, ScoreRank>());
+            var groupingFilter = new BeatmapCarouselFilterGrouping
+            {
+                GetCriteria = () => new FilterCriteria { Group = group },
+                GetCollections = () => new List<BeatmapCollection>(),
+                GetLocalUserTopRanks = _ => new Dictionary<Guid, ScoreRank>()
+            };
 
             return await groupingFilter.Run(beatmapSets.SelectMany(s => s.Beatmaps.Select(b => new CarouselItem(b))).ToList(), CancellationToken.None);
         }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/FavouriteButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/FavouriteButton.cs
@@ -62,6 +62,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                 current.Value = new BeatmapSetFavouriteState(favourited, current.Value.FavouriteCount + (favourited ? 1 : -1));
 
                 SetLoading(false);
+                api.LocalUserState.UpdateFavouriteBeatmapSets();
             };
             favouriteRequest.Failure += e =>
             {

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -238,16 +238,22 @@ namespace osu.Game.Online.API
 
             public BindableList<APIRelation> Friends { get; } = new BindableList<APIRelation>();
             public BindableList<APIRelation> Blocks { get; } = new BindableList<APIRelation>();
+            public BindableList<int> FavouriteBeatmapSets { get; } = new BindableList<int>();
 
             IBindable<APIUser> ILocalUserState.User => User;
             IBindableList<APIRelation> ILocalUserState.Friends => Friends;
             IBindableList<APIRelation> ILocalUserState.Blocks => Blocks;
+            IBindableList<int> ILocalUserState.FavouriteBeatmapSets => FavouriteBeatmapSets;
 
             public void UpdateFriends()
             {
             }
 
             public void UpdateBlocks()
+            {
+            }
+
+            public void UpdateFavouriteBeatmapSets()
             {
             }
         }

--- a/osu.Game/Online/API/ILocalUserState.cs
+++ b/osu.Game/Online/API/ILocalUserState.cs
@@ -11,8 +11,10 @@ namespace osu.Game.Online.API
         IBindable<APIUser> User { get; }
         IBindableList<APIRelation> Friends { get; }
         IBindableList<APIRelation> Blocks { get; }
+        IBindableList<int> FavouriteBeatmapSets { get; }
 
         void UpdateFriends();
         void UpdateBlocks();
+        void UpdateFavouriteBeatmapSets();
     }
 }

--- a/osu.Game/Online/API/Requests/GetMyFavouriteBeatmapSetsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetMyFavouriteBeatmapSetsRequest.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetMyFavouriteBeatmapSetsRequest : APIRequest<GetMyFavouriteBeatmapSetsResponse>
+    {
+        protected override string Target => @"me/beatmapset-favourites";
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/GetMyFavouriteBeatmapSetsResponse.cs
+++ b/osu.Game/Online/API/Requests/Responses/GetMyFavouriteBeatmapSetsResponse.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class GetMyFavouriteBeatmapSetsResponse
+    {
+        [JsonProperty("beatmapset_ids")]
+        public int[] BeatmapSetIds { get; set; } = [];
+    }
+}

--- a/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
@@ -74,6 +74,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
                 {
                     favourited.Toggle();
                     loading.Hide();
+                    api.LocalUserState.UpdateFavouriteBeatmapSets();
                 };
 
                 request.Failure += e =>

--- a/osu.Game/Screens/Ranking/FavouriteButton.cs
+++ b/osu.Game/Screens/Ranking/FavouriteButton.cs
@@ -109,6 +109,7 @@ namespace osu.Game.Screens.Ranking
 
                 Enabled.Value = true;
                 loading.Hide();
+                api.LocalUserState.UpdateFavouriteBeatmapSets();
             };
             favouriteRequest.Failure += e =>
             {

--- a/osu.Game/Screens/Select/Filter/GroupMode.cs
+++ b/osu.Game/Screens/Select/Filter/GroupMode.cs
@@ -32,8 +32,8 @@ namespace osu.Game.Screens.Select.Filter
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Difficulty))]
         Difficulty,
 
-        // [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Favourites))]
-        // Favourites,
+        [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Favourites))]
+        Favourites,
 
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.LastPlayed))]
         LastPlayed,

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -28,6 +28,7 @@ using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select;
@@ -109,7 +110,8 @@ namespace osu.Game.Screens.SelectV2
                 {
                     GetCriteria = () => Criteria!,
                     GetCollections = GetAllCollections,
-                    GetLocalUserTopRanks = GetBeatmapInfoGuidToTopRankMapping
+                    GetLocalUserTopRanks = GetBeatmapInfoGuidToTopRankMapping,
+                    GetFavouriteBeatmapSets = GetFavouriteBeatmapSets,
                 }
             };
 
@@ -809,10 +811,13 @@ namespace osu.Game.Screens.SelectV2
 
         #endregion
 
-        #region Database fetches for grouping support
+        #region Fetches for grouping support
 
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
 
         protected virtual List<BeatmapCollection> GetAllCollections() => realm.Run(r => r.All<BeatmapCollection>().AsEnumerable().Detach());
 
@@ -837,6 +842,13 @@ namespace osu.Game.Screens.SelectV2
 
             return topRankMapping;
         });
+
+        /// <remarks>
+        /// Note that calling <c>.ToHashSet()</c> below has two purposes:
+        /// one being performance of contain checks in filtering code,
+        /// another being slightly better thread safety (as <see cref="ILocalUserState.FavouriteBeatmapSets"/> could be mutated during async filtering).
+        /// </remarks>
+        protected HashSet<int> GetFavouriteBeatmapSets() => api.LocalUserState.FavouriteBeatmapSets.ToHashSet();
 
         #endregion
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -105,7 +105,12 @@ namespace osu.Game.Screens.SelectV2
             {
                 new BeatmapCarouselFilterMatching(() => Criteria!),
                 new BeatmapCarouselFilterSorting(() => Criteria!),
-                grouping = new BeatmapCarouselFilterGrouping(() => Criteria!, GetAllCollections, GetBeatmapInfoGuidToTopRankMapping)
+                grouping = new BeatmapCarouselFilterGrouping
+                {
+                    GetCriteria = () => Criteria!,
+                    GetCollections = GetAllCollections,
+                    GetLocalUserTopRanks = GetBeatmapInfoGuidToTopRankMapping
+                }
             };
 
             AddInternal(loading = new LoadingLayer());

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -39,17 +39,9 @@ namespace osu.Game.Screens.SelectV2
         private Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>> setMap = new Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>>();
         private Dictionary<GroupDefinition, HashSet<CarouselItem>> groupMap = new Dictionary<GroupDefinition, HashSet<CarouselItem>>();
 
-        private readonly Func<FilterCriteria> getCriteria;
-        private readonly Func<List<BeatmapCollection>> getCollections;
-        private readonly Func<FilterCriteria, IReadOnlyDictionary<Guid, ScoreRank>> getLocalUserTopRanks;
-
-        public BeatmapCarouselFilterGrouping(Func<FilterCriteria> getCriteria, Func<List<BeatmapCollection>> getCollections,
-                                             Func<FilterCriteria, IReadOnlyDictionary<Guid, ScoreRank>> getLocalUserTopRanks)
-        {
-            this.getCriteria = getCriteria;
-            this.getCollections = getCollections;
-            this.getLocalUserTopRanks = getLocalUserTopRanks;
-        }
+        public required Func<FilterCriteria> GetCriteria { get; init; }
+        public required Func<List<BeatmapCollection>> GetCollections { get; init; }
+        public required Func<FilterCriteria, IReadOnlyDictionary<Guid, ScoreRank>> GetLocalUserTopRanks { get; init; }
 
         public async Task<List<CarouselItem>> Run(IEnumerable<CarouselItem> items, CancellationToken cancellationToken)
         {
@@ -59,7 +51,7 @@ namespace osu.Game.Screens.SelectV2
                 var newSetMap = new Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>>(setMap.Count);
                 var newGroupMap = new Dictionary<GroupDefinition, HashSet<CarouselItem>>(groupMap.Count);
 
-                var criteria = getCriteria();
+                var criteria = GetCriteria();
                 var newItems = new List<CarouselItem>();
 
                 BeatmapSetsGroupedTogether = ShouldGroupBeatmapsTogether(criteria);
@@ -215,7 +207,7 @@ namespace osu.Game.Screens.SelectV2
 
                 case GroupMode.Collections:
                 {
-                    var collections = getCollections();
+                    var collections = GetCollections();
                     return getGroupsBy(b => defineGroupByCollection(b, collections), items);
                 }
 
@@ -224,7 +216,7 @@ namespace osu.Game.Screens.SelectV2
 
                 case GroupMode.RankAchieved:
                 {
-                    var topRankMapping = getLocalUserTopRanks(criteria);
+                    var topRankMapping = GetLocalUserTopRanks(criteria);
                     return getGroupsBy(b => defineGroupByRankAchieved(b, topRankMapping), items);
                 }
 

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.FavouriteButton.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.FavouriteButton.cs
@@ -233,6 +233,8 @@ namespace osu.Game.Screens.SelectV2
                     // if the beatmap set reference changed under the callback, abort visual updates to avoid showing stale data
                     if (onlineBeatmapSet == null || ReferenceEquals(beatmapSet, onlineBeatmapSet))
                         setBeatmapSet(beatmapSet, withHeartAnimation: hasFavourited);
+
+                    api.LocalUserState.UpdateFavouriteBeatmapSets();
                 };
                 favouriteRequest.Failure += e =>
                 {

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Screens.SelectV2
         private RealmAccess realm { get; set; } = null!;
 
         private IBindable<APIUser> localUser = null!;
+        private readonly IBindableList<int> localUserFavouriteBeatmapSets = new BindableList<int>();
 
         public LocalisableString StatusText
         {
@@ -186,6 +187,7 @@ namespace osu.Game.Screens.SelectV2
             };
 
             localUser = api.LocalUser.GetBoundCopy();
+            localUserFavouriteBeatmapSets.BindTo(api.LocalUserState.FavouriteBeatmapSets);
         }
 
         protected override void LoadComplete()
@@ -237,6 +239,7 @@ namespace osu.Game.Screens.SelectV2
             });
 
             localUser.BindValueChanged(_ => updateCriteria());
+            localUserFavouriteBeatmapSets.BindCollectionChanged((_, _) => updateCriteria());
 
             updateCriteria();
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34494.
- Supersedes / closes https://github.com/ppy/osu/pull/34744.

Main changes in comparison with the superseded PR mentioned above are: the usage of the endpoint added in https://github.com/ppy/osu-web/pull/12360, and general simplification.

Of particular note is https://github.com/ppy/osu/commit/6b56a0611b8ffa9890782b3f80f9bb3217f9b095, wherein the list of user favourites is refetched on every client mutation of favourites, matching precedent of how friends and blocks are handled. This results in simpler code, but a number of refetches that could be considered wasteful, as well as delayed effect of (un)favouriting on song select state. These downsides could likely be remedied, but at the cost of increased code complexity.