### PR TITLE
Hide cursor during background reveal in song select

### DIFF
--- a/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
@@ -53,6 +53,12 @@ namespace osu.Game.Graphics.Cursor
 
         private bool visible;
 
+        public void FadeCursorTo(float alpha, double duration = 200, Easing easing = Easing.OutQuint)
+        {
+            if (visible && State.Value == Visibility.Visible && activeCursor != null)
+                activeCursor.FadeTo(alpha, duration, easing);
+        }
+
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, ScreenshotManager? screenshotManager, AudioManager audio)
         {


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/36238

When using the background reveal feature, the cursor was intrusive and blocked the view of the beatmap background.

This PR makes the cursor fade out in sync with the background reveal animation. The behavior is:

- Cursor fades out when the background reveal starts
- Moving the mouse while viewing the background shows the cursor immediately
- After 1 second of no mouse movement, the cursor fades out again
- Cursor returns to normal when releasing the mouse button

