### PR TITLE
Fix single filtered selection not being reselected after being filtered away

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -89,6 +89,33 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestFilterSingleResult_ReselectedAfterRulesetSwitches()
+        {
+            LoadSongSelect();
+
+            ImportBeatmapForRuleset(0);
+            ImportBeatmapForRuleset(0);
+
+            AddStep("disable converts", () => Config.SetValue(OsuSetting.ShowConvertedBeatmaps, false));
+            AddStep("set filter text", () => filterTextBox.Current.Value = $"\"{Beatmaps.GetAllUsableBeatmapSets().Last().Metadata.Title}\"");
+
+            AddWaitStep("wait for debounce", 5);
+            AddUntilStep("wait for filter", () => !Carousel.IsFiltering);
+            AddUntilStep("selection is second beatmap set", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(Beatmaps.GetAllUsableBeatmapSets().Last().Beatmaps.First()));
+
+            AddStep("select last difficulty", () => Beatmap.Value = Beatmaps.GetWorkingBeatmap(Beatmap.Value.BeatmapSetInfo.Beatmaps.Last()));
+            AddUntilStep("selection is last difficulty of second beatmap set", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(Beatmaps.GetAllUsableBeatmapSets().Last().Beatmaps.Last()));
+
+            ChangeRuleset(1);
+            AddUntilStep("wait for filter", () => !Carousel.IsFiltering);
+            AddUntilStep("selection is default", () => Beatmap.IsDefault);
+
+            ChangeRuleset(0);
+            AddUntilStep("wait for filter", () => !Carousel.IsFiltering);
+            AddUntilStep("selection is last difficulty of second beatmap set", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(Beatmaps.GetAllUsableBeatmapSets().Last().Beatmaps.Last()));
+        }
+
+        [Test]
         public void TestFilterOnResumeAfterChange()
         {
             ImportBeatmapForRuleset(0);

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -561,8 +561,19 @@ namespace osu.Game.Screens.SelectV2
 
             var beatmaps = items.Select(i => i.Model).OfType<GroupedBeatmap>();
 
-            if (beatmaps.Any(b => b.Equals(CurrentSelection as GroupedBeatmap)))
+            // do not request recommended selection if the user already had selected a difficulty within the single filtered beatmap set,
+            // as it could change the difficulty that will be selected
+            var preexistingSelection = beatmaps.FirstOrDefault(b => b.Equals(CurrentSelection as GroupedBeatmap));
+
+            if (preexistingSelection != null)
+            {
+                // the selection might not have an item associated with it, if it was fully filtered away previously
+                // in this case, request to reselect it
+                if (CurrentSelectionItem == null)
+                    RequestSelection(preexistingSelection);
+
                 return;
+            }
 
             RequestRecommendedSelection(beatmaps);
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35003.

Bit dodgy to use `CurrentSelectionItem` for this. Ideally I would use the global `Beatmap.IsDefault`, but I kind of don't want to violate the rule that `BeatmapCarousel` shouldn't have direct access to the global beatmap. And this seems to work, so... maybe fine to use until it doesn't?