### PR TITLE
Consider previous stacked notes repetitive in angle repetition calculations

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -78,12 +78,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 // Rewarding angles, take the smaller velocity as base.
                 double angleBonus = Math.Min(currVelocity, prevVelocity);
 
+                // Consider stacked notes to be repeated movements
+                double stackAngleFactor = 1 - DifficultyCalculationUtils.Smootherstep(osuLastObj.LazyJumpDistance, 0, diameter * 2);
+
                 if (Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) < 1.25 * Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) // If rhythms are the same.
                 {
                     acuteAngleBonus = calcAcuteAngleBonus(currAngle);
 
                     // Penalize angle repetition.
-                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(calcAcuteAngleBonus(lastAngle), 3)));
+                    acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(Math.Max(calcAcuteAngleBonus(lastAngle), stackAngleFactor), 3)));
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
@@ -94,7 +97,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 wideAngleBonus = calcWideAngleBonus(currAngle);
 
                 // Penalize angle repetition.
-                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(calcWideAngleBonus(lastAngle), 3));
+                wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(Math.Max(calcWideAngleBonus(lastAngle), stackAngleFactor), 3));
 
                 // Apply full wide angle bonus for distance more than one diameter
                 wideAngleBonus *= angleBonus * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, 0, diameter);


### PR DESCRIPTION
Currently the various angle bonuses are nerfed by angle repetition by looking at the previous note's angle. In the case of a stacked note this can lead to them bypassing this repetition nerf despite the fact that the player does not move during that note and would not play it any differently than any other angle. The solution this PR proposes is to take the max between the maximum angle repetition nerf and a factor that depends on how stacked a note is such that if a previous note is stacked while its angle is considered "non repetitive" it still gets nerfed regardless.