### PR TITLE
Implement new settings item component

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItemV2.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItemV2.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Tests.Visual.Settings
                                             },
                                         })
                                         {
-                                            ShowDefaultRevertButton = false
+                                            ShowRevertToDefaultButton = false
                                         },
                                         new SettingsItemV2(classicSliderBar = new FormSliderBar<float>
                                         {

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItemV2.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItemV2.cs
@@ -1,0 +1,263 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Cursor;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Settings;
+using osu.Game.Tests.Visual.UserInterface;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Settings
+{
+    public partial class TestSceneSettingsItemV2 : ThemeComparisonTestScene
+    {
+        private readonly Bindable<SettingsNote.Data?> note = new Bindable<SettingsNote.Data?>();
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        private FormSliderBar<float> sliderBar = null!;
+
+        private SearchContainer searchContainer = null!;
+
+        public TestSceneSettingsItemV2()
+            : base(false)
+        {
+        }
+
+        protected override Drawable CreateContent()
+        {
+            return new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new BackgroundBox
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new OsuContextMenuContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Width = 400,
+                        RelativeSizeAxes = Axes.Y,
+                        Child = new PopoverContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Child = new OsuScrollContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                ScrollbarVisible = false,
+                                Child = searchContainer = new SearchContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(7),
+                                    Padding = new MarginPadding { Vertical = 10 },
+                                    Children = new[]
+                                    {
+                                        new SettingsItemV2(new FormTextBox
+                                        {
+                                            Caption = "Artist",
+                                            HintText = "Poot artist here!",
+                                            PlaceholderText = "Here is an artist",
+                                            Current = { Value = string.Empty, Default = string.Empty }
+                                        }),
+                                        new SettingsItemV2(new FormTextBox
+                                        {
+                                            Caption = "Artist",
+                                            HintText = "Poot artist here!",
+                                            PlaceholderText = "Here is an artist",
+                                            Current = { Value = string.Empty, Default = string.Empty, Disabled = true }
+                                        }),
+                                        new SettingsItemV2(new FormNumberBox(allowDecimals: true)
+                                        {
+                                            Caption = "Number",
+                                            HintText = "Insert your favourite number",
+                                            PlaceholderText = "Mine is 42!",
+                                            Current = { Value = string.Empty, Default = string.Empty }
+                                        }),
+                                        new SettingsItemV2(new FormCheckBox
+                                        {
+                                            Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                            HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                        })
+                                        {
+                                            Note = { BindTarget = note },
+                                        },
+                                        new SettingsItemV2(new FormCheckBox
+                                        {
+                                            Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                            HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                            Current = { Disabled = true },
+                                        }),
+                                        new SettingsItemV2(new FormCheckBox
+                                        {
+                                            Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                            HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                            Current = { Value = true, Disabled = true },
+                                        }),
+                                        new SettingsItemV2(new FormEnumDropdown<CountdownType>
+                                        {
+                                            Caption = EditorSetupStrings.EnableCountdown,
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                        }),
+                                        new SettingsItemV2(new FormEnumDropdown<CountdownType>
+                                        {
+                                            Caption = EditorSetupStrings.EnableCountdown,
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                            Current = { Disabled = true },
+                                        }),
+                                        new SettingsItemV2(new FormEnumDropdown<Language>
+                                        {
+                                            Caption = "Dropdown with many items",
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                        })
+                                        {
+                                            Note = { BindTarget = note },
+                                        },
+                                        new SettingsItemV2(sliderBar = new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 10,
+                                                Value = 5,
+                                                Precision = 0.1f,
+                                            },
+                                        }),
+                                        new SettingsItemV2(new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 10,
+                                                Value = 5,
+                                                Precision = 0.1f,
+                                                Disabled = true,
+                                            },
+                                            TransferValueOnCommit = true,
+                                        }),
+                                        new SettingsItemV2(new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider without revert button",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 10,
+                                                Value = 5,
+                                                Precision = 0.1f,
+                                            },
+                                        })
+                                        {
+                                            ShowDefaultRevertButton = false
+                                        },
+                                        new SettingsItemV2(new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider with classic default",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 10,
+                                                Value = 5,
+                                                Precision = 0.1f,
+                                            },
+                                        })
+                                        {
+                                            HasClassicDefault = true,
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    },
+                },
+            };
+        }
+
+        [Test]
+        public void TestDisplay()
+        {
+            AddStep("display", () => CreateThemedContent(OverlayColourScheme.Purple));
+        }
+
+        [Test]
+        public void TestNote()
+        {
+            AddStep("set informational note", () => note.Value = new SettingsNote.Data(LayoutSettingsStrings.OsuIsRunningExclusiveFullscreen.ToString(), SettingsNote.Type.Informational));
+            AddStep("set warning note",
+                () => note.Value = new SettingsNote.Data(
+                    "Using unlimited frame limiter can lead to stutters, bad performance and overheating. It will not improve perceived latency. “2x refresh rate” is recommended.",
+                    SettingsNote.Type.Warning));
+            AddStep("set critical note",
+                () => note.Value = new SettingsNote.Data(
+                    "You have done something so horrible in the game settings to the point we have invented a new note type for this. Look at it, it's in red. It's worse than yellow.",
+                    SettingsNote.Type.Critical));
+            AddStep("clear note", () => note.Value = null);
+        }
+
+        [Test]
+        public void TestFilter()
+        {
+            AddStep("set classic filter", () => searchContainer.SearchTerm = SettingsItemV2.CLASSIC_DEFAULT_SEARCH_TERM);
+            AddStep("set no filter", () => searchContainer.SearchTerm = string.Empty);
+        }
+
+        /// <summary>
+        /// Ensures that the reset to default button uses the correct implementation of IsDefault to determine whether it should be shown or not.
+        /// Values have been chosen so that after being set, Value != Default (but they are close enough that the difference is negligible compared to Precision).
+        /// </summary>
+        [TestCase(4.2f)]
+        [TestCase(9.9f)]
+        public void TestRestoreDefaultValueButtonPrecision(float initialValue)
+        {
+            BindableFloat current = null!;
+            SettingsRevertToDefaultButton revertToDefaultButton = null!;
+
+            AddStep("set current bindable", () => sliderBar.Current = current = new BindableFloat(initialValue)
+            {
+                MinValue = 0,
+                MaxValue = 10,
+                Precision = 0.1f,
+            });
+
+            AddStep("retrieve restore default button", () => revertToDefaultButton = sliderBar.FindClosestParent<SettingsItemV2>().ChildrenOfType<SettingsRevertToDefaultButton>().Single());
+
+            AddAssert("restore button hidden", () => revertToDefaultButton.X == 0);
+
+            AddStep("change value to next closest", () => sliderBar.Current.Value += current.Precision * 0.6f);
+            AddUntilStep("restore button shown", () => revertToDefaultButton.X > 0);
+
+            AddStep("restore default", () => sliderBar.Current.SetDefault());
+            AddUntilStep("restore button hidden", () => revertToDefaultButton.X == 0);
+        }
+
+        private partial class BackgroundBox : Box
+        {
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                Colour = colourProvider.Background4;
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItemV2.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItemV2.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -30,6 +31,7 @@ namespace osu.Game.Tests.Visual.Settings
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
         private FormSliderBar<float> sliderBar = null!;
+        private FormSliderBar<float> classicSliderBar = null!;
 
         private SearchContainer searchContainer = null!;
 
@@ -171,7 +173,7 @@ namespace osu.Game.Tests.Visual.Settings
                                         {
                                             ShowDefaultRevertButton = false
                                         },
-                                        new SettingsItemV2(new FormSliderBar<float>
+                                        new SettingsItemV2(classicSliderBar = new FormSliderBar<float>
                                         {
                                             Caption = "Slider with classic default",
                                             Current = new BindableFloat
@@ -183,7 +185,7 @@ namespace osu.Game.Tests.Visual.Settings
                                             },
                                         })
                                         {
-                                            HasClassicDefault = true,
+                                            ApplyClassicDefault = () => classicSliderBar.Current.Value = 2,
                                         },
                                     },
                                 },
