### PR TITLE
Cache user avatars, covers, and team logos to disk

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -62,6 +62,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
+using osu.Game.Users.Drawables;
 using osu.Game.Utils;
 using RuntimeInfo = osu.Framework.RuntimeInfo;
 
@@ -343,6 +344,8 @@ namespace osu.Game
 
             dependencies.Cache(userCache = new UserLookupCache());
             base.Content.Add(userCache);
+
+            dependencies.Cache(new AvatarStore(Host, userCache));
 
             dependencies.Cache(beatmapCache = new BeatmapLookupCache());
             base.Content.Add(beatmapCache);

--- a/osu.Game/Users/Drawables/AvatarStore.cs
+++ b/osu.Game/Users/Drawables/AvatarStore.cs
@@ -1,0 +1,186 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Text.RegularExpressions;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Database;
+using osu.Game.Online;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Users.Drawables
+{
+    public class AvatarStore
+    {
+        private readonly UserLookupCache userCache;
+        private readonly OnlineStore onlineStore;
+        private readonly Storage avatarStorage;
+        private readonly LargeTextureStore largeTextureStore;
+
+        private static readonly Regex avatar_url_regex =
+            new Regex(@"^https:\/\/a\.ppy\.sh\/(?<userId>\d+)\?(?<filename>\d+\.(gif|jpg|jpeg|png))$", RegexOptions.Compiled);
+
+        private static readonly Regex custom_cover_url_regex =
+            new Regex(@"^https:\/\/assets\.ppy\.sh\/user-profile-covers\/(?<id>\d+)\/(?<filename>[0-9a-fA-F]+\.(gif|jpg|jpeg|png))$", RegexOptions.Compiled);
+
+        private static readonly Regex preset_cover_url_regex =
+            new Regex(@"^https:\/\/assets\.ppy\.sh\/user-cover-presets\/(?<id>\d+)/(?<filename>[0-9a-fA-F]+\.(gif|jpg|jpeg|png))$", RegexOptions.Compiled);
+
+        private static readonly Regex team_flag_url_regex =
+            new Regex(@"^https:\/\/assets\.ppy\.sh\/teams\/flag\/(?<teamId>\d+)/(?<filename>[0-9a-fA-F]+\.(gif|jpg|jpeg|png))$", RegexOptions.Compiled);
+
+        private const string user_avatar_storage = @"user-avatars";
+        private const string custom_cover_storage = @"custom-covers";
+        private const string preset_cover_storage = @"preset-covers";
+        private const string team_flag_storage = @"team-flags";
+
+        public AvatarStore(GameHost host, UserLookupCache userCache)
+        {
+            this.userCache = userCache;
+            onlineStore = new TrustedDomainOnlineStore();
+            avatarStorage = host.CacheStorage.GetStorageForDirectory(@"avatars");
+
+            largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(new StorageBackedResourceStore(avatarStorage)));
+            largeTextureStore.AddTextureSource(host.CreateTextureLoaderStore(onlineStore));
+        }
+
+        public Texture? GetUserAvatar(int userId)
+        {
+            var user = userCache.GetUserAsync(userId).GetResultSafely();
+            return user == null ? null : GetUserAvatar(user);
+        }
+
+        public Texture? GetUserAvatar(APIUser user)
+        {
+            try
+            {
+                string avatarUrl = user.AvatarUrl;
+                if (string.IsNullOrEmpty(avatarUrl))
+                    return null;
+
+                var match = avatar_url_regex.Match(avatarUrl);
+
+                if (!match.Success)
+                {
+                    Logger.Log($@"Unrecognised user avatar URL format ({avatarUrl}), serving online version.", LoggingTarget.Network);
+                    return largeTextureStore.Get(avatarUrl);
+                }
+
+                string userId = match.Groups[@"userId"].Value;
+                string filename = match.Groups[@"filename"].Value;
+                ensureDownloadedToLocalCache(avatarStorage.GetStorageForDirectory(user_avatar_storage).GetStorageForDirectory(userId), filename, avatarUrl);
+
+                string lookupKey = $@"{user_avatar_storage}/{userId}/{filename}";
+                Logger.Log($@"Serving user avatar from local cache ({lookupKey}).", LoggingTarget.Network);
+                return largeTextureStore.Get(lookupKey);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($@"Error when retrieving user avatar: {e}", LoggingTarget.Network);
+                return null;
+            }
+        }
+
+        public Texture? GetUserCover(APIUser user)
+        {
+            try
+            {
+                string? coverUrl = user.CoverUrl;
+                if (string.IsNullOrEmpty(coverUrl))
+                    return null;
+
+                string? coverStorageName = null;
+                Match? match = null;
+
+                if (custom_cover_url_regex.IsMatch(coverUrl))
+                {
+                    coverStorageName = custom_cover_storage;
+                    match = custom_cover_url_regex.Match(coverUrl);
+                }
+
+                if (preset_cover_url_regex.IsMatch(coverUrl))
+                {
+                    coverStorageName = preset_cover_storage;
+                    match = preset_cover_url_regex.Match(coverUrl);
+                }
+
+                if (match?.Success != true)
+                {
+                    Logger.Log(@$"Unrecognised user cover URL format ({coverUrl}), serving online version.", LoggingTarget.Network);
+                    return largeTextureStore.Get(coverUrl);
+                }
+
+                string presetOrUserId = match.Groups[@"id"].Value;
+                string filename = match.Groups[@"filename"].Value;
+                ensureDownloadedToLocalCache(avatarStorage.GetStorageForDirectory(coverStorageName).GetStorageForDirectory(presetOrUserId), filename, coverUrl);
+
+                string lookupKey = $@"{coverStorageName}/{presetOrUserId}/{filename}";
+                return largeTextureStore.Get(lookupKey);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($@"Error when retrieving user cover: {e}", LoggingTarget.Network);
+                return null;
+            }
+        }
+
+        public Texture? GetTeamAvatar(APITeam team)
+        {
+            try
+            {
+                string flagUrl = team.FlagUrl;
+                if (string.IsNullOrEmpty(flagUrl))
+                    return null;
+
+                var match = team_flag_url_regex.Match(flagUrl);
+
+                if (!match.Success)
+                {
+                    Logger.Log($@"Unrecognised team avatar URL format ({flagUrl}), serving online version.", LoggingTarget.Network);
+                    return largeTextureStore.Get(flagUrl);
+                }
+
+                string teamId = match.Groups[@"teamId"].Value;
+                string filename = match.Groups[@"filename"].Value;
+                ensureDownloadedToLocalCache(avatarStorage.GetStorageForDirectory(team_flag_storage).GetStorageForDirectory(teamId), filename, flagUrl);
+
+                string lookupKey = $@"{team_flag_storage}/{teamId}/{filename}";
+                Logger.Log($@"Serving team avatar from local cache ({lookupKey}).", LoggingTarget.Network);
+                return largeTextureStore.Get(lookupKey);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($@"Error when retrieving team avatar: {e}", LoggingTarget.Network);
+                return null;
+            }
+        }
+
+        private void ensureDownloadedToLocalCache(Storage scopedStorage, string localKey, string remoteUrl)
+        {
+            if (scopedStorage.Exists(localKey))
+                return;
+
+            try
+            {
+                foreach (string file in scopedStorage.GetFiles(string.Empty))
+                {
+                    Logger.Log($@"Purging stale cached asset {scopedStorage.GetFullPath(file)}...", LoggingTarget.Network);
+                    scopedStorage.Delete(file);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log($@"Purging stale cached assets under {scopedStorage.GetFullPath(string.Empty)} failed: {e}", LoggingTarget.Network);
+            }
+
+            byte[] onlineResult = onlineStore.Get(remoteUrl);
+
+            using (var stream = scopedStorage.CreateFileSafely(localKey))
+                stream.Write(onlineResult, 0, onlineResult.Length);
+        }
+    }
+}

