### PR TITLE
Fix legacy skin drum roll head circle being underneath ticks

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyDrumRoll.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -21,14 +20,10 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         {
             get
             {
-                // the reason why this calculation is so involved is that the head & tail sprites have different sizes/radii.
-                // therefore naively taking the SSDQs of them and making a quad out of them results in a trapezoid shape and not a box.
-                var headCentre = headCircle.ScreenSpaceDrawQuad.Centre;
+                var headCentre = (body.ScreenSpaceDrawQuad.TopLeft + body.ScreenSpaceDrawQuad.BottomLeft) / 2;
                 var tailCentre = (tailCircle.ScreenSpaceDrawQuad.TopLeft + tailCircle.ScreenSpaceDrawQuad.BottomLeft) / 2;
 
-                float headRadius = headCircle.ScreenSpaceDrawQuad.Height / 2;
-                float tailRadius = tailCircle.ScreenSpaceDrawQuad.Height / 2;
-                float radius = Math.Max(headRadius, tailRadius);
+                float radius = body.ScreenSpaceDrawQuad.Height / 2;
 
                 var rectangle = new RectangleF(headCentre.X, headCentre.Y, tailCentre.X - headCentre.X, 0).Inflate(radius);
                 return new Quad(rectangle.TopLeft, rectangle.TopRight, rectangle.BottomLeft, rectangle.BottomRight);
@@ -36,8 +31,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => ScreenSpaceDrawQuad.Contains(screenSpacePos);
-
-        private LegacyCirclePiece headCircle = null!;
 
         private Sprite body = null!;
 
@@ -65,10 +58,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 {
                     RelativeSizeAxes = Axes.Both,
                     Texture = skin.GetTexture("taiko-roll-middle", WrapMode.ClampToEdge, WrapMode.ClampToEdge),
-                },
-                headCircle = new LegacyCirclePiece
-                {
-                    RelativeSizeAxes = Axes.Y,
                 },
             };
 
@@ -101,7 +90,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         {
             var colour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
 
-            headCircle.AccentColour = colour;
             body.Colour = colour;
             tailCircle.Colour = colour;
         }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -103,6 +103,12 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 {
                     switch (taikoComponent.Component)
                     {
+                        case TaikoSkinComponents.DrumRollHead:
+                            if (GetTexture("taiko-roll-middle") != null)
+                                return new LegacyCirclePiece();
+
+                            return null;
+
                         case TaikoSkinComponents.DrumRollBody:
                             if (GetTexture("taiko-roll-middle") != null)
                                 return new LegacyDrumRoll();

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -8,6 +8,7 @@ namespace osu.Game.Rulesets.Taiko
         InputDrum,
         CentreHit,
         RimHit,
+        DrumRollHead,
         DrumRollBody,
         DrumRollTick,
         Swell,


### PR DESCRIPTION
| master | this PR |
| :-: | :-: |
| ![osu_2025-11-07_15-03-37](https://github.com/user-attachments/assets/87777bc4-e6d4-483f-8067-3d92fee1ba06) | ![osu_2025-11-07_15-28-46](https://github.com/user-attachments/assets/94e33582-0ea2-4958-80b2-7c0598eac8f2) |
| ![osu_2025-11-07_15-03-43](https://github.com/user-attachments/assets/561ea722-eca2-4620-b2d0-b667c8de6a33) | ![osu_2025-11-07_15-28-50](https://github.com/user-attachments/assets/4a2d6d6a-fd3e-432e-8423-65e1baeb5628) |

---

Closes https://github.com/ppy/osu/issues/35321.