### PR TITLE
Prepare form controls for use in settings

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
@@ -1,15 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
+using osu.Game.Overlays;
 using osu.Game.Screens.Edit.Setup;
 using osuTK;
 
@@ -25,109 +28,199 @@ namespace osu.Game.Tests.Visual.UserInterface
         protected override Drawable CreateContent() => new OsuContextMenuContainer
         {
             RelativeSizeAxes = Axes.Both,
-            Child = new PopoverContainer
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Child = new OsuScrollContainer
+                new BackgroundBox
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = new FillFlowContainer
+                },
+                new PopoverContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new OsuScrollContainer
                     {
-                        AutoSizeAxes = Axes.Y,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Width = 400,
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(5),
-                        Padding = new MarginPadding(10),
-                        Children = new Drawable[]
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new FillFlowContainer
                         {
-                            new FormTextBox
+                            AutoSizeAxes = Axes.Y,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Width = 400,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(5),
+                            Padding = new MarginPadding(10),
+                            Children = new Drawable[]
                             {
-                                Caption = "Artist",
-                                HintText = "Poot artist here!",
-                                PlaceholderText = "Here is an artist",
-                                TabbableContentContainer = this,
-                            },
-                            new FormTextBox
-                            {
-                                Caption = "Artist",
-                                HintText = "Poot artist here!",
-                                PlaceholderText = "Here is an artist",
-                                Current = { Disabled = true },
-                                TabbableContentContainer = this,
-                            },
-                            new FormNumberBox(allowDecimals: true)
-                            {
-                                Caption = "Number",
-                                HintText = "Insert your favourite number",
-                                PlaceholderText = "Mine is 42!",
-                                TabbableContentContainer = this,
-                            },
-                            new FormCheckBox
-                            {
-                                Caption = EditorSetupStrings.LetterboxDuringBreaks,
-                                HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
-                            },
-                            new FormCheckBox
-                            {
-                                Caption = EditorSetupStrings.LetterboxDuringBreaks,
-                                HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
-                                Current = { Disabled = true },
-                            },
-                            new FormSliderBar<float>
-                            {
-                                Caption = "Slider",
-                                Current = new BindableFloat
+                                new FormTextBox
                                 {
-                                    MinValue = 0,
-                                    MaxValue = 10,
-                                    Value = 5,
-                                    Precision = 0.1f,
+                                    Caption = "Artist",
+                                    HintText = "Poot artist here!",
+                                    PlaceholderText = "Here is an artist",
+                                    TabbableContentContainer = this,
                                 },
-                                TabbableContentContainer = this,
-                            },
-                            new FormEnumDropdown<CountdownType>
-                            {
-                                Caption = EditorSetupStrings.EnableCountdown,
-                                HintText = EditorSetupStrings.CountdownDescription,
-                            },
-                            new FormFileSelector
-                            {
-                                Caption = "File selector",
-                                PlaceholderText = "Select a file",
-                            },
-                            new FormBeatmapFileSelector(true)
-                            {
-                                Caption = "File selector with intermediate choice dialog",
-                                PlaceholderText = "Select a file",
-                            },
-                            new FormColourPalette
-                            {
-                                Caption = "Combo colours",
-                                Colours =
+                                new FormTextBox
                                 {
-                                    Colour4.Red,
-                                    Colour4.Green,
-                                    Colour4.Blue,
-                                    Colour4.Yellow,
-                                }
-                            },
-                            new FormButton
-                            {
-                                Caption = "No text in button",
-                                Action = () => { },
-                            },
-                            new FormButton
-                            {
-                                Caption = "Text in button which is pretty long and is very likely to wrap",
-                                ButtonText = "Foo the bar",
-                                Action = () => { },
+                                    Caption = "Artist",
+                                    HintText = "Poot artist here!",
+                                    PlaceholderText = "Here is an artist",
+                                    Current = { Disabled = true },
+                                    TabbableContentContainer = this,
+                                },
+                                new FormNumberBox(allowDecimals: true)
+                                {
+                                    Caption = "Number",
+                                    HintText = "Insert your favourite number",
+                                    PlaceholderText = "Mine is 42!",
+                                    TabbableContentContainer = this,
+                                },
+                                new FormCheckBox
+                                {
+                                    Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                    HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                },
+                                new FormCheckBox
+                                {
+                                    Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                    HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                    Current = { Disabled = true },
+                                },
+                                new FormCheckBox
+                                {
+                                    Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                    HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                    Current = { Value = true, Disabled = true },
+                                },
+                                new FormSliderBar<float>
+                                {
+                                    Caption = "Slider",
+                                    HintText = "Slider hint",
+                                    Current = new BindableFloat
+                                    {
+                                        MinValue = 0,
+                                        MaxValue = 10,
+                                        Value = 5,
+                                        Precision = 0.1f,
+                                    },
+                                    TabbableContentContainer = this,
+                                },
+                                new FormSliderBar<float>
+                                {
+                                    Caption = "Slider",
+                                    HintText = "Slider hint",
+                                    Current = new BindableFloat
+                                    {
+                                        MinValue = 0,
+                                        MaxValue = 10,
+                                        Value = 5,
+                                        Precision = 0.1f,
+                                        Disabled = true,
+                                    },
+                                    TransferValueOnCommit = true,
+                                    TabbableContentContainer = this,
+                                },
+                                new FormSliderBar<float>
+                                {
+                                    Caption = "Slider (percentage)",
+                                    HintText = "Percentage slider hint",
+                                    Current = new BindableFloat
+                                    {
+                                        MinValue = 0,
+                                        MaxValue = 1,
+                                        Value = 0.2f,
+                                        Precision = 0.0001f,
+                                    },
+                                    DisplayAsPercentage = true,
+                                    TabbableContentContainer = this,
+                                },
+                                new FormSliderBar<float>
+                                {
+                                    Caption = "Slider (custom)",
+                                    HintText = "Custom slider hint",
+                                    Current = new BindableFloat
+                                    {
+                                        MinValue = 0,
+                                        MaxValue = 1,
+                                        Value = 0.2f,
+                                        Precision = 0.0001f,
+                                    },
+                                    LabelFormat = v => $"{v * 100:0.00} funometer",
+                                    TooltipFormat = v => $"This setting has the value set to {v * 100:0.00} funometer.",
+                                    TabbableContentContainer = this,
+                                },
+                                new FormSliderBar<float>
+                                {
+                                    Caption = "Slider (custom)",
+                                    HintText = "Custom slider hint",
+                                    Current = new BindableFloat
+                                    {
+                                        MinValue = 0,
+                                        MaxValue = 1,
+                                        Value = 0.2f,
+                                        Precision = 0.0001f,
+                                        Disabled = true,
+                                    },
+                                    TransferValueOnCommit = true,
+                                    LabelFormat = v => $"{v * 100:0.00} funometer",
+                                    TooltipFormat = v => $"This setting has the value set to {v * 100:0.00} funometer.",
+                                    TabbableContentContainer = this,
+                                },
+                                new FormEnumDropdown<CountdownType>
+                                {
+                                    Caption = EditorSetupStrings.EnableCountdown,
+                                    HintText = EditorSetupStrings.CountdownDescription,
+                                },
+                                new FormEnumDropdown<CountdownType>
+                                {
+                                    Caption = EditorSetupStrings.EnableCountdown,
+                                    HintText = EditorSetupStrings.CountdownDescription,
+                                    Current = { Disabled = true },
+                                },
+                                new FormFileSelector
+                                {
+                                    Caption = "File selector",
+                                    PlaceholderText = "Select a file",
+                                },
+                                new FormBeatmapFileSelector(true)
+                                {
+                                    Caption = "File selector with intermediate choice dialog",
+                                    PlaceholderText = "Select a file",
+                                },
+                                new FormColourPalette
+                                {
+                                    Caption = "Combo colours",
+                                    Colours =
+                                    {
+                                        Colour4.Red,
+                                        Colour4.Green,
+                                        Colour4.Blue,
+                                        Colour4.Yellow,
+                                    }
+                                },
+                                new FormButton
+                                {
+                                    Caption = "No text in button",
+                                    Action = () => { },
+                                },
+                                new FormButton
+                                {
+                                    Caption = "Text in button which is pretty long and is very likely to wrap",
+                                    ButtonText = "Foo the bar",
+                                    Action = () => { },
+                                },
                             },
                         },
                     },
