### PR TITLE
Account for stacks in angle calculation

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -77,10 +77,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                 if (Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) < 1.25 * Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) // If rhythms are the same.
                 {
-                    acuteAngleBonus = osuCurrObj.CalcAngleFunctionStackWeighted(calcAcuteAngleBonus);
+                    acuteAngleBonus = osuCurrObj.CalcAngleFunctionStackAdjusted(calcAcuteAngleBonus);
 
                     // Penalize angle repetition.
-                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(osuLastObj.CalcAngleFunctionStackWeighted(calcAcuteAngleBonus), 3)));
+                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(osuLastObj.CalcAngleFunctionStackAdjusted(calcAcuteAngleBonus), 3)));
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
@@ -88,10 +88,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                                        DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
                 }
 
-                wideAngleBonus = osuCurrObj.CalcAngleFunctionStackWeighted(calcWideAngleBonus);
+                wideAngleBonus = osuCurrObj.CalcAngleFunctionStackAdjusted(calcWideAngleBonus);
 
                 // Penalize angle repetition.
-                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(osuLastObj.CalcAngleFunctionStackWeighted(calcWideAngleBonus), 3));
+                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(osuLastObj.CalcAngleFunctionStackAdjusted(calcWideAngleBonus), 3));
 
                 // Apply full wide angle bonus for distance more than one diameter
                 wideAngleBonus *= angleBonus * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, 0, diameter);
@@ -101,10 +101,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 wiggleBonus = angleBonus
                               * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, radius, diameter)
                               * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuCurrObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
-                              * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LerpedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60))
+                              * DifficultyCalculationUtils.Smootherstep(osuCurrObj.StackAdjustedAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60))
                               * DifficultyCalculationUtils.Smootherstep(osuLastObj.LazyJumpDistance, radius, diameter)
                               * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuLastObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
-                              * DifficultyCalculationUtils.Smootherstep(osuLastObj.LerpedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60));
+                              * DifficultyCalculationUtils.Smootherstep(osuLastObj.StackAdjustedAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60));
 
                 if (osuLast2Obj != null)
                 {

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
@@ -72,18 +73,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             if (osuCurrObj.Angle != null && osuLastObj.Angle != null)
             {
-                double currAngle = osuCurrObj.Angle.Value;
-                double lastAngle = osuLastObj.Angle.Value;
-
                 // Rewarding angles, take the smaller velocity as base.
                 double angleBonus = Math.Min(currVelocity, prevVelocity);
 
                 if (Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) < 1.25 * Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) // If rhythms are the same.
                 {
-                    acuteAngleBonus = calcAcuteAngleBonus(currAngle);
+                    acuteAngleBonus = calcAngleFunctionStackWeighted(calcAcuteAngleBonus, osuCurrObj);
 
                     // Penalize angle repetition.
-                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(calcAcuteAngleBonus(lastAngle), 3)));
+                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(calcAngleFunctionStackWeighted(calcAcuteAngleBonus, osuLastObj), 3)));
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
@@ -91,10 +89,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                                        DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
                 }
 
-                wideAngleBonus = calcWideAngleBonus(currAngle);
+                wideAngleBonus = calcAngleFunctionStackWeighted(calcWideAngleBonus, osuCurrObj);
 
                 // Penalize angle repetition.
-                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(calcWideAngleBonus(lastAngle), 3));
+                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(calcAngleFunctionStackWeighted(calcWideAngleBonus, osuLastObj), 3));
 
                 // Apply full wide angle bonus for distance more than one diameter
                 wideAngleBonus *= angleBonus * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, 0, diameter);
@@ -104,10 +102,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 wiggleBonus = angleBonus
                               * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, radius, diameter)
                               * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuCurrObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
-                              * DifficultyCalculationUtils.Smootherstep(currAngle, double.DegreesToRadians(110), double.DegreesToRadians(60))
+                              * DifficultyCalculationUtils.Smootherstep(osuCurrObj.WeightedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60))
                               * DifficultyCalculationUtils.Smootherstep(osuLastObj.LazyJumpDistance, radius, diameter)
                               * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuLastObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
