### PR TITLE
Add settings toggle for experimental BASS initialisation mode

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2025.1021.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2025.1025.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Graphics;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
@@ -19,9 +19,11 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
         protected override LocalisableString Header => AudioSettingsStrings.AudioDevicesHeader;
 
         [Resolved]
-        private AudioManager audio { get; set; }
+        private AudioManager audio { get; set; } = null!;
 
-        private SettingsDropdown<string> dropdown;
+        private SettingsDropdown<string> dropdown = null!;
+
+        private SettingsCheckbox? wasapiExperimental;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -32,8 +34,21 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 {
                     LabelText = AudioSettingsStrings.OutputDevice,
                     Keywords = new[] { "speaker", "headphone", "output" }
-                }
+                },
             };
+
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
+            {
+                Add(wasapiExperimental = new SettingsCheckbox
+                {
+                    LabelText = "Use experimental audio mode",
+                    TooltipText = "This will attempt to initialise the WASAPI engine in a lower latency mode.",
+                    Current = audio.UseExperimentalWasapi,
+                    Keywords = new[] { "wasapi", "latency", "exclusive" }
+                });
+
+                wasapiExperimental.Current.ValueChanged += _ => onDeviceChanged(string.Empty);
+            }
 
             updateItems();
 
@@ -42,7 +57,21 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
             dropdown.Current = audio.AudioDevice;
         }
 
-        private void onDeviceChanged(string name) => updateItems();
+        private void onDeviceChanged(string _)
+        {
+            updateItems();
+
+            if (wasapiExperimental != null)
+            {
+                if (wasapiExperimental.Current.Value)
+                {
+                    wasapiExperimental.SetNoticeText(
+                        "Due to reduced latency, your audio offset will need to be adjusted when enabling this setting. Generally expect to subtract 20 - 60 ms from your known value.", true);
+                }
+                else
+                    wasapiExperimental.ClearNoticeText();
+            }
+        }
 
         private void updateItems()
         {
@@ -61,7 +90,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
             // functionality would require involved OS-specific code.
             dropdown.Items = deviceItems
                              // Dropdown doesn't like null items. Somehow we are seeing some arrive here (see https://github.com/ppy/osu/issues/21271)
-                             .Where(i => i != null)
+                             .Where(i => i.IsNotNull())
                              .Distinct()
                              .ToList();
         }
@@ -70,7 +99,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
         {
             base.Dispose(isDisposing);
 
-            if (audio != null)
+            if (audio.IsNotNull())
             {
                 audio.OnNewDevice -= onDeviceChanged;
                 audio.OnLostDevice -= onDeviceChanged;

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 Add(wasapiExperimental = new SettingsCheckbox
                 {
                     LabelText = "Use experimental audio mode",
-                    TooltipText = "This will attempt to initialise the WASAPI engine in a lower latency mode.",
+                    TooltipText = "This will attempt to initialise the audio engine in a lower latency mode.",
                     Current = audio.UseExperimentalWasapi,
                     Keywords = new[] { "wasapi", "latency", "exclusive" }
                 });

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2025.1021.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2025.1025.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2025.1006.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -17,6 +17,6 @@
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2025.1021.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2025.1025.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Intentionally not localised as this may change in the near future (ie become the default).

- [x] Depends on https://github.com/ppy/osu-framework/pull/6659.
- [x] Should be tested to work on windows