### PR TITLE
Add Disk Space Checker

### DIFF
--- a/osu.Game.Tests/Database/DiskUsageTests.cs
+++ b/osu.Game.Tests/Database/DiskUsageTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Game.IO;
+
+namespace osu.Game.Tests.Database
+{
+    [TestFixture]
+    public class DiskUsageTests
+    {
+        private string tempDir = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Create a temporary directory to ensure we are testing against a valid location
+            tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        public void TestSufficientSpace()
+        {
+            // Asking for 0 bytes should always succeed (unless the drive is 100% full)
+            Assert.DoesNotThrow(() => DiskUsage.EnsureSufficientSpace(tempDir, 0));
+        }
+
+        [Test]
+        public void TestInsufficientSpace()
+        {
+            // Asking for the maximum possible long value should always exceed available space
+            Assert.Throws<IOException>(() => DiskUsage.EnsureSufficientSpace(tempDir, long.MaxValue));
+        }
+
+        [Test]
+        public void TestNonExistentDirectory()
+        {
+            string nonExistentPath = Path.Combine(tempDir, "does_not_exist");
+            Assert.Throws<DirectoryNotFoundException>(() => DiskUsage.EnsureSufficientSpace(nonExistentPath));
+        }
+
+        [Test]
+        public async Task TestAsyncWrapper()
+        {
+            await DiskUsage.EnsureSufficientSpaceAsync(tempDir, 0);
+        }
+    }
+}

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -25,6 +25,7 @@ using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
+using osu.Game.IO;
 using osu.Game.Models;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -331,6 +332,16 @@ namespace osu.Game.Database
                     fi.LastWriteTime = DateTime.Now;
             }
             catch { }
+
+            // Check for requisite disk space
+            try
+            {
+                DiskUsage.EnsureSufficientSpace(storage.GetFullPath(string.Empty));
+            }
+            catch (IOException)
+            {
+                Logger.Log("Your device is running low on disk space! Please free up some space to avoid potential issues.", LoggingTarget.Runtime, LogLevel.Important);
+            }
 
             try
             {

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -38,6 +38,7 @@ using osu.Game.Utils;
 using osuTK.Input;
 using Realms;
 using Realms.Exceptions;
+using FileInfo = System.IO.FileInfo;
 
 namespace osu.Game.Database
 {

--- a/osu.Game/IO/DiskUsage.cs
+++ b/osu.Game/IO/DiskUsage.cs
@@ -42,9 +42,9 @@ namespace osu.Game.IO
                 throw new IOException($"Insufficient disk space available! Required: {requiredSpace} | Available: {availableFreeSpace}");
         }
 
-        public static async Task EnsureSufficientSpaceAsync(string checkDirectory, long requiredSpace = required_space_default)
+        public static Task EnsureSufficientSpaceAsync(string checkDirectory, long requiredSpace = required_space_default)
         {
-            await Task.Run(() => EnsureSufficientSpace(checkDirectory, requiredSpace)).ConfigureAwait(false);
+            return Task.Run(() => EnsureSufficientSpace(checkDirectory, requiredSpace));
         }
     }
 }

--- a/osu.Game/IO/DiskUsage.cs
+++ b/osu.Game/IO/DiskUsage.cs
@@ -25,17 +25,17 @@ namespace osu.Game.IO
             if (!Directory.Exists(checkPath))
                 throw new DirectoryNotFoundException($"The directory '{checkPath}' does not exist or could not be found.");
 
-            string validpath = Path.GetFullPath(checkPath);
+            string validPath = Path.GetFullPath(checkPath);
 
-            if (string.IsNullOrEmpty(validpath))
+            if (string.IsNullOrEmpty(validPath))
                 throw new IOException($"The directory '{checkPath}' is not a valid path.");
 
-            var activeDriveInfo = new DriveInfo(validpath);
+            var activeDriveInfo = new DriveInfo(validPath);
 
             long availableFreeSpace = activeDriveInfo.AvailableFreeSpace;
 
 #if DEBUG
-            Logger.Log($"Available disk space for ({validpath}): {availableFreeSpace / 1048576L} MiB");
+            Logger.Log($"Available disk space for ({validPath}): {availableFreeSpace / 1048576L} MiB");
 #endif
 
             if (availableFreeSpace < requiredSpace)

--- a/osu.Game/IO/DiskUsage.cs
+++ b/osu.Game/IO/DiskUsage.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Threading.Tasks;
+using osu.Framework.Logging;
+
+namespace osu.Game.IO
+{
+    public static class DiskUsage
+    {
+        /// <summary>
+        /// 500 MiB
+        /// </summary>
+        private const long required_space_default = 512L * 1024L * 1024L;
+
+        /// <summary>
+        /// Checks if the available free space on the drive containing the path is sufficient for normal operation.
+        /// This method is blocking, and <see cref="EnsureSufficientSpaceAsync"/> should be preferred in IO-bound scenarios.
+        /// </summary>
+        /// <param name="checkPath">A path to a file or directory in which the drive's disk space should be checked.</param>
+        /// <param name="requiredSpace">The amount of space to ensure is available in bytes. Defaults to <see cref="required_space_default"/>.</param>
+        public static void EnsureSufficientSpace(string checkPath, long requiredSpace = required_space_default)
+        {
+            if (!Directory.Exists(checkPath))
+                throw new DirectoryNotFoundException($"The directory '{checkPath}' does not exist or could not be found.");
+
+            string? validPathRoot = Path.GetPathRoot(checkPath);
+
+            if (string.IsNullOrEmpty(validPathRoot))
+                throw new IOException($"The directory '{checkPath}' is not a valid path.");
+
+            var activeDriveInfo = new DriveInfo(validPathRoot);
+
+            long availableFreeSpace = activeDriveInfo.AvailableFreeSpace;
+
+#if DEBUG
+            Logger.Log($"Available disk space: {availableFreeSpace / 1048576L} MiB");
+#endif
+
+            if (availableFreeSpace < requiredSpace)
+                throw new IOException($"Insufficient disk space available! Required: {requiredSpace} | Available: {availableFreeSpace}");
+        }
+
+        public static async Task EnsureSufficientSpaceAsync(string checkDirectory, long requiredSpace = required_space_default)
+        {
+            await Task.Run(() => EnsureSufficientSpace(checkDirectory, requiredSpace)).ConfigureAwait(false);
+        }
+    }
+}

