### PR TITLE
Fix retry sound being cutted by spamming quick restart key

### DIFF
--- a/osu.Game/Overlays/HoldToConfirmOverlay.cs
+++ b/osu.Game/Overlays/HoldToConfirmOverlay.cs
@@ -53,7 +53,6 @@ namespace osu.Game.Overlays
             {
                 double target = p.NewValue * finalFillAlpha;
 
-                audioVolume.Value = 1 - target;
                 overlay.Alpha = (float)target;
             };
 


### PR DESCRIPTION
- closes https://github.com/ppy/osu/issues/35831

### master
https://github.com/user-attachments/assets/5b68b8ea-006d-4783-8589-aec76e876072

### pr
https://github.com/user-attachments/assets/c6765ce4-a59c-45b8-ba8e-78ddb171d6e4
