### PR TITLE
Add ability to view other beatmaps in set when difficulties are split apart

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -17,6 +17,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Screens.SelectV2;
+using osuTK.Input;
 using FilterControl = osu.Game.Screens.SelectV2.FilterControl;
 using NoResultsPlaceholder = osu.Game.Screens.SelectV2.NoResultsPlaceholder;
 
@@ -352,6 +353,30 @@ namespace osu.Game.Tests.Visual.SongSelectV2
 
             AddAssert("hide fails", () => Beatmaps.Hide(Beatmap.Value.BeatmapInfo), () => Is.False);
             checkMatchedBeatmaps(1);
+        }
+
+        [Test]
+        public void TestScopeToBeatmapWhenDifficultiesSplitApart()
+        {
+            ImportBeatmapForRuleset(0);
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+            SortBy(SortMode.Difficulty);
+            checkMatchedBeatmaps(6);
+
+            AddUntilStep("wait for spread indicator", () => this.ChildrenOfType<PanelBeatmapStandalone.SpreadDisplay>().Any(d => d.Enabled.Value));
+            AddStep("click spread indicator", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<PanelBeatmapStandalone.SpreadDisplay>().Single(d => d.Enabled.Value));
+                InputManager.Click(MouseButton.Left);
+            });
+            WaitForFiltering();
+            checkMatchedBeatmaps(3);
+
+            AddStep("press Escape", () => InputManager.Key(Key.Escape));
+            WaitForFiltering();
+            checkMatchedBeatmaps(6);
         }
 
         private NoResultsPlaceholder? getPlaceholder() => SongSelect.ChildrenOfType<NoResultsPlaceholder>().FirstOrDefault();

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -259,6 +259,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString NoMatchingBeatmapsDescription => new TranslatableString(getKey(@"no_matching_beatmaps_description"), @"No beatmaps match your filter criteria!");
 
+        /// <summary>
+        /// "Temporarily showing all beatmaps in"
+        /// </summary>
+        public static LocalisableString TemporarilyShowingAllBeatmapsIn => new TranslatableString(getKey(@"temporarily_showing_all_beatmaps_in"), @"Temporarily showing all beatmaps in");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarouselFilterMatching.cs
@@ -56,10 +56,10 @@ namespace osu.Game.Screens.SelectV2
         {
             bool match = criteria.Ruleset == null || beatmap.AllowGameplayWithRuleset(criteria.Ruleset!, criteria.AllowConvertedBeatmaps);
 
-            if (beatmap.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
+            if (criteria.SelectedBeatmapSet != null)
             {
                 // only check ruleset equality or convertability for selected beatmap
-                return match;
+                return beatmap.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true && match;
             }
 
             if (!match) return false;

--- a/osu.Game/Screens/SelectV2/FilterControl.ScopedBeatmapSetDisplay.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.ScopedBeatmapSetDisplay.cs
@@ -1,0 +1,124 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class FilterControl
+    {
+        public partial class ScopedBeatmapSetDisplay : CompositeDrawable, IKeyBindingHandler<GlobalAction>
+        {
+            public Bindable<BeatmapSetInfo?> ScopedBeatmapSet
+            {
+                get => scopedBeatmapSet.Current;
+                set => scopedBeatmapSet.Current = value;
+            }
+
+            private readonly BindableWithCurrent<BeatmapSetInfo?> scopedBeatmapSet = new BindableWithCurrent<BeatmapSetInfo?>();
+            private Container content = null!;
+            private OsuTextFlowContainer text = null!;
+            private ShearedButton goBackButton = null!;
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+                AutoSizeEasing = Easing.OutQuint;
+                AutoSizeDuration = 200;
+                CornerRadius = 8f;
+                Masking = true;
+                InternalChildren = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Highlight1,
+                    },
+                    content = new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        BypassAutoSizeAxes = Axes.Y,
+                        Shear = -OsuGame.SHEAR,
+                        Padding = new MarginPadding
+                        {
+                            Horizontal = 6,
+                            Vertical = 2,
+                        },
+                        Children = new Drawable[]
+                        {
+                            text = new OsuTextFlowContainer(t => t.Font = OsuFont.Style.Body)
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Colour = colourProvider.Background6,
+                                Padding = new MarginPadding { Right = 80, Vertical = 5 }
+                            },
+                            goBackButton = new ShearedButton(80)
+                            {
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Text = CommonStrings.Back,
+                                RelativeSizeAxes = Axes.Y,
+                                Height = 1,
+                                Action = () => scopedBeatmapSet.Value = null,
+                            }
+                        }
+                    }
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                scopedBeatmapSet.BindValueChanged(_ => updateState(), true);
+            }
+
+            private void updateState()
+            {
+                content.BypassAutoSizeAxes = scopedBeatmapSet.Value != null ? Axes.None : Axes.Y;
+
+                if (scopedBeatmapSet.Value != null)
+                {
+                    text.Clear();
+                    text.AddText(SongSelectStrings.TemporarilyShowingAllBeatmapsIn);
+                    text.AddText(@" ");
+                    text.AddText(scopedBeatmapSet.Value.Metadata.GetDisplayTitleRomanisable(), t => t.Font = OsuFont.Style.Body.With(weight: FontWeight.Bold));
+                }
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+            {
+                if (scopedBeatmapSet.Value != null && e.Action == GlobalAction.Back && !e.Repeat)
+                {
+                    goBackButton.TriggerClick();
+                    return true;
+                }
+
+                return false;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/FilterControl.ScopedBeatmapSetDisplay.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.ScopedBeatmapSetDisplay.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -189,6 +189,7 @@ namespace osu.Game.Screens.SelectV2
                         new ScopedBeatmapSetDisplay
                         {
                             ScopedBeatmapSet = ScopedBeatmapSet,
+                            Depth = float.MinValue, // hack to ensure that the scoped display handles `GlobalAction.Back` input before the filter control
                         }
                     },
                 }