-                },
+                }
             }
         };
+
+        private partial class BackgroundBox : Box
+        {
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                Colour = colourProvider.Background4;
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSwitchButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSwitchButton.cs
@@ -2,14 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     public partial class TestSceneLabelledSwitchButton : OsuTestScene
     {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
+
         [TestCase(false)]
         [TestCase(true)]
         public void TestSwitchButton(bool hasDescription) => createSwitchButton(hasDescription);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSwitchButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSwitchButton.cs
@@ -4,16 +4,21 @@
 #nullable disable
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     public partial class TestSceneSwitchButton : OsuManualInputManagerTestScene
     {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
+
         private SwitchButton switchButton;
 
         [SetUp]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSwitchButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSwitchButton.cs
@@ -5,6 +5,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK.Input;
@@ -41,6 +42,16 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("bind bindable", () => switchButton.Current.BindTo(bindable = new BindableBool()));
             AddStep("toggle bindable", () => bindable.Toggle());
             AddStep("toggle bindable", () => bindable.Toggle());
+        }
+
+        [Test]
+        public void TestDisabledState()
+        {
+            AddToggleStep("toggle disabled", v =>
+            {
+                if (switchButton.IsNotNull())
+                    switchButton.Current.Disabled = v;
+            });
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -8,7 +8,6 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.API;
@@ -56,7 +55,7 @@ namespace osu.Game.Tournament.Screens.Setup
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = OsuColour.Gray(0.2f),
+                    Colour = ColourProvider.Background5,
                 },
                 new OsuScrollContainer
                 {

--- a/osu.Game.Tournament/Screens/TournamentScreen.cs
+++ b/osu.Game.Tournament/Screens/TournamentScreen.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
 using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.Screens
@@ -14,6 +15,9 @@ namespace osu.Game.Tournament.Screens
 
         [Resolved]
         protected LadderInfo LadderInfo { get; private set; } = null!;
+
+        [Cached]
+        protected readonly OverlayColourProvider ColourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
         protected TournamentScreen()
         {

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <summary>
         /// Maximum number of decimal digits to be displayed in the tooltip.
         /// </summary>
-        private const int max_decimal_digits = 5;
+        public const int MAX_DECIMAL_DIGITS = 5;
 
         private Sample sample = null!;
 
@@ -83,6 +83,6 @@ namespace osu.Game.Graphics.UserInterface
             channel.Play();
         }
 
-        protected virtual LocalisableString GetTooltipText(T value) => value.ToStandardFormattedString(max_decimal_digits, DisplayAsPercentage);
+        protected virtual LocalisableString GetTooltipText(T value) => value.ToStandardFormattedString(MAX_DECIMAL_DIGITS, DisplayAsPercentage);
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         public bool DisplayAsPercentage { get; set; }
 
-        public virtual LocalisableString TooltipText { get; private set; }
+        public virtual LocalisableString TooltipText { get; protected set; }
 
         /// <summary>
         /// Maximum number of decimal digits to be displayed in the tooltip.

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Graphics.UserInterface
         private const int max_decimal_digits = 5;
 
         private Sample sample = null!;
+        private Sample sampleDisabled = null!;
 
         private double lastSampleTime;
         private T lastSampleValue;
@@ -41,6 +42,7 @@ namespace osu.Game.Graphics.UserInterface
         private void load(AudioManager audio)
         {
             sample = audio.Samples.Get(@"UI/notch-tick");
+            sampleDisabled = audio.Samples.Get(@"UI/default-select-disabled");
         }
 
         protected override void LoadComplete()
@@ -72,7 +74,7 @@ namespace osu.Game.Graphics.UserInterface
             lastSampleValue = value;
             lastSampleTime = Clock.CurrentTime;
 
-            var channel = sample.GetChannel();
+            var channel = Current.Disabled ? sampleDisabled.GetChannel() : sample.GetChannel();
 
             channel.Frequency.Value = 0.99f + RNG.NextDouble(0.02f) + NormalizedValue * 0.2f;
 

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Graphics.UserInterface
         private const int max_decimal_digits = 5;
 
         private Sample sample = null!;
-        private Sample sampleDisabled = null!;
 
         private double lastSampleTime;
         private T lastSampleValue;
@@ -42,7 +41,6 @@ namespace osu.Game.Graphics.UserInterface
         private void load(AudioManager audio)
         {
             sample = audio.Samples.Get(@"UI/notch-tick");
-            sampleDisabled = audio.Samples.Get(@"UI/default-select-disabled");
         }
 
         protected override void LoadComplete()
@@ -74,7 +72,7 @@ namespace osu.Game.Graphics.UserInterface
             lastSampleValue = value;
             lastSampleTime = Clock.CurrentTime;
 
-            var channel = Current.Disabled ? sampleDisabled.GetChannel() : sample.GetChannel();
+            var channel = sample.GetChannel();
 
             channel.Frequency.Value = 0.99f + RNG.NextDouble(0.02f) + NormalizedValue * 0.2f;
 

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            CurrentNumber.BindValueChanged(current => TooltipText = GetDisplayableValue(current.NewValue), true);
+            CurrentNumber.BindValueChanged(current => TooltipText = GetTooltipText(current.NewValue), true);
         }
 
         protected override void OnUserChange(T value)
@@ -55,7 +55,7 @@ namespace osu.Game.Graphics.UserInterface
 
             playSample(value);
 
-            TooltipText = GetDisplayableValue(value);
+            TooltipText = GetTooltipText(value);
         }
 
         private void playSample(T value)
@@ -83,6 +83,6 @@ namespace osu.Game.Graphics.UserInterface
             channel.Play();
         }
 
