### PR TITLE
Add tiered colours for global rank

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneGlobalRankDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneGlobalRankDisplay.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Tests.Visual.UserInterface;
 using osu.Game.Users;
@@ -34,8 +36,31 @@ namespace osu.Game.Tests.Visual.Online
                 Value = new UserStatistics
                 {
                     GlobalRank = rank,
-                    GlobalRankPercent = rank / 1_000_000,
-                }
+                    GlobalRankPercent = rank / 1_000_000f,
+                    Variants =
+                    [
+                        new UserStatistics.Variant
+                        {
+                            VariantType = UserStatistics.RulesetVariant.FourKey,
+                            GlobalRank = rank / 3,
+                        },
+                        new UserStatistics.Variant
+                        {
+                            VariantType = UserStatistics.RulesetVariant.SevenKey,
+                            GlobalRank = 2 * rank / 3,
+                        }
+                    ]
+                },
+            },
+            HighestRank =
+            {
+                Value = rank == null
+                    ? null
+                    : new APIUser.UserRankHighest
+                    {
+                        Rank = rank.Value / 2,
+                        UpdatedAt = DateTimeOffset.Now.AddMonths(-3),
+                    }
             }
         };
     }

--- a/osu.Game.Tests/Visual/Online/TestSceneGlobalRankDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneGlobalRankDisplay.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Tests.Visual.UserInterface;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public partial class TestSceneGlobalRankDisplay : ThemeComparisonTestScene
+    {
+        public TestSceneGlobalRankDisplay()
+            : base(false)
+        {
+        }
+
+        protected override Drawable CreateContent() => new FillFlowContainer
+        {
+            RelativeSizeAxes = Axes.Both,
+            Direction = FillDirection.Full,
+            Padding = new MarginPadding(20),
+            Spacing = new Vector2(40),
+            ChildrenEnumerable = new int?[] { 64, 423, 1453, 3468, 18_367, 48_342, 178_432, 375_231, 897_783, null }.Select(createDisplay)
+        };
+
+        private GlobalRankDisplay createDisplay(int? rank) => new GlobalRankDisplay
+        {
+            UserStatistics =
+            {
+                Value = new UserStatistics
+                {
+                    GlobalRank = rank,
+                    GlobalRankPercent = rank / 1_000_000,
+                }
+            }
+        };
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/GlobalRankDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GlobalRankDisplay.cs
@@ -8,8 +8,10 @@ using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Scoring;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -20,6 +22,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
         public Bindable<APIUser.UserRankHighest?> HighestRank = new Bindable<APIUser.UserRankHighest?>();
 
         private ProfileValueDisplay info = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         public GlobalRankDisplay()
         {
@@ -47,6 +52,48 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             info.Content.Text = UserStatistics.Value?.GlobalRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
             info.Content.TooltipText = getGlobalRankTooltipText();
+
+            var tier = getRankingTier();
+            info.Content.Colour = tier == null ? colourProvider.Content2 : OsuColour.ForRankingTier(tier.Value);
+            info.Content.Font = info.Content.Font.With(weight: tier == null || tier == RankingTier.Iron ? FontWeight.Regular : FontWeight.Bold);
+        }
+
+        /// <seealso href="https://github.com/ppy/osu-web/blob/6fcd85eb006ce7699d6f747597435c01344b2d2d/resources/js/profile-page/rank.tsx#L19-L46"/>
+        private RankingTier? getRankingTier()
+        {
+            var stats = UserStatistics.Value;
+
+            int? rank = stats?.GlobalRank;
+            float? percent = stats?.GlobalRankPercent;
+
+            if (rank == null || percent == null)
+                return null;
+
+            if (rank <= 100)
+                return RankingTier.Lustrous;
+
+            if (percent < 0.0005)
+                return RankingTier.Radiant;
+
+            if (percent < 0.0025)
+                return RankingTier.Rhodium;
+
+            if (percent < 0.005)
+                return RankingTier.Platinum;
+
+            if (percent < 0.025)
+                return RankingTier.Gold;
+
+            if (percent < 0.05)
+                return RankingTier.Silver;
+
+            if (percent < 0.25)
+                return RankingTier.Bronze;
+
+            if (percent < 0.5)
+                return RankingTier.Iron;
+
+            return null;
         }
 
         private LocalisableString getGlobalRankTooltipText()

--- a/osu.Game/Overlays/Profile/Header/Components/GlobalRankDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GlobalRankDisplay.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Users;
+
+namespace osu.Game.Overlays.Profile.Header.Components
+{
+    public partial class GlobalRankDisplay : CompositeDrawable
+    {
+        public Bindable<UserStatistics?> UserStatistics = new Bindable<UserStatistics?>();
+        public Bindable<APIUser.UserRankHighest?> HighestRank = new Bindable<APIUser.UserRankHighest?>();
+
+        private ProfileValueDisplay info = null!;
+
+        public GlobalRankDisplay()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = info = new ProfileValueDisplay(big: true)
+            {
+                Title = UsersStrings.ShowRankGlobalSimple
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            UserStatistics.BindValueChanged(_ => updateState());
+            HighestRank.BindValueChanged(_ => updateState(), true);
+        }
+
+        private void updateState()
+        {
+            info.Content.Text = UserStatistics.Value?.GlobalRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
+            info.Content.TooltipText = getGlobalRankTooltipText();
+        }
+
+        private LocalisableString getGlobalRankTooltipText()
+        {
+            var rankHighest = HighestRank.Value;
+            var variants = UserStatistics.Value?.Variants;
+
+            LocalisableString? result = null;
+
+            if (variants?.Count > 0)
+            {
+                foreach (var variant in variants)
+                {
+                    if (variant.GlobalRank != null)
+                    {
+                        var variantText = LocalisableString.Interpolate($"{variant.VariantType.GetLocalisableDescription()}: {variant.GlobalRank.ToLocalisableString("\\##,##0")}");
+
+                        if (result == null)
+                            result = variantText;
+                        else
+                            result = LocalisableString.Interpolate($"{result}\n{variantText}");
+                    }
+                }
+            }
+
+            if (rankHighest != null)
+            {
+                var rankHighestText = UsersStrings.ShowRankHighest(
+                    rankHighest.Rank.ToLocalisableString("\\##,##0"),
+                    rankHighest.UpdatedAt.ToLocalisableString(@"d MMM yyyy"));
+
+                if (result == null)
+                    result = rankHighestText;
+                else
+                    result = LocalisableString.Interpolate($"{result}\n{rankHighestText}");
+            }
+
+            return result ?? default;
+        }
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
@@ -156,18 +156,18 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             var user = data?.User;
 
-            medalInfo.Content = user?.Achievements?.Length.ToString() ?? "0";
-            ppInfo.Content = user?.Statistics?.PP?.ToLocalisableString("#,##0") ?? (LocalisableString)"0";
-            ppInfo.ContentTooltipText = getPPInfoTooltipText(user);
+            medalInfo.Content.Text = user?.Achievements?.Length.ToString() ?? "0";
+            ppInfo.Content.Text = user?.Statistics?.PP?.ToLocalisableString("#,##0") ?? (LocalisableString)"0";
+            ppInfo.Content.TooltipText = getPPInfoTooltipText(user);
 
             foreach (var scoreRankInfo in scoreRankInfos)
                 scoreRankInfo.Value.RankCount = user?.Statistics?.GradesCount[scoreRankInfo.Key] ?? 0;
 
-            detailGlobalRank.Content = user?.Statistics?.GlobalRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
-            detailGlobalRank.ContentTooltipText = getGlobalRankTooltipText(user);
+            detailGlobalRank.Content.Text = user?.Statistics?.GlobalRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
+            detailGlobalRank.Content.TooltipText = getGlobalRankTooltipText(user);
 
-            detailCountryRank.Content = user?.Statistics?.CountryRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
-            detailCountryRank.ContentTooltipText = getCountryRankTooltipText(user);
+            detailCountryRank.Content.Text = user?.Statistics?.CountryRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
+            detailCountryRank.Content.TooltipText = getCountryRankTooltipText(user);
 
             rankGraph.Statistics.Value = user?.Statistics;
         }

--- a/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private readonly Dictionary<ScoreRank, ScoreRankInfo> scoreRankInfos = new Dictionary<ScoreRank, ScoreRankInfo>();
         private ProfileValueDisplay medalInfo = null!;
         private ProfileValueDisplay ppInfo = null!;
-        private ProfileValueDisplay detailGlobalRank = null!;
+        private GlobalRankDisplay detailGlobalRank = null!;
         private ProfileValueDisplay detailCountryRank = null!;
         private RankGraph rankGraph = null!;
 
@@ -64,10 +64,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                         {
                             new[]
                             {
-                                detailGlobalRank = new ProfileValueDisplay(true)
-                                {
-                                    Title = UsersStrings.ShowRankGlobalSimple,
-                                },
+                                detailGlobalRank = new GlobalRankDisplay(),
                                 Empty(),
                                 detailCountryRank = new ProfileValueDisplay(true)
                                 {
@@ -163,51 +160,13 @@ namespace osu.Game.Overlays.Profile.Header.Components
             foreach (var scoreRankInfo in scoreRankInfos)
                 scoreRankInfo.Value.RankCount = user?.Statistics?.GradesCount[scoreRankInfo.Key] ?? 0;
 
-            detailGlobalRank.Content.Text = user?.Statistics?.GlobalRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
-            detailGlobalRank.Content.TooltipText = getGlobalRankTooltipText(user);
+            detailGlobalRank.HighestRank.Value = user?.RankHighest;
+            detailGlobalRank.UserStatistics.Value = user?.Statistics;
 
             detailCountryRank.Content.Text = user?.Statistics?.CountryRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
             detailCountryRank.Content.TooltipText = getCountryRankTooltipText(user);
 
             rankGraph.Statistics.Value = user?.Statistics;
-        }
-
-        private static LocalisableString getGlobalRankTooltipText(APIUser? user)
-        {
-            var rankHighest = user?.RankHighest;
-            var variants = user?.Statistics?.Variants;
-
-            LocalisableString? result = null;
-
-            if (variants?.Count > 0)
-            {
-                foreach (var variant in variants)
-                {
-                    if (variant.GlobalRank != null)
-                    {
-                        var variantText = LocalisableString.Interpolate($"{variant.VariantType.GetLocalisableDescription()}: {variant.GlobalRank.ToLocalisableString("\\##,##0")}");
-
-                        if (result == null)
-                            result = variantText;
-                        else
-                            result = LocalisableString.Interpolate($"{result}\n{variantText}");
-                    }
-                }
-            }
-
-            if (rankHighest != null)
-            {
-                var rankHighestText = UsersStrings.ShowRankHighest(
-                    rankHighest.Rank.ToLocalisableString("\\##,##0"),
-                    rankHighest.UpdatedAt.ToLocalisableString(@"d MMM yyyy"));
-
-                if (result == null)
-                    result = rankHighestText;
-                else
-                    result = LocalisableString.Interpolate($"{result}\n{rankHighestText}");
-            }
-
-            return result ?? default;
         }
 
         private static LocalisableString getCountryRankTooltipText(APIUser? user)

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileValueDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileValueDisplay.cs
@@ -14,22 +14,13 @@ namespace osu.Game.Overlays.Profile.Header.Components
     public partial class ProfileValueDisplay : CompositeDrawable
     {
         private readonly OsuSpriteText title;
-        private readonly ContentText content;
 
         public LocalisableString Title
         {
             set => title.Text = value;
         }
 
-        public LocalisableString Content
-        {
-            set => content.Text = value;
-        }
-
-        public LocalisableString ContentTooltipText
-        {
-            set => content.TooltipText = value;
-        }
+        public ContentText Content { get; }
 
         public ProfileValueDisplay(bool big = false, int minimumWidth = 60)
         {
@@ -44,7 +35,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     {
                         Font = OsuFont.GetFont(size: 12)
                     },
-                    content = new ContentText
+                    Content = new ContentText
                     {
                         Font = OsuFont.GetFont(size: big ? 30 : 20, weight: FontWeight.Light),
                     },
@@ -60,10 +51,10 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private void load(OverlayColourProvider colourProvider)
         {
             title.Colour = colourProvider.Content1;
-            content.Colour = colourProvider.Content2;
+            Content.Colour = colourProvider.Content2;
         }
 
-        private partial class ContentText : OsuSpriteText, IHasTooltip
+        public partial class ContentText : OsuSpriteText, IHasTooltip
         {
             public LocalisableString TooltipText { get; set; }
         }

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileValueDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileValueDisplay.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     },
                     Content = new ContentText
                     {
-                        Font = OsuFont.GetFont(size: big ? 30 : 20, weight: FontWeight.Light),
+                        Font = OsuFont.GetFont(size: big ? 30 : 20, weight: big ? FontWeight.Regular : FontWeight.Light),
                     },
                     new Container // Add a minimum size to the FillFlowContainer
                     {

--- a/osu.Game/Overlays/Profile/Header/Components/TotalPlayTime.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/TotalPlayTime.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             InternalChild = info = new ProfileValueDisplay(minimumWidth: 140)
             {
                 Title = UsersStrings.ShowStatsPlayTime,
-                ContentTooltipText = "0 hours",
+                Content = { TooltipText = "0 hours", }
             };
 
             User.BindValueChanged(updateTime, true);
@@ -35,8 +35,8 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private void updateTime(ValueChangedEvent<UserProfileData?> user)
         {
             int? playTime = user.NewValue?.User.Statistics?.PlayTime;
-            info.ContentTooltipText = (playTime ?? 0) / 3600 + " hours";
-            info.Content = formatTime(playTime);
+            info.Content.TooltipText = (playTime ?? 0) / 3600 + " hours";
+            info.Content.Text = formatTime(playTime);
         }
 
         private string formatTime(int? secondsNull)

--- a/osu.Game/Users/UserRankPanel.cs
+++ b/osu.Game/Users/UserRankPanel.cs
@@ -71,8 +71,8 @@ namespace osu.Game.Users
             var statistics = statisticsProvider?.GetStatisticsFor(ruleset.Value);
 
             loadingLayer.State.Value = statistics == null ? Visibility.Visible : Visibility.Hidden;
-            globalRankDisplay.Content = statistics?.GlobalRank?.ToLocalisableString("\\##,##0") ?? "-";
-            countryRankDisplay.Content = statistics?.CountryRank?.ToLocalisableString("\\##,##0") ?? "-";
+            globalRankDisplay.Content.Text = statistics?.GlobalRank?.ToLocalisableString("\\##,##0") ?? "-";
+            countryRankDisplay.Content.Text = statistics?.CountryRank?.ToLocalisableString("\\##,##0") ?? "-";
         }
 
         protected override Drawable CreateLayout()

--- a/osu.Game/Users/UserRankPanel.cs
+++ b/osu.Game/Users/UserRankPanel.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Users
         private const int padding = 10;
         private const int main_content_height = 80;
 
-        private ProfileValueDisplay globalRankDisplay = null!;
+        private GlobalRankDisplay globalRankDisplay = null!;
         private ProfileValueDisplay countryRankDisplay = null!;
         private LoadingLayer loadingLayer = null!;
 
@@ -71,7 +71,12 @@ namespace osu.Game.Users
             var statistics = statisticsProvider?.GetStatisticsFor(ruleset.Value);
 
             loadingLayer.State.Value = statistics == null ? Visibility.Visible : Visibility.Hidden;
-            globalRankDisplay.Content.Text = statistics?.GlobalRank?.ToLocalisableString("\\##,##0") ?? "-";
+
+            // TODO: implement highest rank tooltip
+            // `RankHighest` resides in `APIUser`, but `api.LocalUser` doesn't update
+            // maybe move to `UserStatistics` in api, so `UserStatisticsWatcher` can update the value
+            globalRankDisplay.UserStatistics.Value = statistics;
+
             countryRankDisplay.Content.Text = statistics?.CountryRank?.ToLocalisableString("\\##,##0") ?? "-";
         }
 
@@ -187,13 +192,7 @@ namespace osu.Game.Users
                         {
                             new Drawable[]
                             {
-                                globalRankDisplay = new ProfileValueDisplay(true)
-                                {
-                                    Title = UsersStrings.ShowRankGlobalSimple,
-                                    // TODO: implement highest rank tooltip
-                                    // `RankHighest` resides in `APIUser`, but `api.LocalUser` doesn't update
-                                    // maybe move to `UserStatistics` in api, so `UserStatisticsWatcher` can update the value
-                                },
+                                globalRankDisplay = new GlobalRankDisplay(),
                                 countryRankDisplay = new ProfileValueDisplay(true)
                                 {
                                     Title = UsersStrings.ShowRankCountrySimple,

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -40,6 +40,9 @@ namespace osu.Game.Users
         [JsonProperty(@"global_rank")]
         public int? GlobalRank;
 
+        [JsonProperty(@"global_rank_percent")]
+        public float? GlobalRankPercent;
+
         [JsonProperty(@"country_rank")]
         public int? CountryRank;
 


### PR DESCRIPTION
<img width="1459" height="93" alt="Screenshot 2025-11-03 at 14 30 55" src="https://github.com/user-attachments/assets/ac03bf3f-989e-4329-b4e7-c51d8f0f02c7" />

Will display in local user popup:

<img width="467" height="387" alt="Screenshot 2025-11-03 at 14 31 18" src="https://github.com/user-attachments/assets/dd0c8745-4adc-4446-a5d6-41802d8633ee" />

and on profile overlay:

<img width="562" height="288" alt="Screenshot 2025-11-03 at 14 31 27" src="https://github.com/user-attachments/assets/2d0c6a36-dd14-4741-b2bd-5577437b3a2f" />

---

Port of https://github.com/ppy/osu-web/pull/12483 to client.

~~When testing, will not work on release config / production yet, because the web change hasn't been deployed yet.~~