### PR TITLE
Disable quick retry binding in solo spectator

### DIFF
--- a/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
@@ -21,7 +21,12 @@ namespace osu.Game.Screens.Play
         protected override UserActivity InitialActivity => new UserActivity.SpectatingUser(Score.ScoreInfo);
 
         public SoloSpectatorPlayer(Score score)
-            : base(score, new PlayerConfiguration { AllowUserInteraction = false, ShowLeaderboard = true })
+            : base(score, new PlayerConfiguration
+            {
+                AllowUserInteraction = false,
+                ShowLeaderboard = true,
+                AllowRestart = false
+            })
         {
             this.score = score;
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35870? For some definition of "closes", I guess?

Why would you ever do this, unless on purpose just to break stuff? Don't answer that.

A side effect of setting this flag is that the hold-to-exit menu button that's there on devices that support touch will slightly change behaviour to the behaviour multiplayer play has:

https://github.com/ppy/osu/blob/e3ea38a366601df01f045f4f111765c34d041145/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs#L67
https://github.com/ppy/osu/blob/8d9245c1d4f72db4307da7492d65bd09fc48bc02/osu.Game/Graphics/Containers/HoldToConfirmContainer.cs#L79-L82

but upon thinking about it for three minutes I decided I don't care and it's probably fine because all of this was already racking up to fifteen minutes that I shouldn't have had to spend on any of this.

Notably this shouldn't affect the actual spectated user retrying, because all of that is handled elsewhere via

https://github.com/ppy/osu/blob/2f90bb4d6793475835d1d51bef92b2c40f69112c/osu.Game/Screens/Spectate/SpectatorScreen.cs#L138-L154