### PR TITLE
Fix thai font and spacing for 24-hour time display and chat

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -182,8 +182,7 @@ namespace osu.Game.Overlays.Chat
                                 Shadow = false,
                                 Anchor = Anchor.TopLeft,
                                 Origin = Anchor.TopLeft,
-                                Spacing = new Vector2(-1, 0),
-                                Font = OsuFont.GetFont(size: font_size, weight: FontWeight.SemiBold, fixedWidth: true),
+                                Font = OsuFont.GetFont(size: font_size, weight: FontWeight.SemiBold),
                                 AlwaysPresent = true,
                             },
                             drawableUsername = new DrawableChatUsername(message.Sender)
@@ -301,6 +300,10 @@ namespace osu.Game.Overlays.Chat
         private void updateTimestamp()
         {
             drawableTimestamp.Text = message.Timestamp.LocalDateTime.ToLocalisableString(prefer24HourTime.Value ? @"HH:mm" : @"hh:mm tt");
+            drawableTimestamp.Font = prefer24HourTime.Value
+                ? OsuFont.GetFont(size: font_size, weight: FontWeight.SemiBold, fixedWidth: true)
+                : OsuFont.GetFont(size: font_size, weight: FontWeight.SemiBold);
+            drawableTimestamp.Spacing = prefer24HourTime.Value ? new Vector2(-1, 0) : Vector2.Zero;
         }
 
         private static readonly Color4[] default_username_colours =

--- a/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
@@ -63,7 +63,6 @@ namespace osu.Game.Overlays.Toolbar
                 realTime = new OsuSpriteText
                 {
                     Font = OsuFont.Default.With(fixedWidth: true),
-                    Spacing = new Vector2(-1.5f, 0),
                 },
                 runningText = new FillFlowContainer
                 {
@@ -94,6 +93,8 @@ namespace osu.Game.Overlays.Toolbar
         protected override void UpdateDisplay(DateTimeOffset now)
         {
             realTime.Text = now.ToLocalisableString(use24HourDisplay ? @"HH:mm:ss" : @"h:mm:ss tt");
+            realTime.Font = use24HourDisplay ? OsuFont.Default.With(fixedWidth: true) : OsuFont.Default;
+            realTime.Spacing = use24HourDisplay ? new Vector2(-1.5f, 0) : Vector2.Zero;
             gameTime.Text = $"{new TimeSpan(TimeSpan.TicksPerSecond * (int)(Clock.CurrentTime / 1000)):c}";
         }
 


### PR DESCRIPTION
- Disable fixedWidth font for 12-hour clock display to support Thai AM/PM text
- Remove negative spacing when displaying Thai characters
- Prevent text overlap and incorrect combining character positioning
- 24-hour mode continues using fixedWidth to prevent jitter

| master| fix/time-24h-font-spacing | [osu-framework/fix/font-combining](https://github.com/ppy/osu-framework/pull/6671) | 
| :---: | :---: | :---: |
| <img width="330" height="68" alt="image" src="https://github.com/user-attachments/assets/78e31f6a-517f-4edf-9b5c-96cd3d596db8" /> | <img width="280" height="64" alt="image" src="https://github.com/user-attachments/assets/187c7b6c-0c07-4fbd-8b08-d0df9680f8ee" /> | <img width="279" height="68" alt="image" src="https://github.com/user-attachments/assets/7ecbc58e-c0eb-4de5-8db1-e40d3119129f" /> |
<img width="185" height="566" alt="image" src="https://github.com/user-attachments/assets/f2079268-d397-4eb1-8588-31248dda9ef3" /> |<img width="167" height="559" alt="image" src="https://github.com/user-attachments/assets/d4017fd4-2de4-42b5-a522-ead6414e6131" /> | <img width="157" height="567" alt="image" src="https://github.com/user-attachments/assets/aca6594a-4cb4-41d7-82dd-431c42c5549c" /> |