### PR TITLE
Add support for selecting a "random" quick play item

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectGrid.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectGrid.cs
@@ -197,6 +197,23 @@ namespace osu.Game.Tests.Visual.Matchmaking
             });
         }
 
+        [Test]
+        public void TestPresentRandomItem()
+        {
+            AddStep("present random item panel", () =>
+            {
+                grid.TransferCandidatePanelsToRollContainer(pickRandomItems(4).candidateItems.Append(-1).ToArray(), duration: 0);
+                grid.ArrangeItemsForRollAnimation(duration: 0, stagger: 0);
+                grid.PlayRollAnimation(-1, duration: 0);
+
+                Scheduler.AddDelayed(() => grid.PresentUnanimouslyChosenBeatmap(-1), 500);
+            });
+
+            AddWaitStep("wait for animation", 5);
+
+            AddStep("reveal beatmap", () => grid.RevealRandomItem(new MultiplayerPlaylistItem()));
+        }
+
         private (long[] candidateItems, long finalItem) pickRandomItems(int count)
         {
             long[] candidateItems = items.Select(it => it.ID).ToArray();

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -20,6 +21,24 @@ namespace osu.Game.Tests.Visual.Matchmaking
     {
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("join room", () =>
+            {
+                var room = CreateDefaultRoom(MatchType.Matchmaking);
+                room.Playlist = Enumerable.Range(1, 50).Select(i => new PlaylistItem(new MultiplayerPlaylistItem
+                {
+                    ID = i,
+                    BeatmapID = 0,
+                    StarRating = i / 10.0,
+                })).ToArray();
+
+                JoinRoom(room);
+            });
+        }
 
         [Test]
         public void TestBeatmapPanel()
@@ -58,11 +77,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
             AddStep("remove peppy", () => panel!.RemoveUser(new APIUser { Id = 2 }));
             AddStep("remove maarvin", () => panel!.RemoveUser(new APIUser { Id = 6411631 }));
 
-            AddToggleStep("allow selection", value =>
-            {
-                if (panel != null)
-                    panel.AllowSelection = value;
-            });
+            AddToggleStep("allow selection", value => panel!.AllowSelection = value);
         }
 
         [Test]
@@ -99,6 +114,29 @@ namespace osu.Game.Tests.Visual.Matchmaking
                     }
                 };
             });
+        }
+
+        [Test]
+        public void TestRandomPanel()
+        {
+            BeatmapSelectPanel? panel = null;
+
+            AddStep("add panel", () =>
+            {
+                Child = new OsuContextMenuContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = panel = new BeatmapSelectPanel(new MultiplayerPlaylistItem { ID = -1 })
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                };
+            });
+
+            AddToggleStep("allow selection", value => panel!.AllowSelection = value);
+
+            AddStep("reveal beatmap", () => panel!.DisplayItem(new MultiplayerPlaylistItem()));
         }
     }
 }

--- a/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
@@ -43,11 +43,15 @@ namespace osu.Game.Online.Matchmaking
         /// <summary>
         /// The user has raised a candidate playlist item to be played.
         /// </summary>
+        /// <param name="userId">The notifying user.</param>
+        /// <param name="playlistItemId">The playlist item candidate raised, or -1 as a special value that indicates a random selection.</param>
         Task MatchmakingItemSelected(int userId, long playlistItemId);
 
         /// <summary>
         /// The user has removed a candidate playlist item.
         /// </summary>
+        /// <param name="userId">The notifying user.</param>
+        /// <param name="playlistItemId">The playlist item candidate removed, or -1 as a special value that indicates a random selection.</param>
         Task MatchmakingItemDeselected(int userId, long playlistItemId);
     }
 }

--- a/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Online.Matchmaking
         /// <summary>
         /// Raise a candidate playlist item to be played in the current round.
         /// </summary>
