### PR TITLE
Clamp notification avatar width

### DIFF
--- a/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
+++ b/osu.Game/Overlays/Notifications/UserAvatarNotification.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -39,7 +40,7 @@ namespace osu.Game.Overlays.Notifications
         protected override void Update()
         {
             base.Update();
-            IconContent.Width = IconContent.DrawHeight;
+            IconContent.Width = Math.Min(78, IconContent.DrawHeight);
         }
     }
 }


### PR DESCRIPTION
Resolves #35421

<img width="460" height="327" alt="image" src="https://github.com/user-attachments/assets/4264e435-d4cf-4ad1-b324-a68818e7cf83" />
  
  
Max width was chosen to be equal to a public message height, and also as roughly a quarter of a notification message (280/4=70)
<img width="464" height="327" alt="image" src="https://github.com/user-attachments/assets/79bec008-20a9-41e0-ba82-0d1b68606c21" />

I've considered options of also changing the fill mode to fit and filling the background with either a solid color or a heavily blurred version of the avatar, but the former looks bad and the latter is way too excessive for a simple notification message imo