### PR TITLE
Use batching in `BackgroundDataStoreProcessor` processes

### DIFF
--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -71,20 +71,17 @@ namespace osu.Game.Beatmaps
 
         public void ProcessObjectCounts(BeatmapInfo beatmapInfo, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst)
         {
-            beatmapInfo.Realm!.Write(_ =>
-            {
-                // Before we use below, we want to invalidate.
-                workingBeatmapCache.Invalidate(beatmapInfo);
+            // Before we use below, we want to invalidate.
+            workingBeatmapCache.Invalidate(beatmapInfo);
 
-                var working = workingBeatmapCache.GetWorkingBeatmap(beatmapInfo);
-                var beatmap = working.Beatmap;
+            var working = workingBeatmapCache.GetWorkingBeatmap(beatmapInfo);
+            var beatmap = working.Beatmap;
 
-                beatmapInfo.EndTimeObjectCount = beatmap.HitObjects.Count(h => h is IHasDuration);
-                beatmapInfo.TotalObjectCount = beatmap.HitObjects.Count;
+            beatmapInfo.EndTimeObjectCount = beatmap.HitObjects.Count(h => h is IHasDuration);
+            beatmapInfo.TotalObjectCount = beatmap.HitObjects.Count;
 
-                // And invalidate again afterwards as re-fetching the most up-to-date database metadata will be required.
-                workingBeatmapCache.Invalidate(beatmapInfo);
-            });
+            // And invalidate again afterwards as re-fetching the most up-to-date database metadata will be required.
+            workingBeatmapCache.Invalidate(beatmapInfo);
         }
 
         #region Implementation of IDisposable

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Beatmaps
             {
                 if (db == null)
                 {
-                    db = getConnection();
+                    db = GetConnection();
                     db.Open();
 
                     version = GetCacheVersion(db);
@@ -170,7 +170,7 @@ namespace osu.Game.Beatmaps
             log(@"Local metadata cache purged due to corruption.");
         }
 
-        private SqliteConnection getConnection() =>
+        public SqliteConnection GetConnection() =>
             new SqliteConnection(string.Concat(@"Data Source=", storage.GetFullPath(@"online.db", true)));
 
         public Task FetchCache()
@@ -250,7 +250,7 @@ namespace osu.Game.Beatmaps
         {
             try
             {
-                using (var connection = getConnection())
+                using (var connection = GetConnection())
                 {
                     connection.Open();
                     return GetCacheVersion(connection) >= version;

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Beatmaps
 
         private const string cache_database_name = @"online.db";
 
+        public SqliteConnection? CachedConnection;
+        public int? CachedVersion;
+
         public LocalCachedBeatmapMetadataSource(Storage storage)
         {
             try
@@ -105,10 +108,10 @@ namespace osu.Game.Beatmaps
             {
                 if (db == null)
                 {
-                    db = GetConnection();
+                    db = getConnection();
                     db.Open();
 
-                    version = GetCacheVersion(db);
+                    version = getCacheVersion(db);
                 }
 
                 switch (version)
@@ -170,8 +173,23 @@ namespace osu.Game.Beatmaps
             log(@"Local metadata cache purged due to corruption.");
         }
 
-        public SqliteConnection GetConnection() =>
+        private SqliteConnection getConnection() =>
             new SqliteConnection(string.Concat(@"Data Source=", storage.GetFullPath(@"online.db", true)));
+
+        public void CreateCachedConnection()
+        {
+            try
+            {
+                CachedConnection = getConnection();
+                CachedConnection.Open();
+
+                CachedVersion = getCacheVersion(CachedConnection);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Could not create cached sqlite connection: {e}");
+            }
+        }
 
         public Task FetchCache()
         {
@@ -250,10 +268,10 @@ namespace osu.Game.Beatmaps
         {
             try
             {
-                using (var connection = GetConnection())
+                using (var connection = getConnection())
                 {
                     connection.Open();
-                    return GetCacheVersion(connection) >= version;
+                    return getCacheVersion(connection) >= version;
                 }
             }
             catch (SqliteException ex) when (ex.SqliteErrorCode == 26 || ex.SqliteErrorCode == 11) // SQLITE_NOTADB, SQLITE_CORRUPT
@@ -263,7 +281,7 @@ namespace osu.Game.Beatmaps
             }
         }
 
-        public int GetCacheVersion(SqliteConnection connection)
+        private int getCacheVersion(SqliteConnection connection)
         {
             using (var cmd = connection.CreateCommand())
             {
@@ -414,6 +432,7 @@ namespace osu.Game.Beatmaps
         public void Dispose()
         {
             cacheDownloadRequest?.Dispose();
+            CachedConnection?.Close();
         }
     }
 }

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -81,6 +81,11 @@ namespace osu.Game.Beatmaps
 
         public bool TryLookup(BeatmapInfo beatmapInfo, [NotNullWhen(true)] out OnlineBeatmapMetadata? onlineMetadata)
         {
+            return TryLookup(null, null, beatmapInfo, out onlineMetadata);
+        }
+
+        public bool TryLookup(SqliteConnection? db, int? version, BeatmapInfo beatmapInfo, [NotNullWhen(true)] out OnlineBeatmapMetadata? onlineMetadata)
+        {
             Debug.Assert(beatmapInfo.BeatmapSet != null);
 
             if (!Available)
@@ -98,19 +103,22 @@ namespace osu.Game.Beatmaps
 
             try
             {
-                using (var db = getConnection())
+                if (db == null)
                 {
+                    db = getConnection();
                     db.Open();
 
-                    switch (getCacheVersion(db))
-                    {
-                        case 2:
-                            // can be removed 20260123
-                            return queryCacheVersion2(db, beatmapInfo, out onlineMetadata);
+                    version = GetCacheVersion(db);
+                }
 
-                        case 3:
-                            return queryCacheVersion3(db, beatmapInfo, out onlineMetadata);
-                    }
+                switch (version)
+                {
+                    case 2:
+                        // can be removed 20260123
+                        return queryCacheVersion2(db, beatmapInfo, out onlineMetadata);
+
+                    case 3:
+                        return queryCacheVersion3(db, beatmapInfo, out onlineMetadata);
                 }
 
                 onlineMetadata = null;
@@ -245,7 +253,7 @@ namespace osu.Game.Beatmaps
                 using (var connection = getConnection())
                 {
                     connection.Open();
-                    return getCacheVersion(connection) >= version;
+                    return GetCacheVersion(connection) >= version;
                 }
             }
             catch (SqliteException ex) when (ex.SqliteErrorCode == 26 || ex.SqliteErrorCode == 11) // SQLITE_NOTADB, SQLITE_CORRUPT
@@ -255,7 +263,7 @@ namespace osu.Game.Beatmaps
             }
         }
 
-        private int getCacheVersion(SqliteConnection connection)
+        public int GetCacheVersion(SqliteConnection connection)
         {
             using (var cmd = connection.CreateCommand())
             {

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -76,6 +76,8 @@ namespace osu.Game.Database
 
         private LocalCachedBeatmapMetadataSource localMetadataSource = null!;
 
+        private List<Action<Realm>> actions = [];
+
         protected virtual int TimeToSleepDuringGameplay => 30000;
 
         protected override void LoadComplete()
@@ -189,8 +191,6 @@ namespace osu.Game.Database
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-
-            var actions = new List<Action<Realm>>();
 
             realmAccess.Run(r =>
             {
@@ -342,8 +342,6 @@ namespace osu.Game.Database
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            var actions = new List<Action<Realm>>();
-
             realmAccess.Run(r =>
             {
                 foreach (Guid id in beatmapIds)
@@ -428,8 +426,6 @@ namespace osu.Game.Database
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-
-            var actions = new List<Action<Realm>>();
 
             realmAccess.Run(r =>
             {
@@ -521,8 +517,6 @@ namespace osu.Game.Database
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            var actions = new List<Action<Realm>>();
-
             realmAccess.Run(r =>
             {
                 foreach (Guid id in scoreIds)
@@ -611,8 +605,6 @@ namespace osu.Game.Database
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-
-            var actions = new List<Action<Realm>>();
 
             realmAccess.Run(r =>
             {
@@ -704,8 +696,6 @@ namespace osu.Game.Database
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-
-            var actions = new List<Action<Realm>>();
 
             realmAccess.Run(r =>
             {
@@ -834,8 +824,6 @@ namespace osu.Game.Database
                 return;
             }
 
-            var actions = new List<Action<Realm>>();
-
             realmAccess.Run(r =>
             {
                 foreach (Guid id in beatmapSetIds)
@@ -956,8 +944,6 @@ namespace osu.Game.Database
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-
-            var actions = new List<Action<Realm>>();
 
             SqliteConnection sqliteConnection;
             int sqliteVersion;

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -75,7 +75,6 @@ namespace osu.Game.Database
         private OsuConfigManager config { get; set; } = null!;
 
         private LocalCachedBeatmapMetadataSource localMetadataSource = null!;
-
         private readonly List<Action<Realm>> actions = [];
 
         protected virtual int TimeToSleepDuringGameplay => 30000;
@@ -162,16 +161,13 @@ namespace osu.Game.Database
 
             realmAccess.Run(r =>
             {
-                var beatmaps = r
-                               .All<BeatmapInfo>()
-                               .Where(b => b.StarRating < 0 && b.BeatmapSet != null);
+                var beatmaps = r.All<BeatmapInfo>().Where(b => b.StarRating < 0 && b.BeatmapSet != null);
 
                 int totalCount = beatmaps.Count();
                 int processedCount = 0;
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} beatmaps which require star rating reprocessing.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, "Reprocessing star rating for beatmaps", "beatmaps' star ratings have been updated");
@@ -197,7 +193,6 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     try
@@ -228,7 +223,6 @@ namespace osu.Game.Database
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
                 Logger.Log($"Populating {processedCount} of {totalCount} missing star ratings completed in {stopwatch.ElapsedMilliseconds}ms");
@@ -261,8 +255,7 @@ namespace osu.Game.Database
 
             Logger.Log($"Found {beatmapSetIds.Count} beatmap sets which require online updates.");
 
-            if (beatmapSetIds.Count == 0)
-                return;
+            if (beatmapSetIds.Count == 0) return;
 
             var notification = showProgressNotification(beatmapSetIds.Count, "Updating online data for beatmaps", "beatmaps' online data have been updated");
 
@@ -278,7 +271,6 @@ namespace osu.Game.Database
                     break;
 
                 updateNotificationProgress(notification, processedCount, beatmapSetIds.Count);
-
                 sleepIfRequired();
 
                 realmAccess.Run(r =>
@@ -312,16 +304,13 @@ namespace osu.Game.Database
 
             realmAccess.Run(r =>
             {
-                var beatmaps = r
-                               .All<BeatmapInfo>()
-                               .Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0);
+                var beatmaps = r.All<BeatmapInfo>().Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0);
 
                 int totalCount = beatmaps.Count();
                 int processedCount = 0;
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} beatmaps which require statistics population.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, "Populating missing statistics for beatmaps", "beatmaps have been populated with missing statistics");
@@ -337,7 +326,6 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     var beatmap = b.Detach();
@@ -366,7 +354,6 @@ namespace osu.Game.Database
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
                 Logger.Log($"Processing {processedCount} of {totalCount} missing beatmaps hitobject counts completed in {stopwatch.ElapsedMilliseconds}ms");
@@ -393,7 +380,6 @@ namespace osu.Game.Database
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} scores which require statistics population.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, "Populating missing statistics for scores", "scores have been populated with missing statistics");
@@ -409,7 +395,6 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     try
@@ -417,12 +402,7 @@ namespace osu.Game.Database
                         scoreManager.PopulateMaximumStatistics(score);
                         string maximumStatisticsJson = JsonConvert.SerializeObject(score.MaximumStatistics);
 
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-                            item.MaximumStatisticsJson = maximumStatisticsJson;
-                        });
-
+                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.MaximumStatisticsJson = maximumStatisticsJson);
                         ++processedCount;
                     }
                     catch (ObjectDisposedException)
@@ -432,19 +412,12 @@ namespace osu.Game.Database
                     catch (Exception e)
                     {
                         Logger.Log(@$"Failed to populate maximum statistics for {score.ID}: {e}");
-
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-                            item.BackgroundReprocessingFailed = true;
-                        });
-
+                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
                         ++failedCount;
                     }
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
                 Logger.Log($"Processing {processedCount} of {totalCount} missing scores statistics completed in {stopwatch.ElapsedMilliseconds}ms");
@@ -472,7 +445,6 @@ namespace osu.Game.Database
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} scores which require mod multiplier upgrade.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, "Upgrading scores to new mod multipliers", "scores have been upgraded to the new mod multipliers");
@@ -488,7 +460,6 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     var score = s.Detach();
@@ -518,19 +489,12 @@ namespace osu.Game.Database
                     catch (Exception e)
                     {
                         Logger.Log($"Failed to upgrade mod multipliers for {score.ID}: {e}");
-
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-                            item.BackgroundReprocessingFailed = true;
-                        });
-
+                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
                         ++failedCount;
                     }
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
                 Logger.Log($"Upgrading {processedCount} of {totalCount} scores to new mod multipliers completed in {stopwatch.ElapsedMilliseconds}ms");
@@ -558,7 +522,6 @@ namespace osu.Game.Database
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} scores which require total score conversion.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, "Upgrading scores to new scoring algorithm", "scores have been upgraded to the new scoring algorithm");
@@ -574,7 +537,6 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     var score = s.Detach();
@@ -603,19 +565,12 @@ namespace osu.Game.Database
                     catch (Exception e)
                     {
                         Logger.Log($"Failed to convert total score for {score.ID}: {e}");
-
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-                            item.BackgroundReprocessingFailed = true;
-                        });
-
+                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
                         ++failedCount;
                     }
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
                 Logger.Log($"Converting total score {processedCount} of {totalCount} scores completed in {stopwatch.ElapsedMilliseconds}ms");
@@ -640,7 +595,6 @@ namespace osu.Game.Database
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} scores which require rank upgrades.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, "Adjusting ranks of scores", "scores now have more correct ranks.");
@@ -656,7 +610,6 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     try
@@ -680,19 +633,12 @@ namespace osu.Game.Database
                     catch (Exception e)
                     {
                         Logger.Log($"Failed to update score rank {score.ID}: {e}");
-
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-                            item.BackgroundReprocessingFailed = true;
-                        });
-
+                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
                         ++failedCount;
                     }
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
                 Logger.Log($"Upgrading {processedCount} of {totalCount} score ranks completed in {stopwatch.ElapsedMilliseconds}ms");
@@ -723,6 +669,8 @@ namespace osu.Game.Database
 
             Logger.Log("Querying for beatmap sets that contain missing submission/rank dates...");
 
+            localMetadataSource.CreateCachedConnection();
+
             // find all ranked beatmap sets with missing date ranked or date submitted that have at least one difficulty ranked as well.
             // the reason for checking ranked status of the difficulties is that they can be locally modified or unknown too, and for those the lookup is likely to fail.
             // this is because metadata lookups are primarily based on file hash, so they will fail to match if the beatmap does not match the online version