--- a/osu.Game/Screens/SelectV2/ISongSelect.cs
+++ b/osu.Game/Screens/SelectV2/ISongSelect.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Scoring;
@@ -43,5 +44,10 @@ namespace osu.Game.Screens.SelectV2
         /// Gets relevant actionable items for beatmap context menus, based on the type of song select.
         /// </summary>
         IEnumerable<OsuMenuItem> GetForwardActions(BeatmapInfo beatmap);
+
+        /// <summary>
+        /// Set this to a non-<see langword="null"/> value in order to temporarily bypass filter and show all difficulties of the given beatmap set.
+        /// </summary>
+        Bindable<BeatmapSetInfo?> ScopedBeatmapSet { get; }
     }
 }

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.SpreadDisplay.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.SpreadDisplay.cs
@@ -47,7 +47,8 @@ namespace osu.Game.Screens.SelectV2
 
             public SpreadDisplay()
             {
-                AutoSizeAxes = Axes.Both;
+                AutoSizeAxes = Axes.X;
+                RelativeSizeAxes = Axes.Y;
                 Content.CornerRadius = 5;
             }
 
@@ -57,6 +58,8 @@ namespace osu.Game.Screens.SelectV2
                 Add(new FillFlowContainer
                 {
                     AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(5),
                     Padding = new MarginPadding { Horizontal = 5 },
@@ -132,14 +135,14 @@ namespace osu.Game.Screens.SelectV2
 
             private void updateBeatmap()
             {
-                preceding.Clear();
-                succeeding.Clear();
-
                 if (Beatmap.Value == null || scopedBeatmapSet.Value != null)
                 {
                     this.FadeOut(transition_duration, Easing.OutQuint);
                     return;
                 }
+
+                preceding.Clear();
+                succeeding.Clear();
 
                 var otherStarDifficulties = Beatmap.Value.BeatmapSet!.Beatmaps
                                                    .Except([Beatmap.Value])
@@ -218,7 +221,8 @@ namespace osu.Game.Screens.SelectV2
                 if (!Enabled.Value)
                     return false;
 
-                return base.OnMouseDown(e);
+                base.OnMouseDown(e);
+                return true;
             }
 
             protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.SpreadDisplay.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.SpreadDisplay.cs
@@ -1,0 +1,255 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class PanelBeatmapStandalone
+    {
+        public partial class SpreadDisplay : OsuAnimatedButton
+        {
+            public Bindable<BeatmapInfo?> Beatmap { get; } = new Bindable<BeatmapInfo?>();
+            public Bindable<StarDifficulty> StarDifficulty { get; } = new Bindable<StarDifficulty>();
+
+            private readonly Bindable<BeatmapSetInfo?> scopedBeatmapSet = new Bindable<BeatmapSetInfo?>();
+            private readonly Bindable<bool> showConvertedBeatmaps = new Bindable<bool>();
+
+            private const double transition_duration = 200;
+
+            [Resolved]
+            private Bindable<RulesetInfo> ruleset { get; set; } = null!;
+
+            [Resolved]
+            private OsuColour colours { get; set; } = null!;
+
+            private FillFlowContainer preceding = null!;
+            public Circle Current { get; private set; } = null!;
+            private FillFlowContainer succeeding = null!;
+
+            private OsuSpriteText countText = null!;
+            private SpriteIcon icon = null!;
+
+            public SpreadDisplay()
+            {
+                AutoSizeAxes = Axes.Both;
+                Content.CornerRadius = 5;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(ISongSelect? songSelect, OsuConfigManager configManager)
+            {
+                Add(new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(5),
+                    Padding = new MarginPadding { Horizontal = 5 },
+                    Children = new Drawable[]
+                    {
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(2),
+                            Children = new Drawable[]
+                            {
+                                preceding = new FillFlowContainer
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(1),
+                                    Alpha = 0.5f,
+                                },
+                                Current = new Circle
+                                {
+                                    Size = new Vector2(7, 12),
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                },
+                                succeeding = new FillFlowContainer
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(1),
+                                    Alpha = 0.5f,
+                                }
+                            }
+                        },
+                        countText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Font = OsuFont.Style.Caption2,
+                        },
+                        icon = new SpriteIcon
+                        {
+                            Size = new Vector2(12),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Icon = FontAwesome.Solid.Eye,
+                            Alpha = 0,
+                        }
+                    }
+                });
+
+                if (songSelect != null)
+                    scopedBeatmapSet.BindTo(songSelect.ScopedBeatmapSet);
+
+                configManager.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmaps);
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Beatmap.BindValueChanged(_ => updateBeatmap());
+                StarDifficulty.BindValueChanged(_ => updateBeatmap());
+                showConvertedBeatmaps.BindValueChanged(_ => updateBeatmap());
+                scopedBeatmapSet.BindValueChanged(_ => updateBeatmap(), true);
+                Enabled.BindValueChanged(_ => updateAppearance(), true);
+                FinishTransforms(true);
+            }
+
+            private void updateBeatmap()
+            {
+                preceding.Clear();
+                succeeding.Clear();
+
+                if (Beatmap.Value == null || scopedBeatmapSet.Value != null)
+                {
+                    this.FadeOut(transition_duration, Easing.OutQuint);
+                    return;
+                }
+
+                var otherStarDifficulties = Beatmap.Value.BeatmapSet!.Beatmaps
+                                                   .Except([Beatmap.Value])
+                                                   .Where(b => b.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value))
+                                                   .OrderBy(b => b.StarRating)
+                                                   .Select(b => b.StarRating)
+                                                   .ToList();
+                this.FadeTo(otherStarDifficulties.Count > 0 ? 1 : 0, transition_duration, Easing.OutQuint);
+
+                if (otherStarDifficulties.Count == 0)
+                    return;
+
+                const int max_difficulties_total = 11;
+
+                int startIndex;
+                int endIndex;
+
+                if (otherStarDifficulties.Count <= max_difficulties_total)
+                {
+                    startIndex = 0;
+                    endIndex = otherStarDifficulties.Count - 1;
+                }
+                else
+                {
+                    startIndex = otherStarDifficulties.BinarySearch(StarDifficulty.Value.Stars);
+                    if (startIndex < 0)
+                        startIndex = ~startIndex - 1;
+
+                    startIndex = Math.Clamp(startIndex - max_difficulties_total / 2, 0, otherStarDifficulties.Count - 1);
+                    endIndex = Math.Clamp(startIndex + max_difficulties_total, 0, otherStarDifficulties.Count - 1);
+                }
+
+                for (int i = startIndex; i <= endIndex; i++)
+                {
+                    double otherStarDifficulty = otherStarDifficulties[i];
+                    var target = otherStarDifficulty < StarDifficulty.Value.Stars ? preceding : succeeding;
+
+                    var circle = new Circle
+                    {
+                        Size = new Vector2(5, 10),
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Colour = colours.ForStarDifficulty(otherStarDifficulty)
+                    };
+                    target.Add(circle);
+                    target.SetLayoutPosition(circle, (float)otherStarDifficulty);
+                }
+
+                int countNotShown = otherStarDifficulties.Count - (preceding.Count + succeeding.Count);
+                countText.Alpha = countNotShown > 0 ? 1 : 0;
+                countText.Text = $@"+{countNotShown}";
+
+                if (startIndex > 0)
+                {
+                    for (int i = 0; i < preceding.Count; ++i)
+                    {
+                        var dot = preceding[i];
+                        dot.Alpha = (1 + 4 * (float)(i + 1) / preceding.Count) / 5;
+                    }
+                }
+
+                if (endIndex < otherStarDifficulties.Count - 1)
+                {
+                    for (int i = 0; i < succeeding.Count; ++i)
+                    {
+                        var dot = succeeding[i];
+                        dot.Alpha = (1 + 4 * (float)(succeeding.Count - i) / succeeding.Count) / 5;
+                    }
+                }
+
+                Action = () => scopedBeatmapSet.Value = Beatmap.Value.BeatmapSet!;
+            }
+
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                if (!Enabled.Value)
+                    return false;
+
+                return base.OnMouseDown(e);
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                if (!Enabled.Value)
+                    return false;
+
+                return base.OnClick(e);
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                updateAppearance();
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                updateAppearance();
+                base.OnHoverLost(e);
+            }
+
+            private void updateAppearance()
+            {
+                bool isInteractable = Enabled.Value && IsHovered;
+
+                HoverColour = isInteractable ? Colour4.White.Opacity(0.1f) : Colour4.Transparent;
+                preceding.FadeTo(isInteractable ? 1 : 0.5f, transition_duration, Easing.OutQuint);
+                succeeding.FadeTo(isInteractable ? 1 : 0.5f, transition_duration, Easing.OutQuint);
+                icon.FadeTo(isInteractable ? 1 : 0, transition_duration, Easing.OutQuint);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -18,7 +18,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
@@ -65,7 +64,7 @@ namespace osu.Game.Screens.SelectV2
 
         private ConstrainedIconContainer difficultyIcon = null!;
         private StarRatingDisplay starRatingDisplay = null!;
-        private StarCounter starCounter = null!;
+        private SpreadDisplay spreadDisplay = null!;
         private PanelLocalRankDisplay localRank = null!;
         private OsuSpriteText keyCountText = null!;
         private OsuSpriteText difficultyText = null!;
@@ -193,11 +192,11 @@ namespace osu.Game.Screens.SelectV2
                                             Anchor = Anchor.CentreLeft,
                                             Scale = new Vector2(0.875f),
                                         },
