### PR TITLE
Use new sliders-with-text-input in editor toolboxes

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2025.1118.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2025.1121.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -245,13 +245,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddAssert("grid spacing is distance to slider tail", () =>
             {
                 var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
-                return Precision.AlmostEquals(composer.Spacing.Value.X, 32.05, 0.01)
+                return Precision.AlmostEquals(composer.Spacing.Value.X, 32.05, 0.1)
                        && Precision.AlmostEquals(composer.Spacing.Value.X, composer.Spacing.Value.Y);
             });
             AddAssert("grid rotation points to slider tail", () =>
             {
                 var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
-                return Precision.AlmostEquals(composer.GridLineRotation.Value, 0.09, 0.01);
+                return Precision.AlmostEquals(composer.GridLineRotation.Value, 0.09, 0.1);
             });
 
             AddStep("start grid placement", () => InputManager.Key(Key.Number5));
@@ -280,9 +280,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddAssert("grid spacing and rotation unchanged", () =>
             {
                 var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
-                return Precision.AlmostEquals(composer.Spacing.Value.X, 32.05, 0.01)
+                return Precision.AlmostEquals(composer.Spacing.Value.X, 32.05, 0.1)
                        && Precision.AlmostEquals(composer.Spacing.Value.X, composer.Spacing.Value.Y)
-                       && Precision.AlmostEquals(composer.GridLineRotation.Value, 0.09, 0.01);
+                       && Precision.AlmostEquals(composer.GridLineRotation.Value, 0.09, 0.1);
             });
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/GridPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/GridPlacementBlueprint.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
         {
             this.gridToolboxGroup = gridToolboxGroup;
             originalOrigin = gridToolboxGroup.StartPosition.Value;
-            originalSpacing = gridToolboxGroup.Spacing.Value;
+            originalSpacing = gridToolboxGroup.GridLineSpacing.Value;
             originalRotation = gridToolboxGroup.GridLinesRotation.Value;
         }
 
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
             {
                 // Reset the grid to the default values.
                 gridToolboxGroup.StartPosition.Value = gridToolboxGroup.StartPosition.Default;
-                gridToolboxGroup.Spacing.Value = gridToolboxGroup.Spacing.Default;
+                gridToolboxGroup.GridLineSpacing.Value = gridToolboxGroup.GridLineSpacing.Default;
                 if (!gridToolboxGroup.GridLinesRotation.Disabled)
                     gridToolboxGroup.GridLinesRotation.Value = gridToolboxGroup.GridLinesRotation.Default;
                 EndPlacement(true);
@@ -112,7 +112,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
                 // Default to the original spacing and rotation if the distance is too small.
                 if (Vector2.Distance(gridToolboxGroup.StartPosition.Value, pos) < 2)
                 {
-                    gridToolboxGroup.Spacing.Value = originalSpacing;
+                    gridToolboxGroup.GridLineSpacing.Value = originalSpacing;
                     if (!gridToolboxGroup.GridLinesRotation.Disabled)
                         gridToolboxGroup.GridLinesRotation.Value = originalRotation;
                 }
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
         private void resetGridState()
         {
             gridToolboxGroup.StartPosition.Value = originalOrigin;
-            gridToolboxGroup.Spacing.Value = originalSpacing;
+            gridToolboxGroup.GridLineSpacing.Value = originalSpacing;
             if (!gridToolboxGroup.GridLinesRotation.Disabled)
                 gridToolboxGroup.GridLinesRotation.Value = originalRotation;
         }

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -5,8 +5,10 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -60,6 +62,9 @@ namespace osu.Game.Rulesets.Osu.Edit
         private ExpandableSlider<int> toleranceSlider = null!;
         private ExpandableSlider<int> cornerThresholdSlider = null!;
         private ExpandableSlider<int> circleThresholdSlider = null!;
+
+        [Resolved]
+        private IExpandingContainer? expandingContainer { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -115,6 +120,11 @@ namespace osu.Game.Rulesets.Osu.Edit
             CircleThreshold.BindValueChanged(threshold =>
                 displayCircleThreshold.Value = internalToDisplayCircleThreshold(threshold.NewValue)
             );
+
+            expandingContainer?.Expanded.BindValueChanged(v =>
+            {
+                Spacing = v.NewValue ? new Vector2(5) : new Vector2(15);
+            }, true);
 
             float displayToInternalTolerance(float v) => v / 50f;
             int internalToDisplayTolerance(float v) => (int)Math.Round(v * 50f);

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -68,15 +68,18 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 toleranceSlider = new ExpandableSlider<int>
                 {
-                    Current = displayTolerance
+                    Current = displayTolerance,
+                    ExpandedLabelText = "Control point spacing",
                 },
                 cornerThresholdSlider = new ExpandableSlider<int>
                 {
-                    Current = displayCornerThreshold
+                    Current = displayCornerThreshold,
+                    ExpandedLabelText = "Corner bias",
                 },
                 circleThresholdSlider = new ExpandableSlider<int>
                 {
-                    Current = displayCircleThreshold
+                    Current = displayCircleThreshold,
+                    ExpandedLabelText = "Perfect curve bias"
                 }
             };
         }
