### PR TITLE
Do not distinguish between left/right modifiers when assigning new key combinations

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2025.1121.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2025.1205.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual.Settings
             scrollToAndStartBinding("Increase volume");
             AddStep("press shift", () => InputManager.PressKey(Key.ShiftLeft));
             AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
-            checkBinding("Increase volume", "LShift");
+            checkBinding("Increase volume", "Shift");
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("press shift", () => InputManager.PressKey(Key.ShiftLeft));
             AddStep("press k", () => InputManager.Key(Key.K));
             AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
-            checkBinding("Increase volume", "LShift-K");
+            checkBinding("Increase volume", "Shift-K");
         }
 
         [Test]

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.KeyButton.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.KeyButton.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -139,9 +140,14 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             /// </summary>
             /// <param name="fullState">A <see cref="KeyCombination"/> generated from the full input state.</param>
             /// <param name="triggerKey">The key which triggered this update, and should be used as the binding.</param>
-            public void UpdateKeyCombination(KeyCombination fullState, InputKey triggerKey) =>
-                // TODO: Distinct() can be removed after https://github.com/ppy/osu-framework/pull/6130 is merged.
-                UpdateKeyCombination(new KeyCombination(fullState.Keys.Where(KeyCombination.IsModifierKey).Append(triggerKey).Distinct().ToArray()));
+            public void UpdateKeyCombination(KeyCombination fullState, InputKey triggerKey)
+            {
+                var combination = fullState.Keys.Where(KeyCombination.IsModifierKey)
+                                           .Append(triggerKey)
+                                           .Select(k => k.GetVirtualKey() ?? k)
+                                           .ToArray();
+                UpdateKeyCombination(new KeyCombination(combination));
+            }
 
             public void UpdateKeyCombination(KeyCombination newCombination)
             {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2025.1121.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2025.1205.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2025.1125.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -17,6 +17,6 @@
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2025.1121.1" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2025.1205.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Depends on framework package w/ https://github.com/ppy/osu-framework/pull/6679

Addresses https://github.com/ppy/osu/discussions/35851.

And no I'm not making it "you have to press both modifiers for it to become any of the two" because that's ultra weird.