### PR TITLE
Fix the `Deselect All` button being squeezed into the corner when the `ModSelectOverlay` fades out

### DIFF
--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -330,11 +330,15 @@ namespace osu.Game.Screens.Footer
 
             updateColourScheme(OverlayColourScheme.Aquamarine.GetHue());
 
+            // Only move buttons back to the flow after the transition has completed.
+            // This avoids buttonsFlow's size expanding prematurely and squishing the footer content.
             var footerContent = activeFooterContent;
             this.Delay(timeUntilRun).Schedule(() =>
             {
                 footerContent.Expire();
 
+                // if you switch overlays quickly, we may have already started showing another.
+                // in this case, don't move buttons back to the flow.
                 if (activeFooterContent == null)
                     moveHiddenButtonsToFlow();
             });

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Screens.Footer
                     ColumnDimensions = new[]
                     {
                         new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(GridSizeMode.Absolute, 0),
                         new Dimension(),
                     },
                     Content = new[]
@@ -107,6 +108,13 @@ namespace osu.Game.Screens.Footer
                                 Y = ScreenFooterButton.CORNER_RADIUS,
                                 Direction = FillDirection.Horizontal,
                                 Spacing = new Vector2(7, 0),
+                                AutoSizeAxes = Axes.Both,
+                            },
+                            hiddenButtonsContainer = new Container<ScreenFooterButton>
+                            {
+                                Anchor = Anchor.BottomLeft,
+                                Origin = Anchor.BottomLeft,
+                                Y = ScreenFooterButton.CORNER_RADIUS,
                                 AutoSizeAxes = Axes.Both,
                             },
                             footerContentContainer = new Container
