### PR TITLE
Improve angle calculation to better represent the path taken on sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.55;
-        private const double slider_multiplier = 1.35;
+        private const double slider_multiplier = 1.65;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.3;
-        private const double slider_multiplier = 1.65;
+        private const double slider_multiplier = 1.5;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02; // WARNING: Increasing this multiplier beyond 1.02 reduces difficulty as distance increases. Refer to the desmos link above the wiggle bonus calculation
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -364,9 +364,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             if (lastDifficultyObject.BaseObject is Slider slider && lastDifficultyObject.TravelDistance > 0)
             {
-
                 OsuHitObject secondLastNestedObject = (OsuHitObject)slider.NestedHitObjects[^2];
-
                 lastLastCursorPosition = secondLastNestedObject.StackedPosition;
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -239,39 +239,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             if (lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is not Spinner)
             {
-                Vector2 lastLastCursorPosition = lastLastDifficultyObject.BaseObject.StackedPosition;
-                if (lastLastDifficultyObject.BaseObject is Slider prevPrevSlider)
-                {
-                    OsuHitObject lastNestedObject = (OsuHitObject)prevPrevSlider.NestedHitObjects[^1];
-                    lastLastCursorPosition = lastNestedObject.StackedPosition;
-                }
-
                 if (lastDifficultyObject!.BaseObject is Slider prevSlider && lastDifficultyObject.TravelDistance > 0)
-                {
-                    OsuHitObject lastNestedObject = (OsuHitObject)prevSlider.NestedHitObjects[^1];
-                    OsuHitObject secondLastNestedObject = (OsuHitObject)prevSlider.NestedHitObjects[^2];
+                    lastCursorPosition = prevSlider.HeadCircle.StackedPosition;
+                Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
 
-                    Vector2 lastNestedPosition = lastNestedObject.StackedPosition;
-                    Vector2 secondLastNestedPosition = secondLastNestedObject.StackedPosition;
+                double angle = Math.Abs(calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition));
+                double sliderAngle = Math.Abs(calculateSliderAngle(lastDifficultyObject!, lastLastCursorPosition));
 
-                    double sliderAngle = Math.Abs(calculateAngle(BaseObject.StackedPosition, lastNestedPosition, secondLastNestedPosition));
-
-                    // We always assume that the player tries to ignore the slider tail.
-                    Vector2 assumedNaturalCursorPosition = (BaseObject.StackedPosition + secondLastNestedPosition) / 2;
-                    // This is the distance from the assumed natural cursor position to the slider tail.
-                    double h = (assumedNaturalCursorPosition * scalingFactor - lastNestedPosition * scalingFactor).Length;
-
-                    if (h > NORMALISED_RADIUS * maximum_slider_radius || sliderAngle < double.DegreesToRadians(90))
-                    {
-                        lastCursorPosition = lastNestedPosition;
-                        lastLastCursorPosition = secondLastNestedPosition;
-                    }
-                    else
-                    {
-                        lastCursorPosition = prevSlider.HeadCircle.StackedPosition;
-                    }
-                }
-                Angle = Math.Abs(calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition));
+                Angle = Math.Min(angle, sliderAngle);
             }
         }
 
@@ -381,6 +356,19 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 if (i == nestedObjects.Count - 1)
                     LazyEndPosition = currCursorPosition;
             }
+        }
+
+        private double calculateSliderAngle(OsuDifficultyHitObject lastDifficultyObject, Vector2 lastLastCursorPosition)
+        {
+            Vector2 lastCursorPosition = getEndCursorPosition(lastDifficultyObject);
+
+            if (lastDifficultyObject.BaseObject is Slider prevSlider && lastDifficultyObject.TravelDistance > 0)
+            {
+                OsuHitObject secondLastNestedObject = (OsuHitObject)prevSlider.NestedHitObjects[^2];
+                lastLastCursorPosition = secondLastNestedObject.StackedPosition;
+            }
+
+            return calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition);
         }
 
         private double calculateAngle(Vector2 currentPosition, Vector2 lastPosition, Vector2 lastLastPosition)

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -246,8 +246,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                     lastCursorPosition = prevSlider.HeadCircle.StackedPosition;
                 Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
 
-                double angle = Math.Abs(calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition));
-                double sliderAngle = Math.Abs(calculateSliderAngle(lastDifficultyObject!, lastLastCursorPosition));
+                double angle = calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition);
+                double sliderAngle = calculateSliderAngle(lastDifficultyObject!, lastLastCursorPosition);
 
                 Angle = Math.Min(angle, sliderAngle);
             }
@@ -382,7 +382,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             float dot = Vector2.Dot(v1, v2);
             float det = v1.X * v2.Y - v1.Y * v2.X;
 
