### PR TITLE
Fix bad performance when moving mouse to left side of song select forcibly expands group with current selection

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -689,7 +689,7 @@ namespace osu.Game.Screens.SelectV2
 
             var groupItem = GetCarouselItems()?.FirstOrDefault(i => CheckModelEquality(i.Model, CurrentGroupedBeatmap.Group));
             if (groupItem != null)
-                HandleItemActivated(groupItem);
+                Activate(groupItem);
         }
 
         protected override double? GetScrollTarget()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35514.

Calling `HandleItemActivated()` rather than its intended 'parent method' of `Activate()` meant that selection state was not correctly invalidated:
	https://github.com/ppy/osu/blob/819da1bc38dbc9676f8f1ee3924bfd8d9cb50347/osu.Game/Graphics/Carousel/Carousel.cs#L157

which in turn meant that carousel item Y positions would not be recalculated correctly after the group was expanded, which meant that the items would become

- visible,
- stuck to the bottom of the expanded group,
- one on top of another.

Which is not something that's going to perform well.

Certified OOP moment.