@@ -88,24 +91,18 @@ namespace osu.Game.Rulesets.Osu.Edit
             displayTolerance.BindValueChanged(tolerance =>
             {
                 toleranceSlider.ContractedLabelText = $"C. P. S.: {tolerance.NewValue:N0}";
-                toleranceSlider.ExpandedLabelText = $"Control Point Spacing: {tolerance.NewValue:N0}";
-
                 Tolerance.Value = displayToInternalTolerance(tolerance.NewValue);
             }, true);
 
             displayCornerThreshold.BindValueChanged(threshold =>
             {
-                cornerThresholdSlider.ContractedLabelText = $"C. T.: {threshold.NewValue:N0}";
-                cornerThresholdSlider.ExpandedLabelText = $"Corner Threshold: {threshold.NewValue:N0}";
-
+                cornerThresholdSlider.ContractedLabelText = $"C. B.: {threshold.NewValue:N0}";
                 CornerThreshold.Value = displayToInternalCornerThreshold(threshold.NewValue);
             }, true);
 
             displayCircleThreshold.BindValueChanged(threshold =>
             {
-                circleThresholdSlider.ContractedLabelText = $"P. C. T.: {threshold.NewValue:N0}";
-                circleThresholdSlider.ExpandedLabelText = $"Perfect Curve Threshold: {threshold.NewValue:N0}";
-
+                circleThresholdSlider.ContractedLabelText = $"P. C. B.: {threshold.NewValue:N0}";
                 CircleThreshold.Value = displayToInternalCircleThreshold(threshold.NewValue);
             }, true);
 

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -44,19 +44,22 @@ namespace osu.Game.Rulesets.Osu.Edit
         private readonly BindableInt displayTolerance = new BindableInt(90)
         {
             MinValue = 5,
-            MaxValue = 100
+            MaxValue = 100,
+            Precision = 1,
         };
 
         private readonly BindableInt displayCornerThreshold = new BindableInt(40)
         {
             MinValue = 5,
-            MaxValue = 100
+            MaxValue = 100,
+            Precision = 1,
         };
 
         private readonly BindableInt displayCircleThreshold = new BindableInt(30)
         {
             MinValue = 0,
-            MaxValue = 100
+            MaxValue = 100,
+            Precision = 1,
         };
 
         private ExpandableSlider<int> toleranceSlider = null!;

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = 0f,
             MaxValue = OsuPlayfield.BASE_SIZE.X,
-            Precision = 0.01f,
+            Precision = 0.1f,
         };
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = 0f,
             MaxValue = OsuPlayfield.BASE_SIZE.Y,
-            Precision = 0.01f,
+            Precision = 0.1f,
         };
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = 4f,
             MaxValue = 256f,
-            Precision = 0.01f,
+            Precision = 0.1f,
         };
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = -180f,
             MaxValue = 180f,
-            Precision = 0.01f,
+            Precision = 0.1f,
         };
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// <summary>
         /// The spacing between grid lines.
         /// </summary>
