### PR TITLE
Filter out more exceptions from being sent to sentry

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -603,7 +603,7 @@ namespace osu.Game.Online.API
             cancellationToken.Cancel();
         }
 
-        private class WebRequestFlushedException : Exception
+        internal class WebRequestFlushedException : Exception
         {
             public WebRequestFlushedException(APIState state)
                 : base($@"Request failed from flush operation (state {state})")


### PR DESCRIPTION
More or less covers the first page of client sentry issues sorted by volume, all of which is pretty much useless for anything because it's client-specific-failure noise.