### PR TITLE
Add support for tab key navigation for entire SampleEditPopover

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FocusRing.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FocusRing.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public partial class FocusRing : VisibilityContainer
+    {
+        public float Thickness { get; init; } = 3;
+
+        public double TransitionDuration = 100;
+
+        private readonly Container content;
+
+        public FocusRing()
+        {
+            Alpha = 0.5f;
+
+            Child = content = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Masking = true,
+                Child = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                }
+            };
+        }
+
+        protected override void PopIn()
+        {
+            this.TransformTo(nameof(Padding), new MarginPadding(-Thickness), TransitionDuration, Easing.Out);
+
+            content
+                .FadeIn(TransitionDuration)
+                .TransformTo(nameof(CornerRadius), CornerRadius + Thickness, TransitionDuration, Easing.Out);
+        }
+
+        protected override void PopOut()
+        {
+            this.TransformTo(nameof(Padding), new MarginPadding(0), TransitionDuration, Easing.Out);
+
+            content
+                .FadeOut(TransitionDuration)
+                .TransformTo(nameof(CornerRadius), CornerRadius, TransitionDuration, Easing.Out);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
@@ -6,20 +6,24 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Components.TernaryButtons
 {
-    public partial class DrawableTernaryButton : OsuButton, IHasTooltip, IHasCurrentValue<TernaryState>
+    public partial class DrawableTernaryButton : OsuButton, IHasTooltip, IHasCurrentValue<TernaryState>, ITabbableContainer
     {
         public Bindable<TernaryState> Current
         {
@@ -54,6 +58,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             RelativeSizeAxes = Axes.X;
         }
 
+        private FocusRing focusRing = null!;
+
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
@@ -62,6 +68,15 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 
             defaultIconColour = defaultBackgroundColour.Darken(0.5f);
             selectedIconColour = selectedBackgroundColour.Lighten(0.5f);
+
+            AddInternal(focusRing = new FocusRing
+            {
+                RelativeSizeAxes = Axes.Both,
+                CornerRadius = Content.CornerRadius,
+                Depth = float.MaxValue,
+                Alpha = 0.5f,
+                Colour = colourProvider.Background1,
+            });
 
             Add(Icon = (CreateIcon?.Invoke() ?? new Circle()).With(b =>
             {
@@ -136,5 +151,38 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             Anchor = Anchor.CentreLeft,
             X = 40f
         };
+
+        public bool CanBeTabbedTo { get; init; }
+
+        public override bool AcceptsFocus => CanBeTabbedTo;
+
+        protected override void OnFocus(FocusEvent e)
+        {
+            base.OnFocus(e);
+
+            focusRing.Show();
+        }
+
+        protected override void OnFocusLost(FocusLostEvent e)
+        {
+            base.OnFocusLost(e);
+
+            focusRing.Hide();
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (!HasFocus)
+                return false;
+
+            switch (e.Key)
+            {
+                case Key.Enter:
+                    Toggle();
+                    return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -261,10 +261,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     }
                 };
 
-                bank.TabbableContentContainer = flow;
-                additionBank.TabbableContentContainer = flow;
-                volume.TabbableContentContainer = flow;
-
                 // if the piece belongs to a currently selected object, assume that the user wants to change all selected objects.
                 // if the piece belongs to an unselected object, operate on that object alone, independently of the selection.
                 relevantObjects = (beatmap.SelectedHitObjects.Contains(hitObject) ? beatmap.SelectedHitObjects : hitObject.Yield()).ToArray();
@@ -462,6 +458,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         CreateIcon = () => ComposeBlueprintContainer.GetIconForSample(sampleName),
                         RelativeSizeAxes = Axes.None,
                         Size = new Vector2(40, 40),
+                        CanBeTabbedTo = true,
                     };
                 }
             }
@@ -504,6 +501,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             protected override bool OnKeyDown(KeyDownEvent e)
             {
+                if (e.Key == Key.Tab)
+                {
+                    this.MoveFocusToNextTabStop(e.ShiftPressed, requireFocusedChild: false);
+                    return true;
+                }
+
                 if (e.ControlPressed || e.SuperPressed || !checkRightToggleFromKey(e.Key, out int rightIndex))
                     return base.OnKeyDown(e);
 


### PR DESCRIPTION
Depends on ppy/osu-framework#6657

Allows using tab key to reach all buttons and form elements inside the sample edit popover. Ternary buttons can be toggled with enter key when focused.

Since `DrawableTernaryButton` isin use in other places where this may not make sense, `CanBeTabbedTo` needs to be set to opt in to this behaviour.


https://github.com/user-attachments/assets/e228d352-43d4-4425-87e8-c8d3e227d2b2

