### PR TITLE
Fix incorrect handling of user verification failure response

### DIFF
--- a/osu.Game/Online/API/Requests/VerifySessionRequest.cs
+++ b/osu.Game/Online/API/Requests/VerifySessionRequest.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Online.API.Requests
         private class VerificationFailureResponse
         {
             [JsonProperty("method")]
-            public SessionVerificationMethod RequiredSessionVerificationMethod { get; set; }
+            public SessionVerificationMethod? RequiredSessionVerificationMethod { get; set; }
         }
     }
 }


### PR DESCRIPTION
Reported in https://discord.com/channels/188630481301012481/1097318920991559880/1435953371247939594.

`VerificationFailureResponse.RequiredSessionVerificationMethod` not being nullable means that if it was missing in the verification response, it would not be `null` but default to `TimedOneTimePassword` instead, therefore showing TOTP-related error messages to users that never enabled it rather than the user-facing message they were supposed to via the https://github.com/ppy/osu/blob/5eda9a0fd7bbfef8eb1bfdded914b5c2b3de736e/osu.Game/Online/API/APIAccess.cs#L294-L297 fallback path.

Most easily tested on a local full-stack environment with

```diff
diff --git a/app/Libraries/SessionVerification/MailState.php b/app/Libraries/SessionVerification/MailState.php
index 305a2794ec0..3c2d15f335b 100644
--- a/app/Libraries/SessionVerification/MailState.php
+++ b/app/Libraries/SessionVerification/MailState.php
@@ -14,7 +14,7 @@ use Carbon\CarbonImmutable;

 class MailState
 {
-    private const KEY_VALID_DURATION = 600;
+    private const KEY_VALID_DURATION = 10;

     public readonly CarbonImmutable $expiresAt;
     public readonly string $key;
```

applied so that you don't have to wait 10 minutes to trigger the failure.