--- a/osu.Game/Users/Drawables/DrawableAvatar.cs
+++ b/osu.Game/Users/Drawables/DrawableAvatar.cs
@@ -31,12 +31,10 @@ namespace osu.Game.Users.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(LargeTextureStore textures)
+        private void load(AvatarStore avatarStore, LargeTextureStore textures)
         {
             if (user != null && user.OnlineID > 1)
-                // TODO: The fallback here should not need to exist. Users should be looked up and populated via UserLookupCache or otherwise
-                // in remaining cases where this is required (chat tabs, local leaderboard), at which point this should be removed.
-                Texture = textures.Get((user as APIUser)?.AvatarUrl ?? $@"https://a.ppy.sh/{user.OnlineID}");
+                Texture = user is APIUser apiUser && apiUser.AvatarUrl != null ? avatarStore.GetUserAvatar(apiUser) : avatarStore.GetUserAvatar(user.OnlineID);
 
             Texture ??= textures.Get(@"Online/avatar-guest");
         }

--- a/osu.Game/Users/Drawables/UpdateableTeamFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableTeamFlag.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
@@ -79,7 +78,7 @@ namespace osu.Game.Users.Drawables
             }
 
             [BackgroundDependencyLoader]
-            private void load(LargeTextureStore textures)
+            private void load(AvatarStore avatars)
             {
                 InternalChildren = new Drawable[]
                 {
@@ -92,7 +91,7 @@ namespace osu.Game.Users.Drawables
                     new Sprite
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Texture = textures.Get(team.FlagUrl),
+                        Texture = avatars.GetTeamAvatar(team),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         FillMode = FillMode.Fit,

--- a/osu.Game/Users/UserCoverBackground.cs
+++ b/osu.Game/Users/UserCoverBackground.cs
@@ -9,8 +9,8 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Users.Drawables;
 using osuTK.Graphics;
 
 namespace osu.Game.Users
@@ -51,7 +51,7 @@ namespace osu.Game.Users
             }
 
             [BackgroundDependencyLoader]
-            private void load(LargeTextureStore textures)
+            private void load(AvatarStore avatarStore)
             {
                 if (user == null)
                 {
@@ -66,7 +66,7 @@ namespace osu.Game.Users
                     InternalChild = new Sprite
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Texture = textures.Get(user.CoverUrl),
+                        Texture = avatarStore.GetUserCover(user),
                         FillMode = FillMode.Fill,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre


### PR DESCRIPTION
RFC.

This PR adds a disk caching layer for user avatars, user covers, and team logos.

<img width="597" height="886" alt="Screenshot 2025-12-05 at 11 54 15" src="https://github.com/user-attachments/assets/c666340f-2f9f-478e-b2ab-6b7b6a46e6e9" />

The goals of doing this are as follows:

1. To decrease the amount of assets downloaded by the game on every run, which directly correlates to bandwidth costs.
2. To possibly speed up loading of assets because loading from disk *should* be faster than fetching from online even with the next caveat, which is
3. I intend to use the "avatar store" conjured here as a convenient attachment point to resolving another issue which is that avatars have horrible aliasing artifacts from excessive downscaling without mipmaps, and my angle to resolving that would be to have the "avatar store" accept a target size specification, and downscale the asset to that target size at texture loader level, which would resolve the aliasing caused by excessive downscaling without having to figure out how to purge mipmapped assets.
4. As a minor side effect this removes a long-standing TODO wherein avatars would just hardcode `a.ppy.sh` URLs.

The major downside here is needing to resolve one of the two hardest problems in computer science which is cache invalidation. Web already gives some tools to tackle this; avatar filenames as given by web contain a unix timestamp of time of upload of the asset, while covers and team flag filenames as given by web are hash-like strings which I'm told are actually hashes derived from the asset. This covers online changes to the assets. That said, it does not cover:

- Assets getting corrupted when stored to disk. (Integrity of the assets can't be easily checked without, you know, *fetching* the asset. While covers and team flags contain a hash-like string in the filename, that string is *not actually an SHA256 of the asset*, because it seems like web does some post-processing of the asset that ends up changing the SHA.)
- Assets being potentially modifiable by the end users to do stupid stuff. (See preceding point.)
- This PR does not currently offer any timed eviction scheme for the cache for assets that are long-unused. Could have one, but unsure on what to do with that.

Gonna leave it here and see what everyone says. Would like @ppy/team-web to have at least a read-through of the caching scheme and see if it looks correct from their perspective.