### PR TITLE
Fix: Cosmetic issue animation mishap on mods button. Issue #35973

### DIFF
--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -132,12 +132,12 @@ namespace osu.Game.Screens.Select
                 MultiplierText.FadeColour(Color4.White, 200);
 
             if (Current.Value?.Count > 0)
-                modDisplay.FadeIn();
+                modDisplay.Show();
             else
-                modDisplay.FadeOut();
+                modDisplay.Hide();
 
             bool anyUnrankedMods = Current.Value?.Any(m => !m.Ranked) == true;
-            UnrankedBadge.FadeTo(anyUnrankedMods ? 1 : 0);
+            UnrankedBadge.Alpha = anyUnrankedMods ? 1 : 0;
         });
     }
 }

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -208,15 +208,11 @@ namespace osu.Game.Screens.SelectV2
                 {
                     unrankedBadge.MoveToX(0, duration, easing);
                     unrankedBadge.FadeIn(duration, easing);
-
-                    this.ResizeWidthTo(BUTTON_WIDTH + 5 + unrankedBadge.DrawWidth, duration, easing);
                 }
                 else
                 {
                     unrankedBadge.MoveToX(-unrankedBadge.DrawWidth, duration, easing);
                     unrankedBadge.FadeOut(duration, easing);
-
-                    this.ResizeWidthTo(BUTTON_WIDTH, duration, easing);
                 }
 
                 modDisplayBar.MoveToY(-5, duration, Easing.OutQuint);


### PR DESCRIPTION
The Text "Mods" and also its underline kept sliding away when pressing CTRL + Enter.
Found out by [Issue#35973](https://github.com/ppy/osu/issues/35973) that noticed it.
The issue seemed to happen when AutoPlay with mods is on, once I removed all of the mods line specifically in /osu/osu.Game/Screens/SelectV2/SoloSongSelect.cs that `Mods.Value = mods;` would use the modDisplay classs has built-in animation logic which would conflict with the new one made for the footer buttons, making a weird glitchy effect when pressing CTRL + Enter for the AutoPlay

**Solution**
Found out that `this.ResizeWidthTo(BUTTON_WIDTH, duration, easing);` this line tries to always stretch the mod bar with unranked and the multiplier, however when pressing CTRL + ENTER it. Now it looks like this when in the mod bar.

# Before
<img width="335" height="155" alt="image" src="https://github.com/user-attachments/assets/5baa9982-8a39-4dd4-b02b-98540899ffbb" />

# After
<img width="493" height="155" alt="image" src="https://github.com/user-attachments/assets/dd6bec2f-f1b2-491a-947c-2dafae70bc4e" />


Hope this helps!