--- a/osu.Game/IO/DiskUsage.cs
+++ b/osu.Game/IO/DiskUsage.cs
@@ -25,7 +25,7 @@ namespace osu.Game.IO
             if (!Directory.Exists(checkPath))
                 throw new DirectoryNotFoundException($"The directory '{checkPath}' does not exist or could not be found.");
 
-            string? validPathRoot = Path.GetPathRoot(checkPath);
+            string? validPathRoot = Path.GetFullPath(checkPath);
 
             if (string.IsNullOrEmpty(validPathRoot))
                 throw new IOException($"The directory '{checkPath}' is not a valid path.");
@@ -35,7 +35,7 @@ namespace osu.Game.IO
             long availableFreeSpace = activeDriveInfo.AvailableFreeSpace;
 
 #if DEBUG
-            Logger.Log($"Available disk space: {availableFreeSpace / 1048576L} MiB");
+            Logger.Log($"Available disk space for ({validPathRoot}): {availableFreeSpace / 1048576L} MiB");
 #endif
 
             if (availableFreeSpace < requiredSpace)

--- a/osu.Game/IO/DiskUsage.cs
+++ b/osu.Game/IO/DiskUsage.cs
@@ -25,17 +25,17 @@ namespace osu.Game.IO
             if (!Directory.Exists(checkPath))
                 throw new DirectoryNotFoundException($"The directory '{checkPath}' does not exist or could not be found.");
 
-            string? validPathRoot = Path.GetFullPath(checkPath);
+            string validpath = Path.GetFullPath(checkPath);
 
-            if (string.IsNullOrEmpty(validPathRoot))
+            if (string.IsNullOrEmpty(validpath))
                 throw new IOException($"The directory '{checkPath}' is not a valid path.");
 
-            var activeDriveInfo = new DriveInfo(validPathRoot);
+            var activeDriveInfo = new DriveInfo(validpath);
 
             long availableFreeSpace = activeDriveInfo.AvailableFreeSpace;
 
 #if DEBUG
-            Logger.Log($"Available disk space for ({validPathRoot}): {availableFreeSpace / 1048576L} MiB");
+            Logger.Log($"Available disk space for ({validpath}): {availableFreeSpace / 1048576L} MiB");
 #endif
 
             if (availableFreeSpace < requiredSpace)

--- a/osu.Game/IO/DiskUsage.cs
+++ b/osu.Game/IO/DiskUsage.cs
@@ -39,7 +39,7 @@ namespace osu.Game.IO
 #endif
 
             if (availableFreeSpace < requiredSpace)
-                throw new IOException($"Insufficient disk space available! Required: {requiredSpace} | Available: {availableFreeSpace}");
+                throw new IOException($"Insufficient disk space available! Required: {requiredSpace / 1048576L} MiB | Available: {availableFreeSpace / 1048576L} MiB");
         }
 
         public static Task EnsureSufficientSpaceAsync(string checkDirectory, long requiredSpace = required_space_default)


### PR DESCRIPTION
Closes #5997

### Introduction
This PR adds a static `DiskUsage` class to `osu.Game/IO` with a method to natively determine available disk space given a path to a file or directory, providing a safeguard against running out of space during gameplay.

### Implementation & Notes
- I based the architectural approach on [stable's implementation](https://github.com/ppy/osu/issues/5997#issuecomment-2277135255), focusing on using `DriveInfo` for system-level disk usage checking.
- The disk space check is performed on startup during realm initialization only, rather than during realm file additions or write transactions. This decision prioritizes simplicity and avoids compromising real-time performance.
- An asynchronous version, `EnsureSufficientSpaceAsync`, has been implemented to allow for disk space checks in future IO-bound scenarios without blocking the calling thread.
- The warning threshold has been adjusted from stable's 128 MiB to **512 MiB**. This is intended to function as an earlier warning system, providing users with more time to free up space before they encounter critical issues. This value is open for discussion.
- In `RealmAccess`, I had to add `using FileInfo = System.IO.FileInfo;` due to a `FileInfo` class existing in both `System.IO` and `osu.Game.IO`. Read the [commit](https://github.com/ppy/osu/commit/8ee8c7f31dccb93e7606224e43668360c48bbaaf) for details on that.
- I can move these changes to `osu-framework` if preferred
- Tests are included to ensure basic I/O functionality and path validation are working as expected. These tests complement manual verification performed on MacOS, where the warning notification was successfully triggered on low disk space.

Overall, this is a simple solution to the linked issue, adding roughly 62 LOC excluding tests. I plan to submit smaller PRs (excl. haptics) going forwards to reduce burden on the core team with my contributions.