### PR TITLE
Fix retro skin changing when creating copy for skin editor

### DIFF
--- a/osu.Game/Skinning/RetroSkin.cs
+++ b/osu.Game/Skinning/RetroSkin.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Game.Extensions;
 using osu.Game.IO;
+using osuTK.Graphics;
 
 namespace osu.Game.Skinning
 {
@@ -40,6 +41,23 @@ namespace osu.Game.Skinning
                 new NamespacedResourceStore<byte[]>(resources.Resources, "Skins/Retro")
             )
         {
+            Configuration.ConfigDictionary[@"SliderBallFlip"] = "0";
+            Configuration.ConfigDictionary[@"SliderBallFrames"] = "10";
+            Configuration.ConfigDictionary[@"AllowSliderBallTint"] = "0";
+            Configuration.ConfigDictionary[@"CursorTrailRotate"] = "0";
+            Configuration.ConfigDictionary[@"Version"] = "1";
+
+            Configuration.CustomComboColours =
+            [
+                new Color4(255, 150, 0, 255),
+                new Color4(5, 240, 5, 255),
+                new Color4(5, 5, 240, 255),
+                new Color4(240, 5, 5, 255)
+            ];
+
+            Configuration.ConfigDictionary[@"HitCircleOverlap"] = "3";
+            Configuration.ConfigDictionary[@"ScoreOverlap"] = "3";
+            Configuration.ConfigDictionary[@"ComboOverlap"] = "3";
         }
 
         public override Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -177,9 +177,10 @@ namespace osu.Game.Skinning
 
             if (existingFile == null)
             {
-                // skins without a skin.ini are supposed to import using the "latest version" spec.
+                // skins without a skin.ini are supposed to import using the "latest version" spec, unless we're making a copy of the retro skin which specifies 1.0.
                 // see https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/Graphics/Skinning/SkinManager.cs#L297-L298
-                newLines.Add(FormattableString.Invariant($"Version: {SkinConfiguration.LATEST_VERSION}"));
+                decimal version = item.InstantiationInfo == typeof(RetroSkin).GetInvariantInstantiationInfo() ? 1.0M : SkinConfiguration.LATEST_VERSION;
+                newLines.Add(FormattableString.Invariant($"Version: {version}"));
 
                 // In the case a skin doesn't have a skin.ini yet, let's create one.
                 writeNewSkinIni();


### PR DESCRIPTION
RFC, lowest effort solution for https://github.com/ppy/osu/issues/34979.

The `SkinImporter` conditional *is* hella ugly, but anything less ugly will require taking a hammer to structures. Maybe passing version via the import flow, maybe even trying to make the `EnsureMutableSkin()` flow somehow attempt to read the `skin.ini` that's in resources. No idea.

Properties from `skin.ini` that were defaults or that lazer can't (won't ever?) understand snipped.