@@ -740,29 +688,12 @@ namespace osu.Game.Database
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} beatmap sets with missing submission/rank dates.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, "Populating missing submission and rank dates", "beatmap sets now have correct submission and rank dates.");
 
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
-
-                SqliteConnection sqliteConnection;
-                int sqliteVersion;
-
-                try
-                {
-                    sqliteConnection = localMetadataSource.GetConnection();
-                    sqliteConnection.Open();
-
-                    sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Log($"Could not open sqlite database: {ex}");
-                    return;
-                }
 
                 foreach (var beatmapSet in beatmapsSet)
                 {
@@ -772,14 +703,12 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     try
                     {
                         var beatmap = beatmapSet.Beatmaps.First(b => b.Status >= BeatmapOnlineStatus.Ranked);
-
-                        bool lookupSucceeded = localMetadataSource.TryLookup(sqliteConnection, sqliteVersion, beatmap, out var result);
+                        bool lookupSucceeded = localMetadataSource.TryLookup(localMetadataSource.CachedConnection, localMetadataSource.CachedVersion, beatmap, out var result);
 
                         if (!lookupSucceeded)
                         {
@@ -813,12 +742,12 @@ namespace osu.Game.Database
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-                sqliteConnection.Close();
-
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
                 Logger.Log($"Populating {processedCount} of {totalCount} missing submission and rank dates completed in {stopwatch.ElapsedMilliseconds}ms");
             });
+
+            localMetadataSource.CachedConnection?.Close();
         }
 
         private void backpopulateUserTags(int chunkSize = 2000)
@@ -851,13 +780,13 @@ namespace osu.Game.Database
 
             Logger.Log("Querying for beatmap that has outdated user tags...");
 
+            localMetadataSource.CreateCachedConnection();
+
             // while this is constrained to run every month or so (every time a new online.db cache is retrieved), there's some chance that this will still run much too often and be annoying to users.
             // if that turns out to be the case we may need a better way to debounce this (or just delete the backpopulation logic after some time has passed?)
             realmAccess.Run(r =>
             {
-                var beatmaps = r.All<BeatmapInfo>()
-                                .Filter($"{nameof(BeatmapInfo.StatusInt)} IN {{ 1,2,4 }}")
-                                .AsEnumerable();
+                var beatmaps = r.All<BeatmapInfo>().Filter($"{nameof(BeatmapInfo.StatusInt)} IN {{ 1,2,4 }}");
 
                 int totalCount = beatmaps.Count();
                 int processedCount = 0;
@@ -865,7 +794,6 @@ namespace osu.Game.Database
                 int failedCount = 0;
 
                 Logger.Log($"Found {totalCount} beatmaps with outdated user tags.");
-
                 if (totalCount == 0) return;
 
                 var notification = showProgressNotification(totalCount, @"Updating user tags",
@@ -873,22 +801,6 @@ namespace osu.Game.Database
 
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
-
-                SqliteConnection sqliteConnection;
-                int sqliteVersion;
-
-                try
-                {
-                    sqliteConnection = localMetadataSource.GetConnection();
-                    sqliteConnection.Open();
-
-                    sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Log($"Could not open sqlite database: {ex}");
-                    return;
-                }
 
                 foreach (var beatmap in beatmaps)
                 {
@@ -898,12 +810,11 @@ namespace osu.Game.Database
                     if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
-
                     sleepIfRequired();
 
                     try
                     {
-                        bool lookupSucceeded = localMetadataSource.TryLookup(sqliteConnection, sqliteVersion, beatmap, out var result);
+                        bool lookupSucceeded = localMetadataSource.TryLookup(localMetadataSource.CachedConnection, localMetadataSource.CachedVersion, beatmap, out var result);
 
                         if (!lookupSucceeded)
                         {
@@ -946,7 +857,6 @@ namespace osu.Game.Database
                 }
 
                 if (actions.Count > 0) performWrite(actions);
-                sqliteConnection.Close();
 
                 // Report the updated item count rather than the total processed. Users don't really care about noops here.
                 completeNotification(notification, updatedCount, updatedCount, failedCount);
@@ -955,6 +865,8 @@ namespace osu.Game.Database
 
                 Logger.Log($"Populating {processedCount} of {totalCount} beatmap user tags completed in {stopwatch.ElapsedMilliseconds}ms");
             });
+
+            localMetadataSource.CachedConnection?.Close();
         }
 
         private void performWrite(List<Action<Realm>> actions)

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -514,47 +514,72 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Upgrading scores to new mod multipliers", "scores have been upgraded to the new mod multipliers");
 
+            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
-            foreach (var id in scoreIds)
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var actions = new List<Action<Realm>>();
+
+            realmAccess.Run(r =>
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
-
-                updateNotificationProgress(notification, processedCount, scoreIds.Count);
-
-                sleepIfRequired();
-
-                try
+                foreach (Guid id in scoreIds)
                 {
-                    // Can't use async overload because we're not on the update thread.
-                    // ReSharper disable once MethodHasAsyncOverload
-                    realmAccess.Write(r =>
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
+
+                    if (actions.Count >= chunk_size) performWrite(actions);
+
+                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+
+                    sleepIfRequired();
+
+                    var score = r.Find<ScoreInfo>(id)?.Detach();
+
+                    if (score == null || score.BeatmapInfo == null)
                     {
-                        ScoreInfo s = r.Find<ScoreInfo>(id)!;
-                        if (s.BeatmapInfo == null)
-                            return;
+                        ++processedCount;
+                        continue;
+                    }
 
-                        StandardisedScoreMigrationTools.UpdateToLatestScoreMultipliers(s, s.BeatmapInfo.Difficulty);
-                        s.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
-                    });
+                    try
+                    {
+                        StandardisedScoreMigrationTools.UpdateToLatestScoreMultipliers(score, score.BeatmapInfo.Difficulty);
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+                            item.TotalScore = score.TotalScore;
+                            item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
+                        });
 
-                    ++processedCount;
+                        ++processedCount;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Failed to upgrade mod multipliers for {id}: {e}");
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+                            item.BackgroundReprocessingFailed = true;
+                        });
+
+                        ++failedCount;
+                    }
                 }
-                catch (ObjectDisposedException)
-                {
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log($"Failed to upgrade mod multipliers for {id}: {e}");
-                    realmAccess.Write(r => r.Find<ScoreInfo>(id)!.BackgroundReprocessingFailed = true);
-                    ++failedCount;
-                }
-            }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
 
             completeNotification(notification, processedCount, scoreIds.Count, failedCount);
