### PR TITLE
Fix "kicked" users not being marked as quit

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanelOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanelOverlay.cs
@@ -78,6 +78,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
             client.MatchRoomStateChanged += onRoomStateChanged;
             client.UserJoined += onUserJoined;
             client.UserLeft += onUserLeft;
+            client.UserKicked += onUserLeft;
 
             if (client.Room != null)
             {
@@ -207,6 +208,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                 client.MatchRoomStateChanged -= onRoomStateChanged;
                 client.UserJoined -= onUserJoined;
                 client.UserLeft -= onUserLeft;
+                client.UserKicked -= onUserLeft;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/35876

This is a server-side quirk so no tests have been added.

On disconnect, the server will "kick" users. I'm not entirely sure why it does this as opposed to marking them as left normally, but regardless of whether it's correct or not it sounds appropriate to handle the "kick" state in addition.

I don't see this going away even if server-side changes.