-                                        starCounter = new StarCounter
+                                        spreadDisplay = new SpreadDisplay
                                         {
-                                            Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
-                                            Scale = new Vector2(0.4f)
+                                            Anchor = Anchor.CentreLeft,
+                                            Enabled = { BindTarget = Selected }
                                         }
                                     },
                                 }
@@ -239,6 +238,7 @@ namespace osu.Game.Screens.SelectV2
             authorText.Text = BeatmapsetsStrings.ShowDetailsMappedBy(beatmap.Metadata.Author.Username);
 
             computeStarRating();
+            spreadDisplay.Beatmap.Value = beatmap;
             updateKeyCount();
         }
 
@@ -252,6 +252,7 @@ namespace osu.Game.Screens.SelectV2
             updateButton.BeatmapSet = null;
             localRank.Beatmap = null;
             starDifficultyBindable = null;
+            spreadDisplay.Beatmap.Value = null;
 
             starDifficultyCancellationSource?.Cancel();
         }
@@ -268,7 +269,7 @@ namespace osu.Game.Screens.SelectV2
             starDifficultyBindable.BindValueChanged(starDifficulty =>
             {
                 starRatingDisplay.Current.Value = starDifficulty.NewValue;
-                starCounter.Current = (float)starDifficulty.NewValue.Stars;
+                spreadDisplay.StarDifficulty.Value = starDifficulty.NewValue;
             }, true);
         }
 
