### PR TITLE
Make tracked leaderboard score yellow again

### DIFF
--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboardScore.cs
@@ -357,7 +357,7 @@ namespace osu.Game.Screens.Play.HUD
             else if (Tracked)
             {
                 widthExtension = true;
-                setTrackedPanelColour(BackgroundColour);
+                setPanelColour(BackgroundColour ?? colours.Orange2);
             }
             else if (isFriend)
             {
@@ -378,13 +378,6 @@ namespace osu.Game.Screens.Play.HUD
             leftLayerGradient.Colour = ColourInfo.GradientVertical(baseColour.Opacity(0.2f), baseColour.Opacity(0.5f));
             rightLayerGradient.Colour = ColourInfo.GradientVertical(baseColour.Opacity(0.1f), baseColour.Opacity(0.3f));
             scorePanel.BorderColour = ColourInfo.GradientVertical(baseColour.Opacity(0.2f), baseColour);
-        }
-
-        private void setTrackedPanelColour(Color4? backgroundColour)
-        {
-            leftLayerGradient.Colour = ColourInfo.GradientVertical((backgroundColour ?? colours.Blue2).Opacity(0.3f), backgroundColour ?? colours.Blue2);
-            rightLayerGradient.Colour = ColourInfo.GradientVertical((backgroundColour ?? colours.Blue4).Opacity(0.25f), (backgroundColour ?? colours.Blue3).Opacity(0.6f));
-            scorePanel.BorderColour = ColourInfo.GradientVertical((backgroundColour ?? colours.Blue1).Opacity(0.2f), backgroundColour ?? colours.Blue1);
         }
 
         protected override void Update()


### PR DESCRIPTION
Previously the tracked player was yellow (in code orange for some reason), which made seeing if you were first really easy as you your peripheral was either green or yellow.

This PR reverts whatever change made it blue and removes a function that used to make the blue... a different blue?

Before blue-ification: ([2024.625.2](https://github.com/ppy/osu/releases/tag/2024.625.2))
![image](https://github.com/user-attachments/assets/2d041d13-6392-430f-bb0d-2a8161a67526)

After blue-ification (2025-1029-1)
![image](https://github.com/user-attachments/assets/79354223-f6f9-4efc-b221-4851fe310f61)

After un-blue-ification
![image](https://github.com/user-attachments/assets/aae97d11-e424-4c1e-bfd7-ebea959251eb)
