### PR TITLE
Add settings to flashing hit-objects

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/KiaiFlashFrequency.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/KiaiFlashFrequency.cs
@@ -8,13 +8,13 @@ namespace osu.Game.Rulesets.Osu.Configuration
 {
     public enum KiaiFlashFrequency
     {
-        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency1x))]
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency1X))]
         EveryBeat,
 
-        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency0_5x))]
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency05x))]
         EverySecondBeat,
 
-        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency0_25x))]
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency025X))]
         EveryFourthBeat,
     }
 }

--- a/osu.Game.Rulesets.Osu/Configuration/KiaiFlashFrequency.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/KiaiFlashFrequency.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
         [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency1X))]
         EveryBeat,
 
-        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency05x))]
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency05X))]
         EverySecondBeat,
 
         [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency025X))]

--- a/osu.Game.Rulesets.Osu/Configuration/KiaiFlashFrequency.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/KiaiFlashFrequency.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
+
+namespace osu.Game.Rulesets.Osu.Configuration
+{
+    public enum KiaiFlashFrequency
+    {
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency1x))]
+        EveryBeat,
+
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency0_5x))]
+        EverySecondBeat,
+
+        [LocalisableDescription(typeof(RulesetSettingsStrings), nameof(RulesetSettingsStrings.KiaiFlashFrequency0_25x))]
+        EveryFourthBeat,
+    }
+}

--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -22,6 +22,9 @@ namespace osu.Game.Rulesets.Osu.Configuration
             SetDefault(OsuRulesetSetting.ShowCursorTrail, true);
             SetDefault(OsuRulesetSetting.ShowCursorRipples, false);
             SetDefault(OsuRulesetSetting.PlayfieldBorderStyle, PlayfieldBorderStyle.None);
+            SetDefault(OsuRulesetSetting.HitObjectDimmingStrength, 1f);
+            SetDefault(OsuRulesetSetting.KiaiFlashStrength, 1f);
+            SetDefault(OsuRulesetSetting.KiaiFlashFrequency, KiaiFlashFrequency.EveryBeat);
 
             SetDefault(OsuRulesetSetting.ReplayClickMarkersEnabled, false);
             SetDefault(OsuRulesetSetting.ReplayFrameMarkersEnabled, false);
@@ -38,6 +41,9 @@ namespace osu.Game.Rulesets.Osu.Configuration
         ShowCursorTrail,
         ShowCursorRipples,
         PlayfieldBorderStyle,
+        HitObjectDimmingStrength,
+        KiaiFlashStrength,
+        KiaiFlashFrequency,
 
         // Replay
         ReplayClickMarkersEnabled,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private void applyDim(Drawable piece)
         {
-            float dimmingMultiplier = Math.Clamp(hitObjectDimmingStrength.Value, 0f, 2f);
+            float dimmingMultiplier = hitObjectDimmingStrength.Value;
             byte dimColorValue = (byte)Math.Clamp(Math.Round(255 - (255 - 195) * dimmingMultiplier), 0, 255);
             Color4 dimColour = new Color4(dimColorValue, dimColorValue, dimColorValue, 255);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -126,9 +126,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private void applyDim(Drawable piece)
         {
-            float dimmingAmount = Math.Clamp(hitObjectDimmingStrength.Value, 0f, 2f);
-            byte dimChannel = (byte)Math.Clamp(Math.Round(255 - (255 - 195) * dimmingAmount), 0, 255);
-            Color4 dimColour = new Color4(dimChannel, dimChannel, dimChannel, 255);
+            float dimmingMultiplier = Math.Clamp(hitObjectDimmingStrength.Value, 0f, 2f);
+            byte dimColorValue = (byte)Math.Clamp(Math.Round(255 - (255 - 195) * dimmingMultiplier), 0, 255);
+            Color4 dimColour = new Color4(dimColorValue, dimColorValue, dimColorValue, 255);
 
             piece.FadeColour(dimColour);
             using (piece.BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))

--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Osu.Configuration;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
@@ -16,6 +19,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         private const double fade_length = 80;
 
         private const float flash_opacity = 0.25f;
+
+        [Resolved(canBeNull: true)]
+        private OsuRulesetConfigManager? config { get; set; }
+
+        private readonly BindableFloat kiaiFlashStrength = new BindableFloat(1f);
+        private readonly Bindable<KiaiFlashFrequency> kiaiFlashFrequency = new Bindable<KiaiFlashFrequency>(KiaiFlashFrequency.EveryBeat);
 
         public KiaiFlash()
         {
@@ -30,13 +39,37 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             };
         }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            kiaiFlashStrength.MinValue = 0.5f;