@@ -216,10 +218,16 @@ namespace osu.Game.Tests.Visual.Settings
         }
 
         [Test]
-        public void TestFilter()
+        public void TestClassicDefault()
         {
+            AddStep("modify irrelevant setting", () => sliderBar.Current.Value = 4);
+            AddStep("apply classic defaults", () => this.ChildrenOfType<ISettingsItem>().Where(i => i.HasClassicDefault).ForEach(s => s.ApplyClassicDefault()));
+            AddStep("apply regular defaults", () => this.ChildrenOfType<ISettingsItem>().Where(i => i.HasClassicDefault).ForEach(s => s.ApplyDefault()));
             AddStep("set classic filter", () => searchContainer.SearchTerm = SettingsItemV2.CLASSIC_DEFAULT_SEARCH_TERM);
+            AddStep("apply classic defaults", () => this.ChildrenOfType<ISettingsItem>().Where(i => i.HasClassicDefault).ForEach(s => s.ApplyClassicDefault()));
+            AddStep("apply regular defaults", () => this.ChildrenOfType<ISettingsItem>().Where(i => i.HasClassicDefault).ForEach(s => s.ApplyDefault()));
             AddStep("set no filter", () => searchContainer.SearchTerm = string.Empty);
+            AddAssert("irrelevant setting left out", () => sliderBar.Current.Value, () => Is.EqualTo(4));
         }
 
         /// <summary>

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Graphics
         public static IconUsage EditCircle => get(OsuIconMapping.EditCircle);
         public static IconUsage LeftCircle => get(OsuIconMapping.LeftCircle);
         public static IconUsage RightCircle => get(OsuIconMapping.RightCircle);
+        public static IconUsage Undo => get(OsuIconMapping.Undo);
 
         public static IconUsage Audio => get(OsuIconMapping.Audio);
         public static IconUsage Beatmap => get(OsuIconMapping.Beatmap);
@@ -385,6 +386,9 @@ namespace osu.Game.Graphics
 
             [Description(@"twitter")]
             Twitter,
+
+            [Description(@"undo")]
+            Undo,
 
             [Description(@"user-interface")]
             UserInterface,

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -167,9 +167,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public event Action? ValueChanged;
 
-        public bool IsValueDefault => Current.IsDefault;
+        public bool IsDefault => Current.IsDefault;
 
-        public void SetValueDefault() => Current.SetDefault();
+        public void SetDefault() => Current.SetDefault();
 
         public bool IsDisabled => Current.Disabled;
     }

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -1,10 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -19,7 +22,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormCheckBox : CompositeDrawable, IHasCurrentValue<bool>
+    public partial class FormCheckBox : CompositeDrawable, IHasCurrentValue<bool>, IFormControl
     {
         public Bindable<bool> Current
         {
@@ -109,6 +112,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 updateState();
                 playSamples();
                 background.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
+
+                ValueChanged?.Invoke();
             });
             current.BindDisabledChanged(_ => updateState(), true);
         }
@@ -157,5 +162,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     BorderColour = colourProvider.Light4;
             }
         }
+
+        public IEnumerable<LocalisableString> FilterTerms => Caption.Yield();
+
+        public event Action? ValueChanged;
+
+        public bool IsValueDefault => Current.IsDefault;
+
+        public void SetValueDefault() => Current.SetDefault();
+
+        public bool IsDisabled => Current.Disabled;
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -68,9 +68,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public event Action? ValueChanged;
 
-        public bool IsValueDefault => Current.IsDefault;
+        public bool IsDefault => Current.IsDefault;
 
-        public void SetValueDefault() => Current.SetDefault();
+        public void SetDefault() => Current.SetDefault();
 
         public bool IsDisabled => Current.Disabled;
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -61,8 +59,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 yield return Caption;
 
-                foreach (var item in Items)
-                    yield return item?.ToString() ?? string.Empty;
+                foreach (var item in MenuItems)
+                    yield return item.Text.Value;
             }
         }
 
