### PR TITLE
Fix things breaking when attempting to exit external beatmap edit screen when it's finishing up

### DIFF
--- a/osu.Game/Screens/Edit/ExternalEditScreen.cs
+++ b/osu.Game/Screens/Edit/ExternalEditScreen.cs
@@ -191,6 +191,7 @@ namespace osu.Game.Screens.Edit
 
         private async Task finish()
         {
+            BackButtonVisibility.Value = false;
             string originalDifficulty = editor.Beatmap.Value.Beatmap.BeatmapInfo.DifficultyName;
 
             showSpinner("Cleaning up...");

--- a/osu.Game/Screens/Edit/ExternalEditScreen.cs
+++ b/osu.Game/Screens/Edit/ExternalEditScreen.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Screens.Edit
 
         public ExternalEditOperation<BeatmapSetInfo>? EditOperation { get; private set; }
 
+        private Task? finishOperation;
+
         private FillFlowContainer flow = null!;
 
         [BackgroundDependencyLoader]
@@ -98,11 +100,15 @@ namespace osu.Game.Screens.Edit
             if (fileMountOperation?.IsCompleted == false)
                 return true;
 
+            // Similarly do not allow interrupting an ongoing finish.
+            if (finishOperation?.IsCompleted == false)
+                return true;
+
             // If the operation completed successfully, ensure that we finish the operation before exiting.
             // The finish() call will subsequently call Exit() when done.
-            if (EditOperation != null)
+            if (EditOperation != null && finishOperation == null)
             {
-                finish().FireAndForget();
+                (finishOperation = finish()).FireAndForget();
                 return true;
             }
 
@@ -161,7 +167,7 @@ namespace osu.Game.Screens.Edit
                     Width = 350,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    Action = () => finish().FireAndForget(),
+                    Action = () => (finishOperation = finish()).FireAndForget(),
                     Enabled = { Value = false }
                 }
             };

--- a/osu.Game/Screens/Edit/ExternalEditScreen.cs
+++ b/osu.Game/Screens/Edit/ExternalEditScreen.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Edit
 
         private Task? fileMountOperation;
 
-        public ExternalEditOperation<BeatmapSetInfo>? EditOperation;
+        public ExternalEditOperation<BeatmapSetInfo>? EditOperation { get; private set; }
 
         private FillFlowContainer flow = null!;
 


### PR DESCRIPTION
https://github.com/ppy/osu/discussions/36182

"doctor it hurts when I do this!" ~~maybe don't do it then~~

best tested with a set that has an obscene number of difficulties because that makes the finish last long enough to notice, one example being https://osu.ppy.sh/beatmapsets/2377334#osu/5136070