### PR TITLE
Alleviate song select post-filter update thread hitches by caching a model-to-carousel-item mapping

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -157,6 +157,12 @@ namespace osu.Game.Beatmaps
 
         public bool Equals(IBeatmapInfo? other) => other is BeatmapInfo b && Equals(b);
 
+        public override int GetHashCode()
+        {
+            // ReSharper disable once NonReadonlyMemberInGetHashCode
+            return ID.GetHashCode();
+        }
+
         public bool AudioEquals(BeatmapInfo? other) => other != null
                                                        && BeatmapSet != null
                                                        && other.BeatmapSet != null

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -927,9 +927,6 @@ namespace osu.Game.Screens.SelectV2
             if (x is BeatmapInfo beatmapInfoX && y is BeatmapInfo beatmapInfoY)
                 return beatmapInfoX.Equals(beatmapInfoY);
 
-            if (x is GroupDefinition groupX && y is GroupDefinition groupY)
-                return groupX.Equals(groupY);
-
             if (x is StarDifficultyGroupDefinition starX && y is StarDifficultyGroupDefinition starY)
                 return starX.Equals(starY);
 
@@ -938,6 +935,14 @@ namespace osu.Game.Screens.SelectV2
 
             if (x is RankedStatusGroupDefinition statusX && y is RankedStatusGroupDefinition statusY)
                 return statusX.Equals(statusY);
+
+            // NOTE: this branch must be AFTER all branches that compare `GroupDefinition` subtypes!
+            // this is an optimisation measure. any subclass of `GroupDefinition` will pass the `is GroupDefinition` check,
+            // and testing a subclass of `GroupDefinition` against any other `GroupDefinition` (or subclass thereof)
+            // will result in a casting cascade of `Equals(GroupDefinition) -> Equals(object) -> Equals(GroupDefinitionSubClass)`
+            // (that last one only if the type check passes)
+            if (x is GroupDefinition groupX && y is GroupDefinition groupY)
+                return groupX.Equals(groupY);
 
             return base.CheckModelEquality(x, y);
         }

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Screens.SelectV2
         /// </summary>
         public int BeatmapItemsCount { get; private set; }
 
+        public IDictionary<object, (CarouselItem item, int index)> ItemMap => itemMap;
+
         /// <summary>
         /// Beatmap sets contain difficulties as related panels. This dictionary holds the relationships between set-difficulties to allow expanding them on selection.
         /// </summary>
@@ -36,6 +38,7 @@ namespace osu.Game.Screens.SelectV2
         /// </summary>
         public IDictionary<GroupDefinition, HashSet<CarouselItem>> GroupItems => groupMap;
 
+        private Dictionary<object, (CarouselItem, int)> itemMap = new Dictionary<object, (CarouselItem, int)>();
         private Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>> setMap = new Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>>();
         private Dictionary<GroupDefinition, HashSet<CarouselItem>> groupMap = new Dictionary<GroupDefinition, HashSet<CarouselItem>>();
 
