### PR TITLE
Add ability to view other beatmaps in set when difficulties are grouped by set

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneSongSelectFiltering.cs
@@ -379,6 +379,25 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             checkMatchedBeatmaps(6);
         }
 
+        [Test]
+        public void TestScopeToBeatmapWhenDifficultiesGroupedBySet()
+        {
+            ImportBeatmapForRuleset(0);
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+            SortBy(SortMode.Artist);
+            checkMatchedBeatmaps(6);
+
+            AddStep("click spread indicator", () => this.ChildrenOfType<PanelBeatmapSet.SpreadDisplay>().Single(d => d.Enabled.Value).TriggerClick());
+            WaitForFiltering();
+            checkMatchedBeatmaps(3);
+
+            AddStep("press Escape", () => InputManager.Key(Key.Escape));
+            WaitForFiltering();
+            checkMatchedBeatmaps(6);
+        }
+
         private NoResultsPlaceholder? getPlaceholder() => SongSelect.ChildrenOfType<NoResultsPlaceholder>().FirstOrDefault();
 
         private void checkMatchedBeatmaps(int expected) => AddUntilStep($"{expected} matching shown", () => Carousel.MatchedBeatmapsCount, () => Is.EqualTo(expected));

--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -93,7 +93,8 @@ namespace osu.Game.Graphics.UserInterface
             base.LoadComplete();
 
             Colour = dimColour;
-            Enabled.BindValueChanged(_ => this.FadeColour(dimColour, 200, Easing.OutQuint));
+            Enabled.BindValueChanged(_ => this.FadeColour(dimColour, 200, Easing.OutQuint), true);
+            FinishTransforms(true);
         }
 
         private Color4 dimColour => Enabled.Value ? Color4.White : colours.Gray9;

--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -92,12 +92,12 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.LoadComplete();
 
-            Colour = dimColour;
-            Enabled.BindValueChanged(_ => this.FadeColour(dimColour, 200, Easing.OutQuint), true);
+            Colour = Enabled.Value ? Colour4.White : DimColour;
+            Enabled.BindValueChanged(_ => this.FadeColour(DimColour, 200, Easing.OutQuint), true);
             FinishTransforms(true);
         }
 
-        private Color4 dimColour => Enabled.Value ? Color4.White : colours.Gray9;
+        protected virtual Colour4 DimColour => colours.Gray9;
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -532,6 +532,9 @@ namespace osu.Game.Screens.SelectV2
             // If a group was selected that is not the one containing the selection, attempt to reselect it.
             if (groupForReselection != null && grouping.GroupItems.TryGetValue(groupForReselection, out _))
                 setExpandedGroup(groupForReselection);
+
+            foreach (var item in Scroll.Panels.OfType<PanelBeatmapSet>().Where(p => p.Item != null))
+                updateVisibleBeatmaps((GroupedBeatmapSet)item.Item!.Model, item);
         }
 
         private void selectRecommendedDifficultyForBeatmapSet(GroupedBeatmapSet set)
@@ -959,11 +962,22 @@ namespace osu.Game.Screens.SelectV2
 
                     return beatmapPanelPool.Get();
 
-                case GroupedBeatmapSet:
-                    return setPanelPool.Get();
+                case GroupedBeatmapSet groupedBeatmapSet:
+                    var setPanel = setPanelPool.Get();
+                    updateVisibleBeatmaps(groupedBeatmapSet, setPanel);
+                    return setPanel;
             }
 
             throw new InvalidOperationException();
+        }
+
+        private void updateVisibleBeatmaps(GroupedBeatmapSet groupedBeatmapSet, PanelBeatmapSet setPanel)
+        {
+            HashSet<BeatmapInfo> visibleBeatmaps = [];
+            if (grouping.SetItems.TryGetValue(groupedBeatmapSet, out var visibleItems))
+                visibleBeatmaps = visibleItems.Where(i => i.Model is GroupedBeatmap).Select(i => ((GroupedBeatmap)i.Model).Beatmap).ToHashSet();
+
+            setPanel.VisibleBeatmaps.Value = visibleBeatmaps;
         }
 
         #endregion

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.SpreadDisplay.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.SpreadDisplay.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Screens.SelectV2
 
             public BindableBool Expanded { get; } = new BindableBool();
 