-        public BindableFloat Spacing { get; } = new BindableFloat(4f)
+        public BindableFloat GridLineSpacing { get; } = new BindableFloat(4f)
         {
             MinValue = 4f,
             MaxValue = 256f,
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             float dist = Vector2.Distance(point1, point2);
             while (dist >= max_automatic_spacing)
                 dist /= 2;
-            Spacing.Value = dist;
+            GridLineSpacing.Value = dist;
         }
 
         [BackgroundDependencyLoader]
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 },
                 spacingSlider = new ExpandableSlider<float>
                 {
-                    Current = Spacing,
+                    Current = GridLineSpacing,
                     KeyboardStep = 1,
                     ExpandedLabelText = "Spacing",
                 },
@@ -174,7 +174,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 },
             };
 
-            Spacing.Value = editorBeatmap.GridSize;
+            GridLineSpacing.Value = editorBeatmap.GridSize;
         }
 
         protected override void LoadComplete()
@@ -201,7 +201,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 StartPositionY.Value = pos.NewValue.Y;
             });
 
-            Spacing.BindValueChanged(spacing =>
+            GridLineSpacing.BindValueChanged(spacing =>
             {
                 spacingSlider.ContractedLabelText = $"S: {spacing.NewValue:#,0.##}";
                 SpacingVector.Value = new Vector2(spacing.NewValue);
@@ -239,6 +239,8 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 gridTypeButtons.FadeTo(v.NewValue ? 1f : 0f, 500, Easing.OutQuint);
                 gridTypeButtons.BypassAutoSizeAxes = !v.NewValue ? Axes.Y : Axes.None;
+
+                Spacing = v.NewValue ? new Vector2(5) : new Vector2(15);
             }, true);
         }
 
