### PR TITLE
Change osu difficulty attributes to use performance scaling

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -79,12 +79,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             int totalHits = beatmap.HitObjects.Count;
 
-            double aimDifficultyValue = aim.DifficultyValue();
-            double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
-            double speedDifficultyValue = speed.DifficultyValue();
+            double aimDifficultyValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(aim.DifficultyValue()));
+            double aimNoSlidersDifficultyValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(aimWithoutSliders.DifficultyValue()));
+            double speedDifficultyValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(speed.DifficultyValue()));
 
             double mechanicalDifficultyRating = calculateMechanicalDifficultyRating(aimDifficultyValue, speedDifficultyValue);
-            double sliderFactor = aimDifficultyValue > 0 ? OsuRatingCalculator.CalculateDifficultyRating(aimNoSlidersDifficultyValue) / OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue) : 1;
+            double sliderFactor = aimDifficultyValue > 0 ? aimNoSlidersDifficultyValue / aimDifficultyValue : 1;
 
             var osuRatingCalculator = new OsuRatingCalculator(mods, totalHits, approachRate, overallDifficulty, mechanicalDifficultyRating, sliderFactor);
 
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double flashlightRating = 0.0;
 
             if (flashlight is not null)
-                flashlightRating = osuRatingCalculator.ComputeFlashlightRating(flashlight.DifficultyValue());
+                flashlightRating = osuRatingCalculator.ComputeFlashlightRating(Flashlight.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(flashlight.DifficultyValue())));
 
             double sliderNestedScorePerObject = LegacyScoreUtils.CalculateNestedScorePerObject(beatmap, totalHits);
             double legacyScoreBaseMultiplier = LegacyScoreUtils.CalculateDifficultyPeppyStars(beatmap);
@@ -102,11 +102,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             var simulator = new OsuLegacyScoreSimulator();
             var scoreAttributes = simulator.Simulate(WorkingBeatmap, beatmap);
 
-            double baseAimPerformance = OsuStrainSkill.DifficultyToPerformance(aimRating);
-            double baseSpeedPerformance = OsuStrainSkill.DifficultyToPerformance(speedRating);
-            double baseFlashlightPerformance = Flashlight.DifficultyToPerformance(flashlightRating);
-
-            double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseFlashlightPerformance);
+            double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, aimRating, speedRating, flashlightRating);
 
             double starRating = calculateStarRating(basePerformance);
 
@@ -138,10 +134,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private double calculateMechanicalDifficultyRating(double aimDifficultyValue, double speedDifficultyValue)
         {
-            double aimValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue));
-            double speedValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(speedDifficultyValue));
-
-            double totalValue = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, aimValue, speedValue);
+            double totalValue = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, aimDifficultyValue, speedDifficultyValue);
 
             return calculateStarRating(totalValue);
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -79,22 +79,22 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             int totalHits = beatmap.HitObjects.Count;
 
-            double aimDifficultyValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(aim.DifficultyValue()));
-            double aimNoSlidersDifficultyValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(aimWithoutSliders.DifficultyValue()));
-            double speedDifficultyValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(speed.DifficultyValue()));
+            double aimBasePerformance = aim.PerformanceValue();
+            double aimNoSlidersBasePerformance = aimWithoutSliders.PerformanceValue();
+            double speedBasePerformance = speed.PerformanceValue();
 
-            double mechanicalDifficultyRating = calculateMechanicalDifficultyRating(aimDifficultyValue, speedDifficultyValue);
-            double sliderFactor = aimDifficultyValue > 0 ? aimNoSlidersDifficultyValue / aimDifficultyValue : 1;
+            double mechanicalDifficultyRating = calculateMechanicalDifficultyRating(aimBasePerformance, speedBasePerformance);
+            double sliderFactor = aimBasePerformance > 0 ? aimNoSlidersBasePerformance / aimBasePerformance : 1;
 
             var osuRatingCalculator = new OsuRatingCalculator(mods, totalHits, approachRate, overallDifficulty, mechanicalDifficultyRating, sliderFactor);
 
