### PR TITLE
Add saved beatmap filter functionality with popover UI

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -101,8 +101,9 @@ namespace osu.Game.Database
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
+        /// 52   2025-12-13    Added SavedBeatmapFilter.
         /// </summary>
-        private const int schema_version = 51;
+        private const int schema_version = 52;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -1325,6 +1326,10 @@ namespace osu.Game.Database
                     foreach (var score in migration.NewRealm.All<ScoreInfo>().Where(s => s.LegacyOnlineID == 0))
                         score.LegacyOnlineID = -1;
 
+                    break;
+
+                case 52:
+                    // SavedBeatmapFilter added.
                     break;
             }
 

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Graphics.UserInterface
 
         private readonly Box background;
         protected readonly InnerSearchTextBox TextBox;
+        protected readonly Container BackgroundContent;
+        protected readonly Container RightInterface;
 
         public Bindable<string> Current
         {
@@ -62,6 +64,10 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     RelativeSizeAxes = Axes.Both
                 },
+                BackgroundContent = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
                 new GridContainer
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -70,13 +76,19 @@ namespace osu.Game.Graphics.UserInterface
                         new Drawable[]
                         {
                             TextBox = CreateInnerTextBox(),
-                            new SpriteIcon
+                            RightInterface = new Container
                             {
-                                Icon = FontAwesome.Solid.Search,
-                                Origin = Anchor.Centre,
                                 Anchor = Anchor.Centre,
-                                Size = new Vector2(16),
-                                Shear = -Shear
+                                Origin = Anchor.Centre,
+                                RelativeSizeAxes = Axes.Both,
+                                Child = new SpriteIcon
+                                {
+                                    Icon = FontAwesome.Solid.Search,
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre,
+                                    Size = new Vector2(16),
+                                    Shear = -Shear
+                                }
                             }
                         }
                     },

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -438,8 +438,7 @@ namespace osu.Game.Screens.Select
                 {
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.TopRight,
-                    RelativePositionAxes = Axes.Y,
-                    Y = 1,
+                    Y = -10,
                     Size = Vector2.Zero,
                     CreatePopover = createPopover
                 };

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -10,6 +10,9 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
@@ -17,6 +20,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -130,6 +134,9 @@ namespace osu.Game.Screens.Select
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         HoldFocus = true,
+                                        ApplyFilter = applyFilter,
+                                        SaveFilter = saveFilter,
+                                        Ruleset = ruleset,
                                         ScopedBeatmapSet = { BindTarget = ScopedBeatmapSet },
                                     },
                                 },
@@ -277,6 +284,53 @@ namespace osu.Game.Screens.Select
             collectionsSubscription?.Dispose();
         }
 
+        private void applyFilter(SavedBeatmapFilter filter)
+        {
+            searchTextBox.Current.Value = filter.SearchQuery;
+
+            sortDropdown.Current.Value = Enum.IsDefined(typeof(SortMode), filter.SortMode)
+                ? (SortMode)filter.SortMode
+                : SortMode.Title;
+
+            GroupMode groupMode = Enum.IsDefined(typeof(GroupMode), filter.GroupMode)
+                ? (GroupMode)filter.GroupMode
+                : GroupMode.None;
+
+            groupDropdown.Current.Value = groupDropdown.Items.SingleOrDefault(item => item.Value == groupMode) ?? groupDropdown.Items.Single(item => item.Value == GroupMode.None);
+
+            showConvertedBeatmapsButton.Active.Value = filter.ShowConverted;
+
+            var lowerBound = (BindableNumber<double>)difficultyRangeSlider.LowerBound;
+            var upperBound = (BindableNumber<double>)difficultyRangeSlider.UpperBound;
+
+            double min = Math.Clamp(filter.MinStars, lowerBound.MinValue, lowerBound.MaxValue);
+            double max = Math.Clamp(filter.MaxStars, upperBound.MinValue, upperBound.MaxValue);
+
+            if (min > max)
+                min = max;
+
+            difficultyRangeSlider.LowerBound.Value = min;
+            difficultyRangeSlider.UpperBound.Value = max;
+        }
+
+        private void saveFilter(string name)
+        {
+            if (string.IsNullOrEmpty(ruleset.Value?.ShortName))
+                return;
+
+            realm.Write(r => r.Add(new SavedBeatmapFilter
+            {
+                Name = name.Trim(),
+                SearchQuery = searchTextBox.Current.Value,
+                SortMode = (int)sortDropdown.Current.Value,
+                GroupMode = (int)(groupDropdown.Current.Value?.Value ?? GroupMode.None),
+                ShowConverted = showConvertedBeatmapsButton.Active.Value,
+                MinStars = difficultyRangeSlider.LowerBound.Value,
+                MaxStars = difficultyRangeSlider.UpperBound.Value,
+                RulesetShortName = ruleset.Value.ShortName
+            }));
+        }
+
         /// <summary>
         /// Creates a <see cref="FilterCriteria"/> based on the current state of the controls.
         /// </summary>
