### PR TITLE
Fix skin layout deserialisation eating exceptions without logging

### DIFF
--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -228,8 +228,9 @@ namespace osu.Game.Skinning
                 // First attempt to deserialise using the new SkinLayoutInfo format
                 layout = JsonConvert.DeserializeObject<SkinLayoutInfo>(jsonContent);
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.Log($"Deserialising skin layout to {nameof(SkinLayoutInfo)} failed. Falling back to {nameof(SerialisedDrawableInfo)}[].\nDetails: {ex}");
             }
 
             // If deserialisation using SkinLayoutInfo fails, attempt to deserialise using the old naked list.


### PR DESCRIPTION
Because I just wasted 30 minutes trying to debug why a skin provided by a user in an issue thread was failing to deserialise, only to realise halfway through that the deserialisation error I was seeing was *from the fallback path and thus a complete red herring*.