### PR TITLE
Trim editor timestamp when pasting into `TimeInfoContainer`

### DIFF
--- a/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
+++ b/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Screens.Edit.Components
                     });
                 };
 
-                inputTextBox.Current.BindValueChanged(val => editor?.HandleTimestamp(val.NewValue));
+                inputTextBox.Current.BindValueChanged(val => editor?.HandleTimestamp(val.NewValue.Trim()));
 
                 inputTextBox.OnCommit += (_, __) =>
                 {


### PR DESCRIPTION
Was trying to apply mods from discord on lazer, and sometimes I found myself copypasting timestamps with trailing spaces, and having those not work felt like bad UX.

Also matches stable. 