### PR TITLE
Fix potential sources of empty sequence errors

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
@@ -152,5 +152,32 @@ namespace osu.Game.Tests.Visual.Matchmaking
                 MultiplayerClient.ChangeMatchRoomState(state).WaitSafely();
             });
         }
+
+        [Test]
+        public void TestUserWithNoScore()
+        {
+            AddStep("join another user", () => MultiplayerClient.AddUser(new MultiplayerRoomUser(2)
+            {
+                User = new APIUser
+                {
+                    Id = 2,
+                    Username = "Other user"
+                }
+            }));
+
+            AddStep("show results with no score", () =>
+            {
+                var state = new MatchmakingRoomState
+                {
+                    CurrentRound = 6,
+                    Stage = MatchmakingStage.Ended
+                };
+
+                state.Users.GetOrAdd(API.LocalUser.Value.OnlineID).Rounds.GetOrAdd(1).Placement = 1;
+                state.Users.GetOrAdd(2);
+
+                MultiplayerClient.ChangeMatchRoomState(state).WaitSafely();
+            });
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Results/SubScreenResults.cs
@@ -221,7 +221,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.Results
             int accuracyPlacement = accuracyOrderedUsers.index + 1;
             addStatistic(accuracyPlacement, $"Overall accuracy ({accuracyOrderedUsers.info.avgAcc.FormatAccuracy()})");
 
-            var maxComboOrderedUsers = state.Users.Select(u => (user: u, maxCombo: u.Rounds.Max(r => r.MaxCombo)))
+            var maxComboOrderedUsers = state.Users.Select(u => (user: u, maxCombo: u.Rounds.Select(r => r.MaxCombo).DefaultIfEmpty(0).Max()))
                                             .OrderByDescending(t => t.maxCombo)
                                             .Select((t, i) => (info: t, index: i))
                                             .Single(t => t.info.user.UserId == client.LocalUser!.UserID);
@@ -229,7 +229,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.Results
             addStatistic(maxComboPlacement, $"Best max combo ({maxComboOrderedUsers.info.maxCombo}x)");
 
             var bestPlacement = localUserState.Rounds.MinBy(r => r.Placement);
-            addStatistic(bestPlacement!.Placement, $"Best round placement (round {bestPlacement.Round})");
+            if (bestPlacement != null)
+                addStatistic(bestPlacement.Placement, $"Best round placement (round {bestPlacement.Round})");
 
             void addStatistic(int position, string text) => userStatistics.Add(new PanelUserStatistic(position, text));
         }


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/35510

I noticed this in an earlier implementation, compare to `accuracyOrderedUsers`. This comes up if a user in the room hasn't played a round at all (i.e. not even a failed score).