@@ -252,7 +254,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             switch (e.Action)
             {
                 case GlobalAction.EditorCycleGridSpacing:
-                    Spacing.Value = Spacing.Value * 2 >= max_automatic_spacing ? Spacing.Value / 8 : Spacing.Value * 2;
+                    GridLineSpacing.Value = GridLineSpacing.Value * 2 >= max_automatic_spacing ? GridLineSpacing.Value / 8 : GridLineSpacing.Value * 2;
                     return true;
 
                 case GlobalAction.EditorCycleGridType:

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -127,21 +127,25 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     Current = StartPositionX,
                     KeyboardStep = 1,
+                    ExpandedLabelText = "X offset",
                 },
                 startPositionYSlider = new ExpandableSlider<float>
                 {
                     Current = StartPositionY,
                     KeyboardStep = 1,
+                    ExpandedLabelText = "Y offset",
                 },
                 spacingSlider = new ExpandableSlider<float>
                 {
                     Current = Spacing,
                     KeyboardStep = 1,
+                    ExpandedLabelText = "Spacing",
                 },
                 gridLinesRotationSlider = new ExpandableSlider<float>
                 {
                     Current = GridLinesRotation,
                     KeyboardStep = 1,
+                    ExpandedLabelText = "Rotation",
                 },
                 new FillFlowContainer
                 {
@@ -182,14 +186,12 @@ namespace osu.Game.Rulesets.Osu.Edit
             StartPositionX.BindValueChanged(x =>
             {
                 startPositionXSlider.ContractedLabelText = $"X: {x.NewValue:#,0.##}";
-                startPositionXSlider.ExpandedLabelText = $"X Offset: {x.NewValue:#,0.##}";
                 StartPosition.Value = new Vector2(x.NewValue, StartPosition.Value.Y);
             }, true);
 
             StartPositionY.BindValueChanged(y =>
             {
                 startPositionYSlider.ContractedLabelText = $"Y: {y.NewValue:#,0.##}";
-                startPositionYSlider.ExpandedLabelText = $"Y Offset: {y.NewValue:#,0.##}";
                 StartPosition.Value = new Vector2(StartPosition.Value.X, y.NewValue);
             }, true);
 
@@ -202,7 +204,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             Spacing.BindValueChanged(spacing =>
             {
                 spacingSlider.ContractedLabelText = $"S: {spacing.NewValue:#,0.##}";
-                spacingSlider.ExpandedLabelText = $"Spacing: {spacing.NewValue:#,0.##}";
                 SpacingVector.Value = new Vector2(spacing.NewValue);
                 editorBeatmap.GridSize = (int)spacing.NewValue;
             }, true);
@@ -210,7 +211,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             GridLinesRotation.BindValueChanged(rotation =>
             {
                 gridLinesRotationSlider.ContractedLabelText = $"R: {rotation.NewValue:#,0.##}";
-                gridLinesRotationSlider.ExpandedLabelText = $"Rotation: {rotation.NewValue:#,0.##}";
             }, true);
 
             GridType.BindValueChanged(v =>

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 case PositionSnapGridType.Triangle:
                     var triangularPositionSnapGrid = new TriangularPositionSnapGrid();
 
-                    triangularPositionSnapGrid.Spacing.BindTo(OsuGridToolboxGroup.Spacing);
+                    triangularPositionSnapGrid.Spacing.BindTo(OsuGridToolboxGroup.GridLineSpacing);
                     triangularPositionSnapGrid.GridLineRotation.BindTo(OsuGridToolboxGroup.GridLinesRotation);
 
                     positionSnapGrid = triangularPositionSnapGrid;
@@ -151,7 +151,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 case PositionSnapGridType.Circle:
                     var circularPositionSnapGrid = new CircularPositionSnapGrid();
 
-                    circularPositionSnapGrid.Spacing.BindTo(OsuGridToolboxGroup.Spacing);
+                    circularPositionSnapGrid.Spacing.BindTo(OsuGridToolboxGroup.GridLineSpacing);
 
                     positionSnapGrid = circularPositionSnapGrid;
                     break;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
@@ -20,6 +21,9 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private ExpandableSlider<float> slider1;
         private ExpandableSlider<double> slider2;
+
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
 
         [SetUp]
         public void SetUp() => Schedule(() =>

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Settings.Sections;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -19,7 +18,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         private TestExpandingContainer container;
         private SettingsToolboxGroup toolboxGroup;
 
-        private ExpandableSlider<float, SizeSlider<float>> slider1;
+        private ExpandableSlider<float> slider1;
         private ExpandableSlider<double> slider2;
 
         [SetUp]
@@ -36,7 +35,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Width = 1,
                     Children = new Drawable[]
                     {
-                        slider1 = new ExpandableSlider<float, SizeSlider<float>>
+                        slider1 = new ExpandableSlider<float>
                         {
                             Current = new BindableFloat
                             {
@@ -62,13 +61,13 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             slider1.Current.BindValueChanged(v =>
             {
-                slider1.ExpandedLabelText = $"Slider One ({v.NewValue:0.##x})";
+                slider1.ExpandedLabelText = "Slider One";
                 slider1.ContractedLabelText = $"S. 1. ({v.NewValue:0.##x})";
             }, true);
 
             slider2.Current.BindValueChanged(v =>
             {
-                slider2.ExpandedLabelText = $"Slider Two ({v.NewValue:N2})";
+                slider2.ExpandedLabelText = "Slider Two";
                 slider2.ContractedLabelText = $"S. 2. ({v.NewValue:N2})";
             }, true);
         });

--- a/osu.Game/Graphics/Containers/ExpandingContainer.cs
+++ b/osu.Game/Graphics/Containers/ExpandingContainer.cs
@@ -4,7 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Input.Events;
+using osu.Framework.Input;
 using osu.Framework.Threading;
 
 namespace osu.Game.Graphics.Containers
@@ -58,6 +58,8 @@ namespace osu.Game.Graphics.Containers
 
         protected virtual OsuScrollContainer CreateScrollContainer() => new OsuScrollContainer();
 
+        private InputManager inputManager = null!;
+        private bool? lastMouseInBounds;
         private ScheduledDelegate? hoverExpandEvent;
 
         protected override void LoadComplete()
@@ -68,37 +70,35 @@ namespace osu.Game.Graphics.Containers
             {
                 this.ResizeWidthTo(v.NewValue ? expandedWidth : contractedWidth, TRANSITION_DURATION, Easing.OutQuint);
             }, true);
+
+            inputManager = GetContainingInputManager()!;
         }
 
-        protected override bool OnHover(HoverEvent e)
+        protected override void Update()
         {
-            updateHoverExpansion();
-            return true;
+            base.Update();
+
+            bool mouseInBounds = Contains(inputManager.CurrentState.Mouse.Position);
+
+            if (lastMouseInBounds != mouseInBounds)
+                updateExpansionState(mouseInBounds);
+
+            lastMouseInBounds = mouseInBounds;
         }
 
-        protected override void OnHoverLost(HoverLostEvent e)
-        {
-            if (hoverExpandEvent != null)
-            {
-                hoverExpandEvent?.Cancel();
-                hoverExpandEvent = null;
-
-                Expanded.Value = false;
-                return;
-            }
-
-            base.OnHoverLost(e);
-        }
-
-        private void updateHoverExpansion()
+        private void updateExpansionState(bool mouseInBounds)
         {
             if (!ExpandOnHover)
                 return;
 
             hoverExpandEvent?.Cancel();
+            hoverExpandEvent = null;
 
-            if (IsHovered && !Expanded.Value)
+            if (mouseInBounds && !Expanded.Value)
                 hoverExpandEvent = Scheduler.AddDelayed(() => Expanded.Value = true, HoverExpansionDelay);
+
+            if (!mouseInBounds && Expanded.Value)
+                Expanded.Value = false;
         }
     }
 }

