### PR TITLE
Use actual mod-adjusted map difficulty settings in the `SongBar`

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
@@ -5,6 +5,10 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Legacy;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 
@@ -52,6 +56,7 @@ namespace osu.Game.Tournament.Tests.Components
                 beatmap.ApproachRate = 6.8f;
                 beatmap.OverallDifficulty = 5.5f;
                 beatmap.StarRating = 4.56f;
+                beatmap.DrainRate = 1.23f;
                 beatmap.Length = 123456;
                 beatmap.BPM = 133;
                 beatmap.OnlineID = ladderBeatmap.OnlineID;
@@ -62,11 +67,17 @@ namespace osu.Game.Tournament.Tests.Components
             AddStep("set mods to HR", () => songBar.Mods = LegacyMods.HardRock);
             AddStep("set mods to DT", () => songBar.Mods = LegacyMods.DoubleTime);
             AddStep("set mods to HDHRDT", () => songBar.Mods = LegacyMods.Hidden | LegacyMods.HardRock | LegacyMods.DoubleTime);
+
             AddStep("unset mods", () => songBar.Mods = LegacyMods.None);
 
             AddToggleStep("toggle expanded", expanded => songBar.Expanded = expanded);
 
             AddStep("set null beatmap", () => songBar.Beatmap = null);
+
+            AddStep("set ruleset to osu", () => Ruleset.Value = new OsuRuleset().RulesetInfo);
+            AddStep("set ruleset to taiko", () => Ruleset.Value = new TaikoRuleset().RulesetInfo);
+            AddStep("set ruleset to catch", () => Ruleset.Value = new CatchRuleset().RulesetInfo);
+            AddStep("set ruleset to mania", () => Ruleset.Value = new ManiaRuleset().RulesetInfo);
         }
     }
 }

--- a/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
@@ -61,6 +61,7 @@ namespace osu.Game.Tournament.Tests.Components
 
             AddStep("set mods to HR", () => songBar.Mods = LegacyMods.HardRock);
             AddStep("set mods to DT", () => songBar.Mods = LegacyMods.DoubleTime);
+            AddStep("set mods to HDHRDT", () => songBar.Mods = LegacyMods.Hidden | LegacyMods.HardRock | LegacyMods.DoubleTime);
             AddStep("unset mods", () => songBar.Mods = LegacyMods.None);
 
             AddToggleStep("toggle expanded", expanded => songBar.Expanded = expanded);

--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tournament.Models
 
         public BeatmapSetOnlineCovers Covers { get; set; }
 
-        public APIRuleset Ruleset { get; set; } = new APIRuleset();
+        public IRulesetInfo Ruleset { get; set; } = new APIRuleset();
 
         public TournamentBeatmap()
         {
@@ -50,7 +50,7 @@ namespace osu.Game.Tournament.Models
             Covers = beatmap.BeatmapSet?.Covers ?? new BeatmapSetOnlineCovers();
             EndTimeObjectCount = beatmap.EndTimeObjectCount;
             TotalObjectCount = beatmap.TotalObjectCount;
-            Ruleset = (APIRuleset)beatmap.Ruleset;
+            Ruleset = beatmap.Ruleset;
         }
 
         public bool Equals(IBeatmapInfo? other) => other is TournamentBeatmap b && this.MatchesOnlineID(b);

--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Tournament.Models
 
         string IBeatmapInfo.MD5Hash => throw new NotImplementedException();
 
-        IRulesetInfo IBeatmapInfo.Ruleset => throw new NotImplementedException();
+        IRulesetInfo IBeatmapInfo.Ruleset => new RulesetInfo();
 
         DateTimeOffset IBeatmapSetOnlineInfo.Submitted => throw new NotImplementedException();
 

--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -6,6 +6,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Extensions;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
+using static osu.Game.Online.API.Requests.Responses.APIBeatmap;
 
 namespace osu.Game.Tournament.Models
 {
@@ -31,6 +32,8 @@ namespace osu.Game.Tournament.Models
 
         public BeatmapSetOnlineCovers Covers { get; set; }
 
+        public APIRuleset Ruleset { get; set; } = new APIRuleset();
+
         public TournamentBeatmap()
         {
         }
@@ -47,6 +50,7 @@ namespace osu.Game.Tournament.Models
             Covers = beatmap.BeatmapSet?.Covers ?? new BeatmapSetOnlineCovers();
             EndTimeObjectCount = beatmap.EndTimeObjectCount;
             TotalObjectCount = beatmap.TotalObjectCount;
+            Ruleset = (APIRuleset)beatmap.Ruleset;
         }
 
         public bool Equals(IBeatmapInfo? other) => other is TournamentBeatmap b && this.MatchesOnlineID(b);
@@ -83,7 +87,7 @@ namespace osu.Game.Tournament.Models
 
         string IBeatmapInfo.MD5Hash => throw new NotImplementedException();
 
-        IRulesetInfo IBeatmapInfo.Ruleset => new RulesetInfo();
+        IRulesetInfo IBeatmapInfo.Ruleset => Ruleset;
 
         DateTimeOffset IBeatmapSetOnlineInfo.Submitted => throw new NotImplementedException();
 

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -146,6 +146,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
             public string Name => $@"{nameof(APIRuleset)} (ID: {OnlineID})";
 
+            [JsonIgnore]
             public string ShortName
             {
                 get


### PR DESCRIPTION
This also changes the bpm format to be consistent with the rest of the game. I would love for the SR display to show real values too, but that requires loading a full beatmap and the tournament client only has access to the metadata.

NM:
<img width="458" height="122" alt="image" src="https://github.com/user-attachments/assets/03720049-2b9b-45c1-a92e-21319de8a639" />

HR:
<img width="462" height="113" alt="image" src="https://github.com/user-attachments/assets/a8f7cff1-a457-4929-8299-ca4d710dd2ed" />

DT:
<img width="457" height="110" alt="image" src="https://github.com/user-attachments/assets/fcb61098-0c4b-4d4d-97f0-62fac90d72dc" />

Mania NM:
<img width="456" height="112" alt="image" src="https://github.com/user-attachments/assets/6d4a9319-6ea1-417f-b3a1-5d87ceb903eb" />

Mania HR:
<img width="458" height="108" alt="image" src="https://github.com/user-attachments/assets/427cd7b6-c1f3-4ec8-b2ab-6ab53a543555" />


