### PR TITLE
Switch active carousel group if current selection no longer exists in the previous group

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -4,9 +4,12 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
+using osu.Game.Tests.Resources;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.SongSelectV2
@@ -321,6 +324,39 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             SelectNextSet();
             SelectNextSet();
             AddUntilStep("no beatmap panels visible", () => GetVisiblePanels<PanelBeatmap>().Count(), () => Is.Zero);
+        }
+
+        [Test]
+        public void TestGroupChangedAfterEngagingArtistGrouping()
+        {
+            RemoveAllBeatmaps();
+            AddStep("add test beatmaps", () =>
+            {
+                for (int i = 0; i < 5; ++i)
+                {
+                    var baseTestBeatmap = TestResources.CreateTestBeatmapSetInfo(3);
+
+                    var metadata = new BeatmapMetadata
+                    {
+                        Artist = $"{(char)('A' + i)} artist",
+                        Title = $"{(char)('A' + 4 - i)} title",
+                    };
+
+                    foreach (var b in baseTestBeatmap.Beatmaps)
+                        b.Metadata = metadata;
+
+                    Realm.Write(r => r.Add(baseTestBeatmap, update: true));
+                    BeatmapSets.Add(baseTestBeatmap.Detach());
+                }
+
+                SortAndGroupBy(SortMode.Title, GroupMode.Title);
+                SelectNextSet();
+                SelectNextSet();
+                WaitForExpandedGroup(1);
+
+                SortAndGroupBy(SortMode.Artist, GroupMode.Artist);
+                WaitForExpandedGroup(3);
+            });
         }
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -497,25 +497,35 @@ namespace osu.Game.Screens.SelectV2
             // The filter might have changed the set of available groups, which means that the current selection may point to a stale group.
             // Check whether that is the case.
             bool groupingRemainsOff = currentGroupedBeatmap?.Group == null && grouping.GroupItems.Count == 0;
-            bool groupStillExists = currentGroupedBeatmap?.Group != null && grouping.GroupItems.ContainsKey(currentGroupedBeatmap.Group);
 
-            if (groupingRemainsOff || groupStillExists)
+            bool groupStillValid = false;
+
+            if (currentGroupedBeatmap?.Group != null)
+            {
+                groupStillValid = grouping.GroupItems.TryGetValue(currentGroupedBeatmap.Group, out var items)
+                                  && items.Any(i => CheckModelEquality(i.Model, currentGroupedBeatmap));
+            }
+
+            if (groupingRemainsOff || groupStillValid)
             {
                 // Only update the visual state of the selected item.
                 HandleItemSelected(currentGroupedBeatmap);
             }
             else if (currentGroupedBeatmap != null)
             {
-                // If the group no longer exists, grab an arbitrary other instance of the beatmap under the first group encountered.
+                // If the group no longer exists (or the item no longer exists in the previous group), grab an arbitrary other instance of the beatmap under the first group encountered.
                 var newSelection = GetCarouselItems()?.Select(i => i.Model).OfType<GroupedBeatmap>().FirstOrDefault(gb => gb.Beatmap.Equals(currentGroupedBeatmap.Beatmap));
+
                 // Only change the selection if we actually got a positive hit.
                 // This is necessary so that selection isn't lost if the panel reappears later due to e.g. unapplying some filter criteria that made it disappear in the first place.
                 if (newSelection != null)
+                {
                     CurrentSelection = newSelection;
+                    groupForReselection = newSelection.Group;
+                }
             }
 
             // If a group was selected that is not the one containing the selection, attempt to reselect it.
-            // If the original group was not found, ExpandedGroup will already have been updated to a valid value in `HandleItemSelected` above.
             if (groupForReselection != null && grouping.GroupItems.TryGetValue(groupForReselection, out _))
                 setExpandedGroup(groupForReselection);
         }


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/13430d72-bf70-4c51-8636-214c82a4cfe3

After:

https://github.com/user-attachments/assets/617433a6-66ab-4ad4-80fe-14c62c67263f

---

RFC. This was primarily written to fix https://github.com/ppy/osu/issues/35538, but also incidentally targets some other scenarios, such as:

- When switching from artist filtering to title filtering, selection   sometimes would stay at the group under which the selection's artist was filed, rather than moving to the group under which the selection's title is filed (in other words, the group that *the selection is currently under*).

  This is mostly an artifact of `GroupDefinition` being a record and using the string inside as an equality member. This could potentially be fixed in a different way just by ensuring that `Artist` mode group definitions and `Title` mode group definitions don't compare equal to each other etc.
- When simply assigning a beatmap to a collection such that it would be moved out of the current group, the selection will now follow to the new collection's group rather than staying at its previous position.

  Whether this is desired is highly likely to be extremely situational, but I don't want to introduce complications unless it's absolutely necessary.

This has a significant performance overhead because `CheckModelEquality()` isn't free, but it doesn't seem horrible in
profiling. Here's profiling results from changing group modes:

| before | after |
| :-: | :-: |
| <img width="884" height="262" alt="Screenshot 2025-10-30 at 14 38 06" src="https://github.com/user-attachments/assets/da9a2c49-7aee-4e1b-9665-998027420e29" /> | <img width="1147" height="305" alt="Screenshot 2025-10-30 at 14 38 14" src="https://github.com/user-attachments/assets/8d41b24e-691f-44f5-8489-0ee9ef3436af" /> |

Also seen below, where I'm changing the text filter (which is the worst possible case here, as it will preserve the current group) - the `Any()` call is pure overhead from the check:

<img width="1125" height="402" alt="Screenshot 2025-10-30 at 14 40 48" src="https://github.com/user-attachments/assets/c7652d7a-4491-4bf7-9b46-28369cf75ba8" />