### PR TITLE
Fix potentially incorrect online play beatmap availability

### DIFF
--- a/osu.Game.Tests/Online/TestSceneMultiplayerBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneMultiplayerBeatmapAvailabilityTracker.cs
@@ -44,7 +44,13 @@ namespace osu.Game.Tests.Online
             availableBeatmap = importedSet.Beatmaps[0];
             unavailableBeatmap = importedSet.Beatmaps[1];
 
-            Realm.Write(r => r.Remove(r.Find<BeatmapInfo>(unavailableBeatmap.ID)!));
+            Realm.Write(r =>
+            {
+                BeatmapInfo available = r.Find<BeatmapInfo>(availableBeatmap.ID)!;
+                available.OnlineMD5Hash = available.MD5Hash;
+
+                r.Remove(r.Find<BeatmapInfo>(unavailableBeatmap.ID)!);
+            });
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
@@ -27,6 +27,7 @@ using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual;
+using Realms;
 
 namespace osu.Game.Tests.Online
 {
@@ -228,6 +229,14 @@ namespace osu.Game.Tests.Online
                         throw new TimeoutException("Timeout waiting for import to be allowed.");
 
                     return testBeatmapManager.CurrentImport = base.ImportModel(item, archive, parameters, cancellationToken);
+                }
+
+                protected override void PostImport(BeatmapSetInfo model, Realm realm, ImportParameters parameters)
+                {
+                    foreach (var beatmap in model.Beatmaps)
+                        beatmap.OnlineMD5Hash = beatmap.MD5Hash;
+
+                    base.PostImport(model, realm, parameters);
                 }
             }
         }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -329,6 +329,14 @@ namespace osu.Game.Beatmaps
              .FirstOrDefault()?.Detach());
 
         /// <summary>
+        /// Perform a lookup query on available <see cref="BeatmapInfo"/>s for a specific online ID.
+        /// </summary>
+        /// <returns>A matching local beatmap info if existing and in a valid state.</returns>
+        public BeatmapInfo? QueryOnlineBeatmapId(int id) => Realm.Run(r =>
+            r.All<BeatmapInfo>()
+             .ForOnlineId(id).SingleOrDefault()?.Detach());
+
+        /// <summary>
         /// A default representation of a WorkingBeatmap to use when no beatmap is available.
         /// </summary>
         public IWorkingBeatmap DefaultBeatmap => workingBeatmapCache.DefaultBeatmap;

--- a/osu.Game/Database/RealmExtensions.cs
+++ b/osu.Game/Database/RealmExtensions.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Logging;
+using osu.Game.Beatmaps;
 using Realms;
 
 namespace osu.Game.Database
@@ -102,5 +104,13 @@ namespace osu.Game.Database
         /// Quite often we only care about changes at a collection level. This can be used to guard and early-return when no such changes are in a callback.
         /// </remarks>
         public static bool HasCollectionChanges(this ChangeSet changes) => changes.InsertedIndices.Length > 0 || changes.DeletedIndices.Length > 0 || changes.Moves.Length > 0;
+
+        public static IQueryable<BeatmapInfo> NotDeleted(this IQueryable<BeatmapInfo> beatmaps) =>
+            beatmaps.Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false");
+
+        public static IQueryable<BeatmapInfo> ForOnlineId(this IQueryable<BeatmapInfo> beatmaps, int id) =>
+            beatmaps
+                .NotDeleted()
+                .Filter($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", id);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -489,7 +489,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             if (!screen.IsCurrentScreen())
                 return;
 
-            var beatmap = beatmaps.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", item.Beatmap.OnlineID);
+            var beatmap = beatmaps.QueryOnlineBeatmapId(item.Beatmap.OnlineID);
 
             screen.Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap); // this will gracefully fall back to dummy beatmap if missing locally.
             screen.Ruleset.Value = rulesets.GetRuleset(item.RulesetID);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs
@@ -246,7 +246,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
             // Update global gameplay state to correspond to the new selection.
             // Retrieve the corresponding local beatmap, since we can't directly use the playlist's beatmap info
