### PR TITLE
Don't increase combo for missed slider ends with Classic mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Judgements/OsuSliderJudgementResult.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuSliderJudgementResult.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Osu.Judgements
     {
         public readonly Stack<(double time, bool tracking)> TrackingHistory = new Stack<(double, bool)>();
 
+        public bool AwardsCombo { get; set; } = true;
+
         public OsuSliderJudgementResult(HitObject hitObject, Judgement judgement)
             : base(hitObject, judgement)
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -311,6 +311,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     {
                         double hitFraction = (double)hitTicks / totalTicks;
                         r.Type = hitFraction >= 0.5 ? HitResult.Ok : HitResult.Meh;
+
+                        ((OsuSliderJudgementResult)r).AwardsCombo = false;
                     }
                 });
             }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -34,10 +34,13 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
         protected override bool IncreasesCombo(JudgementResult result)
         {
+            if (!base.IncreasesCombo(result))
+                return false;
+
             if (result is OsuSliderJudgementResult sliderJudgementResult)
                 return sliderJudgementResult.AwardsCombo;
 
-            return base.IncreasesCombo(result);
+            return true;
         }
 
         protected override HitEvent CreateHitEvent(JudgementResult result)

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -32,6 +32,14 @@ namespace osu.Game.Rulesets.Osu.Scoring
             return rank;
         }
 
+        protected override bool IncreasesCombo(JudgementResult result)
+        {
+            if (result is OsuSliderJudgementResult sliderJudgementResult)
+                return sliderJudgementResult.AwardsCombo;
+
+            return base.IncreasesCombo(result);
+        }
+
         protected override HitEvent CreateHitEvent(JudgementResult result)
             => base.CreateHitEvent(result).With((result as OsuHitCircleJudgementResult)?.CursorPositionAtHit);
     }

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -21,15 +21,6 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.Conversion;
 
-        /// <summary>
-        /// Classic mods are not to be ranked yet due to compatibility and multiplier concerns.
-        /// Right now classic mods are considered, for leaderboard purposes, to be equal as scores set on osu-stable.
-        /// But this is not the case.
-        ///
-        /// Some examples for things to resolve before even considering this:
-        ///  - Hit windows differ (https://github.com/ppy/osu/issues/11311).
-        ///  - Sliders always gives combo for slider end, even on miss (https://github.com/ppy/osu/issues/11769).
-        /// </summary>
         public sealed override bool Ranked => false;
 
         public sealed override bool ValidForFreestyleAsRequiredMod => false;

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -232,7 +232,7 @@ namespace osu.Game.Rulesets.Scoring
 
             ScoreResultCounts[result.Type] = ScoreResultCounts.GetValueOrDefault(result.Type) + 1;
 
-            if (result.Type.IncreasesCombo())
+            if (IncreasesCombo(result))
                 Combo.Value++;
             else if (result.Type.BreaksCombo())
                 Combo.Value = 0;
@@ -269,6 +269,12 @@ namespace osu.Game.Rulesets.Scoring
                 updateScore();
             }
         }
+
+        /// <summary>
+        /// Whether a <see cref="JudgementResult"/> increases combo.
+        /// </summary>
+        protected virtual bool IncreasesCombo(JudgementResult result)
+            => result.Type.IncreasesCombo();
 
         /// <summary>
         /// Creates the <see cref="HitEvent"/> that describes a <see cref="JudgementResult"/>.


### PR DESCRIPTION
Resolves #11769.

This seems to be the least obtrusive way to prevent missed slider ends from awarding combo with classic enabled. My goal with this is to unblock ranking the CL mod, since the hit windows issue was already resolved now.

Assuming I'm not massively naive, I don't think there's anything further required to make this work. I wanted to add test coverage but I can't really find where existing tests are for CL-specific slider logic.