### PR TITLE
Fix backround dimming sync issue on beatmap break

### DIFF
--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Screens.Play
 
                 remainingTimeAdjustmentBox
                     .ResizeWidthTo(remaining_time_container_max_size, BREAK_FADE_DURATION, Easing.OutQuint)
-                    .Delay(b.Duration - BREAK_FADE_DURATION)
+                    .Delay(b.Duration)
                     .ResizeWidthTo(0);
 
                 remainingTimeBox.ResizeWidthTo(remainingTimeForCurrentPeriod);
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.Play
                 info.MoveToX(50)
                     .MoveToX(0, BREAK_FADE_DURATION, Easing.OutQuint);
 
-                using (BeginDelayedSequence(b.Duration - BREAK_FADE_DURATION))
+                using (BeginDelayedSequence(b.Duration))
                 {
                     fadeContainer.FadeOut(BREAK_FADE_DURATION);
                     breakArrows.Hide(BREAK_FADE_DURATION);


### PR DESCRIPTION
Fixes #35425 

Issue was bisected to [this commit](https://github.com/ppy/osu/pull/29616/commits/6f1664f0a60fc08995d737e40272b61742fbe580)

All breaks were being initialized with durations 325ms shorter than they should be. I assume it's not a coincidence that this is exactly equal to `BREAK_FADE_DURATION`, but I'm not knowledgeable enough about the codebase to understand why that would be the case only after the commit.

The same problem could be happening in LetterboxOverlay.

Before this commit:
https://github.com/user-attachments/assets/62aefd15-04eb-4c55-89d7-65fc8caea110

After this commit:
https://github.com/user-attachments/assets/a61b9b88-bfb0-4ee0-8c11-3353eb6dc6d4

