### PR TITLE
Add additional hard link notice to FirstRunImportFromStable

### DIFF
--- a/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
+++ b/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
@@ -15,9 +15,9 @@ namespace osu.Game.Localisation
         public static LocalisableString Header => new TranslatableString(getKey(@"header"), @"Import");
 
         /// <summary>
-        /// "If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will not affect your existing installation&#39;s files in any way."
+        /// "If you have an installation of a previous osu! version, you can choose to migrate your existing content. This will not affect your existing installation&#39;s files in any way. Files are hard-linked (shared instead of copied) where possible to save disk space if osu!(lazer) and osu!(stable) are installed on the same drive."
         /// </summary>
-        public static LocalisableString Description => new TranslatableString(getKey(@"description"), @"If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will not affect your existing installation's files in any way.");
+        public static LocalisableString Description => new TranslatableString(getKey(@"description"), @"If you have an installation of a previous osu! version, you can choose to migrate your existing content. This will not affect your existing installation's files in any way. Files are hard-linked (shared instead of copied) where possible to save disk space if osu!(lazer) and osu!(stable) are installed on the same drive.");
 
         /// <summary>
         /// "previous osu! install"


### PR DESCRIPTION
There's been confusion on whether lazer duplicates files and uses up double the disk space when importing files from stable to lazer.

While a [notice](https://github.com/ppy/osu/blob/734c6f933d0b245eb6febe699109997d09b48701/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs#L55) does already exist serving this purpose, this only shows up once a path to a stable installation is selected AND validated. This clearly isn't enough as there's still people from [today](https://discord.com/channels/188630481301012481/1097318920991559880/1450516454364680212), [10 days ago](https://discord.com/channels/188630481301012481/1097318920991559880/1446790520687951884), and much later asking if lazer duplicates disk space when importing from stable.

This PR adds an extra sentence to the description of the import page on the first run overlay, letting users know that hard links are used to effectively share files between stable and lazer when possible. This should give the user two notices that hard links can be utilized, hopefully putting more minds at ease.

Feel free to close if this is deemed unnecessary.