### PR TITLE
Fix quick play crash when presenting random selection

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectGrid.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectGrid.cs
@@ -235,6 +235,22 @@ namespace osu.Game.Tests.Visual.Matchmaking
             });
         }
 
+        [Test]
+        public void TestRollAnimationFinalRandom()
+        {
+            AddStep("play animation", () =>
+            {
+                (long[] candidateItems, _) = pickRandomItems(5);
+
+                candidateItems = candidateItems.Append(-1).ToArray();
+                long finalItem = items.First(i => !candidateItems.Contains(i.ID)).ID;
+
+                grid.RollAndDisplayFinalBeatmap(candidateItems, -1, finalItem);
+            });
+
+            AddWaitStep("wait for animation", 10);
+        }
+
         private (long[] candidateItems, long finalItem) pickRandomItems(int count)
         {
             long[] candidateItems = items.Select(it => it.ID).ToArray();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 this.Delay(ARRANGE_DELAY)
                     .Schedule(() => ArrangeItemsForRollAnimation())
                     .Delay(arrange_duration)
-                    .Schedule(() => PlayRollAnimation(gameplayItemId, roll_duration))
+                    .Schedule(() => PlayRollAnimation(candidateItemId, roll_duration))
                     .Delay(roll_duration + present_beatmap_delay)
                     .Schedule(() => PresentRolledBeatmap(candidateItemId, gameplayItemId));
             }


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/35768

Requires a specific, but common scenario:
- Multiple items to be candidates (i.e. roll animation is played).
- The random item to be one of  the candidates.
- The random item to be the final candidate.
- The random item to result in a final beatmap that is not one of the candidates itself.