### PR TITLE
Prevent local user from displaying in two clouds in QuickPlay

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/CloudVisualisation.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/CloudVisualisation.cs
@@ -24,10 +24,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
     public partial class CloudVisualisation : CompositeDrawable
     {
         private APIUser[] users = [];
+        private APIUser? localUser;
         private Container usersContainer = null!;
 
         private readonly Bindable<double?> lastSamplePlayback = new Bindable<double?>();
 
+        public APIUser? LocalUser
+        {
+        get => localUser;
+        set => localUser = value;
+        }
+        
         public APIUser[] Users
         {
             get => users;
@@ -38,7 +45,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 foreach (var u in usersContainer)
                     u.Delay(RNG.Next(0, 1000)).FadeOut(500).Expire();
 
-                LoadComponentsAsync(users.Select(u => new MovingAvatar(u, lastSamplePlayback)), avatars =>
+                var cloudUsers = users.Where(u => localUser == null || u.Id != localUser.Id);
+
+                LoadComponentsAsync(cloudUsers.Select(u => new MovingAvatar(u, lastSamplePlayback)), avatars =>
                 {
                     if (usersContainer.Count == 0)
                     {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/CloudVisualisation.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/CloudVisualisation.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         public APIUser? LocalUser
         {
-        get => localUser;
-        set => localUser = value;
+            get => localUser;
+            set => localUser = value;
         }
         
         public APIUser[] Users

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/CloudVisualisation.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/CloudVisualisation.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             get => localUser;
             set => localUser = value;
         }
-        
         public APIUser[] Users
         {
             get => users;


### PR DESCRIPTION
Change made in reference to #35552 
Previously, the player's avatar would show as a cloud in the lobby. 
Now, we prevent that by excluding the localUser from the user pool.