### PR TITLE
Fix button spacing in account creation overlay

### DIFF
--- a/osu.Game/Overlays/AccountCreation/ScreenWarning.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenWarning.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Overlays.AccountCreation
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Padding = new MarginPadding(20),
-                    Spacing = new Vector2(0, 5),
+                    Spacing = new Vector2(0, 7),
                     Children = new Drawable[]
                     {
                         new Container


### PR DESCRIPTION
Noticed on passing. Adjusted by hand to match spacing in settings (well, almost).

| Before | After |
|--------|-------|
| <img width="1196" height="829" alt="CleanShot 2025-12-31 at 11 26 37" src="https://github.com/user-attachments/assets/6b1957dd-0e64-4978-afd5-7a87820f2e4a" /> | <img width="1196" height="829" alt="CleanShot 2025-12-31 at 11 26 26" src="https://github.com/user-attachments/assets/27f4b897-dbdb-45a7-b44c-accad5cecfc0" /> |