### PR TITLE
Fix `DrawableDate` not updating

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDrawableDate.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDrawableDate.cs
@@ -2,9 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osuTK;
 using osuTK.Graphics;
@@ -13,25 +16,35 @@ namespace osu.Game.Tests.Visual.UserInterface
 {
     public partial class TestSceneDrawableDate : OsuTestScene
     {
-        public TestSceneDrawableDate()
+        [SetUpSteps]
+        public void SetUpSteps()
         {
-            Child = new FillFlowContainer
+            AddStep("Create 7 dates", () =>
             {
-                Direction = FillDirection.Vertical,
-                AutoSizeAxes = Axes.Both,
-                Origin = Anchor.Centre,
-                Anchor = Anchor.Centre,
-                Children = new Drawable[]
+                Child = new FillFlowContainer
                 {
-                    new PokeyDrawableDate(DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(60))),
-                    new PokeyDrawableDate(DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(55))),
-                    new PokeyDrawableDate(DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(50))),
-                    new PokeyDrawableDate(DateTimeOffset.Now),
-                    new PokeyDrawableDate(DateTimeOffset.Now.Add(TimeSpan.FromSeconds(60))),
-                    new PokeyDrawableDate(DateTimeOffset.Now.Add(TimeSpan.FromSeconds(65))),
-                    new PokeyDrawableDate(DateTimeOffset.Now.Add(TimeSpan.FromSeconds(70))),
-                }
-            };
+                    Direction = FillDirection.Vertical,
+                    AutoSizeAxes = Axes.Both,
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new PokeyDrawableDate(DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(60))),
+                        new PokeyDrawableDate(DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(55))),
+                        new PokeyDrawableDate(DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(50))),
+                        new PokeyDrawableDate(DateTimeOffset.Now),
+                        new PokeyDrawableDate(DateTimeOffset.Now.Add(TimeSpan.FromSeconds(60))),
+                        new PokeyDrawableDate(DateTimeOffset.Now.Add(TimeSpan.FromSeconds(65))),
+                        new PokeyDrawableDate(DateTimeOffset.Now.Add(TimeSpan.FromSeconds(70))),
+                    }
+                };
+            });
+        }
+
+        [Test]
+        public void TestSecondsUpdate()
+        {
+            AddUntilStep("4th date says \"2 seconds ago\"", () => this.ChildrenOfType<DrawableDate>().ElementAt(3).Current.Value == "2 seconds ago");
         }
 
         private partial class PokeyDrawableDate : CompositeDrawable

--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Utils;
@@ -80,7 +81,7 @@ namespace osu.Game.Graphics
 
         public DateTimeOffset TooltipContent => Date;
 
-        private class HumanisedDate : IEquatable<HumanisedDate>, ILocalisableStringData
+        private class HumanisedDate : ILocalisableStringData
         {
             public readonly DateTimeOffset Date;
 
@@ -89,11 +90,18 @@ namespace osu.Game.Graphics
                 Date = date;
             }
 
-            public bool Equals(HumanisedDate? other)
-                => other?.Date != null && Date.Equals(other.Date);
-
-            public bool Equals(ILocalisableStringData? other)
-                => other is HumanisedDate otherDate && Equals(otherDate);
+            /// <remarks>
+            /// Humanizer formats the <see cref="Date"/> relative to the local computer time.
+            /// Therefore, replacing a <see cref="HumanisedDate"/> instance with another instance of the class with the same <see cref="Date"/>
+            /// should have the effect of replacing and re-formatting the text.
+            /// Including <see cref="Date"/> in equality members would stop this from happening, as <see cref="SpriteText.Text"/>
+            /// has equality-based early guards to prevent redundant text replaces.
+            /// Thus, instances of these class just compare <see langword="false"/> to any <see cref="ILocalisableStringData"/> to ensure re-formatting happens correctly.
+            /// There are "technically" more "correct" ways to do this (like also including the current time into equality checks),
+            /// but they are simultaneously functionally equivalent to this and overly convoluted.
+            /// This is a private hack-job of a wrapper around humanizer anyway.
+            /// </remarks>
+            public bool Equals(ILocalisableStringData? other) => false;
 
             public string GetLocalised(LocalisationParameters parameters) => HumanizerUtils.Humanize(Date);
 


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/commit/c8c87089e58fa67ef7bd334eb9d0da4a92d2e579#commitcomment-168271953

Since the date format is relative, the date never changes so the current string should be checked also.