### PR TITLE
Add ability to display autoplay cursor in editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Osu.Configuration
             SetDefault(OsuRulesetSetting.ReplayCursorPathEnabled, false);
             SetDefault(OsuRulesetSetting.ReplayCursorHideEnabled, false);
             SetDefault(OsuRulesetSetting.ReplayAnalysisDisplayLength, 800);
+
+            SetDefault(OsuRulesetSetting.EditorShowGameplayCursor, false);
         }
     }
 
@@ -45,5 +47,8 @@ namespace osu.Game.Rulesets.Osu.Configuration
         ReplayCursorPathEnabled,
         ReplayCursorHideEnabled,
         ReplayAnalysisDisplayLength,
+
+        // Editor
+        EditorShowGameplayCursor,
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
@@ -3,9 +3,11 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit;
@@ -26,14 +28,20 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private partial class OsuEditorPlayfield : OsuPlayfield
         {
+            private readonly BindableBool showCursor = new BindableBool();
+
             [Resolved]
             private EditorBeatmap editorBeatmap { get; set; } = null!;
-
-            protected override GameplayCursorContainer? CreateCursor() => null;
 
             public OsuEditorPlayfield()
             {
                 HitPolicy = new AnyOrderHitPolicy();
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuRulesetConfigManager config)
+            {
+                config.BindWith(OsuRulesetSetting.EditorShowGameplayCursor, showCursor);
             }
 
             protected override void LoadComplete()
@@ -41,6 +49,8 @@ namespace osu.Game.Rulesets.Osu.Edit
                 base.LoadComplete();
 
                 editorBeatmap.BeatmapReprocessed += onBeatmapReprocessed;
+
+                showCursor.BindValueChanged(visible => Cursor!.Alpha = visible.NewValue ? 1 : 0, true);
             }
 
             private void onBeatmapReprocessed() => ApplyCircleSizeToPlayfieldBorder(editorBeatmap);

--- a/osu.Game.Rulesets.Osu/Edit/OsuRulesetEditorMenuBarItems.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuRulesetEditorMenuBarItems.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Osu.Configuration;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Osu.Edit
+{
+    public partial class OsuRulesetEditorMenuBarItems : RulesetEditorMenuBarItems
+    {
+        private readonly BindableBool showCursor = new BindableBool();
+
+        [BackgroundDependencyLoader]
+        private void load(IRulesetConfigCache configCache)
+        {
+            var config = configCache.GetConfigFor(new OsuRuleset()) as OsuRulesetConfigManager;
+
+            config?.BindWith(OsuRulesetSetting.EditorShowGameplayCursor, showCursor);
+        }
+
+        public override IEnumerable<MenuItem> CreateMenuItems(EditorMenuBarItemType type)
+        {
+            switch (type)
+            {
+                case EditorMenuBarItemType.View:
+                    yield return new ToggleMenuItem("Show gameplay cursor")
+                    {
+                        State = { BindTarget = showCursor }
+                    };
+
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -41,6 +41,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
@@ -448,5 +449,7 @@ namespace osu.Game.Rulesets.Osu
         }
 
         public override bool EditorShowScrollSpeed => false;
+
+        public override RulesetEditorMenuBarItems? CreateEditorMenuBarItems() => new OsuRulesetEditorMenuBarItems();
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -450,6 +450,6 @@ namespace osu.Game.Rulesets.Osu
 
         public override bool EditorShowScrollSpeed => false;
 
-        public override RulesetEditorMenuBarItems? CreateEditorMenuBarItems() => new OsuRulesetEditorMenuBarItems();
+        public override RulesetEditorMenuBarItems CreateEditorMenuBarItems() => new OsuRulesetEditorMenuBarItems();
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -62,6 +62,11 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             }
         }
 
+        /// <summary>
+        /// Whether new parts should be added to the trail
+        /// </summary>
+        public bool Enabled = true;
+
         private readonly TrailPart[] parts = new TrailPart[max_sprites];
         private Anchor trailOrigin = Anchor.Centre;
         private int currentIndex;
@@ -205,12 +210,23 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private void addPart(Vector2 localSpacePosition)
         {
+            if (!Enabled)
+                return;
+
             parts[currentIndex].Position = localSpacePosition;
             parts[currentIndex].Time = time + 1;
             parts[currentIndex].Scale = NewPartScale;
             ++parts[currentIndex].InvalidationID;
 
             currentIndex = (currentIndex + 1) % max_sprites;
+        }
+
+        public void ClearParts()
+        {
+            for (int i = 0; i < parts.Length; i++)
+                parts[i] = default;
+
+            currentIndex = 0;
         }
 
         protected override DrawNode CreateDrawNode() => new TrailDrawNode(this);

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private readonly Bindable<bool> showTrail = new Bindable<bool>(true);
 
-        private readonly SkinnableDrawable cursorTrail;
+        protected readonly SkinnableDrawable CursorTrail;
 
         private readonly CursorRippleVisualiser rippleVisualiser;
 
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                 RelativeSizeAxes = Axes.Both,
                 Children = new CompositeDrawable[]
                 {
-                    cursorTrail = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.CursorTrail), _ => new DefaultCursorTrail(), confineMode: ConfineMode.NoScaling),
+                    CursorTrail = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.CursorTrail), _ => new DefaultCursorTrail(), confineMode: ConfineMode.NoScaling),
                     rippleVisualiser = new CursorRippleVisualiser(),
                     new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.CursorParticles), confineMode: ConfineMode.NoScaling),
                 }
