### PR TITLE
Fix several issues with incorrect sample playback

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapSampleConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapSampleConversionTest.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [TestCase("mania-samples")]
         [TestCase("mania-slider")] // e.g. second and fourth notes of https://osu.ppy.sh/beatmapsets/73883#mania/216407
         [TestCase("slider-convert-samples")]
+        [TestCase("spinner-convert-samples")]
         public void Test(string name) => base.Test(name);
 
         protected override IEnumerable<SampleConvertValue> CreateConvertValue(HitObject hitObject)

--- a/osu.Game.Rulesets.Mania.Tests/Resources/SampleLookups/convert-beatmap-custom-sample-bank.osu
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/SampleLookups/convert-beatmap-custom-sample-bank.osu
@@ -1,0 +1,10 @@
+osu file format v14
+
+[General]
+Mode: 0
+
+[TimingPoints]
+0,300,4,0,2,100,1,0
+
+[HitObjects]
+444,320,1000,5,2,0:0:0:0:

--- a/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/spinner-convert-samples-expected-conversion.json
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/spinner-convert-samples-expected-conversion.json
@@ -1,0 +1,16 @@
+{
+  "Mappings": [{
+    "StartTime": 1000.0,
+    "Objects": [{
+      "StartTime": 1000.0,
+      "EndTime": 8000.0,
+      "Column": 0,
+      "PlaySlidingSamples": false,
+      "NodeSamples": [
+        ["Gameplay/soft-hitnormal"],
+        ["Gameplay/soft-hitnormal", "Gameplay/soft-hitfinish"]
+      ],
+      "Samples": ["Gameplay/soft-hitnormal", "Gameplay/soft-hitfinish"],
+    }]
+  }]
+}

--- a/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/spinner-convert-samples.osu
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/Testing/Beatmaps/spinner-convert-samples.osu
@@ -1,0 +1,18 @@
+osu file format v14
+
+[General]
+Mode: 0
+
+[Difficulty]
+HPDrainRate:5
+CircleSize:5
+OverallDifficulty:5
+ApproachRate:5
+SliderMultiplier:1.4
+SliderTickRate:1
+
+[TimingPoints]
+0,500,4,2,0,100,1,0
+
+[HitObjects]
+256,192,1000,8,4,8000,0:2:0:0:

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectSamples.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectSamples.cs
@@ -45,5 +45,19 @@ namespace osu.Game.Rulesets.Mania.Tests
             AssertBeatmapLookup(expected_sample);
             AssertNoLookup(unwanted_sample);
         }
+
+        [Test]
+        public void TestConvertHitObjectCustomSampleBank()
+        {
+            const string beatmap_sample = "normal-hitwhistle2";
+            const string user_skin_sample = "normal-hitnormal";
+
+            SetupSkins(beatmap_sample, user_skin_sample);
+
+            CreateTestWithBeatmap("convert-beatmap-custom-sample-bank.osu");
+
+            AssertBeatmapLookup(beatmap_sample);
+            AssertUserLookup(user_skin_sample);
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
+++ b/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
@@ -11,5 +11,6 @@
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj" />
+    <ProjectReference Include="..\osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
+++ b/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
@@ -11,6 +11,5 @@
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj" />
-    <ProjectReference Include="..\osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/SpinnerPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/SpinnerPatternGenerator.cs
@@ -85,7 +85,11 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
                     Duration = endTime - HitObject.StartTime,
                     Column = column,
                     Samples = HitObject.Samples,
-                    NodeSamples = (HitObject as IHasRepeats)?.NodeSamples
+                    NodeSamples =
+                    [
+                        HitObject.Samples.Where(s => s.Name == HitSampleInfo.HIT_NORMAL).ToList(),
+                        HitObject.Samples
+                    ]
                 };
             }
             else

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -64,11 +64,13 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         private readonly Lazy<bool> hasKeyTexture;
 
         private readonly ManiaBeatmap beatmap;
