### PR TITLE
Quickplay: Update background image to match designs

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/MatchmakingTestScene.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/MatchmakingTestScene.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
+using osu.Game.Tests.Visual.Multiplayer;
+
+namespace osu.Game.Tests.Visual.Matchmaking
+{
+    public abstract partial class MatchmakingTestScene : MultiplayerTestScene
+    {
+        protected override Container<Drawable> Content { get; }
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
+
+        protected MatchmakingTestScene()
+        {
+            base.Content.AddRange(new Drawable[]
+            {
+                new MatchmakingBackgroundScreen.Content
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                Content = new Container { RelativeSizeAxes = Axes.Both }
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Matchmaking/MatchmakingTestScene.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/MatchmakingTestScene.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
+using osu.Game.Screens;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
 using osu.Game.Tests.Visual.Multiplayer;
 
@@ -19,14 +20,15 @@ namespace osu.Game.Tests.Visual.Matchmaking
 
         protected MatchmakingTestScene()
         {
+            BackgroundScreenStack backgroundStack;
+
             base.Content.AddRange(new Drawable[]
             {
-                new MatchmakingBackgroundScreen.Content
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
+                backgroundStack = new BackgroundScreenStack(),
                 Content = new Container { RelativeSizeAxes = Axes.Both }
             });
+
+            backgroundStack.Push(new MatchmakingBackgroundScreen(colourProvider));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectGrid.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectGrid.cs
@@ -17,12 +17,11 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect;
-using osu.Game.Tests.Visual.OnlinePlay;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestSceneBeatmapSelectGrid : OnlinePlayTestScene
+    public partial class TestSceneBeatmapSelectGrid : MatchmakingTestScene
     {
         private MatchmakingPlaylistItem[] items = null!;
 

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
@@ -12,11 +12,10 @@ using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect;
-using osu.Game.Tests.Visual.Multiplayer;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestSceneBeatmapSelectPanel : MultiplayerTestScene
+    public partial class TestSceneBeatmapSelectPanel : MatchmakingTestScene
     {
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingChatDisplay.cs
@@ -11,7 +11,7 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestSceneMatchmakingChatDisplay : ScreenTestScene
+    public partial class TestSceneMatchmakingChatDisplay : MatchmakingTestScene
     {
         private MatchmakingChatDisplay? chat;
 

--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePanelRoomAward.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePanelRoomAward.cs
@@ -3,11 +3,10 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.Results;
-using osu.Game.Tests.Visual.Multiplayer;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestScenePanelRoomAward : MultiplayerTestScene
+    public partial class TestScenePanelRoomAward : MatchmakingTestScene
     {
         public override void SetUpSteps()
         {

--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePickScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePickScreen.cs
@@ -11,11 +11,10 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect;
-using osu.Game.Tests.Visual.Multiplayer;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestScenePickScreen : MultiplayerTestScene
+    public partial class TestScenePickScreen : MatchmakingTestScene
     {
         private readonly IReadOnlyList<APIUser> users = new[]
         {

--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanel.cs
@@ -11,12 +11,11 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
-using osu.Game.Tests.Visual.Multiplayer;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestScenePlayerPanel : MultiplayerTestScene
+    public partial class TestScenePlayerPanel : MatchmakingTestScene
     {
         private PlayerPanel panel = null!;
 

--- a/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanelOverlay.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestScenePlayerPanelOverlay.cs
@@ -15,12 +15,11 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
-using osu.Game.Tests.Visual.Multiplayer;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestScenePlayerPanelOverlay : MultiplayerTestScene
+    public partial class TestScenePlayerPanelOverlay : MatchmakingTestScene
     {
         private PlayerPanelOverlay list = null!;
 

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneResultsScreen.cs
@@ -11,12 +11,11 @@ using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.Results;
-using osu.Game.Tests.Visual.Multiplayer;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestSceneResultsScreen : MultiplayerTestScene
+    public partial class TestSceneResultsScreen : MatchmakingTestScene
     {
         public override void SetUpSteps()
         {

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneRoundResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneRoundResultsScreen.cs
@@ -14,12 +14,11 @@ using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match.RoundResults;
-using osu.Game.Tests.Visual.Multiplayer;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestSceneRoundResultsScreen : MultiplayerTestScene
+    public partial class TestSceneRoundResultsScreen : MatchmakingTestScene
     {
         public override void SetUpSteps()
         {

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneStageDisplay.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneStageDisplay.cs
@@ -9,11 +9,10 @@ using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
-using osu.Game.Tests.Visual.Multiplayer;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
-    public partial class TestSceneStageDisplay : MultiplayerTestScene
+    public partial class TestSceneStageDisplay : MatchmakingTestScene
     {
         [Cached]
         protected readonly OverlayColourProvider ColourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Intro/ScreenIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Intro/ScreenIntro.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -13,7 +12,7 @@ using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
-using osu.Game.Screens.OnlinePlay.Match;
+using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Intro
@@ -53,7 +52,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Intro
 
         private IDisposable? duckOperation;
 
-        protected override BackgroundScreen CreateBackground() => new MatchmakingIntroBackgroundScreen(colourProvider);
+        protected override BackgroundScreen CreateBackground() => new MatchmakingBackgroundScreen(colourProvider);
 
         public ScreenIntro()
         {
@@ -239,28 +238,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Intro
             beatmapWindupChannel?.Stop();
             beatmapImpactChannel?.Stop();
             duckOperation?.Dispose();
-        }
-
-        private partial class MatchmakingIntroBackgroundScreen : RoomBackgroundScreen
-        {
-            private readonly OverlayColourProvider colourProvider;
-
-            public MatchmakingIntroBackgroundScreen(OverlayColourProvider colourProvider)
-                : base(null)
-            {
-                this.colourProvider = colourProvider;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                AddInternal(new Box
-                {
-                    Depth = float.MinValue,
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5.Opacity(0.6f),
-                });
-            }
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingBackgroundScreen.cs
@@ -4,11 +4,9 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Overlays;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 {
@@ -27,29 +25,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             [BackgroundDependencyLoader]
             private void load(TextureStore textures, OverlayColourProvider colourProvider)
             {
-                AddRangeInternal(new Drawable[]
+                InternalChild = new Sprite
                 {
-                    new Sprite
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Texture = textures.Get("Backgrounds/bg1"),
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        FillMode = FillMode.Fill,
-                    },
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colourProvider.Colour4,
-                        Alpha = 0.5f,
-                    },
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.Black,
-                        Alpha = 0.6f,
-                    }
-                });
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = textures.Get("Backgrounds/bg1"),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    FillMode = FillMode.Fill,
+                    Colour = colourProvider.Dark2
+                };
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingBackgroundScreen.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Overlays;
@@ -12,29 +11,25 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 {
     public partial class MatchmakingBackgroundScreen : BackgroundScreen
     {
-        public MatchmakingBackgroundScreen()
+        private readonly OverlayColourProvider colourProvider;
+
+        public MatchmakingBackgroundScreen(OverlayColourProvider colourProvider)
         {
-            InternalChild = new Content
-            {
-                RelativeSizeAxes = Axes.Both
-            };
+            this.colourProvider = colourProvider;
         }
 
-        public partial class Content : CompositeDrawable
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
         {
-            [BackgroundDependencyLoader]
-            private void load(TextureStore textures, OverlayColourProvider colourProvider)
+            InternalChild = new Sprite
             {
-                InternalChild = new Sprite
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Texture = textures.Get("Backgrounds/bg1"),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    FillMode = FillMode.Fill,
-                    Colour = colourProvider.Dark2
-                };
-            }
+                RelativeSizeAxes = Axes.Both,
+                Texture = textures.Get("Backgrounds/bg1"),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                FillMode = FillMode.Fill,
+                Colour = colourProvider.Dark2
+            };
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingBackgroundScreen.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Overlays;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
+{
+    public partial class MatchmakingBackgroundScreen : BackgroundScreen
+    {
+        public MatchmakingBackgroundScreen()
+        {
+            InternalChild = new Content
+            {
+                RelativeSizeAxes = Axes.Both
+            };
+        }
+
+        public partial class Content : CompositeDrawable
+        {
+            [BackgroundDependencyLoader]
+            private void load(TextureStore textures, OverlayColourProvider colourProvider)
+            {
+                AddRangeInternal(new Drawable[]
+                {
+                    new Sprite
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Texture = textures.Get("Backgrounds/bg1"),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        FillMode = FillMode.Fill,
+                    },
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Colour4,
+                        Alpha = 0.5f,
+                    },
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.Black,
+                        Alpha = 0.6f,
+                    }
+                });
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -57,6 +57,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
         public override bool ShowFooter => true;
 
+        protected override BackgroundScreen CreateBackground() => new MatchmakingBackgroundScreen();
+
         [Cached(typeof(OnlinePlayBeatmapAvailabilityTracker))]
         private readonly OnlinePlayBeatmapAvailabilityTracker beatmapAvailabilityTracker = new MultiplayerBeatmapAvailabilityTracker();
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -57,7 +57,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
         public override bool ShowFooter => true;
 
-        protected override BackgroundScreen CreateBackground() => new MatchmakingBackgroundScreen();
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        protected override BackgroundScreen CreateBackground() => new MatchmakingBackgroundScreen(colourProvider);
 
         [Cached(typeof(OnlinePlayBeatmapAvailabilityTracker))]
         private readonly OnlinePlayBeatmapAvailabilityTracker beatmapAvailabilityTracker = new MultiplayerBeatmapAvailabilityTracker();


### PR DESCRIPTION
Adds the new background based on @vatei's designs.
Note that the colors might be a tiny bit off, did so to be able to use the `OverlayColourProvider`.

This also replaces the background for all matchmaking test scenes via the new `MatchmakingTestScene` class.
*exceptions are the Queue-Screen related test scenes & `TestSceneMatchmakingScreen` since it should create the background itself.*

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/ed790d7b-a72d-4d5c-a470-f764daa891e6" />

