### PR TITLE
Fix chat lines flipping colours at maximum history

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -236,7 +236,8 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("add 3 messages", () =>
             {
-                channel.AddNewMessages(new Message
+                channel.AddNewMessages(
+                    new Message
                     {
                         ChannelId = channel.Id,
                         Content = "Message 0",

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -146,5 +146,164 @@ namespace osu.Game.Tests.Visual.Online
                 checkCount++;
             }, 10);
         }
+
+        [Test]
+        public void TestAlternatingBackgroundDoesNotChangeAtMaxHistory()
+        {
+            AddStep("fill up the channel", () =>
+            {
+                for (int i = 0; i < Channel.MAX_HISTORY; i++)
+                {
+                    channel.AddNewMessages(new Message
+                    {
+                        ChannelId = channel.Id,
+                        Content = $"Message {i}",
+                        Timestamp = DateTimeOffset.Now,
+                        Sender = new APIUser
+                        {
+                            Id = 3,
+                            Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                        }
+                    });
+                }
+            });
+
+            AddUntilStep($"{Channel.MAX_HISTORY} messages present", () => drawableChannel.ChildrenOfType<ChatLine>().Count(), () => Is.EqualTo(Channel.MAX_HISTORY));
+
+            ChatLine? lastLine = null;
+            bool lastLineAlternatingBackground = false;
+
+            AddStep("grab last line", () =>
+            {
+                lastLine = drawableChannel.ChildrenOfType<ChatLine>().Last();
+                lastLineAlternatingBackground = lastLine.AlternatingBackground;
+            });
+
+            AddStep("add another message", () => channel.AddNewMessages(new Message
+            {
+                ChannelId = channel.Id,
+                Content = "One final message",
+                Timestamp = DateTimeOffset.Now,
+                Sender = new APIUser
+                {
+                    Id = 3,
+                    Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                }
+            }));
+
+            AddAssert("second-last message has same background", () => lastLine!.AlternatingBackground, () => Is.EqualTo(lastLineAlternatingBackground));
+        }
+
+        [Test]
+        public void TestAlternatingBackgroundUpdatedOnRemoval()
+        {
+            AddStep("add 3 messages", () =>
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    channel.AddNewMessages(new Message
+                    {
+                        ChannelId = channel.Id,
+                        Content = $"Message {i}",
+                        Timestamp = DateTimeOffset.Now,
+                        Sender = new APIUser
+                        {
+                            Id = i,
+                            Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                        }
+                    });
+                }
+            });
+
+            AddUntilStep("3 messages present", () => drawableChannel.ChildrenOfType<ChatLine>().Count(), () => Is.EqualTo(3));
+            assertAlternatingBackground(0, false);
+            assertAlternatingBackground(1, true);
+            assertAlternatingBackground(2, false);
+
+            AddStep("remove middle message", () => channel.RemoveMessagesFromUser(1));
+            AddUntilStep("2 messages present", () => drawableChannel.ChildrenOfType<ChatLine>().Count(), () => Is.EqualTo(2));
+            assertAlternatingBackground(0, true);
+            assertAlternatingBackground(1, false);
+
+            void assertAlternatingBackground(int lineIndex, bool shouldBeAlternating)
+                => AddAssert($"line {lineIndex} {(shouldBeAlternating ? "has" : "does not have")} alternating background",
+                    () => drawableChannel.ChildrenOfType<ChatLine>().ElementAt(lineIndex).AlternatingBackground,
+                    () => Is.EqualTo(shouldBeAlternating));
+        }
+
+        [Test]
+        public void TestTimestampsUpdateOnRemoval()
+        {
+            AddStep("add 3 messages", () =>
+            {
+                channel.AddNewMessages(new Message
+                    {
+                        ChannelId = channel.Id,
+                        Content = "Message 0",
+                        Timestamp = new DateTimeOffset(2022, 11, 21, 20, 0, 0, TimeSpan.Zero),
+                        Sender = new APIUser
+                        {
+                            Id = 0,
+                            Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                        }
+                    },
+                    new Message
+                    {
+                        ChannelId = channel.Id,
+                        Content = "Message 1",
+                        Timestamp = new DateTimeOffset(2022, 11, 21, 20, 0, 0, TimeSpan.Zero).AddSeconds(1),
+                        Sender = new APIUser
+                        {
+                            Id = 1,
+                            Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                        }
+                    },
+                    new Message
+                    {
+                        ChannelId = channel.Id,
+                        Content = "Message 2",
+                        Timestamp = new DateTimeOffset(2022, 11, 21, 20, 0, 0, TimeSpan.Zero).AddMinutes(1),
+                        Sender = new APIUser
+                        {
+                            Id = 2,
+                            Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                        }
+                    },
+                    new Message
+                    {
+                        ChannelId = channel.Id,
+                        Content = "Message 3",
+                        Timestamp = new DateTimeOffset(2022, 11, 21, 20, 0, 0, TimeSpan.Zero).AddMinutes(1).AddSeconds(1),
+                        Sender = new APIUser
+                        {
+                            Id = 3,
+                            Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                        }
+                    }
+                );
+            });
+
+            AddUntilStep("4 messages present", () => drawableChannel.ChildrenOfType<ChatLine>().Count(), () => Is.EqualTo(4));
+            assertTimestamp(0, true);
+            assertTimestamp(1, false);
+            assertTimestamp(2, true);
+            assertTimestamp(3, false);
+
+            AddStep("remove message 0", () => channel.RemoveMessagesFromUser(0));
+            AddUntilStep("3 messages present", () => drawableChannel.ChildrenOfType<ChatLine>().Count(), () => Is.EqualTo(3));
+            assertTimestamp(0, true);
+            assertTimestamp(1, true);
+            assertTimestamp(2, false);
+
+            AddStep("remove message 2", () => channel.RemoveMessagesFromUser(2));
+            AddUntilStep("2 messages present", () => drawableChannel.ChildrenOfType<ChatLine>().Count(), () => Is.EqualTo(2));
+            assertTimestamp(0, true);
+            assertTimestamp(1, true);
+
+            void assertTimestamp(int lineIndex, bool shouldHaveTimestamp)
+                => AddAssert($"line {lineIndex} {(shouldHaveTimestamp ? "has" : "does not have")} timestamp",
+                    () => drawableChannel.ChildrenOfType<ChatLine>().ElementAt(lineIndex).RequiresTimestamp,
+                    () => Is.EqualTo(shouldHaveTimestamp));
+        }
     }
 }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -85,16 +85,13 @@ namespace osu.Game.Overlays.Chat
 
             long? lastMinutes = null;
 