-            double aimRating = osuRatingCalculator.ComputeAimRating(aimDifficultyValue);
-            double speedRating = osuRatingCalculator.ComputeSpeedRating(speedDifficultyValue);
+            double aimRating = osuRatingCalculator.ComputeAimRating(aimBasePerformance);
+            double speedRating = osuRatingCalculator.ComputeSpeedRating(speedBasePerformance);
 
             double flashlightRating = 0.0;
 
             if (flashlight is not null)
-                flashlightRating = osuRatingCalculator.ComputeFlashlightRating(Flashlight.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(flashlight.DifficultyValue())));
+                flashlightRating = osuRatingCalculator.ComputeFlashlightRating(flashlight.PerformanceValue());
 
             double sliderNestedScorePerObject = LegacyScoreUtils.CalculateNestedScorePerObject(beatmap, totalHits);
             double legacyScoreBaseMultiplier = LegacyScoreUtils.CalculateDifficultyPeppyStars(beatmap);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (score.Mods.Any(h => h is OsuModAutopilot))
                 return 0.0;
 
-            double aimDifficulty = attributes.AimDifficulty;
+            double aimValue = attributes.AimDifficulty;
 
             if (attributes.SliderCount > 0 && attributes.AimDifficultSliderCount > 0)
             {
@@ -189,10 +189,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 }
 
                 double sliderNerfFactor = (1 - attributes.SliderFactor) * Math.Pow(1 - estimateImproperlyFollowedDifficultSliders / attributes.AimDifficultSliderCount, 3) + attributes.SliderFactor;
-                aimDifficulty *= sliderNerfFactor;
+                aimValue *= sliderNerfFactor;
             }
