### PR TITLE
Add context menu shortcut to watch local replays from song select

### DIFF
--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -110,6 +110,11 @@ namespace osu.Game.Localisation
         public static LocalisableString UseTheseMods => new TranslatableString(getKey(@"use_these_mods"), @"Use these mods");
 
         /// <summary>
+        /// "Watch replay"
+        /// </summary>
+        public static LocalisableString WatchReplay => new TranslatableString(getKey(@"watch_replay"), @"Watch replay");
+
+        /// <summary>
         /// "For all difficulties"
         /// </summary>
         public static LocalisableString ForAllDifficulties => new TranslatableString(getKey(@"for_all_difficulties"), @"For all difficulties");

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -628,6 +628,8 @@ namespace osu.Game.Screens.SelectV2
 
                 if (Score.Files.Count <= 0) return items.ToArray();
 
+                items.Add(new OsuMenuItemSpacer());
+                items.Add(new OsuMenuItem(SongSelectStrings.WatchReplay, MenuItemType.Standard, () => game?.PresentScore(Score, ScorePresentType.Gameplay)));
                 items.Add(new OsuMenuItem(CommonStrings.Export, MenuItemType.Standard, () => scoreManager.Export(Score)));
                 items.Add(new OsuMenuItem(Resources.Localisation.Web.CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => dialogOverlay?.Push(new LocalScoreDeleteDialog(Score))));
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/d445496c-5265-4766-a967-0a2263abd4e9

---

Addresses https://github.com/ppy/osu/discussions/35811 I guess.

Will only work for local leaderboards for now but maybe good enough for what is essentially a 5 minute job?

Can be made to work with online leaderboards too I guess if need be.