### PR TITLE
Fix quick play notification not setting "accepted" state

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             if (backgroundNotification != null)
                 return;
 
-            notifications?.Post(backgroundNotification = new BackgroundQueueNotification());
+            notifications?.Post(backgroundNotification = new BackgroundQueueNotification(this));
         }
 
         private void closeNotifications()
@@ -154,8 +154,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             [Resolved]
             private MultiplayerClient client { get; set; } = null!;
 
+            private readonly QueueController controller;
+
             private Notification? foundNotification;
             private Sample? matchFoundSample;
+
+            public BackgroundQueueNotification(QueueController controller)
+            {
+                this.controller = controller;
+            }
 
             [BackgroundDependencyLoader]
             private void load(AudioManager audio)
@@ -165,6 +172,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 CompletionClickAction = () =>
                 {
                     client.MatchmakingAcceptInvitation().FireAndForget();
+                    controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom;
+
                     performer?.PerformFromScreen(s => s.Push(new ScreenIntro()));
 
                     Close(false);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/35519

It actually does accept the invitation - it just wasn't setting the client-local state. This stuff needs better testing and refactoring in general - I don't particularly like that it's relying on a client-local state like this.

But it is what it is...

https://github.com/user-attachments/assets/d6d30f8c-74a0-42a2-b50c-993a01514488