### PR TITLE
Support text wrapping in form controls

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
@@ -42,171 +42,236 @@ namespace osu.Game.Tests.Visual.UserInterface
                         RelativeSizeAxes = Axes.Both,
                         Child = new FillFlowContainer
                         {
-                            AutoSizeAxes = Axes.Y,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Width = 400,
-                            Direction = FillDirection.Vertical,
-                            Spacing = new Vector2(5),
-                            Padding = new MarginPadding(10),
-                            Children = new Drawable[]
+                            AutoSizeAxes = Axes.Both,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Direction = FillDirection.Horizontal,
+                            Children = new[]
                             {
-                                new FormTextBox
+                                new FillFlowContainer
                                 {
-                                    Caption = "Artist",
-                                    HintText = "Poot artist here!",
-                                    PlaceholderText = "Here is an artist",
-                                    TabbableContentContainer = this,
-                                },
-                                new FormTextBox
-                                {
-                                    Caption = "Artist",
-                                    HintText = "Poot artist here!",
-                                    PlaceholderText = "Here is an artist",
-                                    Current = { Disabled = true },
-                                    TabbableContentContainer = this,
-                                },
-                                new FormNumberBox(allowDecimals: true)
-                                {
-                                    Caption = "Number",
-                                    HintText = "Insert your favourite number",
-                                    PlaceholderText = "Mine is 42!",
-                                    TabbableContentContainer = this,
-                                },
-                                new FormCheckBox
-                                {
-                                    Caption = EditorSetupStrings.LetterboxDuringBreaks,
-                                    HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
-                                },
-                                new FormCheckBox
-                                {
-                                    Caption = EditorSetupStrings.LetterboxDuringBreaks,
-                                    HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
-                                    Current = { Disabled = true },
-                                },
-                                new FormCheckBox
-                                {
-                                    Caption = EditorSetupStrings.LetterboxDuringBreaks,
-                                    HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
-                                    Current = { Value = true, Disabled = true },
-                                },
-                                new FormSliderBar<float>
-                                {
-                                    Caption = "Slider",
-                                    HintText = "Slider hint",
-                                    Current = new BindableFloat
+                                    AutoSizeAxes = Axes.Y,
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Width = 400,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(5),
+                                    Padding = new MarginPadding(10),
+                                    Children = new Drawable[]
                                     {
-                                        MinValue = 0,
-                                        MaxValue = 10,
-                                        Value = 5,
-                                        Precision = 0.1f,
+                                        new FormTextBox
+                                        {
+                                            Caption = "Artist",
+                                            HintText = "Poot artist here!",
+                                            PlaceholderText = "Here is an artist",
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormTextBox
+                                        {
+                                            Caption = "Artist",
+                                            HintText = "Poot artist here!",
+                                            PlaceholderText = "Here is an artist",
+                                            Current = { Disabled = true },
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormNumberBox(allowDecimals: true)
+                                        {
+                                            Caption = "Number",
+                                            HintText = "Insert your favourite number",
+                                            PlaceholderText = "Mine is 42!",
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormCheckBox
+                                        {
+                                            Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                            HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                        },
+                                        new FormCheckBox
+                                        {
+                                            Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                            HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                            Current = { Disabled = true },
+                                        },
+                                        new FormCheckBox
+                                        {
+                                            Caption = EditorSetupStrings.LetterboxDuringBreaks,
+                                            HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                            Current = { Value = true, Disabled = true },
+                                        },
+                                        new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider",
+                                            HintText = "Slider hint",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 10,
+                                                Value = 5,
+                                                Precision = 0.1f,
+                                            },
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider",
+                                            HintText = "Slider hint",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 10,
+                                                Value = 5,
+                                                Precision = 0.1f,
+                                                Disabled = true,
+                                            },
+                                            TransferValueOnCommit = true,
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider (percentage)",
+                                            HintText = "Percentage slider hint",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 1,
+                                                Value = 0.2f,
+                                                Precision = 0.0001f,
+                                            },
+                                            DisplayAsPercentage = true,
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider (custom)",
+                                            HintText = "Custom slider hint",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 1,
+                                                Value = 0.2f,
+                                                Precision = 0.0001f,
+                                            },
+                                            LabelFormat = v => $"{v * 100:0.00} funometer",
+                                            TooltipFormat = v => $"This setting has the value set to {v * 100:0.00} funometer.",
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormSliderBar<float>
+                                        {
+                                            Caption = "Slider (custom)",
+                                            HintText = "Custom slider hint",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 1,
+                                                Value = 0.2f,
+                                                Precision = 0.0001f,
+                                                Disabled = true,
+                                            },
+                                            TransferValueOnCommit = true,
+                                            LabelFormat = v => $"{v * 100:0.00} funometer",
+                                            TooltipFormat = v => $"This setting has the value set to {v * 100:0.00} funometer.",
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormEnumDropdown<CountdownType>
+                                        {
+                                            Caption = EditorSetupStrings.EnableCountdown,
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                        },
+                                        new FormEnumDropdown<CountdownType>
+                                        {
+                                            Caption = EditorSetupStrings.EnableCountdown,
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                            Current = { Disabled = true },
+                                        },
+                                        new FormFileSelector
+                                        {
+                                            Caption = "File selector",
+                                            PlaceholderText = "Select a file",
+                                        },
+                                        new FormBeatmapFileSelector(true)
+                                        {
+                                            Caption = "File selector with intermediate choice dialog",
+                                            PlaceholderText = "Select a file",
+                                        },
+                                        new FormColourPalette
+                                        {
+                                            Caption = "Combo colours",
+                                            Colours =
+                                            {
+                                                Colour4.Red,
+                                                Colour4.Green,
+                                                Colour4.Blue,
+                                                Colour4.Yellow,
+                                            }
+                                        },
+                                        new FormButton
+                                        {
+                                            Caption = "No text in button",
+                                            Action = () => { },
+                                        },
                                     },
-                                    TabbableContentContainer = this,
                                 },
-                                new FormSliderBar<float>
+                                new FillFlowContainer
                                 {
-                                    Caption = "Slider",
-                                    HintText = "Slider hint",
-                                    Current = new BindableFloat
+                                    AutoSizeAxes = Axes.Y,
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Width = 400,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(5),
+                                    Padding = new MarginPadding(10),
+                                    Children = new Drawable[]
                                     {
-                                        MinValue = 0,
-                                        MaxValue = 10,
-                                        Value = 5,
-                                        Precision = 0.1f,
-                                        Disabled = true,
+                                        new FormNumberBox(allowDecimals: true)
+                                        {
+                                            Caption = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                                            HintText = "Insert your favourite number",
+                                            PlaceholderText = "Mine is 42!",
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormCheckBox
+                                        {
+                                            Caption = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                                            HintText = EditorSetupStrings.LetterboxDuringBreaksDescription,
+                                        },
+                                        new FormSliderBar<float>
+                                        {
+                                            Caption = "Lorem ipsum dolor sit amet, conse adipiscing elit, sed do eiusmod",
+                                            HintText = "Slider hint",
+                                            Current = new BindableFloat
+                                            {
+                                                MinValue = 0,
+                                                MaxValue = 10,
+                                                Value = 5,
+                                                Precision = 0.1f,
+                                            },
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormEnumDropdown<CountdownType>
+                                        {
+                                            Caption = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                        },
+                                        new FormFileSelector
+                                        {
+                                            Caption = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                            PlaceholderText = "Select a file",
+                                        },
+                                        new FormColourPalette
+                                        {
+                                            Caption = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                                            HintText = EditorSetupStrings.CountdownDescription,
+                                            Colours =
+                                            {
+                                                Colour4.Red,
+                                                Colour4.Green,
+                                                Colour4.Blue,
+                                                Colour4.Yellow,
+                                            }
+                                        },
                                     },
-                                    TransferValueOnCommit = true,
-                                    TabbableContentContainer = this,
-                                },
-                                new FormSliderBar<float>
-                                {
-                                    Caption = "Slider (percentage)",
-                                    HintText = "Percentage slider hint",
-                                    Current = new BindableFloat
-                                    {
-                                        MinValue = 0,
-                                        MaxValue = 1,
-                                        Value = 0.2f,
-                                        Precision = 0.0001f,
-                                    },
-                                    DisplayAsPercentage = true,
-                                    TabbableContentContainer = this,
-                                },
-                                new FormSliderBar<float>
-                                {
-                                    Caption = "Slider (custom)",
-                                    HintText = "Custom slider hint",
-                                    Current = new BindableFloat
-                                    {
-                                        MinValue = 0,
-                                        MaxValue = 1,
-                                        Value = 0.2f,
-                                        Precision = 0.0001f,
-                                    },
-                                    LabelFormat = v => $"{v * 100:0.00} funometer",
-                                    TooltipFormat = v => $"This setting has the value set to {v * 100:0.00} funometer.",
-                                    TabbableContentContainer = this,
-                                },
-                                new FormSliderBar<float>
-                                {
-                                    Caption = "Slider (custom)",
-                                    HintText = "Custom slider hint",
-                                    Current = new BindableFloat
-                                    {
-                                        MinValue = 0,
-                                        MaxValue = 1,
-                                        Value = 0.2f,
-                                        Precision = 0.0001f,
-                                        Disabled = true,
-                                    },
-                                    TransferValueOnCommit = true,
-                                    LabelFormat = v => $"{v * 100:0.00} funometer",
-                                    TooltipFormat = v => $"This setting has the value set to {v * 100:0.00} funometer.",
-                                    TabbableContentContainer = this,
-                                },
-                                new FormEnumDropdown<CountdownType>
-                                {
-                                    Caption = EditorSetupStrings.EnableCountdown,
-                                    HintText = EditorSetupStrings.CountdownDescription,
-                                },
-                                new FormEnumDropdown<CountdownType>
-                                {
-                                    Caption = EditorSetupStrings.EnableCountdown,
-                                    HintText = EditorSetupStrings.CountdownDescription,
-                                    Current = { Disabled = true },
-                                },
-                                new FormFileSelector
-                                {
-                                    Caption = "File selector",
-                                    PlaceholderText = "Select a file",
-                                },
-                                new FormBeatmapFileSelector(true)
-                                {
-                                    Caption = "File selector with intermediate choice dialog",
-                                    PlaceholderText = "Select a file",
-                                },
-                                new FormColourPalette
-                                {
-                                    Caption = "Combo colours",
-                                    Colours =
-                                    {
-                                        Colour4.Red,
-                                        Colour4.Green,
-                                        Colour4.Blue,
-                                        Colour4.Yellow,
-                                    }
-                                },
-                                new FormButton
-                                {
-                                    Caption = "No text in button",
-                                    Action = () => { },
-                                },
-                                new FormButton
-                                {
-                                    Caption = "Text in button which is pretty long and is very likely to wrap",
-                                    ButtonText = "Foo the bar",
-                                    Action = () => { },
-                                },
+                                }
                             },
                         },
                     },

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -18,6 +18,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
+using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -56,7 +57,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void load(AudioManager audio)
         {
             RelativeSizeAxes = Axes.X;
-            Height = 50;
+            AutoSizeAxes = Axes.Y;
 
             Masking = true;
             CornerRadius = 5;
@@ -71,22 +72,30 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 },
                 new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding(9),
                     Children = new Drawable[]
                     {
-                        caption = new FormFieldCaption
-                        {
-                            Caption = Caption,
-                            TooltipText = HintText,
-                            Anchor = Anchor.TopLeft,
-                            Origin = Anchor.TopLeft,
-                        },
-                        text = new OsuSpriteText
+                        new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.X,
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Padding = new MarginPadding { Right = SwitchButton.WIDTH + 5 },
+                            Spacing = new Vector2(0f, 4f),
+                            Children = new Drawable[]
+                            {
+                                caption = new FormFieldCaption
+                                {
+                                    Caption = Caption,
+                                    TooltipText = HintText,
+                                },
+                                text = new OsuSpriteText
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                },
+                            },
                         },
                         new SwitchButton
                         {
@@ -97,7 +106,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     },
                 },
             };
