### PR TITLE
Add mechanism for rulesets to add their own menu items to the editor …

### DIFF
--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -28,6 +28,7 @@ using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
@@ -451,5 +452,10 @@ namespace osu.Game.Rulesets
         /// Can be overridden to avoid showing scroll speed changes in the editor.
         /// </summary>
         public virtual bool EditorShowScrollSpeed => true;
+
+        /// <summary>
+        /// Can be overridden to add custom menu items to the <see cref="Editor"/>'s menu bar.
+        /// </summary>
+        public virtual RulesetEditorMenuBarItems CreateEditorMenuBarItems() => new RulesetEditorMenuBarItems.Default();
     }
 }

--- a/osu.Game/Screens/Edit/RulesetEditorMenuBarItems.cs
+++ b/osu.Game/Screens/Edit/RulesetEditorMenuBarItems.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Edit
+{
+    /// <summary>
+    /// Allows for providing custom menu items to be appended to the <see cref="Editor"/>'s menu bar.
+    /// </summary>
+    public abstract partial class RulesetEditorMenuBarItems : Component
+    {
+        /// <summary>
+        /// Creates an enumerable with menu items to be appended to the <see cref="Editor"/>'s menu bar for the supplied <paramref name="type"/>.
+        /// </summary>
+        public abstract IEnumerable<MenuItem> CreateMenuItems(EditorMenuBarItemType type);
+
+        public sealed partial class Default : RulesetEditorMenuBarItems
+        {
+            public override IEnumerable<MenuItem> CreateMenuItems(EditorMenuBarItemType type) => Enumerable.Empty<MenuItem>();
+        }
+    }
+
+    public enum EditorMenuBarItemType
+    {
+        File,
+        Edit,
+        View,
+        Timing
+    }
+}


### PR DESCRIPTION
Prerequisite to #35700 

Adds an API for rulesets to add their own menu items to the editor menubar.

Since at the creation of the menu items access to DI is needed (i.e. to get ahold of a ConfigManager), the `RulesetEditorMenuBarItems` class extends from `Component` and is added as a child to the `Editor`.