### PR TITLE
fix(ModMuted): correct tooltip text for MuteComboSlider when set to 0

### DIFF
--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -100,6 +100,6 @@ namespace osu.Game.Rulesets.Mods
 
     public partial class MuteComboSlider : RoundedSliderBar<int>
     {
-        public override LocalisableString TooltipText => Current.Value == 0 ? "always muted" : base.TooltipText;
+        public override LocalisableString TooltipText => Current.Value == 0 ? "Muted" : base.TooltipText;
     }
 }


### PR DESCRIPTION
## Summary
This PR corrects the tooltip value that was "always muted" when the MuteComboSlider is set to 0 by changing the tooltip text to be "Muted" in those cases

## Files changed:
* osu.Game/Rulesets/Mods/ModMuted.cs

Closes #35992