### PR TITLE
Fix timing of beatmap break overlay

### DIFF
--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -165,7 +165,6 @@ namespace osu.Game.Screens.Play
 
         private void updateDisplay(ValueChangedEvent<Period?> period)
         {
-            FinishTransforms(true);
             Scheduler.CancelDelayedTasks();
 
             if (period.NewValue == null)
@@ -180,12 +179,12 @@ namespace osu.Game.Screens.Play
 
                 remainingTimeAdjustmentBox
                     .ResizeWidthTo(remaining_time_container_max_size, BREAK_FADE_DURATION, Easing.OutQuint)
-                    .Delay(b.Duration - BREAK_FADE_DURATION)
+                    .Delay(b.Duration)
                     .ResizeWidthTo(0);
 
                 remainingTimeBox.ResizeWidthTo(remainingTimeForCurrentPeriod);
 
-                remainingTimeCounter.CountTo(b.Duration).CountTo(0, b.Duration);
+                remainingTimeCounter.CountTo(b.Duration + BREAK_FADE_DURATION).CountTo(0, b.Duration + BREAK_FADE_DURATION);
 
                 remainingTimeCounter.MoveToX(-50)
                                     .MoveToX(0, BREAK_FADE_DURATION, Easing.OutQuint);
@@ -193,7 +192,7 @@ namespace osu.Game.Screens.Play
                 info.MoveToX(50)
                     .MoveToX(0, BREAK_FADE_DURATION, Easing.OutQuint);
 
-                using (BeginDelayedSequence(b.Duration - BREAK_FADE_DURATION))
+                using (BeginDelayedSequence(b.Duration))
                 {
                     fadeContainer.FadeOut(BREAK_FADE_DURATION);
                     breakArrows.Hide(BREAK_FADE_DURATION);

--- a/osu.Game/Screens/Play/LetterboxOverlay.cs
+++ b/osu.Game/Screens/Play/LetterboxOverlay.cs
@@ -61,8 +61,6 @@ namespace osu.Game.Screens.Play
 
         private void updateDisplay(ValueChangedEvent<Period?> period)
         {
-            FinishTransforms(true);
-
             if (period.NewValue == null)
                 return;
 
@@ -71,7 +69,7 @@ namespace osu.Game.Screens.Play
             using (BeginAbsoluteSequence(b.Start))
             {
                 fadeContainer.FadeInFromZero(BreakOverlay.BREAK_FADE_DURATION);
-                using (BeginDelayedSequence(b.Duration - BreakOverlay.BREAK_FADE_DURATION))
+                using (BeginDelayedSequence(b.Duration))
                     fadeContainer.FadeOut(BreakOverlay.BREAK_FADE_DURATION);
             }
         }


### PR DESCRIPTION
Fixes #35425

Issue was bisected to [this commit](https://github.com/ppy/osu/pull/29616/commits/6f1664f0a60fc08995d737e40272b61742fbe580)

After the change to create each break overlay separately instead of all at once, the duration of the breaks passed in is 325ms shorter to align with the rest of the beatmap. The timing was correct, but the overlay was still fading out under the assumption that it needed to account for the fade delay. 

Before:
https://github.com/user-attachments/assets/cd091af8-0a04-4188-811d-4f581796efa9

After:
https://github.com/user-attachments/assets/fcd3e70b-f93d-4d62-8e05-143b265b5ea4