+            protected override Colour4 DimColour => Colour4.White;
+
             private readonly Bindable<BeatmapSetInfo?> scopedBeatmapSet = new Bindable<BeatmapSetInfo?>();
             private readonly Bindable<bool> showConvertedBeatmaps = new Bindable<bool>();
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.SpreadDisplay.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.SpreadDisplay.cs
@@ -1,0 +1,204 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.Screens.SelectV2
+{
+    public partial class PanelBeatmapSet
+    {
+        public partial class SpreadDisplay : OsuAnimatedButton
+        {
+            public Bindable<BeatmapSetInfo?> BeatmapSet { get; } = new Bindable<BeatmapSetInfo?>();
+            public BindableBool Expanded { get; } = new BindableBool();
+
+            private readonly Bindable<BeatmapSetInfo?> scopedBeatmapSet = new Bindable<BeatmapSetInfo?>();
+            private readonly Bindable<bool> showConvertedBeatmaps = new Bindable<bool>();
+
+            private const double transition_duration = 200;
+
+            [Resolved]
+            private Bindable<RulesetInfo> ruleset { get; set; } = null!;
+
+            [Resolved]
+            private OsuColour colours { get; set; } = null!;
+
+            private FillFlowContainer flow = null!;
+            private OsuSpriteText countText = null!; // TODO
+            private SpriteIcon icon = null!;
+
+            public SpreadDisplay()
+            {
+                AutoSizeAxes = Axes.X;
+                Height = 14;
+                Content.CornerRadius = 5;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(ISongSelect? songSelect, OsuConfigManager configManager)
+            {
+                Add(new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Y,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(5),
+                    Padding = new MarginPadding { Horizontal = 5 },
+                    Children = new Drawable[]
+                    {
+                        flow = new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.X,
+                            RelativeSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(2),
+                        },
+                        countText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Font = OsuFont.Style.Caption2,
+                        },
+                        icon = new SpriteIcon
+                        {
+                            Size = new Vector2(12),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Icon = FontAwesome.Solid.Eye,
+                            Alpha = 0,
+                        }
+                    }
+                });
+
+                if (songSelect != null)
+                    scopedBeatmapSet.BindTo(songSelect.ScopedBeatmapSet);
+
+                configManager.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmaps);
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                BeatmapSet.BindValueChanged(_ => updateBeatmapSet());
+                showConvertedBeatmaps.BindValueChanged(_ => updateBeatmapSet(), true);
+                Expanded.BindValueChanged(_ => updateEnabled());
+                scopedBeatmapSet.BindValueChanged(_ => updateEnabled(), true);
+                Enabled.BindValueChanged(_ => updateAppearance(), true);
+                FinishTransforms(true);
+            }
+
+            private void updateBeatmapSet()
+            {
+                if (BeatmapSet.Value == null)
+                {
+                    this.FadeOut(transition_duration, Easing.OutQuint);
+                    return;
+                }
+
+                flow.Clear();
+
+                var starDifficulties = BeatmapSet.Value.Beatmaps
+                                                 .Where(b => b.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value))
+                                                 .OrderBy(b => b.Ruleset.OnlineID)
+                                                 .ThenBy(b => b.StarRating)
+                                                 .Select(b => b.StarRating)
+                                                 .ToList();
+                this.FadeTo(starDifficulties.Count > 0 ? 1 : 0, transition_duration, Easing.OutQuint);
+
+                if (starDifficulties.Count == 0)
+                    return;
+
+                // TODO: figure overflow later
+
+                foreach (double starDifficulty in starDifficulties)
+                {
+                    var circle = new Circle
+                    {
+                        Size = new Vector2(5, 10),
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Colour = colours.ForStarDifficulty(starDifficulty)
+                    };
+                    flow.Add(circle);
+                    flow.SetLayoutPosition(circle, (float)starDifficulty);
+                }
+
+                Action = () => scopedBeatmapSet.Value = BeatmapSet.Value;
+                updateEnabled();
+            }
+
+            private void updateEnabled()
+            {
+                Enabled.Value = Expanded.Value && scopedBeatmapSet.Value == null;
+            }
+
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                if (!Enabled.Value)
+                    return false;
+
+                base.OnMouseDown(e);
+                return true;
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                if (!Enabled.Value)
+                    return false;
+
+                // this is a crude workaround with an issue with `OsuAnimatedButton` that isn't easily fixable.
+                // the issue is that when wanting to turn off the hover layer upon click, `HoverColour` can be set to a transparent colour,
+                // *but* this has to happen *before* `base.OnClick()`.
+                // this is because `base.OnClick()` uses `FlashColour()` to flash the button on click,
+                // but that `FlashColour()` call implicitly copies `hoverColour` *at the point of call* into the transform that ends the flash.
+                updateAppearance(false);
+                return base.OnClick(e);
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                updateAppearance();
+
+                if (!Enabled.Value)
+                    return false;
+
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                updateAppearance();
+
+                if (!Enabled.Value)
+                    return;
+
+                base.OnHoverLost(e);
+            }
+
+            private void updateAppearance(bool? isInteractable = null)
+            {
+                isInteractable ??= Enabled.Value && IsHovered;
+
+                HoverColour = isInteractable.Value ? Colour4.White.Opacity(0.1f) : Colour4.Transparent;
+                icon.FadeTo(isInteractable.Value ? 1 : 0, transition_duration, Easing.OutQuint);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.SelectV2
         private Drawable chevronIcon = null!;
         private PanelUpdateBeatmapButton updateButton = null!;
         private BeatmapSetOnlineStatusPill statusPill = null!;
-        private DifficultySpectrumDisplay difficultiesDisplay = null!;
+        private SpreadDisplay spreadDisplay = null!;
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -151,10 +151,11 @@ namespace osu.Game.Screens.SelectV2
                                     Origin = Anchor.CentreLeft,
                                     Margin = new MarginPadding { Right = 5f, Top = -2f },
                                 },
