### PR TITLE
Move realm collection writes off of update thread

### DIFF
--- a/osu.Game/Collections/CollectionDropdown.cs
+++ b/osu.Game/Collections/CollectionDropdown.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -263,11 +264,11 @@ namespace osu.Game.Collections
             {
                 Debug.Assert(collection != null);
 
-                collection.PerformWrite(c =>
+                Task.Run(() => collection.PerformWrite(c =>
                 {
                     if (!c.BeatmapMD5Hashes.Remove(beatmap.Value.BeatmapInfo.MD5Hash))
                         c.BeatmapMD5Hashes.Add(beatmap.Value.BeatmapInfo.MD5Hash);
-                });
+                }));
             }
 
             protected override Drawable CreateContent() => (Content)base.CreateContent();

--- a/osu.Game/Collections/CollectionToggleMenuItem.cs
+++ b/osu.Game/Collections/CollectionToggleMenuItem.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
@@ -10,7 +11,7 @@ namespace osu.Game.Collections
     public class CollectionToggleMenuItem : ToggleMenuItem
     {
         public CollectionToggleMenuItem(Live<BeatmapCollection> collection, IBeatmapInfo beatmap)
-            : base(collection.PerformRead(c => c.Name), MenuItemType.Standard, state =>
+            : base(collection.PerformRead(c => c.Name), MenuItemType.Standard, state => Task.Run(() =>
             {
                 collection.PerformWrite(c =>
                 {
@@ -19,7 +20,7 @@ namespace osu.Game.Collections
                     else
                         c.BeatmapMD5Hashes.Remove(beatmap.MD5Hash);
                 });
-            })
+            }))
         {
             State.Value = collection.PerformRead(c => c.BeatmapMD5Hashes.Contains(beatmap.MD5Hash));
         }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -328,7 +328,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             return new TernaryStateToggleMenuItem(collection.Name, MenuItemType.Standard, s =>
             {
-                liveCollection.PerformWrite(c =>
+                Task.Run(() => liveCollection.PerformWrite(c =>
                 {
                     foreach (var b in beatmapSet.Beatmaps)
                     {
@@ -346,7 +346,7 @@ namespace osu.Game.Screens.Select.Carousel
                                 break;
                         }
                     }
-                });
+                }));
             })
             {
                 State = { Value = state }

--- a/osu.Game/Screens/SelectV2/CollectionDropdown.cs
+++ b/osu.Game/Screens/SelectV2/CollectionDropdown.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -237,11 +238,11 @@ namespace osu.Game.Screens.SelectV2
             {
                 Debug.Assert(collection != null);
 
-                collection.PerformWrite(c =>
+                Task.Run(() => collection.PerformWrite(c =>
                 {
                     if (!c.BeatmapMD5Hashes.Remove(beatmap.Value.BeatmapInfo.MD5Hash))
                         c.BeatmapMD5Hashes.Add(beatmap.Value.BeatmapInfo.MD5Hash);
-                });
+                }));
             }
 
             protected override Drawable CreateContent() => (Content)base.CreateContent();

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -296,7 +297,7 @@ namespace osu.Game.Screens.SelectV2
 
             return new TernaryStateToggleMenuItem(collection.Name, MenuItemType.Standard, s =>
             {
-                liveCollection.PerformWrite(c =>
+                Task.Run(() => liveCollection.PerformWrite(c =>
                 {
                     foreach (var b in beatmapSet.Beatmaps)
                     {
@@ -314,7 +315,7 @@ namespace osu.Game.Screens.SelectV2
                                 break;
                         }
                     }
-                });
+                }));
             })
             {
                 State = { Value = state }


### PR DESCRIPTION
Probably closes https://github.com/ppy/osu/issues/35650.

Realm slow, episode 23894. I can't reproduce freezes as big as the video in the issue is showing but 'realm slow' is 99% the culprit, because affected user's database is not small.