### PR TITLE
Add global alt scroll to adjust volume

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -57,6 +57,7 @@ using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.OSD;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Overlays.Toolbar;
+using osu.Game.Overlays.Volume;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
@@ -1207,6 +1208,7 @@ namespace osu.Game
             }, topMostOverlayContent.Add);
 
             loadComponentSingleFile(volume = new VolumeOverlay(), leftFloatingOverlayContent.Add, true);
+            topMostOverlayContent.Add(new GlobalAltScrollAdjustsVolume());
 
             onScreenDisplay = new OnScreenDisplay();
 

--- a/osu.Game/Overlays/Volume/GlobalAltScrollAdjustsVolume.cs
+++ b/osu.Game/Overlays/Volume/GlobalAltScrollAdjustsVolume.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.Events;
+
+namespace osu.Game.Overlays.Volume
+{
+    /// <summary>
+    /// Allows adjusting volume via mouse scroll while holding alt, regardless of the current game state.
+    /// </summary>
+    public partial class GlobalAltScrollAdjustsVolume : GlobalScrollAdjustsVolume
+    {
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            if (!e.AltPressed || e.ControlPressed || e.ShiftPressed)
+                return false;
+
+            return base.OnScroll(e);
+        }
+    }
+}

--- a/osu.Game/Overlays/Volume/GlobalAltScrollAdjustsVolume.cs
+++ b/osu.Game/Overlays/Volume/GlobalAltScrollAdjustsVolume.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Framework.Input.Events;
 
 namespace osu.Game.Overlays.Volume
@@ -13,6 +15,10 @@ namespace osu.Game.Overlays.Volume
         protected override bool OnScroll(ScrollEvent e)
         {
             if (!e.AltPressed || e.ControlPressed || e.ShiftPressed)
+                return false;
+
+            var hoveredDrawables = GetContainingInputManager()?.HoveredDrawables;
+            if (hoveredDrawables?.Any(d => d is ZoomableScrollContainer) == true)
                 return false;
 
             return base.OnScroll(e);


### PR DESCRIPTION
Relevant Issues:
- https://github.com/ppy/osu/issues/31675
- https://github.com/ppy/osu/issues/35507

Manual Testing Done:
- Opened multiplayer screen to check I can alt+scroll for volume change.
- Opened editor to check I can still do things like ctrl+alt+scroll for distance snap change and scroll the timeline.
- Made sure I can still alt scroll on timeline to adjust zoom