### PR TITLE
Fix song select collection group order not matching other collection lists when certain characters are used

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -398,15 +398,20 @@ namespace osu.Game.Screens.SelectV2
             return new GroupDefinition(0, source).Yield();
         }
 
-        private IEnumerable<GroupDefinition> defineGroupByCollection(BeatmapInfo beatmap, IEnumerable<BeatmapCollection> collections)
+        private IEnumerable<GroupDefinition> defineGroupByCollection(BeatmapInfo beatmap, List<BeatmapCollection> collections)
         {
             bool anyCollections = false;
 
-            foreach (var collection in collections)
+            for (int i = 0; i < collections.Count; i++)
             {
+                var collection = collections[i];
+
                 if (collection.BeatmapMD5Hashes.Contains(beatmap.MD5Hash))
                 {
-                    yield return new GroupDefinition(0, collection.Name);
+                    // NOTE: the ordering of the incoming collection list is significant and needs to be preserved.
+                    // the fallback to ordering by name cannot be relied on.
+                    // see xmldoc of `BeatmapCarousel.GetAllCollections()`.
+                    yield return new GroupDefinition(i, collection.Name);
 
                     anyCollections = true;
                 }
@@ -415,7 +420,7 @@ namespace osu.Game.Screens.SelectV2
             if (anyCollections)
                 yield break;
 
-            yield return new GroupDefinition(1, "Not in collection");
+            yield return new GroupDefinition(int.MaxValue, "Not in collection");
         }
 
         private IEnumerable<GroupDefinition> defineGroupByOwnMaps(BeatmapInfo beatmap, int? localUserId, string? localUserUsername)


### PR DESCRIPTION
| before | after |
| :-: | :-: |
| <img width="1107" height="740" alt="image" src="https://github.com/user-attachments/assets/3dcf0373-01e7-4454-8314-1b7637c38096" /> | <img width="1106" height="740" alt="image" src="https://github.com/user-attachments/assets/d7901a8a-f0a5-4cba-9ffc-6bfc0024ce3d" /> |

---

Addresses https://github.com/ppy/osu/discussions/35391.

See inline commentary for explanation, or visual explanation below:

<img width="1280" height="996" alt="image" src="https://github.com/user-attachments/assets/3e206d0e-d7c5-4e77-8caf-5b63c24dd168" />