### PR TITLE
Reduce kiai flash frequency on high bpm

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             double beatLength = timingPoint.BeatLength; // bpm = 60000 / beatLength
             double flashingPeriod;
 
-            if (beatLength < 120) // >=500 bpm, flash every 4 beats
+            if (beatLength <= 120) // >=500 bpm, flash every 4 beats
             {
                 if (beatIndex % 4 != 0)
                 {
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
                 flashingPeriod = beatLength * 4;
             }
-            else if (beatLength < 240) // >=250 bpm, flash every 2 beats
+            else if (beatLength <= 240) // >=250 bpm, flash every 2 beats
             {
                 if (beatIndex % 2 != 0)
                 {

--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -35,10 +35,29 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             if (!effectPoint.KiaiMode)
                 return;
 
+            double beatLength = timingPoint.BeatLength;
+            double flashingPeriod;
+            if (beatLength < 120) // >=500 bpm, flash every 4 beats
+            {
+                if (beatIndex % 4 != 0)
+                    return;
+                flashingPeriod = beatLength * 4;
+            }
+            else if (beatLength < 240) // >=250 bpm, flash every 2 beats
+            {
+                if (beatIndex % 2 != 0)
+                    return;
+                flashingPeriod = beatLength * 2;
+            }
+            else // <250 bpm, flash every beat
+            {
+                flashingPeriod = beatLength;
+            }
+
             Child
                 .FadeTo(flash_opacity, EarlyActivationMilliseconds, Easing.OutQuint)
                 .Then()
-                .FadeOut(Math.Max(fade_length, timingPoint.BeatLength - fade_length), Easing.OutSine);
+                .FadeOut(Math.Max(fade_length, flashingPeriod - fade_length), Easing.OutSine);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -37,16 +37,23 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             double beatLength = timingPoint.BeatLength; // bpm = 60000 / beatLength
             double flashingPeriod;
+
             if (beatLength < 120) // >=500 bpm, flash every 4 beats
             {
                 if (beatIndex % 4 != 0)
+                {
                     return;
+                }
+
                 flashingPeriod = beatLength * 4;
             }
             else if (beatLength < 240) // >=250 bpm, flash every 2 beats
             {
                 if (beatIndex % 2 != 0)
+                {
                     return;
+                }
+
                 flashingPeriod = beatLength * 2;
             }
             else // <250 bpm, flash every beat

--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             if (!effectPoint.KiaiMode)
                 return;
 
-            double beatLength = timingPoint.BeatLength;
+            double beatLength = timingPoint.BeatLength; // bpm = 60000 / beatLength
             double flashingPeriod;
             if (beatLength < 120) // >=500 bpm, flash every 4 beats
             {


### PR DESCRIPTION
Reduced kiai frequency on high bpm, maps above 250 bpm kiais are wayyy too noticeable.
Since I'm multiplying the period by power of 2, the effect will sync with all standard songs.

[On this map](https://osu.ppy.sh/beatmapsets/1019721#osu/2133726) particularly it's super noticeable while playing, I don't know if it's because of my skin, but it's like 3x more noticeable on this map than others.
Basically the song is 300 bpm, but mapped as 150, it could even be played with double time and it would pulsate even more.
I think something is off with kiai pulsing and it should use a smoother function, like a sine wave instead of hard peaks.

Could add a toggle for this if needed, or change the bpm boundaries at which the period is adjusted.