-        public LocalisableString GetDisplayableValue(T value) => value.ToStandardFormattedString(max_decimal_digits, DisplayAsPercentage);
+        protected virtual LocalisableString GetTooltipText(T value) => value.ToStandardFormattedString(max_decimal_digits, DisplayAsPercentage);
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
                         },
-                        new FormSwitchButton
+                        new SwitchButton
                         {
                             Anchor = Anchor.CentreRight,
                             Origin = Anchor.CentreRight,
@@ -173,12 +173,5 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public void SetDefault() => Current.SetDefault();
 
         public bool IsDisabled => Current.Disabled;
-
-        private partial class FormSwitchButton : SwitchButton
-        {
-            // it doesn't make sense for this to show hover state or respond to input.
-            // FormCheckBox already handles all of that.
-            public override bool PropagatePositionalInputSubTree => false;
-        }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private Sample? sampleChecked;
         private Sample? sampleUnchecked;
+        private Sample? sampleDisabled;
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -99,6 +100,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             sampleChecked = audio.Samples.Get(@"UI/check-on");
             sampleUnchecked = audio.Samples.Get(@"UI/check-off");
+            sampleDisabled = audio.Samples.Get(@"UI/default-select-disabled");
         }
 
         protected override void LoadComplete()
@@ -140,6 +142,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             if (!Current.Disabled)
                 Current.Value = !Current.Value;