-
-            double aimValue = OsuStrainSkill.DifficultyToPerformance(aimDifficulty);
 
             double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
                                  (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
@@ -225,7 +223,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (score.Mods.Any(h => h is OsuModRelax) || speedDeviation == null)
                 return 0.0;
 
-            double speedValue = OsuStrainSkill.DifficultyToPerformance(attributes.SpeedDifficulty);
+            double speedValue = attributes.SpeedDifficulty;
 
             double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
                                  (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
@@ -314,7 +312,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (!score.Mods.Any(h => h is OsuModFlashlight))
                 return 0.0;
 
-            double flashlightValue = Flashlight.DifficultyToPerformance(attributes.FlashlightDifficulty);
+            double flashlightValue = attributes.FlashlightDifficulty;
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (effectiveMissCount > 0)
@@ -468,7 +466,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (speedDeviation == null)
                 return 0;
 
-            double speedValue = OsuStrainSkill.DifficultyToPerformance(attributes.SpeedDifficulty);
+            double speedValue = attributes.SpeedDifficulty;
 
             // Decides a point where the PP value achieved compared to the speed deviation is assumed to be tapped improperly. Any PP above this point is considered "excess" speed difficulty.
             // This is used to cause PP above the cutoff to scale logarithmically towards the original speed value thus nerfing the value.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -9,7 +9,6 @@ using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Difficulty;
-using osu.Game.Rulesets.Osu.Difficulty.Skills;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 return 0;
 
             if (mods.Any(m => m is OsuModTouchDevice))
-                aimDifficultyValue = Math.Pow(aimDifficultyValue, 0.8);
+                aimDifficultyValue = Math.Pow(aimDifficultyValue, 0.8) * 1.3;
 
             if (mods.Any(m => m is OsuModRelax))
                 aimDifficultyValue *= 0.7;
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 return 0;
 
             if (mods.Any(m => m is OsuModTouchDevice))
-                flashlightDifficultyValue = Math.Pow(flashlightDifficultyValue, 0.8);
+                flashlightDifficultyValue = Math.Pow(flashlightDifficultyValue, 0.8) * 1.9;
 
             if (mods.Any(m => m is OsuModRelax))
                 flashlightDifficultyValue *= 0.5;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 return 0;
 
             if (mods.Any(m => m is OsuModAutopilot))
-                speedDifficultyValue *= 0.5;
+                speedDifficultyValue *= 0.125;
 
             if (mods.Any(m => m is OsuModMagnetised))
             {
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (mods.Any(m => m is OsuModRelax))
                 flashlightDifficultyValue *= 0.5;
             else if (mods.Any(m => m is OsuModAutopilot))
-                flashlightDifficultyValue *= 0.4;
+                flashlightDifficultyValue *= 0.15;
 
             if (mods.Any(m => m is OsuModMagnetised))
             {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -35,18 +35,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (mods.Any(m => m is OsuModAutopilot))
                 return 0;
 
-            double aimRating = CalculateDifficultyRating(aimDifficultyValue);
-
             if (mods.Any(m => m is OsuModTouchDevice))
-                aimRating = Math.Pow(aimRating, 0.8);
+                aimDifficultyValue = Math.Pow(aimDifficultyValue, 0.8);
 
             if (mods.Any(m => m is OsuModRelax))
-                aimRating *= 0.9;
+                aimDifficultyValue *= 0.9;
 
             if (mods.Any(m => m is OsuModMagnetised))
             {
                 float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;
-                aimRating *= 1.0 - magnetisedStrength;
+                aimDifficultyValue *= 1.0 - magnetisedStrength;
             }
 
             double ratingMultiplier = 1.0;
@@ -74,7 +72,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // It is important to consider accuracy difficulty when scaling with accuracy.
             ratingMultiplier *= 0.98 + Math.Pow(Math.Max(0, overallDifficulty), 2) / 2500;
 
-            return aimRating * Math.Cbrt(ratingMultiplier);
+            return aimDifficultyValue * ratingMultiplier;
         }
 
         public double ComputeSpeedRating(double speedDifficultyValue)
@@ -82,16 +80,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (mods.Any(m => m is OsuModRelax))
                 return 0;
 
-            double speedRating = CalculateDifficultyRating(speedDifficultyValue);
-
             if (mods.Any(m => m is OsuModAutopilot))
-                speedRating *= 0.5;
+                speedDifficultyValue *= 0.5;
 
             if (mods.Any(m => m is OsuModMagnetised))
             {
                 // reduce speed rating because of the speed distance scaling, with maximum reduction being 0.7x
                 float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;
-                speedRating *= 1.0 - magnetisedStrength * 0.3;
+                speedDifficultyValue *= 1.0 - magnetisedStrength * 0.3;
             }
 
             double ratingMultiplier = 1.0;
@@ -116,7 +112,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             ratingMultiplier *= 0.95 + Math.Pow(Math.Max(0, overallDifficulty), 2) / 750;
 
-            return speedRating * Math.Cbrt(ratingMultiplier);
+            return speedDifficultyValue * ratingMultiplier;
         }
 
         public double ComputeFlashlightRating(double flashlightDifficultyValue)
@@ -124,26 +120,24 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (!mods.Any(m => m is OsuModFlashlight))
                 return 0;
 
-            double flashlightRating = CalculateDifficultyRating(flashlightDifficultyValue);
-
             if (mods.Any(m => m is OsuModTouchDevice))
-                flashlightRating = Math.Pow(flashlightRating, 0.8);
+                flashlightDifficultyValue = Math.Pow(flashlightDifficultyValue, 0.8);
 
             if (mods.Any(m => m is OsuModRelax))
-                flashlightRating *= 0.7;
+                flashlightDifficultyValue *= 0.7;
             else if (mods.Any(m => m is OsuModAutopilot))
-                flashlightRating *= 0.4;
+                flashlightDifficultyValue *= 0.4;
 
             if (mods.Any(m => m is OsuModMagnetised))
             {
                 float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;
-                flashlightRating *= 1.0 - magnetisedStrength;
+                flashlightDifficultyValue *= 1.0 - magnetisedStrength;
             }
 
             if (mods.Any(m => m is OsuModDeflate))
             {
                 float deflateInitialScale = mods.OfType<OsuModDeflate>().First().StartScale.Value;
-                flashlightRating *= Math.Clamp(DifficultyCalculationUtils.ReverseLerp(deflateInitialScale, 11, 1), 0.1, 1);
+                flashlightDifficultyValue *= Math.Clamp(DifficultyCalculationUtils.ReverseLerp(deflateInitialScale, 11, 1), 0.1, 1);
             }
 
             double ratingMultiplier = 1.0;
@@ -155,7 +149,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // It is important to consider accuracy difficulty when scaling with accuracy.
             ratingMultiplier *= 0.98 + Math.Pow(Math.Max(0, overallDifficulty), 2) / 2500;
 
-            return flashlightRating * Math.Sqrt(ratingMultiplier);
+            return flashlightDifficultyValue * ratingMultiplier;
         }
 
         private double calculateAimVisibilityFactor(double approachRate)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimDifficultyValue = Math.Pow(aimDifficultyValue, 0.8);
 
             if (mods.Any(m => m is OsuModRelax))
-                aimDifficultyValue *= 0.9;
+                aimDifficultyValue *= 0.7;
 
             if (mods.Any(m => m is OsuModMagnetised))
             {
@@ -124,7 +124,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 flashlightDifficultyValue = Math.Pow(flashlightDifficultyValue, 0.8);
 
             if (mods.Any(m => m is OsuModRelax))
-                flashlightDifficultyValue *= 0.7;
+                flashlightDifficultyValue *= 0.5;
             else if (mods.Any(m => m is OsuModAutopilot))
                 flashlightDifficultyValue *= 0.4;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -43,6 +43,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override double DifficultyValue() => GetCurrentStrainPeaks().Sum();
 
-        public static double DifficultyToPerformance(double difficulty) => 25 * Math.Pow(difficulty, 2);
+        public double PerformanceValue()
+        {
+            double difficultyRating = OsuRatingCalculator.CalculateDifficultyRating(DifficultyValue());
+            return 25.0 * Math.Pow(difficultyRating, 2.0);
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -57,9 +57,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return difficulty;
         }
 
-        public double PerformanceValue()
+        public double PerformanceValue(double difficultyValue)
         {
-            double difficultyRating = OsuRatingCalculator.CalculateDifficultyRating(DifficultyValue());
+            double difficultyRating = OsuRatingCalculator.CalculateDifficultyRating(difficultyValue);
             return 4.0 * Math.Pow(difficultyRating, 3.0);
         }
     }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -57,6 +57,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return difficulty;
         }
 
