### PR TITLE
Fix `OsuAutoGenerator` failing to alternate when objects are exactly 50ms apart

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneAutoGeneration.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneAutoGeneration.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [TestFixture]
+    [HeadlessTest]
+    public partial class TestSceneAutoGeneration : OsuTestScene
+    {
+        [TestCase(-1, true)]
+        [TestCase(0, false)]
+        [TestCase(1, false)]
+        public void TestAlternating(double offset, bool shouldAlternate)
+        {
+            const double first_object_time = 1000;
+            double secondObjectTime = first_object_time + AutoGenerator.KEY_UP_DELAY + OsuAutoGenerator.MIN_FRAME_SEPARATION_FOR_ALTERNATING + offset;
+
+            var beatmap = new OsuBeatmap();
+            beatmap.HitObjects.Add(new HitCircle { StartTime = first_object_time });
+            beatmap.HitObjects.Add(new HitCircle { StartTime = secondObjectTime });
+
+            var generated = new OsuAutoGenerator(beatmap, []).Generate();
+            var frames = generated.Frames.OfType<OsuReplayFrame>().ToList();
+
+            Assert.That(frames.Exists(f => f.Time == first_object_time && f.Actions.SingleOrDefault() == OsuAction.LeftButton));
+            Assert.That(frames.Exists(f => f.Time == first_object_time + AutoGenerator.KEY_UP_DELAY && !f.Actions.Any()));
+
+            Assert.That(frames.Exists(f => f.Time == secondObjectTime && f.Actions.SingleOrDefault() == (shouldAlternate ? OsuAction.RightButton : OsuAction.LeftButton)));
+            Assert.That(frames.Exists(f => f.Time == secondObjectTime + AutoGenerator.KEY_UP_DELAY && !f.Actions.Any()));
+        }
+
+        [TestCase(300)]
+        [TestCase(600)]
+        [TestCase(1200)]
+        public void TestAlternatingSpecificBPM(double bpm)
+        {
+            const double first_object_time = 1000;
+            double secondObjectTime = first_object_time + 60000 / bpm;
+
+            var beatmap = new OsuBeatmap();
+            beatmap.HitObjects.Add(new HitCircle { StartTime = first_object_time });
+            beatmap.HitObjects.Add(new HitCircle { StartTime = secondObjectTime });
+
+            var generated = new OsuAutoGenerator(beatmap, []).Generate();
+            var frames = generated.Frames.OfType<OsuReplayFrame>().ToList();
+
+            Assert.That(frames.Exists(f => f.Time == first_object_time && f.Actions.SingleOrDefault() == OsuAction.LeftButton));
+            Assert.That(frames.Exists(f => f.Time == first_object_time + AutoGenerator.KEY_UP_DELAY && !f.Actions.Any()));
+
+            Assert.That(frames.Exists(f => f.Time == secondObjectTime && f.Actions.SingleOrDefault() == OsuAction.RightButton));
+            Assert.That(frames.Exists(f => f.Time == secondObjectTime + AutoGenerator.KEY_UP_DELAY && !f.Actions.Any()));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -266,7 +266,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             }
 
             // Start alternating once the time separation is too small (faster than ~225BPM).
-            if (timeDifference > 0 && timeDifference < 266)
+            if (timeDifference >= 0 && timeDifference < 266)
                 buttonIndex++;
             else
                 buttonIndex = 0;

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Osu.Replays
 {
     public class OsuAutoGenerator : OsuAutoGeneratorBase
     {
+        public const double MIN_FRAME_SEPARATION_FOR_ALTERNATING = 266;
+
         public new OsuBeatmap Beatmap => (OsuBeatmap)base.Beatmap;
 
         #region Parameters
@@ -266,7 +268,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             }
 
             // Start alternating once the time separation is too small (faster than ~225BPM).
-            if (timeDifference >= 0 && timeDifference < 266)
+            if (timeDifference >= 0 && timeDifference < MIN_FRAME_SEPARATION_FOR_ALTERNATING)
                 buttonIndex++;
             else
                 buttonIndex = 0;

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -245,7 +245,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             double timeDifference = ApplyModsToTimeDelta(lastFrame.Time, h.StartTime);
             OsuReplayFrame? lastLastFrame = Frames.Count >= 2 ? (OsuReplayFrame)Frames[^2] : null;
 
-            if (timeDifference > 0)
+            if (timeDifference >= 0)
             {
                 // If the last frame is a key-up frame and there has been no wait period, adjust the last frame's position such that it begins eased movement instantaneously.
                 if (lastLastFrame != null && lastFrame is OsuKeyUpReplayFrame && !hasWaited)


### PR DESCRIPTION
Closes #36213, closes #22353
Probably also resolves several comments on #26559 (osu-ruleset only, anything mention maps with 150 or 300bpm)

Currently, if 2 objects are exactly 50ms (1/4 at 300bpm) apart the autoplay generator will generate frames that make it impossible to hit the second object without frame-stability, leading to hitsounds & hit animations not working in the editor for those objects.

There's a combination of 3 things happening that cause this problem, fixing either one of them fixes the problem.

- The autoplay generator inserts key-up events exactly 50ms (`AutoGenerator.KEY_UP_DELAY`) after an object's end time into the replay. 
If the next object starts *before* this key-up frame, that frame is later removed when the next object's click frames are generated.
If the objects are exactly 50ms apart the next frame and the key-up frame will have the exact same time.
- `buttonIndex` will only be incremented when the difference between the current and last frame is greater than 0, effectively disabling alternating if the objects are <= 50ms apart.
- As a fallback, when determining the button to use for a given frame, the generator examines the previous frame's pressed buttons, and make sure they don't use the same button. However, if the objects are >= 50ms apart the previous frame will be the key-up frame, which will have no active actions.

Basically, at exactly 50ms both mechanisms that ensure alternating don't work and the generated replay will put the key-down frame at the exact same time as the key-up frame and will use the exact same button as for the previous object. Without frame stability (i.e. in the editor) the key-up frame will always be skipped.

<img width="512" height="648" alt="image" src="https://github.com/user-attachments/assets/0d7baeda-573a-4619-a736-29c17342e0b3" />

As far as I can tell there's 3 (relatively simple) ways to fix this:

- Make sure the key-up frame is always before the next hitobject's start time ([Diff](https://gist.github.com/minetoblend/c282daa751a3ae8cf479ee1762ac4254))
- Make sure buttons also alternate if difference to last frame is 0 (this pr)
- Make sure previous frame actually starts before the curent frame's time when checking the previously pressed buttons ([Diff](https://gist.github.com/minetoblend/18aefa7c9541213cd318dab64d91ff74))

I opted with the second fix because there's another bug in the same method that should also be fixed:

https://github.com/ppy/osu/blob/b6dc64668e9a7b9468fc1d54002a0b9a57a0c56a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs#L248

This statement has the same issue. It's purpose is to interpolate the previouss frame's position if it is too close to the current frame, except it won't get interpolated when the difference is 0. This leads to the cursor teleporting to the object at it's start time:

https://github.com/user-attachments/assets/4d2ea6fe-e80c-49d7-9faa-2728a4bf4d79

A better long-term solution would probably to simplify the autoplay generator so it doesn't take several hours of debugging to figure out what half of the code in it actually does but that's for another time.

### Before:

https://github.com/user-attachments/assets/43c8fa12-3654-4fc6-a83f-c48cc7202eea

https://github.com/user-attachments/assets/298cb714-1946-477a-948f-3109522efa0a

### After:

https://github.com/user-attachments/assets/70be1e5c-d414-4b36-acb1-c4f46f893b0f

https://github.com/user-attachments/assets/84d0c9f9-ff70-4a64-915d-227ee5960a44
