### PR TITLE
More quick play notification improvements

### DIFF
--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -162,16 +162,17 @@ namespace osu.Game.Overlays
         private int runningDepth;
 
         private readonly Scheduler postScheduler = new Scheduler();
+        private readonly Scheduler criticalPostScheduler = new Scheduler();
 
         public override bool IsPresent =>
             // Delegate presence as we need to consider the toast tray in addition to the main overlay.
-            State.Value == Visibility.Visible || mainContent.IsPresent || toastTray.IsPresent || postScheduler.HasPendingTasks;
+            State.Value == Visibility.Visible || mainContent.IsPresent || toastTray.IsPresent || postScheduler.HasPendingTasks || criticalPostScheduler.HasPendingTasks;
 
         private bool processingPosts = true;
 
         private double? lastSamplePlayback;
 
-        public void Post(Notification notification) => postScheduler.Add(() =>
+        public void Post(Notification notification) => (notification.IsCritical ? criticalPostScheduler : postScheduler).Add(() =>
         {
             ++runningDepth;
 
@@ -219,6 +220,8 @@ namespace osu.Game.Overlays
         protected override void Update()
         {
             base.Update();
+
+            criticalPostScheduler.Update();
 
             if (processingPosts)
                 postScheduler.Update();

--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -91,7 +91,12 @@ namespace osu.Game.Overlays
         public void FlushAllToasts()
         {
             foreach (var notification in toastFlow.ToArray())
+            {
+                if (notification.IsCritical)
+                    continue;
+
                 forwardNotification(notification);
+            }
         }
 
         public void Post(Notification notification)

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.Notifications
         /// <summary>
         /// Critical notifications show even during gameplay or other scenarios where notifications would usually be suppressed.
         /// </summary>
-        public bool IsCritical { get; init; } = false;
+        public bool IsCritical { get; init; }
 
         /// <summary>
         /// Transient notifications only show as a toast, and do not linger in notification history.

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -40,6 +40,11 @@ namespace osu.Game.Overlays.Notifications
         public bool IsImportant { get; init; } = true;
 
         /// <summary>
+        /// Critical notifications show even during gameplay or other scenarios where notifications would usually be suppressed.
+        /// </summary>
+        public bool IsCritical { get; init; } = false;
+
+        /// <summary>
         /// Transient notifications only show as a toast, and do not linger in notification history.
         /// </summary>
         public bool Transient { get; init; }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -7,7 +7,10 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Screens;
+using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -200,7 +203,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             public partial class MatchFoundNotification : ProgressCompletionNotification
             {
-                // for future use.
+                protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
+
+                [BackgroundDependencyLoader]
+                private void load(OsuColour colours)
+                {
+                    Icon = FontAwesome.Solid.Bolt;
+                    IconContent.Colour = ColourInfo.GradientVertical(colours.YellowDark, colours.YellowLight);
+                }
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -205,6 +205,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
 
+                public MatchFoundNotification()
+                {
+                    IsCritical = true;
+                }
+
                 [BackgroundDependencyLoader]
                 private void load(OsuColour colours)
                 {


### PR DESCRIPTION
Icons are more correct, custom colour to distinguish it a bit from other notifications, and shows during gameplay now.

A bit barebones but I think this puts us in a usable state, and I think having it fully display (rather than semi-offscreen or something) is *good* for notifications of this level.

https://github.com/user-attachments/assets/c481d373-f57b-483f-9807-d39754d8ef95