+            kiaiFlashStrength.MaxValue = 2f;
+            kiaiFlashStrength.Precision = 0.05f;
+
+            config?.BindWith(OsuRulesetSetting.KiaiFlashStrength, kiaiFlashStrength);
+            config?.BindWith(OsuRulesetSetting.KiaiFlashFrequency, kiaiFlashFrequency);
+        }
+
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
             if (!effectPoint.KiaiMode)
                 return;
 
+            int interval = kiaiFlashFrequency.Value switch
+            {
+                KiaiFlashFrequency.EveryBeat => 1,
+                KiaiFlashFrequency.EverySecondBeat => 2,
+                KiaiFlashFrequency.EveryFourthBeat => 4,
+                _ => 1,
+            };
+
+            if (beatIndex % interval != 0)
+                return;
+
+            float opacityMultiplier = Math.Clamp(kiaiFlashStrength.Value, 0.5f, 2f);
+
             Child
-                .FadeTo(flash_opacity, EarlyActivationMilliseconds, Easing.OutQuint)
+                .FadeTo(flash_opacity * opacityMultiplier, EarlyActivationMilliseconds, Easing.OutQuint)
                 .Then()
                 .FadeOut(Math.Max(fade_length, timingPoint.BeatLength - fade_length), Easing.OutSine);
         }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             if (beatIndex % interval != 0)
                 return;
 
-            float opacityMultiplier = Math.Clamp(kiaiFlashStrength.Value, 0.5f, 2f);
+            float opacityMultiplier = Math.Clamp(kiaiFlashStrength.Value, 0.0f, 10.0f);
 
             Child
                 .FadeTo(flash_opacity * opacityMultiplier, EarlyActivationMilliseconds, Easing.OutQuint)

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Localisation;
@@ -20,10 +21,29 @@ namespace osu.Game.Rulesets.Osu.UI
         {
         }
 
+        private readonly BindableFloat hitObjectDimmingStrength = new BindableFloat
+        {
+            MinValue = 0f,
+            MaxValue = 2f,
+            Precision = 0.05f,
+            Default = 1f,
+        };
+
+        private readonly BindableFloat kiaiFlashStrength = new BindableFloat
+        {
+            MinValue = 0.5f,
+            MaxValue = 2f,
+            Precision = 0.05f,
+            Default = 1f,
+        };
+
         [BackgroundDependencyLoader]
         private void load()
         {
             var config = (OsuRulesetConfigManager)Config;
+
+            config.BindWith(OsuRulesetSetting.HitObjectDimmingStrength, hitObjectDimmingStrength);
+            config.BindWith(OsuRulesetSetting.KiaiFlashStrength, kiaiFlashStrength);
 
             Children = new Drawable[]
             {
@@ -52,6 +72,26 @@ namespace osu.Game.Rulesets.Osu.UI
                 {
                     LabelText = RulesetSettingsStrings.PlayfieldBorderStyle,
                     Current = config.GetBindable<PlayfieldBorderStyle>(OsuRulesetSetting.PlayfieldBorderStyle),
+                },
+                new SettingsSlider<float>
+                {
+                    LabelText = RulesetSettingsStrings.HitObjectDimmingStrength,
+                    Keywords = new[] { "dimming", "lightup", "pre-hit" },
+                    KeyboardStep = 0.05f,
+                    Current = hitObjectDimmingStrength,
+                },
+                new SettingsSlider<float>
+                {
+                    LabelText = RulesetSettingsStrings.KiaiFlashStrength,
+                    Keywords = new[] { "kiai", "flash", "intensity" },
+                    KeyboardStep = 0.05f,
+                    Current = kiaiFlashStrength,
+                },
+                new SettingsEnumDropdown<KiaiFlashFrequency>
+                {
+                    LabelText = RulesetSettingsStrings.KiaiFlashFrequency,
+                    Keywords = new[] { "kiai", "frequency", "cadence", "beat" },
+                    Current = config.GetBindable<KiaiFlashFrequency>(OsuRulesetSetting.KiaiFlashFrequency),
                 },
             };
         }

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -40,6 +40,36 @@ namespace osu.Game.Localisation
         public static LocalisableString PlayfieldBorderStyle => new TranslatableString(getKey(@"playfield_border_style"), @"Playfield border style");
 
         /// <summary>
