### PR TITLE
Consider abandon time for user placements

### DIFF
--- a/osu.Game.Tests/Online/Matchmaking/MatchmakingRoomStateTest.cs
+++ b/osu.Game.Tests/Online/Matchmaking/MatchmakingRoomStateTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
@@ -148,6 +149,34 @@ namespace osu.Game.Tests.Online.Matchmaking
             Assert.AreEqual(4, state.Users.GetOrAdd(4).Placement);
             Assert.AreEqual(5, state.Users.GetOrAdd(5).Placement);
             Assert.AreEqual(6, state.Users.GetOrAdd(6).Placement);
+        }
+
+        [Test]
+        public void AbandonOrder()
+        {
+            var state = new MatchmakingRoomState();
+
+            state.AdvanceRound();
+            state.RecordScores(
+            [
+                new SoloScoreInfo { UserID = 1, TotalScore = 1000 },
+                new SoloScoreInfo { UserID = 2, TotalScore = 500 },
+            ], placement_points);
+
+            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
+
+            state.Users.GetOrAdd(1).AbandonedAt = DateTimeOffset.Now;
+            state.RecordScores([], placement_points);
+
+            Assert.AreEqual(2, state.Users.GetOrAdd(1).Placement);
+            Assert.AreEqual(1, state.Users.GetOrAdd(2).Placement);
+
+            state.Users.GetOrAdd(2).AbandonedAt = DateTimeOffset.Now - TimeSpan.FromMinutes(1);
+            state.RecordScores([], placement_points);
+
+            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
         }
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUser.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingUser.cs
@@ -36,5 +36,11 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
         /// </summary>
         [Key(3)]
         public MatchmakingRoundList Rounds { get; set; } = new MatchmakingRoundList();
+
+        /// <summary>
+        /// The time at which this user abandoned the match.
+        /// </summary>
+        [Key(4)]
+        public DateTimeOffset? AbandonedAt { get; set; }
     }
 }


### PR DESCRIPTION
RFC.

This has no effects without accompanying server-side changes.

Adds a new `AbandonedAt` field to `MatchmakingUser` denoting the time at which the user left the match. It's used to determine their placement in the match, which influences their order in Elo calculations.

The reason this is an RFC is because I'm not 100% sure it should affect the placement - the obvious case being someone #\1 in points is not marked as #\1 for the match as a whole. But from the context of this being the final order of users in the match as pertaining to Elo, this also seems natural?