### PR TITLE
Add "Report an issue" button to general settings

### DIFF
--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -80,6 +80,16 @@ namespace osu.Game.Localisation
         public static LocalisableString LearnMoreAboutLazerTooltip => new TranslatableString(getKey(@"check_out_the_feature_comparison"), @"Check out the feature comparison and FAQ");
 
         /// <summary>
+        /// "Report an issue"
+        /// </summary>
+        public static LocalisableString ReportIssue => new TranslatableString(getKey(@"report_issue"), @"Report an issue");
+
+        /// <summary>
+        /// "Report a problem with the game to the developers."
+        /// </summary>
+        public static LocalisableString ReportIssueTooltip => new TranslatableString(getKey(@"report_issue_tooltip"), @"Report a problem with the game to the developers.");
+
+        /// <summary>
         /// "Check with your package manager / provider for other release streams."
         /// </summary>
         public static LocalisableString ChangeReleaseStreamPackageManagerWarning => new TranslatableString(getKey(@"change_release_stream_package_warning"), @"Check with your package manager / provider for other release streams.");

--- a/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
@@ -45,6 +45,12 @@ namespace osu.Game.Overlays.Settings.Sections
                     BackgroundColour = colours.YellowDark,
                     Action = () => game?.ShowWiki(@"Help_centre/Upgrading_to_lazer")
                 },
+                new SettingsButton
+                {
+                    Text = GeneralSettingsStrings.ReportIssue,
+                    TooltipText = GeneralSettingsStrings.ReportIssueTooltip,
+                    Action = () => game?.OpenUrlExternally(@"https://osu.ppy.sh/community/forums/topics/create?forum_id=5")
+                },
                 new LanguageSettings(),
                 new UpdateSettings(),
             };

--- a/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
+using osu.Game.Online.Chat;
 using osu.Game.Overlays.Settings.Sections.General;
 
 namespace osu.Game.Overlays.Settings.Sections
@@ -49,7 +50,8 @@ namespace osu.Game.Overlays.Settings.Sections
                 {
                     Text = GeneralSettingsStrings.ReportIssue,
                     TooltipText = GeneralSettingsStrings.ReportIssueTooltip,
-                    Action = () => game?.OpenUrlExternally(@"https://osu.ppy.sh/community/forums/topics/create?forum_id=5")
+                    BackgroundColour = colours.DarkOrange2,
+                    Action = () => game?.OpenUrlExternally(@"https://osu.ppy.sh/community/forums/topics/create?forum_id=5", LinkWarnMode.NeverWarn)
                 },
                 new LanguageSettings(),
                 new UpdateSettings(),


### PR DESCRIPTION
<img width="814" height="623" alt="Screenshot 2025-11-10 at 11 31 48" src="https://github.com/user-attachments/assets/95ffd38a-cadd-4fde-9664-839f3b752aa1" />

Clicking the button opens the browser, on the "new topic" page inside the help forum.

---

Web can now correctly read the build number of the client since https://github.com/ppy/osu-web/pull/12478 so I see no reason not to.

Minimal effort implementation. Stemmed from discussion in https://discord.com/channels/90072389919997952/299846395031060480/1437368033734561792.

I am committed to keeping up with the help forum and have done so for several months (years?). I mirror things into github issues as required, or just fix them myself.

Not really interested in putting more effort into this at this point, if this is not considered acceptable then just close the PR and this can be revisited more properly at a later date.