@@ -350,7 +404,63 @@ namespace osu.Game.Screens.Select
 
         internal partial class SongSelectSearchTextBox : ShearedFilterTextBox
         {
+            public Action<SavedBeatmapFilter>? ApplyFilter { get; set; }
+            public Action<string>? SaveFilter { get; set; }
+            public IBindable<RulesetInfo> Ruleset { get; set; } = null!;
+
             public IBindable<BeatmapSetInfo?> ScopedBeatmapSet { get; } = new Bindable<BeatmapSetInfo?>();
+
+            private readonly Box hoverBox;
+
+            public SongSelectSearchTextBox()
+            {
+                var filterButton = new SearchFilterButton
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                };
+
+                RightInterface.Clear();
+                RightInterface.Add(filterButton);
+
+                hoverBox = new Box
+                {
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 55,
+                    Alpha = 0,
+                };
+
+                BackgroundContent.Add(hoverBox);
+
+                var popoverTarget = new PopoverTarget
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.TopRight,
+                    RelativePositionAxes = Axes.Y,
+                    Y = 1,
+                    Size = Vector2.Zero,
+                    CreatePopover = createPopover
+                };
+
+                AddInternal(popoverTarget);
+
+                filterButton.HoverTarget = hoverBox;
+                filterButton.PopoverTarget = popoverTarget;
+                filterButton.SetIconShear(-Shear);
+            }
+
+            [Resolved]
+            private OsuColour colours { get; set; } = null!;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                hoverBox.Colour = colours.Blue;
+            }
+
+            private Popover createPopover() => new SavedFiltersPopover(f => ApplyFilter?.Invoke(f), n => SaveFilter?.Invoke(n), Ruleset.Value);
 
             protected override InnerSearchTextBox CreateInnerTextBox() => new InnerTextBox
             {
@@ -383,6 +493,13 @@ namespace osu.Game.Screens.Select
 
                     return base.OnPressed(e);
                 }
+            }
+
+            private partial class PopoverTarget : Container, IHasPopover
+            {
+                public Func<Popover>? CreatePopover { get; set; }
+
+                public Popover GetPopover() => CreatePopover?.Invoke()!;
             }
         }
 

--- a/osu.Game/Screens/Select/SavedBeatmapFilter.cs
+++ b/osu.Game/Screens/Select/SavedBeatmapFilter.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Database;
+using Realms;
+
+namespace osu.Game.Screens.Select
+{
+    public class SavedBeatmapFilter : RealmObject, IHasGuidPrimaryKey
+    {
+        [PrimaryKey]
+        public Guid ID { get; set; } = Guid.NewGuid();
+
+        public string Name { get; set; } = string.Empty;
+
+        public string SearchQuery { get; set; } = string.Empty;
+
+        public int SortMode { get; set; }
+        public int GroupMode { get; set; }
+
+        public bool ShowConverted { get; set; }
+
+        public double MinStars { get; set; }
+        public double MaxStars { get; set; }
+
+        public string RulesetShortName { get; set; } = string.Empty;
+    }
+}