+        /// "Hit object dimming"
+        /// </summary>
+        public static LocalisableString HitObjectDimmingStrength => new TranslatableString(getKey(@"hit_object_dimming_strength"), @"Hit object dimming");
+
+        /// <summary>
+        /// "Kiai flash strength"
+        /// </summary>
+        public static LocalisableString KiaiFlashStrength => new TranslatableString(getKey(@"kiai_flash_strength"), @"Kiai flash strength");
+
+        /// <summary>
+        /// "Kiai flash frequency"
+        /// </summary>
+        public static LocalisableString KiaiFlashFrequency => new TranslatableString(getKey(@"kiai_flash_frequency"), @"Kiai flash frequency");
+
+        /// <summary>
+        /// "1× (every beat)"
+        /// </summary>
+        public static LocalisableString KiaiFlashFrequency1x => new TranslatableString(getKey(@"kiai_flash_frequency_1x"), @"1× (every beat)");
+
+        /// <summary>
+        /// "0.5× (every second beat)"
+        /// </summary>
+        public static LocalisableString KiaiFlashFrequency0_5x => new TranslatableString(getKey(@"kiai_flash_frequency_0_5x"), @"0.5× (every second beat)");
+
+        /// <summary>
+        /// "0.25× (every fourth beat)"
+        /// </summary>
+        public static LocalisableString KiaiFlashFrequency0_25x => new TranslatableString(getKey(@"kiai_flash_frequency_0_25x"), @"0.25× (every fourth beat)");
+
+        /// <summary>
         /// "None"
         /// </summary>
         public static LocalisableString BorderNone => new TranslatableString(getKey(@"no_borders"), @"None");

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "0.5× (every second beat)"
         /// </summary>
-        public static LocalisableString KiaiFlashFrequency05x => new TranslatableString(getKey(@"kiai_flash_frequency_0_5x"), @"0.5× (every second beat)");
+        public static LocalisableString KiaiFlashFrequency05X => new TranslatableString(getKey(@"kiai_flash_frequency_0_5x"), @"0.5× (every second beat)");
 
         /// <summary>
         /// "0.25× (every fourth beat)"

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -57,17 +57,17 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "1× (every beat)"
         /// </summary>
-        public static LocalisableString KiaiFlashFrequency1x => new TranslatableString(getKey(@"kiai_flash_frequency_1x"), @"1× (every beat)");
+        public static LocalisableString KiaiFlashFrequency1X => new TranslatableString(getKey(@"kiai_flash_frequency_1x"), @"1× (every beat)");
 
         /// <summary>
         /// "0.5× (every second beat)"
         /// </summary>
-        public static LocalisableString KiaiFlashFrequency0_5x => new TranslatableString(getKey(@"kiai_flash_frequency_0_5x"), @"0.5× (every second beat)");
+        public static LocalisableString KiaiFlashFrequency05x => new TranslatableString(getKey(@"kiai_flash_frequency_0_5x"), @"0.5× (every second beat)");
 
         /// <summary>
         /// "0.25× (every fourth beat)"
         /// </summary>
-        public static LocalisableString KiaiFlashFrequency0_25x => new TranslatableString(getKey(@"kiai_flash_frequency_0_25x"), @"0.25× (every fourth beat)");
+        public static LocalisableString KiaiFlashFrequency025X => new TranslatableString(getKey(@"kiai_flash_frequency_0_25x"), @"0.25× (every fourth beat)");
 
         /// <summary>
         /// "None"


### PR DESCRIPTION
This PR adds 3 settings:
- kiai flash strength: a slider dictating how obnoxious the kiai flashes are
- kiai flash frequency: an option between every 1/2/4 beats to make higher bpm maps less obnoxious (I don't think that you should have a flash every beat on a 300bpm map, or even 400?)
- hit object dimming strength: option which dictates how strong the before-hit lightup is

I believe having a range of options to choose for each of those is very beneficial for:
- players having light sensitivity
- players having eye strain
- players who wants to increase the strength of those effects for better visuals
- "pro" players who might want to decrease the strength of those effects for better gameplay
- players who uses their own skins, I think the current values are optimized for the default?

I don't see how this could be harmful if the range in the settings is small enough to still have those effects.
I'd encourage storing the settings of players in a database to further analyze what settings the community would want to have, we could even store what settings were used in the score metadata, so players could see what kind of visual obfuscations were used.

Currently there is no reward system in place for having the visual effects turned on. I think it's a bit lame to have visuals which 95% of players turn off, I'd rather see a separate leaderboard for having them enabled, or maybe add score/pp multipliers.