### PR TITLE
Log version hash to sentry

### DIFF
--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -176,6 +176,7 @@ namespace osu.Game.Utils
                     scope.SetTag(@"beatmap", $"{beatmap.OnlineID}");
                     scope.SetTag(@"ruleset", ruleset.ShortName);
                     scope.SetTag(@"os", $"{RuntimeInfo.OS} ({Environment.OSVersion})");
+                    scope.SetTag(@"version hash", game.VersionHash);
                     scope.SetTag(@"processor count", Environment.ProcessorCount.ToString());
                 });
             }


### PR DESCRIPTION
This is the counterpart to https://github.com/ppy/osu-server-spectator/pull/413. The goal is to log the value which is seemingly failing to work correctly client-side as well.

The reason for doing that is two-fold:

- To eliminate possibility of freakazoid issues wherein some computers miscalculate the version hash somehow
- To eliminate possibility of the version hash somehow getting lost in transit (e.g. present client-side but no longer present server-side).