### PR TITLE
Fix dragging volume meter to adjust volume closing overlays if mouse is released outside of overlay content

### DIFF
--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -321,6 +321,8 @@ namespace osu.Game.Overlays.Volume
 
         private float dragDelta;
 
+        protected override bool OnMouseDown(MouseDownEvent e) => true; // handle to prevent drawables behind from potentially receiving the mouse down
+
         protected override bool OnDragStart(DragStartEvent e)
         {
             dragDelta = 0;


### PR DESCRIPTION
Fixes https://osu.ppy.sh/community/forums/topics/2159553.