### PR TITLE
Fix cursor incorrectly flashing red after a rewind in replays with Alternate mod active

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected OsuAction? LastAcceptedAction { get; private set; }
 
+        private double? lastUpdateTime;
+
         /// <summary>
         /// A tracker for periods where alternate should not be forced (i.e. non-gameplay periods).
         /// </summary>
@@ -67,6 +69,13 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             if (LastAcceptedAction != null && nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
                 LastAcceptedAction = null;
+
+            if (lastUpdateTime != null && playfield.Time.Current < lastUpdateTime)
+            {
+                LastAcceptedAction = null;
+            }
+
+            lastUpdateTime = playfield.Time.Current;
         }
 
         protected abstract bool CheckValidNewAction(OsuAction action);

--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected OsuAction? LastAcceptedAction { get; private set; }
 
-        private double? lastUpdateTime;
-
         /// <summary>
         /// A tracker for periods where alternate should not be forced (i.e. non-gameplay periods).
         /// </summary>
@@ -70,12 +68,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             if (LastAcceptedAction != null && nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
                 LastAcceptedAction = null;
 
-            if (lastUpdateTime != null && playfield.Time.Current < lastUpdateTime)
-            {
+            if (LastAcceptedAction != null && gameplayClock.IsRewinding)
                 LastAcceptedAction = null;
-            }
-
-            lastUpdateTime = playfield.Time.Current;
         }
 
         protected abstract bool CheckValidNewAction(OsuAction action);


### PR DESCRIPTION
fixes #18973 
If you rewind a replay with the alternate mod and find yourself at a point where the same key was pressed as before the rewind, the cursor will remain red until the player in the replay presses the same key twice, or until a break occurs.
The simplest fix is ​​to detect that the rewind was used (based on game time) and forget the previous keypress. This isn't a perfect fix, since if you rewind to a point where the same key is pressed a second time, it won't be visible, but otherwise everything works.
Another option would be to record the history of all keypresses and see what was pressed at that point when rewinding, but that's a pretty terrible idea.