### PR TITLE
Adjust vote-to-skip messaging flow to be explicit about states

### DIFF
--- a/osu.Game/Online/Multiplayer/IMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/IMultiplayerClient.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// Signals that a user has requested to skip the beatmap intro.
         /// </summary>
-        Task UserVotedToSkipIntro(int userId);
+        Task UserVotedToSkipIntro(int userId, bool voted);
 
         /// <summary>
         /// Signals that the vote to skip the beatmap intro has passed.

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Online.Multiplayer
         public event Action<int, long>? MatchmakingItemDeselected;
         public event Action<MatchRoomState>? MatchRoomStateChanged;
 
-        public event Action<int>? UserVotedToSkipIntro;
+        public event Action<int, bool>? UserVotedToSkipIntro;
         public event Action? VoteToSkipIntroPassed;
 
         public event Action<MultiplayerRoomUser, BeatmapAvailability>? BeatmapAvailabilityChanged;
@@ -854,10 +854,6 @@ namespace osu.Game.Online.Multiplayer
             handleRoomRequest(() =>
             {
                 Debug.Assert(Room != null);
-
-                foreach (var user in Room.Users)
-                    user.VotedToSkipIntro = false;
-
                 GameplayStarted?.Invoke();
             });
 
@@ -928,7 +924,7 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
-        Task IMultiplayerClient.UserVotedToSkipIntro(int userId)
+        Task IMultiplayerClient.UserVotedToSkipIntro(int userId, bool voted)
         {
             handleRoomRequest(() =>
             {
@@ -940,9 +936,8 @@ namespace osu.Game.Online.Multiplayer
                 if (user == null)
                     return;
 
-                user.VotedToSkipIntro = true;
-
-                UserVotedToSkipIntro?.Invoke(userId);
+                user.VotedToSkipIntro = voted;
+                UserVotedToSkipIntro?.Invoke(userId, voted);
             });
 
             return Task.CompletedTask;

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Online.Multiplayer
                     connection.On<MultiplayerPlaylistItem>(nameof(IMultiplayerClient.PlaylistItemAdded), ((IMultiplayerClient)this).PlaylistItemAdded);
                     connection.On<long>(nameof(IMultiplayerClient.PlaylistItemRemoved), ((IMultiplayerClient)this).PlaylistItemRemoved);
                     connection.On<MultiplayerPlaylistItem>(nameof(IMultiplayerClient.PlaylistItemChanged), ((IMultiplayerClient)this).PlaylistItemChanged);
-                    connection.On<int>(nameof(IMultiplayerClient.UserVotedToSkipIntro), ((IMultiplayerClient)this).UserVotedToSkipIntro);
+                    connection.On<int, bool>(nameof(IMultiplayerClient.UserVotedToSkipIntro), ((IMultiplayerClient)this).UserVotedToSkipIntro);
                     connection.On(nameof(IMultiplayerClient.VoteToSkipIntroPassed), ((IMultiplayerClient)this).VoteToSkipIntroPassed);
 
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueJoined), ((IMatchmakingClient)this).MatchmakingQueueJoined);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void onUserStateChanged(MultiplayerRoomUser user, MultiplayerUserState state) => Schedule(updateCount);
 
-        private void onUserVotedToSkipIntro(int userId) => Schedule(() =>
+        private void onUserVotedToSkipIntro(int userId, bool voted) => Schedule(() =>
         {
             FadingContent.TriggerShow();
             updateCount();

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -568,7 +568,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public async Task UserVoteToSkipIntro(int userId)
         {
-            await ((IMultiplayerClient)this).UserVotedToSkipIntro(userId).ConfigureAwait(false);
+            await ((IMultiplayerClient)this).UserVotedToSkipIntro(userId, true).ConfigureAwait(false);
         }
 
         protected override Task<MultiplayerRoom> CreateRoomInternal(MultiplayerRoom room)


### PR DESCRIPTION
RFC. Want to see if this structure is agreeable, or if we need a more common "ResetStatesForGameplay" method.

There's two compounding issues with the current skip implementation that I didn't consider:
1. Skip can be triggered after `Player` has loaded and _before_ all other players have finished loading, or in other words _before_ the room is in a `Playing` state. This results in a client-side error because the server rejects this call. The button gets disabled so the user can no longer skip.
2. The server cannot simply allow skips in the leadup states, because both it _and_ the client independently reset the state.

... The result of which leads to this broken interaction:

https://github.com/user-attachments/assets/7611e88a-0e9a-40f0-987d-9a11a964339b

So the primary idea of these changes is to reset (or rather, _set_) the states exactly as the server requires us to do. That will then allow the server to move this wherever is appropriate - see https://github.com/ppy/osu-server-spectator/pull/388