### PR TITLE
Fix editor not seeking smoothly when paused

### DIFF
--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -228,7 +228,7 @@ namespace osu.Game.Overlays
 
         private void onSeek(double progress)
         {
-            if (lastSeekTime == null || Time.Current - lastSeekTime > TRACK_DRAG_SEEK_DEBOUNCE)
+            if (!musicController.IsPlaying || lastSeekTime == null || Time.Current - lastSeekTime > TRACK_DRAG_SEEK_DEBOUNCE)
             {
                 musicController.SeekTo(progress);
                 lastSeekTime = Time.Current;

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             double seekDestination = markerPos / DrawWidth * editorClock.TrackLength;
             marker.X = (float)seekDestination;
 
-            if (!instant && lastSeekTime != null && Time.Current - lastSeekTime < NowPlayingOverlay.TRACK_DRAG_SEEK_DEBOUNCE)
+            if (editorClock.IsRunning && !instant && lastSeekTime != null && Time.Current - lastSeekTime < NowPlayingOverlay.TRACK_DRAG_SEEK_DEBOUNCE)
                 return;
 
             editorClock.SeekSmoothlyTo(seekDestination);


### PR DESCRIPTION
This fixes the editor no longer seeking smoothly when paused.

Closes https://github.com/ppy/osu/issues/35963.