-            var localBeatmap = beatmapManager.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", item.BeatmapID);
+            var localBeatmap = beatmapManager.QueryOnlineBeatmapId(item.BeatmapID);
 
             if (localBeatmap != null)
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -510,7 +510,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             {
                 MultiplayerPlaylistItem item = client.Room.CurrentPlaylistItem;
 
-                var newBeatmap = beatmapManager.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", item.BeatmapID);
+                var newBeatmap = beatmapManager.QueryOnlineBeatmapId(item.BeatmapID);
 
                 if (!Beatmap.Value.BeatmapSetInfo.Equals(newBeatmap?.BeatmapSet))
                     this.MakeCurrent();
@@ -652,7 +652,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             // Update global gameplay state to correspond to the new selection.
             // Retrieve the corresponding local beatmap, since we can't directly use the playlist's beatmap info
-            var localBeatmap = beatmapManager.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", gameplayBeatmapId);
+            var localBeatmap = beatmapManager.QueryOnlineBeatmapId(gameplayBeatmapId);
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
             Ruleset.Value = ruleset;
             Mods.Value = client.LocalUser.Mods.Concat(item.RequiredMods).Select(m => m.ToMod(rulesetInstance)).ToArray();

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -17,7 +17,6 @@ using osu.Game.Database;
 using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
-using Realms;
 
 namespace osu.Game.Screens.OnlinePlay
 {
@@ -153,13 +152,9 @@ namespace osu.Game.Screens.OnlinePlay
                 }
             }
 
-            IQueryable<BeatmapInfo> queryBeatmap()
-            {
-                // See: BeatmapManager.QueryBeatmap()
-                return realm.Realm.All<BeatmapInfo>()
-                            .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")
-                            .Filter($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", beatmap.OnlineID);
-            }
+            IQueryable<BeatmapInfo> queryBeatmap() =>
+                realm.Realm.All<BeatmapInfo>()
+                     .ForOnlineId(beatmap.OnlineID);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -153,8 +153,13 @@ namespace osu.Game.Screens.OnlinePlay
                 }
             }
 
-            IQueryable<BeatmapInfo> queryBeatmap() =>
-                realm.Realm.All<BeatmapInfo>().Filter("OnlineID == $0 && MD5Hash == $1 && BeatmapSet.DeletePending == false", beatmap.OnlineID, beatmap.MD5Hash);
+            IQueryable<BeatmapInfo> queryBeatmap()
+            {
+                // See: BeatmapManager.QueryBeatmap()
+                return realm.Realm.All<BeatmapInfo>()
+                            .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")
+                            .Filter($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", beatmap.OnlineID);
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemResultsScreen.cs
@@ -62,8 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         [BackgroundDependencyLoader]
         private void load()
         {
-            var localBeatmap = beatmapManager.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}",
-                PlaylistItem.Beatmap.OnlineID);
+            var localBeatmap = beatmapManager.QueryOnlineBeatmapId(PlaylistItem.Beatmap.OnlineID);
             itemBeatmap = beatmapManager.GetWorkingBeatmap(localBeatmap);
 
             AddInternal(new Container

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -609,7 +609,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             // Update global gameplay state to correspond to the new selection.
             // Retrieve the corresponding local beatmap, since we can't directly use the playlist's beatmap info
-            var localBeatmap = beatmapManager.QueryBeatmap($@"{nameof(BeatmapInfo.OnlineID)} == $0 AND {nameof(BeatmapInfo.MD5Hash)} == {nameof(BeatmapInfo.OnlineMD5Hash)}", gameplayBeatmap.OnlineID);
+            var localBeatmap = beatmapManager.QueryOnlineBeatmapId(gameplayBeatmap.OnlineID);
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
             Ruleset.Value = gameplayRuleset;
             Mods.Value = UserMods.Value.Concat(item.RequiredMods.Select(m => m.ToMod(rulesetInstance))).ToArray();


### PR DESCRIPTION
Has been discussed several times already. The condition added in this PR is the same as used in [multiplayer](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L655-L656), [playlists](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs#L612-L613), [DC](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs#L492), and [QP](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs#L249).

I believe this to be one of the contributors to https://github.com/ppy/osu/issues/36045. Some background knowledge is necessary:
- The multiplayer server sends `LoadRequested` to all users in the room regardless of their beatmap availability. This is an issue on its own that will be fixed separately.
- Additionally to the above, there is no guard in the client that, upon receiving `LoadRequested`, blocks gameplay from being entered if not in the correct (`WaitingForLoad` or `Spectating`) state.
- Quick play sends both a [`Ready`](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs#L257-L259) state and [beatmap availability](https://github.com/ppy/osu/blob/1340e18d939ca5f738568ea33799a73bdec514d0/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs#L268) to the server BUT only [relies](https://github.com/ppy/osu-server-spectator/blob/6c844e6327d9e9f6d7386f6e5e4bb678fb0d27e5/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/MatchmakingMatchController.cs#L469-L472) on the ready state to decide when a match can be started.
- So if the ready state and beatmap availability get out of sync and critically one user does not have the beatmap available, then quick play will force-start the match, send `LoadRequested` to all users, but only keep track of those that have the [beatmap available](https://github.com/ppy/osu-server-spectator/blob/6c844e6327d9e9f6d7386f6e5e4bb678fb0d27e5/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs#L296-L299) for gameplay purposes.

tl;dr: It's all messed up. Iteratively returning to sanity.