### PR TITLE
Add pooling support to smoke segments

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSmoke.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSmoke.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
@@ -10,6 +11,7 @@ using osu.Framework.Input.States;
 using osu.Framework.Logging;
 using osu.Framework.Testing.Input;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Skinning;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
@@ -58,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
                 foreach (var smokeContainer in smokeContainers)
                 {
-                    if (smokeContainer.Children.Count != 0)
+                    if (smokeContainer.Children.OfType<SkinnableDrawable>().Any())
                         return false;
                 }
 

--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -77,9 +77,14 @@ namespace osu.Game.Rulesets.Osu.Skinning
             base.LoadComplete();
 
             RelativeSizeAxes = Axes.Both;
+        }
 
-            LifetimeStart = smokeStartTime = Time.Current;
-
+        public void StartDrawing(double time)
+        {
+            LifetimeStart = smokeStartTime = time;
+            LifetimeEnd = smokeEndTime = double.MaxValue;
+            SmokePoints.Clear();
+            lastPosition = null;
             totalDistance = pointInterval;
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/35703
- Supersedes / closes https://github.com/ppy/osu/pull/35711

Can test using something dumb like

```diff
diff --git a/osu.Game/Skinning/LegacySkin.cs b/osu.Game/Skinning/LegacySkin.cs index 11b3b5c71d..e21d8389ef 100644
--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -8,6 +8,7 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using JetBrains.Annotations;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
@@ -540,6 +541,10 @@ protected override void ParseConfigurationStream(Stream stream)
                 case "Menu/fountain-star":
                     componentName = "star2";
                     break;
+
+                case "cursor-smoke":
+                    Thread.Sleep(500);
+                    break;
             }

             Texture? texture = null;
```