### PR TITLE
Fix quick retry/exit overlay volume dimming potentially sticking at results

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -266,7 +266,11 @@ namespace osu.Game.Tests.Visual.Background
 
             FadeAccessibleResults results = null;
 
-            AddStep("Transition to Results", () => player.Push(results = new FadeAccessibleResults(TestResources.CreateTestScoreInfo())));
+            AddStep("Transition to Results", () =>
+            {
+                player.ValidForResume = false;
+                player.Push(results = new FadeAccessibleResults(TestResources.CreateTestScoreInfo()));
+            });
 
             AddUntilStep("Wait for results is current", () => results.IsCurrentScreen());
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -320,7 +320,7 @@ namespace osu.Game.Screens.Play
                     OnRetry = Configuration.AllowUserInteraction ? () => Restart() : null,
                     OnQuit = () => PerformExitWithConfirmation(),
                 },
-                new HotkeyExitOverlay
+                exitOverlay = new HotkeyExitOverlay
                 {
                     Action = () =>
                     {
@@ -338,7 +338,7 @@ namespace osu.Game.Screens.Play
             {
                 rulesetSkinProvider.AddRange(new Drawable[]
                 {
-                    new HotkeyRetryOverlay
+                    retryOverlay = new HotkeyRetryOverlay
                     {
                         Action = () =>
                         {
@@ -1033,6 +1033,9 @@ namespace osu.Game.Screens.Play
 
         private double? lastPauseActionTime;
 
+        private HotkeyRetryOverlay retryOverlay;
+        private HotkeyExitOverlay exitOverlay;
+
         protected bool PauseCooldownActive =>
             PlayingState.Value == LocalUserPlayingState.Playing && lastPauseActionTime.HasValue && GameplayClockContainer.CurrentTime < lastPauseActionTime + PauseCooldownDuration;
 
@@ -1170,6 +1173,10 @@ namespace osu.Game.Screens.Play
         public override void OnSuspending(ScreenTransitionEvent e)
         {
             screenSuspension?.RemoveAndDisposeImmediately();
+
+            // If these are not disposed, audio volume dimming can get stuck.
+            retryOverlay?.RemoveAndDisposeImmediately();
+            exitOverlay?.RemoveAndDisposeImmediately();
 
             fadeOut();
             base.OnSuspending(e);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1172,6 +1172,8 @@ namespace osu.Game.Screens.Play
 
         public override void OnSuspending(ScreenTransitionEvent e)
         {
+            Debug.Assert(!ValidForResume);
+
             screenSuspension?.RemoveAndDisposeImmediately();
 
             // If these are not disposed, audio volume dimming can get stuck.


### PR DESCRIPTION
Closes #35737.

Tested manually because timing of automated testing seems hard.