### PR TITLE
Fix legacy score base multiplier being calculated using modded difficulty values

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 flashlightRating = osuRatingCalculator.ComputeFlashlightRating(flashlight.DifficultyValue());
 
             double sliderNestedScorePerObject = LegacyScoreUtils.CalculateNestedScorePerObject(beatmap, totalHits);
-            double legacyScoreBaseMultiplier = LegacyScoreUtils.CalculateDifficultyPeppyStars(beatmap);
+            double legacyScoreBaseMultiplier = LegacyScoreUtils.CalculateDifficultyPeppyStars(WorkingBeatmap.Beatmap);
 
             var simulator = new OsuLegacyScoreSimulator();
             var scoreAttributes = simulator.Simulate(WorkingBeatmap, beatmap);


### PR DESCRIPTION
Fun correctness bug.

ScoreV1 multiplier uses the **nomod** peppy stars (i.e the beatmap's "base" HP, OD and CS) in all cases, which was generally the intention with this code but it passes the wrong beatmap resulting in it using modded values for this.

Cross referenced with stable and this now results in the expected multipliers.

Results in some very minor (<3pp from my testing) changes for HR and EZ scores with combo breaks.