### PR TITLE
Fix incorrect `OsuAnimatedButton`'s `DimColour` for child classes without override

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -92,12 +92,12 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.LoadComplete();
 
-            Colour = Enabled.Value ? Colour4.White : DimColour;
+            Colour = DimColour;
             Enabled.BindValueChanged(_ => this.FadeColour(DimColour, 200, Easing.OutQuint), true);
             FinishTransforms(true);
         }
 
-        protected virtual Colour4 DimColour => colours.Gray9;
+        protected virtual Colour4 DimColour => Enabled.Value ? Color4.White : colours.Gray9;
 
         protected override bool OnHover(HoverEvent e)
         {


### PR DESCRIPTION
- reported in https://discord.com/channels/188630481301012481/1097318920991559880/1456334234301104148
- regressed in https://github.com/ppy/osu/commit/a6545bea684b40addb800cc3aec6d7c77934816b

| master | pr |
|-|-|
| <img width="386" height="216" alt="image" src="https://github.com/user-attachments/assets/6ef567fb-ca84-4e21-a4b7-0ac6cd8eec97" /> | <img width="421" height="146" alt="osu_2026-01-01_20-44-36" src="https://github.com/user-attachments/assets/fb0c0024-d232-4d0e-b275-02f5a4062b00" /> |
| <img width="596" height="116" alt="image2" src="https://github.com/user-attachments/assets/fe582336-3184-4d31-bd5b-052115701a21" /> | <img width="594" height="216" alt="osu_2026-01-01_20-42-09" src="https://github.com/user-attachments/assets/b5c4fa7f-d4a3-4f61-9aa1-1ce95d1210c1" /> |
| <img width="309" height="70" alt="image3" src="https://github.com/user-attachments/assets/ce33da68-4f35-4c16-a98b-e23420533c0e" /> | <img width="246" height="59" alt="osu_2026-01-01_20-42-28" src="https://github.com/user-attachments/assets/3f90ffef-bc80-4df0-af12-26ed72a9c5f6" /> |