### PR TITLE
Adjust message on successful report to match bancho

### DIFF
--- a/osu.Game/Overlays/Chat/ReportChatPopover.cs
+++ b/osu.Game/Overlays/Chat/ReportChatPopover.cs
@@ -33,7 +33,27 @@ namespace osu.Game.Overlays.Chat
         {
             var request = new ChatReportRequest(message.Id, reason, comments);
 
-            request.Success += () => channelManager.CurrentChannel.Value.AddNewMessages(new InfoMessage(UsersStrings.ReportThanks.ToString()));
+            request.Success += () =>
+            {
+                string thanksMessage;
+
+                switch (channelManager.CurrentChannel.Value.Type)
+                {
+                    case ChannelType.PM:
+                        thanksMessage = """
+                                  Chat moderators have been alerted. You have reported a private message so they will not be able to read history to maintain your privacy. Please make sure to include as much details as you can.
+                                  You can submit a second report with more details if required, or contact abuse@ppy.sh if a user is being extremely offensive.
+                                  You can also block a user via the block button on their user profile, or by right-clicking on their name in the chat and selecting "Block".
+                                  """;
+                        break;
+
+                    default:
+                        thanksMessage = @"Chat moderators have been alerted. Thanks for your help.";
+                        break;
+                }
+
+                channelManager.CurrentChannel.Value.AddNewMessages(new InfoMessage(thanksMessage));
+            };
 
             api.Queue(request);
         }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/36004.

In public channels:
<img width="667" height="30" alt="Screenshot 2025-12-16 at 11 10 45" src="https://github.com/user-attachments/assets/784c00fa-1931-49ac-8771-c26a9cd22320" />

In PMs:
<img width="1321" height="81" alt="Screenshot 2025-12-16 at 11 21 39" src="https://github.com/user-attachments/assets/4a9ca963-e29b-462d-b886-d5ef78188518" />

Caveats:

- Not adding localisation because the previous implementation was `.ToString()`ing anyway.
- Would have made the abuse e-mail a link but `mailto:` doesn't work with `MessageFormatter` and I don't want to go into that right now.
- The message *almost* matches stable. The "almost" is because it doesn't mention the `/ignore` chat command. I was just going to implement the command, but I went to check what it does, and backed away slowly because it has like weird scoping to chat, highlights, and/or PMs, so [`nope.avi`](https://www.youtube.com/watch?v=gvdf5n-zI14).