### PR TITLE
Fix quick play "view beatmap" showing incorrect difficulty

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
@@ -53,6 +53,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
+        [Resolved]
+        private BeatmapSetOverlay? beatmapSetOverlay { get; set; }
+
         public BeatmapCardMatchmaking(APIBeatmap beatmap)
             : base(beatmap.BeatmapSet!, false)
         {
@@ -319,7 +322,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
             {
                 List<MenuItem> items = new List<MenuItem>
                 {
-                    new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, DefaultAction)
+                    new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, () => beatmapSetOverlay?.FetchAndShowBeatmap(beatmap.OnlineID))
                 };
 
                 foreach (var button in buttonContainer.Buttons)


### PR DESCRIPTION
`DefaultAction` is implemented as showing the beatmap set here:

https://github.com/ppy/osu/blob/5af9bb784be1f058b22d83b0a93d484e588dc982/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs#L84-L101