@@ -280,8 +278,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
     public partial class FormEnumDropdown<T> : FormDropdown<T>
         where T : struct, Enum
     {
-        public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(Items.Select(i => i.GetLocalisableDescription()));
-
         public FormEnumDropdown()
         {
             Items = Enum.GetValues<T>();

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -32,6 +32,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public LocalisableString HintText { get; init; }
 
+        /// <summary>
+        /// The maximum height of the dropdown's menu.
+        /// By default, this is set to 200px high. Set to <see cref="float.PositiveInfinity"/> to remove such limit.
+        /// </summary>
+        public float MaxHeight { get; set; } = 200;
+
         private FormDropdownHeader header = null!;
 
         [BackgroundDependencyLoader]
@@ -73,7 +79,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
             Dropdown = this,
         };
 
-        protected override DropdownMenu CreateMenu() => new FormDropdownMenu();
+        protected override DropdownMenu CreateMenu() => new FormDropdownMenu
+        {
+            MaxHeight = MaxHeight,
+        };
 
         private partial class FormDropdownHeader : DropdownHeader
         {

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using osu.Framework.Allocation;
@@ -22,7 +23,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormSliderBar<T> : CompositeDrawable, IHasCurrentValue<T>
+    public partial class FormSliderBar<T> : CompositeDrawable, IHasCurrentValue<T>, IFormControl
         where T : struct, INumber<T>, IMinMaxValue<T>
     {
         public Bindable<T> Current
@@ -194,7 +195,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
             slider.IsDragging.BindValueChanged(_ => updateState());
             slider.Focused.BindValueChanged(_ => updateState());
 
-            current.ValueChanged += e => currentNumberInstantaneous.Value = e.NewValue;
+            current.ValueChanged += e =>
+            {
+                currentNumberInstantaneous.Value = e.NewValue;
+                ValueChanged?.Invoke();
+            };
+
             current.MinValueChanged += v => currentNumberInstantaneous.MinValue = v;
             current.MaxValueChanged += v => currentNumberInstantaneous.MaxValue = v;
             current.PrecisionChanged += v => currentNumberInstantaneous.Precision = v;
@@ -475,5 +481,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 return true;
             }
         }
+
+        public IEnumerable<LocalisableString> FilterTerms => new[] { Caption, HintText };
+
+        public event Action? ValueChanged;
+
+        public bool IsValueDefault => Current.IsDefault;
+
+        public void SetValueDefault() => Current.SetDefault();
+
+        public bool IsDisabled => Current.Disabled;
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -440,7 +440,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             private void updateState()
             {
                 rightBox.Colour = colourProvider.Background6;
-                leftBox.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Dark2;
+                leftBox.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Highlight1.Opacity(0.3f);
                 nub.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1 : colourProvider.Light4;
             }
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -486,9 +486,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public event Action? ValueChanged;
 
-        public bool IsValueDefault => Current.IsDefault;
+        public bool IsDefault => Current.IsDefault;
 
-        public void SetValueDefault() => Current.SetDefault();
+        public void SetDefault() => Current.SetDefault();
 
         public bool IsDisabled => Current.Disabled;
     }

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -20,7 +22,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormTextBox : CompositeDrawable, IHasCurrentValue<string>
+    public partial class FormTextBox : CompositeDrawable, IHasCurrentValue<string>, IFormControl
     {
         public Bindable<string> Current
         {
@@ -157,6 +159,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             focusManager = GetContainingFocusManager()!;
             textBox.Focused.BindValueChanged(_ => updateState());
+
+            current.BindValueChanged(_ => ValueChanged?.Invoke());
             current.BindDisabledChanged(_ => updateState(), true);
         }
 
@@ -247,5 +251,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 OnInputError?.Invoke();
             }
         }
+
+        public event Action? ValueChanged;
+
+        public bool IsValueDefault => current.IsDefault;
+
+        public void SetValueDefault() => current.SetDefault();
+
+        public bool IsDisabled => current.Disabled;
+
+        public IEnumerable<LocalisableString> FilterTerms => Caption.Yield();
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -254,9 +254,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public event Action? ValueChanged;
 
-        public bool IsValueDefault => current.IsDefault;
+        public bool IsDefault => current.IsDefault;
 
-        public void SetValueDefault() => current.SetDefault();
+        public void SetDefault() => current.SetDefault();
 
         public bool IsDisabled => current.Disabled;
 

--- a/osu.Game/Graphics/UserInterfaceV2/IFormControl.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/IFormControl.cs
@@ -20,12 +20,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// <summary>
         /// Whether the value of this control is in a default state.
         /// </summary>
-        bool IsValueDefault { get; }
+        bool IsDefault { get; }
 
         /// <summary>
         /// If enabled, resets the control to its default state.
         /// </summary>
-        void SetValueDefault();
+        void SetDefault();
 
         /// <summary>
         /// Whether the control is currently disabled.

--- a/osu.Game/Graphics/UserInterfaceV2/IFormControl.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/IFormControl.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    /// <summary>
+    /// Represents an interface for all form controls.
+    /// </summary>
+    public interface IFormControl : IDrawable, IHasFilterTerms
+    {
+        /// <summary>
+        /// Invoked when the value of the control has changed.
+        /// </summary>
+        event Action ValueChanged;
+
+        /// <summary>
+        /// Whether the value of this control is in a default state.
+        /// </summary>
+        bool IsValueDefault { get; }
+
+        /// <summary>
+        /// If enabled, resets the control to its default state.
+        /// </summary>
+        void SetValueDefault();
+
+        /// <summary>
+        /// Whether the control is currently disabled.
+        /// </summary>
+        bool IsDisabled { get; }
+    }
+}

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -21,9 +21,9 @@ namespace osu.Game.Overlays.Settings
         private readonly BindableBool controlEnabled = new BindableBool(true);
 
         /// <summary>
-        /// Whether a revert-to-default button should be displayed.
+        /// Whether a revert button should be displayed when the control is modified away from default state.
         /// </summary>
-        public bool ShowDefaultRevertButton { get; init; } = true;
+        public bool ShowRevertToDefaultButton { get; init; } = true;
 
         /// <summary>
         /// A note to display underneath the setting.
