### PR TITLE
Add PP breakdown to osu!mania profiles

### DIFF
--- a/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
@@ -251,7 +251,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
                         result = variantText;
                     else
                         result = LocalisableString.Interpolate($"{result}\n{variantText}");
-
                 }
             }
 

--- a/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
@@ -158,6 +158,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
             medalInfo.Content = user?.Achievements?.Length.ToString() ?? "0";
             ppInfo.Content = user?.Statistics?.PP?.ToLocalisableString("#,##0") ?? (LocalisableString)"0";
+            ppInfo.ContentTooltipText = getPPInfoTooltipText(user);
 
             foreach (var scoreRankInfo in scoreRankInfos)
                 scoreRankInfo.Value.RankCount = user?.Statistics?.GradesCount[scoreRankInfo.Key] ?? 0;
@@ -228,6 +229,29 @@ namespace osu.Game.Overlays.Profile.Header.Components
                         else
                             result = LocalisableString.Interpolate($"{result}\n{variantText}");
                     }
+                }
+            }
+
+            return result ?? default;
+        }
+
+        private static LocalisableString getPPInfoTooltipText(APIUser? user)
+        {
+            var variants = user?.Statistics?.Variants;
+
+            LocalisableString? result = null;
+
+            if (variants?.Count > 0)
+            {
+                foreach (var variant in variants)
+                {
+                    var variantText = LocalisableString.Interpolate($"{variant.VariantType.GetLocalisableDescription()}: {variant.PP.ToLocalisableString("#,##0")}");
+
+                    if (result == null)
+                        result = variantText;
+                    else
+                        result = LocalisableString.Interpolate($"{result}\n{variantText}");
+
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/35582

Upon hovering, if the user has any PP in osu!mania, the 4K and 7K breakdown will be shown, as on the website