### PR TITLE
Add support for global rank parsing in /users/ batch lookups

### DIFF
--- a/osu.Game/Online/API/Requests/LookupUsersRequest.cs
+++ b/osu.Game/Online/API/Requests/LookupUsersRequest.cs
@@ -10,21 +10,26 @@ namespace osu.Game.Online.API.Requests
     /// Looks up users with the given <see cref="UserIds"/>.
     /// In comparison to <see cref="GetUsersRequest"/>, the response here does not contain <see cref="APIUser.RulesetsStatistics"/>,
     /// but in exchange is subject to less stringent rate limiting, making it suitable for mass user listings.
+    ///
+    /// Providing a ruleset ID will give `global_rank`s in the response.
     /// </summary>
     public class LookupUsersRequest : APIRequest<GetUsersResponse>
     {
         public readonly int[] UserIds;
 
+        public readonly int? RulesetId;
+
         private const int max_ids_per_request = 50;
 
-        public LookupUsersRequest(int[] userIds)
+        public LookupUsersRequest(int[] userIds, int? rulesetId = null)
         {
             if (userIds.Length > max_ids_per_request)
                 throw new ArgumentException($"{nameof(LookupUsersRequest)} calls only support up to {max_ids_per_request} IDs at once");
 
             UserIds = userIds;
+            RulesetId = rulesetId;
         }
 
-        protected override string Target => @"users/lookup/?ids[]=" + string.Join(@"&ids[]=", UserIds);
+        protected override string Target => @"users/lookup/?ids[]=" + string.Join(@"&ids[]=", UserIds) + (RulesetId != null ? "&ruleset_id=" + RulesetId : "");
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -247,6 +247,20 @@ namespace osu.Game.Online.API.Requests.Responses
             }
         }
 
+        // Only provided via /users/ batch lookups. Usually implicitly comes inside `UserStatistics`.
+        [JsonProperty(@"global_rank")]
+        [CanBeNull]
+        public GlobalRank Rank { get; set; }
+
+        public class GlobalRank
+        {
+            [JsonProperty(@"rank")]
+            public int? Rank;
+
+            [JsonProperty(@"ruleset_id")]
+            public int RulesetId;
+        }
+
         [JsonProperty(@"rank_history")]
         private APIRankHistory rankHistory
         {


### PR DESCRIPTION
See https://github.com/ppy/osu-web/pull/12651 for web-side
implementation.
To be used to fix https://github.com/ppy/osu/pull/33649/changes#diff-32784a778b34c671e1f72c00e1f4161a5e774e849aae5631ee71b31fc32e5d42R218
(have tested this works there).


Am reluctant about overloading `APIUser` to handle this "slim" case, but I think splitting it out is going to be somewhat of a headache.