+            else
+                sampleDisabled?.Play();
+
             return true;
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -147,20 +147,18 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateState()
         {
-            background.Colour = Current.Disabled ? colourProvider.Background4 : colourProvider.Background5;
-            caption.Colour = Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;
-            checkbox.Colour = Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
-            text.Colour = Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
+            caption.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+            text.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
 
             text.Text = Current.Value ? CommonStrings.Enabled : CommonStrings.Disabled;
 
-            if (!Current.Disabled)
-            {
-                BorderThickness = IsHovered ? 2 : 0;
+            // use FadeColour to override any existing colour transform (i.e. FlashColour on click).
+            background.FadeColour(IsHovered
+                ? ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4)
+                : colourProvider.Background5);
 
-                if (IsHovered)
-                    BorderColour = colourProvider.Light4;
-            }
+            BorderThickness = IsHovered ? 2 : 0;
+            BorderColour = Current.Disabled ? colourProvider.Dark1 : colourProvider.Light4;
         }
 
         public IEnumerable<LocalisableString> FilterTerms => Caption.Yield();

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -16,7 +16,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 
@@ -45,7 +44,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private Box background = null!;
         private FormFieldCaption caption = null!;
         private OsuSpriteText text = null!;
-        private Nub checkbox = null!;
 
         private Sample? sampleChecked;
         private Sample? sampleUnchecked;