@@ -57,14 +57,14 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         {
             base.LoadComplete();
 
-            showTrail.BindValueChanged(v => cursorTrail.FadeTo(v.NewValue ? 1 : 0, 200), true);
+            showTrail.BindValueChanged(v => CursorTrail.FadeTo(v.NewValue ? 1 : 0, 200), true);
 
             ActiveCursor.CursorScale.BindValueChanged(e =>
             {
                 var newScale = new Vector2(e.NewValue);
 
                 rippleVisualiser.CursorScale = newScale;
-                cursorTrail.Scale = newScale;
+                CursorTrail.Scale = newScale;
             }, true);
         }
 
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         {
             base.Update();
 
-            if (cursorTrail.Drawable is CursorTrail trail)
+            if (CursorTrail.Drawable is CursorTrail trail)
             {
                 trail.NewPartScale = ActiveCursor.CurrentExpandedScale;
                 trail.PartRotation = ActiveCursor.CurrentRotation;

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -28,6 +28,7 @@ using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
@@ -451,5 +452,10 @@ namespace osu.Game.Rulesets
         /// Can be overridden to avoid showing scroll speed changes in the editor.
         /// </summary>
         public virtual bool EditorShowScrollSpeed => true;
+
+        /// <summary>
+        /// Can be overridden to add custom menu items to the <see cref="Editor"/>'s menu bar.
+        /// </summary>
+        public virtual RulesetEditorMenuBarItems CreateEditorMenuBarItems() => new RulesetEditorMenuBarItems.Default();
     }
 }

--- a/osu.Game/Screens/Edit/RulesetEditorMenuBarItems.cs
+++ b/osu.Game/Screens/Edit/RulesetEditorMenuBarItems.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Edit
+{
+    /// <summary>
+    /// Allows for providing custom menu items to be appended to the <see cref="Editor"/>'s menu bar.
+    /// </summary>
+    public abstract partial class RulesetEditorMenuBarItems : Component
+    {
+        /// <summary>
+        /// Creates an enumerable with menu items to be appended to the <see cref="Editor"/>'s menu bar for the supplied <paramref name="type"/>.
+        /// </summary>
+        public abstract IEnumerable<MenuItem> CreateMenuItems(EditorMenuBarItemType type);
+
+        public sealed partial class Default : RulesetEditorMenuBarItems
+        {
+            public override IEnumerable<MenuItem> CreateMenuItems(EditorMenuBarItemType type) => Enumerable.Empty<MenuItem>();
+        }
+    }
+
+    public enum EditorMenuBarItemType
+    {
+        File,
+        Edit,
+        View,
+        Timing
+    }
+}


### PR DESCRIPTION
Depends on #35699
Closes #35486 

Adds the ability to display the autoplay cursor in the osu-ruleset editor.

https://github.com/user-attachments/assets/ac593e3c-9936-44a9-a1b8-79c7694881ba

also, you should play the [map](https://osu.ppy.sh/beatmapsets/1557153#osu/3181080) used for the video, it's very fun.
