### PR TITLE
Quickplay: Update top level layout to match designs

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.ScreenStack.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.ScreenStack.cs
@@ -36,10 +36,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                     new Container
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Padding = new MarginPadding(6)
-                        {
-                            Bottom = StageDisplay.HEIGHT + 6,
-                        },
+                        Padding = new MarginPadding { Top = StageDisplay.HEIGHT, Bottom = 6 },
                         Children = new Drawable[]
                         {
                             screenStack = new Framework.Screens.ScreenStack(),
@@ -51,8 +48,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                     },
                     new StageDisplay
                     {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
                         RelativeSizeAxes = Axes.X
                     }
                 };

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -13,7 +13,6 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
@@ -124,7 +123,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load()
         {
             sampleStart = audio.Samples.Get(@"SongSelect/confirm-selection");
 
@@ -143,8 +142,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                             RelativeSizeAxes = Axes.Both,
                             Padding = new MarginPadding
                             {
-                                Horizontal = WaveOverlayContainer.WIDTH_PADDING,
-                                Top = row_padding,
+                                Horizontal = HORIZONTAL_OVERFLOW_PADDING,
                             },
                             RowDimensions = new[]
                             {
@@ -155,21 +153,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                             Content = new Drawable[]?[]
                             {
                                 [
-                                    new Container
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Masking = true,
-                                        CornerRadius = 10,
-                                        Children = new Drawable[]
-                                        {
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Colour = colourProvider.Background6,
-                                            },
-                                            new ScreenStack(),
-                                        }
-                                    }
+                                    new ScreenStack(),
                                 ],
                                 null,
                                 [

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
         public override bool ShowFooter => true;
 
-        [Resolved]
-        private OverlayColourProvider colourProvider { get; set; } = null!;
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
 
         protected override BackgroundScreen CreateBackground() => new MatchmakingBackgroundScreen(colourProvider);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.StageSegment.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.StageSegment.cs
@@ -7,7 +7,6 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
@@ -92,11 +91,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                                 new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour =
-                                        ColourInfo.GradientVertical(
-                                            colourProvider.Dark2,
-                                            colourProvider.Dark1
-                                        ),
+                                    Colour = colourProvider.Dark3,
                                 },
                                 progressBar = new Box
                                 {
@@ -104,7 +99,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                                     EdgeSmoothness = new Vector2(1),
                                     RelativeSizeAxes = Axes.Both,
                                     Width = 0,
-                                    Colour = colourProvider.Dark3,
+                                    Colour = colourProvider.Colour3,
                                 },
                                 new OsuSpriteText
                                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Transforms;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -31,7 +32,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
         private const int round_count = 5;
 
         private OsuScrollContainer scroll = null!;
-        private FillFlowContainer flow = null!;
+        private FillFlowContainer<StageSegment> flow = null!;
 
         private CurrentRoundDisplay roundDisplay = null!;
 
@@ -48,8 +49,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             {
                 new Box
                 {
-                    Colour = colourProvider.Dark6,
+                    Colour = ColourInfo.GradientHorizontal(colourProvider.Dark6, colourProvider.Dark6.Opacity(0.5f)),
                     RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.7f
                 },
                 new Container
                 {
@@ -63,7 +65,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                             ClampExtension = 0,
                             RelativeSizeAxes = Axes.X,
                             Height = HEIGHT,
-                            Child = flow = new FillFlowContainer
+                            Child = flow = new FillFlowContainer<StageSegment>
                             {
                                 Padding = new MarginPadding { Horizontal = 2000 },
                                 AutoSizeAxes = Axes.Both,
@@ -83,15 +85,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                             Y = 32,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre
-                        },
-                        new Box
-                        {
-                            Colour = ColourInfo.GradientHorizontal(
-                                colourProvider.Dark4,
-                                colourProvider.Dark5.Opacity(0)
-                            ),
-                            RelativeSizeAxes = Axes.Y,
-                            Width = 240,
                         },
                         roundDisplay = new CurrentRoundDisplay
                         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
@@ -19,6 +19,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Overlays;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 {
@@ -48,11 +49,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
         {
             InternalChildren = new Drawable[]
             {
-                new Box
+                new BufferedContainer(cachedFrameBuffer: true)
                 {
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Dark6, colourProvider.Dark6.Opacity(0.5f)),
                     RelativeSizeAxes = Axes.Both,
-                    Alpha = 0.7f
+                    Colour = ColourInfo.GradientVertical(Color4.White, Color4.Transparent),
+                    Alpha = 0.8f,
+                    Child = new Box
+                    {
+                        Colour = ColourInfo.GradientHorizontal(colourProvider.Dark6, colourProvider.Dark6.Opacity(0.5f)),
+                        RelativeSizeAxes = Axes.Both,
+                    }
                 },
                 new Container
                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Graphics.UserInterface;
@@ -151,47 +152,55 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             {
                 Size = new Vector2(76);
 
+                progress = new CircularProgress
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Colour = colours.Colour2,
+                    InnerRadius = 0.1f,
+                    RelativeSizeAxes = Axes.Both,
+                    RoundedCaps = true,
+                };
                 InternalChildren = new Drawable[]
                 {
                     new Circle
                     {
-                        Colour = ColourInfo.GradientVertical(
-                            colours.Dark2,
-                            colours.Dark4
-                        ),
+                        Colour = colours.Dark4,
                         RelativeSizeAxes = Axes.Both,
                     },
-                    progress = new CircularProgress
+                    (progress = new CircularProgress
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Colour = ColourInfo.GradientVertical(
-                            colours.Light1,
-                            colours.Dark2
-                        ),
+                        Colour = colours.Colour2,
                         InnerRadius = 0.1f,
-                        RelativeSizeAxes = Axes.Both,
-                    },
+                        Size = Size,
+                    }).WithEffect(new GlowEffect
+                    {
+                        Colour = colours.Colour2,
+                        BlurSigma = new Vector2(10),
+                        Strength = 2f,
+                        Placement = EffectPlacement.Behind,
+                        PadExtent = true,
+                    }),
                     innerCircle = new Circle
                     {
                         Alpha = 0.2f,
                         Blending = BlendingParameters.Additive,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Colour = ColourInfo.GradientVertical(
-                            colours.Dark1,
-                            colours.Dark2
-                        ),
+                        Colour = colours.Dark1,
                         Scale = new Vector2(0.9f),
                         RelativeSizeAxes = Axes.Both,
                     },
                     new OsuSpriteText
                     {
-                        Y = 10,
+                        Y = 13,
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
                         Font = OsuFont.Style.Caption2,
                         Text = "Round",
+                        Colour = colours.Content2
                     },
                     text = new OsuSpriteText
                     {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
@@ -122,6 +122,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             }
         }
 
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            foreach (var segment in flow)
+            {
+                if (segment.Active)
+                    return;
+
+                float offset = segment.ToSpaceOfOtherDrawable(Vector2.Zero, this).X;
+
+                segment.Alpha = float.Clamp(offset / 300, 0.1f, 0.5f);
+            }
+        }
+
         private partial class StageScrollContainer : OsuScrollContainer
         {
             public override bool HandlePositionalInput => false;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
@@ -238,10 +238,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                     round = value.Value;
 
                     this.ScaleTo(6, 1000, Easing.OutPow10)
-                        .MoveToY(-300, 1000, Easing.OutPow10)
+                        .MoveToY(300, 1000, Easing.OutPow10)
                         .Then()
-                        .MoveToY(0, 500, Easing.InQuart)
-                        .ScaleTo(1, 500, Easing.InQuart);
+                        .MoveToY(0, 500, new CubicBezierEasingFunction(0.8, 0, 0.6, 1))
+                        .ScaleTo(1, 500, new CubicBezierEasingFunction(0.8, 0, 0.6, 1));
 
                     swishChannel = swishSample?.GetChannel();
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/StageDisplay.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
         protected override void Update()
         {
             base.Update();
-            var bubble = flow.OfType<StageSegment>().FirstOrDefault(b => b.Active);
+            var bubble = flow.FirstOrDefault(b => b.Active);
 
             if (bubble != null)
             {


### PR DESCRIPTION
Changes the top level layout & adjusts some of the colours to match the new designs.

List of Changes
- Remove background box behind matchmaking screenstack
- Remove padding between screen border & matchmaking screenstack
- Move `StageDisplay` to the top of the screen
- Flip animation in `CurrentRoundDisplay` vertically and add a tiny bit of ease-out
- Adjust colours in `StageDisplay` to match the new designs (leaving other design adjustments to the segments for the future)
- Use `OverlayColourScheme.Pink` for the entire screen
- Add a bit of glow to the `CurrentRoundDisplay` to match the designs

https://github.com/user-attachments/assets/61d214f8-42bc-4faa-9bfd-81ec8767c2dc

