### PR TITLE
Fix gameplay leaderboard tracked player not using team colour

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableGameplayLeaderboardScore.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableGameplayLeaderboardScore.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Select.Leaderboards;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public partial class TestSceneDrawableGameplayLeaderboardScore : OsuTestScene
+    {
+        private readonly APIUser user = new APIUser { Username = "user" };
+        private readonly BindableLong totalScore = new BindableLong();
+        private readonly Bindable<int?> position = new Bindable<int?>();
+        private readonly BindableBool quit = new BindableBool();
+        private readonly BindableBool expanded = new BindableBool();
+
+        public TestSceneDrawableGameplayLeaderboardScore()
+        {
+            AddSliderStep("total score", 0, 1_000_000, 500_000, s => totalScore.Value = s);
+            AddSliderStep("position", 1, 100, 5, s => position.Value = s);
+            AddToggleStep("toggle quit", q => quit.Value = q);
+            AddToggleStep("toggle expanded", e => expanded.Value = e);
+        }
+
+        private static readonly OsuColour osu_colour = new OsuColour();
+
+        private static readonly object?[][] leaderboard_variants =
+        {
+            new object?[] { false, null },
+            new object?[] { true, null },
+            new object?[] { false, osu_colour.TeamColourRed },
+            new object?[] { true, osu_colour.TeamColourRed },
+            new object?[] { false, osu_colour.TeamColourBlue },
+            new object?[] { true, osu_colour.TeamColourBlue },
+        };
+
+        [TestCaseSource(nameof(leaderboard_variants))]
+        public void TestVariants(bool tracked, Color4? teamColour)
+        {
+            AddStep("show", () =>
+            {
+                GameplayLeaderboardScore score = new GameplayLeaderboardScore(user, tracked, totalScore)
+                {
+                    Position = { BindTarget = position },
+                    HasQuit = { BindTarget = quit },
+                    TeamColour = teamColour,
+                };
+                Child = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 250,
+                    Child = new DrawableGameplayLeaderboardScore(score)
+                    {
+                        Expanded = { BindTarget = expanded },
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                };
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboardScore.cs
@@ -357,7 +357,7 @@ namespace osu.Game.Screens.Play.HUD
             else if (Tracked)
             {
                 widthExtension = true;
-                setPanelColourAsTracked();
+                setTrackedPanelColour(BackgroundColour);
             }
             else if (isFriend)
             {
@@ -380,11 +380,11 @@ namespace osu.Game.Screens.Play.HUD
             scorePanel.BorderColour = ColourInfo.GradientVertical(baseColour.Opacity(0.2f), baseColour);
         }
 
-        private void setPanelColourAsTracked()
+        private void setTrackedPanelColour(Color4? backgroundColour)
         {
-            leftLayerGradient.Colour = ColourInfo.GradientVertical(colours.Blue2.Opacity(0.3f), colours.Blue2);
-            rightLayerGradient.Colour = ColourInfo.GradientVertical(colours.Blue4.Opacity(0.25f), colours.Blue3.Opacity(0.6f));
-            scorePanel.BorderColour = ColourInfo.GradientVertical(colours.Blue1.Opacity(0.2f), colours.Blue1);
+            leftLayerGradient.Colour = ColourInfo.GradientVertical((backgroundColour ?? colours.Blue2).Opacity(0.3f), backgroundColour ?? colours.Blue2);
+            rightLayerGradient.Colour = ColourInfo.GradientVertical((backgroundColour ?? colours.Blue4).Opacity(0.25f), (backgroundColour ?? colours.Blue3).Opacity(0.6f));
+            scorePanel.BorderColour = ColourInfo.GradientVertical((backgroundColour ?? colours.Blue1).Opacity(0.2f), backgroundColour ?? colours.Blue1);
         }
 
         protected override void Update()


### PR DESCRIPTION
| | before | after |
| :-: | :-: | :-: |
| solo, not tracked | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 13" src="https://github.com/user-attachments/assets/91000033-3486-4ceb-82eb-4c2fb84bc35e" /> | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 50" src="https://github.com/user-attachments/assets/eaa9f1d0-9ced-4d26-9150-e26dfc1b3eaa" /> |
| solo, tracked | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 18" src="https://github.com/user-attachments/assets/2ac37ecc-9af2-4209-8070-926494a82e2f" /> | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 52" src="https://github.com/user-attachments/assets/53d31ee8-997d-4939-bcb5-1965bc2b0a15" /> |
| red team, not tracked | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 20" src="https://github.com/user-attachments/assets/a3505dc6-522b-4dac-8589-9c1550e231c7" /> | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 55" src="https://github.com/user-attachments/assets/a8feba2f-795a-4c8c-9aaf-4c1094b1290f" /> |
| red team, tracked | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 23" src="https://github.com/user-attachments/assets/8c203066-41b9-4d4a-a92e-72d537d3538e" /> | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 57" src="https://github.com/user-attachments/assets/7d4a511b-c320-48b2-a5df-49604e154a68" /> |
| blue team, not tracked | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 25" src="https://github.com/user-attachments/assets/4250c302-8d97-47a5-8971-990e28713270" /> | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 59" src="https://github.com/user-attachments/assets/edb05244-8d64-4234-8ff5-e579a0caa694" /> |
| blue team, tracked | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 27 27" src="https://github.com/user-attachments/assets/8479c17e-8cc4-4b01-b9d9-b5920665145d" /> | <img width="303" height="73" alt="Screenshot 2025-11-27 at 12 28 01" src="https://github.com/user-attachments/assets/728d05cd-ab60-4e09-9f6f-2ff0c4e65e44" /> |

---

Closes https://github.com/ppy/osu/issues/35806.

Regressed in https://github.com/ppy/osu/pull/34339.