-
             sampleChecked = audio.Samples.Get(@"UI/check-on");
             sampleUnchecked = audio.Samples.Get(@"UI/check-off");
             sampleDisabled = audio.Samples.Get(@"UI/default-select-disabled");

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
@@ -140,30 +141,30 @@ namespace osu.Game.Graphics.UserInterfaceV2
             [BackgroundDependencyLoader]
             private void load()
             {
-                RelativeSizeAxes = Axes.X;
-                AutoSizeAxes = Axes.None;
-                Height = 50;
-
                 Masking = true;
                 CornerRadius = 5;
 
-                Foreground.AutoSizeAxes = Axes.None;
-                Foreground.RelativeSizeAxes = Axes.Both;
                 Foreground.Padding = new MarginPadding(9);
                 Foreground.Children = new Drawable[]
                 {
-                    caption = new FormFieldCaption
-                    {
-                        Anchor = Anchor.TopLeft,
-                        Origin = Anchor.TopLeft,
-                        Caption = Caption,
-                        TooltipText = HintText,
-                    },
-                    label = new OsuSpriteText
+                    new FillFlowContainer
                     {
                         RelativeSizeAxes = Axes.X,
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(0, 4),
+                        Children = new Drawable[]
+                        {
+                            caption = new FormFieldCaption
+                            {
+                                Caption = Caption,
+                                TooltipText = HintText,
+                            },
+                            label = new OsuSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                            },
+                        }
                     },
                     chevron = new SpriteIcon
                     {

--- a/osu.Game/Graphics/UserInterfaceV2/FormFieldCaption.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFieldCaption.cs
@@ -2,19 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.Containers;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class FormFieldCaption : CompositeDrawable, IHasTooltip
     {
+        private OsuTextFlowContainer textFlow = null!;
+
         private LocalisableString caption;
 
         public LocalisableString Caption
@@ -24,45 +25,60 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 caption = value;
 
-                if (captionText.IsNotNull())
-                    captionText.Text = value;
+                if (IsLoaded)
+                    updateDisplay();
             }
         }
 
-        private OsuSpriteText captionText = null!;
+        private LocalisableString tooltipText;
 
-        public LocalisableString TooltipText { get; set; }
+        public LocalisableString TooltipText
+        {
+            get => tooltipText;
+            set
+            {
+                tooltipText = value;
+
+                if (IsLoaded)
+                    updateDisplay();
+            }
+        }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            AutoSizeAxes = Axes.Both;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
 
-            InternalChild = new FillFlowContainer
+            InternalChild = textFlow = new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(size: 12, weight: FontWeight.SemiBold))
             {
-                AutoSizeAxes = Axes.Both,
-                Direction = FillDirection.Horizontal,
-                Spacing = new Vector2(5),
-                Children = new Drawable[]
-                {
-                    captionText = new OsuSpriteText
-                    {
-                        Text = caption,
-                        Font = OsuFont.Default.With(size: 12, weight: FontWeight.SemiBold),
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                    },
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Alpha = TooltipText == default ? 0 : 1,
-                        Size = new Vector2(10),
-                        Icon = FontAwesome.Solid.QuestionCircle,
-                        Margin = new MarginPadding { Top = 1, },
-                    }
-                },
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateDisplay();
+        }
+
+        private void updateDisplay()
+        {
+            textFlow.Text = caption;
+
+            if (TooltipText != default)
+            {
+                textFlow.AddArbitraryDrawable(new SpriteIcon
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Size = new Vector2(10),
+                    Icon = FontAwesome.Solid.QuestionCircle,
+                    Margin = new MarginPadding { Left = 5 },
+                    Y = 1f,
+                });
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
@@ -117,34 +117,46 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 new Container
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = 50,
+                    AutoSizeAxes = Axes.Y,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     Padding = new MarginPadding(9),
                     Children = new Drawable[]
                     {
-                        caption = new FormFieldCaption
+                        new FillFlowContainer
                         {
-                            Anchor = Anchor.TopLeft,
-                            Origin = Anchor.TopLeft,
-                            Caption = Caption,
-                            TooltipText = HintText,
-                        },
-                        placeholderText = new OsuSpriteText
-                        {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
                             RelativeSizeAxes = Axes.X,
-                            Width = 1,
-                            Text = PlaceholderText,
-                            Colour = colourProvider.Foreground1,
-                        },
-                        filenameText = new OsuSpriteText
-                        {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
-                            RelativeSizeAxes = Axes.X,
-                            Width = 1,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0f, 4f),
+                            Children = new Drawable[]
+                            {
+                                caption = new FormFieldCaption
+                                {
+                                    Caption = Caption,
+                                    TooltipText = HintText,
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = new[]
+                                    {
+                                        placeholderText = new OsuSpriteText
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            Width = 1,
+                                            Text = PlaceholderText,
+                                            Colour = colourProvider.Foreground1,
+                                        },
+                                        filenameText = new OsuSpriteText
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            Width = 1,
+                                        },
+                                    }
+                                }
+                            },
                         },
                         new SpriteIcon
                         {
@@ -242,7 +254,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         Task ICanAcceptFiles.Import(ImportTask[] tasks, ImportParameters parameters) => throw new NotImplementedException();
 
-        protected virtual FileChooserPopover CreatePopover(string[] handledExtensions, Bindable<FileInfo?> current, string? chooserPath) => new FileChooserPopover(handledExtensions, current, chooserPath);
+        protected virtual FileChooserPopover CreatePopover(string[] handledExtensions, Bindable<FileInfo?> current, string? chooserPath) =>
+            new FileChooserPopover(handledExtensions, current, chooserPath);
 
         public Popover GetPopover()
         {

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -22,6 +22,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
+using Vector2 = osuTK.Vector2;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -143,7 +144,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void load(OsuColour colours, OsuGame? game)
         {
             RelativeSizeAxes = Axes.X;
-            Height = 50;
+            AutoSizeAxes = Axes.Y;
 
             Masking = true;
             CornerRadius = 5;
@@ -162,47 +163,64 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 },
                 new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding
                     {
-                        Vertical = 9,
+                        Vertical = 5,
                         Left = 9,
                         Right = 5,
                     },
                     Children = new Drawable[]
                     {
-                        captionText = new FormFieldCaption
+                        new FillFlowContainer
                         {
-                            Anchor = Anchor.TopLeft,
-                            Origin = Anchor.TopLeft,
-                            TooltipText = HintText,
-                        },
-                        textBox = new FormNumberBox.InnerNumberBox(allowDecimals: true)
-                        {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
                             RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0f, 4f),
                             Width = 0.5f,
-                            // the textbox is hidden when the control is unfocused,
-                            // but clicking on the label should reach the textbox,
-                            // therefore make it always present.
-                            AlwaysPresent = true,
-                            CommitOnFocusLost = true,
-                            SelectAllOnFocus = true,
-                            OnInputError = () =>
+                            Padding = new MarginPadding
                             {
-                                flashLayer.Colour = ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3);
-                                flashLayer.FadeOutFromOne(200, Easing.OutQuint);
+                                Right = 10,
+                                Vertical = 4,
                             },
-                            TabbableContentContainer = tabbableContentContainer,
-                        },
-                        valueLabel = new TruncatingSpriteText
-                        {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
-                            RelativeSizeAxes = Axes.X,
-                            Width = 0.5f,
-                            Padding = new MarginPadding { Right = 5 },
+                            Children = new Drawable[]
+                            {
+                                captionText = new FormFieldCaption
+                                {
+                                    TooltipText = HintText,
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = new Drawable[]
+                                    {
+                                        textBox = new FormNumberBox.InnerNumberBox(allowDecimals: true)
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            // the textbox is hidden when the control is unfocused,
+                                            // but clicking on the label should reach the textbox,
+                                            // therefore make it always present.
+                                            AlwaysPresent = true,
+                                            CommitOnFocusLost = true,
+                                            SelectAllOnFocus = true,
+                                            OnInputError = () =>
+                                            {
+                                                flashLayer.Colour = ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3);
+                                                flashLayer.FadeOutFromOne(200, Easing.OutQuint);
+                                            },
+                                            TabbableContentContainer = tabbableContentContainer,
+                                        },
+                                        valueLabel = new TruncatingSpriteText
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            Padding = new MarginPadding { Right = 5 },
+                                        },
+                                    },
+                                },
+                            },
                         },
                         slider = new InnerSlider
                         {

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -19,6 +19,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -89,7 +90,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void load(OsuColour colours)
         {
             RelativeSizeAxes = Axes.X;
-            Height = 50;
+            AutoSizeAxes = Axes.Y;
 
             Masking = true;
             CornerRadius = 5;
@@ -107,10 +108,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     RelativeSizeAxes = Axes.Both,
                     Colour = Colour4.Transparent,
                 },
-                new Container
+                new FillFlowContainer
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding(9),
+                    Spacing = new Vector2(0, 4),
                     Children = new Drawable[]
                     {
                         caption = new FormFieldCaption
@@ -122,8 +125,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                         },
                         textBox = CreateTextBox().With(t =>
                         {
-                            t.Anchor = Anchor.BottomRight;
-                            t.Origin = Anchor.BottomRight;
                             t.RelativeSizeAxes = Axes.X;
                             t.Width = 1;
                             t.PlaceholderText = PlaceholderText;

--- a/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class SwitchButton : Checkbox
     {
+        public const float WIDTH = 45;
+
         private const float border_thickness = 4.5f;
         private const float padding = 1.25f;
 
@@ -35,7 +37,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public SwitchButton()
         {
-            Size = new Vector2(45, 20);
+            Size = new Vector2(WIDTH, 20);
 
             InternalChild = content = new CircularContainer
             {


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/pull/36193#issuecomment-3707868959

Preview:

<img width="400" alt="CleanShot 2026-01-05 at 16 18 07" src="https://github.com/user-attachments/assets/e25bf8e3-756b-41f9-b6a1-1a72cdc8fe69" />

Does not cover `FormButton` as I'm not sure how text wrapping is meant to work there, it currently can wrap up to 3 lines correctly, but any number above that causes caption to go off screen.


