### PR TITLE
Disable save replay on fail overlay when spectating

### DIFF
--- a/osu.Game/Screens/Play/FailOverlay.cs
+++ b/osu.Game/Screens/Play/FailOverlay.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Play
 {
     public partial class FailOverlay : GameplayMenuOverlay
     {
-        public Func<Task<ScoreInfo>>? SaveReplay;
+        public Func<Task<ScoreInfo>>? SaveReplay { get; init; }
 
         public override LocalisableString Header => GameplayMenuOverlayStrings.FailedHeader;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -316,7 +316,7 @@ namespace osu.Game.Screens.Play
                 },
                 FailOverlay = new FailOverlay
                 {
-                    SaveReplay = async () => await prepareAndImportScoreAsync(true).ConfigureAwait(false),
+                    SaveReplay = Configuration.AllowUserInteraction ? async () => await prepareAndImportScoreAsync(true).ConfigureAwait(false) : null,
                     OnRetry = Configuration.AllowUserInteraction ? () => Restart() : null,
                     OnQuit = () => PerformExitWithConfirmation(),
                 },

--- a/osu.Game/Screens/Play/SaveFailedScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveFailedScoreButton.cs
@@ -96,8 +96,17 @@ namespace osu.Game.Screens.Play
                         break;
 
                     default:
-                        button.TooltipText = @"save score";
-                        button.Enabled.Value = true;
+                        if (importFailedScore != null)
+                        {
+                            button.TooltipText = @"save score";
+                            button.Enabled.Value = true;
+                        }
+                        else
+                        {
+                            button.TooltipText = @"replay unavailable";
+                            button.Enabled.Value = false;
+                        }
+
                         break;
                 }
             }, true);


### PR DESCRIPTION
"Closes" https://github.com/ppy/osu/issues/35920.

The button can't easily work anyway since it's not guaranteed that the spectating user has all of the frames of the replay (think entering spectate midway through a play).

This matches the results screen in spectator too.