### PR TITLE
Revert "Expand group that current selection resides in when moving mouse to left side of song select"

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelect.cs
@@ -22,7 +22,6 @@ using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
-using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Screens.SelectV2;
 using osu.Game.Tests.Resources;
@@ -142,41 +141,6 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddUntilStep("wait for osu beatmap selected", () => Beatmap.Value.BeatmapInfo.Ruleset.OnlineID, () => Is.EqualTo(0));
 
             void onScreenPushed(IScreen lastScreen, IScreen newScreen) => screensPushed.Add(lastScreen);
-        }
-
-        [TestCase(true)]
-        [TestCase(false)]
-        public void TestHoveringLeftSideReexpandsGroupSelectionIsIn(bool mouseOverPanel)
-        {
-            ImportBeatmapForRuleset(0);
-
-            LoadSongSelect();
-            SortAndGroupBy(SortMode.Difficulty, GroupMode.Difficulty);
-
-            AddStep("move mouse to carousel", () => InputManager.MoveMouseTo(Carousel));
-
-            AddUntilStep("expanded group is below 1 star",
-                () => (Carousel.ChildrenOfType<PanelGroupStarDifficulty>().SingleOrDefault(p => p.Expanded.Value)?.Item?.Model as StarDifficultyGroupDefinition)?.Difficulty.Stars,
-                () => Is.EqualTo(0));
-
-            AddStep("select next group", () =>
-            {
-                InputManager.PressKey(Key.ShiftLeft);
-                InputManager.Key(Key.Right);
-                InputManager.ReleaseKey(Key.ShiftLeft);
-            });
-            AddUntilStep("expanded group is 3 star",
-                () => (Carousel.ChildrenOfType<PanelGroupStarDifficulty>().SingleOrDefault(p => p.Expanded.Value)?.Item?.Model as StarDifficultyGroupDefinition)?.Difficulty.Stars,
-                () => Is.EqualTo(3));
-
-            if (mouseOverPanel)
-                AddStep("move mouse over left panel", () => InputManager.MoveMouseTo(this.ChildrenOfType<BeatmapTitleWedge>().Single()));
-            else
-                AddStep("move mouse to left side container", () => InputManager.MoveMouseTo(this.ChildrenOfType<Screens.Select.SongSelect.LeftSideInteractionContainer>().Single()));
-
-            AddUntilStep("expanded group is below 1 star",
-                () => (Carousel.ChildrenOfType<PanelGroupStarDifficulty>().Single(p => p.Expanded.Value).Item?.Model as StarDifficultyGroupDefinition)?.Difficulty.Stars,
-                () => Is.EqualTo(0));
         }
 
         #region Hotkeys

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -693,18 +693,6 @@ namespace osu.Game.Screens.SelectV2
             }
         }
 
-        public void ExpandGroupForCurrentSelection()
-        {
-            if (CurrentGroupedBeatmap?.Group == null)
-                return;
-
-            if (CheckModelEquality(ExpandedGroup, CurrentGroupedBeatmap.Group))
-                return;
-
-            if (grouping.ItemMap.TryGetValue(CurrentGroupedBeatmap.Group, out var groupItem))
-                Activate(groupItem.item);
-        }
-
         protected override double? GetScrollTarget()
         {
             double? target = base.GetScrollTarget();

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -214,11 +214,7 @@ namespace osu.Game.Screens.SelectV2
                                                         // Pad enough to only reset scroll when well into the left wedge areas.
                                                         Padding = new MarginPadding { Right = 40 },
                                                         RelativeSizeAxes = Axes.Both,
-                                                        Child = new Select.SongSelect.LeftSideInteractionContainer(() =>
-                                                        {
-                                                            carousel.ExpandGroupForCurrentSelection();
-                                                            carousel.ScrollToSelection();
-                                                        })
+                                                        Child = new Select.SongSelect.LeftSideInteractionContainer(() => carousel.ScrollToSelection())
                                                         {
                                                             RelativeSizeAxes = Axes.Both,
                                                         },


### PR DESCRIPTION
Reverts https://github.com/ppy/osu/pull/35184 as per https://github.com/ppy/osu/discussions/35683#discussioncomment-15034835.