-                                difficultiesDisplay = new DifficultySpectrumDisplay
+                                spreadDisplay = new SpreadDisplay
                                 {
-                                    Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
+                                    Anchor = Anchor.CentreLeft,
+                                    Expanded = { BindTarget = Expanded }
                                 },
                             },
                         }
@@ -200,7 +201,7 @@ namespace osu.Game.Screens.SelectV2
             artistText.Text = new RomanisableString(beatmapSet.Metadata.ArtistUnicode, beatmapSet.Metadata.Artist);
             updateButton.BeatmapSet = beatmapSet;
             statusPill.Status = beatmapSet.Status;
-            difficultiesDisplay.BeatmapSet = beatmapSet;
+            spreadDisplay.BeatmapSet.Value = beatmapSet;
         }
 
         protected override void FreeAfterUse()
@@ -211,7 +212,7 @@ namespace osu.Game.Screens.SelectV2
             scheduledBackgroundRetrieval = null;
             setBackground.Beatmap = null;
             updateButton.BeatmapSet = null;
-            difficultiesDisplay.BeatmapSet = null;
+            spreadDisplay.BeatmapSet.Value = null;
         }
 
         [Resolved]

--- a/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapSet.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Screens.SelectV2
     {
         public const float HEIGHT = CarouselItem.DEFAULT_HEIGHT * 1.6f;
 
+        public Bindable<HashSet<BeatmapInfo>?> VisibleBeatmaps { get; } = new Bindable<HashSet<BeatmapInfo>?>();
+
         private Box chevronBackground = null!;
         private PanelSetBackground setBackground = null!;
         private ScheduledDelegate? scheduledBackgroundRetrieval;
@@ -155,7 +157,8 @@ namespace osu.Game.Screens.SelectV2
                                 {
                                     Origin = Anchor.CentreLeft,
                                     Anchor = Anchor.CentreLeft,
-                                    Expanded = { BindTarget = Expanded }
+                                    Expanded = { BindTarget = Expanded },
+                                    VisibleBeatmaps = { BindTarget = VisibleBeatmaps },
                                 },
                             },
                         }

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.SpreadDisplay.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.SpreadDisplay.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Screens.SelectV2
             public Bindable<BeatmapInfo?> Beatmap { get; } = new Bindable<BeatmapInfo?>();
             public Bindable<StarDifficulty> StarDifficulty { get; } = new Bindable<StarDifficulty>();
 
+            protected override Colour4 DimColour => Colour4.White;
+
             private readonly Bindable<BeatmapSetInfo?> scopedBeatmapSet = new Bindable<BeatmapSetInfo?>();
             private readonly Bindable<bool> showConvertedBeatmaps = new Bindable<bool>();
 


### PR DESCRIPTION
Additionally pills corresponding to difficulties that are currently filtered out are now less prominent.

https://github.com/user-attachments/assets/4b39f4ff-32d5-4017-8359-09353b050a19

---

Closes https://github.com/ppy/osu/issues/36039.

The part that makes this show the filtered out difficulties required some new crimes; see https://github.com/ppy/osu/commit/e07b828f30731ca4416c531cb936844d759534f2.

I have not done any benchmarking of this, want to see if this survives the initial review barrage.