### PR TITLE
Improve loading time of collection grouping mode

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -397,10 +397,10 @@ namespace osu.Game.Screens.SelectV2
         }
 
         // This record is used in the getCollectionGroups function
-        // The `index` field corresponds to the index of the given item in the list given prior to grouping
+        // The `Index` field corresponds to the index of the given item in the list given prior to grouping
         // We have to save that index in order to preserve the ordering of `CarouselItem`s because sorting happens before grouping
-        // The `inGroup` field is used to create a final group for `CarouselItem`s that are in no collections
-        private record CarouselItemInGroup(CarouselItem item, int index, bool inGroup);
+        // The `InGroup` field is used to create a final group for `CarouselItem`s that are in no collections
+        private record CarouselItemInGroup(CarouselItem Item, int Index, bool InGroup);
 
         private List<GroupMapping> getCollectionGroups(List<BeatmapCollection> collections, List<CarouselItem> items)
         {
@@ -429,8 +429,8 @@ namespace osu.Game.Screens.SelectV2
                     // This check is necessary because some collections might contain maps that are not installed
                     if (MD5HashToCarouselItemMap.TryGetValue(MD5Hash, out var carouselItemInGroup))
                     {
-                        sortedItems.Add(carouselItemInGroup.index, carouselItemInGroup.item);
-                        MD5HashToCarouselItemMap[MD5Hash] = carouselItemInGroup with { inGroup = true };
+                        sortedItems.Add(carouselItemInGroup.Index, carouselItemInGroup.Item);
+                        MD5HashToCarouselItemMap[MD5Hash] = carouselItemInGroup with { InGroup = true };
                     }
                 }
 

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -404,12 +404,13 @@ namespace osu.Game.Screens.SelectV2
 
         private List<GroupMapping> getCollectionGroups(List<BeatmapCollection> collections, List<CarouselItem> items)
         {
-            var MD5HashToCarouselItemMap = new Dictionary<string, CarouselItemInGroup>();
+            var md5HashToCarouselItemMap = new Dictionary<string, CarouselItemInGroup>();
+
             for (int i = 0; i < items.Count; i++)
             {
                 CarouselItem item = items[i];
                 BeatmapInfo b = (BeatmapInfo)item.Model;
-                MD5HashToCarouselItemMap[b.MD5Hash] = new CarouselItemInGroup(item, i, false);
+                md5HashToCarouselItemMap[b.MD5Hash] = new CarouselItemInGroup(item, i, false);
             }
 
             var groups = new List<GroupMapping>();
@@ -424,13 +425,13 @@ namespace osu.Game.Screens.SelectV2
 
                 var sortedItems = new SortedList<int, CarouselItem>();
 
-                foreach (var MD5Hash in collection.BeatmapMD5Hashes)
+                foreach (string md5Hash in collection.BeatmapMD5Hashes)
                 {
                     // This check is necessary because some collections might contain maps that are not installed
-                    if (MD5HashToCarouselItemMap.TryGetValue(MD5Hash, out var carouselItemInGroup))
+                    if (md5HashToCarouselItemMap.TryGetValue(md5Hash, out var carouselItemInGroup))
                     {
                         sortedItems.Add(carouselItemInGroup.Index, carouselItemInGroup.Item);
-                        MD5HashToCarouselItemMap[MD5Hash] = carouselItemInGroup with { InGroup = true };
+                        md5HashToCarouselItemMap[md5Hash] = carouselItemInGroup with { InGroup = true };
                     }
                 }
 
@@ -443,7 +444,8 @@ namespace osu.Game.Screens.SelectV2
             }
 
             var itemsNotInCollection = new SortedList<int, CarouselItem>();
-            foreach (var (item, index, inGroup) in MD5HashToCarouselItemMap.Values)
+
+            foreach (var (item, index, inGroup) in md5HashToCarouselItemMap.Values)
             {
                 if (!inGroup)
                 {

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterGrouping.cs
@@ -422,7 +422,6 @@ namespace osu.Game.Screens.SelectV2
                 var collection = collections[i];
                 var collectionGroupDefinition = new GroupDefinition(i, collection.Name);
 
-                // Preserve carousel sorting
                 var sortedItems = new SortedList<int, CarouselItem>();
 
                 foreach (var MD5Hash in collection.BeatmapMD5Hashes)


### PR DESCRIPTION
### Before
https://www.youtube.com/watch?v=uZzhPqDG5s4

### After
https://www.youtube.com/watch?v=lnmJrXZut3g

Loading time goes from ~77 seconds to ~1 second

The old algorithm was going through the list of every map in every collection for **every** carousel item, amounting to N*M complexity, where N is the amount of maps, and M is the amount of maps in collections. This nested loop is unnecessary, as collections are already a representation of beatmap groups, and so the operation should not take quadratic time.

The new algorithm goes as follows :
- Go through the list of carousel items once and build a dictionary to lookup by `MD5Hash`
- Go through each collection, and create the groups by looking up the `CarouselItem`s in the previously built dictionary
- Make an additional group for beatmaps with no collections

The ugly part here is that because sorting happens before grouping, we have to store the index of `CarouselItem`s in order to preserve the sorting. This explains the usage of `SortedList`.