@@ -89,7 +87,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
                         },
-                        checkbox = new Nub
+                        new FormSwitchButton
                         {
                             Anchor = Anchor.CentreRight,
                             Origin = Anchor.CentreRight,
@@ -170,5 +168,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public void SetDefault() => Current.SetDefault();
 
         public bool IsDisabled => Current.Disabled;
+
+        private partial class FormSwitchButton : SwitchButton
+        {
+            public override bool PropagatePositionalInputSubTree => false;
+        }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -176,6 +176,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private partial class FormSwitchButton : SwitchButton
         {
+            // it doesn't make sense for this to show hover state or respond to input.
+            // FormCheckBox already handles all of that.
             public override bool PropagatePositionalInputSubTree => false;
         }
     }

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -171,6 +171,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                         Size = new Vector2(16),
+                        Margin = new MarginPadding { Right = 5 },
                     },
                 };
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -210,29 +210,26 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 label.Alpha = string.IsNullOrEmpty(SearchBar.SearchTerm.Value) ? 1 : 0;
 
-                caption.Colour = Dropdown.Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;
-                label.Colour = Dropdown.Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
-                chevron.Colour = Dropdown.Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
+                caption.Colour = Dropdown.Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+                label.Colour = Dropdown.Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
+                chevron.Colour = Dropdown.Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
                 DisabledColour = Colour4.White;
 
                 bool dropdownOpen = Dropdown.Menu.State == MenuState.Open;
 
-                if (!Dropdown.Current.Disabled)
-                {
-                    BorderThickness = IsHovered || dropdownOpen ? 2 : 0;
+                BorderThickness = IsHovered || dropdownOpen ? 2 : 0;
+
+                if (Dropdown.Current.Disabled)
+                    BorderColour = colourProvider.Dark1;
+                else
                     BorderColour = dropdownOpen ? colourProvider.Highlight1 : colourProvider.Light4;
 
-                    if (dropdownOpen)
-                        Background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
-                    else if (IsHovered)
-                        Background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
-                    else
-                        Background.Colour = colourProvider.Background5;
-                }
+                if (dropdownOpen)
+                    Background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
+                else if (IsHovered)
+                    Background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
                 else
-                {
-                    Background.Colour = colourProvider.Background4;
-                }
+                    Background.Colour = colourProvider.Background5;
             }
 
             private void updateChevron()

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -175,7 +175,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     },
                 };
 
-                AddInternal(new HoverClickSounds());
+                AddInternal(new HoverClickSounds
+                {
+                    Enabled = { BindTarget = Enabled },
+                });
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -386,6 +386,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             public Action? OnCommit { get; set; }
 
+            public sealed override LocalisableString TooltipText => base.TooltipText;
+
             public required Func<T, LocalisableString> TooltipFormat { get; init; }
 
             private Box leftBox = null!;
@@ -530,7 +532,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 return result;
             }
 
-            protected override LocalisableString GetTooltipText(T value) => TooltipFormat(value);
+            protected sealed override LocalisableString GetTooltipText(T value) => TooltipFormat(value);
         }
 
         private partial class InnerSliderNub : Circle

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -302,12 +302,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
             textBox.Alpha = 1;
             textBox.ReadOnly = Current.Disabled;
 
