### PR TITLE
Display mods in quick play beatmap cards

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
@@ -12,6 +12,7 @@ using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect;
 using osu.Game.Tests.Visual.Multiplayer;
 
@@ -137,6 +138,34 @@ namespace osu.Game.Tests.Visual.Matchmaking
             AddToggleStep("allow selection", value => panel!.AllowSelection = value);
 
             AddStep("reveal beatmap", () => panel!.DisplayItem(new MultiplayerPlaylistItem()));
+        }
+
+        [Test]
+        public void TestBeatmapWithMods()
+        {
+            AddStep("add panel", () =>
+            {
+                BeatmapSelectPanel? panel;
+
+                Child = new OsuContextMenuContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = panel = new BeatmapSelectPanel(new MultiplayerPlaylistItem
+                    {
+                        RequiredMods = [new APIMod(new OsuModHardRock()), new APIMod(new OsuModDoubleTime())]
+                    })
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                };
+
+                panel.AddUser(new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                });
+            });
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmaking.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -11,6 +12,8 @@ using osu.Game.Database;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 {
@@ -21,6 +24,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 
         [Resolved]
         private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesetStore { get; set; } = null!;
 
         private readonly List<APIUser> users = new List<APIUser>();
 
@@ -65,6 +71,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 
         public void DisplayItem(MultiplayerPlaylistItem item)
         {
+            Ruleset? ruleset = rulesetStore.GetRuleset(item.RulesetID)?.CreateInstance();
+
+            if (ruleset == null)
+                return;
+
+            Mod[] mods = item.RequiredMods.Select(m => m.ToMod(ruleset)).ToArray();
+
             Task.Run(loadBeatmap);
 
             async Task loadBeatmap()
@@ -84,7 +97,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 
                 beatmap.StarRating = item.StarRating;
 
-                loadContent(new BeatmapCardMatchmakingBeatmapContent(beatmap));
+                loadContent(new BeatmapCardMatchmakingBeatmapContent(beatmap, mods));
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingBeatmapContent.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapCardMatchmakingBeatmapContent.cs
@@ -26,6 +26,8 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Play.HUD;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
@@ -45,6 +47,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
         private readonly Bindable<BeatmapSetFavouriteState> favouriteState = new Bindable<BeatmapSetFavouriteState>();
         private readonly APIBeatmapSet beatmapSet;
         private readonly APIBeatmap beatmap;
+        private readonly Mod[] mods;
 
         private BeatmapCardThumbnail thumbnail = null!;
         private CollapsibleButtonContainer buttonContainer = null!;
@@ -52,9 +55,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
         private BeatmapCardDownloadProgressBar downloadProgressBar = null!;
         private AvatarOverlay selectionOverlay = null!;
 
-        public BeatmapCardMatchmakingBeatmapContent(APIBeatmap beatmap)
+        public BeatmapCardMatchmakingBeatmapContent(APIBeatmap beatmap, Mod[] mods)
         {
             this.beatmap = beatmap;
+            this.mods = mods;
 
             beatmapSet = beatmap.BeatmapSet!;
             favouriteState.Value = new BeatmapSetFavouriteState(beatmapSet.HasFavourited, beatmapSet.FavouriteCount);
@@ -193,42 +197,69 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                                     AlwaysPresent = true,
                                     Children = new Drawable[]
                                     {
-                                        new Container
+                                        new GridContainer
                                         {
-                                            Masking = true,
-                                            CornerRadius = BeatmapCard.CORNER_RADIUS,
                                             RelativeSizeAxes = Axes.X,
                                             AutoSizeAxes = Axes.Y,
-                                            Children = new Drawable[]
+                                            ColumnDimensions = new[]
                                             {
-                                                new Box
+                                                new Dimension(),
+                                                new Dimension(GridSizeMode.AutoSize)
+                                            },
+                                            RowDimensions = new[]
+                                            {
+                                                new Dimension(GridSizeMode.AutoSize)
+                                            },
+                                            Content = new[]
+                                            {
+                                                new Drawable[]
                                                 {
-                                                    Colour = colours.ForStarDifficulty(beatmap.StarRating).Darken(0.8f),
-                                                    RelativeSizeAxes = Axes.Both,
-                                                },
-                                                new FillFlowContainer
-                                                {
-                                                    Padding = new MarginPadding(4),
-                                                    RelativeSizeAxes = Axes.X,
-                                                    AutoSizeAxes = Axes.Y,
-                                                    Direction = FillDirection.Horizontal,
-                                                    Spacing = new Vector2(6, 0),
-                                                    Children = new Drawable[]
+                                                    new Container
                                                     {
-                                                        new StarRatingDisplay(new StarDifficulty(beatmap.StarRating, 0), StarRatingDisplaySize.Small, animated: true)
+                                                        Masking = true,
+                                                        CornerRadius = BeatmapCard.CORNER_RADIUS,
+                                                        RelativeSizeAxes = Axes.X,
+                                                        AutoSizeAxes = Axes.Y,
+                                                        Children = new Drawable[]
                                                         {
-                                                            Origin = Anchor.CentreLeft,
-                                                            Anchor = Anchor.CentreLeft,
-                                                            Scale = new Vector2(0.9f),
-                                                        },
-                                                        new TruncatingSpriteText
-                                                        {
-                                                            Text = beatmap.DifficultyName,
-                                                            Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
-                                                            Anchor = Anchor.CentreLeft,
-                                                            Origin = Anchor.CentreLeft,
+                                                            new Box
+                                                            {
+                                                                Colour = colours.ForStarDifficulty(beatmap.StarRating).Darken(0.8f),
+                                                                RelativeSizeAxes = Axes.Both,
+                                                            },
+                                                            new FillFlowContainer
+                                                            {
+                                                                Padding = new MarginPadding(4),
+                                                                RelativeSizeAxes = Axes.X,
+                                                                AutoSizeAxes = Axes.Y,
+                                                                Direction = FillDirection.Horizontal,
+                                                                Spacing = new Vector2(6, 0),
+                                                                Children = new Drawable[]
+                                                                {
+                                                                    new StarRatingDisplay(new StarDifficulty(beatmap.StarRating, 0), StarRatingDisplaySize.Small, animated: true)
+                                                                    {
+                                                                        Origin = Anchor.CentreLeft,
+                                                                        Anchor = Anchor.CentreLeft,
+                                                                        Scale = new Vector2(0.9f),
+                                                                    },
+                                                                    new TruncatingSpriteText
+                                                                    {
+                                                                        Text = beatmap.DifficultyName,
+                                                                        Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                                                                        Anchor = Anchor.CentreLeft,
+                                                                        Origin = Anchor.CentreLeft,
+                                                                    },
+                                                                }
+                                                            },
                                                         }
-                                                    }
+                                                    },
+                                                    new ModFlowDisplay
+                                                    {
+                                                        AutoSizeAxes = Axes.Both,
+                                                        Scale = new Vector2(0.5f),
+                                                        Margin = new MarginPadding { Left = 5 },
+                                                        Current = { Value = mods }
+                                                    },
                                                 },
                                             }
                                         },


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/35637

Some beatmaps that will be added in the next wave will have mods. This is just something simple without redesigning the entire panel (because I'm not 100% on the new design either).

<img width="375" height="96" alt="Screenshot 2025-11-07 at 17 58 15" src="https://github.com/user-attachments/assets/4e0db9f1-4d34-4a67-9226-94c63fb36f58" />

<img width="1449" height="691" alt="Screenshot 2025-11-07 at 18 01 24" src="https://github.com/user-attachments/assets/56b53472-ab14-4319-ae00-c38890278b11" />