### PR TITLE
Add beatmap attributes to quick play panels

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Tests.Visual.Matchmaking
                     new APIBeatmapTag { TagId = 23, VoteCount = 5 },
                 ];
 
+                beatmap.BeatmapSet!.HasExplicitContent = true;
+                beatmap.BeatmapSet!.HasVideo = true;
+                beatmap.BeatmapSet!.HasStoryboard = true;
+                beatmap.BeatmapSet.FeaturedInSpotlight = true;
+                beatmap.BeatmapSet.TrackId = 1;
                 beatmap.BeatmapSet!.RelatedTags =
                 [
                     new APITag
@@ -127,6 +132,12 @@ namespace osu.Game.Tests.Visual.Matchmaking
                     }
                 };
             });
+
+            AddStep("add peppy", () => panel!.AddUser(new APIUser
+            {
+                Id = 2,
+                Username = "peppy",
+            }));
 
             AddToggleStep("allow selection", value => panel!.AllowSelection = value);
 

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneBeatmapSelectPanel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -45,10 +46,41 @@ namespace osu.Game.Tests.Visual.Matchmaking
 
             AddStep("add panel", () =>
             {
+                var beatmap = CreateAPIBeatmap();
+
+                beatmap.TopTags =
+                [
+                    new APIBeatmapTag { TagId = 4, VoteCount = 1 },
+                    new APIBeatmapTag { TagId = 2, VoteCount = 1 },
+                    new APIBeatmapTag { TagId = 23, VoteCount = 5 },
+                ];
+
+                beatmap.BeatmapSet!.RelatedTags =
+                [
+                    new APITag
+                    {
+                        Id = 2,
+                        Name = "song representation/simple",
+                        Description = "Accessible and straightforward map design."
+                    },
+                    new APITag
+                    {
+                        Id = 4,
+                        Name = "style/clean",
+                        Description = "Visually uncluttered and organised patterns, often involving few overlaps and equal visual spacing between objects."
+                    },
+                    new APITag
+                    {
+                        Id = 23,
+                        Name = "aim/aim control",
+                        Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern."
+                    }
+                ];
+
                 Child = new OsuContextMenuContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = panel = new MatchmakingSelectPanelBeatmap(new MatchmakingPlaylistItem(new MultiplayerPlaylistItem(), CreateAPIBeatmap(), []))
+                    Child = panel = new MatchmakingSelectPanelBeatmap(new MatchmakingPlaylistItem(new MultiplayerPlaylistItem(), beatmap, []))
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"owners")]
         public BeatmapOwner[] BeatmapOwners { get; set; } = Array.Empty<BeatmapOwner>();
 
-        public APITag[] GetTopUserTags()
+        public (APITag Tag, int VoteCount)[] GetTopUserTags()
         {
             if (TopTags == null || TopTags.Length == 0 || BeatmapSet?.RelatedTags == null)
                 return [];
@@ -130,7 +130,7 @@ namespace osu.Game.Online.API.Requests.Responses
                    // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
                    .OrderByDescending(t => t.topTag.VoteCount)
                    .ThenBy(t => t.relatedTag!.Name)
-                   .Select(t => t.relatedTag!)
+                   .Select(t => (t.relatedTag!, t.topTag.VoteCount))
                    .ToArray();
         }
 

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
@@ -114,6 +116,23 @@ namespace osu.Game.Online.API.Requests.Responses
 
         [JsonProperty(@"owners")]
         public BeatmapOwner[] BeatmapOwners { get; set; } = Array.Empty<BeatmapOwner>();
