### PR TITLE
Change editor to not seek smoothly when performing distant seeks

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             if (editorClock.IsRunning && !instant && lastSeekTime != null && Time.Current - lastSeekTime < NowPlayingOverlay.TRACK_DRAG_SEEK_DEBOUNCE)
                 return;
 
-            editorClock.SeekSmoothlyTo(seekDestination);
+            editorClock.Seek(seekDestination);
 
             lastSeekTime = instant ? null : Time.Current;
         }

--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Screens.Edit
         }
 
         /// <summary>
-        /// Seek smoothly to the provided destination.
+        /// Seek smoothly to the provided destination, if within a certain proximity to the current viewport.
         /// Use <see cref="Seek"/> to perform an immediate seek.
         /// </summary>
         /// <param name="seekDestination"></param>
@@ -217,12 +217,17 @@ namespace osu.Game.Screens.Edit
         {
             seekingOrStopped.Value = true;
 
-            if (IsRunning)
-                Seek(seekDestination);
-            else
+            // The whole point of seeking smoothly is to maintain continuity for the user.
+            // Above a certain proximity, there's little reason to do this as the jump is already huge.
+            const double smooth_seek_max_proximity = 5000;
+
+            if (IsRunning || Math.Abs(seekDestination - currentTime) > smooth_seek_max_proximity)
             {
-                transformSeekTo(seekDestination, transform_time, Easing.OutQuint);
+                Seek(seekDestination);
+                return;
             }
+
+            transformSeekTo(seekDestination, transform_time, Easing.OutQuint);
         }
 
         public void BindAdjustments() => track.Value?.BindAdjustments(AudioAdjustments);


### PR DESCRIPTION
This reverts to the way stable does things. Smooth seeking is nice and all, but slows things down and doesn't give the instant reponse that mappers are used to.

This should fix some performance issues regarding seeking as it no longer tries to render large portions of the map during the seek operation.

Note that I've also forced the summary timeline to always non-smooth seek. It was bugging out in weird ways when doing smooth seeks and I don't want to attempt to fix it.