### PR TITLE
Add NVIDIA Reflex

### DIFF
--- a/osu.Desktop/LowLatency/NVAPIDirect3D11LowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/NVAPIDirect3D11LowLatencyProvider.cs
@@ -15,7 +15,7 @@ namespace osu.Desktop.LowLatency
     /// </summary>
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SupportedOSPlatform("windows")]
-    internal sealed class NVAPILowLatencyProvider : ILowLatencyProvider
+    internal sealed class NVAPIDirect3D11LowLatencyProvider : IDirect3D11LowLatencyProvider
     {
         public bool IsAvailable { get; private set; }
 

--- a/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
@@ -25,6 +25,9 @@ namespace osu.Desktop.LowLatency
         {
             _deviceHandle = nativeDeviceHandle;
             IsAvailable = NVAPI.Available && _deviceHandle != IntPtr.Zero;
+
+            if (!IsAvailable)
+                throw new InvalidOperationException("NVAPI is not available or the provided device handle is invalid.");
         }
 
         public void SetMode(LatencyMode mode)
@@ -36,7 +39,8 @@ namespace osu.Desktop.LowLatency
             bool boost = mode == LatencyMode.Boost;
             var status = NVAPI.SetSleepModeHelper(_deviceHandle, enable, boost, boost, 0);
 
-            Console.WriteLine("NVAPI SetSleepMode status: " + status);
+            if (status != NvStatus.OK)
+                throw new InvalidOperationException($"Failed to set NVAPI low latency (Sleep) mode: {status}");
         }
 
         public void SetMarker(LatencyMarker marker, ulong frameId)
@@ -45,6 +49,9 @@ namespace osu.Desktop.LowLatency
                 return;
 
             var status = NVAPI.SetLatencyMarkerHelper(_deviceHandle, (uint)marker, frameId);
+
+            if (status != NvStatus.OK)
+                throw new InvalidOperationException($"Failed to set NVAPI latency marker: {status}");
         }
 
         public void FrameSleep()
@@ -53,6 +60,9 @@ namespace osu.Desktop.LowLatency
                 return;
 
             var status = NVAPI.FrameSleepHelper(_deviceHandle);
+
+            if (status != NvStatus.OK)
+                throw new InvalidOperationException($"Failed to perform NVAPI frame sleep: {status}");
         }
     }
 }

--- a/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#pragma warning disable IDE1006 // Naming rule violation
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
+using osu.Framework.Graphics.Rendering.LowLatency;
+
+namespace osu.Desktop.LowLatency
+{
+    /// <summary>
+    /// Provider for NVIDIA's NVAPI (Reflex) low latency features.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SupportedOSPlatform("windows")]
+    internal sealed class NVAPILowLatencyProvider : ILowLatencyProvider
+    {
+        public bool IsAvailable { get; private set; }
+
+        private IntPtr _deviceHandle;
+
+        public void Initialize(IntPtr nativeDeviceHandle)
+        {
+            _deviceHandle = nativeDeviceHandle;
+            IsAvailable = NVAPI.Available && _deviceHandle != IntPtr.Zero;
+        }
+
+        public void SetMode(LatencyMode mode)
+        {
+            if (!IsAvailable || _deviceHandle == IntPtr.Zero)
+                return;
+
+            bool enable = mode != LatencyMode.Off;
+            bool boost = mode == LatencyMode.Boost;
+            var status = NVAPI.SetSleepModeHelper(_deviceHandle, enable, boost, boost, 1000);
+            Console.WriteLine("NVAPI SetSleepMode status: " + status);
+        }
+
+        public void SetMarker(LatencyMarker marker, ulong frameId)
+        {
+            if (!IsAvailable || _deviceHandle == IntPtr.Zero)
+                return;
+
+            var status = NVAPI.SetLatencyMarkerHelper(_deviceHandle, (uint)marker, frameId);
+            Console.WriteLine("NVAPI SetMarker status: " + status);
+        }
+
+        public void FrameSleep()
+        {
+            if (!IsAvailable || _deviceHandle == IntPtr.Zero)
+                return;
+
+            var status = NVAPI.FrameSleepHelper(_deviceHandle);
+            Console.WriteLine("NVAPI FrameSleep status: " + status);
+        }
+    }
+}

