### PR TITLE
Provide default overlay colour scheme at game level

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
@@ -9,9 +9,9 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Chat;
 using osuTK.Graphics;
 
@@ -35,9 +35,9 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load()
         {
-            linkColour = colours.Blue;
+            linkColour = new OverlayColourProvider(ColourScheme).Light2;
 
             var chatManager = new ChannelManager(API);
             BindableList<Channel> availableChannels = (BindableList<Channel>)chatManager.AvailableChannels;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -171,6 +171,9 @@ namespace osu.Game
         [Cached]
         private readonly ScreenshotManager screenshotManager = new ScreenshotManager();
 
+        [Cached]
+        private readonly OverlayColourProvider overlayColourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
+
         protected SentryLogger SentryLogger;
 
         public virtual StableStorage GetStorageForStableInstall() => null;

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Tests.Visual
         [Cached]
         protected Bindable<IReadOnlyList<Mod>> SelectedMods { get; } = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
+        [Cached]
+        private readonly OverlayColourProvider colourProvider;
+
+        protected virtual OverlayColourScheme ColourScheme => OverlayColourScheme.Pink;
+
         protected new DependencyContainer Dependencies { get; private set; }
 
         protected IResourceStore<byte[]> Resources;
@@ -189,6 +194,8 @@ namespace osu.Game.Tests.Visual
         protected OsuTestScene()
         {
             base.Content.Add(content = new DrawSizePreservingFillContainer());
+
+            colourProvider = new OverlayColourProvider(ColourScheme);
         }
 
         public virtual void RecycleLocalStorage(bool isDisposing)


### PR DESCRIPTION
Over time, it became tedious and pointless to try providing fallback colours on the assumption that `OverlayColourProvider` may not be available for some components. To the point `ThemeComparisonTestScene` was altered to opt-out the "no colour provider" visual case.

After [recent discussion](https://discord.com/channels/90072389919997952/1327149041511043134/1448508393630470164), we agreed to provide a default colour scheme at game/test level. I've chosen `OverlayColourScheme.Pink` as most UI controls usually fall back to pink, and the scheme itself feels more at home than aquamarine.

I've took a spin through the game and there were no visual changes as far as I can see.