### PR TITLE
Change last year placing from integer to string in tournament overlay

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Tournament.Tests.Screens
                 {
                     FullName = { Value = @"Japan" },
                     Acronym = { Value = "JPN" },
+                    Seed = { Value = "#28" },
+                    LastYearPlacing = { Value = "#17-24" },
                     SeedingResults =
                     {
                         new SeedingResult
@@ -36,20 +38,38 @@ namespace osu.Game.Tournament.Tests.Screens
                             Seed = { Value = 8 }
                         }
                     }
+                },
+                new TournamentTeam
+                {
+                    Acronym = { Value = "USA" },
+                    FlagName = { Value = "US" },
+                    FullName = { Value = "United States" },
                 }
             }
         };
 
-        [Test]
-        public void TestBasic()
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            AddStep("create seeding screen", () => Add(new SeedingScreen
+            Add(new SeedingScreen
             {
                 FillMode = FillMode.Fit,
                 FillAspectRatio = 16 / 9f
-            }));
+            });
+        }
 
-            AddStep("set team to Japan", () => this.ChildrenOfType<SettingsTeamDropdown>().Single().Current.Value = ladder.Teams.Single());
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("set team to Japan", () =>
+                this.ChildrenOfType<SettingsTeamDropdown>().Single().Current.Value = ladder.Teams.Single(t => t.FullName.Value == "Japan"));
+        }
+
+        [Test]
+        public void TestNoSeed()
+        {
+            AddStep("set team to USA", () =>
+                this.ChildrenOfType<SettingsTeamDropdown>().Single().Current.Value = ladder.Teams.Single(t => t.FullName.Value == "United States"));
         }
     }
 }

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Tournament.Tests
                     Acronym = { Value = "JPN" },
                     FlagName = { Value = "JP" },
                     FullName = { Value = "Japan" },
-                    LastYearPlacing = { Value = 10 },
+                    LastYearPlacing = { Value = "#10" },
                     Seed = { Value = "#12" },
                     SeedingResults =
                     {

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -49,11 +49,7 @@ namespace osu.Game.Tournament.Models
 
         public Bindable<string> Seed = new Bindable<string>(string.Empty);
 
-        public Bindable<int> LastYearPlacing = new BindableInt
-        {
-            MinValue = 0,
-            MaxValue = 256
-        };
+        public Bindable<string> LastYearPlacing = new Bindable<string>("N/A");
 
         [JsonProperty]
         public BindableList<TournamentUser> Players { get; } = new BindableList<TournamentUser>();

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -49,7 +49,25 @@ namespace osu.Game.Tournament.Models
 
         public Bindable<string> Seed = new Bindable<string>(string.Empty);
 
+        [JsonIgnore]
         public Bindable<string> LastYearPlacing = new Bindable<string>("N/A");
+
+        /// <summary>
+        /// Previously, a value of 0 was meant to indicate "no placement last year".
+        /// This will convert the number 0 from an old bracket.json file back to the "N/A" string (new default).
+        /// </summary>
+        [JsonProperty("LastYearPlacing")]
+        private object lastYearPlacing
+        {
+            get => LastYearPlacing.Value;
+            set
+            {
+                if (value is long oldValue && oldValue == 0)
+                    LastYearPlacing.Value = LastYearPlacing.Default;
+                else
+                    LastYearPlacing.Value = value.ToString() ?? LastYearPlacing.Default;
+            }
+        }
 
         [JsonProperty]
         public BindableList<TournamentUser> Players { get; } = new BindableList<TournamentUser>();

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
@@ -49,25 +50,9 @@ namespace osu.Game.Tournament.Models
 
         public Bindable<string> Seed = new Bindable<string>(string.Empty);
 
-        [JsonIgnore]
-        public Bindable<string> LastYearPlacing = new Bindable<string>("N/A");
-
-        /// <summary>
-        /// Previously, a value of 0 was meant to indicate "no placement last year".
-        /// This will convert the number 0 from an old bracket.json file back to the "N/A" string (new default).
-        /// </summary>
-        [JsonProperty("LastYearPlacing")]
-        private object lastYearPlacing
-        {
-            get => LastYearPlacing.Value;
-            set
-            {
-                if (value is long oldValue && oldValue == 0)
-                    LastYearPlacing.Value = LastYearPlacing.Default;
-                else
-                    LastYearPlacing.Value = value.ToString() ?? LastYearPlacing.Default;
-            }
-        }
+        [JsonProperty]
+        [JsonConverter(typeof(LastYearPlacingConverter))]
+        public Bindable<string> LastYearPlacing = new Bindable<string>(@"N/A");
 
         [JsonProperty]
         public BindableList<TournamentUser> Players { get; } = new BindableList<TournamentUser>();
@@ -90,5 +75,37 @@ namespace osu.Game.Tournament.Models
         }
 
         public override string ToString() => FullName.Value ?? Acronym.Value;
