### PR TITLE
Reduce audio seek debounce time downwards

### DIFF
--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays
 {
     public partial class NowPlayingOverlay : OsuFocusedOverlayContainer, INamedOverlayComponent
     {
-        public const double TRACK_DRAG_SEEK_DEBOUNCE = 200;
+        public const double TRACK_DRAG_SEEK_DEBOUNCE = 40;
 
         public IconUsage Icon => OsuIcon.Music;
         public LocalisableString Title => NowPlayingStrings.HeaderTitle;


### PR DESCRIPTION
I found this way too high in the editor, not giving enough feedback when seeking.

To recap, this was put in place to avoid glitchy sounding audio. Such glitchiness only occurs with *very* fast seeks. This is still well within sane range.