### PR TITLE
Fix/animation mishap new

### DIFF
--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Screens.SelectV2
             }
             else
             {
-                if (Current.Value.Any(m => !m.Ranked))
+                if (Current.Value.Any(m => !m.Ranked && m is not ModAutoplay))
                 {
                     unrankedBadge.MoveToX(0, duration, easing);
                     unrankedBadge.FadeIn(duration, easing);

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -189,7 +189,8 @@ namespace osu.Game.Screens.SelectV2
 
         private void updateDisplay()
         {
-            if (Current.Value.Count == 0)
+            // Autoplay should not trigger the mod display bar.
+            if (!Current.Value.Any(m => m is not ModAutoplay))
             {
                 modDisplayBar.MoveToY(20, duration, easing);
                 modDisplayBar.FadeOut(duration, easing);
@@ -204,6 +205,7 @@ namespace osu.Game.Screens.SelectV2
             }
             else
             {
+                // Only show the "Unranked" badge for mods other than Autoplay.
                 if (Current.Value.Any(m => !m.Ranked && m is not ModAutoplay))
                 {
                     unrankedBadge.MoveToX(0, duration, easing);

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -189,8 +189,7 @@ namespace osu.Game.Screens.SelectV2
 
         private void updateDisplay()
         {
-            // Autoplay should not trigger the mod display bar.
-            if (!Current.Value.Any(m => m is not ModAutoplay))
+            if (Current.Value.Count == 0)
             {
                 modDisplayBar.MoveToY(20, duration, easing);
                 modDisplayBar.FadeOut(duration, easing);
@@ -205,8 +204,8 @@ namespace osu.Game.Screens.SelectV2
             }
             else
             {
-                // Only show the "Unranked" badge for mods other than Autoplay.
-                if (Current.Value.Any(m => !m.Ranked && m is not ModAutoplay))
+                // Only show the "Unranked" badge for user-playable mods.
+                if (Current.Value.Any(m => !m.Ranked && m.UserPlayable))
                 {
                     unrankedBadge.MoveToX(0, duration, easing);
                     unrankedBadge.FadeIn(duration, easing);


### PR DESCRIPTION
Fixes the glitching "artifacts" from issue #35973 by changing the behaviour of the unranked badge to check if UserPlayable is also True. This way it eliminates all possible artifacts from pressing CTRL + Enter and also addresses a possible issue that could have caused in CinemaMode.
Including a video showcasing the fix that closed my previous pull request at #36014 

https://github.com/user-attachments/assets/634df3ba-f8be-4b31-a92a-084a039c28a7