+        private readonly bool isBeatmapConverted;
 
         public ManiaLegacySkinTransformer(ISkin skin, IBeatmap beatmap)
             : base(skin)
         {
             this.beatmap = (ManiaBeatmap)beatmap;
+            isBeatmapConverted = !beatmap.BeatmapInfo.Ruleset.Equals(new ManiaRuleset().RulesetInfo);
 
             isLegacySkin = new Lazy<bool>(() => GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version) != null);
             hasKeyTexture = new Lazy<bool>(() =>
@@ -196,8 +198,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         public override ISample GetSample(ISampleInfo sampleInfo)
         {
-            // layered hit sounds never play in mania
-            if (sampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacySample && legacySample.IsLayered)
+            // layered hit sounds never play in mania-native beatmaps (but do play on converts)
+            if (sampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacySample && legacySample.IsLayered && !isBeatmapConverted)
                 return new SampleVirtual();
 
             return base.GetSample(sampleInfo);

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
@@ -127,6 +127,22 @@ namespace osu.Game.Tests.Gameplay
         }
 
         /// <summary>
+        /// Tests that a hitobject which specifies a specific sample file which doesn't exist (or isn't allowed to be looked up)
+        /// falls back to a normal sample.
+        /// </summary>
+        [Test]
+        public void TestFileSampleFallsBackToNormal()
+        {
+            const string expected_sample = "normal-hitnormal";
+
+            SetupSkins(null, expected_sample);
+
+            CreateTestWithBeatmap("file-beatmap-sample.osu");
+
+            AssertUserLookup(expected_sample);
+        }
+
+        /// <summary>
         /// Tests that a default hitobject and control point causes <see cref="TestDefaultSampleFromUserSkin"/>.
         /// </summary>
         [Test]

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -544,7 +544,7 @@ namespace osu.Game.Beatmaps.Formats
             if (!banksOnly)
             {
                 int customSampleBank = toLegacyCustomSampleBank(samples.FirstOrDefault(s => !string.IsNullOrEmpty(s.Name)));
-                string sampleFilename = samples.FirstOrDefault(s => string.IsNullOrEmpty(s.Name))?.LookupNames.First() ?? string.Empty;
+                string sampleFilename = samples.FirstOrDefault(s => s is ConvertHitObjectParser.FileHitSampleInfo)?.LookupNames.First() ?? string.Empty;
                 int volume = samples.FirstOrDefault()?.Volume ?? 100;
 
                 // We want to ignore custom sample banks and volume when not encoding to the mania game mode,

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -550,7 +550,6 @@ namespace osu.Game.Rulesets.Objects.Legacy
             }
             else
             {
-                // Todo: This should set the normal SampleInfo if the specified sample file isn't found, but that's a pretty edge-case scenario
                 soundTypes.Add(new FileHitSampleInfo(bankInfo.Filename, bankInfo.Volume));
             }
 
@@ -686,8 +685,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             public FileHitSampleInfo(string filename, int volume)
                 // Force CSS=1 to make sure that the LegacyBeatmapSkin does not fall back to the user skin.
-                // Note that this does not change the lookup names, as they are overridden locally.
-                : base(string.Empty, customSampleBank: 1, volume: volume)
+                : base(HIT_NORMAL, customSampleBank: 1, volume: volume)
             {
                 Filename = filename;
             }
@@ -696,7 +694,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             {
                 Filename,
                 Path.ChangeExtension(Filename, null)
-            };
+            }.Concat(base.LookupNames);
 
             public sealed override LegacyHitSampleInfo With(Optional<string> newName = default, Optional<string> newBank = default, Optional<int> newVolume = default,
                                                             Optional<bool> newEditorAutoBank = default, Optional<int> newCustomSampleBank = default, Optional<bool> newIsLayered = default)

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -679,13 +679,13 @@ namespace osu.Game.Rulesets.Objects.Legacy
             public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), CustomSampleBank, IsLayered);
         }
 
