### PR TITLE
Forcefully leave room on multiplayer exit

### DIFF
--- a/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
+++ b/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// Request to leave the currently joined room.
         /// </summary>
-        /// <exception cref="NotJoinedRoomException">If the user is not in a room.</exception>
         Task LeaveRoom();
 
         /// <summary>

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -319,9 +319,6 @@ namespace osu.Game.Online.Multiplayer
 
         public Task LeaveRoom()
         {
-            if (Room == null)
-                return Task.CompletedTask;
-
             // The join may have not completed yet, so certain tasks that either update the room or reference the room should be cancelled.
             // This includes the setting of Room itself along with the initial update of the room settings on join.
             joinCancellationSource?.Cancel();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -90,6 +90,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 client.ChangeState(MultiplayerUserState.Idle).FireAndForget();
         }
 
+        public override bool OnExiting(ScreenExitEvent e)
+        {
+            if (base.OnExiting(e))
+                return true;
+
+            client.LeaveRoom().FireAndForget();
+            return false;
+        }
+
         protected override string ScreenTitle => "Multiplayer";
 
         protected override LoungeSubScreen CreateLounge() => new MultiplayerLoungeSubScreen();


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/35886#issuecomment-3641200582

Seems pretty difficult to unit test this so I've only tested via:

```diff
diff --git a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
index 7cfa036dcd..e65d1b0738 100644
--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -121,6 +121,8 @@ protected override async Task<MultiplayerRoom> JoinRoomInternal(long roomId, str
 
             Debug.Assert(connection != null);
 
+            await Task.Delay(5000).ConfigureAwait(false);
+
             try
             {
                 return await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), roomId, password ?? string.Empty).ConfigureAwait(false);

```
Will document more in comments on the PR itself.