### PR TITLE
Always show HUD while editing skin layout

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -363,9 +363,9 @@ namespace osu.Game.Overlays.SkinEditor
             if (State.Value == Visibility.Visible)
             {
                 leasedVisibilityMode = configVisibilityMode?.BeginLease(true);
-                // only when HUD visibility mode is not set to Always.
                 if (leasedVisibilityMode != null)
                 {
+                    // only when HUD visibility mode is not set to Always.
                     if (leasedVisibilityMode.Value != HUDVisibilityMode.Always)
                         leasedVisibilityMode.Value = HUDVisibilityMode.Always;
                 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Overlays.SkinEditor
         private readonly LayoutValue drawSizeLayout;
 
         private Bindable<HUDVisibilityMode> configVisibilityMode;
+        private LeasedBindable<HUDVisibilityMode>? leasedVisibilityMode;
         private HUDVisibilityMode previousHUDVisibility;
 
         public SkinEditorOverlay(ScalingContainer scalingContainer)
@@ -363,15 +364,19 @@ namespace osu.Game.Overlays.SkinEditor
             if (State.Value == Visibility.Visible)
             {
                 previousHUDVisibility = configVisibilityMode.Value;
-                // only when HUD visibility mode is set to Never.
-                if (configVisibilityMode.Value == HUDVisibilityMode.Never)
-                    configVisibilityMode.Value = HUDVisibilityMode.Always;
+
+                leasedVisibilityMode = configVisibilityMode.BeginLease(false);
+                // only when HUD visibility mode is not set to Always.
+                if (leasedVisibilityMode.Value != HUDVisibilityMode.Always)
+                    leasedVisibilityMode.Value = HUDVisibilityMode.Always;
             }
             else
             {
-                // and restore it to Never after closing editor.
-                if (previousHUDVisibility == HUDVisibilityMode.Never)
-                    configVisibilityMode.Value = HUDVisibilityMode.Never;
+                if (leasedVisibilityMode != null)
+                    leasedVisibilityMode.Value = previousHUDVisibility;
+
+                leasedVisibilityMode?.Return();
+                leasedVisibilityMode = null;
             }
         }
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -363,6 +363,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (State.Value == Visibility.Visible)
             {
                 leasedVisibilityMode = configVisibilityMode?.BeginLease(true);
+
                 if (leasedVisibilityMode != null)
                 {
                     // only when HUD visibility mode is not set to Always.

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -81,7 +81,6 @@ namespace osu.Game.Overlays.SkinEditor
 
         private Bindable<HUDVisibilityMode> configVisibilityMode;
         private LeasedBindable<HUDVisibilityMode>? leasedVisibilityMode;
-        private HUDVisibilityMode previousHUDVisibility;
 
         public SkinEditorOverlay(ScalingContainer scalingContainer)
         {
@@ -363,18 +362,13 @@ namespace osu.Game.Overlays.SkinEditor
             // Make HUD visible while editing skin layout
             if (State.Value == Visibility.Visible)
             {
-                previousHUDVisibility = configVisibilityMode.Value;
-
-                leasedVisibilityMode = configVisibilityMode.BeginLease(false);
+                leasedVisibilityMode = configVisibilityMode.BeginLease(true);
                 // only when HUD visibility mode is not set to Always.
                 if (leasedVisibilityMode.Value != HUDVisibilityMode.Always)
                     leasedVisibilityMode.Value = HUDVisibilityMode.Always;
             }
             else
             {
-                if (leasedVisibilityMode != null)
-                    leasedVisibilityMode.Value = previousHUDVisibility;
-
                 leasedVisibilityMode?.Return();
                 leasedVisibilityMode = null;
             }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         private readonly LayoutValue drawSizeLayout;
 
-        private Bindable<HUDVisibilityMode> configVisibilityMode;
+        private Bindable<HUDVisibilityMode>? configVisibilityMode;
         private LeasedBindable<HUDVisibilityMode>? leasedVisibilityMode;
 
         public SkinEditorOverlay(ScalingContainer scalingContainer)
@@ -362,10 +362,13 @@ namespace osu.Game.Overlays.SkinEditor
             // Make HUD visible while editing skin layout
             if (State.Value == Visibility.Visible)
             {
-                leasedVisibilityMode = configVisibilityMode.BeginLease(true);
+                leasedVisibilityMode = configVisibilityMode?.BeginLease(true);
                 // only when HUD visibility mode is not set to Always.
-                if (leasedVisibilityMode.Value != HUDVisibilityMode.Always)
-                    leasedVisibilityMode.Value = HUDVisibilityMode.Always;
+                if (leasedVisibilityMode != null)
+                {
+                    if (leasedVisibilityMode.Value != HUDVisibilityMode.Always)
+                        leasedVisibilityMode.Value = HUDVisibilityMode.Always;
+                }
             }
             else
             {

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -19,6 +19,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -113,6 +114,9 @@ namespace osu.Game.Screens.Play
         /// </summary>
         internal readonly Drawable PlayfieldSkinLayer;
 
+        [CanBeNull]
+        private SkinEditorOverlay skinEditor;
+
         public HUDOverlay([CanBeNull] DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods)
         {
             Container rightSettings;
@@ -194,7 +198,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, RealmKeyBindingStore keyBindingStore, INotificationOverlay notificationOverlay)
+        private void load(OsuConfigManager config, RealmKeyBindingStore keyBindingStore, INotificationOverlay notificationOverlay, [CanBeNull] SkinEditorOverlay skinEditor)
         {
             if (drawableRuleset != null)
             {
@@ -206,6 +210,9 @@ namespace osu.Game.Screens.Play
             configVisibilityMode = config.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode);
             configLeaderboardVisibility = config.GetBindable<bool>(OsuSetting.GameplayLeaderboard);
             configSettingsOverlay = config.GetBindable<bool>(OsuSetting.ReplaySettingsOverlay);
+
+            skinEditor?.State.BindValueChanged(_ => updateVisibility());
+            this.skinEditor = skinEditor;
 
             if (configVisibilityMode.Value == HUDVisibilityMode.Never && !hasShownNotificationOnce)
             {
@@ -346,6 +353,16 @@ namespace osu.Game.Screens.Play
         {
             if (ShowHud.Disabled)
                 return;
+
+            // Always show HUD while editing skin layout.
+            if (skinEditor != null)
+            {
+                if (skinEditor.State.Value == Visibility.Visible)
+                {
+                    ShowHud.Value = true;
+                    return;
+                }
+            }
 
             if (holdingForHUD.Value)
             {

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -19,7 +19,6 @@ using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
-using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -114,9 +113,6 @@ namespace osu.Game.Screens.Play
         /// </summary>
         internal readonly Drawable PlayfieldSkinLayer;
 
-        [CanBeNull]
-        private SkinEditorOverlay skinEditor;
-
         public HUDOverlay([CanBeNull] DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods)
         {
             Container rightSettings;
@@ -198,7 +194,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, RealmKeyBindingStore keyBindingStore, INotificationOverlay notificationOverlay, [CanBeNull] SkinEditorOverlay skinEditor)
+        private void load(OsuConfigManager config, RealmKeyBindingStore keyBindingStore, INotificationOverlay notificationOverlay)
         {
             if (drawableRuleset != null)
             {
@@ -210,9 +206,6 @@ namespace osu.Game.Screens.Play
             configVisibilityMode = config.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode);
             configLeaderboardVisibility = config.GetBindable<bool>(OsuSetting.GameplayLeaderboard);
             configSettingsOverlay = config.GetBindable<bool>(OsuSetting.ReplaySettingsOverlay);
-
-            skinEditor?.State.BindValueChanged(_ => updateVisibility());
-            this.skinEditor = skinEditor;
 
             if (configVisibilityMode.Value == HUDVisibilityMode.Never && !hasShownNotificationOnce)
             {
@@ -353,16 +346,6 @@ namespace osu.Game.Screens.Play
         {
             if (ShowHud.Disabled)
                 return;
-
-            // Always show HUD while editing skin layout.
-            if (skinEditor != null)
-            {
-                if (skinEditor.State.Value == Visibility.Visible)
-                {
-                    ShowHud.Value = true;
-                    return;
-                }
-            }
 
             if (holdingForHUD.Value)
             {


### PR DESCRIPTION
The HUD overlay will be hidden in skin layout editor when HUD overlay visibility mode is set to never. I think this is not expected while editing skin.