--- a/osu.Game/Screens/Select/SavedFiltersPopover.cs
+++ b/osu.Game/Screens/Select/SavedFiltersPopover.cs
@@ -1,0 +1,299 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Database;
+using osu.Game.Extensions;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Select
+{
+    public partial class SavedFiltersPopover : OsuPopover
+    {
+        private readonly Action<SavedBeatmapFilter> onSelect;
+        private readonly Action<string> onSave;
+
+        [Resolved]
+        private RealmAccess? realm { get; set; }
+
+        private readonly RulesetInfo ruleset;
+
+        public SavedFiltersPopover(Action<SavedBeatmapFilter> onSelect, Action<string> onSave, RulesetInfo ruleset)
+        {
+            this.onSelect = onSelect;
+            this.onSave = onSave;
+            this.ruleset = ruleset;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            Content.Padding = new MarginPadding(5);
+
+            var flow = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                Width = 250,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(0, 5),
+            };
+
+            Body.Shear = OsuGame.SHEAR;
+
+            Child = flow;
+
+            var filterSection = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(0, 5),
+            };
+
+            flow.Add(filterSection);
+
+            var savedFilters = realm?.Realm.All<SavedBeatmapFilter>().Where(f => f.RulesetShortName == ruleset.ShortName);
+
+            var filtersFlow = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+            };
+
+            var separator = new Box
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 1,
+                Colour = colours.Gray4,
+            };
+
+            var emptyStateText = new OsuSpriteText
+            {
+                Text = "No saved filters",
+                Colour = colours.Gray8,
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                Shear = -OsuGame.SHEAR,
+            };
+
+            void refreshFilterSection()
+            {
+                filterSection.Clear(false);
+
+                if (filtersFlow.Children.Count > 0)
+                {
+                    filterSection.Add(filtersFlow);
+                    filterSection.Add(separator);
+                }
+                else
+                    filterSection.Add(emptyStateText);
+            }
+
+            if (savedFilters != null)
+            {
+                foreach (var filter in savedFilters)
+                {
+                    var localFilter = filter;
+
+                    var item = new SavedFilterItem(localFilter, onSelect, () =>
+                    {
+                        realm?.Write(r => r.Remove(localFilter));
+
+                        var toRemove = filtersFlow.Children.OfType<SavedFilterItem>().FirstOrDefault(f => System.Collections.Generic.EqualityComparer<SavedBeatmapFilter>.Default.Equals(f.Filter, localFilter));
+
+                        if (toRemove != null)
+                        {
+                            filtersFlow.Remove(toRemove, true);
+                            refreshFilterSection();
+                        }
+                    });
+
+                    filtersFlow.Add(item);
+                }
+            }
+
+            refreshFilterSection();
+
+            var nameTextBox = new ShearedTextBox
+            {
+                PlaceholderText = "Filter name",
+                RelativeSizeAxes = Axes.X,
+                Height = 30
+            };
+
+            flow.Add(nameTextBox);
+
+            flow.Add(new ShearedRoundedButton
+            {
+                Text = "Save current filter",
+                RelativeSizeAxes = Axes.X,
+                Action = () =>
+                {
+                    string name = nameTextBox.Text.Trim();
+
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        nameTextBox.FlashColour(Color4.Red, 500);
+                        nameTextBox.Shake();
+                        return;
+                    }
+
+                    if (string.IsNullOrEmpty(ruleset.ShortName))
+                    {
+                        nameTextBox.FlashColour(Color4.Red, 500);
+                        nameTextBox.Shake();
+                        return;
+                    }
+
+                    if (name.Length > 40)
+                    {
+                        nameTextBox.FlashColour(Color4.Red, 500);
+                        nameTextBox.Shake();
+                        return;
+                    }
+
+                    if (realm?.Realm.All<SavedBeatmapFilter>().Any(f => f.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && f.RulesetShortName == ruleset.ShortName) == true)
+                    {
+                        nameTextBox.FlashColour(Color4.Red, 500);
+                        nameTextBox.Shake();
+                        return;
+                    }
+
+                    onSave(name);
+                    Hide();
+                }
+            });
+        }
+
+        private partial class ShearedTextBox : OsuTextBox
+        {
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Schedule(() => TextContainer.Shear = -OsuGame.SHEAR);
+            }
+
+            protected override SpriteText CreatePlaceholder()
+            {
+                var placeholder = base.CreatePlaceholder();
+                placeholder.Shear = Vector2.Zero;
+                return placeholder;
+            }
+        }
+
+        private partial class ShearedRoundedButton : RoundedButton
+        {
+            protected override SpriteText CreateText() => new OsuSpriteText
+            {
+                Depth = -1,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Font = OsuFont.GetFont(weight: FontWeight.Bold),
+                Shear = -OsuGame.SHEAR,
+            };
+        }
+
+        private partial class SavedFilterItem : ClickableContainer
+        {
+            public SavedBeatmapFilter Filter { get; }
+
+            private readonly Box background;
+            private readonly SpriteIcon arrow;
+
+            public SavedFilterItem(SavedBeatmapFilter filter, Action<SavedBeatmapFilter> action, Action onDelete)
+            {
+                Filter = filter;
+                RelativeSizeAxes = Axes.X;
+                Height = 20;
+                Action = () => action(filter);
+                CornerRadius = 5;
+                Masking = true;
+
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0,
+                    },
+                    arrow = new SpriteIcon
+                    {
+                        Icon = FontAwesome.Solid.ChevronRight,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Size = new Vector2(8),
+                        X = 0,
+                        Alpha = 0,
+                        Shear = -OsuGame.SHEAR,
+                        Margin = new MarginPadding { Left = 3, Right = 3 },
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = filter.Name,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        X = 15,
+                        Shear = -OsuGame.SHEAR,
+                    },
+                    new IconButton
+                    {
+                        Icon = FontAwesome.Solid.Trash,
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Action = onDelete,
+                        Scale = new Vector2(0.55f),
+                        X = -5,
+                        Shear = -OsuGame.SHEAR,
+                    }
+                };
+            }
+
+            [Resolved]
+            private OsuColour colours { get; set; } = null!;
+
+            [Resolved(CanBeNull = true)]
+            private OverlayColourProvider? colourProvider { get; set; }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                background.Colour = colourProvider?.Light4 ?? colours.BlueDark;
+                arrow.Colour = colourProvider?.Background5 ?? Color4.Black;
+
+                AddInternal(new HoverSounds());
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                background.FadeIn(100, Easing.OutQuint);
+                arrow.FadeIn(400, Easing.OutQuint);
+                arrow.MoveToX(3, 400, Easing.OutQuint);
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                background.FadeOut(600, Easing.OutQuint);
+                arrow.FadeOut(200);
+                arrow.MoveToX(0, 200, Easing.In);
+                base.OnHoverLost(e);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Select/SavedFiltersPopover.cs
+++ b/osu.Game/Screens/Select/SavedFiltersPopover.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Screens.Select
             this.onSelect = onSelect;
             this.onSave = onSave;
             this.ruleset = ruleset;