-                              * DifficultyCalculationUtils.Smootherstep(lastAngle, double.DegreesToRadians(110), double.DegreesToRadians(60));
+                              * DifficultyCalculationUtils.Smootherstep(osuLastObj.WeightedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60));
 
                 if (osuLast2Obj != null)
                 {
@@ -163,6 +161,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 aimStrain += sliderBonus * slider_multiplier;
 
             return aimStrain;
+        }
+
+        private static double calcAngleFunctionStackWeighted(Func<double, double> func, OsuDifficultyHitObject osuHitObject, double defaultValue = 0)
+        {
+            if (osuHitObject.Angle == null) return defaultValue;
+            return func(osuHitObject.StackAngle!.Value) * osuHitObject.StackWeight + func(osuHitObject.Angle!.Value) * (1 - osuHitObject.StackWeight);
         }
 
         private static double calcWideAngleBonus(double angle) => DifficultyCalculationUtils.Smoothstep(angle, double.DegreesToRadians(40), double.DegreesToRadians(140));

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
@@ -78,10 +77,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                 if (Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) < 1.25 * Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) // If rhythms are the same.
                 {
-                    acuteAngleBonus = calcAngleFunctionStackWeighted(calcAcuteAngleBonus, osuCurrObj);
+                    acuteAngleBonus = osuCurrObj.CalcAngleFunctionStackWeighted(calcAcuteAngleBonus);
 
                     // Penalize angle repetition.
-                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(calcAngleFunctionStackWeighted(calcAcuteAngleBonus, osuLastObj), 3)));
+                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(osuLastObj.CalcAngleFunctionStackWeighted(calcAcuteAngleBonus), 3)));
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
@@ -89,10 +88,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                                        DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
                 }
 
-                wideAngleBonus = calcAngleFunctionStackWeighted(calcWideAngleBonus, osuCurrObj);
+                wideAngleBonus = osuCurrObj.CalcAngleFunctionStackWeighted(calcWideAngleBonus);
 
                 // Penalize angle repetition.
-                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(calcAngleFunctionStackWeighted(calcWideAngleBonus, osuLastObj), 3));
+                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(osuLastObj.CalcAngleFunctionStackWeighted(calcWideAngleBonus), 3));
 
                 // Apply full wide angle bonus for distance more than one diameter
                 wideAngleBonus *= angleBonus * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, 0, diameter);
@@ -102,10 +101,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 wiggleBonus = angleBonus
                               * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, radius, diameter)
                               * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuCurrObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
-                              * DifficultyCalculationUtils.Smootherstep(osuCurrObj.WeightedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60))
+                              * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LerpedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60))
                               * DifficultyCalculationUtils.Smootherstep(osuLastObj.LazyJumpDistance, radius, diameter)
                               * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuLastObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
-                              * DifficultyCalculationUtils.Smootherstep(osuLastObj.WeightedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60));
+                              * DifficultyCalculationUtils.Smootherstep(osuLastObj.LerpedStackAngle!.Value, double.DegreesToRadians(110), double.DegreesToRadians(60));
 
                 if (osuLast2Obj != null)
                 {
@@ -161,12 +160,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 aimStrain += sliderBonus * slider_multiplier;
 
             return aimStrain;
-        }
-
-        private static double calcAngleFunctionStackWeighted(Func<double, double> func, OsuDifficultyHitObject osuHitObject, double defaultValue = 0)
-        {
-            if (osuHitObject.Angle == null) return defaultValue;
-            return func(osuHitObject.StackAngle!.Value) * osuHitObject.StackWeight + func(osuHitObject.Angle!.Value) * (1 - osuHitObject.StackWeight);
         }
 
         private static double calcWideAngleBonus(double angle) => DifficultyCalculationUtils.Smoothstep(angle, double.DegreesToRadians(40), double.DegreesToRadians(140));

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -101,11 +101,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         /// </summary>
         public double? Angle { get; private set; }
 
-        public double? StackAngle { get; private set; }
+        private double normalWeight;
 
-        public double StackWeight { get; private set; }
+        private double? stackAngle1;
+        private double stackWeight1;
 
-        public double? WeightedStackAngle => Angle != null ? double.Lerp(Angle.Value, StackAngle!.Value, StackWeight) : null;
+        private double? stackAngle2;
+        private double stackWeight2;
+
+        public double? LerpedStackAngle => Angle != null ? Angle * normalWeight + stackAngle1 * stackWeight1 + stackAngle2 * stackWeight2 : null;
 
         /// <summary>
         /// Retrieves the full hit window for a Great <see cref="HitResult"/>.
@@ -119,6 +123,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
         private readonly OsuDifficultyHitObject? lastLastDifficultyObject;
         private readonly OsuDifficultyHitObject? lastDifficultyObject;
+
+        public double CalcAngleFunctionStackWeighted(Func<double, double> func, double defaultValue = 0)
+        {
+            if (Angle == null) return defaultValue;
+            return func(Angle!.Value) * normalWeight + func(stackAngle1!.Value) * stackWeight1 + func(stackAngle2!.Value) * stackWeight2;
+        }
 
         public OsuDifficultyHitObject(HitObject hitObject, HitObject lastObject, double clockRate, List<DifficultyHitObject> objects, int index)
             : base(hitObject, lastObject, clockRate, objects, index)
