### PR TITLE
Attempt to prevent main menu osu! logo being triggered by media keys

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -286,6 +286,9 @@ namespace osu.Game.Screens.Menu
             if (e.Key >= Key.F1 && e.Key <= Key.F35)
                 return false;
 
+            if (e.Key >= Key.Mute && e.Key <= Key.TrackNext)
+                return false;
+
             switch (e.Key)
             {
                 case Key.Escape:


### PR DESCRIPTION
Maybe addresses https://github.com/ppy/osu/discussions/35813. I can't reproduce on macOS, may be a `$USER_OS` idiosyncrasy.