--- a/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
@@ -35,6 +35,7 @@ namespace osu.Desktop.LowLatency
             bool enable = mode != LatencyMode.Off;
             bool boost = mode == LatencyMode.Boost;
             var status = NVAPI.SetSleepModeHelper(_deviceHandle, enable, boost, boost, 1000);
+
             Console.WriteLine("NVAPI SetSleepMode status: " + status);
         }
 
@@ -44,7 +45,6 @@ namespace osu.Desktop.LowLatency
                 return;
 
             var status = NVAPI.SetLatencyMarkerHelper(_deviceHandle, (uint)marker, frameId);
-            Console.WriteLine("NVAPI SetMarker status: " + status);
         }
 
         public void FrameSleep()
@@ -53,7 +53,6 @@ namespace osu.Desktop.LowLatency
                 return;
 
             var status = NVAPI.FrameSleepHelper(_deviceHandle);
-            Console.WriteLine("NVAPI FrameSleep status: " + status);
         }
     }
 }

--- a/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
@@ -21,6 +21,11 @@ namespace osu.Desktop.LowLatency
 
         private IntPtr _deviceHandle;
 
+        /// <summary>
+        /// Initialize the NVAPI low latency provider with a native device handle. Ensure NVAPI is available before calling this method.
+        /// </summary>
+        /// <param name="nativeDeviceHandle">An <see cref="IntPtr"/> to the handle of the D3D11 device.</param>
+        /// <exception cref="InvalidOperationException">Throws an exception if NVAPI is unavailable, or the device handle provided was invalid.</exception>
         public void Initialize(IntPtr nativeDeviceHandle)
         {
             _deviceHandle = nativeDeviceHandle;
@@ -30,6 +35,11 @@ namespace osu.Desktop.LowLatency
                 throw new InvalidOperationException("NVAPI is not available or the provided device handle is invalid.");
         }
 
+        /// <summary>
+        /// Set the low latency mode.
+        /// </summary>
+        /// <param name="mode">The <see cref="LatencyMode"/> to use.</param>
+        /// <exception cref="InvalidOperationException">Throws an exception if an attempt to set the low latency mode was unsuccessful.</exception>
         public void SetMode(LatencyMode mode)
         {
             if (!IsAvailable || _deviceHandle == IntPtr.Zero)
@@ -43,6 +53,13 @@ namespace osu.Desktop.LowLatency
                 throw new InvalidOperationException($"Failed to set NVAPI low latency (Sleep) mode: {status}");
         }
 
+        /// <summary>
+        /// Set a latency marker for the current frame.
+        /// </summary>
+        /// <remarks>WARNING: Do not log any errors that come from this method, they should be ignored as this method runs in a realtime environment.</remarks>
+        /// <param name="marker">The <see cref="LatencyMarker"/> to set.</param>
+        /// <param name="frameId">The frame number this marker is for.</param>
+        /// <exception cref="InvalidOperationException">Throws an exception if the attempt to set the marker was unsuccessful. Please ensure this exception is ignored.</exception>
         public void SetMarker(LatencyMarker marker, ulong frameId)
         {
             if (!IsAvailable || _deviceHandle == IntPtr.Zero)
@@ -54,6 +71,10 @@ namespace osu.Desktop.LowLatency
                 throw new InvalidOperationException($"Failed to set NVAPI latency marker: {status}");
         }
 
+        /// <summary>
+        /// Ensure this is called once per frame, at the start of the Update phase, to allow NVAPI to manage frame sleep timing.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Throws an exception if the Sleep attempt was unsuccessful.</exception>
         public void FrameSleep()
         {
             if (!IsAvailable || _deviceHandle == IntPtr.Zero)

--- a/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/NVAPILowLatencyProvider.cs
@@ -34,7 +34,7 @@ namespace osu.Desktop.LowLatency
 
             bool enable = mode != LatencyMode.Off;
             bool boost = mode == LatencyMode.Boost;
-            var status = NVAPI.SetSleepModeHelper(_deviceHandle, enable, boost, boost, 1000);
+            var status = NVAPI.SetSleepModeHelper(_deviceHandle, enable, boost, boost, 0);
 
             Console.WriteLine("NVAPI SetSleepMode status: " + status);
         }

--- a/osu.Desktop/NVAPI.cs
+++ b/osu.Desktop/NVAPI.cs
@@ -104,6 +104,21 @@ namespace osu.Desktop
 
         private static readonly SaveSettingsDelegate SaveSettings;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate NvStatus SetSleepModeDelegate(IntPtr pDevice, ref NvSetSleepModeParams pParams);
