### PR TITLE
Avoid nuking logged in user's joined channels on showing match chat in tournament client

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays.Chat;
@@ -61,13 +63,32 @@ namespace osu.Game.Tournament.Tests.Components
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             });
-
-            chatDisplay.Channel.Value = testChannel;
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            AddStep("set up API", () =>
+            {
+                ((DummyAPIAccess)API).HandleRequest = req =>
+                {
+                    switch (req)
+                    {
+                        case JoinChannelRequest joinChannelRequest:
+                            joinChannelRequest.TriggerSuccess();
+                            return true;
+
+                        case LeaveChannelRequest leaveChannelRequest:
+                            leaveChannelRequest.TriggerSuccess();
+                            return true;
+
+                        default:
+                            return false;
+                    }
+                };
+            });
+            AddStep("set channel", () => chatDisplay.Channel.Value = testChannel);
 
             AddStep("message from admin", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {

--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -41,30 +41,33 @@ namespace osu.Game.Tournament.Components
                 chatChannel.BindTo(ipc.ChatChannel);
                 chatChannel.BindValueChanged(c =>
                 {
-                    if (string.IsNullOrWhiteSpace(c.NewValue))
-                        return;
-
-                    int id = int.Parse(c.NewValue);
-
-                    if (id <= 0) return;
-
                     if (manager == null)
                     {
                         AddInternal(manager = new ChannelManager(api));
                         Channel.BindTo(manager.CurrentChannel);
                     }
 
-                    foreach (var ch in manager.JoinedChannels.ToList())
-                        manager.LeaveChannel(ch);
-
-                    var channel = new Channel
+                    if (int.TryParse(c.OldValue, out int oldChannelId) && oldChannelId > 0)
                     {
-                        Id = id,
-                        Type = ChannelType.Public
-                    };
+                        var joinedChannel = manager.JoinedChannels.SingleOrDefault(ch => ch.Id == oldChannelId);
+                        if (joinedChannel != null)
+                            manager.LeaveChannel(joinedChannel);
+                    }
 
-                    manager.JoinChannel(channel);
-                    manager.CurrentChannel.Value = channel;
+                    if (string.IsNullOrWhiteSpace(c.NewValue))
+                        return;
+
+                    if (int.TryParse(c.NewValue, out int newChannelId) && newChannelId > 0)
+                    {
+                        var channel = new Channel
+                        {
+                            Id = newChannelId,
+                            Type = ChannelType.Public
+                        };
+
+                        manager.JoinChannel(channel);
+                        manager.CurrentChannel.Value = channel;
+                    }
                 }, true);
             }
         }

--- a/osu.Game/Properties/AssemblyInfo.cs
+++ b/osu.Game/Properties/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("osu.Game.Tests.Dynamic")]
 [assembly: InternalsVisibleTo("osu.Game.Tests.iOS")]
 [assembly: InternalsVisibleTo("osu.Game.Tests.Android")]
+[assembly: InternalsVisibleTo("osu.Game.Tournament.Tests")]
 
 // intended for Moq usage
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35721.

I worry that straight up removing the nuke and not adding any channel leave calls in exchange is going to leave tourney client users with the *inverse* problem of being joined into a gorillion channels from multiplayer matches they broadcasted, so this attempts to strike a reasonable balance.

Crudely tested to work on dev via manual emulation of `ipc-channel.txt` but not in an actual full-stack tournament-like setting. If someone who has everything set up correctly is so inclined (@ThePooN?) I invite extra testing.