### PR TITLE
Fix disabled form slider bars being half-baked

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
@@ -107,5 +107,63 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddAssert("slider is default", () => slider.Current.IsDefault);
         }
+
+        [Test]
+        public void TestDisabled()
+        {
+            FormSliderBar<float> slider = null!;
+
+            AddStep("create content", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 0.5f,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(10),
+                    Children = new Drawable[]
+                    {
+                        slider = new FormSliderBar<float>
+                        {
+                            Caption = "Slider",
+                            Current = new BindableFloat
+                            {
+                                MinValue = 0,
+                                MaxValue = 10,
+                                Precision = 0.1f,
+                                Default = 5f,
+                            }
+                        },
+                    }
+                };
+            });
+            AddStep("set slider to 1", () => slider.Current.Value = 1);
+            AddStep("disable slider", () => slider.Current.Disabled = true);
+
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));
+
+            AddStep("double click nub", () =>
+            {
+                InputManager.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("slider is still at 1", () => slider.Current.Value, () => Is.EqualTo(1));
+
+            AddStep("click on textbox part", () =>
+            {
+                InputManager.MoveMouseTo(slider.ChildrenOfType<FormTextBox.InnerTextBox>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("no text selected", () => slider.ChildrenOfType<FormTextBox.InnerTextBox>().Single().SelectedText, () => Is.Empty);
+            AddStep("attempt to input text", () =>
+            {
+                InputManager.Key(Key.Number4);
+                InputManager.Key(Key.Enter);
+            });
+            AddAssert("slider is still at 1", () => slider.Current.Value, () => Is.EqualTo(1));
+        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
@@ -165,5 +165,47 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
             AddAssert("slider is still at 1", () => slider.Current.Value, () => Is.EqualTo(1));
         }
+
+        [Test]
+        public void TestDisabledImmediately()
+        {
+            FormSliderBar<float> slider = null!;
+
+            AddStep("create content", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 0.5f,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(10),
+                    Children = new Drawable[]
+                    {
+                        slider = new FormSliderBar<float>
+                        {
+                            Caption = "Slider",
+                            Current = new BindableFloat
+                            {
+                                MinValue = 0,
+                                MaxValue = 10,
+                                Precision = 0.1f,
+                                Default = 5f,
+                                Disabled = true,
+                            },
+                            TransferValueOnCommit = true,
+                        },
+                    }
+                };
+            });
+
+            AddStep("click on textbox part", () =>
+            {
+                InputManager.MoveMouseTo(slider.ChildrenOfType<FormTextBox.InnerTextBox>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("no text selected", () => slider.ChildrenOfType<FormTextBox.InnerTextBox>().Single().SelectedText, () => Is.Empty);
+        }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -207,6 +207,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 }
 
                 currentNumberInstantaneous.Disabled = disabled;
+                textBox.ReadOnly = disabled;
+                updateState();
             };
 
             current.CopyTo(currentNumberInstantaneous);
@@ -283,7 +285,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         protected override bool OnClick(ClickEvent e)
         {
-            focusManager.ChangeFocus(textBox);
+            if (!Current.Disabled)
+                focusManager.ChangeFocus(textBox);
             return true;
         }
 
@@ -380,7 +383,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                updateState();
+                Current.BindDisabledChanged(_ => updateState(), true);
             }
 
             protected override void UpdateAfterChildren()
@@ -434,8 +437,17 @@ namespace osu.Game.Graphics.UserInterfaceV2
             private void updateState()
             {
                 rightBox.Colour = colourProvider.Background6;
-                leftBox.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Dark2;
-                nub.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1 : colourProvider.Light4;
+
+                if (Current.Disabled)
+                {
+                    leftBox.Colour = colourProvider.Dark3;
+                    nub.Colour = colourProvider.Dark1;
+                }
+                else
+                {
+                    leftBox.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Dark2;
+                    nub.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1 : colourProvider.Light4;
+                }
             }
 
             protected override void UpdateValue(float value)

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -207,7 +207,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 }
 
                 currentNumberInstantaneous.Disabled = disabled;
-                textBox.ReadOnly = disabled;
                 updateState();
             };
 
@@ -295,6 +294,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             bool childHasFocus = slider.Focused.Value || textBox.Focused.Value;
 
             textBox.Alpha = 1;
+            textBox.ReadOnly = Current.Disabled;
 
             background.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background4 : colourProvider.Background5;
             captionText.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;


### PR DESCRIPTION
Noticed during review of https://github.com/ppy/osu/pull/36055.

Before:

https://github.com/user-attachments/assets/9056bce7-bd05-4582-8b64-63fea4606e07

After:

https://github.com/user-attachments/assets/a9fb1a63-eff7-4cce-9e83-32bcba8d5072

In order of severity:

- You could actually click on the textbox portion of a disabled textbox, focus it, select text, input stuff, and commit, which would die on the spot.
- The slider part had no visual indication that it's not interactable anymore.