### PR TITLE
Quickplay: Force screen exit on disconnect

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -208,6 +208,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             if (this.IsCurrentScreen() && client.Room == null)
             {
                 Logger.Log($"{this} exiting due to loss of room or connection");
+                exitConfirmed = true;
                 this.Exit();
             }
         }


### PR DESCRIPTION
Closes a related issue within #35655.

When disconnecting from the room, you'll be prompted to exit the match instead. To the end user, this may be seen as a mistake even if a disconnection notification was issued.

Changing this to forcing the user out of the screen as a guarantee the user knows they've been disconnected.

~~The original issue calls for match not disconnecting all players when the match ends, but if the behavior is intended, this is enough.~~