### PR TITLE
Bump `CodeFileSanity`, `jetbrains.resharper.globaltools` version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2023.3.3",
+      "version": "2025.3.0.4",
       "commands": [
         "jb"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "codefilesanity": {
-      "version": "0.0.37",
+      "version": "0.0.40",
       "commands": [
         "CodeFileSanity"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           exit $exit_code
 
       - name: InspectCode
-        run: dotnet jb inspectcode $(pwd)/osu.Desktop.slnf --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
+        run: dotnet jb inspectcode $(pwd)/osu.Desktop.slnf --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN --f="xml"
 
       - name: NVika
         run: dotnet nvika parsereport "${{github.workspace}}/inspectcodereport.xml" --treatwarningsaserrors

--- a/InspectCode.ps1
+++ b/InspectCode.ps1
@@ -5,7 +5,7 @@ dotnet tool restore
   # - cmd: dotnet format --dry-run --check
 
 dotnet CodeFileSanity
-dotnet jb inspectcode "osu.Desktop.slnf" --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
+dotnet jb inspectcode "osu.Desktop.slnf" --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN --f="xml"
 dotnet nvika parsereport "inspectcodereport.xml" --treatwarningsaserrors
 
 exit $LASTEXITCODE

--- a/InspectCode.sh
+++ b/InspectCode.sh
@@ -2,5 +2,5 @@
 
 dotnet tool restore
 dotnet CodeFileSanity
-dotnet jb inspectcode "osu.Desktop.slnf" --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
+dotnet jb inspectcode "osu.Desktop.slnf" --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN --f="xml"
 dotnet nvika parsereport "inspectcodereport.xml" --treatwarningsaserrors


### PR DESCRIPTION
https://github.com/peppy/CodeFileSanity/pull/10

- [x] Requires https://github.com/peppy/CodeFileSanity/pull/11

~`jetbrains.resharper.globaltools` seems to be outdated as well (2023.3.3), not sure if it should be bumped too or not~