-            return Math.Atan2(det, dot);
+            return Math.Abs(Math.Atan2(det, dot));
         }
 
         private Vector2 getEndCursorPosition(OsuDifficultyHitObject difficultyHitObject)

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -239,15 +239,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             if (lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is not Spinner)
             {
-                Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
-
-                Vector2 v1 = lastLastCursorPosition - LastObject.StackedPosition;
-                Vector2 v2 = BaseObject.StackedPosition - lastCursorPosition;
-
-                float dot = Vector2.Dot(v1, v2);
-                float det = v1.X * v2.Y - v1.Y * v2.X;
-
-                Angle = Math.Abs(Math.Atan2(det, dot));
+                Angle = Math.Abs(calculateAngle(lastDifficultyObject!, lastLastDifficultyObject!));
             }
         }
 
@@ -357,6 +349,31 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 if (i == nestedObjects.Count - 1)
                     LazyEndPosition = currCursorPosition;
             }
+        }
+
+        private double calculateAngle(OsuDifficultyHitObject lastDifficultyObject, OsuDifficultyHitObject lastLastDifficultyObject)
+        {
+            Vector2 lastCursorPosition = getEndCursorPosition(lastDifficultyObject);
+            Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
+
+            if (lastDifficultyObject.BaseObject is Slider slider && lastDifficultyObject.TravelDistance > 0)
+            {
+                IList<HitObject> nestedObjects = slider.NestedHitObjects;
+
+                OsuHitObject lastNestedObject = (OsuHitObject)nestedObjects[^1];
+                OsuHitObject secondLastNestedObject = (OsuHitObject)nestedObjects[^2];
+
+                lastCursorPosition = lastNestedObject.StackedPosition;
+                lastLastCursorPosition = secondLastNestedObject.StackedPosition;
+            }
+
+            Vector2 v1 = lastLastCursorPosition - lastCursorPosition;
+            Vector2 v2 = BaseObject.StackedPosition - lastCursorPosition;
+
+            float dot = Vector2.Dot(v1, v2);
+            float det = v1.X * v2.Y - v1.Y * v2.X;
+
+            return Math.Atan2(det, dot);
         }
 
         private Vector2 getEndCursorPosition(OsuDifficultyHitObject difficultyHitObject)

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -244,6 +244,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             {
                 if (lastDifficultyObject!.BaseObject is Slider prevSlider && lastDifficultyObject.TravelDistance > 0)
                     lastCursorPosition = prevSlider.HeadCircle.StackedPosition;
+
                 Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
 
                 double angle = calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition);

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -239,8 +239,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             if (lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is not Spinner)
             {
-                if (lastDifficultyObject!.BaseObject is Slider slider && lastDifficultyObject.TravelDistance > 0)
-                    lastCursorPosition = slider.HeadCircle.StackedPosition;
+                if (lastDifficultyObject!.BaseObject is Slider prevSlider && lastDifficultyObject.TravelDistance > 0)
+                    lastCursorPosition = prevSlider.HeadCircle.StackedPosition;
                 Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
 
                 double angle = Math.Abs(calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition));
@@ -362,9 +362,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         {
             Vector2 lastCursorPosition = getEndCursorPosition(lastDifficultyObject);
 
-            if (lastDifficultyObject.BaseObject is Slider slider && lastDifficultyObject.TravelDistance > 0)
+            if (lastDifficultyObject.BaseObject is Slider prevSlider && lastDifficultyObject.TravelDistance > 0)
             {
-                OsuHitObject secondLastNestedObject = (OsuHitObject)slider.NestedHitObjects[^2];
+                OsuHitObject secondLastNestedObject = (OsuHitObject)prevSlider.NestedHitObjects[^2];
                 lastLastCursorPosition = secondLastNestedObject.StackedPosition;
             }
 


### PR DESCRIPTION
## This pr resolves the issue with the angle calculation.
The old system calculated the angle between three objects. If the last object was a long slider that the player needed to follow, the system calculated the angle using only the slider’s end point and the previous object, which caused long sliders to have incorrect angle values.
> As an example https://osu.ppy.sh/beatmapsets/1455997#osu/2992705 there was a section in which all sliders with acute angles were incorrectly calculated as having wide angles.
> <img width="930" height="523" alt="oldsis" src="https://github.com/user-attachments/assets/7f5829ad-3e09-4b90-b467-bfc1737e7949" />

The new system checks whether the player needs to follow the previous slider.
If that is the case, it calculates the angle using the position of the slider end and the last tick, or the head if no ticks are present.
> <img width="930" height="523" alt="newsis" src="https://github.com/user-attachments/assets/d42cc5d9-c2b6-441c-a954-ac763209e3ac" />

Edit:
In the previous commit, the system had issues handling sliders with a circle in front, incorrectly applying a wide angle even though the player’s natural movement should be sharp.
> This is how my system saw this pattern before the bug fix.
> <img width="651" height="483" alt="bug-new" src="https://github.com/user-attachments/assets/63c31bdb-b999-4e9d-a5e4-5d31f3e712ca" />

> This is how the live system sees the pattern.
> <img width="651" height="483" alt="bug-old" src="https://github.com/user-attachments/assets/0574943a-7a2d-4118-8bb2-fbfedb5f0a16" />

> This is how my system sees the pattern after the bug fix.
> <img width="651" height="483" alt="new" src="https://github.com/user-attachments/assets/d5f7a544-7d5f-4a44-9ce9-1a04e4fc089b" />