@@ -49,6 +52,7 @@ namespace osu.Game.Screens.SelectV2
             return await Task.Run(() =>
             {
                 // preallocate space for the new mappings using last known estimates
+                var newItemMap = new Dictionary<object, (CarouselItem, int)>(itemMap.Count);
                 var newSetMap = new Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>>(setMap.Count);
                 var newGroupMap = new Dictionary<GroupDefinition, HashSet<CarouselItem>>(groupMap.Count);
 
@@ -127,6 +131,7 @@ namespace osu.Game.Screens.SelectV2
                     {
                         newItems.Add(i);
 
+                        newItemMap[i.Model] = (i, newItems.Count - 1);
                         currentGroupItems?.Add(i);
                         currentSetItems?.Add(i);
 
@@ -136,6 +141,7 @@ namespace osu.Game.Screens.SelectV2
 
                 cancellationToken.ThrowIfCancellationRequested();
 
+                Interlocked.Exchange(ref itemMap, newItemMap);
                 Interlocked.Exchange(ref setMap, newSetMap);
                 Interlocked.Exchange(ref groupMap, newGroupMap);
                 BeatmapItemsCount = displayedBeatmapsCount;


### PR DESCRIPTION
## [Fix post-filter update thread hitches by caching a model-to-carousel-item mapping](https://github.com/ppy/osu/commit/fc88aa0e210abd124c75b214706e8f185e7f95de) 

RFC.

This started as a follow-up to https://github.com/ppy/osu/pull/35545#issuecomment-3471439305, but increased in scope as I saw a bunch of other places that could benefit from a similar optimisation.

The villain of this PR is `CheckModelEquality()`. The reasons it is the villain are as follows:

- On master, it gets called *a lot* in two particular usage sites which can be thought of as $O(n)$ range where $n$ is the number of the local user's beatmaps.

  The first usage site is the one added in the aforementioned PR. It will "only" linearly scan the current selection's group with `CheckModelEquality()`, but worst case scenario, the "current selection's group" could be *pretty much all of the user's beatmaps*.

  The second bad usage site is `Carousel.refreshAfterSelection()`, where every single carousel item is scanned with `CheckModelEquality()` to determine whether it is the current selection.

  This in profiling highlights some particularly nasty codegen, like the fact that auto-generated record equality isn't great when you start factoring in record inheritance, because you get stacks like

  ```
  StarDifficultyGroupDefinition.Equals(StarDifficultyGroupDefinition)
  StarDifficultyGroupDefinition.Equals(object)
  StarDifficultyGroupDefinition.Equals(GroupDefinition)
  BeatmapCarousel.CheckModelEquality(object?, object?)
  ```

  which is caused by the `GroupDefinition`-comparing branch of `CheckModelEquality()` being *above* the branches that compare its more-derived sub-records.

  But that's kind of beside the point because this PR just intends to circumvent *all* of the work.

Noting the fact that both affected usage sites have a common goal of "I just want to find a carousel panel for this model", this PR proposes using a dictionary to facilitate retrieving just that.

The caveats here are:

- This heavily relies on `object.GetHashCode()`. How reliable that is going to be is a bit of a mystery inside of an enigma because `object.GetHashCode()` is, in the same vein as all virtual methods on `object`, one of the most unmaintainable things to use, because objects are free to not implement it, or worse, implement it *wrongly*, and you will *not* notice until something breaks. Tests don't, but it's up in the air as to how much that's worth. Removing the override of it on `BeatmapInfo` added here does break a few tests, so the answer to that question is "it's worth something", I guess?

- The way this is packaged is ugly because the `Carousel.refreshAfterSelection()` *can't physically access* the mapping, because it's designed to be an abstract being, unless I invent the `FindCarouselItemsForSelection()` wart. It's OOP crap, sure, and I still continue to not understand the `Carousel`-`BeatmapCarousel` split because it's only made functional problems for me personally, but I'm also not about to merge them into one being over a potentially-throwaway performance PR.

All that notwithstanding, I think the gains here are appealing enough to at least consider this, maybe not in precisely this package, but some other form that may be more appealing yet.

Screenshots from profiling:

| master | this PR |
| :-: | :-: |
| <img width="971" height="567" alt="Screenshot 2025-11-06 at 12 03 35" src="https://github.com/user-attachments/assets/4c3fdb88-b7a7-4c89-aa4d-78087c3b756d" /> | <img width="1032" height="403" alt="Screenshot 2025-11-06 at 12 06 50" src="https://github.com/user-attachments/assets/d47f47cc-f010-4af2-957f-ba7aa4fa60e3" /> |
| <img width="1133" height="687" alt="Screenshot 2025-11-06 at 12 04 06" src="https://github.com/user-attachments/assets/2330dad8-dddb-40a7-83cd-94282966c90f" /> | <img width="1143" height="602" alt="Screenshot 2025-11-06 at 12 07 21" src="https://github.com/user-attachments/assets/d119ada7-e9e4-4d94-856e-fc0df43569bd" /> |


## [Adjust CheckModelEquality() comparison order to be more optimal](https://github.com/ppy/osu/commit/7d9587febb0783a48cfce26e6ccd7d72880a3bbd)

Mostly immaterial after the preceding commit, but possibly helpful nonetheless.