+
+            // Only allow placement below the trigger, with horizontal side chosen by available space.
+            AllowableAnchors = new[] { Anchor.BottomLeft, Anchor.BottomRight };
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Select/SearchFilterButton.cs
+++ b/osu.Game/Screens/Select/SearchFilterButton.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osuTK;
+
+namespace osu.Game.Screens.Select
+{
+    public partial class SearchFilterButton : ClickableContainer
+    {
+        public Drawable? HoverTarget { get; set; }
+
+        public IHasPopover? PopoverTarget { get; set; }
+
+        private SpriteIcon? icon;
+        private Vector2 pendingShear;
+
+        public SearchFilterButton()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = icon = new SpriteIcon
+            {
+                Icon = FontAwesome.Solid.Search,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Size = new Vector2(16),
+                Shear = pendingShear
+            };
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            HoverTarget?.FadeIn(200);
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            HoverTarget?.FadeOut(200);
+            base.OnHoverLost(e);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (PopoverTarget is Drawable drawable)
+                drawable.HidePopover();
+
+            return base.OnMouseDown(e);
+        }
+
+        protected override void OnMouseUp(MouseUpEvent e)
+        {
+            if (IsHovered && PopoverTarget is IHasPopover hasPopover)
+                hasPopover.ShowPopover();
+
+            base.OnMouseUp(e);
+        }
+
+        public void SetIconShear(Vector2 shear)
+        {
+            pendingShear = shear;
+            if (icon != null)
+                icon.Shear = shear;
+        }
+    }
+}


### PR DESCRIPTION
Add the ability to save and re-apply beatmap selection filters in Song Select (SelectV2). It introduces a small popover UI accessible from the search box area, allowing users to:
- View saved filters (per ruleset)
- Apply a saved filter to the current controls
- Save the current filter state under a custom name
- Delete saved filters

Related discussions: https://github.com/ppy/osu/discussions/30403, https://github.com/ppy/osu/discussions/13010

https://github.com/user-attachments/assets/586707b0-c2e1-4e1c-ab37-0f7d1430d2c2

*This is my first contribution to this repository and also my first experience with C#. Thanks in advance for your time and feedback!*