-            background.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background4 : colourProvider.Background5;
-            captionText.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;
-            textBox.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
+            captionText.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+            textBox.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content1;
 
             BorderThickness = childHasFocus || IsHovered || slider.IsDragging.Value ? 2 : 0;
-            BorderColour = childHasFocus ? colourProvider.Highlight1 : colourProvider.Light4;
+
+            if (Current.Disabled)
+                BorderColour = colourProvider.Dark1;
+            else
+                BorderColour = childHasFocus ? colourProvider.Highlight1 : colourProvider.Light4;
 
             if (childHasFocus)
                 background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -372,11 +372,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             if (updatingFromTextBox) return;
 
-            textBox.Text = currentNumberInstantaneous.Value.ToStandardFormattedString(5);
+            textBox.Text = currentNumberInstantaneous.Value.ToStandardFormattedString(OsuSliderBar<T>.MAX_DECIMAL_DIGITS);
             valueLabel.Text = LabelFormat(currentNumberInstantaneous.Value);
         }
 
-        private LocalisableString defaultLabelFormat(T value) => currentNumberInstantaneous.Value.ToStandardFormattedString(5, DisplayAsPercentage);
+        private LocalisableString defaultLabelFormat(T value) => currentNumberInstantaneous.Value.ToStandardFormattedString(OsuSliderBar<T>.MAX_DECIMAL_DIGITS, DisplayAsPercentage);
 
         private partial class InnerSlider : OsuSliderBar<T>
         {

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -391,6 +391,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             private Box leftBox = null!;
             private Box rightBox = null!;
             private InnerSliderNub nub = null!;
+            private HoverClickSounds sounds = null!;
             public const float NUB_WIDTH = 10;
 
             [Resolved]
@@ -439,7 +440,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             }
                         }
                     },
-                    new HoverClickSounds()
+                    sounds = new HoverClickSounds()
                 };
             }
 
@@ -499,6 +500,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             private void updateState()
             {
+                sounds.Enabled.Value = !Current.Disabled;
                 rightBox.Colour = colourProvider.Background6;
 
                 if (Current.Disabled)

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -189,26 +189,22 @@ namespace osu.Game.Graphics.UserInterfaceV2
             textBox.ReadOnly = disabled;
             textBox.Alpha = 1;
 
-            caption.Colour = disabled ? colourProvider.Foreground1 : colourProvider.Content2;
+            caption.Colour = disabled ? colourProvider.Background1 : colourProvider.Content2;
             textBox.Colour = disabled ? colourProvider.Foreground1 : colourProvider.Content1;
 
-            if (!disabled)
-            {
-                BorderThickness = IsHovered || textBox.Focused.Value ? 2 : 0;
+            BorderThickness = IsHovered || textBox.Focused.Value ? 2 : 0;
+
+            if (disabled)
+                BorderColour = colourProvider.Dark1;
+            else
                 BorderColour = textBox.Focused.Value ? colourProvider.Highlight1 : colourProvider.Light4;
 
-                if (textBox.Focused.Value)
-                    background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
-                else if (IsHovered)
-                    background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
-                else
-                    background.Colour = colourProvider.Background5;
-            }
+            if (textBox.Focused.Value)
+                background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
+            else if (IsHovered)
+                background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
             else
-            {
-                BorderThickness = 0;
-                background.Colour = colourProvider.Background4;
-            }
+                background.Colour = colourProvider.Background5;
         }
 
         internal partial class InnerTextBox : OsuTextBox

--- a/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private const float padding = 1.25f;
 
         private readonly Box fill;
-        private readonly Container switchContainer;
-        private readonly Drawable switchCircle;
-        private readonly CircularContainer circularContainer;
+        private readonly Container nubContainer;
+        private readonly Drawable nub;
+        private readonly CircularContainer content;
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -37,7 +37,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             Size = new Vector2(45, 20);
 