-        public static double DifficultyToPerformance(double difficulty) => 4.0 * Math.Pow(difficulty, 3.0);
+        public double PerformanceValue()
+        {
+            double difficultyRating = OsuRatingCalculator.CalculateDifficultyRating(DifficultyValue());
+            return 4.0 * Math.Pow(difficultyRating, 3.0);
+        }
     }
 }


### PR DESCRIPTION
Use performance as a base difficulty attribute to ensure that they all have the same scaling and to avoid unnecessary conversions.
Potentially `CalculateDifficultyRating` function could also be removed and instead - it would be a part of rescale formula in `PerformanceValue`.

Relax multipliers change:
Aim: 0.9^3 = 0.729 -> 0.7 (slight nerf)
Flashlight: 0.7^2 = 0.49 -> 0.5 (slight buff)

Autopilot multipliers change:
Speed: 0.5^3 = 0.125 -> 0.125 (no change)
Flashlight: 0.4^2 = 0.16 -> 0.15 (slight nerf)

Touch Device multipliers change:
Aim: x^0.8 -> x^0.8 * 1.3
Flashlight: x^0.8 -> x^0.8 * 1.9
Those multipliers result in almost the same values as currently. Made them accurate because it's a ranked mod and I don't want any out of scope big balance changes.

I haven't adjusted Magnetised and Deflate multipliers. In order to make them match live - you need to raise them to the power of 3 and 2 accordingly, but I don't sure this is needed, as from my testing current values are too harsh (8 star aim drops to less than 5 star on 0.5x, despite spacing being only being decreased in 2 times at most).