### PR TITLE
Adjust alpha handling for values exceeding 1 for storyboard sprite transforms to match stable behavior.

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -51,6 +51,34 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestSpriteFadeOverflowBehaviour()
+        {
+            AddStep("create sprite", () => SetContents(_ =>
+            {
+                var layer = storyboard.GetLayer("Background");
+
+                var sprite = new StoryboardSprite(lookup_name, Anchor.TopLeft, new Vector2(256, 192));
+                sprite.Commands.AddAlpha(Easing.None, Time.Current, Time.Current + 2000, 0, 2);
+
+                layer.Elements.Clear();
+                layer.Add(sprite);
+
+                return new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        storyboard.CreateDrawable()
+                    }
+                };
+            }));
+
+            AddUntilStep("sprite reached high opacity once", () => sprites.All(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Alpha > 0.8f)));
+            AddUntilStep("sprite reset to low opacity", () => sprites.All(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Alpha < 0.2f)));
+            AddUntilStep("sprite reached high opacity twice", () => sprites.All(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Alpha > 0.8f)));
+        }
+
+        [Test]
         public void TestLookupFromStoryboard()
         {
             AddStep("allow storyboard lookup", () =>

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -89,13 +89,19 @@ namespace osu.Game.Storyboards.Drawables
             LifetimeEnd = animation.EndTimeForDisplay;
         }
 
-        // Match stable behavior with alpha values > 1 during interpolation (eg. overshoot easings like InOutElastic etc.)
         protected override void Update()
         {
             base.Update();
+
+            // In stable, alpha transforms exceeding values of 1 would result in sprites disappearing from view.
+            // Over the years, storyboard(ers) have taken advantage of this to create "flicker" patterns.
+            // This is quite a common technique, so we are reproducing it here for now.
+            //
+            // NOTE TO FUTURE VISTIORS: If we do ever update the storyboard spec, we may want to move such flicker effects to their
+            // own transform type, and make this a legacy behaviour. It feels very flimsy.
             if (Alpha > 1) Alpha = 0;
         }
-        
+
         [Resolved]
         private ISkinSource skin { get; set; }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -94,12 +94,14 @@ namespace osu.Game.Storyboards.Drawables
             base.Update();
 
             // In stable, alpha transforms exceeding values of 1 would result in sprites disappearing from view.
+            // See https://github.com/peppy/osu-stable-reference/blob/08e3dafd525934cf48880b08e91c24ce4ad8b761/osu!/Graphics/Sprites/pSprite.cs#L413-L414
+            //
             // Over the years, storyboard(ers) have taken advantage of this to create "flicker" patterns.
             // This is quite a common technique, so we are reproducing it here for now.
             //
             // NOTE TO FUTURE VISTIORS: If we do ever update the storyboard spec, we may want to move such flicker effects to their
             // own transform type, and make this a legacy behaviour. It feels very flimsy.
-            if (Alpha > 1) Alpha = 0;
+            if (Alpha > 1) Alpha %= 1;
         }
 
         [Resolved]

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -89,6 +89,13 @@ namespace osu.Game.Storyboards.Drawables
             LifetimeEnd = animation.EndTimeForDisplay;
         }
 
+        // Match stable behavior with alpha values > 1 during interpolation (eg. overshoot easings like InOutElastic etc.)
+        protected override void Update()
+        {
+            base.Update();
+            if (Alpha > 1) Alpha = 0;
+        }
+        
         [Resolved]
         private ISkinSource skin { get; set; }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -79,12 +79,14 @@ namespace osu.Game.Storyboards.Drawables
             base.Update();
 
             // In stable, alpha transforms exceeding values of 1 would result in sprites disappearing from view.
+            // See https://github.com/peppy/osu-stable-reference/blob/08e3dafd525934cf48880b08e91c24ce4ad8b761/osu!/Graphics/Sprites/pSprite.cs#L413-L414
+            //
             // Over the years, storyboard(ers) have taken advantage of this to create "flicker" patterns.
             // This is quite a common technique, so we are reproducing it here for now.
             //
-            // NOTE TO FUTURE VISTIORS: If we do ever update the storyboard spec, we may want to move such flicker effects to their
+            // NOTE TO FUTURE VISITORS: If we do ever update the storyboard spec, we may want to move such flicker effects to their
             // own transform type, and make this a legacy behaviour. It feels very flimsy.
-            if (Alpha > 1) Alpha = 0;
+            if (Alpha > 1) Alpha %= 1;
         }
 
         [Resolved]

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -74,6 +74,13 @@ namespace osu.Game.Storyboards.Drawables
         public override bool IsPresent
             => !float.IsNaN(DrawPosition.X) && !float.IsNaN(DrawPosition.Y) && base.IsPresent;
 
+        // Match stable behavior with alpha values > 1 during interpolation (eg. overshoot easings like InOutElastic etc.)
+        protected override void Update()
+        {
+            base.Update();
+            if (Alpha > 1) Alpha = 0;
+        }
+
         [Resolved]
         private ISkinSource skin { get; set; } = null!;
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -74,10 +74,16 @@ namespace osu.Game.Storyboards.Drawables
         public override bool IsPresent
             => !float.IsNaN(DrawPosition.X) && !float.IsNaN(DrawPosition.Y) && base.IsPresent;
 
-        // Match stable behavior with alpha values > 1 during interpolation (eg. overshoot easings like InOutElastic etc.)
         protected override void Update()
         {
             base.Update();
+
+            // In stable, alpha transforms exceeding values of 1 would result in sprites disappearing from view.
+            // Over the years, storyboard(ers) have taken advantage of this to create "flicker" patterns.
+            // This is quite a common technique, so we are reproducing it here for now.
+            //
+            // NOTE TO FUTURE VISTIORS: If we do ever update the storyboard spec, we may want to move such flicker effects to their
+            // own transform type, and make this a legacy behaviour. It feels very flimsy.
             if (Alpha > 1) Alpha = 0;
         }
 


### PR DESCRIPTION
On stable, storyboarders often incorporate 'overshoot' easings (like `InElastic`, `OutElastic`, `InOutElastic` etc.) with the fade command `F` to create a 'flicker' effect. While I'm not sure whether this was intended behavior on stable or not, since it's a common practice among storyboarders (with even the recent OWC 2025 Finals TB [Gumbarlzo!](https://osu.ppy.sh/beatmapsets/2472011#osu/5416200) utilizing this technique), it'd probably be best to preserve this behavior to maintain the intended visuals for storyboards from stable.

Example storyboard command to achieve this effect:
```
F,28,170550,171083,0,1
```
(fade from 0 to 1 with 28 easing (InOutElastic) to achieve the flicker effect when the interpolated values go above 1.)

This PR sets the `Alpha` value to `0` if it exceeds `1`. For a visual on what exactly it changes:

|Stable Behavior|
|---|
|![stable](https://github.com/user-attachments/assets/18755f2c-ad86-4777-aedc-60c76ccebea5)|

|Main Branch (current behavior)|This PR|
|---|---|
|![master](https://github.com/user-attachments/assets/3e6b567a-6234-4fcc-ac87-d83b2d0b6575)|![pr](https://github.com/user-attachments/assets/3841810a-dca3-4677-96ca-52235b6f118c)|