-            InternalChild = circularContainer = new CircularContainer
+            InternalChild = content = new CircularContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 BorderColour = Color4.White,
@@ -55,15 +55,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     {
                         RelativeSizeAxes = Axes.Both,
                         Padding = new MarginPadding(border_thickness + padding),
-                        Child = switchContainer = new Container
+                        Child = nubContainer = new Container
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Child = switchCircle = new CircularContainer
+                            Child = nub = new Circle
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 FillMode = FillMode.Fit,
                                 Masking = true,
-                                Child = new Box { RelativeSizeAxes = Axes.Both }
                             }
                         }
                     }
@@ -90,7 +89,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateState()
         {
-            switchCircle.MoveToX(Current.Value ? switchContainer.DrawWidth - switchCircle.DrawWidth : 0, 200, Easing.OutQuint);
+            nub.MoveToX(Current.Value ? nubContainer.DrawWidth - nub.DrawWidth : 0, 200, Easing.OutQuint);
             fill.FadeTo(Current.Value ? 1 : 0, 250, Easing.OutQuint);
 
             updateColours();
@@ -120,32 +119,33 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateColours()
         {
-            ColourInfo targetSwitchColour;
-            ColourInfo targetBorderColour;
+            ColourInfo borderColour;
+            ColourInfo switchColour;
 
             if (Current.Disabled)
             {
-                if (Current.Value)
-                    targetBorderColour = colourProvider.Dark1.Opacity(0.5f);
-                else
-                    targetBorderColour = colourProvider.Background2.Opacity(0.5f);
-
-                targetSwitchColour = colourProvider.Dark1.Opacity(0.5f);
-                fill.Colour = colourProvider.Background5;
+                borderColour = colourProvider.Dark2;
+                switchColour = colourProvider.Dark1;
+                fill.Colour = colourProvider.Dark5;
             }
             else
             {
-                if (Current.Value)
-                    targetBorderColour = IsHovered ? colourProvider.Highlight1.Lighten(0.3f) : colourProvider.Highlight1;
-                else
-                    targetBorderColour = IsHovered ? colourProvider.Background1 : colourProvider.Background2;
+                bool hover = IsHovered && !Current.Disabled;
 
-                targetSwitchColour = colourProvider.Highlight1;
-                fill.Colour = colourProvider.Background4;
+                borderColour = hover ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Highlight1.Opacity(0.3f);
+                switchColour = hover ? colourProvider.Highlight1 : colourProvider.Light4;
+
+                if (!Current.Value)
+                {
+                    borderColour = borderColour.MultiplyAlpha(0.8f);
+                    switchColour = switchColour.MultiplyAlpha(0.8f);
+                }
+
+                fill.Colour = colourProvider.Background6;
             }
 
-            switchContainer.FadeColour(targetSwitchColour, 250, Easing.OutQuint);
-            circularContainer.TransformTo(nameof(BorderColour), targetBorderColour, 250, Easing.OutQuint);
+            nubContainer.FadeColour(switchColour, 250, Easing.OutQuint);
+            content.TransformTo(nameof(BorderColour), borderColour, 250, Easing.OutQuint);
         }
     }
 }


### PR DESCRIPTION
This applies visual and audible changes, and adds new features for form controls to be ready for use in settings overlay. Changes are summarized as such:
- All disabled form controls match sliders visually (dark background and greyed content).
- Checkbox nubs are replaced with switch buttons.
- Sliders properly support percentage and custom label and tooltip formatting display.

| Before | After |
|--------|-------|
| <img width="200" alt="CleanShot 2025-12-22 at 20 27 19" src="https://github.com/user-attachments/assets/43f03a8b-3fef-4cf2-a614-252d59ddccad" /> | <img width="200" alt="CleanShot 2025-12-22 at 20 30 30" src="https://github.com/user-attachments/assets/573d6c19-2039-457d-ae42-f0dc80f314b1" /> |

Video preview:

<details>
<summary>preview</summary>

https://github.com/user-attachments/assets/5353f6d3-aae7-4b8c-b581-cb44c7406004

</details>