+
+        private static readonly SetSleepModeDelegate SetSleepMode;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate NvStatus SetLatencyMarkerDelegate(IntPtr pDevice, uint marker, ulong frameId);
+
+        private static readonly SetLatencyMarkerDelegate SetLatencyMarker;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate NvStatus SleepDelegate(IntPtr pDevice);
+
+        private static readonly SleepDelegate Sleep;
+
         public static NvStatus Status { get; private set; } = NvStatus.OK;
         public static bool Available { get; private set; }
 
@@ -338,6 +353,27 @@ namespace osu.Desktop
             return !checkError(SaveSettings(sessionHandle), nameof(SaveSettings));
         }
 
+        internal static NvStatus SetSleepModeHelper(IntPtr devicePtr, bool enable, bool boost, bool useMarkersOptimize, uint minimumIntervalUs)
+        {
+            if (!Available)
+                return NvStatus.NO_IMPLEMENTATION;
+
+            NvSetSleepModeParams sleepParams = new NvSetSleepModeParams
+            {
+                version = NvSetSleepModeParams.Stride,
+                bLowLatencyMode = enable ? 1u : 0u,
+                bLowLatencyBoost = boost ? 1u : 0u,
+                bUseMarkersToOptimize = useMarkersOptimize ? 1u : 0u,
+                minimumIntervalUs = minimumIntervalUs,
+            };
+
+            return SetSleepMode(devicePtr, ref sleepParams);
+        }
+
+        internal static NvStatus SetLatencyMarkerHelper(IntPtr devicePtr, uint marker, ulong frameId) => SetLatencyMarker(devicePtr, marker, frameId);
+
+        internal static NvStatus FrameSleepHelper(IntPtr devicePtr) => Sleep(devicePtr);
+
         /// <summary>
         /// Creates a session to access the driver configuration.
         /// </summary>
@@ -400,6 +436,9 @@ namespace osu.Desktop
                     getDelegate(0x7FA2173A, out EnumApplications);
                     getDelegate(0x4347A9DE, out CreateApplication);
                     getDelegate(0xFCBC7E14, out SaveSettings);
+                    getDelegate(0xAC1CA9E0, out SetSleepMode);
+                    getDelegate(0xD9984C05, out SetLatencyMarker);
+                    getDelegate(0x852CD1D2, out Sleep);
                 }
 
                 if (createSession())
