### PR TITLE
Remove now-unnecessary timestamp updates

### DIFF
--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -79,22 +79,6 @@ namespace osu.Game.Overlays.Chat
             highlightedMessage.BindValueChanged(_ => processMessageHighlighting(), true);
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            long? lastMinutes = null;
-
-            foreach (var line in chatLines)
-            {
-                long minutes = line.Message.Timestamp.ToUnixTimeSeconds() / 60;
-
-                line.RequiresTimestamp = minutes != lastMinutes;
-
-                lastMinutes = minutes;
-            }
-        }
-
         /// <summary>
         /// Processes any pending message in <see cref="highlightedMessage"/>.
         /// </summary>


### PR DESCRIPTION
Since #35820, this is now handled when messages are added and removed.