### PR TITLE
Fix casing in random selection algorithm dropdown

### DIFF
--- a/osu.Game/Localisation/UserInterfaceStrings.cs
+++ b/osu.Game/Localisation/UserInterfaceStrings.cs
@@ -165,9 +165,9 @@ namespace osu.Game.Localisation
         public static LocalisableString NeverRepeat => new TranslatableString(getKey(@"never_repeat_random"), @"Never repeat");
 
         /// <summary>
-        /// "True Random"
+        /// "True random"
         /// </summary>
-        public static LocalisableString TrueRandom => new TranslatableString(getKey(@"true_random"), @"True Random");
+        public static LocalisableString TrueRandom => new TranslatableString(getKey(@"true_random"), @"True random");
 
         /// <summary>
         /// "Selected Mods"


### PR DESCRIPTION
Incorrectly using title casing:

<img width="671" height="260" alt="image" src="https://github.com/user-attachments/assets/4626d1de-ad32-4c8f-8866-76c9f768f1b6" />