@@ -247,21 +257,57 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             if (lastDifficultyObject != null && lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is not Spinner)
             {
                 Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
+                Angle = Math.Abs(calculateAngle(lastLastCursorPosition - LastObject.StackedPosition, BaseObject.StackedPosition - lastCursorPosition));
 
-                Vector2 v1 = lastLastCursorPosition - LastObject.StackedPosition;
-                Vector2 v2 = BaseObject.StackedPosition - lastCursorPosition;
+                stackAngle1 = Angle;
+                stackAngle2 = Angle;
 
-                float dot = Vector2.Dot(v1, v2);
-                float det = v1.X * v2.Y - v1.Y * v2.X;
+                // We have two cases: either the current object is a stack, so we need to angle between last 3 objects before this
+                // one, or the last object is a stack, so we need to angle between last 2 objects before this one and this one.
 
-                Angle = Math.Abs(Math.Atan2(det, dot));
+                // If current distance is larger then the last one, then the only possible case is that last object is stacked
+                // We have strict if else check because in case of both distances being similar - stack weight would be 0 in any of the branches
+                if (LazyJumpDistance > lastDifficultyObject.LazyJumpDistance)
+                {
+                    OsuDifficultyHitObject? last2DifficultyObject = (OsuDifficultyHitObject?)Previous(2);
 
-                StackAngle = lastDifficultyObject.Angle ?? Angle;
+                    // If there's no objects before last last or it's a spinner - we cannot compute an angle
+                    // In this case stack weight would be 0, and normal angle would be used
+                    if (last2DifficultyObject != null && last2DifficultyObject.BaseObject is not Spinner)
+                    {
+                        Vector2 last2CursorPosition = getEndCursorPosition(last2DifficultyObject);
+                        stackAngle1 = Math.Abs(calculateAngle(last2CursorPosition - lastDifficultyObject.LastObject.StackedPosition, BaseObject.StackedPosition - lastCursorPosition));
 
-                // Only consider it stacked if current is very close, but prev isn't that close
-                // If evaluator require correct angle for more than 3 last notes - it should use several stack weights according to it's need
-                StackWeight = DifficultyCalculationUtils.ReverseLerp(LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_RADIUS)
-                    * DifficultyCalculationUtils.ReverseLerp(lastDifficultyObject.LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_DIAMETER * 2);
+                        stackWeight1 = DifficultyCalculationUtils.ReverseLerp(lastDifficultyObject.LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_RADIUS)
+                            * DifficultyCalculationUtils.ReverseLerp(LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_DIAMETER * 2);
+                    }
+                }
+                // In other case , if last distance is larger, then current object may be stacked
+                else
+                {
+                    stackAngle1 = lastDifficultyObject.Angle ?? Angle;
+
+                    stackWeight1 = DifficultyCalculationUtils.ReverseLerp(LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_RADIUS)
+                        * DifficultyCalculationUtils.ReverseLerp(lastDifficultyObject.LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_DIAMETER * 2);
+
+                    // Here we also need to handle cases where last last object is also stacked
+                    OsuDifficultyHitObject? last3DifficultyObject = (OsuDifficultyHitObject?)Previous(3);
+
+                    if (last3DifficultyObject != null && last3DifficultyObject.BaseObject is not Spinner)
+                    {
+                        Vector2 last3CursorPosition = getEndCursorPosition(last3DifficultyObject);
+                        stackAngle2 = Math.Abs(calculateAngle(last3CursorPosition - lastLastDifficultyObject.LastObject.StackedPosition, LastObject.StackedPosition - lastLastCursorPosition));
+
+                        stackWeight2 = DifficultyCalculationUtils.ReverseLerp(lastLastDifficultyObject.LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_RADIUS)
+                            * DifficultyCalculationUtils.ReverseLerp(lastDifficultyObject.LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_DIAMETER * 2);
+
+                        // Rescale stack weights
+                        stackWeight2 *= stackWeight1;
+                        stackWeight1 -= stackWeight2;
+                    }
+                }
+
+                normalWeight = 1 - (stackWeight1 + stackWeight2);
             }
         }
 
@@ -376,6 +422,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         private Vector2 getEndCursorPosition(OsuDifficultyHitObject difficultyHitObject)
         {
             return difficultyHitObject.LazyEndPosition ?? difficultyHitObject.BaseObject.StackedPosition;
+        }
+
+        private double calculateAngle(Vector2 v1, Vector2 v2)
+        {
+            float dot = Vector2.Dot(v1, v2);
+            float det = v1.X * v2.Y - v1.Y * v2.X;
+            return Math.Atan2(det, dot);
         }
     }
 }


### PR DESCRIPTION
The stable version of "correct" angle calculation. 
Made with doubles in mind since they're the main issues when it comes to angle-related bonuses.
Flashlight changes are not included intentionally because I'm not sure what is expected here.
PRing this for research and discussion purposes (in the sense that is it needed at all), also to calculate sheet of deltas.

Brief explanation of "why it's so complex":
It calculates 3 angles, where first angle is normal, second is accounting for one double, third is accounting for two doubles in a row. Each angle has weight of how likely that the respective objects are stacked.
Compared to "stack threshold" approach - this one is smooth and stable, meaning that as distance between notes in the stack would increase - it would be smoothly transitioning between "stacked" and "non-stacked" values, instead of big jump when distance passed certain threshold.