+
+        public APITag[] GetTopUserTags()
+        {
+            if (TopTags == null || TopTags.Length == 0 || BeatmapSet?.RelatedTags == null)
+                return [];
+
+            var tagsById = BeatmapSet.RelatedTags.ToDictionary(t => t.Id);
+
+            return TopTags
+                   .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
+                   .Where(t => t.relatedTag != null)
+                   // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
+                   .OrderByDescending(t => t.topTag.VoteCount)
+                   .ThenBy(t => t.relatedTag!.Name)
+                   .Select(t => t.relatedTag!)
+                   .ToArray();
+        }
 
         #region Implementation of IBeatmapInfo
 

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private void updateUserTags()
         {
-            userTags.Metadata = Beatmap.Value.GetTopUserTags().Select(t => t.Tag.Name).ToArray();
+            userTags.Metadata = Beatmap.Value?.GetTopUserTags().Select(t => t.Tag.Name).ToArray();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -130,21 +129,7 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private void updateUserTags()
         {
-            if (Beatmap.Value?.TopTags == null || Beatmap.Value.TopTags.Length == 0 || BeatmapSet.Value?.RelatedTags == null)
-            {
-                userTags.Metadata = null;
-                return;
-            }
-
-            var tagsById = BeatmapSet.Value.RelatedTags.ToDictionary(t => t.Id);
-            userTags.Metadata = Beatmap.Value.TopTags
-                                       .Select(t => (topTag: t, relatedTag: tagsById.GetValueOrDefault(t.TagId)))
-                                       .Where(t => t.relatedTag != null)
-                                       // see https://github.com/ppy/osu-web/blob/bb3bd2e7c6f84f26066df5ea20a81c77ec9bb60a/resources/js/beatmapsets-show/controller.ts#L103-L106 for sort criteria
-                                       .OrderByDescending(t => t.topTag.VoteCount)
-                                       .ThenBy(t => t.relatedTag!.Name)
-                                       .Select(t => t.relatedTag!.Name)
-                                       .ToArray();
+            userTags.Metadata = Beatmap.Value.GetTopUserTags().Select(t => t.Name).ToArray();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private void updateUserTags()
         {
-            userTags.Metadata = Beatmap.Value.GetTopUserTags().Select(t => t.Name).ToArray();
+            userTags.Metadata = Beatmap.Value.GetTopUserTags().Select(t => t.Tag.Name).ToArray();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/BeatmapSelectGrid.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Action = i => ItemSelected?.Invoke(i),
+                    Depth = -(float)item.PlaylistItem.StarRating
                 };
 
                 panelGridContainer.Add(panel);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
@@ -458,7 +458,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                             new OsuSpriteText
                             {
                                 Padding = new MarginPadding { Vertical = 3, Horizontal = 8 },
-                                Text = beatmap.GetTopUserTags().FirstOrDefault()?.Name ?? string.Empty,
+                                Text = beatmap.GetTopUserTags().FirstOrDefault().Tag?.Name ?? string.Empty,
                                 AlwaysPresent = true,
                                 Colour = colourProvider.Content2,
                                 Font = OsuFont.Style.Caption2,
@@ -468,7 +468,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                     };
                 }
 
-                public LocalisableString TooltipText => string.Join('\n', beatmap.GetTopUserTags().Select(t => t.Name));
+                public LocalisableString TooltipText => string.Join('\n', beatmap.GetTopUserTags().Select(t => $"{t.Tag.Name} ({t.VoteCount})"));
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 FillFlowContainer leftIconArea;
                 Container explicitBadgeArea;
 
-                InternalChildren = new Drawable[]
+                InternalChildren = new[]
                 {
                     new Container
                     {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
@@ -28,7 +28,6 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Resources.Localisation.Web;
-using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play.HUD;
 using osuTK;
@@ -46,9 +45,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
 
             [Resolved]
             private BeatmapSetOverlay? beatmapSetOverlay { get; set; }
-
-            [Resolved]
-            private RulesetStore rulesets { get; set; } = null!;
 
             private readonly IBindable<DownloadState> downloadState = new Bindable<DownloadState>();
             private readonly IBindableNumber<double> downloadProgress = new BindableDouble();
@@ -77,157 +73,66 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
             private void load(OsuColour colours)
             {
                 FillFlowContainer leftIconArea;
-                FillFlowContainer titleBadgeArea;
-                GridContainer artistContainer;
+                Container explicitBadgeArea;
 
                 InternalChildren = new Drawable[]
                 {
-                    new BeatmapDownloadTracker(beatmap.BeatmapSet!)
+                    new Container
                     {
-                        State = { BindTarget = downloadState },
-                        Progress = { BindTarget = downloadProgress },
-                    },
-                    thumbnail = new BeatmapCardThumbnail(beatmapSet, beatmapSet, keepLoaded: true)
-                    {
-                        Name = @"Left (icon) area",
-                        Size = new Vector2(MatchmakingSelectPanel.HEIGHT),
-                        Padding = new MarginPadding { Right = BeatmapCard.CORNER_RADIUS },
-                        Child = leftIconArea = new FillFlowContainer
-                        {
-                            Margin = new MarginPadding(4),
-                            AutoSizeAxes = Axes.Both,
-                            Direction = FillDirection.Horizontal,
-                            Spacing = new Vector2(1)
-                        }
-                    },
-                    buttonContainer = new CollapsibleButtonContainer(beatmapSet, allowNavigationToBeatmap: false, keepBackgroundLoaded: true)
-                    {
-                        X = MatchmakingSelectPanel.HEIGHT - BeatmapCard.CORNER_RADIUS,
-                        Width = BeatmapCard.WIDTH - MatchmakingSelectPanel.HEIGHT + BeatmapCard.CORNER_RADIUS,
-                        FavouriteState = { BindTarget = favouriteState },
-                        ButtonsCollapsedWidth = 0,
-                        ButtonsExpandedWidth = 24,
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        CornerRadius = BeatmapCard.CORNER_RADIUS,
                         Children = new Drawable[]
                         {
-                            new FillFlowContainer
+                            new BeatmapDownloadTracker(beatmap.BeatmapSet!)
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                Direction = FillDirection.Vertical,
-                                Children = new Drawable[]
-                                {
-                                    new GridContainer
-                                    {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        ColumnDimensions = new[]
-                                        {
-                                            new Dimension(),
-                                            new Dimension(GridSizeMode.AutoSize),
-                                        },
-                                        RowDimensions = new[]
-                                        {
-                                            new Dimension(GridSizeMode.AutoSize)
-                                        },
-                                        Content = new[]
-                                        {
-                                            new Drawable[]
-                                            {
-                                                new TruncatingSpriteText
-                                                {
-                                                    Text = new RomanisableString(beatmapSet.TitleUnicode, beatmapSet.Title),
-                                                    Font = OsuFont.Default.With(size: 18f, weight: FontWeight.SemiBold),
-                                                    RelativeSizeAxes = Axes.X,
-                                                },
-                                                titleBadgeArea = new FillFlowContainer
-                                                {
-                                                    Anchor = Anchor.BottomRight,
-                                                    Origin = Anchor.BottomRight,
-                                                    AutoSizeAxes = Axes.Both,
-                                                    Direction = FillDirection.Horizontal,
-                                                }
-                                            }
-                                        }
-                                    },
-                                    artistContainer = new GridContainer
-                                    {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        ColumnDimensions = new[]
-                                        {
-                                            new Dimension(),
-                                            new Dimension(GridSizeMode.AutoSize)
-                                        },
-                                        RowDimensions = new[]
-                                        {
-                                            new Dimension(GridSizeMode.AutoSize)
-                                        },
-                                        Content = new[]
-                                        {
-                                            new[]
-                                            {
-                                                new TruncatingSpriteText
-                                                {
-                                                    Text = BeatmapsetsStrings.ShowDetailsByArtist(new RomanisableString(beatmapSet.ArtistUnicode, beatmapSet.Artist)),
-                                                    Font = OsuFont.Default.With(size: 14f, weight: FontWeight.SemiBold),
-                                                    RelativeSizeAxes = Axes.X,
-                                                },
-                                                Empty()
-                                            },
-                                        }
-                                    },
-                                    new LinkFlowContainer(s =>
-                                    {
-                                        s.Shadow = false;
-                                        s.Font = OsuFont.GetFont(size: 11f, weight: FontWeight.SemiBold);
-                                    }).With(d =>
-                                    {
-                                        d.AutoSizeAxes = Axes.Both;
-                                        d.Margin = new MarginPadding { Top = 1 };
-                                        d.AddText("mapped by ", t => t.Colour = colourProvider.Content2);
-                                        d.AddUserLink(beatmapSet.Author);
-                                    }),
-                                }
+                                State = { BindTarget = downloadState },
+                                Progress = { BindTarget = downloadProgress },
                             },
-                            new FillFlowContainer
+                            thumbnail = new BeatmapCardThumbnail(beatmapSet, beatmapSet, keepLoaded: true)
                             {
-                                Anchor = Anchor.TopRight,
-                                Origin = Anchor.TopRight,
-                                AutoSizeAxes = Axes.Both,
-                                Direction = FillDirection.Vertical,
-                                Spacing = new Vector2(2),
+                                Name = @"Left (icon) area",
+                                Size = new Vector2(MatchmakingSelectPanel.HEIGHT),
+                                Padding = new MarginPadding { Right = BeatmapCard.CORNER_RADIUS },
                                 Children = new Drawable[]
                                 {
-                                    new TopTagPill(beatmap)
+                                    leftIconArea = new FillFlowContainer
                                     {
-                                        Anchor = Anchor.TopRight,
-                                        Origin = Anchor.TopRight,
-                                    },
-                                    beatmapAttributesText = new OsuTextFlowContainer
-                                    {
-                                        Anchor = Anchor.TopRight,
-                                        Origin = Anchor.TopRight,
                                         AutoSizeAxes = Axes.Both,
+                                        Margin = new MarginPadding(4),
+                                        Direction = FillDirection.Horizontal,
+                                        Spacing = new Vector2(1)
+                                    },
+                                    explicitBadgeArea = new Container
+                                    {
+                                        Anchor = Anchor.BottomCentre,
+                                        Origin = Anchor.BottomCentre,
+                                        AutoSizeAxes = Axes.Both,
+                                        Margin = new MarginPadding(4),
                                     }
                                 }
                             },
-                            new Container
+                            buttonContainer = new CollapsibleButtonContainer(beatmapSet, allowNavigationToBeatmap: false, keepBackgroundLoaded: true)
                             {
-                                Name = @"Bottom content",
-                                RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y,
-                                Anchor = Anchor.BottomLeft,
-                                Origin = Anchor.BottomLeft,
+                                X = MatchmakingSelectPanel.HEIGHT - BeatmapCard.CORNER_RADIUS,
+                                Width = BeatmapCard.WIDTH - MatchmakingSelectPanel.HEIGHT + BeatmapCard.CORNER_RADIUS,
+                                FavouriteState = { BindTarget = favouriteState },
+                                ButtonsCollapsedWidth = 0,
+                                ButtonsExpandedWidth = 24,
                                 Children = new Drawable[]
                                 {
-                                    idleBottomContent = new FillFlowContainer
+                                    new FillFlowContainer
                                     {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
+                                        RelativeSizeAxes = Axes.Both,
                                         Direction = FillDirection.Vertical,
-                                        Spacing = new Vector2(0, 2),
-                                        AlwaysPresent = true,
                                         Children = new Drawable[]
                                         {
+                                            new TruncatingSpriteText
+                                            {
+                                                Text = new RomanisableString(beatmapSet.TitleUnicode, beatmapSet.Title),
+                                                Font = OsuFont.Default.With(size: 18f, weight: FontWeight.SemiBold),
+                                                RelativeSizeAxes = Axes.X,
+                                            },
                                             new GridContainer
                                             {
                                                 RelativeSizeAxes = Axes.X,
@@ -245,80 +150,160 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                                                 {
                                                     new Drawable[]
                                                     {
-                                                        new Container
+                                                        new TruncatingSpriteText
                                                         {
-                                                            Masking = true,
-                                                            CornerRadius = BeatmapCard.CORNER_RADIUS,
+                                                            Text = BeatmapsetsStrings.ShowDetailsByArtist(new RomanisableString(beatmapSet.ArtistUnicode, beatmapSet.Artist)),
+                                                            Font = OsuFont.Default.With(size: 14f, weight: FontWeight.SemiBold),
                                                             RelativeSizeAxes = Axes.X,
-                                                            AutoSizeAxes = Axes.Y,
-                                                            Children = new Drawable[]
-                                                            {
-                                                                new Box
-                                                                {
-                                                                    Colour = colours.ForStarDifficulty(beatmap.StarRating).Darken(0.8f),
-                                                                    RelativeSizeAxes = Axes.Both,
-                                                                },
-                                                                new FillFlowContainer
-                                                                {
-                                                                    Padding = new MarginPadding(4),
-                                                                    RelativeSizeAxes = Axes.X,
-                                                                    AutoSizeAxes = Axes.Y,
-                                                                    Direction = FillDirection.Horizontal,
-                                                                    Spacing = new Vector2(6, 0),
-                                                                    Children = new Drawable[]
-                                                                    {
-                                                                        new StarRatingDisplay(new StarDifficulty(beatmap.StarRating, 0), StarRatingDisplaySize.Small, animated: true)
-                                                                        {
-                                                                            Origin = Anchor.CentreLeft,
-                                                                            Anchor = Anchor.CentreLeft,
-                                                                            Scale = new Vector2(0.9f),
-                                                                        },
-                                                                        new TruncatingSpriteText
-                                                                        {
-                                                                            Text = beatmap.DifficultyName,
-                                                                            Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
-                                                                            Anchor = Anchor.CentreLeft,
-                                                                            Origin = Anchor.CentreLeft,
-                                                                        },
-                                                                    }
-                                                                },
-                                                            }
                                                         },
-                                                        new Container
+                                                        new TopTagPill(beatmap)
                                                         {
-                                                            AutoSizeAxes = Axes.Both,
-                                                            Alpha = mods.Length > 0 ? 1 : 0,
-                                                            Child = new ModFlowDisplay
-                                                            {
-                                                                AutoSizeAxes = Axes.Both,
-                                                                Scale = new Vector2(0.5f),
-                                                                Margin = new MarginPadding { Left = 5 },
-                                                                Current = { Value = mods },
-                                                            }
+                                                            Anchor = Anchor.CentreRight,
+                                                            Origin = Anchor.CentreRight,
                                                         }
                                                     },
                                                 }
                                             },
+                                            new Container
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Children = new Drawable[]
+                                                {
+                                                    new LinkFlowContainer(s =>
+                                                    {
+                                                        s.Shadow = false;
+                                                        s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.SemiBold);
+                                                    }).With(d =>
+                                                    {
+                                                        d.AutoSizeAxes = Axes.Both;
+                                                        d.Margin = new MarginPadding { Top = 1 };
+                                                        d.AddText("mapped by ", t => t.Colour = colourProvider.Content2);
+                                                        d.AddUserLink(beatmapSet.Author);
+                                                    }),
+                                                    beatmapAttributesText = new OsuTextFlowContainer
+                                                    {
+                                                        Anchor = Anchor.CentreRight,
+                                                        Origin = Anchor.CentreRight,
+                                                        AutoSizeAxes = Axes.Both,
+                                                    }
+                                                }
+                                            }
                                         }
                                     },
-                                    downloadProgressBar = new BeatmapCardDownloadProgressBar
+                                    new Container
                                     {
+                                        Name = @"Bottom content",
                                         RelativeSizeAxes = Axes.X,
-                                        Height = 5,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        State = { BindTarget = downloadState },
-                                        Progress = { BindTarget = downloadProgress }
+                                        AutoSizeAxes = Axes.Y,
+                                        Anchor = Anchor.BottomLeft,
+                                        Origin = Anchor.BottomLeft,
+                                        Children = new Drawable[]
+                                        {
+                                            idleBottomContent = new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Direction = FillDirection.Vertical,
+                                                Spacing = new Vector2(0, 2),
+                                                AlwaysPresent = true,
+                                                Children = new Drawable[]
+                                                {
+                                                    new GridContainer
+                                                    {
+                                                        RelativeSizeAxes = Axes.X,
+                                                        AutoSizeAxes = Axes.Y,
+                                                        ColumnDimensions = new[]
+                                                        {
+                                                            new Dimension(),
+                                                            new Dimension(GridSizeMode.AutoSize)
+                                                        },
+                                                        RowDimensions = new[]
+                                                        {
+                                                            new Dimension(GridSizeMode.AutoSize)
+                                                        },
+                                                        Content = new[]
+                                                        {
+                                                            new Drawable[]
+                                                            {
+                                                                new Container
+                                                                {
+                                                                    Masking = true,
+                                                                    CornerRadius = BeatmapCard.CORNER_RADIUS,
+                                                                    RelativeSizeAxes = Axes.X,
+                                                                    AutoSizeAxes = Axes.Y,
+                                                                    Children = new Drawable[]
+                                                                    {
+                                                                        new Box
+                                                                        {
+                                                                            Colour = colours.ForStarDifficulty(beatmap.StarRating).Darken(0.8f),
+                                                                            RelativeSizeAxes = Axes.Both,
+                                                                        },
+                                                                        new FillFlowContainer
+                                                                        {
+                                                                            Padding = new MarginPadding(4),
+                                                                            RelativeSizeAxes = Axes.X,
+                                                                            AutoSizeAxes = Axes.Y,
+                                                                            Direction = FillDirection.Horizontal,
+                                                                            Spacing = new Vector2(6, 0),
+                                                                            Children = new Drawable[]
+                                                                            {
+                                                                                new StarRatingDisplay(new StarDifficulty(beatmap.StarRating, 0), StarRatingDisplaySize.Small, animated: true)
+                                                                                {
+                                                                                    Origin = Anchor.CentreLeft,
+                                                                                    Anchor = Anchor.CentreLeft,
+                                                                                    Scale = new Vector2(0.9f),
+                                                                                },
+                                                                                new TruncatingSpriteText
+                                                                                {
+                                                                                    Text = beatmap.DifficultyName,
+                                                                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold),
+                                                                                    Anchor = Anchor.CentreLeft,
+                                                                                    Origin = Anchor.CentreLeft,
+                                                                                },
+                                                                            }
+                                                                        },
+                                                                    }
+                                                                },
+                                                                new Container
+                                                                {
+                                                                    AutoSizeAxes = Axes.Both,
+                                                                    Alpha = mods.Length > 0 ? 1 : 0,
+                                                                    Child = new ModFlowDisplay
+                                                                    {
+                                                                        AutoSizeAxes = Axes.Both,
+                                                                        Scale = new Vector2(0.5f),
+                                                                        Margin = new MarginPadding { Left = 5 },
+                                                                        Current = { Value = mods },
+                                                                    }
+                                                                }
+                                                            },
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            downloadProgressBar = new BeatmapCardDownloadProgressBar
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                Height = 5,
+                                                Anchor = Anchor.Centre,
+                                                Origin = Anchor.Centre,
+                                                State = { BindTarget = downloadState },
+                                                Progress = { BindTarget = downloadProgress }
+                                            }
+                                        }
+                                    },
+                                    selectionOverlay = new AvatarOverlay
+                                    {
+                                        Anchor = Anchor.TopRight,
+                                        Origin = Anchor.TopRight,
+                                        Margin = new MarginPadding { Top = -20 }
                                     }
                                 }
                             },
-                            selectionOverlay = new AvatarOverlay
-                            {
-                                Anchor = Anchor.TopRight,
-                                Origin = Anchor.TopRight,
-                            }
                         }
-                    }
+                    },
+                    selectionOverlay.CreateProxy()
                 };
 
                 if (beatmapSet.HasVideo)
@@ -327,34 +312,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 if (beatmapSet.HasStoryboard)
                     leftIconArea.Add(new StoryboardIconPill { IconSize = new Vector2(16) });
 
-                if (beatmapSet.FeaturedInSpotlight)
-                {
-                    titleBadgeArea.Add(new SpotlightBeatmapBadge
-                    {
-                        Anchor = Anchor.BottomRight,
-                        Origin = Anchor.BottomRight,
-                        Margin = new MarginPadding { Left = 4 }
-                    });
-                }
-
                 if (beatmapSet.HasExplicitContent)
                 {
-                    titleBadgeArea.Add(new ExplicitContentBeatmapBadge
+                    explicitBadgeArea.Add(new ExplicitContentBeatmapBadge
                     {
-                        Anchor = Anchor.BottomRight,
-                        Origin = Anchor.BottomRight,
                         Margin = new MarginPadding { Left = 4 }
                     });
-                }
-
-                if (beatmapSet.TrackId != null)
-                {
-                    artistContainer.Content[0][1] = new FeaturedArtistBeatmapBadge
-                    {
-                        Anchor = Anchor.BottomRight,
-                        Origin = Anchor.BottomRight,
-                        Margin = new MarginPadding { Left = 4 }
-                    };
                 }
 
                 bool firstAttribute = true;
@@ -494,10 +457,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                             },
                             new OsuSpriteText
                             {
-                                Padding = new MarginPadding { Vertical = 2, Horizontal = 8 },
+                                Padding = new MarginPadding { Vertical = 3, Horizontal = 8 },
                                 Text = beatmap.GetTopUserTags().FirstOrDefault()?.Name ?? string.Empty,
+                                AlwaysPresent = true,
                                 Colour = colourProvider.Content2,
-                                Font = OsuFont.Style.Caption2
+                                Font = OsuFont.Style.Caption2,
+                                UseFullGlyphHeight = false,
                             }
                         }
                     };

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentRandom.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentRandom.cs
@@ -3,9 +3,11 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -29,37 +31,44 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
             [BackgroundDependencyLoader]
             private void load()
             {
-                InternalChildren = new Drawable[]
+                InternalChild = new Container
                 {
-                    new Box
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = BeatmapCard.CORNER_RADIUS,
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colourProvider.Dark5,
-                    },
-                    new TrianglesV2
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Alpha = 0.1f,
-                    },
-                    Label = new OsuSpriteText
-                    {
-                        Y = 20,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Text = "Random"
-                    },
-                    Dice = new SpriteIcon
-                    {
-                        Y = -10,
-                        Size = new Vector2(28),
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Icon = randomDiceIcon(),
-                    },
-                    selectionOverlay = new AvatarOverlay
-                    {
-                        Anchor = Anchor.TopRight,
-                        Origin = Anchor.TopRight,
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colourProvider.Dark5,
+                        },
+                        new TrianglesV2
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Alpha = 0.1f,
+                        },
+                        Label = new OsuSpriteText
+                        {
+                            Y = 20,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Text = "Random"
+                        },
+                        Dice = new SpriteIcon
+                        {
+                            Y = -10,
+                            Size = new Vector2(28),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Icon = randomDiceIcon(),
+                        },
+                        selectionOverlay = new AvatarOverlay
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Margin = new MarginPadding { Right = 5 }
+                        }
                     }
                 };
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.cs
@@ -61,21 +61,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                     {
                         new Container
                         {
+                            RelativeSizeAxes = Axes.Both,
                             Masking = true,
                             CornerRadius = BeatmapCard.CORNER_RADIUS,
                             CornerExponent = 10,
-                            RelativeSizeAxes = Axes.Both,
-                            Children = new[]
+                            Child = lighting = new Box
                             {
-                                Content,
-                                lighting = new Box
-                                {
-                                    Blending = BlendingParameters.Additive,
-                                    RelativeSizeAxes = Axes.Both,
-                                    Alpha = 0,
-                                },
+                                Blending = BlendingParameters.Additive,
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0,
                             }
                         },
+                        Content,
                         border = new Container
                         {
                             Alpha = 0,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanelRandom.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanelRandom.cs
@@ -6,9 +6,11 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input.Events;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osuTK;
@@ -69,7 +71,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 AddRange(new Drawable[]
                 {
                     new CardContentBeatmap(playlistItem.Beatmap, playlistItem.Mods),
-                    flashLayer,
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        CornerRadius = BeatmapCard.CORNER_RADIUS,
+                        Child = flashLayer
+                    }
                 });
 
                 foreach (var user in users)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingAvatar.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/MatchmakingAvatar.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
 
             AddInternal(new Container
             {
-                Padding = new MarginPadding(2),
+                Padding = new MarginPadding(isOwnUser ? 2 : 0),
                 RelativeSizeAxes = Axes.Both,
                 Child = new CircularContainer
                 {


### PR DESCRIPTION
I've removed the spotlights/featured artist displays because they couldn't fit. With every possible attribute displayed, it now looks like this:

<img width="473" height="152" alt="image" src="https://github.com/user-attachments/assets/21412db5-4631-4361-be16-0eb9953b5192" />

And on the dev server:

<img width="1916" height="978" alt="image" src="https://github.com/user-attachments/assets/65d4499d-5a18-474c-87c3-1cc27e711d42" />