### PR TITLE
Fix potential quick play crash if beatmap lookup fails

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectPanel.cs
@@ -111,7 +111,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
             {
                 Debug.Assert(card == null);
 
-                var beatmap = b.GetResultSafely()!;
+                APIBeatmap beatmap = b.GetResultSafely() ?? new APIBeatmap
+                {
+                    BeatmapSet = new APIBeatmapSet
+                    {
+                        Title = "unknown beatmap",
+                        TitleUnicode = "unknown beatmap",
+                        Artist = "unknown artist",
+                        ArtistUnicode = "unknown artist",
+                    }
+                };
+
                 beatmap.StarRating = Item.StarRating;
 
                 mainContent.Add(card = new BeatmapCardMatchmaking(beatmap)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/35346

In a perfect world this shouldn't happen, but we do not live in a perfect world (this happened during server outages).