### PR TITLE
Fix bad localisation reuse in pause overlay

### DIFF
--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -22,6 +22,7 @@ using osu.Game.Input.Bindings;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Utils;
 
 namespace osu.Game.Screens.Play
@@ -236,7 +237,7 @@ namespace osu.Game.Screens.Play
             if (gameplayState != null)
             {
                 playInfoText.NewLine();
-                playInfoText.AddText(SongSelectStrings.Accuracy);
+                playInfoText.AddText(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy);
                 playInfoText.AddText(": ");
                 playInfoText.AddText(gameplayState!.ScoreProcessor.Accuracy.Value.FormatAccuracy(), cp => cp.Font = cp.Font.With(weight: FontWeight.Bold));
             }


### PR DESCRIPTION
Closes https://github.com/ppy/osu-resources/issues/393.

Matches break overlay:

https://github.com/ppy/osu/blob/5dc44fbdf9dfaff573f596b0085a954c6f420e07/osu.Game/Screens/Play/Break/BreakInfo.cs#L48