### PR TITLE
Fix various screens not registering themselves as `IPreviewTrackOwner`

### DIFF
--- a/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
+++ b/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
@@ -220,10 +220,13 @@ namespace osu.Game.Tests.Visual.Components
 
             protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             {
-                var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
                 if (registerAsOwner)
-                    dependencies.CacheAs<IPreviewTrackOwner>(this);
-                return dependencies;
+                {
+                    // Automatically handled by interface caching.
+                    return base.CreateChildDependencies(parent);
+                }
+
+                return new DependencyContainer();
             }
         }
 

--- a/osu.Game/Audio/IPreviewTrackOwner.cs
+++ b/osu.Game/Audio/IPreviewTrackOwner.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+
 namespace osu.Game.Audio
 {
     /// <summary>
@@ -10,6 +12,7 @@ namespace osu.Game.Audio
     /// <see cref="IPreviewTrackOwner"/>s can cancel the currently playing <see cref="PreviewTrack"/> through the
     /// global <see cref="PreviewTrackManager"/> if they're the owner of the playing <see cref="PreviewTrack"/>.
     /// </remarks>
+    [Cached]
     public interface IPreviewTrackOwner
     {
     }

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -15,7 +15,6 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.Containers
 {
-    [Cached(typeof(IPreviewTrackOwner))]
     public abstract partial class OsuFocusedOverlayContainer : FocusedOverlayContainer, IPreviewTrackOwner, IKeyBindingHandler<GlobalAction>
     {
         protected readonly IBindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -44,7 +44,6 @@ using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
-    [Cached(typeof(IPreviewTrackOwner))]
     public partial class DailyChallenge : OsuScreen, IPreviewTrackOwner, IHandlePresentBeatmap
     {
         private readonly Room room;

--- a/osu.Game/Screens/Play/SoloSpectatorScreen.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorScreen.cs
@@ -30,7 +30,6 @@ using osuTK;
 
 namespace osu.Game.Screens.Play
 {
-    [Cached(typeof(IPreviewTrackOwner))]
     public partial class SoloSpectatorScreen : SpectatorScreen, IPreviewTrackOwner
     {
         [Resolved]


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/35707

This affected multiplayer, playlists, and matchmaking.