### PR TITLE
Add beatmap skinned slider body colours

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
@@ -19,7 +19,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
             base.LoadComplete();
 
-            AccentColourBindable.BindValueChanged(accent => BorderColour = accent.NewValue, true);
+            if (SliderBorder == null)
+                AccentColourBindable.BindValueChanged(accent => BorderColour = accent.NewValue, true);
             ScaleBindable.BindValueChanged(scale => PathRadius = path_radius * scale.NewValue, true);
 
             // This border size thing is kind of weird, hey.

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -25,6 +25,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         private readonly Bindable<bool> configSnakingOut = new Bindable<bool>();
 
+        protected Color4? SliderTrackOverride;
+
+        protected Color4? SliderBorder;
+
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin, DrawableHitObject drawableObject)
         {
@@ -35,6 +39,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             pathVersion = drawableSlider.PathVersion.GetBoundCopy();
             pathVersion.BindValueChanged(_ => Scheduler.AddOnce(Refresh));
+
+            SliderTrackOverride = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderTrackOverride)?.Value;
+
+            SliderBorder = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value;
 
             AccentColourBindable = drawableObject.AccentColour.GetBoundCopy();
             AccentColourBindable.BindValueChanged(accent => AccentColour = GetBodyAccentColour(skin, accent.NewValue), true);
@@ -47,8 +55,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             BorderColour = GetBorderColour(skin);
         }
 
-        protected virtual Color4 GetBorderColour(ISkinSource skin) => Color4.White;
+        protected virtual Color4 GetBorderColour(ISkinSource skin) => SliderBorder ?? Color4.White;
 
-        protected virtual Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour) => hitObjectAccentColour;
+        protected virtual Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour) => SliderTrackOverride ?? hitObjectAccentColour;
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         protected override Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour)
             // legacy skins use a constant value for slider track alpha, regardless of the source colour.
-            => (skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderTrackOverride)?.Value ?? hitObjectAccentColour).Opacity(0.7f);
+            => base.GetBodyAccentColour(skin, hitObjectAccentColour).Opacity(0.7f);
 
         private partial class LegacyDrawableSliderPath : DrawableSliderPath
         {


### PR DESCRIPTION
## Fix #35424 
Test with https://osu.ppy.sh/b/3886217

|Legacy|Triangles|Argon|
|-|-|-|
|<img width="682" height="590" alt="Image" src="https://github.com/user-attachments/assets/23cc6bbf-b621-477a-b601-4cdc43150c41" />|<img width="704" height="620" alt="Image" src="https://github.com/user-attachments/assets/3e7c01bc-b97e-4a5d-a6d6-6a86032766f2" />|<img width="692" height="592" alt="Image" src="https://github.com/user-attachments/assets/1dfe680b-ec8e-444f-9f89-91891a1aeb55" />|

Argon colour is not as bright as classic, because it use `Darken(4)`:
https://github.com/ppy/osu/blob/5c1171f358ebd134635cc75b521c8e63c4bbf2f3/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs#L45C1-L45C47

**Maybe Argon colour should be bright like Legacy? Or use a different `Darken`?**

It looks kinda weird for me when it's as bright as legacy specially with a repeat icon for example?

Example with different `Darken`:

|Darken(4)|Darken(2)|Darken(1)|Darken(0.5f)|Normal|
|-|-|-|-|-|
|<img width="412" height="596" alt="20251030_13h37m07s_grim" src="https://github.com/user-attachments/assets/2c856e16-7af9-401c-925b-7800fe0c3a79" />|<img width="422" height="588" alt="20251030_14h09m32s_grim" src="https://github.com/user-attachments/assets/c7e22e16-9870-495f-88bb-fe846bbd7690" />|<img width="430" height="592" alt="20251030_14h00m55s_grim" src="https://github.com/user-attachments/assets/b2725ab3-0a1a-4169-a423-acaab77e792b" />|<img width="424" height="590" alt="20251030_14h02m27s_grim" src="https://github.com/user-attachments/assets/8dce0b9c-fc28-48fe-9a80-6efb81f5d013" />|<img width="444" height="584" alt="20251030_13h46m56s_grim" src="https://github.com/user-attachments/assets/d88a4eb0-608b-46fc-b2d1-46a41a8d4b6e" />|