### PR TITLE
Fix skip overlay potentially not allowing skipping

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
@@ -42,10 +42,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
         }
 
-        protected override OsuClickableContainer CreateButton() => skipButton = new Button
+        protected override OsuClickableContainer CreateButton(IBindable<bool> inSkipPeriod) => skipButton = new Button
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
+            InSkipPeriod = { BindTarget = inSkipPeriod },
         };
 
         protected override void LoadComplete()
@@ -119,6 +120,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             public readonly BindableInt SkippedCount = new BindableInt();
             public readonly BindableInt RequiredCount = new BindableInt();
+            public readonly BindableBool InSkipPeriod = new BindableBool();
+
+            private readonly BindableBool clicked = new BindableBool();
 
             [Resolved]
             private OsuColour colours { get; set; } = null!;
@@ -201,10 +205,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
                 SkippedCount.BindValueChanged(_ => updateCount());
                 RequiredCount.BindValueChanged(_ => updateCount(), true);
+
+                InSkipPeriod.BindValueChanged(_ => updateEnabledState());
+                clicked.BindValueChanged(_ => updateEnabledState(), true);
+
                 Enabled.BindValueChanged(_ => updateColours(), true);
 
                 FinishTransforms(true);
             }
+
+            private void updateEnabledState() => Enabled.Value = InSkipPeriod.Value && !clicked.Value;
 
             private void updateChevronsSpacing()
             {
@@ -300,7 +310,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
                 base.OnClick(e);
 
-                Enabled.Value = false;
+                clicked.Value = true;
                 return true;
             }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/35959

As per https://github.com/ppy/osu/issues/35959#issuecomment-3650374412, this is a "bandaid" fix which makes the skip overlay resilient to any unexpected clock states.

There's no way to write a test for this, but I've tested it manually through this diff just for sanity:
```diff
diff --git a/osu.Game/Screens/Play/SkipOverlay.cs b/osu.Game/Screens/Play/SkipOverlay.cs
index f9752706ad..3d9564db48 100644
--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -180,6 +180,8 @@ void attemptNextSkip() => Scheduler.AddDelayed(() =>
             }, 200);
         }
 
+        private bool first = true;
+
         protected override void Update()
         {
             base.Update();
@@ -193,7 +195,9 @@ protected override void Update()
 
             RemainingTimeBox.Width = (float)Interpolation.Lerp(RemainingTimeBox.Width, progress, Math.Clamp(Time.Elapsed / 40, 0, 1));
 
-            inSkipPeriod.Value = progress > 0;
+            inSkipPeriod.Value = !first && progress > 0;
+            first = false;
+
             buttonContainer.State.Value = inSkipPeriod.Value ? Visibility.Visible : Visibility.Hidden;
         }
 

```