### PR TITLE
Fix progress time with rate-changing mods

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 double progress = Math.Clamp(lastMouseX, 0, DrawWidth) / DrawWidth;
 
-                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress));
+                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress) / GameplayClock.Rate);
 
                 int seconds = currentSpan.Duration().Seconds;
                 int minutes = (int)Math.Floor(currentSpan.Duration().TotalMinutes);

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 double progress = Math.Clamp(lastMouseX, 0, DrawWidth) / DrawWidth;
 
-                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress / Math.Max(GameplayClock.Rate, 0.001)));
+                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress / Math.Max(GameplayClock?.Rate ?? 0, 0.001)));
 
                 int seconds = currentSpan.Duration().Seconds;
                 int minutes = (int)Math.Floor(currentSpan.Duration().TotalMinutes);

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 double progress = Math.Clamp(lastMouseX, 0, DrawWidth) / DrawWidth;
 
-                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress) / GameplayClock.Rate);
+                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress / Math.Max(GameplayClock.Rate, 0.001)));
 
                 int seconds = currentSpan.Duration().Seconds;
                 int minutes = (int)Math.Floor(currentSpan.Duration().TotalMinutes);

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 double progress = Math.Clamp(lastMouseX, 0, DrawWidth) / DrawWidth;
 
-                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress / Math.Max(GameplayClock?.Rate ?? 0, 0.001)));
+                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress / Math.Max(GameplayClock.Rate, 0.001)));
 
                 int seconds = currentSpan.Duration().Seconds;
                 int minutes = (int)Math.Floor(currentSpan.Duration().TotalMinutes);

--- a/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
@@ -156,8 +156,8 @@ namespace osu.Game.Screens.Play.HUD
 
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
-                timeCurrent.Text = formatTime(TimeSpan.FromSeconds(currentSecond / Math.Max(gameplayClock.Rate, 0.001)));
-                timeLeft.Text = formatTime(TimeSpan.FromMilliseconds((endTime - time) / Math.Max(gameplayClock.Rate, 0.001)));
+                timeCurrent.Text = formatTime(TimeSpan.FromSeconds(currentSecond / Math.Max(gameplayClock?.Rate ?? 0, 0.001)));
+                timeLeft.Text = formatTime(TimeSpan.FromMilliseconds((endTime - time) / Math.Max(gameplayClock?.Rate ?? 0, 0.001)));
 
                 previousSecond = currentSecond;
             }

--- a/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
@@ -156,8 +156,8 @@ namespace osu.Game.Screens.Play.HUD
 
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
-                timeCurrent.Text = formatTime(TimeSpan.FromSeconds(currentSecond));
-                timeLeft.Text = formatTime(TimeSpan.FromMilliseconds(endTime - time));
+                timeCurrent.Text = formatTime(TimeSpan.FromSeconds(currentSecond) / gameplayClock.Rate);
+                timeLeft.Text = formatTime(TimeSpan.FromMilliseconds(endTime - time) / gameplayClock.Rate);
 
                 previousSecond = currentSecond;
             }

--- a/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
@@ -156,8 +156,8 @@ namespace osu.Game.Screens.Play.HUD
 
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
-                timeCurrent.Text = formatTime(TimeSpan.FromSeconds(currentSecond) / gameplayClock.Rate);
-                timeLeft.Text = formatTime(TimeSpan.FromMilliseconds(endTime - time) / gameplayClock.Rate);
+                timeCurrent.Text = formatTime(TimeSpan.FromSeconds(currentSecond / Math.Max(gameplayClock.Rate, 0.001)));
+                timeLeft.Text = formatTime(TimeSpan.FromMilliseconds((endTime - time) / Math.Max(gameplayClock.Rate, 0.001)));
 
                 previousSecond = currentSecond;
             }


### PR DESCRIPTION
This PR aims to fix an issue in the skin elements that show progression time (ArgonSongProgressBar.cs and SongProgressInfo.cs). Previously, the skin would show the wrong time in the progress bar when using mods that change the song speed; it displayed the unmodified time instead of the modified one. After this PR, the time calculated for the progress bar correctly takes into account the song’s rate change.

| Skin/Mod     | Old Behavior                                                                                             | New Behavior                                                                                           |
| ------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| Argon NM     | ![Vecchio Nm Argon](https://github.com/user-attachments/assets/60d4a80f-9164-42d2-a8b8-95778dc5c325)     | ![Nuovo Nm Argon](https://github.com/user-attachments/assets/20f73844-5f49-4acf-bced-b5c0a6e291de)     |
| Argon DT     | ![Vecchio Dt Argon](https://github.com/user-attachments/assets/c64faa59-231e-4193-bf29-d0775d563a99)     | ![Nuovo Dt Argon](https://github.com/user-attachments/assets/9966030b-43cc-4228-9845-f6f37b70852d)     |
| Argon HT     | ![Vecchio Ht Argon](https://github.com/user-attachments/assets/c9eb5756-21ec-4aa4-af02-1658546a9550)     | ![Nuovo Ht Argon](https://github.com/user-attachments/assets/a8122f6f-1ca9-4c86-a933-9fea285a25e7)     |
| Triangles NM | ![Vecchio Triangles Nm](https://github.com/user-attachments/assets/b96119e7-8e3f-4a7c-b8a4-1a43c4ecbdce) | ![Nuovo Triangles Nm](https://github.com/user-attachments/assets/bd0caf75-24d6-4df1-832e-0c73d966e8e4) |
| Triangles DT | ![Vecchio Triangles Dt](https://github.com/user-attachments/assets/419349df-0fd4-465e-9442-00518a74b612) | ![Nuovo Triangles Dt](https://github.com/user-attachments/assets/bb665af2-3e1c-4aaa-b3b1-5971d69ff2f3) |
| Triangles HT | ![Vecchio Triangles Ht](https://github.com/user-attachments/assets/86179490-1903-43b2-ba9b-ce7740b624c0) | ![Nuovo Triangles Ht](https://github.com/user-attachments/assets/97d7adc5-801a-46ee-a047-441359444091) |