--- a/osu.Game/Graphics/Containers/ExpandingContainer.cs
+++ b/osu.Game/Graphics/Containers/ExpandingContainer.cs
@@ -59,7 +59,18 @@ namespace osu.Game.Graphics.Containers
         protected virtual OsuScrollContainer CreateScrollContainer() => new OsuScrollContainer();
 
         private InputManager inputManager = null!;
+
+        /// <summary>
+        /// Tracks whether the mouse was in bounds of this expanding container in the last frame.
+        /// </summary>
         private bool? lastMouseInBounds;
+
+        /// <summary>
+        /// Tracks whether the last expansion of the container was caused by the mouse moving into its bounds
+        /// (as opposed to an external set of `Expanded`, in which case moving the mouse outside of its bounds should not contract).
+        /// </summary>
+        private bool? expandedByMouse;
+
         private ScheduledDelegate? hoverExpandEvent;
 
         protected override void LoadComplete()
@@ -95,10 +106,18 @@ namespace osu.Game.Graphics.Containers
             hoverExpandEvent = null;
 
             if (mouseInBounds && !Expanded.Value)
+            {
                 hoverExpandEvent = Scheduler.AddDelayed(() => Expanded.Value = true, HoverExpansionDelay);
+                expandedByMouse = true;
+            }
 
             if (!mouseInBounds && Expanded.Value)
