### PR TITLE
Update language display name from "Bahasa Indonesia" to "Indonesia"

### DIFF
--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Localisation
         [Description(@"Magyar")]
         hu,
 
-        [Description(@"Bahasa Indonesia")]
+        [Description(@"Indonesia")]
         id,
 
         [Description(@"Italiano")]


### PR DESCRIPTION
This pull request updates the language description in Language.cs for the Indonesian locale.

- Changed `[Description("Bahasa Indonesia")]` to `[Description("Indonesia")]`
- This aligns with how other languages are displayed (e.g., "English" instead of "Bahasa Inggris")
- No functional changes, purely cosmetic for UI consistency

Let me know if further adjustments are needed!