### PR TITLE
Show copied text on copied to clipboard toast

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -558,7 +558,7 @@ namespace osu.Game
         public void CopyToClipboard(string value) => waitForReady(() => onScreenDisplay, _ =>
         {
             dependencies.Get<Clipboard>().SetText(value);
-            onScreenDisplay.Display(new CopiedToClipboardToast());
+            onScreenDisplay.Display(new CopiedToClipboardToast(value));
         });
 
         public void OpenUrlExternally(string url, LinkWarnMode warnMode = LinkWarnMode.Default) => waitForReady(() => externalLinkOpener, _ => externalLinkOpener.OpenUrlExternally(url, warnMode));

--- a/osu.Game/Overlays/OSD/CopiedToClipboardToast.cs
+++ b/osu.Game/Overlays/OSD/CopiedToClipboardToast.cs
@@ -7,8 +7,8 @@ namespace osu.Game.Overlays.OSD
 {
     public partial class CopiedToClipboardToast : Toast
     {
-        public CopiedToClipboardToast()
-            : base(CommonStrings.General, ToastStrings.CopiedToClipboard, "")
+        public CopiedToClipboardToast(string text)
+            : base(CommonStrings.General, ToastStrings.CopiedToClipboard, text)
         {
         }
     }


### PR DESCRIPTION
- [ ] Kinda depends on https://github.com/ppy/osu/pull/35771 (second commit)

Having "no key bound" as the shortcut/hint text doesn't make sense. It could be ctrl-c (when the framework shortcut lookup gets implemented), but it's not really relevant with the "copy link" buttons, only the editor case, and it's a common shortcut most people know about.

Also provides a UX improvement to what gets copied when ctrl-c is pressed in the editor (needs above PR to see).

<img width="429" height="175" alt="Screenshot 2025-11-23 at 4 28 32 PM" src="https://github.com/user-attachments/assets/b05379fe-6bfc-4016-9192-9866a26379c8" />