-                Expanded.Value = false;
+            {
+                if (expandedByMouse == true)
+                    Expanded.Value = false;
+
+                expandedByMouse = false;
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
 using Vector2 = osuTK.Vector2;
 
 namespace osu.Game.Graphics.UserInterface
@@ -19,49 +20,27 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public partial class ExpandableSlider<T, TSlider> : CompositeDrawable, IExpandable, IHasCurrentValue<T>
         where T : struct, INumber<T>, IMinMaxValue<T>
-        where TSlider : RoundedSliderBar<T>, new()
+        where TSlider : FormSliderBar<T>, new()
     {
-        private readonly OsuSpriteText label;
+        private readonly OsuSpriteText contractedLabel;
         private readonly TSlider slider;
-
-        private LocalisableString contractedLabelText;
 
         /// <summary>
         /// The label text to display when this slider is in a contracted state.
         /// </summary>
         public LocalisableString ContractedLabelText
         {
-            get => contractedLabelText;
-            set
-            {
-                if (value == contractedLabelText)
-                    return;
-
-                contractedLabelText = value;
-
-                if (!Expanded.Value)
-                    label.Text = value;
-            }
+            get => contractedLabel.Text;
+            set => contractedLabel.Text = value;
         }
-
-        private LocalisableString expandedLabelText;
 
         /// <summary>
         /// The label text to display when this slider is in an expanded state.
         /// </summary>
         public LocalisableString ExpandedLabelText
         {
-            get => expandedLabelText;
-            set
-            {
-                if (value == expandedLabelText)
-                    return;
-
-                expandedLabelText = value;
-
-                if (Expanded.Value)
-                    label.Text = value;
-            }
+            get => slider.Caption;
+            set => slider.Caption = value;
         }
 
         public Bindable<T> Current
@@ -95,7 +74,7 @@ namespace osu.Game.Graphics.UserInterface
                 Spacing = new Vector2(0f, 10f),
                 Children = new Drawable[]
                 {
-                    label = new OsuSpriteText(),
+                    contractedLabel = new OsuSpriteText(),
                     slider = new TSlider
                     {
                         RelativeSizeAxes = Axes.X,
@@ -118,7 +97,8 @@ namespace osu.Game.Graphics.UserInterface
 
             Expanded.BindValueChanged(v =>
             {
-                label.Text = v.NewValue ? expandedLabelText : contractedLabelText;
+                contractedLabel.FadeTo(v.NewValue ? 0 : 1);
+
                 slider.FadeTo(v.NewValue ? Current.Disabled ? 0.3f : 1f : 0f, 500, Easing.OutQuint);
                 slider.BypassAutoSizeAxes = !v.NewValue ? Axes.Y : Axes.None;
             }, true);
@@ -133,7 +113,7 @@ namespace osu.Game.Graphics.UserInterface
     /// <summary>
     /// An <see cref="IExpandable"/> implementation for the UI slider bar control.
     /// </summary>
-    public partial class ExpandableSlider<T> : ExpandableSlider<T, RoundedSliderBar<T>>
+    public partial class ExpandableSlider<T> : ExpandableSlider<T, FormSliderBar<T>>
         where T : struct, INumber<T>, IMinMaxValue<T>
     {
     }

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -58,26 +58,49 @@ namespace osu.Game.Graphics.UserInterfaceV2
             }
         }
 
+        private LocalisableString caption;
+
         /// <summary>
         /// Caption describing this slider bar, displayed on top of the controls.
         /// </summary>
-        public LocalisableString Caption { get; init; }
+        public LocalisableString Caption
+        {
+            get => caption;
+            set
+            {
+                caption = value;
+
+                if (IsLoaded)
+                    captionText.Caption = value;
+            }
+        }
 
         /// <summary>
         /// Hint text containing an extended description of this slider bar, displayed in a tooltip when hovering the caption.
         /// </summary>
         public LocalisableString HintText { get; init; }
 
+        private float keyboardStep;
+
         /// <summary>
         /// A custom step value for each key press which actuates a change on this control.
         /// </summary>
-        public float KeyboardStep { get; init; }
+        public float KeyboardStep
+        {
+            get => keyboardStep;
+            set
+            {
+                keyboardStep = value;
+                if (IsLoaded)
+                    slider.KeyboardStep = value;
+            }
+        }
 
         private Box background = null!;
         private Box flashLayer = null!;
         private FormTextBox.InnerTextBox textBox = null!;
         private InnerSlider slider = null!;
-        private FormFieldCaption caption = null!;
+        private FormFieldCaption captionText = null!;
         private IFocusManager focusManager = null!;
 
         [Resolved]
@@ -117,11 +140,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     },
                     Children = new Drawable[]
                     {
-                        caption = new FormFieldCaption
+                        captionText = new FormFieldCaption
                         {
                             Anchor = Anchor.TopLeft,
                             Origin = Anchor.TopLeft,
-                            Caption = Caption,
                             TooltipText = HintText,
                         },
                         textBox = new FormNumberBox.InnerNumberBox(allowDecimals: true)
@@ -145,7 +167,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             Origin = Anchor.CentreRight,
                             RelativeSizeAxes = Axes.X,
                             Width = 0.5f,
-                            KeyboardStep = KeyboardStep,
                             Current = currentNumberInstantaneous,
                             OnCommit = () => current.Value = currentNumberInstantaneous.Value,
                         }
@@ -160,6 +181,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            slider.KeyboardStep = keyboardStep;
+            captionText.Caption = caption;
 
             focusManager = GetContainingFocusManager()!;
 
@@ -270,7 +294,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             textBox.Alpha = 1;
 
             background.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background4 : colourProvider.Background5;
-            caption.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;
+            captionText.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;
             textBox.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
 
             BorderThickness = childHasFocus || IsHovered || slider.IsDragging.Value ? 2 : 0;

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -46,6 +46,12 @@ namespace osu.Game.Overlays
 
         public BindableBool Expanded { get; } = new BindableBool(true);
 
+        public Vector2 Spacing
+        {
+            get => content.Spacing;
+            set => content.Spacing = value;
+        }
+
         private OsuSpriteText headerText = null!;
 
         private Container headerContent = null!;

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -20,7 +20,6 @@ using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Overlays.OSD;
-using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI;
@@ -42,7 +41,7 @@ namespace osu.Game.Rulesets.Edit
 
         Bindable<double> IDistanceSnapProvider.DistanceSpacingMultiplier => DistanceSpacingMultiplier;
 
-        private ExpandableSlider<double, SizeSlider<double>> distanceSpacingSlider = null!;
+        private ExpandableSlider<double> distanceSpacingSlider = null!;
         private ExpandableButton currentDistanceSpacingButton = null!;
 
         [Resolved]
@@ -78,11 +77,12 @@ namespace osu.Game.Rulesets.Edit
                 Alpha = DistanceSpacingMultiplier.Disabled ? 0 : 1,
                 Children = new Drawable[]
                 {
-                    distanceSpacingSlider = new ExpandableSlider<double, SizeSlider<double>>
+                    distanceSpacingSlider = new ExpandableSlider<double>
                     {
                         KeyboardStep = adjust_step,
                         // Manual binding in LoadComplete to handle one-way event flow.
                         Current = DistanceSpacingMultiplier.GetUnboundCopy(),
+                        ExpandedLabelText = "Distance spacing",
                     },
                     currentDistanceSpacingButton = new ExpandableButton
                     {
@@ -104,7 +104,6 @@ namespace osu.Game.Rulesets.Edit
             DistanceSpacingMultiplier.BindValueChanged(multiplier =>
             {
                 distanceSpacingSlider.ContractedLabelText = $"D. S. ({multiplier.NewValue:0.##x})";
-                distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({multiplier.NewValue:0.##x})";
 
                 if (multiplier.NewValue != multiplier.OldValue)
                     onScreenDisplay?.Display(new DistanceSpacingToast(multiplier.NewValue.ToLocalisableString(@"0.##x"), multiplier));

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -25,6 +25,7 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
+using osuTK;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -74,6 +75,7 @@ namespace osu.Game.Rulesets.Edit
             toolboxContainer.Add(toolboxGroup = new EditorToolboxGroup("snapping")
             {
                 Name = "snapping",
+                Spacing = new Vector2(5),
                 Alpha = DistanceSpacingMultiplier.Disabled ? 0 : 1,
                 Children = new Drawable[]
                 {
@@ -104,6 +106,7 @@ namespace osu.Game.Rulesets.Edit
             DistanceSpacingMultiplier.BindValueChanged(multiplier =>
             {
                 distanceSpacingSlider.ContractedLabelText = $"D. S. ({multiplier.NewValue:0.##x})";
+                distanceSpacingSlider.Current.Value = multiplier.NewValue;
 
                 if (multiplier.NewValue != multiplier.OldValue)
                     onScreenDisplay?.Display(new DistanceSpacingToast(multiplier.NewValue.ToLocalisableString(@"0.##x"), multiplier));

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2025.1118.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2025.1121.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2025.1116.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -17,6 +17,6 @@
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2025.1118.1" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2025.1121.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
https://github.com/user-attachments/assets/23f16135-7be5-4448-a4e0-eebd096efa6a

---

- [x] Depends on https://github.com/ppy/osu-framework/pull/6672

Addresses https://github.com/ppy/osu/discussions/35732.

And yes, I renamed "perfect curve threshold" to "bias" so that the text can fit. Sue me.