### PR TITLE
Visual addition of whitespaces to the FPS counter

### DIFF
--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -232,14 +232,14 @@ namespace osu.Game.Graphics.UserInterface
         private void updateFpsDisplay()
         {
             counterDrawFPS.Colour = getColour(displayedFpsCount / aimDrawFPS);
-            counterDrawFPS.Text = $"{displayedFpsCount:#,0}fps";
+            counterDrawFPS.Text = $"{displayedFpsCount:#,0} fps";
         }
 
         private void updateFrameTimeDisplay()
         {
             counterUpdateFrameTime.Text = displayedFrameTime < 5
-                ? $"{displayedFrameTime:N1}ms"
-                : $"{displayedFrameTime:N0}ms";
+                ? $"{displayedFrameTime:N1} ms"
+                : $"{displayedFrameTime:N0} ms";
 
             counterUpdateFrameTime.Colour = getColour((1000 / displayedFrameTime) / aimUpdateFPS);
         }

--- a/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Graphics.UserInterface
                         ? $"/{(clock.MaximumUpdateHz > 0 && clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞"),4}"
                         : string.Empty;
 
-                    textFlow.AddParagraph($"{clock.FramesPerSecond:0}{maximum}fps ({clock.ElapsedFrameTime:0.00}ms)");
+                    textFlow.AddParagraph($"{clock.FramesPerSecond:0}{maximum} fps ({clock.ElapsedFrameTime:0.00} ms)");
                 }
             }
         }


### PR DESCRIPTION
Since the game-side FPS counter got added in https://github.com/ppy/osu/pull/19250 there hasn't really been a visual/cosmetic change to it's appearance.

---

This is only a visual change that adds a whitespace in between the value and the indicator.
* Added a whitespace for both ms and fps in FPSCounter.cs.
* Added a whitespace for both ms and fps in FPSCounterTooltip.cs. I saw that in @peppy's PR he mentioned this tooltip is temporary. Since it has been around 2 ½ years, I decided to add the whitespaces there as well to make it a bit more uniform with the changes I have made.

https://github.com/user-attachments/assets/8311002e-da87-4cfe-b7c8-c1b0e977b18b