@@ -289,7 +290,7 @@ namespace osu.Game.Screens.SelectV2
             var diffColour = starRatingDisplay.DisplayedDifficultyColour;
 
             AccentColour = diffColour;
-            starCounter.Colour = diffColour;
+            spreadDisplay.Current.Colour = diffColour;
 
             backgroundBorder.Colour = diffColour;
             difficultyIcon.Colour = starRatingDisplay.DisplayedStars.Value > OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : colourProvider.Background5;

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -1204,6 +1204,8 @@ namespace osu.Game.Screens.SelectV2
                 beatmaps.Restore(b);
         }
 
+        public Bindable<BeatmapSetInfo?> ScopedBeatmapSet => filterControl.ScopedBeatmapSet;
+
         #endregion
     }
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/c95913d3-3fe3-4fcc-b89c-1777421f5005

---

First part of https://github.com/ppy/osu/issues/36039, see also https://github.com/ppy/osu/discussions/33784.

The goal is to add this back to the set panels too, but that one is more complicated than this if you can believe it (because it requires being able to tell which other difficulties of the set are filtered out to fade them out which is not super easy given new song select structure). I also foresee the display logic to vary significantly there.

Of note, for this to work in beatmaps-split-apart mode, this requires a change of behaviour in the filtering logic. Old song select when given a "selected beatmap set" would *include* that in results regardless of the filter, but that doesn't work for beatmaps-split-apart for reasons that are hopefully obvious, so this changes the behaviour to *entirely bypass* the filter and just show the set. Unsure how angry will people be with that.

Also of note, when in the scoped mode, altering any filter criteria will dismiss the scope.