### PR TITLE
Hide cursor during background reveal in song select

### DIFF
--- a/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
@@ -220,16 +220,18 @@ namespace osu.Game.Graphics.Cursor
         {
             activeCursor.FadeTo(1, 250, Easing.OutQuint);
             activeCursor.ScaleTo(1, 400, Easing.OutQuint);
-            activeCursor.RotateTo(0, 400, Easing.OutQuint);
-            dragRotationState = DragRotationState.NotDragging;
+
+            if (dragRotationState == DragRotationState.NotDragging)
+                activeCursor.RotateTo(0, 400, Easing.OutQuint);
         }
 
         protected override void PopOut()
         {
             activeCursor.FadeTo(0, 250, Easing.OutQuint);
             activeCursor.ScaleTo(0.6f, 250, Easing.In);
-            activeCursor.RotateTo(0, 400, Easing.OutQuint);
-            dragRotationState = DragRotationState.NotDragging;
+
+            if (dragRotationState == DragRotationState.NotDragging)
+                activeCursor.RotateTo(0, 400, Easing.OutQuint);
         }
 
         private void playTapSample(double baseFrequency = 1f)

--- a/osu.Game/Screens/SelectV2/SongSelect.cs
+++ b/osu.Game/Screens/SelectV2/SongSelect.cs
@@ -119,6 +119,8 @@ namespace osu.Game.Screens.SelectV2
         private Container mainContent = null!;
         private SkinnableContainer skinnableContent = null!;
 
+        private GridContainer mainGridContainer = null!;
+
         private NoResultsPlaceholder noResultsPlaceholder = null!;
 
         public override bool? ApplyModTrackAdjustments => true;
@@ -812,7 +814,7 @@ namespace osu.Game.Screens.SelectV2
             // Probably needs more thought because this needs to be in every `ApplyToBackground` currently to restore sane defaults.
             backgroundModeBeatmap.FadeColour(Color4.White, 250);
 
-            bool backgroundRevealActive = revealingBackground?.State == ScheduledDelegate.RunState.Running || revealingBackground?.State == ScheduledDelegate.RunState.Complete;
+            bool backgroundRevealActive = revealBackgroundDelegate?.State == ScheduledDelegate.RunState.Running || revealBackgroundDelegate?.State == ScheduledDelegate.RunState.Complete;
             backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value && !backgroundRevealActive ? 20 : 0f;
         });
 
@@ -908,28 +910,14 @@ namespace osu.Game.Screens.SelectV2
 
         #endregion
 
-        #region Input
+        #region Background reveal
 
-        private ScheduledDelegate? revealingBackground;
-        private bool isRevealingBackground;
-        private double? lastCursorMoveTimeDuringReveal;
-
-        private bool cursorRecentlyMoved => lastCursorMoveTimeDuringReveal.HasValue &&
-                                            Clock.CurrentTime - lastCursorMoveTimeDuringReveal.Value < 1000;
+        private ScheduledDelegate? revealBackgroundDelegate;
 
         public CursorContainer? Cursor => null;
-        public bool ProvidingUserCursor => isRevealingBackground && !cursorRecentlyMoved;
+        bool IProvideCursor.ProvidingUserCursor => revealBackgroundDelegate?.Completed == true;
 
         protected override bool OnHover(HoverEvent e) => true;
-
-        protected override bool OnMouseMove(MouseMoveEvent e)
-        {
-            if (isRevealingBackground)
-                lastCursorMoveTimeDuringReveal = Clock.CurrentTime;
-            return base.OnMouseMove(e);
-        }
-
-        private GridContainer mainGridContainer = null!;
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
@@ -944,13 +932,13 @@ namespace osu.Game.Screens.SelectV2
             // For simplicity, disable this functionality on mobile.
             bool isTouchInput = e.CurrentState.Mouse.LastSource is ISourcedFromTouch;
 
-            if (!carousel.AbsoluteScrolling && !isTouchInput && mouseDownPriority && revealingBackground == null)
+            if (!carousel.AbsoluteScrolling && !isTouchInput && mouseDownPriority && revealBackgroundDelegate == null)
             {
-                revealingBackground = Scheduler.AddDelayed(() =>
+                revealBackgroundDelegate = Scheduler.AddDelayed(() =>
                 {
                     if (containingInputManager.DraggedDrawable != null)
                     {
-                        revealingBackground = null;
+                        revealBackgroundDelegate = null;
                         return;
                     }
 
@@ -965,9 +953,6 @@ namespace osu.Game.Screens.SelectV2
                     updateBackgroundDim();
 
                     Footer?.Hide();
-
-                    isRevealingBackground = true;
-                    lastCursorMoveTimeDuringReveal = null;
                 }, 200);
             }
 
@@ -982,10 +967,10 @@ namespace osu.Game.Screens.SelectV2
 
         private void restoreBackground()
         {
-            if (revealingBackground == null)
+            if (revealBackgroundDelegate == null)
                 return;
 
-            if (revealingBackground.State == ScheduledDelegate.RunState.Complete)
+            if (revealBackgroundDelegate.State == ScheduledDelegate.RunState.Complete)
             {
                 mainContent.ResizeWidthTo(1f, 500, Easing.OutQuint);
                 mainContent.ScaleTo(1, 500, Easing.OutQuint);
@@ -998,14 +983,15 @@ namespace osu.Game.Screens.SelectV2
                 Footer?.Show();
             }
 
-            revealingBackground.Cancel();
-            revealingBackground = null;
-
-            isRevealingBackground = false;
-            lastCursorMoveTimeDuringReveal = null;
+            revealBackgroundDelegate.Cancel();
+            revealBackgroundDelegate = null;
 
             updateBackgroundDim();
         }
+
+        #endregion
+
+        #region Input
 
         public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/36238

When using the background reveal feature, the cursor was intrusive and blocked the view of the beatmap background.

This PR makes the cursor fade out in sync with the background reveal animation. The behavior is:

- Cursor fades out when the background reveal starts
- Moving the mouse while viewing the background shows the cursor immediately
- After 1 second of no mouse movement, the cursor fades out again
- Cursor returns to normal when releasing the mouse button

Note: Also includes a small fix to `MenuCursorContainer` to preserve cursor rotation state during hide/show cycles. I am not entirely sure if this was needed but I decided to include it to keep cursor rotation while revealing the background.