### PR TITLE
Use correct object for the aim slider bonus

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -143,10 +143,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 velocityChangeBonus *= Math.Pow(Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) / Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime), 2);
             }
 
-            if (osuLastObj.BaseObject is Slider)
+            if (osuCurrObj.BaseObject is Slider)
             {
                 // Reward sliders based on velocity.
-                sliderBonus = osuLastObj.TravelDistance / osuLastObj.TravelTime;
+                sliderBonus = osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
             }
 
             aimStrain += wiggleBonus * wiggle_multiplier;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double currentStrain;
 
-        private double skillMultiplier => 26;
+        private double skillMultiplier => 25.9;
         private double strainDecayBase => 0.15;
 
         private readonly List<double> sliderStrains = new List<double>();


### PR DESCRIPTION
Currently the slider bonus works on the assumption that the travel velocity of the previous slider is a part of the current object's difficulty because it is part of the movement from prev to curr. However, this is contradicted by the fact that `currVelocity` is a combination of prev->curr + curr slider velocity and is actually breaking the assumption that slider difficulty is contained in the slider itself that we take when calculating difficult slider strains.

This makes it so that the slider bonus difficulty is contained in the slider itself instead of buffing the next object, which makes both the calculation overall more consistent and the slider factor calculation actually work as expected.

Aim multiplier got slightly lowered because this change makes most of the sliders gain a little bit