### PR TITLE
Ensure to never display "0th" placement

### DIFF
--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUser.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUser.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
         /// The aggregate room placement (1-based).
         /// </summary>
         [Key(1)]
-        public int Placement { get; set; }
+        public int? Placement { get; set; }
 
         /// <summary>
         /// The aggregate points.

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
@@ -414,11 +414,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             if (!matchmakingState.Users.UserDictionary.TryGetValue(User.Id, out MatchmakingUser? userScore))
                 return;
 
-            if (userScore.Placement == 0)
+            if (userScore.Placement == null)
                 return;
 
-            rankText.Text = userScore.Placement.Ordinalize(CultureInfo.CurrentCulture);
-            rankText.FadeColour(SubScreenResults.ColourForPlacement(userScore.Placement));
+            rankText.Text = userScore.Placement.Value.Ordinalize(CultureInfo.CurrentCulture);
+            rankText.FadeColour(SubScreenResults.ColourForPlacement(userScore.Placement.Value));
             scoreText.Text = $"{userScore.Points} pts";
         });
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
@@ -414,6 +414,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             if (!matchmakingState.Users.UserDictionary.TryGetValue(User.Id, out MatchmakingUser? userScore))
                 return;
 
+            if (userScore.Placement == 0)
+                return;
+
             rankText.Text = userScore.Placement.Ordinalize(CultureInfo.CurrentCulture);
             rankText.FadeColour(SubScreenResults.ColourForPlacement(userScore.Placement));
             scoreText.Text = $"{userScore.Points} pts";

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanelOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanelOverlay.cs
@@ -239,8 +239,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                     if (client.Room?.MatchState is not MatchmakingRoomState matchmakingState)
                         continue;
 
-                    if (matchmakingState.Users.UserDictionary.TryGetValue(panels[i].User.Id, out MatchmakingUser? user))
-                        SetLayoutPosition(Children[i], user.Placement);
+                    if (matchmakingState.Users.UserDictionary.TryGetValue(panels[i].User.Id, out MatchmakingUser? user) && user.Placement != null)
+                        SetLayoutPosition(Children[i], user.Placement.Value);
                     else
                         SetLayoutPosition(Children[i], float.MaxValue);
                 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
@@ -201,13 +201,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.Results
                 return;
             }
 
-            int overallPlacement = state.Users[client.LocalUser!.UserID].Placement;
+            int? overallPlacement = state.Users[client.LocalUser!.UserID].Placement;
 
-            placementText.Text = overallPlacement.Ordinalize(CultureInfo.CurrentCulture);
-            placementText.Colour = ColourForPlacement(overallPlacement);
+            if (overallPlacement != null)
+            {
+                placementText.Text = overallPlacement.Value.Ordinalize(CultureInfo.CurrentCulture);
+                placementText.Colour = ColourForPlacement(overallPlacement.Value);
 
-            int overallPoints = state.Users[client.LocalUser!.UserID].Points;
-            addStatistic(overallPlacement, $"Overall position ({overallPoints} points)");
+                int overallPoints = state.Users[client.LocalUser!.UserID].Points;
+                addStatistic(overallPlacement.Value, $"Overall position ({overallPoints} points)");
+            }
 
             var accuracyOrderedUsers = state.Users.Select(u => (user: u, avgAcc: u.Rounds.Select(r => r.Accuracy).DefaultIfEmpty(0).Average()))
                                             .OrderByDescending(t => t.avgAcc)


### PR DESCRIPTION
Noticed in https://github.com/ppy/osu/pull/35470, where I was testing in combination with https://github.com/ppy/osu-server-spectator/pull/321.

In short, the server-spectator PR would make it so that the users dictionary is always populated, meaning "0th" would be displayed on initial display.