### PR TITLE
Add explicit menu item for exporting guest difficulties from editor

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -476,9 +476,11 @@ namespace osu.Game.Beatmaps
         public Task<ExternalEditOperation<BeatmapSetInfo>> BeginExternalEditing(BeatmapSetInfo model) =>
             beatmapImporter.BeginExternalEditing(model);
 
-        public Task Export(BeatmapSetInfo beatmap) => beatmapExporter.ExportAsync(beatmap.ToLive(Realm));
+        public Task Export(BeatmapSetInfo beatmapSet) => beatmapExporter.ExportAsync(beatmapSet.ToLive(Realm));
 
-        public Task ExportLegacy(BeatmapSetInfo beatmap) => legacyBeatmapExporter.ExportAsync(beatmap.ToLive(Realm));
+        public Task ExportLegacy(BeatmapSetInfo beatmapSet) => legacyBeatmapExporter.ExportAsync(beatmapSet.ToLive(Realm));
+
+        public Task ExportLegacy(BeatmapInfo beatmap) => legacyBeatmapExporter.ExportAsync(beatmap.ToLive(Realm));
 
         private void updateHashAndMarkDirty(BeatmapSetInfo setInfo)
         {

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ExportForCompatibility => new TranslatableString(getKey(@"export_for_compatibility"), @"For compatibility (.osz)");
 
         /// <summary>
+        /// "Guest difficulty (.osu)"
+        /// </summary>
+        public static LocalisableString ExportGuestDifficulty => new TranslatableString(getKey(@"export_guest_difficulty"), @"Guest difficulty (.osu)");
+
+        /// <summary>
         /// "Create new difficulty"
         /// </summary>
         public static LocalisableString CreateNewDifficulty => new TranslatableString(getKey(@"create_new_difficulty"), @"Create new difficulty");


### PR DESCRIPTION
A few facts of life:

- Guest difficulties are at this point a staple of mapping.
- People are very much used to flinging `.osu`s around (because there's no better alternative).
- Currently there are two ways to get an `.osu` out of lazer. You can:

  - Export the beatmap as "compatibility" to an `.osz`, then transmogrify the `.osz` to a `.zip`, then extract the `.zip`, then pluck out the `.osu`. This is the "correct" way to make sure stable works, but is also stupidly arcane.

  - Use "edit externally" to mount the beatmap files to disk, then copy-paste out the `.osu`. This is the *wrong* way to make sure stable works, because the mounting process exposes the raw "for editing" format with features stable doesn't support, but it *is* the actual easy one.

- Reports about guest difficulties exported from lazer "working wrong on stable" are prevalent. Probably mostly because of the preceding point.

What this PR does is introduce a *third* method to export an `.osu`, which is designed to be both the easiest one yet *and* correct. I am hoping this will curb the complaints until support for direct submission of guest difficulties is added - which I still hope to see, but it will be a significant effort *client-side* (the server side has been ready for years now).

<img width="548" height="411" alt="Screenshot 2025-12-22 at 11 20 49" src="https://github.com/user-attachments/assets/ecaccfef-d48a-4270-87e7-78c173beae50" />

---

And yes, you will notice that much of the code added in `LegacyBeatmapExporter` related to manipulation of the path is copy-pasted from `LegacyExporter`. I don't care enough to invent protected / abstract / whatever else OOP faff for something that may not survive review and is mostly a weird semi-temporary wart.