### PR TITLE
Fix keycounter being wrong for Triangles in TestSceneKeyCounter scene

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableKeyCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableKeyCounter.cs
@@ -35,7 +35,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected override Ruleset CreateRulesetForSkinProvider() => new OsuRuleset();
 
-        protected override Drawable CreateDefaultImplementation() => new ArgonKeyCounterDisplay();
+        protected override Drawable CreateArgonImplementation() => new ArgonKeyCounterDisplay();
+
+        protected override Drawable CreateDefaultImplementation() => new DefaultKeyCounterDisplay();
 
         protected override Drawable CreateLegacyImplementation() => new LegacyKeyCounterDisplay();
     }


### PR DESCRIPTION
This error is quite negligible, but I still feel like it is worth being fixed, since I don't think it was correct to show an Argon's keycounter in case with Triangles skin

Comparison:

|[`master`](https://github.com/ppy/osu/tree/master)|[`this PR`](https://github.com/tadatomix/osu/tree/test-scene/triangles-key-counter)|
|---|---|
|<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/13c6e1e8-f1b7-4f7e-9030-21de2b27fa28" />|<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/02a4529f-a3b3-4781-a2b6-36d990c61a9f" />|