### PR TITLE
Allow window resizing on iPadOS

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -25,8 +25,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIRequiresFullScreen</key>
-	<true/>
 	<key>UIStatusBarHidden</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/35850

The flag has been set there almost since the game's initial commit. Removing it and testing it shows no issues at all.

One thing to note however, there is now a black bar at the top of the game, and it seems to be device-dependent (I see it on my iPad Pro 11" 4th gen, but not on iPad A16 by simulator). This black bar does not exist on master even when resizing the window down from full-screen mode, so it's technically brought about by this PR.

It stems from a top safe area padding that is applied for some reason, and so it can be overriden by the `OsuGameIOS.SafeAreaOverrideEdges` flag to go away:

| ipad before | ipad after |
|-------------|------------|
| ![IMG_0510](https://github.com/user-attachments/assets/192c982f-109c-42dc-84c7-f9607d0331b9) | ![IMG_0512](https://github.com/user-attachments/assets/2b415ddc-2619-4e57-bdbe-fd6da4feaa54) |

Applying this directly though affects iPhones on portrait mode, as the top "non-safe" area in a portrait mode consists of the notch and the gap above it, and the effect may be more of a negative than a positive:

| before iphone | after iphone |
|---------------|--------------|
| <img width="200" height="1034" alt="CleanShot 2025-11-30 at 05 45 21" src="https://github.com/user-attachments/assets/1243f68b-8420-4587-bb61-842c7e465689" /> | <img width="200" height="1034" alt="CleanShot 2025-11-30 at 05 44 21" src="https://github.com/user-attachments/assets/2d5123e9-a6e1-41d1-9743-bcdf67762548" /> |

As such, I'm unsure whether to apply this change to fix the black bar on iPad, or leave it as it is. This tells us that we may want better safe area handling in osu!, but that's not of any priority in the current scheme of things. @peppy thoughts on this?