### PR TITLE
Ensure all invocations of spectator server hub methods have their errors observed

### DIFF
--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -89,13 +89,13 @@ namespace osu.Game.Online.Metadata
             userStatus.BindValueChanged(status =>
             {
                 if (localUser.Value is not GuestUser)
-                    UpdateStatus(status.NewValue);
+                    UpdateStatus(status.NewValue).FireAndForget();
             }, true);
 
             userActivity.BindValueChanged(activity =>
             {
                 if (localUser.Value is not GuestUser)
-                    UpdateActivity(activity.NewValue);
+                    UpdateActivity(activity.NewValue).FireAndForget();
             }, true);
         }
 
@@ -121,8 +121,8 @@ namespace osu.Game.Online.Metadata
 
             if (localUser.Value is not GuestUser)
             {
-                UpdateActivity(userActivity.Value);
-                UpdateStatus(userStatus.Value);
+                UpdateActivity(userActivity.Value).FireAndForget();
+                UpdateStatus(userStatus.Value).FireAndForget();
             }
 
             if (lastQueueId.Value >= 0)

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -201,7 +201,7 @@ namespace osu.Game.Online.Multiplayer
                 if (!connected.NewValue)
                 {
                     if (Room != null)
-                        LeaveRoom();
+                        LeaveRoom().FireAndForget();
 
                     MatchmakingQueueLeft?.Invoke();
                 }
@@ -560,7 +560,7 @@ namespace osu.Game.Online.Multiplayer
                     return;
 
                 if (user.Equals(LocalUser))
-                    LeaveRoom();
+                    LeaveRoom().FireAndForget();
 
                 handleUserLeft(user, UserKicked);
             });

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
@@ -203,7 +204,7 @@ namespace osu.Game.Online.Spectator
 
         Task IStatefulUserHubClient.DisconnectRequested()
         {
-            Schedule(() => DisconnectInternal());
+            Schedule(() => DisconnectInternal().FireAndForget());
             return Task.CompletedTask;
         }
 
@@ -290,7 +291,7 @@ namespace osu.Game.Online.Spectator
                 else
                     currentState.State = SpectatedUserState.Quit;
 
-                EndPlayingInternal(currentState);
+                EndPlayingInternal(currentState).FireAndForget();
             });
         }
 
@@ -304,7 +305,7 @@ namespace osu.Game.Online.Spectator
                 return;
             }
 
-            WatchUserInternal(userId);
+            WatchUserInternal(userId).FireAndForget();
         }
 
         public void StopWatchingUser(int userId)
@@ -321,7 +322,7 @@ namespace osu.Game.Online.Spectator
 
                 watchedUsersRefCounts.Remove(userId);
                 watchedUserStates.Remove(userId);
-                StopWatchingUserInternal(userId);
+                StopWatchingUserInternal(userId).FireAndForget();
             });
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -392,7 +392,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                 return;
             }
 
-            client.ChangeState(MultiplayerUserState.Idle);
+            client.ChangeState(MultiplayerUserState.Idle).FireAndForget();
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             Debug.Assert(client.LocalUser != null);
 
             if (client.LocalUser.State == MultiplayerUserState.Results)
-                client.ChangeState(MultiplayerUserState.Idle);
+                client.ChangeState(MultiplayerUserState.Idle).FireAndForget();
         }
 
         protected override string ScreenTitle => "Multiplayer";

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -618,7 +618,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     updateGameplayState();
 
                     if (client.LocalUser.State == MultiplayerUserState.Ready)
-                        client.ChangeState(MultiplayerUserState.Idle);
+                        client.ChangeState(MultiplayerUserState.Idle).FireAndForget();
                     break;
             }
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (client.LocalUser?.State == MultiplayerUserState.Loaded)
             {
                 loadingDisplay.Show();
-                client.ChangeState(MultiplayerUserState.ReadyForGameplay);
+                client.ChangeState(MultiplayerUserState.ReadyForGameplay).FireAndForget();
             }
 
             // This will pause the clock, pending the gameplay started callback from the server.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -296,7 +296,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             // On a manual exit, set the player back to idle unless gameplay has finished.
             // Of note, this doesn't cover exiting using alt-f4 or menu home option.
             if (multiplayerClient.Room.State != MultiplayerRoomState.Open)
-                multiplayerClient.ChangeState(MultiplayerUserState.Idle);
+                multiplayerClient.ChangeState(MultiplayerUserState.Idle).FireAndForget();
 
             return base.OnBackButton();
         }


### PR DESCRIPTION
Fell out when attempting https://github.com/ppy/osu-server-spectator/pull/346 (see point (4) therein).

Functionally, if a true non-`HubException` is produced via an invocation of a spectator server hub method, this doesn't really do much - the error will still log as 'unobserved' due to the default handler, it will still show up on sentry, etc. The only difference is that it'll get handled via the continuation installed in `FireAndForget()` rather than the `TaskScheduler.UnobservedTaskException` event.

The only real case where this is relevant is when the server throws `HubException`s, which will now instead bubble up to a more human-readable form. Which is relevant to the aforementioned PR because that one makes any hub method potentially throw a `HubException` if the client version is too old.

Obviously this does nothing for the existing old clients.