+
+        public class LastYearPlacingConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType) => objectType == typeof(Bindable<string>);
+
+            public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+                => serializer.Serialize(writer, ((Bindable<string>)value!).Value);
+
+            public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+            {
+                var lastYearPlacing = existingValue as Bindable<string>;
+                Debug.Assert(lastYearPlacing != null);
+
+                switch (reader.TokenType)
+                {
+                    case JsonToken.String:
+                        lastYearPlacing.Value = (string?)reader.Value ?? lastYearPlacing.Default;
+                        break;
+
+                    case JsonToken.Integer:
+                        long value = (long)reader.Value!;
+                        lastYearPlacing.Value = value > 0 ? $@"#{value}" : lastYearPlacing.Default;
+                        break;
+
+                    default:
+                        reader.Read();
+                        break;
+                }
+
+                return lastYearPlacing;
+            }
+        }
     }
 }

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -109,42 +109,42 @@ namespace osu.Game.Tournament.Screens.Editors
                             new SettingsTextBox
                             {
                                 LabelText = "Name",
-                                Width = 0.2f,
+                                Width = 0.33f,
                                 Current = Model.FullName
                             },
                             acronymTextBox = new SettingsTextBox
                             {
                                 LabelText = "Acronym",
-                                Width = 0.2f,
+                                Width = 0.25f,
                                 Current = Model.Acronym
                             },
                             new SettingsTextBox
                             {
                                 LabelText = "Flag",
-                                Width = 0.2f,
+                                Width = 0.25f,
                                 Current = Model.FlagName
-                            },
-                            new SettingsTextBox
-                            {
-                                LabelText = "Seed",
-                                Width = 0.2f,
-                                Current = Model.Seed
-                            },
-                            new SettingsTextBox
-                            {
-                                LabelText = "Last Year Placement",
-                                Width = 0.33f,
-                                Current = Model.LastYearPlacing
                             },
                             new SettingsButton
                             {
-                                Width = 0.2f,
-                                Margin = new MarginPadding(10),
+                                Width = 0.33f,
+                                Margin = new MarginPadding { Top = 20 },
                                 Text = "Edit seeding results",
                                 Action = () =>
                                 {
                                     sceneManager?.SetScreen(new SeedingEditorScreen(team, parent));
                                 }
+                            },
+                            new SettingsTextBox
+                            {
+                                LabelText = "Seed",
+                                Width = 0.25f,
+                                Current = Model.Seed
+                            },
+                            new SettingsTextBox
+                            {
+                                LabelText = "Last Year Placement",
+                                Width = 0.25f,
+                                Current = Model.LastYearPlacing
                             },
                             playerEditor,
                             new SettingsButton

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -10,9 +10,7 @@ using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Localisation;
 using osu.Game.Graphics;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Models;
@@ -132,7 +130,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 Width = 0.2f,
                                 Current = Model.Seed
                             },
-                            new SettingsSlider<int, LastYearPlacementSlider>
+                            new SettingsTextBox
                             {
                                 LabelText = "Last Year Placement",
                                 Width = 0.33f,
@@ -198,11 +196,6 @@ namespace osu.Game.Tournament.Screens.Editors
                     else
                         acronymTextBox.ClearNoticeText();
                 }, true);
-            }
-
-            private partial class LastYearPlacementSlider : RoundedSliderBar<int>
-            {
-                public override LocalisableString TooltipText => Current.Value == 0 ? "N/A" : base.TooltipText;
             }
 
             public partial class PlayerEditor : CompositeDrawable

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -274,7 +274,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                             new TeamDisplay(team) { Margin = new MarginPadding { Bottom = 30 } },
                             new RowDisplay("Average Rank:", $"#{team.AverageRank:#,0}"),
                             new RowDisplay("Seed:", team.Seed.Value),
-                            new RowDisplay("Last year's placing:", team.LastYearPlacing.Value > 0 ? $"#{team.LastYearPlacing:#,0}" : "N/A"),
+                            new RowDisplay("Last year's placing:", team.LastYearPlacing.Value),
                             new Container { Margin = new MarginPadding { Bottom = 30 } },
                         }
                     },


### PR DESCRIPTION
This PR changes the "Last year's placing" field from an integer to a string, matching what is currently used for the "Seed" field. This also slightly adjusts the textboxes in the team editor screen to better fit the textbox which replaced the last year placing slider.

Tournaments often show teams' last year placing as a range instead of a simple number as a result of bracket elimination. For example, in OWC2025, Japan was eliminated in the lower bracket round 2 along with 8 other teams, which gives them a placement of 17th-24th. 

Team editor screen:

| Before | <img width="1343" height="460" alt="image" src="https://github.com/user-attachments/assets/fa85fb1e-8d21-44a2-9c18-55dc87e54cba" /> |
| --- | --- |
| After | <img width="1344" height="456" alt="image" src="https://github.com/user-attachments/assets/38486c99-f86f-412f-9c88-2683fe062cde" /> |

Seeding screen:

| With seed and placement | No seed nor placing |
| --- | ---
| <img width="321" height="243" alt="image" src="https://github.com/user-attachments/assets/c77eaa41-358c-4551-927d-68f2c3076644" /> | <img width="308" height="238" alt="image" src="https://github.com/user-attachments/assets/fc071e51-f528-4f15-b325-e2e22fa504ed" /> |