-            for (int i = 0; i < ChatLineFlow.Count; i++)
+            foreach (var line in chatLines)
             {
-                if (ChatLineFlow[i] is ChatLine chatline)
-                {
-                    long minutes = chatline.Message.Timestamp.ToUnixTimeSeconds() / 60;
+                long minutes = line.Message.Timestamp.ToUnixTimeSeconds() / 60;
 
-                    chatline.AlternatingBackground = i % 2 == 0;
-                    chatline.RequiresTimestamp = minutes != lastMinutes;
-                    lastMinutes = minutes;
-                }
+                line.RequiresTimestamp = minutes != lastMinutes;
+
+                lastMinutes = minutes;
             }
         }
 
@@ -145,19 +142,28 @@ namespace osu.Game.Overlays.Chat
             // Add up to last Channel.MAX_HISTORY messages
             var displayMessages = newMessages.Skip(Math.Max(0, newMessages.Count() - Channel.MAX_HISTORY));
 
-            Message lastMessage = chatLines.LastOrDefault()?.Message;
+            ChatLine lastLine = chatLines.LastOrDefault();
+            Message lastMessage = lastLine?.Message;
 
             foreach (var message in displayMessages)
             {
                 addDaySeparatorIfRequired(lastMessage, message);
 
-                var chatLine = CreateChatLine(message);
+                ChatLine line = CreateChatLine(message);
 
-                if (chatLine != null)
-                {
-                    ChatLineFlow.Add(chatLine);
-                    lastMessage = message;
-                }
+                if (line == null)
+                    continue;
+
+                long minutes = line.Message.Timestamp.ToUnixTimeSeconds() / 60;
+                long? lastMinutes = lastLine?.Message.Timestamp.ToUnixTimeSeconds() / 60;
+
+                line.AlternatingBackground = lastLine?.AlternatingBackground == false;
+                line.RequiresTimestamp = minutes != lastMinutes;
+
+                ChatLineFlow.Add(line);
+
+                lastMessage = message;
+                lastLine = line;
             }
 
             var staleMessages = chatLines.Where(c => c.LifetimeEnd == double.MaxValue).ToArray();
@@ -232,7 +238,41 @@ namespace osu.Game.Overlays.Chat
 
         private void messageRemoved(Message removed) => Schedule(() =>
         {
-            chatLines.FirstOrDefault(c => c.Message == removed)?.FadeColour(Color4.Red, 400).FadeOut(600).Expire();
+            const double fade_time = 600;
+
+            ChatLine removedLine = chatLines.FirstOrDefault(c => c.Message == removed);
+
+            if (removedLine == null)
+                return;
+
+            removedLine.FadeColour(Color4.Red, 400).FadeOut(fade_time).Expire();
+
+            // Resolve new colours and timestamps resulting from the removal.
+            this.Delay(fade_time).Schedule(() =>
+            {
+                ChatLine lastLine = null;
+
+                // Preserve the colours of most-recent messages while updating the ones upwards in the list.
+                foreach (var line in chatLines.Reverse().Except([removedLine]))
+                {
+                    if (lastLine != null)
+                        line.AlternatingBackground = !lastLine.AlternatingBackground;
+
+                    lastLine = line;
+                }
+
+                lastLine = null;
+
+                // Timestamps may migrate to more recent messages.
+                foreach (var line in chatLines.Except([removedLine]))
+                {
+                    long minutes = line.Message.Timestamp.ToUnixTimeSeconds() / 60;
+                    long? lastMinutes = lastLine?.Message.Timestamp.ToUnixTimeSeconds() / 60;
+                    line.RequiresTimestamp = minutes != lastMinutes;
+
+                    lastLine = line;
+                }
+            });
         });
 
         private IEnumerable<ChatLine> chatLines => ChatLineFlow.Children.OfType<ChatLine>();


### PR DESCRIPTION
This is a second attempt at fixing https://github.com/ppy/osu/issues/29572.
Previous attempt here: https://github.com/ppy/osu/pull/29631

I've tried to fix the behaviour mentioned in https://github.com/ppy/osu/pull/29631#issuecomment-2318409419, though I disagree with it - I think the colours should be maintained as is and not be updated on removal.