### PR TITLE
Fix quick play results screen crash when no one plays

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
@@ -137,5 +137,20 @@ namespace osu.Game.Tests.Visual.Matchmaking
                 MultiplayerClient.ChangeMatchRoomState(state).WaitSafely();
             });
         }
+
+        [Test]
+        public void TestNoUsers()
+        {
+            AddStep("show results with no users", () =>
+            {
+                var state = new MatchmakingRoomState
+                {
+                    CurrentRound = 6,
+                    Stage = MatchmakingStage.Ended
+                };
+
+                MultiplayerClient.ChangeMatchRoomState(state).WaitSafely();
+            });
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
@@ -255,27 +255,27 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.Results
             roomAwards.Clear();
 
             long maxScore = long.MinValue;
-            int maxScoreUserId = 0;
+            int maxScoreUserId = -1;
 
             double maxAccuracy = double.MinValue;
-            int maxAccuracyUserId = 0;
+            int maxAccuracyUserId = -1;
 
             int maxCombo = int.MinValue;
-            int maxComboUserId = 0;
+            int maxComboUserId = -1;
 
             long maxBonusScore = 0;
-            int maxBonusScoreUserId = 0;
+            int maxBonusScoreUserId = -1;
 
             long largestScoreDifference = long.MinValue;
-            int largestScoreDifferenceUserId = 0;
+            int largestScoreDifferenceUserId = -1;
 
             long smallestScoreDifference = long.MaxValue;
-            int smallestScoreDifferenceUserId = 0;
+            int smallestScoreDifferenceUserId = -1;
 
             for (int round = 1; round <= state.CurrentRound; round++)
             {
                 long roundHighestScore = long.MinValue;
-                int roundHighestScoreUserId = 0;
+                int roundHighestScoreUserId = -1;
 
                 long roundLowestScore = long.MaxValue;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
@@ -344,11 +344,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.Results
                 }
             }
 
-            addAward(maxScoreUserId, "Score champ", "Highest score in a single round");
+            if (maxScoreUserId > 0)
+                addAward(maxScoreUserId, "Score champ", "Highest score in a single round");
 
-            addAward(maxAccuracyUserId, "Most accurate", "Highest accuracy in a single round");
+            if (maxAccuracyUserId > 0)
+                addAward(maxAccuracyUserId, "Most accurate", "Highest accuracy in a single round");
 
-            addAward(maxComboUserId, "Top combo", "Highest combo in a single round");
+            if (maxComboUserId > 0)
+                addAward(maxComboUserId, "Top combo", "Highest combo in a single round");
 
             if (maxBonusScoreUserId > 0)
                 addAward(maxBonusScoreUserId, "Biggest bonus", "Biggest bonus score across all rounds");


### PR DESCRIPTION
Edgest of edge cases, but I actually encounter this one quite a bit locally and it feels pretty awkward to not fix.