### PR TITLE
Open user profile with the current ruleset

### DIFF
--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -24,6 +24,7 @@ using osu.Game.Resources.Localisation.Web;
 using osu.Game.Localisation;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Rulesets;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
 using osu.Game.Users.Drawables;
@@ -40,6 +41,12 @@ namespace osu.Game.Users
         /// This should be used to perform auxiliary tasks and not as a primary action for clicking a user panel (to maintain a consistent UX).
         /// </summary>
         public new Action? Action;
+
+        /// <summary>
+        /// The ruleset for which this user panel primarily applies to.
+        /// Used to decide which ruleset to open when showing the profile.
+        /// </summary>
+        protected virtual RulesetInfo? Ruleset => null;
 
         protected Action ViewProfile { get; private set; } = null!;
 
@@ -103,7 +110,7 @@ namespace osu.Game.Users
             base.Action = ViewProfile = () =>
             {
                 Action?.Invoke();
-                profileOverlay?.ShowUser(User);
+                profileOverlay?.ShowUser(User, Ruleset);
             };
         }
 

--- a/osu.Game/Users/UserRankPanel.cs
+++ b/osu.Game/Users/UserRankPanel.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Users
         private const int padding = 10;
         private const int main_content_height = 80;
 
+        protected override RulesetInfo Ruleset => ruleset.Value;
+
         private GlobalRankDisplay globalRankDisplay = null!;
         private ProfileValueDisplay countryRankDisplay = null!;
         private LoadingLayer loadingLayer = null!;


### PR DESCRIPTION
This always bothered me a bit, when having a mania session for example and I want to view top plays, I keep forgetting to change ruleset from taiko (my default). Not sure if always using the player's default ruleset was intended UX, couldn't find any discussion on it.

Again small enough to not warrant a UI feedback discussion thread imo.

On implementation: I wasn't sure whether to have a specific bool like `OpenToCurrentRuleset` or this more generic `Ruleset` property. The latter felt reasonable as the panel can more easily be reused for some other screen (other than friends list).