### PR TITLE
Fix audio track potentially muting after gameplay with bad network

### DIFF
--- a/osu.Game/Overlays/HoldToConfirmOverlay.cs
+++ b/osu.Game/Overlays/HoldToConfirmOverlay.cs
@@ -61,10 +61,15 @@ namespace osu.Game.Overlays
             audio.Samples.AddAdjustment(AdjustableProperty.Volume, audioVolume);
         }
 
-        protected override void Dispose(bool isDisposing)
+        protected void RemoveAudioAdjustments()
         {
             audio?.Tracks.RemoveAdjustment(AdjustableProperty.Volume, audioVolume);
             audio?.Samples.RemoveAdjustment(AdjustableProperty.Volume, audioVolume);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            RemoveAudioAdjustments();
             base.Dispose(isDisposing);
         }
     }

--- a/osu.Game/Screens/Play/HotkeyExitOverlay.cs
+++ b/osu.Game/Screens/Play/HotkeyExitOverlay.cs
@@ -27,5 +27,14 @@ namespace osu.Game.Screens.Play
 
             AbortConfirm();
         }
+
+        protected override void Confirm()
+        {
+            base.Confirm();
+
+            // Not removing immediately can lead to delays due to async disposal.
+            // This is done here rather than in `Player` because it's simpler to handle.
+            RemoveAudioAdjustments();
+        }
     }
 }

--- a/osu.Game/Screens/Play/HotkeyRetryOverlay.cs
+++ b/osu.Game/Screens/Play/HotkeyRetryOverlay.cs
@@ -27,5 +27,14 @@ namespace osu.Game.Screens.Play
 
             AbortConfirm();
         }
+
+        protected override void Confirm()
+        {
+            base.Confirm();
+
+            // Not removing immediately can lead to delays due to async disposal.
+            // This is done here rather than in `Player` because it's simpler to handle.
+            RemoveAudioAdjustments();
+        }
     }
 }


### PR DESCRIPTION
The schedules required to make this work are ugly.

An alternative would be removing the audio adjustments inside the overlays:

```diff
diff --git a/osu.Game/Overlays/HoldToConfirmOverlay.cs b/osu.Game/Overlays/HoldToConfirmOverlay.cs
index 6cdbc6450d..b9c32f9f8c 100644
--- a/osu.Game/Overlays/HoldToConfirmOverlay.cs
+++ b/osu.Game/Overlays/HoldToConfirmOverlay.cs
@@ -61,10 +61,15 @@ private void load()
             audio.Samples.AddAdjustment(AdjustableProperty.Volume, audioVolume);
         }
 
-        protected override void Dispose(bool isDisposing)
+        protected void RemoveAudioAdjustments()
         {
             audio?.Tracks.RemoveAdjustment(AdjustableProperty.Volume, audioVolume);
             audio?.Samples.RemoveAdjustment(AdjustableProperty.Volume, audioVolume);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            RemoveAudioAdjustments();
             base.Dispose(isDisposing);
         }
     }
diff --git a/osu.Game/Screens/Play/HotkeyExitOverlay.cs b/osu.Game/Screens/Play/HotkeyExitOverlay.cs
index bcd9bd7cd6..29f7dd08b4 100644
--- a/osu.Game/Screens/Play/HotkeyExitOverlay.cs
+++ b/osu.Game/Screens/Play/HotkeyExitOverlay.cs
@@ -27,5 +27,12 @@ public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
 
             AbortConfirm();
         }
+
+        protected override void Confirm()
+        {
+            base.Confirm();
+            RemoveAudioAdjustments();
+        }
+
     }
 }
diff --git a/osu.Game/Screens/Play/HotkeyRetryOverlay.cs b/osu.Game/Screens/Play/HotkeyRetryOverlay.cs
index 11d0b4f84f..8afe41f430 100644
--- a/osu.Game/Screens/Play/HotkeyRetryOverlay.cs
+++ b/osu.Game/Screens/Play/HotkeyRetryOverlay.cs
@@ -27,5 +27,12 @@ public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
 
             AbortConfirm();
         }
+
+        protected override void Confirm()
+        {
+            base.Confirm();
+            RemoveAudioAdjustments();
+        }
+
     }
 }

```

Closes #22164.