### PR TITLE
Fix replay files potentially getting misclassified as zip archives

### DIFF
--- a/osu.Game/Utils/ZipUtils.cs
+++ b/osu.Game/Utils/ZipUtils.cs
@@ -23,9 +23,15 @@ namespace osu.Game.Utils
                         {
                         }
                     }
-                }
 
-                return true;
+                    // aside from opening every zip entry not failing, we also require there to *be* at least one entry.
+                    // if there are no entries, the best case is that it's an actual empty zip
+                    // and as such probably useless to whatever wants to use it later.
+                    // the worst case is that it's actually *not* a zip and instead a stream of binary
+                    // which *accidentally* happened to contain the magic sequence of bytes for the zip header (50 4b 05 06),
+                    // and if that's the case, then we are *misclassifying* it as a zip by returning `true` unconditionally.
+                    return arc.Entries.Count > 0;
+                }
             }
             catch (Exception)
             {
@@ -52,9 +58,15 @@ namespace osu.Game.Utils
                         {
                         }
                     }
-                }
 
-                return true;
+                    // aside from opening every zip entry not failing, we also require there to *be* at least one entry.
+                    // if there are no entries, the best case is that it's an actual empty zip
+                    // and as such probably useless to whatever wants to use it later.
+                    // the worst case is that it's actually *not* a zip and instead a stream of binary
+                    // which *accidentally* happened to contain the magic sequence of bytes for the zip header (50 4b 05 06),
+                    // and if that's the case, then we are *misclassifying* it as a zip by returning `true` unconditionally.
+                    return arc.Entries.Count > 0;
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/discussions/36107.

The replay linked in the aforementioned discussion happens to contain the magic sequence for ZIP headers in the binary stream (`50 4b 05 06`):

<img width="630" height="66" alt="Screenshot 2025-12-23 at 08 25 09" src="https://github.com/user-attachments/assets/9ac6568e-88e6-4ce2-a317-30e1ee9586f8" />

which led to it getting classified as a ZIP with no entries and completely bogus everything in the header at
	https://github.com/ppy/osu/blob/c8b18acd4dd1d98170a069240b6666cea3d5da07/osu.Game/Database/ImportTask.cs#L51-L56

and then finally dying of

	2025-12-23 07:26:45 [error]: [?????] Model creation of replay-osu_2040232_4828629841.osr failed.
	2025-12-23 07:26:45 [error]: System.InvalidOperationException: Sequence contains no matching element
	2025-12-23 07:26:45 [error]: at System.Linq.ThrowHelper.ThrowNoMatchException()
	2025-12-23 07:26:45 [error]: at System.Linq.Enumerable.First[TSource](IEnumerable`1 source, Func`2 predicate)
	2025-12-23 07:26:45 [error]: at osu.Game.Scoring.ScoreImporter.CreateModel(ArchiveReader archive, ImportParameters parameters)
	2025-12-23 07:26:45 [error]: at osu.Game.Database.RealmArchiveModelImporter`1.importFromArchive(ArchiveReader archive, ImportParameters parameters, CancellationToken cancellationToken)

at

https://github.com/ppy/osu/blob/554961036e23615b35eb6b66b341b10924664c4d/osu.Game/Scoring/ScoreImporter.cs#L46