+
+            Logger.Log($"Upgrading {processedCount} of {scoreIds.Count} scores to new mod multipliers completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void convertLegacyTotalScoreToStandardised()

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Database
 
         private LocalCachedBeatmapMetadataSource localMetadataSource = null!;
 
-        private List<Action<Realm>> actions = [];
+        private readonly List<Action<Realm>> actions = [];
 
         protected virtual int TimeToSleepDuringGameplay => 30000;
 
@@ -156,15 +156,15 @@ namespace osu.Game.Database
         /// from the <see cref="beatmapUpdater"/> firing online requests as part of the update.
         /// Star rating recalculations can be ran strictly locally.
         /// </remarks>
-        private void populateMissingStarRatings(int chunk_size = 500)
+        private void populateMissingStarRatings(int chunkSize = 500)
         {
             Logger.Log("Querying for beatmaps with missing star ratings...");
 
             realmAccess.Run(r =>
             {
                 var beatmaps = r
-                 .All<BeatmapInfo>()
-                 .Where(b => b.StarRating < 0 && b.BeatmapSet != null);
+                               .All<BeatmapInfo>()
+                               .Where(b => b.StarRating < 0 && b.BeatmapSet != null);
 
                 int totalCount = beatmaps.Count();
                 int processedCount = 0;
@@ -189,22 +189,16 @@ namespace osu.Game.Database
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
 
-                foreach (var beatmap in beatmaps)
+                foreach (BeatmapInfo beatmap in beatmaps)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    if (beatmap == null)
-                    {
-                        ++processedCount;
-                        continue;
-                    }
 
                     try
                     {
@@ -312,15 +306,15 @@ namespace osu.Game.Database
             Logger.Log($"Processing {processedCount} of {beatmapSetIds.Count} online beatmap sets completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void processBeatmapsWithMissingObjectCounts(int chunk_size = 500)
+        private void processBeatmapsWithMissingObjectCounts(int chunkSize = 500)
         {
             Logger.Log("Querying for beatmaps with missing hitobject counts to reprocess...");
 
             realmAccess.Run(r =>
             {
                 var beatmaps = r
-                 .All<BeatmapInfo>()
-                 .Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0);
+                               .All<BeatmapInfo>()
+                               .Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0);
 
                 int totalCount = beatmaps.Count();
                 int processedCount = 0;
@@ -340,19 +334,13 @@ namespace osu.Game.Database
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
 
-                    var beatmap = b?.Detach();
-
-                    if (beatmap == null)
-                    {
-                        ++processedCount;
-                        continue;
-                    }
+                    var beatmap = b.Detach();
 
                     try
                     {
@@ -385,20 +373,20 @@ namespace osu.Game.Database
             });
         }
 
-        private void processScoresWithMissingStatistics(int chunk_size = 1000)
+        private void processScoresWithMissingStatistics(int chunkSize = 1000)
         {
             Logger.Log("Querying for scores to reprocess...");
 
             realmAccess.Run(r =>
             {
                 var scores = r
-                 .All<ScoreInfo>()
-                 .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null)
-                 .AsEnumerable()
-                 // must be done after materialisation, as realm doesn't want to support
-                 // nested property predicates
-                 .Where(s => s.Statistics.Sum(kvp => kvp.Value) > 0
-                             && s.MaximumStatistics.Sum(kvp => kvp.Value) == 0);
+                             .All<ScoreInfo>()
+                             .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null)
+                             .AsEnumerable()
+                             // must be done after materialisation, as realm doesn't want to support
+                             // nested property predicates
+                             .Where(s => s.Statistics.Sum(kvp => kvp.Value) > 0
+                                         && s.MaximumStatistics.Sum(kvp => kvp.Value) == 0);
 
                 int totalCount = scores.Count();
                 int processedCount = 0;
@@ -418,17 +406,11 @@ namespace osu.Game.Database
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    if (score == null)
-                    {
-                        ++processedCount;
-                        continue;
-                    }
 
                     try
                     {
@@ -469,21 +451,21 @@ namespace osu.Game.Database
             });
         }
 
-        private void upgradeModMultipliers(int chunk_size = 500)
+        private void upgradeModMultipliers(int chunkSize = 500)
         {
             Logger.Log("Querying for scores that need mod multiplier upgrade...");
 
             realmAccess.Run(r =>
             {
                 var scores = r.All<ScoreInfo>()
-                 .Where(s => !s.BackgroundReprocessingFailed
-                             && s.BeatmapInfo != null
-                             && s.TotalScoreVersion < 30000017 // version number represents version with latest mod multiplier change
-                             && s.TotalScoreWithoutMods > 0)
-                 .AsEnumerable()
-                 // must be done after materialisation, as realm doesn't want to support
-                 // nested property predicates
-                 .Where(s => s.Ruleset.IsLegacyRuleset());
+                              .Where(s => !s.BackgroundReprocessingFailed
+                                          && s.BeatmapInfo != null
+                                          && s.TotalScoreVersion < 30000017 // version number represents version with latest mod multiplier change
+                                          && s.TotalScoreWithoutMods > 0)
+                              .AsEnumerable()
+                              // must be done after materialisation, as realm doesn't want to support
+                              // nested property predicates
+                              .Where(s => s.Ruleset.IsLegacyRuleset());
 
                 int totalCount = scores.Count();
                 int processedCount = 0;
@@ -503,15 +485,15 @@ namespace osu.Game.Database
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
 
-                    var score = s?.Detach();
+                    var score = s.Detach();
 
-                    if (score == null || score.BeatmapInfo == null)
+                    if (score.BeatmapInfo == null)
                     {
                         ++processedCount;
                         continue;
@@ -555,21 +537,21 @@ namespace osu.Game.Database
             });
         }
 
-        private void convertLegacyTotalScoreToStandardised(int chunk_size = 500)
+        private void convertLegacyTotalScoreToStandardised(int chunkSize = 500)
         {
             Logger.Log("Querying for scores that need total score conversion...");
 
             realmAccess.Run(r =>
             {
                 var scores = r.All<ScoreInfo>()
-                 .Where(s => !s.BackgroundReprocessingFailed
-                             && s.BeatmapInfo != null
-                             && s.IsLegacyScore
-                             && s.TotalScoreVersion < LegacyScoreEncoder.LATEST_VERSION)
-                 .AsEnumerable()
-                 // must be done after materialisation, as realm doesn't want to support
-                 // nested property predicates
-                 .Where(s => s.Ruleset.IsLegacyRuleset());
+                              .Where(s => !s.BackgroundReprocessingFailed
+                                          && s.BeatmapInfo != null
+                                          && s.IsLegacyScore
+                                          && s.TotalScoreVersion < LegacyScoreEncoder.LATEST_VERSION)
+                              .AsEnumerable()
+                              // must be done after materialisation, as realm doesn't want to support
+                              // nested property predicates
+                              .Where(s => s.Ruleset.IsLegacyRuleset());
 
                 int totalCount = scores.Count();
                 int processedCount = 0;
@@ -589,19 +571,13 @@ namespace osu.Game.Database
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
 
-                    var score = s?.Detach();
-
-                    if (score == null)
-                    {
-                        processedCount++;
-                        continue;
-                    }
+                    var score = s.Detach();
 
                     try
                     {
@@ -646,18 +622,18 @@ namespace osu.Game.Database
             });
         }
 
-        private void upgradeScoreRanks(int chunk_size = 3000)
+        private void upgradeScoreRanks(int chunkSize = 3000)
         {
             Logger.Log("Querying for scores that need rank upgrades...");
 
             realmAccess.Run(r =>
             {
                 var scores = r.All<ScoreInfo>()
-                 .Where(s => s.TotalScoreVersion < 30000013 && !s.BackgroundReprocessingFailed) // last total score version with a significant change to ranks
-                 .AsEnumerable()
-                 // must be done after materialisation, as realm doesn't support
-                 // filtering on nested property predicates or projection via `.Select()`
-                 .Where(s => s.Ruleset.IsLegacyRuleset());
+                              .Where(s => s.TotalScoreVersion < 30000013 && !s.BackgroundReprocessingFailed) // last total score version with a significant change to ranks
+                              .AsEnumerable()
+                              // must be done after materialisation, as realm doesn't support
+                              // filtering on nested property predicates or projection via `.Select()`
+                              .Where(s => s.Ruleset.IsLegacyRuleset());
 
                 int totalCount = scores.Count();
                 int processedCount = 0;
@@ -677,17 +653,11 @@ namespace osu.Game.Database
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    if (score == null)
-                    {
-                        processedCount++;
-                        continue;
-                    }
 
                     try
                     {
@@ -729,7 +699,7 @@ namespace osu.Game.Database
             });
         }
 
-        private void backpopulateMissingSubmissionAndRankDates(int chunk_size = 1000)
+        private void backpopulateMissingSubmissionAndRankDates(int chunkSize = 1000)
         {
             if (!localMetadataSource.Available)
             {
@@ -761,9 +731,9 @@ namespace osu.Game.Database
             realmAccess.Run(r =>
             {
                 var beatmapsSet = r.All<BeatmapSetInfo>()
-                 .Filter($@"{nameof(BeatmapSetInfo.StatusInt)} > 0 && ({nameof(BeatmapSetInfo.DateRanked)} == null || {nameof(BeatmapSetInfo.DateSubmitted)} == null) "
-                         + $@"&& ANY {nameof(BeatmapSetInfo.Beatmaps)}.{nameof(BeatmapInfo.StatusInt)} > 0")
-                 .AsEnumerable();
+                                   .Filter($@"{nameof(BeatmapSetInfo.StatusInt)} > 0 && ({nameof(BeatmapSetInfo.DateRanked)} == null || {nameof(BeatmapSetInfo.DateSubmitted)} == null) "
+                                           + $@"&& ANY {nameof(BeatmapSetInfo.Beatmaps)}.{nameof(BeatmapInfo.StatusInt)} > 0")
+                                   .AsEnumerable();
 
                 int totalCount = beatmapsSet.Count();
                 int processedCount = 0;
@@ -799,17 +769,11 @@ namespace osu.Game.Database
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    if (beatmapSet == null)
-                    {
-                        processedCount++;
-                        continue;
-                    }
 
                     try
                     {
@@ -857,7 +821,7 @@ namespace osu.Game.Database
             });
         }
 
-        private void backpopulateUserTags(int chunk_size = 2000)
+        private void backpopulateUserTags(int chunkSize = 2000)
         {
             if (!localMetadataSource.Available || !localMetadataSource.IsAtLeastVersion(3))
             {
@@ -892,8 +856,8 @@ namespace osu.Game.Database
             realmAccess.Run(r =>
             {
                 var beatmaps = r.All<BeatmapInfo>()
-                 .Filter($"{nameof(BeatmapInfo.StatusInt)} IN {{ 1,2,4 }}")
-                 .AsEnumerable();
+                                .Filter($"{nameof(BeatmapInfo.StatusInt)} IN {{ 1,2,4 }}")
+                                .AsEnumerable();
 
                 int totalCount = beatmaps.Count();
                 int processedCount = 0;
@@ -931,17 +895,11 @@ namespace osu.Game.Database
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
-                    if (actions.Count >= chunk_size) performWrite(actions);
+                    if (actions.Count >= chunkSize) performWrite(actions);
 
                     updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    if (beatmap == null)
-                    {
-                        processedCount++;
-                        continue;
-                    }
 
                     try
                     {

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Database
         /// from the <see cref="beatmapUpdater"/> firing online requests as part of the update.
         /// Star rating recalculations can be ran strictly locally.
         /// </remarks>
-        private void populateMissingStarRatings()
+        private void populateMissingStarRatings(int chunk_size = 500)
         {
             HashSet<Guid> beatmapIds = new HashSet<Guid>();
 
@@ -175,7 +175,6 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(beatmapIds.Count, "Reprocessing star rating for beatmaps", "beatmaps' star ratings have been updated");
 
-            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -316,7 +315,7 @@ namespace osu.Game.Database
             Logger.Log($"Processing {processedCount} of {beatmapSetIds.Count} online beatmapsets completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void processBeatmapsWithMissingObjectCounts()
+        private void processBeatmapsWithMissingObjectCounts(int chunk_size = 500)
         {
             Logger.Log("Querying for beatmaps with missing hitobject counts to reprocess...");
 
@@ -335,7 +334,6 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(beatmapIds.Count, "Populating missing statistics for beatmaps", "beatmaps have been populated with missing statistics");
 
-            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -394,7 +392,7 @@ namespace osu.Game.Database
             Logger.Log($"Processing {processedCount} of {beatmapIds.Count} beatmaps object counts completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void processScoresWithMissingStatistics()
+        private void processScoresWithMissingStatistics(int chunk_size = 1000)
         {
             HashSet<Guid> scoreIds = new HashSet<Guid>();
 
@@ -420,7 +418,6 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Populating missing statistics for scores", "scores have been populated with missing statistics");
 
-            const int chunk_size = 1000;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -487,7 +484,7 @@ namespace osu.Game.Database
             Logger.Log($"Processing {processedCount} of {scoreIds.Count} missing scores statistics completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void upgradeModMultipliers()
+        private void upgradeModMultipliers(int chunk_size = 500)
         {
             Logger.Log("Querying for scores that need mod multiplier upgrade...");
 
@@ -510,7 +507,6 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Upgrading scores to new mod multipliers", "scores have been upgraded to the new mod multipliers");
 
-            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -576,7 +572,7 @@ namespace osu.Game.Database
             Logger.Log($"Upgrading {processedCount} of {scoreIds.Count} scores to new mod multipliers completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void convertLegacyTotalScoreToStandardised()
+        private void convertLegacyTotalScoreToStandardised(int chunk_size = 500)
         {
             Logger.Log("Querying for scores that need total score conversion...");
 
@@ -599,7 +595,6 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Upgrading scores to new scoring algorithm", "scores have been upgraded to the new scoring algorithm");
 
-            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -670,7 +665,7 @@ namespace osu.Game.Database
             Logger.Log($"Converting totalScore {processedCount} of {scoreIds.Count} scores completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void upgradeScoreRanks()
+        private void upgradeScoreRanks(int chunk_size = 3000)
         {
             Logger.Log("Querying for scores that need rank upgrades...");
 
@@ -690,7 +685,6 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Adjusting ranks of scores", "scores now have more correct ranks.");
 
-            const int chunk_size = 3000;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -758,7 +752,7 @@ namespace osu.Game.Database
             Logger.Log($"Upgrading {processedCount} of {scoreIds.Count} score ranks completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void backpopulateMissingSubmissionAndRankDates()
+        private void backpopulateMissingSubmissionAndRankDates(int chunk_size = 1000)
         {
             if (!localMetadataSource.Available)
             {
@@ -801,7 +795,6 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(beatmapSetIds.Count, "Populating missing submission and rank dates", "beatmap sets now have correct submission and rank dates.");
 
-            const int chunk_size = 1000;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -891,7 +884,7 @@ namespace osu.Game.Database
             Logger.Log($"Populating {processedCount} of {beatmapSetIds.Count} missing submission and rank dates completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
-        private void backpopulateUserTags()
+        private void backpopulateUserTags(int chunk_size = 2000)
         {
             if (!localMetadataSource.Available || !localMetadataSource.IsAtLeastVersion(3))
             {
@@ -937,7 +930,6 @@ namespace osu.Game.Database
             var notification = showProgressNotification(beatmapIds.Count, @"Updating user tags",
                 @"beatmaps have had their tags updated. This runs once a month to allow searching user tags.");
 
-            const int chunk_size = 2000;
             int processedCount = 0;
             int updatedCount = 0;
             int failedCount = 0;

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Database
 
             ProcessingTask = Task.Factory.StartNew(() =>
             {
-                Logger.Log("Beginning background data store processing..");
+                Logger.Log("Beginning background data store processing...");
 
                 clearOutdatedStarRatings();
                 populateMissingStarRatings();
@@ -107,7 +107,7 @@ namespace osu.Game.Database
             {
                 if (t.Exception?.InnerException is ObjectDisposedException)
                 {
-                    Logger.Log("Finished background aborted during shutdown");
+                    Logger.Log("Background data store processing aborted during shutdown.");
                     return;
                 }
 
@@ -381,7 +381,7 @@ namespace osu.Game.Database
 
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
-                Logger.Log($"Processing {processedCount} of {totalCount} beatmaps object counts completed in {stopwatch.ElapsedMilliseconds}ms");
+                Logger.Log($"Processing {processedCount} of {totalCount} missing beatmaps hitobject counts completed in {stopwatch.ElapsedMilliseconds}ms");
             });
         }
 
@@ -642,7 +642,7 @@ namespace osu.Game.Database
 
                 completeNotification(notification, processedCount, totalCount, failedCount);
 
-                Logger.Log($"Converting totalScore {processedCount} of {totalCount} scores completed in {stopwatch.ElapsedMilliseconds}ms");
+                Logger.Log($"Converting total score {processedCount} of {totalCount} scores completed in {stopwatch.ElapsedMilliseconds}ms");
             });
         }
 
@@ -751,7 +751,7 @@ namespace osu.Game.Database
                 return;
             }
 
-            Logger.Log("Querying for beatmap sets that contain missing submission/rank date...");
+            Logger.Log("Querying for beatmap sets that contain missing submission/rank dates...");
 
             // find all ranked beatmap sets with missing date ranked or date submitted that have at least one difficulty ranked as well.
             // the reason for checking ranked status of the difficulties is that they can be locally modified or unknown too, and for those the lookup is likely to fail.
@@ -769,7 +769,7 @@ namespace osu.Game.Database
                 int processedCount = 0;
                 int failedCount = 0;
 
-                Logger.Log($"Found {totalCount} beatmap sets with missing submission/rank date.");
+                Logger.Log($"Found {totalCount} beatmap sets with missing submission/rank dates.");
 
                 if (totalCount == 0) return;
 
@@ -885,7 +885,7 @@ namespace osu.Game.Database
                 return;
             }
 
-            Logger.Log(@"Updating user tags");
+            Logger.Log("Querying for beatmap that has outdated user tags...");
 
             // while this is constrained to run every month or so (every time a new online.db cache is retrieved), there's some chance that this will still run much too often and be annoying to users.
             // if that turns out to be the case we may need a better way to debounce this (or just delete the backpopulation logic after some time has passed?)
@@ -900,7 +900,7 @@ namespace osu.Game.Database
                 int updatedCount = 0;
                 int failedCount = 0;
 
-                Logger.Log($@"Checking for tag updates for {totalCount} beatmaps.");
+                Logger.Log($"Found {totalCount} beatmaps with outdated user tags.");
 
                 if (totalCount == 0) return;
 

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -172,6 +173,7 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(beatmapIds.Count, "Reprocessing star rating for beatmaps", "beatmaps' star ratings have been updated");
 
+            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
@@ -188,44 +190,58 @@ namespace osu.Game.Database
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (Guid id in beatmapIds)
+            var actions = new List<Action<Realm>>();
+
+            realmAccess.Run(r =>
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
-
-                updateNotificationProgress(notification, processedCount, beatmapIds.Count);
-
-                sleepIfRequired();
-
-                var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
-
-                if (beatmap == null)
-                    return;
-
-                try
+                foreach (Guid id in beatmapIds)
                 {
-                    var working = beatmapManager.GetWorkingBeatmap(beatmap);
-                    var ruleset = getRuleset(working.BeatmapInfo.Ruleset);
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
 
-                    Debug.Assert(ruleset != null);
+                    if (actions.Count >= chunk_size) performWrite(actions);
 
-                    var calculator = ruleset.CreateDifficultyCalculator(working);
+                    updateNotificationProgress(notification, processedCount, beatmapIds.Count);
 
-                    double starRating = calculator.Calculate().StarRating;
-                    realmAccess.Write(r =>
+                    sleepIfRequired();
+
+                    var beatmap = r.Find<BeatmapInfo>(id);
+
+                    if (beatmap == null)
                     {
-                        if (r.Find<BeatmapInfo>(id) is BeatmapInfo liveBeatmapInfo)
-                            liveBeatmapInfo.StarRating = starRating;
-                    });
-                    ((IWorkingBeatmapCache)beatmapManager).Invalidate(beatmap);
-                    ++processedCount;
+                        ++processedCount;
+                        continue;
+                    }
+
+                    try
+                    {
+                        var working = beatmapManager.GetWorkingBeatmap(beatmap);
+                        var ruleset = getRuleset(working.BeatmapInfo.Ruleset);
+
+                        Debug.Assert(ruleset != null);
+
+                        var calculator = ruleset.CreateDifficultyCalculator(working);
+                        double starRating = calculator.Calculate().StarRating;
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<BeatmapInfo>(id)!;
+                            item.StarRating = starRating;
+
+                            ((IWorkingBeatmapCache)beatmapManager).Invalidate(item);
+                        });
+
+                        ++processedCount;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Background processing failed on {beatmap}: {e}");
+                        ++failedCount;
+                    }
                 }
-                catch (Exception e)
-                {
-                    Logger.Log($"Background processing failed on {beatmap}: {e}");
-                    ++failedCount;
-                }
-            }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
 
             completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
 
@@ -385,50 +401,69 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Populating missing statistics for scores", "scores have been populated with missing statistics");
 
+            const int chunk_size = 1000;
             int processedCount = 0;
             int failedCount = 0;
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (var id in scoreIds)
+            var actions = new List<Action<Realm>>();
+
+            realmAccess.Run(r =>
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
-
-                updateNotificationProgress(notification, processedCount, scoreIds.Count);
-
-                sleepIfRequired();
-
-                try
+                foreach (Guid id in scoreIds)
                 {
-                    var score = scoreManager.Query(s => s.ID == id);
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
 
-                    if (score != null)
+                    if (actions.Count >= chunk_size) performWrite(actions);
+
+                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+
+                    sleepIfRequired();
+
+                    var score = r.Find<ScoreInfo>(id)?.Detach();
+
+                    if (score == null)
                     {
-                        scoreManager.PopulateMaximumStatistics(score);
-
-                        // Can't use async overload because we're not on the update thread.
-                        // ReSharper disable once MethodHasAsyncOverload
-                        realmAccess.Write(r =>
-                        {
-                            r.Find<ScoreInfo>(id)!.MaximumStatisticsJson = JsonConvert.SerializeObject(score.MaximumStatistics);
-                        });
+                        ++processedCount;
+                        continue;
                     }
 
-                    ++processedCount;
+                    try
+                    {
+                        scoreManager.PopulateMaximumStatistics(score);
+                        string maximumStatisticsJson = JsonConvert.SerializeObject(score.MaximumStatistics);
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+                            item.MaximumStatisticsJson = maximumStatisticsJson;
+                        });
+
+                        ++processedCount;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log(@$"Failed to populate maximum statistics for {id}: {e}");
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+                            item.BackgroundReprocessingFailed = true;
+                        });
+
+                        ++failedCount;
+                    }
                 }
-                catch (ObjectDisposedException)
-                {
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log(@$"Failed to populate maximum statistics for {id}: {e}");
-                    realmAccess.Write(r => r.Find<ScoreInfo>(id)!.BackgroundReprocessingFailed = true);
-                    ++failedCount;
-                }
-            }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
 
             completeNotification(notification, processedCount, scoreIds.Count, failedCount);
 
@@ -524,45 +559,73 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Upgrading scores to new scoring algorithm", "scores have been upgraded to the new scoring algorithm");
 
+            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (var id in scoreIds)
+            var actions = new List<Action<Realm>>();
+
+            realmAccess.Run(r =>
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
-
-                updateNotificationProgress(notification, processedCount, scoreIds.Count);
-
-                sleepIfRequired();
-
-                try
+                foreach (Guid id in scoreIds)
                 {
-                    // Can't use async overload because we're not on the update thread.
-                    // ReSharper disable once MethodHasAsyncOverload
-                    realmAccess.Write(r =>
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
+
+                    if (actions.Count >= chunk_size) performWrite(actions);
+
+                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+
+                    sleepIfRequired();
+
+                    var score = r.Find<ScoreInfo>(id)?.Detach();
+
+                    if (score == null)
                     {
-                        ScoreInfo s = r.Find<ScoreInfo>(id)!;
-                        StandardisedScoreMigrationTools.UpdateFromLegacy(s, beatmapManager.GetWorkingBeatmap(s.BeatmapInfo));
-                        s.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
-                    });
+                        processedCount++;
+                        continue;
+                    }
 
-                    ++processedCount;
+                    try
+                    {
+                        StandardisedScoreMigrationTools.UpdateFromLegacy(score, beatmapManager.GetWorkingBeatmap(score.BeatmapInfo));
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+
+                            item.Accuracy = score.Accuracy;
+                            item.Rank = score.Rank;
+                            item.TotalScore = score.TotalScore;
+                            item.TotalScoreWithoutMods = score.TotalScoreWithoutMods;
+                            item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
+                        });
+
+                        ++processedCount;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Failed to convert total score for {id}: {e}");
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+                            item.BackgroundReprocessingFailed = true;
+                        });
+
+                        ++failedCount;
+                    }
                 }
-                catch (ObjectDisposedException)
-                {
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log($"Failed to convert total score for {id}: {e}");
-                    realmAccess.Write(r => r.Find<ScoreInfo>(id)!.BackgroundReprocessingFailed = true);
-                    ++failedCount;
-                }
-            }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
 
             completeNotification(notification, processedCount, scoreIds.Count, failedCount);
 
@@ -589,45 +652,70 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(scoreIds.Count, "Adjusting ranks of scores", "scores now have more correct ranks.");
 
+            const int chunk_size = 3000;
             int processedCount = 0;
             int failedCount = 0;
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (var id in scoreIds)
+            var actions = new List<Action<Realm>>();
+
+            realmAccess.Run(r =>
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
-
-                updateNotificationProgress(notification, processedCount, scoreIds.Count);
-
-                sleepIfRequired();
-
-                try
+                foreach (Guid id in scoreIds)
                 {
-                    // Can't use async overload because we're not on the update thread.
-                    // ReSharper disable once MethodHasAsyncOverload
-                    realmAccess.Write(r =>
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
+
+                    if (actions.Count >= chunk_size) performWrite(actions);
+
+                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+
+                    sleepIfRequired();
+
+                    var score = r.Find<ScoreInfo>(id);
+
+                    if (score == null)
                     {
-                        ScoreInfo s = r.Find<ScoreInfo>(id)!;
-                        s.Rank = StandardisedScoreMigrationTools.ComputeRank(s);
-                        s.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
-                    });
+                        processedCount++;
+                        continue;
+                    }
 
-                    ++processedCount;
+                    try
+                    {
+                        var rank = StandardisedScoreMigrationTools.ComputeRank(score);
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+
+                            item.Rank = rank;
+                            item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
+                        });
+
+                        ++processedCount;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Failed to update rank score {id}: {e}");
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<ScoreInfo>(id)!;
+                            item.BackgroundReprocessingFailed = true;
+                        });
+
+                        ++failedCount;
+                    }
                 }
-                catch (ObjectDisposedException)
-                {
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log($"Failed to update rank score {id}: {e}");
-                    realmAccess.Write(r => r.Find<ScoreInfo>(id)!.BackgroundReprocessingFailed = true);
-                    ++failedCount;
-                }
-            }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
 
             completeNotification(notification, processedCount, scoreIds.Count, failedCount);
 
@@ -677,60 +765,92 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(beatmapSetIds.Count, "Populating missing submission and rank dates", "beatmap sets now have correct submission and rank dates.");
 
+            const int chunk_size = 1000;
             int processedCount = 0;
             int failedCount = 0;
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (var id in beatmapSetIds)
+            SqliteConnection sqliteConnection;
+            int sqliteVersion;
+
+            try
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
+                sqliteConnection = localMetadataSource.GetConnection();
+                sqliteConnection.Open();
 
-                updateNotificationProgress(notification, processedCount, beatmapSetIds.Count);
+                sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Could not open sqlite database: {ex}");
+                return;
+            }
 
-                sleepIfRequired();
+            var actions = new List<Action<Realm>>();
 
-                try
+            realmAccess.Run(r =>
+            {
+                foreach (Guid id in beatmapSetIds)
                 {
-                    // Can't use async overload because we're not on the update thread.
-                    // ReSharper disable once MethodHasAsyncOverload
-                    bool succeeded = realmAccess.Write(r =>
-                    {
-                        BeatmapSetInfo beatmapSet = r.Find<BeatmapSetInfo>(id)!;
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
 
+                    if (actions.Count >= chunk_size) performWrite(actions);
+
+                    updateNotificationProgress(notification, processedCount, beatmapSetIds.Count);
+
+                    sleepIfRequired();
+
+                    var beatmapSet = r.Find<BeatmapSetInfo>(id);
+
+                    if (beatmapSet == null)
+                    {
+                        processedCount++;
+                        continue;
+                    }
+
+                    try
+                    {
                         var beatmap = beatmapSet.Beatmaps.First(b => b.Status >= BeatmapOnlineStatus.Ranked);
 
-                        bool lookupSucceeded = localMetadataSource.TryLookup(beatmap, out var result);
+                        bool lookupSucceeded = localMetadataSource.TryLookup(sqliteConnection, sqliteVersion, beatmap, out var result);
 
-                        if (lookupSucceeded)
+                        if (!lookupSucceeded)
                         {
-                            Debug.Assert(result != null);
-                            beatmapSet.DateRanked = result.DateRanked;
-                            beatmapSet.DateSubmitted = result.DateSubmitted;
-                            return true;
+                            Logger.Log($"Could not find {beatmapSet.GetDisplayString()} in local cache while backpopulating missing submission/rank date");
+                            ++failedCount;
+
+                            continue;
                         }
 
-                        Logger.Log($"Could not find {beatmapSet.GetDisplayString()} in local cache while backpopulating missing submission/rank date");
-                        return false;
-                    });
+                        Debug.Assert(result != null);
 
-                    if (succeeded)
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<BeatmapSetInfo>(id)!;
+
+                            item.DateRanked = result.DateRanked;
+                            item.DateSubmitted = result.DateSubmitted;
+                        });
+
                         ++processedCount;
-                    else
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Failed to update ranked/submitted dates for beatmap set {id}: {e}");
                         ++failedCount;
+                    }
                 }
-                catch (ObjectDisposedException)
-                {
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log($"Failed to update ranked/submitted dates for beatmap set {id}: {e}");
-                    ++failedCount;
-                }
-            }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
+            sqliteConnection.Close();
 
             completeNotification(notification, processedCount, beatmapSetIds.Count, failedCount);
 
@@ -783,6 +903,7 @@ namespace osu.Game.Database
             var notification = showProgressNotification(beatmapIds.Count, @"Updating user tags",
                 @"beatmaps have had their tags updated. This runs once a month to allow searching user tags.");
 
+            const int chunk_size = 2000;
             int processedCount = 0;
             int updatedCount = 0;
             int failedCount = 0;
@@ -790,61 +911,92 @@ namespace osu.Game.Database
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (var id in beatmapIds)
+            var actions = new List<Action<Realm>>();
+
+            SqliteConnection sqliteConnection;
+            int sqliteVersion;
+
+            try
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
+                sqliteConnection = localMetadataSource.GetConnection();
+                sqliteConnection.Open();
 
-                updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+                sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Could not open sqlite database: {ex}");
+                return;
+            }
 
-                sleepIfRequired();
-
-                try
+            realmAccess.Run(r =>
+            {
+                foreach (Guid id in beatmapIds)
                 {
-                    var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
 
-                    if (beatmap == null) continue;
+                    if (actions.Count >= chunk_size) performWrite(actions);
 
-                    bool lookupSucceeded = localMetadataSource.TryLookup(beatmap, out var result);
+                    updateNotificationProgress(notification, processedCount, beatmapIds.Count);
 
-                    if (lookupSucceeded)
+                    sleepIfRequired();
+
+                    var beatmap = r.Find<BeatmapInfo>(id);
+
+                    if (beatmap == null)
                     {
+                        processedCount++;
+                        continue;
+                    }
+
+                    try
+                    {
+                        bool lookupSucceeded = localMetadataSource.TryLookup(sqliteConnection, sqliteVersion, beatmap, out var result);
+
+                        if (!lookupSucceeded)
+                        {
+                            Logger.Log(@$"Could not find {beatmap.GetDisplayString()} in local cache while backpopulating missing user tags");
+                            ++processedCount;
+
+                            continue;
+                        }
+
                         Debug.Assert(result != null);
 
-                        HashSet<string> userTags = result.UserTags.ToHashSet();
+                        var userTags = result.UserTags.ToHashSet();
 
-                        if (!userTags.SetEquals(beatmap.Metadata.UserTags))
+                        if (userTags.SetEquals(beatmap.Metadata.UserTags))
                         {
-                            ++updatedCount;
-                            realmAccess.Write(r =>
-                            {
-                                beatmap = r.Find<BeatmapInfo>(id);
-
-                                if (beatmap == null)
-                                    return;
-
-                                beatmap.Metadata.UserTags.Clear();
-                                beatmap.Metadata.UserTags.AddRange(userTags);
-                            });
+                            ++processedCount;
+                            continue;
                         }
-                    }
-                    else
-                    {
-                        Logger.Log(@$"Could not find {beatmap.GetDisplayString()} in local cache while backpopulating missing user tags");
-                    }
 
-                    ++processedCount;
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<BeatmapInfo>(id)!;
+
+                            item.Metadata.UserTags.Clear();
+                            item.Metadata.UserTags.AddRange(userTags);
+                        });
+
+                        ++processedCount;
+                        ++updatedCount;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log(@$"Failed to update user tags for beatmap {id}: {e}");
+                        ++failedCount;
+                    }
                 }
-                catch (ObjectDisposedException)
-                {
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log(@$"Failed to update user tags for beatmap {id}: {e}");
-                    ++failedCount;
-                }
-            }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
+            sqliteConnection.Close();
 
             // Report the updated item count rather than the total processed. Users don't really care about noops here.
             completeNotification(notification, updatedCount, updatedCount, failedCount);
@@ -852,6 +1004,12 @@ namespace osu.Game.Database
             config.SetValue(OsuSetting.LastOnlineTagsPopulation, metadataSourceFetchDate);
 
             Logger.Log($"Populating {processedCount} of {beatmapIds.Count} beatmap user tags completed in {stopwatch.ElapsedMilliseconds}ms");
+        }
+
+        private void performWrite(List<Action<Realm>> actions)
+        {
+            realmAccess.BulkWrite(actions);
+            actions.Clear();
         }
 
         private void updateNotificationProgress(ProgressNotification? notification, int processedCount, int totalCount)

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -335,40 +335,61 @@ namespace osu.Game.Database
 
             var notification = showProgressNotification(beatmapIds.Count, "Populating missing statistics for beatmaps", "beatmaps have been populated with missing statistics");
 
+            const int chunk_size = 500;
             int processedCount = 0;
             int failedCount = 0;
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (var id in beatmapIds)
+            var actions = new List<Action<Realm>>();
+
+            realmAccess.Run(r =>
             {
-                if (notification?.State == ProgressNotificationState.Cancelled)
-                    break;
-
-                updateNotificationProgress(notification, processedCount, beatmapIds.Count);
-
-                sleepIfRequired();
-
-                realmAccess.Run(r =>
+                foreach (Guid id in beatmapIds)
                 {
-                    var beatmap = r.Find<BeatmapInfo>(id);
+                    if (notification?.State == ProgressNotificationState.Cancelled)
+                        break;
 
-                    if (beatmap != null)
+                    if (actions.Count >= chunk_size) performWrite(actions);
+
+                    updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+
+                    sleepIfRequired();
+
+                    var beatmap = r.Find<BeatmapInfo>(id)?.Detach();
+
+                    if (beatmap == null)
                     {
-                        try
-                        {
-                            beatmapUpdater.ProcessObjectCounts(beatmap);
-                            ++processedCount;
-                        }
-                        catch (Exception e)
-                        {
-                            Logger.Log($"Background processing failed on {beatmap}: {e}");
-                            ++failedCount;
-                        }
+                        ++processedCount;
+                        continue;
                     }
-                });
-            }
+
+                    try
+                    {
+                        beatmapUpdater.ProcessObjectCounts(beatmap);
+
+                        actions.Add(realm =>
+                        {
+                            var item = realm.Find<BeatmapInfo>(id)!;
+
+                            item.TotalObjectCount = beatmap.TotalObjectCount;
+                            item.EndTimeObjectCount = beatmap.EndTimeObjectCount;
+
+                            ((IWorkingBeatmapCache)beatmapManager).Invalidate(item);
+                        });
+
+                        ++processedCount;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log($"Background processing failed on {beatmap}: {e}");
+                        ++failedCount;
+                    }
+                }
+            });
+
+            if (actions.Count > 0) performWrite(actions);
 
             completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
 

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -158,53 +158,47 @@ namespace osu.Game.Database
         /// </remarks>
         private void populateMissingStarRatings(int chunk_size = 500)
         {
-            HashSet<Guid> beatmapIds = new HashSet<Guid>();
-
             Logger.Log("Querying for beatmaps with missing star ratings...");
 
             realmAccess.Run(r =>
             {
-                foreach (var b in r.All<BeatmapInfo>().Where(b => b.StarRating < 0 && b.BeatmapSet != null))
-                    beatmapIds.Add(b.ID);
-            });
+                var beatmaps = r
+                 .All<BeatmapInfo>()
+                 .Where(b => b.StarRating < 0 && b.BeatmapSet != null);
 
-            if (beatmapIds.Count == 0)
-                return;
+                int totalCount = beatmaps.Count();
+                int processedCount = 0;
+                int failedCount = 0;
 
-            Logger.Log($"Found {beatmapIds.Count} beatmaps which require star rating reprocessing.");
+                Logger.Log($"Found {totalCount} beatmaps which require star rating reprocessing.");
 
-            var notification = showProgressNotification(beatmapIds.Count, "Reprocessing star rating for beatmaps", "beatmaps' star ratings have been updated");
+                if (totalCount == 0) return;
 
-            int processedCount = 0;
-            int failedCount = 0;
+                var notification = showProgressNotification(totalCount, "Reprocessing star rating for beatmaps", "beatmaps' star ratings have been updated");
 
-            Dictionary<string, Ruleset> rulesetCache = new Dictionary<string, Ruleset>();
+                Dictionary<string, Ruleset> rulesetCache = new Dictionary<string, Ruleset>();
 
-            Ruleset getRuleset(RulesetInfo rulesetInfo)
-            {
-                if (!rulesetCache.TryGetValue(rulesetInfo.ShortName, out var ruleset))
-                    ruleset = rulesetCache[rulesetInfo.ShortName] = rulesetInfo.CreateInstance();
+                Ruleset getRuleset(RulesetInfo rulesetInfo)
+                {
+                    if (!rulesetCache.TryGetValue(rulesetInfo.ShortName, out var ruleset))
+                        ruleset = rulesetCache[rulesetInfo.ShortName] = rulesetInfo.CreateInstance();
 
-                return ruleset;
-            }
+                    return ruleset;
+                }
 
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
 
-            realmAccess.Run(r =>
-            {
-                foreach (Guid id in beatmapIds)
+                foreach (var beatmap in beatmaps)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    var beatmap = r.Find<BeatmapInfo>(id);
 
                     if (beatmap == null)
                     {
@@ -224,7 +218,7 @@ namespace osu.Game.Database
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<BeatmapInfo>(id)!;
+                            var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
                             item.StarRating = starRating;
 
                             ((IWorkingBeatmapCache)beatmapManager).Invalidate(item);
@@ -234,44 +228,47 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log($"Background processing failed on {beatmap}: {e}");
+                        Logger.Log($"Background processing failed on beatmap {beatmap.ID}: {e}");
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+
+                completeNotification(notification, processedCount, totalCount, failedCount);
+
+                Logger.Log($"Populating {processedCount} of {totalCount} missing star ratings completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-
-            completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
-
-            Logger.Log($"Populating {processedCount} of {beatmapIds.Count} missing star ratings completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void processOnlineBeatmapSetsWithNoUpdate()
         {
+            // BeatmapProcessor is responsible for both online and local processing.
+            // In the case a user isn't logged in, it won't update LastOnlineUpdate and therefore re-queue,
+            // causing overhead from the non-online processing to redundantly run every startup.
+            //
+            // We may eventually consider making the Process call more specific (or avoid this in any number
+            // of other possible ways), but for now avoid queueing if the user isn't logged in at startup.
+            if (!api.IsLoggedIn)
+            {
+                Logger.Log("Not logged in for beatmap sets to reprocess...");
+                return;
+            }
+
             HashSet<Guid> beatmapSetIds = new HashSet<Guid>();
 
             Logger.Log("Querying for beatmap sets to reprocess...");
 
             realmAccess.Run(r =>
             {
-                // BeatmapProcessor is responsible for both online and local processing.
-                // In the case a user isn't logged in, it won't update LastOnlineUpdate and therefore re-queue,
-                // causing overhead from the non-online processing to redundantly run every startup.
-                //
-                // We may eventually consider making the Process call more specific (or avoid this in any number
-                // of other possible ways), but for now avoid queueing if the user isn't logged in at startup.
-                if (api.IsLoggedIn)
-                {
-                    foreach (var b in r.All<BeatmapInfo>().Where(b => b.OnlineID > 0 && b.LastOnlineUpdate == null && b.BeatmapSet != null))
-                        beatmapSetIds.Add(b.BeatmapSet!.ID);
-                }
+                foreach (var b in r.All<BeatmapInfo>().Where(b => b.OnlineID > 0 && b.LastOnlineUpdate == null && b.BeatmapSet != null))
+                    beatmapSetIds.Add(b.BeatmapSet!.ID);
             });
+
+            Logger.Log($"Found {beatmapSetIds.Count} beatmap sets which require online updates.");
 
             if (beatmapSetIds.Count == 0)
                 return;
-
-            Logger.Log($"Found {beatmapSetIds.Count} beatmap sets which require online updates.");
 
             var notification = showProgressNotification(beatmapSetIds.Count, "Updating online data for beatmaps", "beatmaps' online data have been updated");
 
@@ -281,7 +278,7 @@ namespace osu.Game.Database
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach (var id in beatmapSetIds)
+            foreach (Guid id in beatmapSetIds)
             {
                 if (notification?.State == ProgressNotificationState.Cancelled)
                     break;
@@ -303,7 +300,7 @@ namespace osu.Game.Database
                         }
                         catch (Exception e)
                         {
-                            Logger.Log($"Background processing failed on {set}: {e}");
+                            Logger.Log($"Background processing failed on beatmap set {id}: {e}");
                             ++failedCount;
                         }
                     }
@@ -312,48 +309,44 @@ namespace osu.Game.Database
 
             completeNotification(notification, processedCount, beatmapSetIds.Count, failedCount);
 
-            Logger.Log($"Processing {processedCount} of {beatmapSetIds.Count} online beatmapsets completed in {stopwatch.ElapsedMilliseconds}ms");
+            Logger.Log($"Processing {processedCount} of {beatmapSetIds.Count} online beatmap sets completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void processBeatmapsWithMissingObjectCounts(int chunk_size = 500)
         {
             Logger.Log("Querying for beatmaps with missing hitobject counts to reprocess...");
 
-            HashSet<Guid> beatmapIds = new HashSet<Guid>();
-
             realmAccess.Run(r =>
             {
-                foreach (var b in r.All<BeatmapInfo>().Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0))
-                    beatmapIds.Add(b.ID);
-            });
+                var beatmaps = r
+                 .All<BeatmapInfo>()
+                 .Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0);
 
-            if (beatmapIds.Count == 0)
-                return;
+                int totalCount = beatmaps.Count();
+                int processedCount = 0;
+                int failedCount = 0;
 
-            Logger.Log($"Found {beatmapIds.Count} beatmaps which require statistics population.");
+                Logger.Log($"Found {totalCount} beatmaps which require statistics population.");
 
-            var notification = showProgressNotification(beatmapIds.Count, "Populating missing statistics for beatmaps", "beatmaps have been populated with missing statistics");
+                if (totalCount == 0) return;
 
-            int processedCount = 0;
-            int failedCount = 0;
+                var notification = showProgressNotification(totalCount, "Populating missing statistics for beatmaps", "beatmaps have been populated with missing statistics");
 
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
 
-            realmAccess.Run(r =>
-            {
-                foreach (Guid id in beatmapIds)
+                foreach (var b in beatmaps)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
 
-                    var beatmap = r.Find<BeatmapInfo>(id)?.Detach();
+                    var beatmap = b?.Detach();
 
                     if (beatmap == null)
                     {
@@ -367,7 +360,7 @@ namespace osu.Game.Database
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<BeatmapInfo>(id)!;
+                            var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
 
                             item.TotalObjectCount = beatmap.TotalObjectCount;
                             item.EndTimeObjectCount = beatmap.EndTimeObjectCount;
@@ -379,65 +372,57 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log($"Background processing failed on {beatmap}: {e}");
+                        Logger.Log($"Background processing failed on beatmap {beatmap.ID}: {e}");
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+
+                completeNotification(notification, processedCount, totalCount, failedCount);
+
+                Logger.Log($"Processing {processedCount} of {totalCount} beatmaps object counts completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-
-            completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
-
-            Logger.Log($"Processing {processedCount} of {beatmapIds.Count} beatmaps object counts completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void processScoresWithMissingStatistics(int chunk_size = 1000)
         {
-            HashSet<Guid> scoreIds = new HashSet<Guid>();
-
             Logger.Log("Querying for scores to reprocess...");
 
             realmAccess.Run(r =>
             {
-                foreach (var score in r.All<ScoreInfo>().Where(s => !s.BackgroundReprocessingFailed))
-                {
-                    if (score.BeatmapInfo != null
-                        && score.Statistics.Sum(kvp => kvp.Value) > 0
-                        && score.MaximumStatistics.Sum(kvp => kvp.Value) == 0)
-                    {
-                        scoreIds.Add(score.ID);
-                    }
-                }
-            });
+                var scores = r
+                 .All<ScoreInfo>()
+                 .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null)
+                 .AsEnumerable()
+                 // must be done after materialisation, as realm doesn't want to support
+                 // nested property predicates
+                 .Where(s => s.Statistics.Sum(kvp => kvp.Value) > 0
+                             && s.MaximumStatistics.Sum(kvp => kvp.Value) == 0);
 
-            if (scoreIds.Count == 0)
-                return;
+                int totalCount = scores.Count();
+                int processedCount = 0;
+                int failedCount = 0;
 
-            Logger.Log($"Found {scoreIds.Count} scores which require statistics population.");
+                Logger.Log($"Found {totalCount} scores which require statistics population.");
 
-            var notification = showProgressNotification(scoreIds.Count, "Populating missing statistics for scores", "scores have been populated with missing statistics");
+                if (totalCount == 0) return;
 
-            int processedCount = 0;
-            int failedCount = 0;
+                var notification = showProgressNotification(totalCount, "Populating missing statistics for scores", "scores have been populated with missing statistics");
 
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
 
-            realmAccess.Run(r =>
-            {
-                foreach (Guid id in scoreIds)
+                foreach (var score in scores)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    var score = r.Find<ScoreInfo>(id)?.Detach();
 
                     if (score == null)
                     {
@@ -452,7 +437,7 @@ namespace osu.Game.Database
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
                             item.MaximumStatisticsJson = maximumStatisticsJson;
                         });
 
@@ -464,32 +449,33 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log(@$"Failed to populate maximum statistics for {id}: {e}");
+                        Logger.Log(@$"Failed to populate maximum statistics for {score.ID}: {e}");
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
                             item.BackgroundReprocessingFailed = true;
                         });
 
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+
+                completeNotification(notification, processedCount, totalCount, failedCount);
+
+                Logger.Log($"Processing {processedCount} of {totalCount} missing scores statistics completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-
-            completeNotification(notification, processedCount, scoreIds.Count, failedCount);
-
-            Logger.Log($"Processing {processedCount} of {scoreIds.Count} missing scores statistics completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void upgradeModMultipliers(int chunk_size = 500)
         {
             Logger.Log("Querying for scores that need mod multiplier upgrade...");
 
-            HashSet<Guid> scoreIds = realmAccess.Run(r => new HashSet<Guid>(
-                r.All<ScoreInfo>()
+            realmAccess.Run(r =>
+            {
+                var scores = r.All<ScoreInfo>()
                  .Where(s => !s.BackgroundReprocessingFailed
                              && s.BeatmapInfo != null
                              && s.TotalScoreVersion < 30000017 // version number represents version with latest mod multiplier change
@@ -497,36 +483,33 @@ namespace osu.Game.Database
                  .AsEnumerable()
                  // must be done after materialisation, as realm doesn't want to support
                  // nested property predicates
-                 .Where(s => s.Ruleset.IsLegacyRuleset())
-                 .Select(s => s.ID)));
+                 .Where(s => s.Ruleset.IsLegacyRuleset());
 
-            Logger.Log($"Found {scoreIds.Count} scores which require mod multiplier upgrade.");
+                int totalCount = scores.Count();
+                int processedCount = 0;
+                int failedCount = 0;
 
-            if (scoreIds.Count == 0)
-                return;
+                Logger.Log($"Found {totalCount} scores which require mod multiplier upgrade.");
 
-            var notification = showProgressNotification(scoreIds.Count, "Upgrading scores to new mod multipliers", "scores have been upgraded to the new mod multipliers");
+                if (totalCount == 0) return;
 
-            int processedCount = 0;
-            int failedCount = 0;
+                var notification = showProgressNotification(totalCount, "Upgrading scores to new mod multipliers", "scores have been upgraded to the new mod multipliers");
 
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
 
-            realmAccess.Run(r =>
-            {
-                foreach (Guid id in scoreIds)
+                foreach (var s in scores)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
 
-                    var score = r.Find<ScoreInfo>(id)?.Detach();
+                    var score = s?.Detach();
 
                     if (score == null || score.BeatmapInfo == null)
                     {
@@ -539,7 +522,7 @@ namespace osu.Game.Database
                         StandardisedScoreMigrationTools.UpdateToLatestScoreMultipliers(score, score.BeatmapInfo.Difficulty);
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
                             item.TotalScore = score.TotalScore;
                             item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
                         });
@@ -552,32 +535,33 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log($"Failed to upgrade mod multipliers for {id}: {e}");
+                        Logger.Log($"Failed to upgrade mod multipliers for {score.ID}: {e}");
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
                             item.BackgroundReprocessingFailed = true;
                         });
 
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+
+                completeNotification(notification, processedCount, totalCount, failedCount);
+
+                Logger.Log($"Upgrading {processedCount} of {totalCount} scores to new mod multipliers completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-
-            completeNotification(notification, processedCount, scoreIds.Count, failedCount);
-
-            Logger.Log($"Upgrading {processedCount} of {scoreIds.Count} scores to new mod multipliers completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void convertLegacyTotalScoreToStandardised(int chunk_size = 500)
         {
             Logger.Log("Querying for scores that need total score conversion...");
 
-            HashSet<Guid> scoreIds = realmAccess.Run(r => new HashSet<Guid>(
-                r.All<ScoreInfo>()
+            realmAccess.Run(r =>
+            {
+                var scores = r.All<ScoreInfo>()
                  .Where(s => !s.BackgroundReprocessingFailed
                              && s.BeatmapInfo != null
                              && s.IsLegacyScore
@@ -585,36 +569,33 @@ namespace osu.Game.Database
                  .AsEnumerable()
                  // must be done after materialisation, as realm doesn't want to support
                  // nested property predicates
-                 .Where(s => s.Ruleset.IsLegacyRuleset())
-                 .Select(s => s.ID)));
+                 .Where(s => s.Ruleset.IsLegacyRuleset());
 
-            Logger.Log($"Found {scoreIds.Count} scores which require total score conversion.");
+                int totalCount = scores.Count();
+                int processedCount = 0;
+                int failedCount = 0;
 
-            if (scoreIds.Count == 0)
-                return;
+                Logger.Log($"Found {totalCount} scores which require total score conversion.");
 
-            var notification = showProgressNotification(scoreIds.Count, "Upgrading scores to new scoring algorithm", "scores have been upgraded to the new scoring algorithm");
+                if (totalCount == 0) return;
 
-            int processedCount = 0;
-            int failedCount = 0;
+                var notification = showProgressNotification(totalCount, "Upgrading scores to new scoring algorithm", "scores have been upgraded to the new scoring algorithm");
 
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
 
-            realmAccess.Run(r =>
-            {
-                foreach (Guid id in scoreIds)
+                foreach (var s in scores)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
 
-                    var score = r.Find<ScoreInfo>(id)?.Detach();
+                    var score = s?.Detach();
 
                     if (score == null)
                     {
@@ -628,7 +609,7 @@ namespace osu.Game.Database
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
 
                             item.Accuracy = score.Accuracy;
                             item.Rank = score.Rank;
@@ -645,66 +626,62 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log($"Failed to convert total score for {id}: {e}");
+                        Logger.Log($"Failed to convert total score for {score.ID}: {e}");
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
                             item.BackgroundReprocessingFailed = true;
                         });
 
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+
+                completeNotification(notification, processedCount, totalCount, failedCount);
+
+                Logger.Log($"Converting totalScore {processedCount} of {totalCount} scores completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-
-            completeNotification(notification, processedCount, scoreIds.Count, failedCount);
-
-            Logger.Log($"Converting totalScore {processedCount} of {scoreIds.Count} scores completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void upgradeScoreRanks(int chunk_size = 3000)
         {
             Logger.Log("Querying for scores that need rank upgrades...");
 
-            HashSet<Guid> scoreIds = realmAccess.Run(r => new HashSet<Guid>(
-                r.All<ScoreInfo>()
+            realmAccess.Run(r =>
+            {
+                var scores = r.All<ScoreInfo>()
                  .Where(s => s.TotalScoreVersion < 30000013 && !s.BackgroundReprocessingFailed) // last total score version with a significant change to ranks
                  .AsEnumerable()
                  // must be done after materialisation, as realm doesn't support
                  // filtering on nested property predicates or projection via `.Select()`
-                 .Where(s => s.Ruleset.IsLegacyRuleset())
-                 .Select(s => s.ID)));
+                 .Where(s => s.Ruleset.IsLegacyRuleset());
 
-            Logger.Log($"Found {scoreIds.Count} scores which require rank upgrades.");
+                int totalCount = scores.Count();
+                int processedCount = 0;
+                int failedCount = 0;
 
-            if (scoreIds.Count == 0)
-                return;
+                Logger.Log($"Found {totalCount} scores which require rank upgrades.");
 
-            var notification = showProgressNotification(scoreIds.Count, "Adjusting ranks of scores", "scores now have more correct ranks.");
+                if (totalCount == 0) return;
 
-            int processedCount = 0;
-            int failedCount = 0;
+                var notification = showProgressNotification(totalCount, "Adjusting ranks of scores", "scores now have more correct ranks.");
 
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
 
-            realmAccess.Run(r =>
-            {
-                foreach (Guid id in scoreIds)
+                foreach (var score in scores)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, scoreIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    var score = r.Find<ScoreInfo>(id);
 
                     if (score == null)
                     {
@@ -718,7 +695,7 @@ namespace osu.Game.Database
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
 
                             item.Rank = rank;
                             item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
@@ -732,24 +709,24 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log($"Failed to update rank score {id}: {e}");
+                        Logger.Log($"Failed to update score rank {score.ID}: {e}");
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<ScoreInfo>(id)!;
+                            var item = realm.Find<ScoreInfo>(score.ID)!;
                             item.BackgroundReprocessingFailed = true;
                         });
 
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+
+                completeNotification(notification, processedCount, totalCount, failedCount);
+
+                Logger.Log($"Upgrading {processedCount} of {totalCount} score ranks completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-
-            completeNotification(notification, processedCount, scoreIds.Count, failedCount);
-
-            Logger.Log($"Upgrading {processedCount} of {scoreIds.Count} score ranks completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void backpopulateMissingSubmissionAndRankDates(int chunk_size = 1000)
@@ -781,56 +758,52 @@ namespace osu.Game.Database
             // this is because metadata lookups are primarily based on file hash, so they will fail to match if the beatmap does not match the online version
             // (which is likely to be the case if the beatmap is locally modified or unknown).
             // that said, one difficulty in ranked state is enough for the backpopulation to work.
-            HashSet<Guid> beatmapSetIds = realmAccess.Run(r => new HashSet<Guid>(
-                r.All<BeatmapSetInfo>()
-                 .Filter($@"{nameof(BeatmapSetInfo.StatusInt)} > 0 && ({nameof(BeatmapSetInfo.DateRanked)} == null || {nameof(BeatmapSetInfo.DateSubmitted)} == null) "
-                         + $@"&& ANY {nameof(BeatmapSetInfo.Beatmaps)}.{nameof(BeatmapInfo.StatusInt)} > 0")
-                 .AsEnumerable()
-                 .Select(b => b.ID)));
-
-            if (beatmapSetIds.Count == 0)
-                return;
-
-            Logger.Log($"Found {beatmapSetIds.Count} beatmap sets with missing submission/rank date.");
-
-            var notification = showProgressNotification(beatmapSetIds.Count, "Populating missing submission and rank dates", "beatmap sets now have correct submission and rank dates.");
-
-            int processedCount = 0;
-            int failedCount = 0;
-
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-
-            SqliteConnection sqliteConnection;
-            int sqliteVersion;
-
-            try
-            {
-                sqliteConnection = localMetadataSource.GetConnection();
-                sqliteConnection.Open();
-
-                sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"Could not open sqlite database: {ex}");
-                return;
-            }
-
             realmAccess.Run(r =>
             {
-                foreach (Guid id in beatmapSetIds)
+                var beatmapsSet = r.All<BeatmapSetInfo>()
+                 .Filter($@"{nameof(BeatmapSetInfo.StatusInt)} > 0 && ({nameof(BeatmapSetInfo.DateRanked)} == null || {nameof(BeatmapSetInfo.DateSubmitted)} == null) "
+                         + $@"&& ANY {nameof(BeatmapSetInfo.Beatmaps)}.{nameof(BeatmapInfo.StatusInt)} > 0")
+                 .AsEnumerable();
+
+                int totalCount = beatmapsSet.Count();
+                int processedCount = 0;
+                int failedCount = 0;
+
+                Logger.Log($"Found {totalCount} beatmap sets with missing submission/rank date.");
+
+                if (totalCount == 0) return;
+
+                var notification = showProgressNotification(totalCount, "Populating missing submission and rank dates", "beatmap sets now have correct submission and rank dates.");
+
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+
+                SqliteConnection sqliteConnection;
+                int sqliteVersion;
+
+                try
+                {
+                    sqliteConnection = localMetadataSource.GetConnection();
+                    sqliteConnection.Open();
+
+                    sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Could not open sqlite database: {ex}");
+                    return;
+                }
+
+                foreach (var beatmapSet in beatmapsSet)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, beatmapSetIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    var beatmapSet = r.Find<BeatmapSetInfo>(id);
 
                     if (beatmapSet == null)
                     {
@@ -856,7 +829,7 @@ namespace osu.Game.Database
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<BeatmapSetInfo>(id)!;
+                            var item = realm.Find<BeatmapSetInfo>(beatmapSet.ID)!;
 
                             item.DateRanked = result.DateRanked;
                             item.DateSubmitted = result.DateSubmitted;
@@ -870,18 +843,18 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log($"Failed to update ranked/submitted dates for beatmap set {id}: {e}");
+                        Logger.Log($"Failed to update ranked/submitted dates for beatmap set {beatmapSet.ID}: {e}");
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+                sqliteConnection.Close();
+
+                completeNotification(notification, processedCount, totalCount, failedCount);
+
+                Logger.Log($"Populating {processedCount} of {totalCount} missing submission and rank dates completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-            sqliteConnection.Close();
-
-            completeNotification(notification, processedCount, beatmapSetIds.Count, failedCount);
-
-            Logger.Log($"Populating {processedCount} of {beatmapSetIds.Count} missing submission and rank dates completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void backpopulateUserTags(int chunk_size = 2000)
@@ -916,57 +889,53 @@ namespace osu.Game.Database
 
             // while this is constrained to run every month or so (every time a new online.db cache is retrieved), there's some chance that this will still run much too often and be annoying to users.
             // if that turns out to be the case we may need a better way to debounce this (or just delete the backpopulation logic after some time has passed?)
-            HashSet<Guid> beatmapIds = realmAccess.Run(r => new HashSet<Guid>(
-                r.All<BeatmapInfo>()
-                 .Filter($"{nameof(BeatmapInfo.StatusInt)} IN {{ 1,2,4 }}")
-                 .AsEnumerable()
-                 .Select(b => b.ID)));
-
-            if (beatmapIds.Count == 0)
-                return;
-
-            Logger.Log($@"Checking for tag updates for {beatmapIds.Count} beatmaps.");
-
-            var notification = showProgressNotification(beatmapIds.Count, @"Updating user tags",
-                @"beatmaps have had their tags updated. This runs once a month to allow searching user tags.");
-
-            int processedCount = 0;
-            int updatedCount = 0;
-            int failedCount = 0;
-
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-
-            SqliteConnection sqliteConnection;
-            int sqliteVersion;
-
-            try
-            {
-                sqliteConnection = localMetadataSource.GetConnection();
-                sqliteConnection.Open();
-
-                sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"Could not open sqlite database: {ex}");
-                return;
-            }
-
             realmAccess.Run(r =>
             {
-                foreach (Guid id in beatmapIds)
+                var beatmaps = r.All<BeatmapInfo>()
+                 .Filter($"{nameof(BeatmapInfo.StatusInt)} IN {{ 1,2,4 }}")
+                 .AsEnumerable();
+
+                int totalCount = beatmaps.Count();
+                int processedCount = 0;
+                int updatedCount = 0;
+                int failedCount = 0;
+
+                Logger.Log($@"Checking for tag updates for {totalCount} beatmaps.");
+
+                if (totalCount == 0) return;
+
+                var notification = showProgressNotification(totalCount, @"Updating user tags",
+                    @"beatmaps have had their tags updated. This runs once a month to allow searching user tags.");
+
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+
+                SqliteConnection sqliteConnection;
+                int sqliteVersion;
+
+                try
+                {
+                    sqliteConnection = localMetadataSource.GetConnection();
+                    sqliteConnection.Open();
+
+                    sqliteVersion = localMetadataSource.GetCacheVersion(sqliteConnection);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Could not open sqlite database: {ex}");
+                    return;
+                }
+
+                foreach (var beatmap in beatmaps)
                 {
                     if (notification?.State == ProgressNotificationState.Cancelled)
                         break;
 
                     if (actions.Count >= chunk_size) performWrite(actions);
 
-                    updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+                    updateNotificationProgress(notification, processedCount, totalCount);
 
                     sleepIfRequired();
-
-                    var beatmap = r.Find<BeatmapInfo>(id);
 
                     if (beatmap == null)
                     {
@@ -998,7 +967,7 @@ namespace osu.Game.Database
 
                         actions.Add(realm =>
                         {
-                            var item = realm.Find<BeatmapInfo>(id)!;
+                            var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
 
                             item.Metadata.UserTags.Clear();
                             item.Metadata.UserTags.AddRange(userTags);
@@ -1013,21 +982,21 @@ namespace osu.Game.Database
                     }
                     catch (Exception e)
                     {
-                        Logger.Log(@$"Failed to update user tags for beatmap {id}: {e}");
+                        Logger.Log(@$"Failed to update user tags for beatmap {beatmap.ID}: {e}");
                         ++failedCount;
                     }
                 }
+
+                if (actions.Count > 0) performWrite(actions);
+                sqliteConnection.Close();
+
+                // Report the updated item count rather than the total processed. Users don't really care about noops here.
+                completeNotification(notification, updatedCount, updatedCount, failedCount);
+
+                config.SetValue(OsuSetting.LastOnlineTagsPopulation, metadataSourceFetchDate);
+
+                Logger.Log($"Populating {processedCount} of {totalCount} beatmap user tags completed in {stopwatch.ElapsedMilliseconds}ms");
             });
-
-            if (actions.Count > 0) performWrite(actions);
-            sqliteConnection.Close();
-
-            // Report the updated item count rather than the total processed. Users don't really care about noops here.
-            completeNotification(notification, updatedCount, updatedCount, failedCount);
-
-            config.SetValue(OsuSetting.LastOnlineTagsPopulation, metadataSourceFetchDate);
-
-            Logger.Log($"Populating {processedCount} of {beatmapIds.Count} beatmap user tags completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void performWrite(List<Action<Realm>> actions)

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Sqlite;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -161,17 +160,6 @@ namespace osu.Game.Database
 
             realmAccess.Run(r =>
             {
-                var beatmaps = r.All<BeatmapInfo>().Where(b => b.StarRating < 0 && b.BeatmapSet != null);
-
-                int totalCount = beatmaps.Count();
-                int processedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} beatmaps which require star rating reprocessing.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, "Reprocessing star rating for beatmaps", "beatmaps' star ratings have been updated");
-
                 Dictionary<string, Ruleset> rulesetCache = new Dictionary<string, Ruleset>();
 
                 Ruleset getRuleset(RulesetInfo rulesetInfo)
@@ -182,21 +170,13 @@ namespace osu.Game.Database
                     return ruleset;
                 }
 
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (BeatmapInfo beatmap in beatmaps)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    try
+                var beatmaps = r.All<BeatmapInfo>().Where(b => b.StarRating < 0 && b.BeatmapSet != null);
+                batchedProcessing(
+                    items: beatmaps,
+                    processItem: b =>
                     {
+                        var beatmap = b.Detach();
+
                         var working = beatmapManager.GetWorkingBeatmap(beatmap);
                         var ruleset = getRuleset(working.BeatmapInfo.Ruleset);
 
@@ -205,27 +185,25 @@ namespace osu.Game.Database
                         var calculator = ruleset.CreateDifficultyCalculator(working);
                         double starRating = calculator.Calculate().StarRating;
 
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
-                            item.StarRating = starRating;
-
-                            ((IWorkingBeatmapCache)beatmapManager).Invalidate(item);
-                        });
-
-                        ++processedCount;
-                    }
-                    catch (Exception e)
+                        return starRating;
+                    },
+                    saveItem: (realm, beatmap, starRating) =>
                     {
-                        Logger.Log($"Background processing failed on beatmap {beatmap.ID}: {e}");
-                        ++failedCount;
+                        var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
+                        item.StarRating = starRating;
+
+                        ((IWorkingBeatmapCache)beatmapManager).Invalidate(item);
+                    },
+                    new BatchOptions
+                    {
+                        ChunkSize = chunkSize,
+                        FoundTemplate = "Found {total} beatmaps which require star rating reprocessing.",
+                        RunningNotificationTemplate = "Reprocessing star rating for beatmaps",
+                        CompletedNotificationTemplate = "beatmaps' star ratings have been updated",
+                        ExceptionTemplate = "Calculating star rating failed",
+                        FinishedTemplate = "Populating {processed} of {total} missing star ratings completed in {elapsed}ms"
                     }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-                completeNotification(notification, processedCount, totalCount, failedCount);
-
-                Logger.Log($"Populating {processedCount} of {totalCount} missing star ratings completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
         }
 
@@ -305,58 +283,34 @@ namespace osu.Game.Database
             realmAccess.Run(r =>
             {
                 var beatmaps = r.All<BeatmapInfo>().Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0);
-
-                int totalCount = beatmaps.Count();
-                int processedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} beatmaps which require statistics population.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, "Populating missing statistics for beatmaps", "beatmaps have been populated with missing statistics");
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (var b in beatmaps)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    var beatmap = b.Detach();
-
-                    try
+                batchedProcessing<BeatmapInfo, BeatmapInfo>(
+                    items: beatmaps,
+                    processItem: b =>
                     {
+                        var beatmap = b.Detach();
                         beatmapUpdater.ProcessObjectCounts(beatmap);
 
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
-
-                            item.TotalObjectCount = beatmap.TotalObjectCount;
-                            item.EndTimeObjectCount = beatmap.EndTimeObjectCount;
-
-                            ((IWorkingBeatmapCache)beatmapManager).Invalidate(item);
-                        });
-
-                        ++processedCount;
-                    }
-                    catch (Exception e)
+                        return beatmap;
+                    },
+                    saveItem: (realm, beatmap, result) =>
                     {
-                        Logger.Log($"Background processing failed on beatmap {beatmap.ID}: {e}");
-                        ++failedCount;
+                        var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
+
+                        item.TotalObjectCount = result.TotalObjectCount;
+                        item.EndTimeObjectCount = result.EndTimeObjectCount;
+
+                        ((IWorkingBeatmapCache)beatmapManager).Invalidate(item);
+                    },
+                    new BatchOptions
+                    {
+                        ChunkSize = chunkSize,
+                        FoundTemplate = "Found {total} beatmaps which require statistics population.",
+                        RunningNotificationTemplate = "Populating missing statistics for beatmaps",
+                        CompletedNotificationTemplate = "beatmaps have been populated with missing statistics",
+                        ExceptionTemplate = "Calculating hitobject counts failed",
+                        FinishedTemplate = "Processing {processed} of {total} missing beatmaps hitobject counts completed in {elapsed}ms"
                     }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-                completeNotification(notification, processedCount, totalCount, failedCount);
-
-                Logger.Log($"Processing {processedCount} of {totalCount} missing beatmaps hitobject counts completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
         }
 
@@ -366,61 +320,33 @@ namespace osu.Game.Database
 
             realmAccess.Run(r =>
             {
-                var scores = r
-                             .All<ScoreInfo>()
-                             .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null)
-                             .AsEnumerable()
-                             // must be done after materialisation, as realm doesn't want to support
-                             // nested property predicates
-                             .Where(s => s.Statistics.Sum(kvp => kvp.Value) > 0
-                                         && s.MaximumStatistics.Sum(kvp => kvp.Value) == 0);
+                var scores = r.All<ScoreInfo>()
+                              .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null)
+                              .AsEnumerable()
+                              // must be done after materialisation, as realm doesn't want to support
+                              // nested property predicates
+                              .Where(s => s.Statistics.Sum(kvp => kvp.Value) > 0
+                                          && s.MaximumStatistics.Sum(kvp => kvp.Value) == 0);
 
-                int totalCount = scores.Count();
-                int processedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} scores which require statistics population.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, "Populating missing statistics for scores", "scores have been populated with missing statistics");
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (var score in scores)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    try
+                batchedProcessing<ScoreInfo, string>(
+                    items: scores,
+                    processItem: score =>
                     {
                         scoreManager.PopulateMaximumStatistics(score);
-                        string maximumStatisticsJson = JsonConvert.SerializeObject(score.MaximumStatistics);
-
-                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.MaximumStatisticsJson = maximumStatisticsJson);
-                        ++processedCount;
-                    }
-                    catch (ObjectDisposedException)
+                        return JsonConvert.SerializeObject(score.MaximumStatistics);
+                    },
+                    saveItem: (realm, score, result) => realm.Find<ScoreInfo>(score.ID)!.MaximumStatisticsJson = result,
+                    new BatchOptions
                     {
-                        throw;
+                        ChunkSize = chunkSize,
+                        MarkAsFailedOnException = true,
+                        FoundTemplate = "Found {total} scores which require statistics population.",
+                        RunningNotificationTemplate = "Populating missing statistics for scores",
+                        CompletedNotificationTemplate = "scores have been populated with missing statistics",
+                        ExceptionTemplate = "Failed to populate maximum statistics",
+                        FinishedTemplate = "Processing {processed} of {total} missing scores statistics completed in {elapsed}ms"
                     }
-                    catch (Exception e)
-                    {
-                        Logger.Log(@$"Failed to populate maximum statistics for {score.ID}: {e}");
-                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
-                        ++failedCount;
-                    }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-                completeNotification(notification, processedCount, totalCount, failedCount);
-
-                Logger.Log($"Processing {processedCount} of {totalCount} missing scores statistics completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
         }
 
@@ -440,64 +366,34 @@ namespace osu.Game.Database
                               // nested property predicates
                               .Where(s => s.Ruleset.IsLegacyRuleset());
 
-                int totalCount = scores.Count();
-                int processedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} scores which require mod multiplier upgrade.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, "Upgrading scores to new mod multipliers", "scores have been upgraded to the new mod multipliers");
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (var s in scores)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    var score = s.Detach();
-
-                    if (score.BeatmapInfo == null)
+                batchedProcessing<ScoreInfo, ScoreInfo>(
+                    items: scores,
+                    processItem: s =>
                     {
-                        ++processedCount;
-                        continue;
-                    }
+                        var score = s.Detach();
+                        if (score.BeatmapInfo == null)
+                            return null;
 
-                    try
-                    {
                         StandardisedScoreMigrationTools.UpdateToLatestScoreMultipliers(score, score.BeatmapInfo.Difficulty);
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-                            item.TotalScore = score.TotalScore;
-                            item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
-                        });
-
-                        ++processedCount;
-                    }
-                    catch (ObjectDisposedException)
+                        return score;
+                    },
+                    saveItem: (realm, score, result) =>
                     {
-                        throw;
-                    }
-                    catch (Exception e)
+                        var item = realm.Find<ScoreInfo>(score.ID)!;
+                        item.TotalScore = result.TotalScore;
+                        item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
+                    },
+                    new BatchOptions
                     {
-                        Logger.Log($"Failed to upgrade mod multipliers for {score.ID}: {e}");
-                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
-                        ++failedCount;
+                        ChunkSize = chunkSize,
+                        MarkAsFailedOnException = true,
+                        FoundTemplate = "Found {total} scores which require mod multiplier upgrade.",
+                        RunningNotificationTemplate = "Upgrading scores to new mod multipliers",
+                        CompletedNotificationTemplate = "scores have been upgraded to the new mod multipliers",
+                        ExceptionTemplate = "Failed to upgrade mod multipliers",
+                        FinishedTemplate = "Upgrading {processed} of {total} scores to new mod multipliers completed in {elapsed}ms"
                     }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-                completeNotification(notification, processedCount, totalCount, failedCount);
-
-                Logger.Log($"Upgrading {processedCount} of {totalCount} scores to new mod multipliers completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
         }
 
@@ -517,63 +413,36 @@ namespace osu.Game.Database
                               // nested property predicates
                               .Where(s => s.Ruleset.IsLegacyRuleset());
 
-                int totalCount = scores.Count();
-                int processedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} scores which require total score conversion.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, "Upgrading scores to new scoring algorithm", "scores have been upgraded to the new scoring algorithm");
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (var s in scores)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    var score = s.Detach();
-
-                    try
+                batchedProcessing<ScoreInfo, ScoreInfo>(
+                    items: scores,
+                    processItem: s =>
                     {
+                        var score = s.Detach();
                         StandardisedScoreMigrationTools.UpdateFromLegacy(score, beatmapManager.GetWorkingBeatmap(score.BeatmapInfo));
 
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-
-                            item.Accuracy = score.Accuracy;
-                            item.Rank = score.Rank;
-                            item.TotalScore = score.TotalScore;
-                            item.TotalScoreWithoutMods = score.TotalScoreWithoutMods;
-                            item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
-                        });
-
-                        ++processedCount;
-                    }
-                    catch (ObjectDisposedException)
+                        return score;
+                    },
+                    saveItem: (realm, score, result) =>
                     {
-                        throw;
-                    }
-                    catch (Exception e)
+                        var item = realm.Find<ScoreInfo>(score.ID)!;
+
+                        item.Accuracy = result.Accuracy;
+                        item.Rank = result.Rank;
+                        item.TotalScore = result.TotalScore;
+                        item.TotalScoreWithoutMods = result.TotalScoreWithoutMods;
+                        item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
+                    },
+                    new BatchOptions
                     {
-                        Logger.Log($"Failed to convert total score for {score.ID}: {e}");
-                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
-                        ++failedCount;
+                        ChunkSize = chunkSize,
+                        MarkAsFailedOnException = true,
+                        FoundTemplate = "Found {total} scores which require total score conversion.",
+                        RunningNotificationTemplate = "Upgrading scores to new scoring algorithm",
+                        CompletedNotificationTemplate = "scores have been upgraded to the new scoring algorithm",
+                        ExceptionTemplate = "Failed to convert total score",
+                        FinishedTemplate = "Converting total score {processed} of {total} scores completed in {elapsed}ms"
                     }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-                completeNotification(notification, processedCount, totalCount, failedCount);
-
-                Logger.Log($"Converting total score {processedCount} of {totalCount} scores completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
         }
 
@@ -590,58 +459,27 @@ namespace osu.Game.Database
                               // filtering on nested property predicates or projection via `.Select()`
                               .Where(s => s.Ruleset.IsLegacyRuleset());
 
-                int totalCount = scores.Count();
-                int processedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} scores which require rank upgrades.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, "Adjusting ranks of scores", "scores now have more correct ranks.");
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (var score in scores)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    try
+                batchedProcessing(
+                    items: scores,
+                    processItem: StandardisedScoreMigrationTools.ComputeRank,
+                    saveItem: (realm, score, rank) =>
                     {
-                        var rank = StandardisedScoreMigrationTools.ComputeRank(score);
+                        var item = realm.Find<ScoreInfo>(score.ID)!;
 
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<ScoreInfo>(score.ID)!;
-
-                            item.Rank = rank;
-                            item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
-                        });
-
-                        ++processedCount;
-                    }
-                    catch (ObjectDisposedException)
+                        item.Rank = rank;
+                        item.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
+                    },
+                    new BatchOptions
                     {
-                        throw;
+                        ChunkSize = chunkSize,
+                        MarkAsFailedOnException = true,
+                        FoundTemplate = "Found {total} scores which require rank upgrades.",
+                        RunningNotificationTemplate = "Adjusting ranks of scores",
+                        CompletedNotificationTemplate = "scores now have more correct ranks.",
+                        ExceptionTemplate = "Failed to update score rank",
+                        FinishedTemplate = "Upgrading {processed} of {total} score ranks completed in {elapsed}ms"
                     }
-                    catch (Exception e)
-                    {
-                        Logger.Log($"Failed to update score rank {score.ID}: {e}");
-                        actions.Add(realm => realm.Find<ScoreInfo>(score.ID)!.BackgroundReprocessingFailed = true);
-                        ++failedCount;
-                    }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-                completeNotification(notification, processedCount, totalCount, failedCount);
-
-                Logger.Log($"Upgrading {processedCount} of {totalCount} score ranks completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
         }
 
@@ -678,34 +516,14 @@ namespace osu.Game.Database
             // that said, one difficulty in ranked state is enough for the backpopulation to work.
             realmAccess.Run(r =>
             {
-                var beatmapsSet = r.All<BeatmapSetInfo>()
-                                   .Filter($@"{nameof(BeatmapSetInfo.StatusInt)} > 0 && ({nameof(BeatmapSetInfo.DateRanked)} == null || {nameof(BeatmapSetInfo.DateSubmitted)} == null) "
-                                           + $@"&& ANY {nameof(BeatmapSetInfo.Beatmaps)}.{nameof(BeatmapInfo.StatusInt)} > 0")
-                                   .AsEnumerable();
+                var beatmapsSets = r.All<BeatmapSetInfo>()
+                                    .Filter($@"{nameof(BeatmapSetInfo.StatusInt)} > 0 && ({nameof(BeatmapSetInfo.DateRanked)} == null || {nameof(BeatmapSetInfo.DateSubmitted)} == null) "
+                                            + $@"&& ANY {nameof(BeatmapSetInfo.Beatmaps)}.{nameof(BeatmapInfo.StatusInt)} > 0")
+                                    .AsEnumerable();
 
-                int totalCount = beatmapsSet.Count();
-                int processedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} beatmap sets with missing submission/rank dates.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, "Populating missing submission and rank dates", "beatmap sets now have correct submission and rank dates.");
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (var beatmapSet in beatmapsSet)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    try
+                batchedProcessing<BeatmapSetInfo, OnlineBeatmapMetadata>(
+                    items: beatmapsSets,
+                    processItem: beatmapSet =>
                     {
                         var beatmap = beatmapSet.Beatmaps.First(b => b.Status >= BeatmapOnlineStatus.Ranked);
                         bool lookupSucceeded = localMetadataSource.TryLookup(localMetadataSource.CachedConnection, localMetadataSource.CachedVersion, beatmap, out var result);
@@ -713,38 +531,30 @@ namespace osu.Game.Database
                         if (!lookupSucceeded)
                         {
                             Logger.Log($"Could not find {beatmapSet.GetDisplayString()} in local cache while backpopulating missing submission/rank date");
-                            ++failedCount;
-
-                            continue;
+                            return null;
                         }
 
                         Debug.Assert(result != null);
 
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<BeatmapSetInfo>(beatmapSet.ID)!;
-
-                            item.DateRanked = result.DateRanked;
-                            item.DateSubmitted = result.DateSubmitted;
-                        });
-
-                        ++processedCount;
-                    }
-                    catch (ObjectDisposedException)
+                        return result;
+                    },
+                    saveItem: (realm, beatmapSet, result) =>
                     {
-                        throw;
-                    }
-                    catch (Exception e)
+                        var item = realm.Find<BeatmapSetInfo>(beatmapSet.ID)!;
+
+                        item.DateRanked = result.DateRanked;
+                        item.DateSubmitted = result.DateSubmitted;
+                    },
+                    new BatchOptions
                     {
-                        Logger.Log($"Failed to update ranked/submitted dates for beatmap set {beatmapSet.ID}: {e}");
-                        ++failedCount;
+                        ChunkSize = chunkSize,
+                        FoundTemplate = "Found {total} beatmap sets with missing submission/rank dates.",
+                        RunningNotificationTemplate = "Populating missing submission and rank dates",
+                        CompletedNotificationTemplate = "beatmap sets now have correct submission and rank dates.",
+                        ExceptionTemplate = "Failed to update ranked/submitted dates for beatmap set {id}",
+                        FinishedTemplate = "Populating {processed} of {total} missing submission and rank dates completed in {elapsed}ms"
                     }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-                completeNotification(notification, processedCount, totalCount, failedCount);
-
-                Logger.Log($"Populating {processedCount} of {totalCount} missing submission and rank dates completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
 
             localMetadataSource.CachedConnection?.Close();
@@ -788,40 +598,16 @@ namespace osu.Game.Database
             {
                 var beatmaps = r.All<BeatmapInfo>().Filter($"{nameof(BeatmapInfo.StatusInt)} IN {{ 1,2,4 }}");
 
-                int totalCount = beatmaps.Count();
-                int processedCount = 0;
-                int updatedCount = 0;
-                int failedCount = 0;
-
-                Logger.Log($"Found {totalCount} beatmaps with outdated user tags.");
-                if (totalCount == 0) return;
-
-                var notification = showProgressNotification(totalCount, @"Updating user tags",
-                    @"beatmaps have had their tags updated. This runs once a month to allow searching user tags.");
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                foreach (var beatmap in beatmaps)
-                {
-                    if (notification?.State == ProgressNotificationState.Cancelled)
-                        break;
-
-                    if (actions.Count >= chunkSize) performWrite(actions);
-
-                    updateNotificationProgress(notification, processedCount, totalCount);
-                    sleepIfRequired();
-
-                    try
+                batchedProcessing<BeatmapInfo, HashSet<string>>(
+                    items: beatmaps,
+                    processItem: beatmap =>
                     {
                         bool lookupSucceeded = localMetadataSource.TryLookup(localMetadataSource.CachedConnection, localMetadataSource.CachedVersion, beatmap, out var result);
 
                         if (!lookupSucceeded)
                         {
                             Logger.Log(@$"Could not find {beatmap.GetDisplayString()} in local cache while backpopulating missing user tags");
-                            ++processedCount;
-
-                            continue;
+                            return null;
                         }
 
                         Debug.Assert(result != null);
@@ -830,43 +616,102 @@ namespace osu.Game.Database
 
                         if (userTags.SetEquals(beatmap.Metadata.UserTags))
                         {
-                            ++processedCount;
-                            continue;
+                            return null;
                         }
 
-                        actions.Add(realm =>
-                        {
-                            var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
-
-                            item.Metadata.UserTags.Clear();
-                            item.Metadata.UserTags.AddRange(userTags);
-                        });
-
-                        ++processedCount;
-                        ++updatedCount;
-                    }
-                    catch (ObjectDisposedException)
+                        return userTags;
+                    },
+                    saveItem: (realm, beatmap, userTags) =>
                     {
-                        throw;
-                    }
-                    catch (Exception e)
+                        var item = realm.Find<BeatmapInfo>(beatmap.ID)!;
+
+                        item.Metadata.UserTags.Clear();
+                        item.Metadata.UserTags.AddRange(userTags);
+                    },
+                    new BatchOptions
                     {
-                        Logger.Log(@$"Failed to update user tags for beatmap {beatmap.ID}: {e}");
-                        ++failedCount;
+                        ChunkSize = chunkSize,
+                        FoundTemplate = "Found beatmaps with outdated user tags.",
+                        RunningNotificationTemplate = "Updating user tags",
+                        CompletedNotificationTemplate = "beatmaps have had their tags updated. This runs once a month to allow searching user tags.",
+                        ExceptionTemplate = "Failed to update user tags",
+                        FinishedTemplate = "Populating {processed} of {total} beatmap user tags completed in {elapsed}ms"
                     }
-                }
-
-                if (actions.Count > 0) performWrite(actions);
-
-                // Report the updated item count rather than the total processed. Users don't really care about noops here.
-                completeNotification(notification, updatedCount, updatedCount, failedCount);
-
-                config.SetValue(OsuSetting.LastOnlineTagsPopulation, metadataSourceFetchDate);
-
-                Logger.Log($"Populating {processedCount} of {totalCount} beatmap user tags completed in {stopwatch.ElapsedMilliseconds}ms");
+                );
             });
 
             localMetadataSource.CachedConnection?.Close();
+        }
+
+        /// <summary>
+        /// Helper method to process realm items in a batch of variable size to reduce writes to disk,
+        /// and it speed up processes by huge amount,
+        /// especially one's that run fast such as "upgradeScoreRanks" or "backpopulateMissingSubmissionAndRankDates".
+        /// </summary>
+        /// <typeparam name="T">a type of single item.</typeparam>
+        /// <typeparam name="R">a return type for <paramref name="processItem"/></typeparam>
+        /// <param name="items">collection of items to process.</param>
+        /// <param name="processItem">a function that transforms each item <typeparamref name="T"/> into type <typeparamref name="R"/> or null.</param>
+        /// <param name="saveItem">a function to save item in realm.Write transaction.</param>
+        /// <param name="options">See <see cref="BatchOptions"/></param>
+        private void batchedProcessing<T, R>(
+            IEnumerable<T> items,
+            Func<T, R?> processItem,
+            Action<Realm, T, R> saveItem,
+            BatchOptions options
+        ) where T : RealmObjectBase
+        {
+            int totalCount = items.Count();
+            int processedCount = 0;
+            int failedCount = 0;
+
+            Logger.Log(options.FoundTemplate.Replace("{total}", totalCount.ToString()));
+            if (totalCount == 0) return;
+
+            var notification = showProgressNotification(totalCount, options.RunningNotificationTemplate, options.CompletedNotificationTemplate);
+            var stopwatch = Stopwatch.StartNew();
+
+            foreach (var item in items)
+            {
+                if (notification?.State == ProgressNotificationState.Cancelled)
+                    break;
+
+                if (actions.Count >= options.ChunkSize) performWrite(actions);
+
+                updateNotificationProgress(notification, processedCount + failedCount, totalCount);
+                sleepIfRequired();
+
+                // i don't know how to get ID in other way, please help
+                var id = (item as ScoreInfo)?.ID;
+
+                try
+                {
+                    var result = processItem(item);
+
+                    if (result == null)
+                    {
+                        ++failedCount;
+                        continue;
+                    }
+
+                    actions.Add(realm => saveItem(realm, item, result));
+                    processedCount++;
+                }
+                catch (Exception e)
+                {
+                    Logger.Log($"{options.ExceptionTemplate.Replace("{id}", id.ToString())}: {e}");
+                    if (options.MarkAsFailedOnException)
+                        actions.Add(realm => realm.Find<ScoreInfo>(id)!.BackgroundReprocessingFailed = true);
+                    ++failedCount;
+                }
+            }
+
+            if (actions.Count > 0) performWrite(actions);
+            completeNotification(notification, processedCount + failedCount, totalCount, failedCount);
+
+            Logger.Log(options.FinishedTemplate.Replace("{processed}", processedCount.ToString())
+                              .Replace("{total}", totalCount.ToString())
+                              .Replace("{elapsed}", $"{stopwatch.ElapsedMilliseconds}ms"));
         }
 
         private void performWrite(List<Action<Realm>> actions)
@@ -943,6 +788,47 @@ namespace osu.Game.Database
                 Logger.Log("Background processing sleeping due to active gameplay...");
                 Thread.Sleep(TimeToSleepDuringGameplay);
             }
+        }
+
+        private record BatchOptions
+        {
+            public int ChunkSize = 100;
+
+            /// <summary>
+            /// Sets <see cref="ScoreInfo.BackgroundReprocessingFailed"/> to true
+            /// </summary>
+            /// <remarks>Should be only used for <see cref="ScoreInfo"/>.</remarks>
+            public bool MarkAsFailedOnException;
+
+            /// <summary>
+            /// Template for a log message of total found items.
+            /// </summary>
+            /// <remarks>Supports placeholders: {total}.</remarks>
+            public string FoundTemplate = "";
+
+            /// <summary>
+            /// Template for notification message of running process.
+            /// </summary>
+            /// <remarks>No placeholders.</remarks>
+            public string RunningNotificationTemplate = "";
+
+            /// <summary>
+            /// Template for notification message of completed process.
+            /// </summary>
+            /// <remarks>No placeholders.</remarks>
+            public string CompletedNotificationTemplate = "";
+
+            /// <summary>
+            /// Template for a log message of an exception.
+            /// </summary>
+            /// <remarks>Supports placeholders: {id}.</remarks>
+            public string ExceptionTemplate = "";
+
+            /// <summary>
+            /// Template for a log message of finished process.
+            /// </summary>
+            /// <remarks>Supports placeholders: {processed}, {total}, {elapsed}.</remarks>
+            public string FinishedTemplate = "";
         }
     }
 }

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -131,11 +131,11 @@ namespace osu.Game.Database
 
                     realmAccess.Write(r =>
                     {
-                        foreach (var b in r.All<BeatmapInfo>())
+                        foreach (var beatmap in r.All<BeatmapInfo>())
                         {
-                            if (b.Ruleset.ShortName == ruleset.ShortName)
+                            if (beatmap.Ruleset.ShortName == ruleset.ShortName)
                             {
-                                b.StarRating = -1;
+                                beatmap.StarRating = -1;
                                 countReset++;
                             }
                         }
@@ -185,6 +185,9 @@ namespace osu.Game.Database
                 return ruleset;
             }
 
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             foreach (Guid id in beatmapIds)
             {
                 if (notification?.State == ProgressNotificationState.Cancelled)
@@ -225,6 +228,8 @@ namespace osu.Game.Database
             }
 
             completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
+
+            Logger.Log($"Populating {processedCount} of {beatmapIds.Count} missing star ratings completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void processOnlineBeatmapSetsWithNoUpdate()
@@ -258,6 +263,9 @@ namespace osu.Game.Database
             int processedCount = 0;
             int failedCount = 0;
 
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             foreach (var id in beatmapSetIds)
             {
                 if (notification?.State == ProgressNotificationState.Cancelled)
@@ -288,6 +296,8 @@ namespace osu.Game.Database
             }
 
             completeNotification(notification, processedCount, beatmapSetIds.Count, failedCount);
+
+            Logger.Log($"Processing {processedCount} of {beatmapSetIds.Count} online beatmapsets completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void processBeatmapsWithMissingObjectCounts()
@@ -311,6 +321,9 @@ namespace osu.Game.Database
 
             int processedCount = 0;
             int failedCount = 0;
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
 
             foreach (var id in beatmapIds)
             {
@@ -342,6 +355,8 @@ namespace osu.Game.Database
             }
 
             completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
+
+            Logger.Log($"Processing {processedCount} of {beatmapIds.Count} beatmaps object counts completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void processScoresWithMissingStatistics()
@@ -372,6 +387,9 @@ namespace osu.Game.Database
 
             int processedCount = 0;
             int failedCount = 0;
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
 
             foreach (var id in scoreIds)
             {
@@ -413,6 +431,8 @@ namespace osu.Game.Database
             }
 
             completeNotification(notification, processedCount, scoreIds.Count, failedCount);
+
+            Logger.Log($"Processing {processedCount} of {scoreIds.Count} missing scores statistics completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void upgradeModMultipliers()
@@ -507,6 +527,9 @@ namespace osu.Game.Database
             int processedCount = 0;
             int failedCount = 0;
 
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             foreach (var id in scoreIds)
             {
                 if (notification?.State == ProgressNotificationState.Cancelled)
@@ -542,6 +565,8 @@ namespace osu.Game.Database
             }
 
             completeNotification(notification, processedCount, scoreIds.Count, failedCount);
+
+            Logger.Log($"Converting totalScore {processedCount} of {scoreIds.Count} scores completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void upgradeScoreRanks()
@@ -566,6 +591,9 @@ namespace osu.Game.Database
 
             int processedCount = 0;
             int failedCount = 0;
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
 
             foreach (var id in scoreIds)
             {
@@ -602,6 +630,8 @@ namespace osu.Game.Database
             }
 
             completeNotification(notification, processedCount, scoreIds.Count, failedCount);
+
+            Logger.Log($"Upgrading {processedCount} of {scoreIds.Count} score ranks completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void backpopulateMissingSubmissionAndRankDates()
@@ -649,6 +679,9 @@ namespace osu.Game.Database
 
             int processedCount = 0;
             int failedCount = 0;
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
 
             foreach (var id in beatmapSetIds)
             {
@@ -700,6 +733,8 @@ namespace osu.Game.Database
             }
 
             completeNotification(notification, processedCount, beatmapSetIds.Count, failedCount);
+
+            Logger.Log($"Populating {processedCount} of {beatmapSetIds.Count} missing submission and rank dates completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void backpopulateUserTags()
@@ -751,6 +786,9 @@ namespace osu.Game.Database
             int processedCount = 0;
             int updatedCount = 0;
             int failedCount = 0;
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
 
             foreach (var id in beatmapIds)
             {
@@ -812,6 +850,8 @@ namespace osu.Game.Database
             completeNotification(notification, updatedCount, updatedCount, failedCount);
 
             config.SetValue(OsuSetting.LastOnlineTagsPopulation, metadataSourceFetchDate);
+
+            Logger.Log($"Populating {processedCount} of {beatmapIds.Count} beatmap user tags completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private void updateNotificationProgress(ProgressNotification? notification, int processedCount, int totalCount)

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -534,6 +534,26 @@ namespace osu.Game.Database
         }
 
         /// <summary>
+        /// Write bulk changes to realm.
+        /// </summary>
+        /// <param name="actions">The work to run.</param>
+        public void BulkWrite(List<Action<Realm>> actions)
+        {
+            if (ThreadSafety.IsUpdateThread)
+            {
+                total_writes_update.Value++;
+                Realm.BulkWrite(actions);
+            }
+            else
+            {
+                total_writes_async.Value++;
+
+                using (var realm = getRealmInstance())
+                    realm.BulkWrite(actions);
+            }
+        }
+
+        /// <summary>
         /// Write changes to realm asynchronously, guaranteeing order of execution.
         /// </summary>
         /// <param name="action">The work to run.</param>

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -519,18 +519,7 @@ namespace osu.Game.Database
         /// <param name="action">The work to run.</param>
         public void Write(Action<Realm> action)
         {
-            if (ThreadSafety.IsUpdateThread)
-            {
-                total_writes_update.Value++;
-                Realm.Write(action);
-            }
-            else
-            {
-                total_writes_async.Value++;
-
-                using (var realm = getRealmInstance())
-                    realm.Write(action);
-            }
+            BulkWrite([action]);
         }
 
         /// <summary>

--- a/osu.Game/Database/RealmExtensions.cs
+++ b/osu.Game/Database/RealmExtensions.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
@@ -89,6 +90,36 @@ namespace osu.Game.Database
                 transaction?.Commit();
 
                 return result;
+            }
+            finally
+            {
+                transaction?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Perform a bulk write operation against the provided realm instance.
+        /// </summary>
+        /// <remarks>
+        /// This will automatically start a transaction if not already in one.
+        /// </remarks>
+        /// <param name="realm">The realm to operate on.</param>
+        /// <param name="functions">The write operations to run.</param>
+        public static void BulkWrite(this Realm realm, List<Action<Realm>> functions)
+        {
+            Transaction? transaction = null;
+
+            try
+            {
+                if (!realm.IsInTransaction)
+                    transaction = realm.BeginWrite();
+
+                foreach (var function in functions)
+                {
+                    function(realm);
+                }
+
+                transaction?.Commit();
             }
             finally
             {

--- a/osu.Game/Database/RealmExtensions.cs
+++ b/osu.Game/Database/RealmExtensions.cs
@@ -51,21 +51,7 @@ namespace osu.Game.Database
         /// <param name="function">The write operation to run.</param>
         public static void Write(this Realm realm, Action<Realm> function)
         {
-            Transaction? transaction = null;
-
-            try
-            {
-                if (!realm.IsInTransaction)
-                    transaction = realm.BeginWrite();
-
-                function(realm);
-
-                transaction?.Commit();
-            }
-            finally
-            {
-                transaction?.Dispose();
-            }
+            BulkWrite(realm, [function]);
         }
 
         /// <summary>


### PR DESCRIPTION
- Added `BulkWrite` method to realm
- Added `TryLookup` method to reusable sqlite connection in `LocalCachedBeatmapMetadataSource`

<br>

### benchmark (updated 2026-01-20)

|   | star ratings (45492) | object counts (45492) | scores statistics (3928) | total score (3928) | ranks (3928) | submission and rank dates (9695) | user tags (25412) |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| Before | 4111953ms | 1766952ms | 103199ms | 104935ms | 101620ms | 279318ms | 770134ms |
| After | 2286840ms | 391678ms | 2221ms | 4765ms | 257ms | 5918ms | 10191ms |
| Speed up | 1.798x | 4.511x | 46.465x | 22.022x | 395.408x | 47.198x | 75.570x |


Tests done offline on HDD WD20EZBX - 275Mb/s(?)

<br>

## Notes

- On these changes i was getting game freezes for a 20-40s due to `backpopulateMissingSubmissionAndRankDates` method sending 9k sets to `RealmDetachedBeatmapStore` subscription
- ~~TryLookup in sqlite have duplicated code, since i wasnt sure if i allowed to touch this one~~
- I didnt touch `processOnlineBeatmapSetsWithNoUpdate` because `beatmapUpdater.Process` used in other place and im not if i should touch it.
- i tried to make benchmark project but couldnt because i lack knowledge of codebase and c#
- https://github.com/ppy/osu/pull/36128/changes/dd889ea5107a4a716ba4ebeb1fddd6cd24ecda18, might be bad idea but not sure