### PR TITLE
Fix attempting to select beatmap which was just externally edited in song select crashing

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -459,6 +459,8 @@ namespace osu.Game.Screens.SelectV2
                         // - Background user tag population runs and causes a realm update.
                         //   We don't display user tags so want to ignore this.
                         bool equalForDisplayPurposes =
+                            // covers import-as-update flows, such as updating the beatmap with the latest online versions, or external editing inside editor
+                            oldBeatmap.ID == newBeatmap.ID &&
                             // covers metadata changes
                             oldBeatmap.Hash == newBeatmap.Hash &&
                             // sanity check


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35651.

The reproduction steps provided in the issue are too complex even. In my testing all you need to do is go into editor, replace the background via external editing, and exit out to song select; you'll immediately see loss of selection on the carousel, the set panel still using the old background, and eventually a crash when you attempt to re-select any of the difficulties of the edited set.

`HandleItemsChanged()` - an optimisation aiming to reduce the number of redundant re-filters due to minor changes to realm models that aren't visible to the user anyway - ignoring changes to `BeatmapInfo.ID` after re-entering song select post-external edit meant that song select would retain stale beatmap models that no longer existed in the realm database, thus failing refetch attempts via `GetWorkingBeatmap()` or

https://github.com/ppy/osu/blob/8f6f859c15bdfc9f10d5754c254fca7b9dd9bc9b/osu.Game/Screens/SelectV2/FooterButtonOptions.cs#L56-L57