### PR TITLE
Improve fullcombo threshold formula

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -115,9 +115,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double missCount = 0;
 
+            // If sliders in the map are hard - it's likely for player to drop sliderends
+            // If map has easy sliders - it's more likely for player to sliderbreak
+            double likelyMissedSliderendPortion = 0.02 + 0.18 * (1 - Math.Pow(attributes.SliderFactor, 5));
+
             // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
-            // In classic scores we can't know the amount of dropped sliders so we estimate to 10% of all sliders on the map
-            double fullComboThreshold = attributes.MaxCombo - 0.1 * attributes.SliderCount;
+            // In classic scores we can't know the amount of dropped sliders so we estimate it
+            double fullComboThreshold = attributes.MaxCombo - likelyMissedSliderendPortion * attributes.SliderCount;
 
             if (score.MaxCombo < fullComboThreshold)
                 missCount = Math.Pow(fullComboThreshold / Math.Max(1.0, score.MaxCombo), 2.5);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -117,11 +117,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // If sliders in the map are hard - it's likely for player to drop sliderends
             // If map has easy sliders - it's more likely for player to sliderbreak
-            double likelyMissedSliderendPortion = 0.03 + 0.12 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
+            double likelyMissedSliderendPortion = 0.04 + 0.06 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
 
             // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
             // In classic scores we can't know the amount of dropped sliders so we estimate it
-            double fullComboThreshold = attributes.MaxCombo - Math.Min(5 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
+            double fullComboThreshold = attributes.MaxCombo - Math.Min(4 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
 
             if (score.MaxCombo < fullComboThreshold)
                 missCount = Math.Pow(fullComboThreshold / Math.Max(1.0, score.MaxCombo), 2.5);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // If sliders in the map are hard - it's likely for player to drop sliderends
             // If map has easy sliders - it's more likely for player to sliderbreak
-            double likelyMissedSliderendPortion = 0.02 + 0.18 * (1 - Math.Pow(attributes.SliderFactor, 5));
+            double likelyMissedSliderendPortion = 0.05 + 0.15 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
 
             // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
             // In classic scores we can't know the amount of dropped sliders so we estimate it

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -117,11 +117,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // If sliders in the map are hard - it's likely for player to drop sliderends
             // If map has easy sliders - it's more likely for player to sliderbreak
-            double likelyMissedSliderendPortion = 0.05 + 0.15 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
+            double likelyMissedSliderendPortion = 0.03 + 0.12 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
 
             // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
             // In classic scores we can't know the amount of dropped sliders so we estimate it
-            double fullComboThreshold = attributes.MaxCombo - likelyMissedSliderendPortion * attributes.SliderCount;
+            double fullComboThreshold = attributes.MaxCombo - Math.Min(5 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
 
             if (score.MaxCombo < fullComboThreshold)
                 missCount = Math.Pow(fullComboThreshold / Math.Max(1.0, score.MaxCombo), 2.5);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -345,7 +345,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
                 // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
                 // In classic scores we can't know the amount of dropped sliders so we estimate it
-                double fullComboThreshold = attributes.MaxCombo - likelyMissedSliderendPortion * attributes.SliderCount;
+                double fullComboThreshold = attributes.MaxCombo - Math.Min(5 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
 
                 if (scoreMaxCombo < fullComboThreshold)
                     missCount = fullComboThreshold / Math.Max(1.0, scoreMaxCombo);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -341,7 +341,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             {
                 // If sliders in the map are hard - it's likely for player to drop sliderends
                 // If map has easy sliders - it's more likely for player to sliderbreak
-                double likelyMissedSliderendPortion = 0.02 + 0.18 * (1 - Math.Pow(attributes.SliderFactor, 5));
+                double likelyMissedSliderendPortion = 0.05 + 0.15 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
 
                 // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
                 // In classic scores we can't know the amount of dropped sliders so we estimate it

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -339,9 +339,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (usingClassicSliderAccuracy)
             {
+                // If sliders in the map are hard - it's likely for player to drop sliderends
+                // If map has easy sliders - it's more likely for player to sliderbreak
+                double likelyMissedSliderendPortion = 0.02 + 0.18 * (1 - Math.Pow(attributes.SliderFactor, 5));
+
                 // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
-                // In classic scores we can't know the amount of dropped sliders so we estimate to 10% of all sliders on the map
-                double fullComboThreshold = attributes.MaxCombo - 0.1 * attributes.SliderCount;
+                // In classic scores we can't know the amount of dropped sliders so we estimate it
+                double fullComboThreshold = attributes.MaxCombo - likelyMissedSliderendPortion * attributes.SliderCount;
 
                 if (scoreMaxCombo < fullComboThreshold)
                     missCount = fullComboThreshold / Math.Max(1.0, scoreMaxCombo);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -341,11 +341,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             {
                 // If sliders in the map are hard - it's likely for player to drop sliderends
                 // If map has easy sliders - it's more likely for player to sliderbreak
-                double likelyMissedSliderendPortion = 0.05 + 0.15 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
+                double likelyMissedSliderendPortion = 0.04 + 0.06 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
 
                 // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
                 // In classic scores we can't know the amount of dropped sliders so we estimate it
-                double fullComboThreshold = attributes.MaxCombo - Math.Min(5 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
+                double fullComboThreshold = attributes.MaxCombo - Math.Min(4 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
 
                 if (scoreMaxCombo < fullComboThreshold)
                     missCount = fullComboThreshold / Math.Max(1.0, scoreMaxCombo);


### PR DESCRIPTION
It used to always take 10%.
Now it's down to 5% if map has no hard sliders, since in this case probability of dropping many sliderends is low.
For maps with hard sliders the portion can reach up to 20%.