### PR TITLE
Skip score-based miss count estimation for ScoreV2

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -18,21 +18,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private bool scoreV2;
 
-        private int countGreat;
-        private int countOk;
-        private int countMeh;
-        private int countMiss;
-
         public OsuLegacyScoreMissCalculator(ScoreInfo scoreInfo, OsuDifficultyAttributes attributes)
         {
             score = scoreInfo;
             this.attributes = attributes;
 
             scoreV2 = score.Mods.Any(m => m is ModScoreV2);
-            countGreat = score.Statistics.GetValueOrDefault(HitResult.Great);
-            countOk = score.Statistics.GetValueOrDefault(HitResult.Ok);
-            countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
-            countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
         }
 
         public double Calculate()
@@ -81,6 +72,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         /// </summary>
         private double calculateScoreAtCombo(double combo, double relevantComboPerObject, double scoreV1Multiplier)
         {
+            int countGreat = score.Statistics.GetValueOrDefault(HitResult.Great);
+            int countOk = score.Statistics.GetValueOrDefault(HitResult.Ok);
+            int countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
+            int countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
+
+            int totalHits = countGreat + countOk + countMeh + countMiss;
+
             double estimatedObjects = combo / relevantComboPerObject - 1;
 
             // The combo portion of ScoreV1 follows arithmetic progression
@@ -127,8 +125,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         /// </summary>
         private double calculateMaximumComboBasedMissCount()
         {
+            int countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
+
             if (attributes.SliderCount <= 0)
                 return countMiss;
+
+            int countOk = score.Statistics.GetValueOrDefault(HitResult.Ok);
+            int countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
 
             int totalImperfectHits = countOk + countMeh + countMiss;
 
@@ -213,7 +216,5 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             return multiplier;
         }
-
-        private int totalHits => countGreat + countOk + countMeh + countMiss;
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         private readonly ScoreInfo score;
         private readonly OsuDifficultyAttributes attributes;
 
-        private bool scoreV2;
+        private readonly bool scoreV2;
 
         public OsuLegacyScoreMissCalculator(ScoreInfo scoreInfo, OsuDifficultyAttributes attributes)
         {
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double comboScore = relevantComboPerObject > 0 ? (2 * (relevantComboPerObject - 1) + (estimatedObjects - 1) * relevantComboPerObject) * estimatedObjects / 2 : 0;
 
             // We then apply the accuracy and ScoreV1 multipliers to the resulting score.
-            comboScore *= 300 / 25 * scoreV1Multiplier;
+            comboScore *= scoreV1Multiplier * 300 / 25;
 
             // For scoreV2 we need only combo score not scaled by accuracy.
             // This is technically incorrect because scoreV2 is using different formula,

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double comboBasedEstimatedMissCount = calculateComboBasedEstimatedMissCount(osuAttributes);
             double? scoreBasedEstimatedMissCount = null;
 
-            if (usingClassicSliderAccuracy && score.LegacyTotalScore != null)
+            if (usingClassicSliderAccuracy && !usingScoreV2 && score.LegacyTotalScore != null)
             {
                 var legacyScoreMissCalculator = new OsuLegacyScoreMissCalculator(score, osuAttributes);
                 scoreBasedEstimatedMissCount = legacyScoreMissCalculator.Calculate();


### PR DESCRIPTION
This is not a technically correct implementation, but at least it will give reasonable results instead of completely messing up pp in ScoreV2 scores.