-        /// <param name="playlistItemId">The playlist item.</param>
+        /// <param name="playlistItemId">The playlist item, or -1 to indicate a random selection.</param>
         Task MatchmakingToggleSelection(long playlistItemId);
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
@@ -2,465 +2,105 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
-using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Localisation;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.Drawables;
-using osu.Game.Beatmaps.Drawables.Cards;
-using osu.Game.Graphics;
+using osu.Game.Database;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Localisation;
-using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Overlays;
-using osu.Game.Overlays.BeatmapSet;
-using osu.Game.Resources.Localisation.Web;
-using osuTK;
+using osu.Game.Online.Rooms;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 {
-    public partial class BeatmapCardMatchmaking : BeatmapCard
+    public partial class BeatmapCardMatchmaking : OsuClickableContainer
     {
-        private readonly APIBeatmap beatmap;
-
-        protected override Drawable IdleContent => idleBottomContent;
-        protected override Drawable DownloadInProgressContent => downloadProgressBar;
-
+        public const float WIDTH = 345;
         public const float HEIGHT = 80;
 
-        [Cached]
-        private readonly BeatmapCardContent content;
-
-        private BeatmapCardThumbnail thumbnail = null!;
-        private CollapsibleButtonContainer buttonContainer = null!;
-
-        private FillFlowContainer idleBottomContent = null!;
-        private BeatmapCardDownloadProgressBar downloadProgressBar = null!;
-
-        public AvatarOverlay SelectionOverlay = null!;
-
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; } = null!;
+        private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
 
-        [Resolved]
-        private BeatmapSetOverlay? beatmapSetOverlay { get; set; }
+        private readonly List<APIUser> users = new List<APIUser>();
 
-        public BeatmapCardMatchmaking(APIBeatmap beatmap)
-            : base(beatmap.BeatmapSet!, false)
-        {
-            this.beatmap = beatmap;
-            content = new BeatmapCardContent(HEIGHT);
-        }
+        private Container contentContainer = null!;
+        private Drawable flashLayer = null!;
+        private BeatmapCardMatchmakingContent? content;
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        public BeatmapCardMatchmaking()
         {
             Width = WIDTH;
             Height = HEIGHT;
+        }
 
-            FillFlowContainer leftIconArea = null!;
-            FillFlowContainer titleBadgeArea = null!;
-            GridContainer artistContainer = null!;
-
-            Child = content.With(c =>
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new[]
             {
-                c.MainContent = new Container
+                contentContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                flashLayer = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    Alpha = 0
+                }
+            };
+        }
+
+        public void AddUser(APIUser user)
+        {
+            users.Add(user);
+            content?.SelectionOverlay.AddUser(user);
+        }
+
+        public void RemoveUser(APIUser user)
+        {
+            users.Remove(user);
+            content?.SelectionOverlay.RemoveUser(user.Id);
+        }
+
+        public void DisplayItem(MultiplayerPlaylistItem item)
+        {
+            Task.Run(loadBeatmap);
+
+            async Task loadBeatmap()
+            {
+                APIBeatmap? beatmap = await beatmapLookupCache.GetBeatmapAsync(item.BeatmapID).ConfigureAwait(false);
+
+                beatmap ??= new APIBeatmap
+                {
+                    BeatmapSet = new APIBeatmapSet
                     {
-                        thumbnail = new BeatmapCardThumbnail(BeatmapSet, BeatmapSet, keepLoaded: true)
-                        {
-                            Name = @"Left (icon) area",
-                            Size = new Vector2(HEIGHT),
-                            Padding = new MarginPadding { Right = CORNER_RADIUS },
-                            Child = leftIconArea = new FillFlowContainer
-                            {
-                                Margin = new MarginPadding(4),
-                                AutoSizeAxes = Axes.Both,
-                                Direction = FillDirection.Horizontal,
-                                Spacing = new Vector2(1)
-                            }
-                        },
-                        buttonContainer = new CollapsibleButtonContainer(BeatmapSet, allowNavigationToBeatmap: false, keepBackgroundLoaded: true)
-                        {
-                            X = HEIGHT - CORNER_RADIUS,
-                            Width = WIDTH - HEIGHT + CORNER_RADIUS,
-                            FavouriteState = { BindTarget = FavouriteState },
-                            ButtonsCollapsedWidth = 0,
-                            ButtonsExpandedWidth = 24,
-                            Children = new Drawable[]
-                            {
-                                new FillFlowContainer
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Direction = FillDirection.Vertical,
-                                    Children = new Drawable[]
-                                    {
-                                        new GridContainer
-                                        {
-                                            RelativeSizeAxes = Axes.X,
-                                            AutoSizeAxes = Axes.Y,
-                                            ColumnDimensions = new[]
-                                            {
-                                                new Dimension(),
-                                                new Dimension(GridSizeMode.AutoSize),
-                                            },
-                                            RowDimensions = new[]
-                                            {
-                                                new Dimension(GridSizeMode.AutoSize)
-                                            },
-                                            Content = new[]
-                                            {
-                                                new Drawable[]
-                                                {
-                                                    new TruncatingSpriteText
-                                                    {
-                                                        Text = new RomanisableString(BeatmapSet.TitleUnicode, BeatmapSet.Title),
-                                                        Font = OsuFont.Default.With(size: 18f, weight: FontWeight.SemiBold),
-                                                        RelativeSizeAxes = Axes.X,
-                                                    },
-                                                    titleBadgeArea = new FillFlowContainer
-                                                    {
-                                                        Anchor = Anchor.BottomRight,
-                                                        Origin = Anchor.BottomRight,
-                                                        AutoSizeAxes = Axes.Both,
-                                                        Direction = FillDirection.Horizontal,
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        artistContainer = new GridContainer
-                                        {
-                                            RelativeSizeAxes = Axes.X,
-                                            AutoSizeAxes = Axes.Y,
-                                            ColumnDimensions = new[]
-                                            {
-                                                new Dimension(),
-                                                new Dimension(GridSizeMode.AutoSize)
-                                            },
-                                            RowDimensions = new[]
-                                            {
-                                                new Dimension(GridSizeMode.AutoSize)
-                                            },
-                                            Content = new[]
-                                            {
-                                                new[]
-                                                {
-                                                    new TruncatingSpriteText
-                                                    {
-                                                        Text = createArtistText(),
-                                                        Font = OsuFont.Default.With(size: 14f, weight: FontWeight.SemiBold),
-                                                        RelativeSizeAxes = Axes.X,
-                                                    },
-                                                    Empty()
-                                                },
-                                            }
-                                        },
-                                        new LinkFlowContainer(s =>
-                                        {
-                                            s.Shadow = false;
-                                            s.Font = OsuFont.GetFont(size: 11f, weight: FontWeight.SemiBold);
-                                        }).With(d =>
-                                        {
-                                            d.AutoSizeAxes = Axes.Both;
-                                            d.Margin = new MarginPadding { Top = 1 };
-                                            d.AddText("mapped by ", t => t.Colour = colourProvider.Content2);
-                                            d.AddUserLink(BeatmapSet.Author);
-                                        }),
-                                    }
-                                },
-                                new Container
-                                {
-                                    Name = @"Bottom content",
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                    Children = new Drawable[]
-                                    {
-                                        idleBottomContent = new FillFlowContainer
-                                        {
-                                            RelativeSizeAxes = Axes.X,
-                                            AutoSizeAxes = Axes.Y,
-                                            Direction = FillDirection.Vertical,
-                                            Spacing = new Vector2(0, 2),
-                                            AlwaysPresent = true,
-                                            Children = new Drawable[]
-                                            {
-                                                new Container
-                                                {
-                                                    Masking = true,
-                                                    CornerRadius = CORNER_RADIUS,
-                                                    RelativeSizeAxes = Axes.X,
-                                                    AutoSizeAxes = Axes.Y,
-                                                    Children = new Drawable[]
-                                                    {
-                                                        new Box
-                                                        {
-                                                            Colour = colours.ForStarDifficulty(beatmap.StarRating).Darken(0.8f),
-                                                            RelativeSizeAxes = Axes.Both,
-                                                        },
-                                                        new FillFlowContainer
-                                                        {
-                                                            Padding = new MarginPadding(4),
-                                                            RelativeSizeAxes = Axes.X,
-                                                            AutoSizeAxes = Axes.Y,
-                                                            Direction = FillDirection.Horizontal,
-                                                            Spacing = new Vector2(6, 0),
-                                                            Children = new Drawable[]
-                                                            {
-                                                                new StarRatingDisplay(new StarDifficulty(beatmap.StarRating, 0), StarRatingDisplaySize.Small, animated: true)
-                                                                {
-                                                                    Origin = Anchor.CentreLeft,
-                                                                    Anchor = Anchor.CentreLeft,
-                                                                    Scale = new Vector2(0.9f),
-                                                                },
-                                                                new TruncatingSpriteText
-                                                                {
-                                                                    Text = beatmap.DifficultyName,
-                                                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
-                                                                    Anchor = Anchor.CentreLeft,
-                                                                    Origin = Anchor.CentreLeft,
-                                                                }
-                                                            }
-                                                        },
-                                                    }
-                                                },
-                                            }
-                                        },
-                                        downloadProgressBar = new BeatmapCardDownloadProgressBar
-                                        {
-                                            RelativeSizeAxes = Axes.X,
-                                            Height = 5,
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            State = { BindTarget = DownloadTracker.State },
-                                            Progress = { BindTarget = DownloadTracker.Progress }
-                                        }
-                                    }
-                                },
-                                SelectionOverlay = new AvatarOverlay
-                                {
-                                    Anchor = Anchor.TopRight,
-                                    Origin = Anchor.TopRight,
-                                }
-                            }
-                        }
+                        Title = "unknown beatmap",
+                        TitleUnicode = "unknown beatmap",
+                        Artist = "unknown artist",
+                        ArtistUnicode = "unknown artist",
                     }
                 };
-                c.Expanded.BindTarget = Expanded;
-            });
 
-            if (BeatmapSet.HasVideo)
-                leftIconArea.Add(new VideoIconPill { IconSize = new Vector2(16) });
+                beatmap.StarRating = item.StarRating;
 
-            if (BeatmapSet.HasStoryboard)
-                leftIconArea.Add(new StoryboardIconPill { IconSize = new Vector2(16) });
-
-            if (BeatmapSet.FeaturedInSpotlight)
-            {
-                titleBadgeArea.Add(new SpotlightBeatmapBadge
-                {
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
-                    Margin = new MarginPadding { Left = 4 }
-                });
-            }
-
-            if (BeatmapSet.HasExplicitContent)
-            {
-                titleBadgeArea.Add(new ExplicitContentBeatmapBadge
-                {
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
-                    Margin = new MarginPadding { Left = 4 }
-                });
-            }
-
-            if (BeatmapSet.TrackId != null)
-            {
-                artistContainer.Content[0][1] = new FeaturedArtistBeatmapBadge
-                {
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
-                    Margin = new MarginPadding { Left = 4 }
-                };
+                loadContent(new BeatmapCardMatchmakingBeatmapContent(beatmap));
             }
         }
 
-        private LocalisableString createArtistText()
+        public void DisplayRandom() => loadContent(new BeatmapCardMatchmakingRandomContent());
+
+        private void loadContent(BeatmapCardMatchmakingContent newContent) => Schedule(() =>
         {
-            var romanisableArtist = new RomanisableString(BeatmapSet.ArtistUnicode, BeatmapSet.Artist);
-            return BeatmapsetsStrings.ShowDetailsByArtist(romanisableArtist);
-        }
+            bool flashNewContent = content != null;
 
-        protected override void UpdateState()
-        {
-            base.UpdateState();
+            contentContainer.Child = content = newContent;
 
-            bool showDetails = IsHovered;
+            foreach (var user in users)
+                newContent.SelectionOverlay.AddUser(user);
 
-            buttonContainer.ShowDetails.Value = showDetails;
-            thumbnail.Dimmed.Value = showDetails;
-        }
-
-        public override MenuItem[] ContextMenuItems
-        {
-            get
-            {
-                List<MenuItem> items = new List<MenuItem>
-                {
-                    new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, () => beatmapSetOverlay?.FetchAndShowBeatmap(beatmap.OnlineID))
-                };
-
-                foreach (var button in buttonContainer.Buttons)
-                {
-                    if (button.Enabled.Value)
-                        items.Add(new OsuMenuItem(button.TooltipText.ToSentence(), MenuItemType.Standard, () => button.TriggerClick()));
-                }
-
-                return items.ToArray();
-            }
-        }
-
-        public partial class AvatarOverlay : CompositeDrawable
-        {
-            private readonly Container<SelectionAvatar> avatars;
-
-            private Sample? userAddedSample;
-            private double? lastSamplePlayback;
-
-            [Resolved]
-            private IAPIProvider api { get; set; } = null!;
-
-            public AvatarOverlay()
-            {
-                AutoSizeAxes = Axes.Both;
-
-                InternalChild = avatars = new Container<SelectionAvatar>
-                {
-                    AutoSizeAxes = Axes.X,
-                    Height = SelectionAvatar.AVATAR_SIZE,
-                };
-
-                Padding = new MarginPadding { Vertical = 5 };
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(AudioManager audio)
-            {
-                userAddedSample = audio.Samples.Get(@"Multiplayer/player-ready");
-            }
-
-            public bool AddUser(APIUser user)
-            {
-                if (avatars.Any(a => a.User.Id == user.Id))
-                    return false;
-
-                var avatar = new SelectionAvatar(user, user.Equals(api.LocalUser.Value));
-
-                avatars.Add(avatar);
-
-                if (lastSamplePlayback == null || Time.Current - lastSamplePlayback > OsuGameBase.SAMPLE_DEBOUNCE_TIME)
-                {
-                    userAddedSample?.Play();
-                    lastSamplePlayback = Time.Current;
-                }
-
-                updateAvatarLayout();
-
-                avatar.FinishTransforms();
-
-                return true;
-            }
-
-            public bool RemoveUser(int id)
-            {
-                if (avatars.SingleOrDefault(a => a.User.Id == id) is not SelectionAvatar avatar)
-                    return false;
-
-                avatar.PopOutAndExpire();
-                avatars.ChangeChildDepth(avatar, float.MaxValue);
-
-                updateAvatarLayout();
-
-                return true;
-            }
-
-            private void updateAvatarLayout()
-            {
-                const double stagger = 30;
-                const float spacing = 4;
-
-                double delay = 0;
-                float x = 0;
-
-                for (int i = avatars.Count - 1; i >= 0; i--)
-                {
-                    var avatar = avatars[i];
-
-                    if (avatar.Expired)
-                        continue;
-
-                    avatar.Delay(delay).MoveToX(x, 500, Easing.OutElasticQuarter);
-
-                    x -= avatar.LayoutSize.X + spacing;
-
-                    delay += stagger;
-                }
-            }
-
-            public partial class SelectionAvatar : CompositeDrawable
-            {
-                public const float AVATAR_SIZE = 30;
-
-                public APIUser User { get; }
-
-                public bool Expired { get; private set; }
-
-                private readonly MatchmakingAvatar avatar;
-
-                public SelectionAvatar(APIUser user, bool isOwnUser)
-                {
-                    User = user;
-                    Size = new Vector2(AVATAR_SIZE);
-
-                    InternalChild = avatar = new MatchmakingAvatar(user, isOwnUser)
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                    };
-                }
-
-                protected override void LoadComplete()
-                {
-                    base.LoadComplete();
-
-                    avatar.ScaleTo(0)
-                          .ScaleTo(1, 500, Easing.OutElasticHalf)
-                          .FadeIn(200);
-                }
-
-                public void PopOutAndExpire()
-                {
-                    avatar.ScaleTo(0, 400, Easing.OutExpo);
-
-                    this.FadeOut(100).Expire();
-                    Expired = true;
-                }
-            }
-        }
+            if (flashNewContent)
+                flashLayer.FadeOutFromOne(1000, Easing.In);
+        });
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingBeatmapContent.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingBeatmapContent.cs
@@ -1,0 +1,347 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
+using osu.Game.Online;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.BeatmapSet;
+using osu.Game.Resources.Localisation.Web;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
+{
+    public partial class BeatmapCardMatchmakingBeatmapContent : BeatmapCardMatchmakingContent, IHasContextMenu
+    {
+        public override AvatarOverlay SelectionOverlay => selectionOverlay;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapSetOverlay? beatmapSetOverlay { get; set; }
+
+        private readonly IBindable<DownloadState> downloadState = new Bindable<DownloadState>();
+        private readonly IBindableNumber<double> downloadProgress = new BindableDouble();
+        private readonly Bindable<BeatmapSetFavouriteState> favouriteState = new Bindable<BeatmapSetFavouriteState>();
+        private readonly APIBeatmapSet beatmapSet;
+        private readonly APIBeatmap beatmap;
+
+        private BeatmapCardThumbnail thumbnail = null!;
+        private CollapsibleButtonContainer buttonContainer = null!;
+        private FillFlowContainer idleBottomContent = null!;
+        private BeatmapCardDownloadProgressBar downloadProgressBar = null!;
+        private AvatarOverlay selectionOverlay = null!;
+
+        public BeatmapCardMatchmakingBeatmapContent(APIBeatmap beatmap)
+        {
+            this.beatmap = beatmap;
+
+            beatmapSet = beatmap.BeatmapSet!;
+            favouriteState.Value = new BeatmapSetFavouriteState(beatmapSet.HasFavourited, beatmapSet.FavouriteCount);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            FillFlowContainer leftIconArea;
+            FillFlowContainer titleBadgeArea;
+            GridContainer artistContainer;
+
+            InternalChildren = new Drawable[]
+            {
+                new BeatmapDownloadTracker(beatmap.BeatmapSet!)
+                {
+                    State = { BindTarget = downloadState },
+                    Progress = { BindTarget = downloadProgress },
+                },
+                thumbnail = new BeatmapCardThumbnail(beatmapSet, beatmapSet, keepLoaded: true)
+                {
+                    Name = @"Left (icon) area",
+                    Size = new Vector2(BeatmapCardMatchmaking.HEIGHT),
+                    Padding = new MarginPadding { Right = BeatmapCard.CORNER_RADIUS },
+                    Child = leftIconArea = new FillFlowContainer
+                    {
+                        Margin = new MarginPadding(4),
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(1)
+                    }
+                },
+                buttonContainer = new CollapsibleButtonContainer(beatmapSet, allowNavigationToBeatmap: false, keepBackgroundLoaded: true)
+                {
+                    X = BeatmapCardMatchmaking.HEIGHT - BeatmapCard.CORNER_RADIUS,
+                    Width = BeatmapCard.WIDTH - BeatmapCardMatchmaking.HEIGHT + BeatmapCard.CORNER_RADIUS,
+                    FavouriteState = { BindTarget = favouriteState },
+                    ButtonsCollapsedWidth = 0,
+                    ButtonsExpandedWidth = 24,
+                    Children = new Drawable[]
+                    {
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Direction = FillDirection.Vertical,
+                            Children = new Drawable[]
+                            {
+                                new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    ColumnDimensions = new[]
+                                    {
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize),
+                                    },
+                                    RowDimensions = new[]
+                                    {
+                                        new Dimension(GridSizeMode.AutoSize)
+                                    },
+                                    Content = new[]
+                                    {
+                                        new Drawable[]
+                                        {
+                                            new TruncatingSpriteText
+                                            {
+                                                Text = new RomanisableString(beatmapSet.TitleUnicode, beatmapSet.Title),
+                                                Font = OsuFont.Default.With(size: 18f, weight: FontWeight.SemiBold),
+                                                RelativeSizeAxes = Axes.X,
+                                            },
+                                            titleBadgeArea = new FillFlowContainer
+                                            {
+                                                Anchor = Anchor.BottomRight,
+                                                Origin = Anchor.BottomRight,
+                                                AutoSizeAxes = Axes.Both,
+                                                Direction = FillDirection.Horizontal,
+                                            }
+                                        }
+                                    }
+                                },
+                                artistContainer = new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    ColumnDimensions = new[]
+                                    {
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize)
+                                    },
+                                    RowDimensions = new[]
+                                    {
+                                        new Dimension(GridSizeMode.AutoSize)
+                                    },
+                                    Content = new[]
+                                    {
+                                        new[]
+                                        {
+                                            new TruncatingSpriteText
+                                            {
+                                                Text = BeatmapsetsStrings.ShowDetailsByArtist(new RomanisableString(beatmapSet.ArtistUnicode, beatmapSet.Artist)),
+                                                Font = OsuFont.Default.With(size: 14f, weight: FontWeight.SemiBold),
+                                                RelativeSizeAxes = Axes.X,
+                                            },
+                                            Empty()
+                                        },
+                                    }
+                                },
+                                new LinkFlowContainer(s =>
+                                {
+                                    s.Shadow = false;
+                                    s.Font = OsuFont.GetFont(size: 11f, weight: FontWeight.SemiBold);
+                                }).With(d =>
+                                {
+                                    d.AutoSizeAxes = Axes.Both;
+                                    d.Margin = new MarginPadding { Top = 1 };
+                                    d.AddText("mapped by ", t => t.Colour = colourProvider.Content2);
+                                    d.AddUserLink(beatmapSet.Author);
+                                }),
+                            }
+                        },
+                        new Container
+                        {
+                            Name = @"Bottom content",
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            Children = new Drawable[]
+                            {
+                                idleBottomContent = new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(0, 2),
+                                    AlwaysPresent = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Container
+                                        {
+                                            Masking = true,
+                                            CornerRadius = BeatmapCard.CORNER_RADIUS,
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Children = new Drawable[]
+                                            {
+                                                new Box
+                                                {
+                                                    Colour = colours.ForStarDifficulty(beatmap.StarRating).Darken(0.8f),
+                                                    RelativeSizeAxes = Axes.Both,
+                                                },
+                                                new FillFlowContainer
+                                                {
+                                                    Padding = new MarginPadding(4),
+                                                    RelativeSizeAxes = Axes.X,
+                                                    AutoSizeAxes = Axes.Y,
+                                                    Direction = FillDirection.Horizontal,
+                                                    Spacing = new Vector2(6, 0),
+                                                    Children = new Drawable[]
+                                                    {
+                                                        new StarRatingDisplay(new StarDifficulty(beatmap.StarRating, 0), StarRatingDisplaySize.Small, animated: true)
+                                                        {
+                                                            Origin = Anchor.CentreLeft,
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Scale = new Vector2(0.9f),
+                                                        },
+                                                        new TruncatingSpriteText
+                                                        {
+                                                            Text = beatmap.DifficultyName,
+                                                            Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Origin = Anchor.CentreLeft,
+                                                        }
+                                                    }
+                                                },
+                                            }
+                                        },
+                                    }
+                                },
+                                downloadProgressBar = new BeatmapCardDownloadProgressBar
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = 5,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    State = { BindTarget = downloadState },
+                                    Progress = { BindTarget = downloadProgress }
+                                }
+                            }
+                        },
+                        selectionOverlay = new AvatarOverlay
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                        }
+                    }
+                }
+            };
+
+            if (beatmapSet.HasVideo)
+                leftIconArea.Add(new VideoIconPill { IconSize = new Vector2(16) });
+
+            if (beatmapSet.HasStoryboard)
+                leftIconArea.Add(new StoryboardIconPill { IconSize = new Vector2(16) });
+
+            if (beatmapSet.FeaturedInSpotlight)
+            {
+                titleBadgeArea.Add(new SpotlightBeatmapBadge
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Margin = new MarginPadding { Left = 4 }
+                });
+            }
+
+            if (beatmapSet.HasExplicitContent)
+            {
+                titleBadgeArea.Add(new ExplicitContentBeatmapBadge
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Margin = new MarginPadding { Left = 4 }
+                });
+            }
+
+            if (beatmapSet.TrackId != null)
+            {
+                artistContainer.Content[0][1] = new FeaturedArtistBeatmapBadge
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Margin = new MarginPadding { Left = 4 }
+                };
+            }
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            downloadState.BindValueChanged(_ => updateState(), true);
+
+            FinishTransforms(true);
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateState();
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            updateState();
+            base.OnHoverLost(e);
+        }
+
+        private void updateState()
+        {
+            bool showDetails = IsHovered;
+
+            buttonContainer.ShowDetails.Value = showDetails;
+            thumbnail.Dimmed.Value = showDetails;
+
+            bool showProgress = downloadState.Value == DownloadState.Downloading || downloadState.Value == DownloadState.Importing;
+
+            idleBottomContent.FadeTo(showProgress ? 0 : 1, 340, Easing.OutQuint);
+            downloadProgressBar.FadeTo(showProgress ? 1 : 0, 340, Easing.OutQuint);
+        }
+
+        public MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                List<MenuItem> items = new List<MenuItem>
+                {
+                    new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, () => beatmapSetOverlay?.FetchAndShowBeatmap(beatmap.OnlineID))
+                };
+
+                foreach (var button in buttonContainer.Buttons)
+                {
+                    if (button.Enabled.Value)
+                        items.Add(new OsuMenuItem(button.TooltipText.ToSentence(), MenuItemType.Standard, () => button.TriggerClick()));
+                }
+
+                return items.ToArray();
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingContent.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingContent.cs
@@ -1,0 +1,153 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
+{
+    public abstract partial class BeatmapCardMatchmakingContent : CompositeDrawable
+    {
+        public abstract AvatarOverlay SelectionOverlay { get; }
+
+        protected BeatmapCardMatchmakingContent()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        public partial class AvatarOverlay : CompositeDrawable
+        {
+            private readonly Container<SelectionAvatar> avatars;
+
+            private Sample? userAddedSample;
+            private double? lastSamplePlayback;
+
+            [Resolved]
+            private IAPIProvider api { get; set; } = null!;
+
+            public AvatarOverlay()
+            {
+                AutoSizeAxes = Axes.Both;
+
+                InternalChild = avatars = new Container<SelectionAvatar>
+                {
+                    AutoSizeAxes = Axes.X,
+                    Height = SelectionAvatar.AVATAR_SIZE,
+                };
+
+                Padding = new MarginPadding { Vertical = 5 };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(AudioManager audio)
+            {
+                userAddedSample = audio.Samples.Get(@"Multiplayer/player-ready");
+            }
+
+            public bool AddUser(APIUser user)
+            {
+                if (avatars.Any(a => a.User.Id == user.Id))
+                    return false;
+
+                var avatar = new SelectionAvatar(user, user.Equals(api.LocalUser.Value));
+
+                avatars.Add(avatar);
+
+                if (lastSamplePlayback == null || Time.Current - lastSamplePlayback > OsuGameBase.SAMPLE_DEBOUNCE_TIME)
+                {
+                    userAddedSample?.Play();
+                    lastSamplePlayback = Time.Current;
+                }
+
+                updateAvatarLayout();
+
+                avatar.FinishTransforms();
+
+                return true;
+            }
+
+            public bool RemoveUser(int id)
+            {
+                if (avatars.SingleOrDefault(a => a.User.Id == id) is not SelectionAvatar avatar)
+                    return false;
+
+                avatar.PopOutAndExpire();
+                avatars.ChangeChildDepth(avatar, float.MaxValue);
+
+                updateAvatarLayout();
+
+                return true;
+            }
+
+            private void updateAvatarLayout()
+            {
+                const double stagger = 30;
+                const float spacing = 4;
+
+                double delay = 0;
+                float x = 0;
+
+                for (int i = avatars.Count - 1; i >= 0; i--)
+                {
+                    var avatar = avatars[i];
+
+                    if (avatar.Expired)
+                        continue;
+
+                    avatar.Delay(delay).MoveToX(x, 500, Easing.OutElasticQuarter);
+
+                    x -= avatar.LayoutSize.X + spacing;
+
+                    delay += stagger;
+                }
+            }
+
+            public partial class SelectionAvatar : CompositeDrawable
+            {
+                public const float AVATAR_SIZE = 30;
+
+                public APIUser User { get; }
+
+                public bool Expired { get; private set; }
+
+                private readonly MatchmakingAvatar avatar;
+
+                public SelectionAvatar(APIUser user, bool isOwnUser)
+                {
+                    User = user;
+                    Size = new Vector2(AVATAR_SIZE);
+
+                    InternalChild = avatar = new MatchmakingAvatar(user, isOwnUser)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    };
+                }
+
+                protected override void LoadComplete()
+                {
+                    base.LoadComplete();
+
+                    avatar.ScaleTo(0)
+                          .ScaleTo(1, 500, Easing.OutElasticHalf)
+                          .FadeIn(200);
+                }
+
+                public void PopOutAndExpire()
+                {
+                    avatar.ScaleTo(0, 400, Easing.OutExpo);
+
+                    this.FadeOut(100).Expire();
+                    Expired = true;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingRandomContent.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingRandomContent.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
+{
+    public partial class BeatmapCardMatchmakingRandomContent : BeatmapCardMatchmakingContent
+    {
+        public override AvatarOverlay SelectionOverlay => selectionOverlay;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private AvatarOverlay selectionOverlay = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background2,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding
+                    {
+                        Horizontal = 10,
+                        Vertical = 4
+                    },
+                    Children = new Drawable[]
+                    {
+                        new FillFlowContainer
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Vertical,
+                            Children =
+                            [
+                                new SpriteIcon
+                                {
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Size = new Vector2(32),
+                                    Icon = FontAwesome.Solid.Random,
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Text = "Random",
+                                }
+                            ]
+                        },
+                        selectionOverlay = new AvatarOverlay
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 AllowSelection = allowSelection,
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
-                Action = ItemSelected,
+                Action = i => ItemSelected?.Invoke(i),
             };
 
             panelGridContainer.Add(panel);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
@@ -69,6 +69,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                     Masking = true,
                 },
             };
+
+            // Special item denoting a random selection.
+            AddItem(new MultiplayerPlaylistItem { ID = -1 });
         }
 
         [BackgroundDependencyLoader]
@@ -116,14 +119,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
             panelGridContainer.SetLayoutPosition(panel, (float)item.StarRating);
         }
 
-        public void RemoveItem(long id)
-        {
-            if (!panelLookup.Remove(id, out var panel))
-                return;
-
-            panel.Expire();
-        }
-
         public void SetUserSelection(APIUser user, long itemId, bool selected)
         {
             if (!panelLookup.TryGetValue(itemId, out var panel))
@@ -133,6 +128,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 panel.AddUser(user);
             else
                 panel.RemoveUser(user);
+        }
+
+        public void RevealRandomItem(MultiplayerPlaylistItem item)
+        {
+            if (!panelLookup.TryGetValue(-1, out var panel))
+                return;
+
+            panel.DisplayItem(item);
         }
 
         public void RollAndDisplayFinalBeatmap(long[] candidateItemIds, long finalItemId)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/SubScreenBeatmapSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/SubScreenBeatmapSelect.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
@@ -58,6 +59,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 
             client.MatchmakingItemSelected += onItemSelected;
             client.MatchmakingItemDeselected += onItemDeselected;
+            client.SettingsChanged += onSettingsChanged;
         }
 
         private void onItemAdded(MultiplayerPlaylistItem item) => Scheduler.Add(() =>
@@ -80,6 +82,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
             beatmapSelectGrid.SetUserSelection(user, itemId, false);
         }
 
+        private void onSettingsChanged(MultiplayerRoomSettings settings)
+        {
+            if (client.Room!.MatchState is not MatchmakingRoomState matchmakingState)
+                return;
+
+            if (matchmakingState.CandidateItem != -1 || client.Room!.CurrentPlaylistItem.Expired)
+                return;
+
+            beatmapSelectGrid.RevealRandomItem(client.Room!.CurrentPlaylistItem);
+        }
+
         public void RollFinalBeatmap(long[] candidateItems, long finalItem) => beatmapSelectGrid.RollAndDisplayFinalBeatmap(candidateItems, finalItem);
 
         protected override void Dispose(bool isDisposing)
@@ -91,6 +104,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 client.ItemAdded -= onItemAdded;
                 client.MatchmakingItemSelected -= onItemSelected;
                 client.MatchmakingItemDeselected -= onItemDeselected;
+                client.SettingsChanged -= onSettingsChanged;
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/SubScreenBeatmapSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/SubScreenBeatmapSelect.cs
@@ -87,7 +87,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
             if (client.Room!.MatchState is not MatchmakingRoomState matchmakingState)
                 return;
 
-            if (matchmakingState.CandidateItem != -1 || client.Room!.CurrentPlaylistItem.Expired)
+            if (matchmakingState.Stage != MatchmakingStage.ServerBeatmapFinalised)
+                return;
+
+            if (matchmakingState.CandidateItem != -1)
                 return;
 
             beatmapSelectGrid.RevealRandomItem(client.Room!.CurrentPlaylistItem);


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/365

https://github.com/user-attachments/assets/ea1e56ee-e796-45b3-9d3b-e1c6e9750e22

This PR's going to be rough to review - I'm sorry in advance.

My brain couldn't work with the `BeatmapCard` hierarchy, so I've split out the visual content of `BeatmapCardMatchmaking` and its parenting class `BeatmapCard` into `BeatmapCardMatchmakingBeatmapContent`. I've tried to keep the implementation similar so neither visuals nor operation should have changed, but it is not exactly 1:1. With this, quick play no longer inherits from `BeatmapCard`.

New visual implementation rests in `BeatmapCardMatchmakingRandomContent`.

`BeatmapCardMatchmaking` now exists as the medium that provides primarily the ability to load and display new beatmap content.