-        private class FileHitSampleInfo : LegacyHitSampleInfo, IEquatable<FileHitSampleInfo>
+        public class FileHitSampleInfo : LegacyHitSampleInfo, IEquatable<FileHitSampleInfo>
         {
             public readonly string Filename;
 
             public FileHitSampleInfo(string filename, int volume)
                 // Force CSS=1 to make sure that the LegacyBeatmapSkin does not fall back to the user skin.
-                : base(HIT_NORMAL, customSampleBank: 1, volume: volume)
+                : base(HIT_NORMAL, SampleControlPoint.DEFAULT_BANK, customSampleBank: 1, volume: volume)
             {
                 Filename = filename;
             }

--- a/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
+++ b/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
@@ -86,9 +86,7 @@ namespace osu.Game.Tests.Beatmaps
                         currentTestBeatmap = Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
 
                     // populate ruleset for beatmap converters that require it to be present.
-                    var ruleset = rulesetStore.GetRuleset(currentTestBeatmap.BeatmapInfo.Ruleset.OnlineID);
-
-                    Debug.Assert(ruleset != null);
+                    var ruleset = rulesetStore.GetRuleset(currentTestBeatmap.BeatmapInfo.Ruleset.OnlineID) ?? new RulesetInfo { OnlineID = currentTestBeatmap.BeatmapInfo.Ruleset.OnlineID };
 
                     currentTestBeatmap.BeatmapInfo.Ruleset = ruleset;
                 });


### PR DESCRIPTION
Should fix the entirety of https://github.com/ppy/osu/issues/35596 which was like three issues at once but I just want to get that closed. If you prefer this split then I can do on request.

## [Add failing test coverage for layered hit samples not playing in mania when beatmap is converted](https://github.com/ppy/osu/commit/12e3d32a52e9dcf3e0446d9a962d0d0c6c0b3d18)

~~Adding the `osu.Game.Rulesets.Osu` reference to the mania test project is required so that `HitObjectSampleTest` base logic doesn't die on~~

https://github.com/ppy/osu/blob/f0aeeeea966f06add12cf2bca3dd48dac8573e82/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs#L88-L91

Reverted and replaced with alternative workaround (https://github.com/ppy/osu/pull/35685/commits/b2cace9ccb9e26f1bc83a05dcc197b3484c5ac85).

## [Fix layered hit sounds not playing on converted beatmaps in mania](https://github.com/ppy/osu/commit/a428d4bf8c1fe0021e8861219b159a1854bd9d59)

Compare [stable logic](https://github.com/peppy/osu-stable-reference/blob/f9e58b4864a10f801393199e7652b2192c7342c3/osu!/GameplayElements/HitObjects/HitObject.cs#L476-L477).

In case of converted beatmaps, the last condition there (`BeatmapManager.Current.PlayMode != PlayModes.OsuMania`) fails, and thus layered hitsounds are allowed to play.

## [Fix mania beatmap conversion assigning wrong samples to spinners](https://github.com/ppy/osu/commit/d75b073f4b1a65bee05bd61b22dbf12bea3fd8da)

A spinner is never `IHasRepeats`. It was a dead condition, leading to the hitobject generating fallback `NodeSamples`, which in particular feature a silent tail which stable doesn't do.

Noticeably, stable also appears to [force the head of the generated hold note to have no addition sounds](https://github.com/peppy/osu-stable-reference/blob/f9e58b4864a10f801393199e7652b2192c7342c3/osu!/GameplayElements/HitObjects/Mania/SpinnerMania.cs#L86-L89).

## [Allow `FileHitSampleInfo` to fall back to standard samples if the file is not found (or not allowed to be looked up)](https://github.com/ppy/osu/commit/d18865b3fb84a006004b70a1545587af96bddd02) 

I'm honestly not 100% as to how closely this matches stable because I reached the point wherein I'd rather not look at stable code anymore, so as long as this passes tests I'm fine to wait for someone else to report new breakage.