@@ -424,6 +463,20 @@ namespace osu.Desktop
         private static extern IntPtr queryInterface64(uint id);
 
         private delegate NvStatus InitializeDelegate();
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct NvSetSleepModeParams
+    {
+        public uint version;
+        public uint bLowLatencyMode;
+        public uint bLowLatencyBoost;
+        public uint bUseMarkersToOptimize;
+        public uint minimumIntervalUs;
+        public uint reserved0;
+        public uint reserved1;
+        public uint reserved2;
+        public static uint Stride => (uint)Marshal.SizeOf(typeof(NvSetSleepModeParams)) | (1 << 16);
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -9,7 +9,6 @@ using osu.Desktop.LowLatency;
 using osu.Desktop.Windows;
 using osu.Framework;
 using osu.Framework.Development;
-using osu.Framework.Graphics.Rendering.LowLatency;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game;
@@ -141,7 +140,6 @@ namespace osu.Desktop
                 else
                 {
                     host.SetLowLatencyProvider(new NVAPILowLatencyProvider());
-                    host.SetLowLatencyMode(LatencyMode.On);
                     host.Run(new OsuGameDesktop(args)
                     {
                         IsFirstRun = isFirstRun

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -5,9 +5,11 @@ using System;
 using System.IO;
 using System.Runtime.Versioning;
 using osu.Desktop.LegacyIpc;
+using osu.Desktop.LowLatency;
 using osu.Desktop.Windows;
 using osu.Framework;
 using osu.Framework.Development;
+using osu.Framework.Graphics.Rendering.LowLatency;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game;
@@ -138,6 +140,8 @@ namespace osu.Desktop
                     host.Run(new TournamentGame());
                 else
                 {
+                    host.SetLowLatencyProvider(new NVAPILowLatencyProvider());
+                    host.SetLowLatencyMode(LatencyMode.On);
                     host.Run(new OsuGameDesktop(args)
                     {
                         IsFirstRun = isFirstRun

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -139,8 +139,8 @@ namespace osu.Desktop
                     host.Run(new TournamentGame());
                 else
                 {
-                    // If we're on windows, attempt to use the NVAPI Low Latency Provider
-                    if (OperatingSystem.IsWindows())
+                    // Attempt to use the NVAPI Low Latency Provider. This should only succeed on systems with NVIDIA GPUs and the proper drivers installed.
+                    if (NVAPI.Available)
                         host.SetLowLatencyProvider(new NVAPILowLatencyProvider());
 
                     host.Run(new OsuGameDesktop(args)

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -139,7 +139,10 @@ namespace osu.Desktop
                     host.Run(new TournamentGame());
                 else
                 {
-                    host.SetLowLatencyProvider(new NVAPILowLatencyProvider());
+                    // If we're on windows, attempt to use the NVAPI Low Latency Provider
+                    if (OperatingSystem.IsWindows())
+                        host.SetLowLatencyProvider(new NVAPILowLatencyProvider());
+
                     host.Run(new OsuGameDesktop(args)
                     {
                         IsFirstRun = isFirstRun

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -141,7 +141,7 @@ namespace osu.Desktop
                 {
                     // Attempt to use the NVAPI Low Latency Provider. This should only succeed on systems with NVIDIA GPUs and the proper drivers installed.
                     if (NVAPI.Available)
-                        host.SetLowLatencyProvider(new NVAPILowLatencyProvider());
+                        host.SetLowLatencyProvider(new NVAPIDirect3D11LowLatencyProvider());
 
                     host.Run(new OsuGameDesktop(args)
                     {

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Rendering.LowLatency;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Configuration;
@@ -26,6 +27,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
         {
             var renderer = config.GetBindable<RendererType>(FrameworkSetting.Renderer);
             automaticRendererInUse = renderer.Value == RendererType.Automatic;
+            var reflexMode = config.GetBindable<LatencyMode>(FrameworkSetting.LatencyMode);
 
             Children = new Drawable[]
             {
@@ -51,12 +53,22 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                     LabelText = GraphicsSettingsStrings.ThreadingMode,
                     Current = config.GetBindable<ExecutionMode>(FrameworkSetting.ExecutionMode)
                 },
+                new SettingsEnumDropdown<LatencyMode>
+                {
+                    LabelText = "Reflex",
+                    Current = reflexMode
+                },
                 new SettingsCheckbox
                 {
                     LabelText = GraphicsSettingsStrings.ShowFPS,
                     Current = osuConfig.GetBindable<bool>(OsuSetting.ShowFpsDisplay)
                 },
             };
+
+            reflexMode.BindValueChanged(r =>
+            {
+                host.SetLowLatencyMode(r.NewValue);
+            });
 
             renderer.BindValueChanged(r =>
             {

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -78,8 +78,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
             reflexMode.BindValueChanged(r =>
             {
-                host.SetLowLatencyMode(r.NewValue);
-
                 reflexSetting.ClearNoticeText();
                 if (r.NewValue == LatencyMode.Boost) setReflexBoostNotice();
             }, true);

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -81,10 +81,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             // Disable frame limiter if reflex is enabled and add notice when reflex boost is enabled
             reflexMode.BindValueChanged(r =>
             {
-                if (r.NewValue != LatencyMode.Off)
-                    frameSyncMode.Disabled = true;
-
-                frameSyncMode.Disabled = false;
+                frameSyncMode.Disabled = r.NewValue != LatencyMode.Off;
 
                 reflexSetting.ClearNoticeText();
 


### PR DESCRIPTION
Prerequisites:
-  https://github.com/ppy/osu-framework/pull/6666

Resources:
- [Original Discord Message](https://discord.com/channels/188630481301012481/188630652340404224/1437338808696700999)
- Relevant NVIDIA Reflex documentation can be found [here](https://developer.nvidia.com/performance-rendering-tools/reflex) by downloading the Reflex SDK and opening `NVIDIA Reflex SDK Integration Guide.pdf`. Due to the copyright license attached to the SDK I can't provide a direct link to the implementation docs.

## Introduction
NVIDIA Reflex is an API for Windows + NVIDIA GPU's that allows the game to effectively report its internal render loop timings to the GPU, allowing it to sync the render queue with the CPU, enabling just-in-time rendering, which results in lower input-to-image latency, improved frame consistency, and reduced stuttering. Additionally, Reflex allows us to gather detailed analytics on the game's render latency, paving the way for future optimization, both in terms of game performance, and for end users attempting to lower system latency.

This [video](https://youtu.be/-cXg7GQogAE) does a good job of explaining how Reflex works.

## Implementation & Notes

<details>
<summary>Frame Limiting</summary>
From the NVIDIA Reflex Docs:

> [...] The benefit of allowing the driver to be aware of the framerate limit that the application wishes to enforce (i.e. at a menu or load screen) is that the driver can compare it against other limits that may come from different components of the driver itself (low power mode for laptops, etc.). The driver can take the lowest limit and enforce it at the best place in the pipeline for ensuring the lowest latency, which is the `NvAPI_D3D_Sleep` call at the start of the main / simulation thread execution. This function will account for the limit that was passed into `NvAPI_D3D_SetSleepMode` as well as the appropriate timing for Reflex Low Latency mode (if enabled), and there is no need for the application to perform any additional Sleep on its own.
> 
> If you do not want any limit enforced, this `minimumIntervalUs` value should be 0. The requested framerate limit interval combined with the execution of the `NvAPI_D3D_Sleep` function can be used whether or not you have the Retlex Low Latency mode enabled. They are orthogonal, and you can safely use `NvAPI_D3D_Sleep` to replace an existing framerate limit Sleep implementation in your engine.

What this means is that we can use NVIDIA Reflex to limit FPS instead of limiting FPS ourselves on NVIDIA + Windows systems. This allows the GPU driver to automatically apply the lowest FPS limit. Say the user sets an FPS limit in their NVIDIA settings for when their PC is running on battery, offloading frame limiting to the GPU driver allows the game to respect that FPS limit set by the user. This also includes if the user set a limit for when the game is out of focus, or if the user set a global frame limit in their settings. And importantly, it lets the GPU driver automatically cap the FPS to just under the user's refresh rate if they're using GSYNC. Functioning much like an "Optimal" or otherwise intelligent FPS limiting mode.

Also, speaking of capping FPS to just under the user's refresh rate, a goal of mine when it comes to this implementation is to ~completely disable our built-in FPS limiting system on NVIDIA + Windows systems~. It has been [stated](https://github.com/ppy/osu/wiki/Latency-and-unlimited-frame-rates#going-forward) that going forwards, the goal is to lock FPS to the monitor refresh rate with ideally no impact on latency. This feature of NVIDIA Reflex should hopefully achieve that.

As a result, this PR will try to move that vision forwards by completely disabling the FPS limit setting when NVIDIA Reflex is detected to be on and enabled. When Reflex is on, the game will limit its Draw FPS to the monitors refresh rate. With Reflex off, the game will allow modification of the FPS limit (to what is currently available), ~but still attempt to use the GPU driver to set that limit, rather than our own fps limiting logic~.

Note: For any concerned players, Lazer already does this on MacOS (Metal renderer) and achieves low latency despite it. [More frames does not mean better performance.](https://github.com/ppy/osu/wiki/Latency-and-unlimited-frame-rates#changes-to-unlimited-frame-limiter)

---
Update: After some testing on my part, and [discussion](https://github.com/ppy/osu/pull/35678#issuecomment-3530265789) on the topic, using NVIDIA Reflex's built in frame limiter *would* introduce audio latency as a result of limiting the refresh rate of the Update thread in addition to the Draw thread. This is sub-optimal, and is good reason to *not* offload frame limiting to Reflex. 

The most likely direction with this feature going forwards is:
- Not using Reflex's FPS limiter, forcing the Update thread to run at 1000hz for audio & input responsiveness
- Using the built-in limiter to limit the Draw thread to refresh rate, as Reflex's just-in-time rendering allows this to be done without impacting latency
</details>

<details>
<summary>Markers & Cross Platform Behaviour</summary>
From the NVIDIA Reflex Docs:

> Reflex Latency and PC Latency markers help to measure the time taken by each section of your app. These measurements are independent of whether or not Reflex Low Latency Mode (or Reflex Low Latency Boost Mode) is enabled. As a result, they can be used to measure and test the savings in latency that you get from using Reflex Low Latency Mode (or Reflex Low Latency Boost Mode). **And the application must always call in to these markers, regardless of whether Reflex Low Latency Mode is enabled or disabled.**

The last sentence is heavily significant as continuing to report the markers even if Reflex is off enables the functionality described in the Front-End Render Latency Telemetry section below.

As for cross-platform behaviour, there is a rather clever way to ensure that the markers are only reported if the game is running on Windows. We initialize and set the default `LowLatencyProvider` in `GameHost` as a No-Op implementation. Then, in `osu.Desktop`, only if NVAPI is available, do we switch the `LowLatencyProvider` to the `NVAPILowLatencyProvider`. **This basically means that the marker code does absolutely nothing on non-NVIDIA and non-Windows environments**, and therefore has no overhead.

As a small side note, if lazer's Vulkan API is brought back from deprecation, NVIDIA Reflex can (theoretically) be made to work on Linux by leveraging the Reflex Vulkan API.
</details>

<details>
<summary>Boost Mode</summary>
Boost Mode is an NVIDIA Reflex feature which aims to optimize the game in CPU-bound scenarios.

When a game is CPU-bound, the GPU will automatically lower its clocks to save on power consumption. This is typically fine, but it becomes an issue when the game transitions to being GPU-bound. The GPU now has to increase its clocks to keep up with the CPU, which causes stutters while the GPU spools up. Reflex's Boost Mode aims to fix this by constantly running the GPU at the maximum possible clock. This comes at the cost of significantly higher power consumption & possibly more latency (due to the overhead of running the GPU at max performance), but usually less stuttering as the GPU is always ready and in a high-performance state.

In this implementation, I added the option to use Boost as is recommended by the NVIDIA Reflex SDK Docs, but I added a warning about power draw and potential for it to actually backfire and reduce performance.
</details>

<details>
<summary>Render Latency Telemetry</summary>

#### Front-End
Reflex, even in its Off mode, will continue to set markers and gather telemetry on latency. This allows players to use the NVIDIA Overlay to measure render latency, which is objectively a better metric for players to obsess about rather than the current frametime metric in the "Show FPS" panel. Aside from the obvious benefit of transparency, this allows players to measure total system latency if they have a compatible 360hz GSYNC monitor.

#### Back-End
The Reflex latency telemetry is highly accurate, and according to NVIDIA, completely [replaces the need for a high speed camera](https://www.nvidia.com/en-us/geforce/news/reflex-latency-analyzer-360hz-g-sync-monitors/#:~:text=without%20the%20need%20for%20expensive%20high-speed%20cameras%20and%20other%20hardware%20sensors) to measure latency. This can be useful for internal analysis for the core team, and can help shed light on areas of the game that drive up latency, and might require optimization.
</details>

## Testing
Our own methodological testing can be found [here](https://github.com/ppy/osu/pull/35678#issuecomment-3525085184)

> [!WARNING]
> Please backup your osu!(lazer) data and read the [contributing docs](https://github.com/ppy/osu/blob/master/CONTRIBUTING.md) before doing this. Running lazer in the `Release` configuration can brick your typical lazer installation, but is necessary for a change like this.

1. Clone my [osu reflex branch](https://github.com/smallketchup82/osu/tree/reflex)
2. Clone my [osu-framework reflex branch](https://github.com/smallketchup82/osu-framework)
3. Ensure the `osu` and `osu-framework` folders are under the same parent directory
4. Run the `UseLocalFramework.(ps1|sh)` script in `osu` according to your system
5. Run `dotnet run osu.Desktop -c Release` in `osu`
6. Enable Reflex in the in-game settings under the Graphics section. Ensure you are using the `DirectX` renderer

To find the render latency metric, you can either use the NVIDIA Overlay that comes with the NVIDIA app or GeForce Experience app, or you can use the Reflex Testing HUD found in the Reflex SDK linked above.

## What's Left?
- [x] Limit Draw FPS to refresh rate
  - [ ] Allow using VSYNC
- [x] Mark PR as ready for review
- [x] Final touches (improving logging, cleaning up comments, renaming symbols, etc.)
- [ ] Turn Reflex on by default
- [ ] (Optional) Adding in methods for programmatically grabbing render latency & other debugging stats
  - [ ] (Optional) Replace current frametime statistic in "Show FPS" panel with the current render latency
 
AMD has a Reflex-like SDK for reducing latency on AMD cards. This SDK is called [AMD Radeon Anti-Lag 2](https://gpuopen.com/anti-lag-2/). While I would like to implement this beside Reflex (in a different PR), I don't own an AMD GPU to be able to test it out and make sure it works.