@@ -88,7 +88,7 @@ namespace osu.Game.Overlays.Settings
 
         private void updateDefaultState()
         {
-            bool showRevertButton = !controlDefault.Value && controlEnabled.Value && ShowDefaultRevertButton;
+            bool showRevertButton = !controlDefault.Value && controlEnabled.Value && ShowRevertToDefaultButton;
 
             if (showRevertButton)
                 revertButton.Show();

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -105,23 +105,13 @@ namespace osu.Game.Overlays.Settings
 
         #region ISettingsItem
 
-        public bool HasClassicDefault { get; private set; }
-
-        private Action? applyClassicDefault;
+        public bool HasClassicDefault => ApplyClassicDefault != null;
 
         /// <summary>
         /// If set, this setting is considered as having a "classic" default value,
         /// and this is the function for overwriting the control with that value.
         /// </summary>
-        public Action? ApplyClassicDefault
-        {
-            get => applyClassicDefault;
-            set
-            {
-                applyClassicDefault = value;
-                HasClassicDefault = true;
-            }
-        }
+        public Action? ApplyClassicDefault { get; set; }
 
         void ISettingsItem.ApplyClassicDefault() => ApplyClassicDefault?.Invoke();
 

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -105,13 +105,25 @@ namespace osu.Game.Overlays.Settings
 
         #region ISettingsItem
 
-        public bool HasClassicDefault { get; init; }
+        public bool HasClassicDefault { get; private set; }
 
-        public void ApplyClassicDefault()
+        private Action? applyClassicDefault;
+
+        /// <summary>
+        /// If set, this setting is considered as having a "classic" default value,
+        /// and this is the function for overwriting the control with that value.
+        /// </summary>
+        public Action? ApplyClassicDefault
         {
-            // will be removed soon.
-            throw new NotSupportedException();
+            get => applyClassicDefault;
+            set
+            {
+                applyClassicDefault = value;
+                HasClassicDefault = true;
+            }
         }
+
+        void ISettingsItem.ApplyClassicDefault() => ApplyClassicDefault?.Invoke();
 
         public void ApplyDefault()
         {

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -1,0 +1,176 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Overlays.Settings
+{
+    public sealed partial class SettingsItemV2 : CompositeDrawable, ISettingsItem, IConditionalFilterable
+    {
+        private readonly IFormControl control;
+        private readonly SettingsRevertToDefaultButton revertButton;
+
+        private readonly BindableBool controlDefault = new BindableBool(true);
+        private readonly BindableBool controlEnabled = new BindableBool(true);
+
+        /// <summary>
+        /// Whether a revert-to-default button should be displayed.
+        /// </summary>
+        public bool ShowDefaultRevertButton { get; init; } = true;
+
+        /// <summary>
+        /// A note to display underneath the setting.
+        /// </summary>
+        public readonly Bindable<SettingsNote.Data?> Note = new Bindable<SettingsNote.Data?>();
+
+        public SettingsItemV2(IFormControl control)
+        {
+            this.control = control;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS_RIGHT },
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Children = new[]
+                        {
+                            revertButton = new SettingsRevertToDefaultButton
+                            {
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                Action = ApplyDefault,
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Child = (Drawable)control,
+                            }
+                        }
+                    },
+                    new SettingsNote
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Current = { BindTarget = Note },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            controlDefault.Value = control.IsValueDefault;
+            controlEnabled.Value = !control.IsDisabled;
+
+            controlDefault.BindValueChanged(_ => updateDefaultState());
+            controlEnabled.BindValueChanged(_ => updateDefaultState(), true);
+            FinishTransforms(true);
+        }
+
+        private void updateDefaultState()
+        {
+            bool showRevertButton = !controlDefault.Value && controlEnabled.Value && ShowDefaultRevertButton;
+
+            if (showRevertButton)
+                revertButton.Show();
+            else
+                revertButton.Hide();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            controlDefault.Value = control.IsValueDefault;
+            controlEnabled.Value = !control.IsDisabled;
+        }
+
+        #region ISettingsItem
+
+        public bool HasClassicDefault { get; init; }
+
+        public void ApplyClassicDefault()
+        {
+            // will be removed soon.
+            throw new NotSupportedException();
+        }
+
+        public void ApplyDefault()
+        {
+            if (!control.IsDisabled)
+                control.SetValueDefault();
+        }
+
+        public event Action SettingChanged
+        {
+            add => control.ValueChanged += value;
+            remove => control.ValueChanged -= value;
+        }
+
+        #endregion
+
+        #region Filtering
+
+        public const string CLASSIC_DEFAULT_SEARCH_TERM = @"has-classic-default";
+
+        public IEnumerable<string> Keywords { get; init; } = Enumerable.Empty<string>();
+
+        public IEnumerable<LocalisableString> FilterTerms
+        {
+            get
+            {
+                var filterTerms = new List<LocalisableString>(Keywords.Select(k => (LocalisableString)k));
+                filterTerms.AddRange(control.FilterTerms);
+
+                if (HasClassicDefault)
+                    filterTerms.Add(CLASSIC_DEFAULT_SEARCH_TERM);
+
+                return filterTerms;
+            }
+        }
+
+        private bool matchingFilter = true;
+
+        public bool MatchingFilter
+        {
+            get => matchingFilter;
+            set
+            {
+                bool wasPresent = IsPresent;
+
+                matchingFilter = value;
+
+                if (IsPresent != wasPresent)
+                    Invalidate(Invalidation.Presence);
+            }
+        }
+
+        public override bool IsPresent => base.IsPresent && MatchingFilter;
+
+        public bool FilteringActive { get; set; }
+
+        public BindableBool CanBeShown { get; } = new BindableBool(true);
+
+        IBindable<bool> IConditionalFilterable.CanBeShown => CanBeShown;
+
+        #endregion
+    }
+}

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Overlays.Settings
         {
             base.LoadComplete();
 
-            controlDefault.Value = control.IsValueDefault;
+            controlDefault.Value = control.IsDefault;
             controlEnabled.Value = !control.IsDisabled;
 
             controlDefault.BindValueChanged(_ => updateDefaultState());
@@ -99,7 +99,7 @@ namespace osu.Game.Overlays.Settings
         protected override void Update()
         {
             base.Update();
-            controlDefault.Value = control.IsValueDefault;
+            controlDefault.Value = control.IsDefault;
             controlEnabled.Value = !control.IsDisabled;
         }
 
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.Settings
         public void ApplyDefault()
         {
             if (!control.IsDisabled)
-                control.SetValueDefault();
+                control.SetDefault();
         }
 
         public event Action SettingChanged

--- a/osu.Game/Overlays/Settings/SettingsNote.cs
+++ b/osu.Game/Overlays/Settings/SettingsNote.cs
@@ -1,0 +1,117 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osuTK.Graphics;
+
+namespace osu.Game.Overlays.Settings
+{
+    public sealed partial class SettingsNote : CompositeDrawable
+    {
+        public readonly Bindable<Data?> Current = new Bindable<Data?>();
+
+        private Box background = null!;
+        private OsuTextFlowContainer text = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AutoSizeDuration = 300;
+            AutoSizeEasing = Easing.OutQuint;
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding { Top = 5, Bottom = 5 },
+                Child = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    CornerRadius = 5,
+                    CornerExponent = 2.5f,
+                    Masking = true,
+                    Children = new Drawable[]
+                    {
+                        background = new Box
+                        {
+                            Colour = Color4.Black,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        text = new OsuTextFlowContainer(s => s.Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold))
+                        {
+                            Padding = new MarginPadding(8),
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                        },
+                    }
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Current.BindValueChanged(_ => updateDisplay(), true);
+            FinishTransforms(true);
+        }
+
+        private void updateDisplay()
+        {
+            ClearTransforms();
+
+            if (Current.Value == null)
+            {
+                AutoSizeAxes = Axes.None;
+                this.ResizeHeightTo(0, 300, Easing.OutQuint);
+                this.FadeOut(250, Easing.OutQuint);
+                return;
+            }
+
+            AutoSizeAxes = Axes.Y;
+            this.FadeIn(250, Easing.OutQuint);
+
+            switch (Current.Value.Type)
+            {
+                case Type.Informational:
+                    background.Colour = colourProvider.Dark2;
+                    text.Colour = colourProvider.Content2;
+                    break;
+
+                case Type.Warning:
+                    background.Colour = colours.Orange1;
+                    text.Colour = colourProvider.Background5;
+                    break;
+
+                case Type.Critical:
+                    background.Colour = colours.Red1;
+                    text.Colour = colourProvider.Background5;
+                    break;
+            }
+
+            text.Text = Current.Value.Text;
+        }
+
+        public record Data(LocalisableString Text, Type Type);
+
+        public enum Type
+        {
+            Informational,
+            Warning,
+            Critical,
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/SettingsNote.cs
+++ b/osu.Game/Overlays/Settings/SettingsNote.cs
@@ -71,6 +71,7 @@ namespace osu.Game.Overlays.Settings
 
         private void updateDisplay()
         {
+            // Explicitly use ClearTransforms to clear any existing auto-size transform before modifying size / flag.
             ClearTransforms();
 
             if (Current.Value == null)

--- a/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
@@ -82,12 +82,12 @@ namespace osu.Game.Overlays.Settings
 
         public override void Show()
         {
-            this.FadeIn().MoveToX(WIDTH - 10, 300, Easing.OutQuint);
+            this.FadeIn().MoveToX(WIDTH - 10, 200, Easing.OutElasticQuarter);
         }
 
         public override void Hide()
         {
-            this.MoveToX(0, 300, Easing.OutQuint).Then().FadeOut();
+            this.MoveToX(0, 120, Easing.OutExpo).Then().FadeOut();
         }
 
         private void updateDisplay()

--- a/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
@@ -6,8 +6,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Localisation;
 using osuTK;
 
 namespace osu.Game.Overlays.Settings
@@ -63,6 +65,8 @@ namespace osu.Game.Overlays.Settings
             base.LoadComplete();
             Enabled.BindValueChanged(_ => updateDisplay(), true);
         }
+
+        public override LocalisableString TooltipText => CommonStrings.RevertToDefault;
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osuTK;
+
+namespace osu.Game.Overlays.Settings
+{
+    public partial class SettingsRevertToDefaultButton : OsuClickableContainer
+    {
+        public const float WIDTH = 32;
+
+        public float IconSize { get; init; } = 14;
+
+        private Box background = null!;
+        private SpriteIcon spriteIcon = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        // this is done to ensure a click on this button doesn't trigger focus on a parent element which contains the button.
+        public override bool AcceptsFocus => true;
+
+        public SettingsRevertToDefaultButton()
+        {
+            Size = new Vector2(WIDTH, 50);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Masking = true;
+            CornerRadius = 5;
+            CornerExponent = 2.5f;
+
+            Children = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background3,
+                },
+                spriteIcon = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Colour = colourProvider.Light1,
+                    Icon = OsuIcon.Undo,
+                    Margin = new MarginPadding { Left = 12, Right = 5 },
+                    Size = new Vector2(IconSize),
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Enabled.BindValueChanged(_ => updateDisplay(), true);
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateDisplay();
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            updateDisplay();
+            base.OnHoverLost(e);
+        }
+
+        public override void Show()
+        {
+            this.FadeIn().MoveToX(WIDTH - 10, 300, Easing.OutQuint);
+        }
+
+        public override void Hide()
+        {
+            this.MoveToX(0, 300, Easing.OutQuint).Then().FadeOut();
+        }
+
+        private void updateDisplay()
+        {
+            spriteIcon.FadeColour(IsHovered ? colourProvider.Content2 : colourProvider.Light1, 300, Easing.OutQuint);
+            background.FadeColour(IsHovered ? colourProvider.Background2 : colourProvider.Background3, 300, Easing.OutQuint);
+        }
+    }
+}

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -31,6 +31,9 @@ namespace osu.Game.Overlays
     {
         public const float CONTENT_MARGINS = 20;
 
+        // extra margin to give room to the revert-to-default button in settings controls.
+        public const float CONTENT_MARGINS_RIGHT = 30;
+
         public const float TRANSITION_LENGTH = 600;
 
         private const float sidebar_width = SettingsSidebar.EXPANDED_WIDTH;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2025.1209.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.1215.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.1218.0" />
     <PackageReference Include="Sentry" Version="5.1.1" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.39.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-resources/pull/398

First step towards https://github.com/ppy/osu/issues/36040, and a solution to a long-standing issue with the code quality of the existing `SettingsItem` and its entire hierarchy of subclasses. 

Opening notes:

- This PR only implements the new component, it does not use it anywhere in the game yet.
- Adjustments to the form control visuals and UX will be done in a separate PR.

## New version

The new version `SettingsItemV2` utilizes composition (as proposed by @bdach and @peppy) to wrap the UI control in a component that offers a revert-to-default button and filtering functionality. The class is sealed given its design.

Example usage:
```csharp
new SettingsItemV2(new FormSliderBar<float>
{
    Caption = "Some slider setting",
    HintText = "Some slider setting hint",
    Current = someBindable,
    KeyboardStep = 0.1f
})
{
    Note = { BindTarget = someNote },
    Keywords = new[] { "some", "slider", "setting" },
    //ShowDefaultRevertButton = true,
    //HasClassicDefault = true,
};

...

someNote.Value = new SettingsNote.Data("some note", SettingsNote.Type.Warning);
someNote.Value = null;
```

## Drawbacks

There are few drawbacks worth mentioning from this approach, one which has already been discussed, and another I kept until opening this PR so it's easier to discuss it code-wise.

### `SettingsItemV2` cannot be aware of any bindable

This necessitated the presence of a non-generic `IFormControl` interface, implemented across all form controls, exposing basic bindable interaction API for `SettingsItemV2` to utilize.

This has been discussed already and we've agreed to push forward with the interface above. I'm hoping for a day where o!f bindables directly support non-generic interaction, but I don't expect that happening any time soon due to the core idea of `IBindable` interfaces being readonly (making a function like `SetDefault` violate rules if placed there).

### `SettingsItemV2` cannot store "classic" default values

Due to `SettingsItemV2` not being generic and not support applying arbitrary values to the underlying wrapped control, this feature is impossible to implement within `SettingsItemV2`.

~~My initial approach was to take this feature completely away from `SettingsItemV2` and into where each settings item is instantiated (i.e. `SettingsSubsection`). However, part of this feature is filtering all settings based on those who have a classic default value set, therefore `SettingsItemV2` must have a `HasClassicDefault` flag present in order to feed it to its filter terms.~~

~~I've sat around for a bit thinking about any way to approach this, but no bright ideas came to mind. So I've bit the bullet and kept the flag, expecting each settings declaration in `SettingsSubsection` to set the flag, then override a new `ApplyClassicDefaults` method to overwrite all relevant settings in the subsection to their classic defaults.~~

~~Need feedback on this. I would ideally want an approach which takes `HasClassicDefault` away from `SettingsItemV2` altogether.~~

This has been addressed by the suggestion in https://github.com/ppy/osu/pull/36055#issuecomment-3669612870.

## Sample implementation

Lastly, to give a full idea of how `SettingsItemV2` would transform the coding structure of existing settings, below is the diff of `LayoutSettings` alone, the heaviest settings subsection I found code-wise:

<details>
<summary>Sample implementation</summary>

```diff
diff --git a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
index cdc4f328c3..df6a1e76b0 100644
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -18,7 +18,7 @@
 using osu.Framework.Platform.Windows;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osuTK;
 using osuTK.Graphics;
@@ -29,8 +29,8 @@ public partial class LayoutSettings : SettingsSubsection
     {
         protected override LocalisableString Header => GraphicsSettingsStrings.LayoutHeader;
 
-        private FillFlowContainer<SettingsSlider<float>> scalingSettings = null!;
-        private SettingsSlider<float> dimSlider = null!;
+        private FillFlowContainer<SettingsItemV2> scalingSettings = null!;
+        private SettingsItemV2 dimSliderSetting = null!;
 
         private readonly Bindable<Display> currentDisplay = new Bindable<Display>();
 
@@ -51,12 +51,17 @@ public partial class LayoutSettings : SettingsSubsection
 
         private IWindow? window;
 
-        private SettingsDropdown<Size> resolutionFullscreenDropdown = null!;
-        private SettingsDropdown<Size> resolutionWindowedDropdown = null!;
-        private SettingsDropdown<Display> displayDropdown = null!;
-        private SettingsDropdown<WindowMode> windowModeDropdown = null!;
-        private SettingsCheckbox minimiseOnFocusLossCheckbox = null!;
-        private SettingsCheckbox safeAreaConsiderationsCheckbox = null!;
+        private readonly BindableBool resolutionFullscreenCanBeShown = new BindableBool(true);
+        private readonly BindableBool resolutionWindowedCanBeShown = new BindableBool(true);
+        private readonly BindableBool displayDropdownCanBeShown = new BindableBool(true);
+        private readonly BindableBool minimiseOnFocusLossCanBeShown = new BindableBool(true);
+        private readonly BindableBool safeAreaConsiderationsCanBeShown = new BindableBool(true);
+
+        private FormDropdown<Size> resolutionWindowedDropdown = null!;
+        private FormDropdown<Display> displayDropdown = null!;
+        private FormDropdown<WindowMode> windowModeDropdown = null!;
+
+        private readonly Bindable<SettingsNote.Data?> windowModeDropdownNote = new Bindable<SettingsNote.Data?>();
 
         private Bindable<double> windowedPositionX = null!;
         private Bindable<double> windowedPositionY = null!;
@@ -98,105 +103,141 @@ private void load(FrameworkConfigManager config, OsuConfigManager osuConfig, Gam
 
             Children = new Drawable[]
             {
-                windowModeDropdown = new SettingsDropdown<WindowMode>
+                new SettingsItemV2(windowModeDropdown = new FormDropdown<WindowMode>
                 {
-                    LabelText = GraphicsSettingsStrings.ScreenMode,
+                    Caption = GraphicsSettingsStrings.ScreenMode,
                     Items = window?.SupportedWindowModes,
-                    CanBeShown = { Value = window?.SupportedWindowModes.Count() > 1 },
                     Current = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode),
+                })
+                {
+                    CanBeShown = { Value = window?.SupportedWindowModes.Count() > 1 },
+                    Note = { BindTarget = windowModeDropdownNote },
                 },
-                displayDropdown = new DisplaySettingsDropdown
+                new SettingsItemV2(displayDropdown = new DisplayDropdown
                 {
-                    LabelText = GraphicsSettingsStrings.Display,
+                    Caption = GraphicsSettingsStrings.Display,
                     Items = window?.Displays,
                     Current = currentDisplay,
+                })
+                {
+                    CanBeShown = { BindTarget = displayDropdownCanBeShown }
                 },
-                resolutionFullscreenDropdown = new ResolutionSettingsDropdown
+                new SettingsItemV2(new ResolutionDropdown
                 {
-                    LabelText = GraphicsSettingsStrings.Resolution,
-                    ShowsDefaultIndicator = false,
+                    Caption = GraphicsSettingsStrings.Resolution,
                     ItemSource = resolutionsFullscreen,
                     Current = sizeFullscreen
+                })
+                {
+                    CanBeShown = { BindTarget = resolutionFullscreenCanBeShown },
+                    ShowDefaultRevertButton = false,
                 },
-                resolutionWindowedDropdown = new ResolutionSettingsDropdown
+                new SettingsItemV2(resolutionWindowedDropdown = new ResolutionDropdown
                 {
-                    LabelText = GraphicsSettingsStrings.Resolution,
-                    ShowsDefaultIndicator = false,
+                    Caption = GraphicsSettingsStrings.Resolution,
                     ItemSource = resolutionsWindowed,
                     Current = windowedResolution
+                })
+                {
+                    CanBeShown = { BindTarget = resolutionWindowedCanBeShown },
+                    ShowDefaultRevertButton = false,
                 },
-                minimiseOnFocusLossCheckbox = new SettingsCheckbox
+                new SettingsItemV2(new FormCheckBox
                 {
-                    LabelText = GraphicsSettingsStrings.MinimiseOnFocusLoss,
+                    Caption = GraphicsSettingsStrings.MinimiseOnFocusLoss,
                     Current = config.GetBindable<bool>(FrameworkSetting.MinimiseOnFocusLossInFullscreen),
+                })
+                {
+                    CanBeShown = { BindTarget = minimiseOnFocusLossCanBeShown },
                     Keywords = new[] { "alt-tab", "minimize", "focus", "hide" },
                 },
-                safeAreaConsiderationsCheckbox = new SettingsCheckbox
+                new SettingsItemV2(new FormCheckBox
                 {
-                    LabelText = GraphicsSettingsStrings.ShrinkGameToSafeArea,
+                    Caption = GraphicsSettingsStrings.ShrinkGameToSafeArea,
                     Current = osuConfig.GetBindable<bool>(OsuSetting.SafeAreaConsiderations),
+                })
+                {
+                    CanBeShown = { BindTarget = safeAreaConsiderationsCanBeShown },
                 },
-                new SettingsSlider<float, UIScaleSlider>
+                new SettingsItemV2(new FormSliderBar<float>
                 {
-                    LabelText = GraphicsSettingsStrings.UIScaling,
+                    Caption = GraphicsSettingsStrings.UIScaling,
                     TransferValueOnCommit = true,
                     Current = osuConfig.GetBindable<float>(OsuSetting.UIScale),
                     KeyboardStep = 0.01f,
+                    // LabelFormat = v => $@"{v:0.##}x",
+                })
+                {
                     Keywords = new[] { "scale", "letterbox" },
                 },
-                new SettingsEnumDropdown<ScalingMode>
+                new SettingsItemV2(new FormEnumDropdown<ScalingMode>
                 {
-                    LabelText = GraphicsSettingsStrings.ScreenScaling,
+                    Caption = GraphicsSettingsStrings.ScreenScaling,
                     Current = osuConfig.GetBindable<ScalingMode>(OsuSetting.Scaling),
+                })
+                {
                     Keywords = new[] { "scale", "letterbox" },
                 },
-                scalingSettings = new FillFlowContainer<SettingsSlider<float>>
+                scalingSettings = new FillFlowContainer<SettingsItemV2>
                 {
                     Direction = FillDirection.Vertical,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Masking = true,
+                    Spacing = new Vector2(0, SettingsSection.ITEM_SPACING),
                     Children = new[]
                     {
-                        new SettingsSlider<float>
+                        new SettingsItemV2(new FormSliderBar<float>
                         {
-                            LabelText = GraphicsSettingsStrings.HorizontalPosition,
-                            Keywords = new[] { "screen", "scaling" },
+                            Caption = GraphicsSettingsStrings.HorizontalPosition,
                             Current = scalingPositionX,
                             KeyboardStep = 0.01f,
-                            DisplayAsPercentage = true
-                        },
-                        new SettingsSlider<float>
+                            // DisplayAsPercentage = true,
+                            TransferValueOnCommit = scalingMode.Value == ScalingMode.Everything,
+                        }.With(bindPreviewEvent))
                         {
-                            LabelText = GraphicsSettingsStrings.VerticalPosition,
                             Keywords = new[] { "screen", "scaling" },
+                        },
+                        new SettingsItemV2(new FormSliderBar<float>
+                        {
+                            Caption = GraphicsSettingsStrings.VerticalPosition,
                             Current = scalingPositionY,
                             KeyboardStep = 0.01f,
-                            DisplayAsPercentage = true
-                        },
-                        new SettingsSlider<float>
+                            // DisplayAsPercentage = true,
+                            TransferValueOnCommit = scalingMode.Value == ScalingMode.Everything,
+                        }.With(bindPreviewEvent))
                         {
-                            LabelText = GraphicsSettingsStrings.HorizontalScale,
                             Keywords = new[] { "screen", "scaling" },
+                        },
+                        new SettingsItemV2(new FormSliderBar<float>
+                        {
+                            Caption = GraphicsSettingsStrings.HorizontalScale,
                             Current = scalingSizeX,
                             KeyboardStep = 0.01f,
-                            DisplayAsPercentage = true
-                        },
-                        new SettingsSlider<float>
+                            // DisplayAsPercentage = true,
+                            TransferValueOnCommit = scalingMode.Value == ScalingMode.Everything,
+                        }.With(bindPreviewEvent))
                         {
-                            LabelText = GraphicsSettingsStrings.VerticalScale,
                             Keywords = new[] { "screen", "scaling" },
+                        },
+                        new SettingsItemV2(new FormSliderBar<float>
+                        {
+                            Caption = GraphicsSettingsStrings.VerticalScale,
                             Current = scalingSizeY,
                             KeyboardStep = 0.01f,
-                            DisplayAsPercentage = true
+                            // DisplayAsPercentage = true,
+                            TransferValueOnCommit = scalingMode.Value == ScalingMode.Everything,
+                        }.With(bindPreviewEvent))
+                        {
+                            Keywords = new[] { "screen", "scaling" },
                         },
-                        dimSlider = new SettingsSlider<float>
+                        dimSliderSetting = new SettingsItemV2(new FormSliderBar<float>
                         {
-                            LabelText = GameplaySettingsStrings.BackgroundDim,
+                            Caption = GameplaySettingsStrings.BackgroundDim,
                             Current = scalingBackgroundDim,
                             KeyboardStep = 0.01f,
-                            DisplayAsPercentage = true,
-                        },
+                            // DisplayAsPercentage = true,
+                        }.With(bindPreviewEvent)),
                     }
                 },
             };
@@ -208,8 +249,6 @@ protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
-
             windowModeDropdown.Current.BindValueChanged(_ =>
             {
                 updateDisplaySettingsVisibility();
@@ -300,15 +339,10 @@ void updateScalingModeVisibility()
                 scalingSettings.AutoSizeAxes = scalingMode.Value != ScalingMode.Off ? Axes.Y : Axes.None;
                 scalingSettings.ForEach(s =>
                 {
-                    if (s == dimSlider)
-                    {
+                    if (s == dimSliderSetting)
                         s.CanBeShown.Value = scalingMode.Value == ScalingMode.Everything || scalingMode.Value == ScalingMode.ExcludeOverlays;
-                    }
                     else
-                    {
-                        s.TransferValueOnCommit = scalingMode.Value == ScalingMode.Everything;
                         s.CanBeShown.Value = scalingMode.Value != ScalingMode.Off;
-                    }
                 });
             }
         }
@@ -325,12 +359,12 @@ private void onDisplaysChanged(IEnumerable<Display> displays)
 
         private void updateDisplaySettingsVisibility()
         {
-            resolutionFullscreenDropdown.CanBeShown.Value = windowModeDropdown.Current.Value == WindowMode.Fullscreen && resolutionsFullscreen.Count > 1;
-            resolutionWindowedDropdown.CanBeShown.Value = windowModeDropdown.Current.Value == WindowMode.Windowed && resolutionsWindowed.Count > 1;
+            resolutionFullscreenCanBeShown.Value = windowModeDropdown.Current.Value == WindowMode.Fullscreen && resolutionsFullscreen.Count > 1;
+            resolutionWindowedCanBeShown.Value = windowModeDropdown.Current.Value == WindowMode.Windowed && resolutionsWindowed.Count > 1;
 
-            displayDropdown.CanBeShown.Value = displayDropdown.Items.Count() > 1;
-            minimiseOnFocusLossCheckbox.CanBeShown.Value = RuntimeInfo.IsDesktop && windowModeDropdown.Current.Value == WindowMode.Fullscreen;
-            safeAreaConsiderationsCheckbox.CanBeShown.Value = host.Window?.SafeAreaPadding.Value.Total != Vector2.Zero;
+            displayDropdownCanBeShown.Value = displayDropdown.Items.Count() > 1;
+            minimiseOnFocusLossCanBeShown.Value = RuntimeInfo.IsDesktop && windowModeDropdown.Current.Value == WindowMode.Fullscreen;
+            safeAreaConsiderationsCanBeShown.Value = host.Window?.SafeAreaPadding.Value.Total != Vector2.Zero;
         }
 
         private void updateScreenModeWarning()
@@ -339,16 +373,16 @@ private void updateScreenModeWarning()
             if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS && !FrameworkEnvironment.UseSDL3)
             {
                 if (windowModeDropdown.Current.Value == WindowMode.Fullscreen)
-                    windowModeDropdown.SetNoticeText(LayoutSettingsStrings.FullscreenMacOSNote, true);
+                    windowModeDropdownNote.Value = new SettingsNote.Data(LayoutSettingsStrings.FullscreenMacOSNote, SettingsNote.Type.Warning);
                 else
-                    windowModeDropdown.ClearNoticeText();
+                    windowModeDropdownNote.Value = null;
 
                 return;
             }
 
             if (windowModeDropdown.Current.Value != WindowMode.Fullscreen)
             {
-                windowModeDropdown.SetNoticeText(GraphicsSettingsStrings.NotFullscreenNote, true);
+                windowModeDropdownNote.Value = new SettingsNote.Data(GraphicsSettingsStrings.NotFullscreenNote, SettingsNote.Type.Warning);
                 return;
             }
 
@@ -357,28 +391,28 @@ private void updateScreenModeWarning()
                 switch (fullscreenCapability.Value)
                 {
                     case FullscreenCapability.Unknown:
-                        windowModeDropdown.SetNoticeText(LayoutSettingsStrings.CheckingForFullscreenCapabilities, true);
+                        windowModeDropdownNote.Value = new SettingsNote.Data(LayoutSettingsStrings.CheckingForFullscreenCapabilities, SettingsNote.Type.Warning);
                         break;
 
                     case FullscreenCapability.Capable:
-                        windowModeDropdown.SetNoticeText(LayoutSettingsStrings.OsuIsRunningExclusiveFullscreen);
+                        windowModeDropdownNote.Value = new SettingsNote.Data(LayoutSettingsStrings.OsuIsRunningExclusiveFullscreen, SettingsNote.Type.Informational);
                         break;
 
                     case FullscreenCapability.Incapable:
-                        windowModeDropdown.SetNoticeText(LayoutSettingsStrings.UnableToRunExclusiveFullscreen, true);
+                        windowModeDropdownNote.Value = new SettingsNote.Data(LayoutSettingsStrings.UnableToRunExclusiveFullscreen, SettingsNote.Type.Warning);
                         break;
                 }
             }
             else
             {
                 // We can only detect exclusive fullscreen status on windows currently.
-                windowModeDropdown.ClearNoticeText();
+                windowModeDropdownNote.Value = null;
             }
         }
 
-        private void bindPreviewEvent(Bindable<float> bindable)
+        private void bindPreviewEvent(FormSliderBar<float> slider)
         {
-            bindable.ValueChanged += _ =>
+            slider.Current.ValueChanged += _ =>
             {
                 switch (scalingMode.Value)
                 {
@@ -421,37 +455,22 @@ public ScalingPreview()
             }
         }
 
-        private partial class UIScaleSlider : RoundedSliderBar<float>
+        private partial class DisplayDropdown : FormDropdown<Display>
         {
-            public override LocalisableString TooltipText => base.TooltipText + "x";
-        }
-
-        private partial class DisplaySettingsDropdown : SettingsDropdown<Display>
-        {
-            protected override OsuDropdown<Display> CreateDropdown() => new DisplaySettingsDropdownControl();
-
-            private partial class DisplaySettingsDropdownControl : DropdownControl
+            protected override LocalisableString GenerateItemText(Display item)
             {
-                protected override LocalisableString GenerateItemText(Display item)
-                {
-                    return $"{item.Index}: {item.Name} ({item.Bounds.Width}x{item.Bounds.Height})";
-                }
+                return $"{item.Index}: {item.Name} ({item.Bounds.Width}x{item.Bounds.Height})";
             }
         }
 
-        private partial class ResolutionSettingsDropdown : SettingsDropdown<Size>
+        private partial class ResolutionDropdown : FormDropdown<Size>
         {
-            protected override OsuDropdown<Size> CreateDropdown() => new ResolutionDropdownControl();
-
-            private partial class ResolutionDropdownControl : DropdownControl
+            protected override LocalisableString GenerateItemText(Size item)
             {
-                protected override LocalisableString GenerateItemText(Size item)
-                {
-                    if (item == new Size(9999, 9999))
-                        return CommonStrings.Default;
+                if (item == new Size(9999, 9999))
+                    return CommonStrings.Default;
 
-                    return $"{item.Width}x{item.Height}";
-                }
+                return $"{item.Width}x{item.Height}";
             }
         }
 

```

</details>