@@ -123,14 +131,6 @@ namespace osu.Game.Screens.Footer
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     Action = onBackPressed,
-                },
-                hiddenButtonsContainer = new Container<ScreenFooterButton>
-                {
-                    Margin = new MarginPadding { Left = OsuGame.SCREEN_EDGE_MARGIN + ScreenBackButton.BUTTON_WIDTH + padding },
-                    Y = ScreenFooterButton.CORNER_RADIUS,
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    AutoSizeAxes = Axes.Both,
                 },
                 (logoTrackingContainer = new LogoTrackingContainer
                 {
@@ -262,10 +262,14 @@ namespace osu.Game.Screens.Footer
             {
                 var button = temporarilyHiddenButtons[i];
                 buttonsFlow.Remove(button, false);
-                hiddenButtonsContainer.Add(button);
 
                 makeButtonDisappearToBottom(button, 0, 0, false);
             }
+
+            hiddenButtonsContainer.X = -buttonsFlow.Width;
+
+            for (int i = 0; i < temporarilyHiddenButtons.Count; i++)
+                hiddenButtonsContainer.Add(temporarilyHiddenButtons[i]);
 
             updateColourScheme(overlay.ColourProvider.Hue);
 

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -250,8 +250,6 @@ namespace osu.Game.Screens.Footer
 
             moveHiddenButtonsToFlow();
 
-            Debug.Assert(hiddenButtonsContainer.Count == 0);
-
             var targetButton = buttonsFlow.SingleOrDefault(b => b.Overlay == overlay);
 
             temporarilyHiddenButtons.AddRange(targetButton != null
@@ -332,6 +330,7 @@ namespace osu.Game.Screens.Footer
                 buttonsFlow.Add(button);
             }
 
+            hiddenButtonsContainer.Clear();
             temporarilyHiddenButtons.Clear();
         }
 

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Screens.Footer
         private readonly List<OverlayContainer> overlays = new List<OverlayContainer>();
 
         private Box background = null!;
+        private Container positionPreservingContainer = null!;
         private FillFlowContainer<ScreenFooterButton> buttonsFlow = null!;
         private Container footerContentContainer = null!;
         private Container<ScreenFooterButton> hiddenButtonsContainer = null!;
@@ -93,6 +94,7 @@ namespace osu.Game.Screens.Footer
                     Padding = new MarginPadding { Left = OsuGame.SCREEN_EDGE_MARGIN + ScreenBackButton.BUTTON_WIDTH + padding },
                     ColumnDimensions = new[]
                     {
+                        new Dimension(GridSizeMode.Absolute, 0),
                         new Dimension(GridSizeMode.AutoSize),
                         new Dimension(GridSizeMode.Absolute, 0),
                         new Dimension(),
@@ -101,6 +103,13 @@ namespace osu.Game.Screens.Footer
                     {
                         new Drawable[]
                         {
+                            positionPreservingContainer = new Container
+                            {
+                                Anchor = Anchor.BottomLeft,
+                                Origin = Anchor.BottomLeft,
+                                Y = ScreenFooterButton.CORNER_RADIUS,
+                                AutoSizeAxes = Axes.Both,
+                            },
                             buttonsFlow = new FillFlowContainer<ScreenFooterButton>
                             {
                                 Anchor = Anchor.BottomLeft,
@@ -198,7 +207,7 @@ namespace osu.Game.Screens.Footer
                 oldButton.Enabled.Value = false;
 
                 buttonsFlow.Remove(oldButton, false);
-                hiddenButtonsContainer.Add(oldButton);
+                positionPreservingContainer.Add(oldButton);
 
                 if (buttons.Count > 0)
                     makeButtonDisappearToRight(oldButton, i, oldButtons.Length, true);

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -248,6 +248,8 @@ namespace osu.Game.Screens.Footer
 
             ActiveOverlay = overlay;
 
+            moveHiddenButtonsToFlow();
+
             Debug.Assert(temporarilyHiddenButtons.Count == 0);
 
             var targetButton = buttonsFlow.SingleOrDefault(b => b.Overlay == overlay);
@@ -295,19 +297,38 @@ namespace osu.Game.Screens.Footer
             for (int i = 0; i < temporarilyHiddenButtons.Count; i++)
             {
                 var button = temporarilyHiddenButtons[i];
-                hiddenButtonsContainer.Remove(button, false);
-                buttonsFlow.Add(button);
 
                 makeButtonAppearFromBottom(button, 0);
             }
 
-            temporarilyHiddenButtons.Clear();
-
             updateColourScheme(OverlayColourScheme.Aquamarine.GetHue());
 
-            activeFooterContent.Delay(timeUntilRun).Expire();
-            activeFooterContent = null;
+            var footerContent = activeFooterContent;
+            this.Delay(timeUntilRun).Schedule(() =>
+            {
+                footerContent.Expire();
+
+                if (activeFooterContent == footerContent)
+                    activeFooterContent = null;
+
+                if (activeFooterContent == null)
+                    moveHiddenButtonsToFlow();
+            });
+
             ActiveOverlay = null;
+        }
+
+        private void moveHiddenButtonsToFlow()
+        {
+            for (int i = 0; i < temporarilyHiddenButtons.Count; i++)
+            {
+                var button = temporarilyHiddenButtons[i];
+
+                hiddenButtonsContainer.Remove(button, false);
+                buttonsFlow.Add(button);
+            }
+
+            temporarilyHiddenButtons.Clear();
         }
 
         private void updateColourScheme(int hue)

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -310,13 +310,11 @@ namespace osu.Game.Screens.Footer
             {
                 footerContent.Expire();
 
-                if (activeFooterContent == footerContent)
-                    activeFooterContent = null;
-
                 if (activeFooterContent == null)
                     moveHiddenButtonsToFlow();
             });
 
+            activeFooterContent = null;
             ActiveOverlay = null;
         }
 

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Screens.Footer
 
         public void SetButtons(IReadOnlyList<ScreenFooterButton> buttons)
         {
-            temporarilyHiddenButtons.Clear();
+            moveHiddenButtonsToFlow();
             overlays.Clear();
 
             this.HidePopover();
@@ -250,7 +250,7 @@ namespace osu.Game.Screens.Footer
 
             moveHiddenButtonsToFlow();
 
-            Debug.Assert(temporarilyHiddenButtons.Count == 0);
+            Debug.Assert(hiddenButtonsContainer.Count == 0);
 
             var targetButton = buttonsFlow.SingleOrDefault(b => b.Overlay == overlay);
 


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/3b0bc93a-8569-4505-ac58-71a56cad4319

After:

https://github.com/user-attachments/assets/1ab3bd52-8dba-4160-b9dc-0b5176d81e7d

You can see the `Deselect All` button being squeezed into the corner when I clicked the *Mods* button because the hidden buttons were added to `buttonsFlow` immediately, making `buttonsFlow` expand.

https://github.com/ppy/osu/blob/5faf791ca09eee23996c4b24e05c74b9412c45df/osu.Game/Screens/Footer/ScreenFooter.cs#L298-L299

This bug was introduced in #32531, the issue also appears in the *After* video at about 00:08.

I didn't add tests because the bug only exists during the animation and is thus hard to assert.
