### PR TITLE
Perform online ID checks during import in more proper sequence

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -778,7 +778,19 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealmAsync(async (realm, storage) =>
             {
-                var importer = new BeatmapImporter(storage, realm);
+                var importer = new BeatmapImporter(storage, realm)
+                {
+                    ProcessBeatmap = (set, _) =>
+                    {
+                        set.OnlineID = 1234;
+                        // note: this is only intended to be a quick-and-easy approximation of proper operation
+                        // the more proper way to do this would be to assign IDs based on content hash or something, but it largely doesn't matter here
+                        // so long as the beatmaps in the set get assigned an ID by the process flow
+                        for (int i = 0; i < set.Beatmaps.Count; ++i)
+                            set.Beatmaps[i].OnlineID = 5678 + i;
+                    }
+                };
+
                 using var store = new RealmRulesetStore(realm, storage);
 
                 string? pathOriginal = TestResources.GetTestBeatmapForImport();

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -182,19 +182,6 @@ namespace osu.Game.Beatmaps
             }
 
             validateOnlineIds(beatmapSet, realm);
-
-            bool hadOnlineIDs = beatmapSet.Beatmaps.Any(b => b.OnlineID > 0);
-
-            // TODO: this may no longer be valid as we aren't doing an online population at this point.
-            // ensure at least one beatmap was able to retrieve or keep an online ID, else drop the set ID.
-            if (hadOnlineIDs && !beatmapSet.Beatmaps.Any(b => b.OnlineID > 0))
-            {
-                if (beatmapSet.OnlineID > 0)
-                {
-                    beatmapSet.OnlineID = -1;
-                    LogForModel(beatmapSet, "Disassociating beatmap set ID due to loss of all beatmap IDs");
-                }
-            }
         }
 
         protected override void PreImport(BeatmapSetInfo beatmapSet, Realm realm)
@@ -235,6 +222,15 @@ namespace osu.Game.Beatmaps
             }
 
             ProcessBeatmap?.Invoke(model, parameters.Batch ? MetadataLookupScope.LocalCacheFirst : MetadataLookupScope.OnlineFirst);
+
+            bool hadOnlineIDs = model.OnlineID > 0 || model.Beatmaps.Any(b => b.OnlineID > 0);
+
+            // ensure at least one beatmap was able to retrieve or keep an online ID, else drop the set ID.
+            if (hadOnlineIDs && !model.Beatmaps.Any(b => b.OnlineID > 0))
+            {
+                model.OnlineID = -1;
+                LogForModel(model, "Disassociating beatmap set ID due to loss of all beatmap IDs");
+            }
         }
 
         private void validateOnlineIds(BeatmapSetInfo beatmapSet, Realm realm)


### PR DESCRIPTION
The overarching theme here is preventing https://osu.ppy.sh/community/forums/topics/2162457?n=8 from happening again.

Recommend reading commit-by-commit because the diff of the entire PR makes it look way worse than it actually is.

## [Move online ID validation check into its proper location](https://github.com/ppy/osu/commit/17143ca0a8eaa36687edb55d4b6e780f505f6954)

The end of `Populate()` is too early to do any validation of online IDs of this kind, as population happens in `PostImport()` via `ProcessBeatmap`.

Additionally, this modifies the check to also include the set's ID. This is one part of curtailing issues like https://osu.ppy.sh/community/forums/topics/2162457?n=8 - the featured artist template beatmap in question has a single difficulty with a bogus positive beatmap set ID and a beatmap ID of 0, and my opinion is that this sort of situation should for all intents and purposes cause the beatmap set's ID to be reset even if you have multiple difficulties with clearly invalid IDs.

## [Only perform replace-on-import based on online beatmap set ID after it's validated](https://github.com/ppy/osu/commit/44df9047aec190dad0409185d631b5b7a45c2e31)

Even without the ID resetting logic before `Populate()` getting broken and annotated with a TODO, this was kinda stupid. Why was purging logic allowed to run *using a not-yet-completely-validated online ID of the set*?

This is the other part of hopefully fixing scenarios like https://osu.ppy.sh/community/forums/topics/2162457?n=8 (hopefully with no babies poured out with the bathwater, but only time will tell).

At least the update flow appears to still function correctly.