### PR TITLE
Display quick play pool name as sub-heading in selector

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingPoolSelector.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingPoolSelector.cs
@@ -22,11 +22,11 @@ namespace osu.Game.Tests.Visual.Matchmaking
                 {
                     Value =
                     [
-                        new MatchmakingPool { Id = 0, RulesetId = 0, Name = "osu!" },
-                        new MatchmakingPool { Id = 1, RulesetId = 1, Name = "osu!taiko" },
-                        new MatchmakingPool { Id = 2, RulesetId = 2, Name = "osu!catch" },
-                        new MatchmakingPool { Id = 3, RulesetId = 3, Variant = 4, Name = "osu!mania (4k)" },
-                        new MatchmakingPool { Id = 4, RulesetId = 3, Variant = 7, Name = "osu!mania (7k)" },
+                        new MatchmakingPool { Id = 0, RulesetId = 0, Name = "Free-for-all" },
+                        new MatchmakingPool { Id = 1, RulesetId = 1, Name = "1v1" },
+                        new MatchmakingPool { Id = 2, RulesetId = 2, Name = "1v1" },
+                        new MatchmakingPool { Id = 3, RulesetId = 3, Variant = 4, Name = "1v1" },
+                        new MatchmakingPool { Id = 4, RulesetId = 3, Variant = 7, Name = "1v1" },
                     ]
                 }
             });

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/PoolSelector.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/PoolSelector.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private partial class SelectorButton : OsuAnimatedButton
         {
-            public static readonly Vector2 SIZE = new Vector2(84, 64);
+            public static readonly Vector2 SIZE = new Vector2(84, 78);
 
             public bool IsSelected => SelectedPool.Value?.Equals(pool) == true;
 
@@ -105,8 +105,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             private Drawable iconSprite = null!;
 
             private Box flashLayer = null!;
-
-            private OsuSpriteText text = null!;
 
             public SelectorButton(MatchmakingPool pool)
                 : base(HoverSampleSet.ButtonSidebar)
@@ -122,6 +120,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 Content.Masking = true;
                 Content.CornerRadius = 16;
                 Content.CornerExponent = 10;
+
+                Ruleset? rulesetInstance = rulesetStore.GetRuleset(pool.RulesetId)?.CreateInstance();
+
+                string rulesetName = rulesetInstance?.Description ?? string.Empty;
+                if (pool.Variant != 0)
+                    rulesetName += $" {pool.Variant}K";
 
                 Children = new Drawable[]
                 {
@@ -156,13 +160,28 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                     iconSprite = createIcon(),
                                 }
                             },
-                            text = new OsuSpriteText
+                            new FillFlowContainer
                             {
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                Font = OsuFont.Style.Caption2,
-                                Text = pool.Name,
-                            },
+                                RelativeSizeAxes = Axes.Both,
+                                Direction = FillDirection.Vertical,
+                                Children = new Drawable[]
+                                {
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
+                                        Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                                        Text = rulesetName,
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
+                                        Font = OsuFont.Style.Caption2,
+                                        Text = pool.Name
+                                    }
+                                }
+                            }
                         }
                     },
                 };
@@ -198,14 +217,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 {
                     this.ScaleTo(1.2f, 200, Easing.OutQuint);
                     iconSprite.FadeColour(Color4.Gold, 100, Easing.OutQuint);
-                    text.Font = text.Font.With(weight: FontWeight.Bold);
                     flashLayer.FadeTo(0.1f, 200, Easing.OutQuint);
                 }
                 else
                 {
                     this.ScaleTo(1f, 200, Easing.OutQuint);
                     iconSprite.FadeColour(OsuColour.Gray(0.5f), 100);
-                    text.Font = text.Font.With(weight: FontWeight.Regular);
                     flashLayer.FadeOut(200, Easing.OutQuint);
                 }
             }


### PR DESCRIPTION
This was discussed IRL as an alternative/replacement for https://github.com/ppy/osu-web/pull/12570.

<img width="503" height="134" alt="image" src="https://github.com/user-attachments/assets/3fcc97fc-407a-44ab-a9f8-24c06a1c7c49" />
