### PR TITLE
Allow uploading screenshots to osu-web

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -108,6 +108,7 @@ namespace osu.Game.Input.Bindings
 
             new KeyBinding(InputKey.F10, GlobalAction.ToggleGameplayMouseButtons),
             new KeyBinding(InputKey.F12, GlobalAction.TakeScreenshot),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.F12 }, GlobalAction.TakeAndUploadScreeshot),
         };
 
         private static IEnumerable<KeyBinding> overlayKeyBindings => new[]
@@ -274,6 +275,9 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.TakeScreenshot))]
         TakeScreenshot,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.TakeAndUploadScreenshot))]
+        TakeAndUploadScreeshot,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleGameplayMouseButtons))]
         ToggleGameplayMouseButtons,

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -70,6 +70,11 @@ namespace osu.Game.Localisation
         public static LocalisableString TakeScreenshot => new TranslatableString(getKey(@"take_screenshot"), @"Take screenshot");
 
         /// <summary>
+        /// "Take and upload screenshot"
+        /// </summary>
+        public static LocalisableString TakeAndUploadScreenshot => new TranslatableString(getKey(@"take_and_upload_screenshot"), @"Take and upload screenshot");
+
+        /// <summary>
         /// "Toggle gameplay mouse buttons"
         /// </summary>
         public static LocalisableString ToggleGameplayMouseButtons => new TranslatableString(getKey(@"toggle_gameplay_mouse_buttons"), @"Toggle gameplay mouse buttons");

--- a/osu.Game/Localisation/ScreenshotManagerStrings.cs
+++ b/osu.Game/Localisation/ScreenshotManagerStrings.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ScreenshotManagerStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ScreenshotManager";
+
+        /// <summary>
+        /// "Uploading screenshot..."
+        /// </summary>
+        public static LocalisableString UploadingScreenshot => new TranslatableString(getKey(@"uploading_screenshot"), @"Uploading screenshot...");
+
+        /// <summary>
+        /// "Screenshot uploaded! The link has been copied to the clipboard."
+        /// </summary>
+        public static LocalisableString UploadSuccess => new TranslatableString(getKey(@"upload_success"), @"Screenshot uploaded! The link has been copied to the clipboard.");
+
+        /// <summary>
+        /// "Failed to upload screenshot."
+        /// </summary>
+        public static LocalisableString UploadFailure => new TranslatableString(getKey(@"upload_failure"), @"Failed to upload screenshot.");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Online/API/Requests/APIUploadRequest.cs
+++ b/osu.Game/Online/API/Requests/APIUploadRequest.cs
@@ -6,6 +6,24 @@ using osu.Framework.IO.Network;
 
 namespace osu.Game.Online.API.Requests
 {
+    public abstract class APIUploadRequest<T> : APIRequest<T> where T : class
+    {
+        protected override WebRequest CreateWebRequest()
+        {
+            var request = base.CreateWebRequest();
+            request.UploadProgress += onUploadProgress;
+            return request;
+        }
+
+        private void onUploadProgress(long current, long total)
+        {
+            Debug.Assert(API != null);
+            API.Schedule(() => Progressed?.Invoke(current, total));
+        }
+
+        public event APIProgressHandler? Progressed;
+    }
+
     public abstract class APIUploadRequest : APIRequest
     {
         protected override WebRequest CreateWebRequest()

--- a/osu.Game/Online/API/Requests/Responses/APIScreenshot.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScreenshot.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+
+#nullable disable
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class APIScreenshot
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+    }
+}

--- a/osu.Game/Online/API/Requests/UploadScreenshot.cs
+++ b/osu.Game/Online/API/Requests/UploadScreenshot.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Net.Http;
+using osu.Framework.IO.Network;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class UploadScreenshot : APIUploadRequest<APIScreenshot>
+    {
+        public readonly byte[] File;
+
+        public UploadScreenshot(byte[] file)
+        {
+            File = file;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+
+            req.Method = HttpMethod.Post;
+            req.AddFile(@"screenshot", File);
+
+            return req;
+        }
+
+        protected override string Target => @"screenshots";
+    }
+}


### PR DESCRIPTION
Resolves #10718. Requires ppy/osu-web#12618.

The way I implemented this, the upload task will implicitly convert the saved screenshot to JPEG to save server space if the user set their screenshots to save in PNG. This is probably less messy than trying to throw more responsibilities on the screenshot task, and it also respects the user's settings.

---

https://github.com/user-attachments/assets/a2db8117-0c6d-4a38-bb37-a0a0bc47b88d