### PR TITLE
Refactor UserCoverBackground to be used with other models

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Set cover to expanded", () => configManager.SetValue(OsuSetting.ProfileCoverExpanded, true));
             AddStep("Show example user", () => header.User.Value = new UserProfileData(TestSceneUserProfileOverlay.TEST_USER, new OsuRuleset().RulesetInfo));
-            AddUntilStep("Cover is expanded", () => header.ChildrenOfType<UserCoverBackground>().Single().Height, () => Is.GreaterThan(0));
+            AddUntilStep("Cover is expanded", () => header.ChildrenOfType<CoverBackground>().Single().Height, () => Is.GreaterThan(0));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Set cover to collapsed", () => configManager.SetValue(OsuSetting.ProfileCoverExpanded, false));
             AddStep("Show example user", () => header.User.Value = new UserProfileData(TestSceneUserProfileOverlay.TEST_USER, new OsuRuleset().RulesetInfo));
-            AddUntilStep("Cover is collapsed", () => header.ChildrenOfType<UserCoverBackground>().Single().Height, () => Is.EqualTo(0));
+            AddUntilStep("Cover is collapsed", () => header.ChildrenOfType<CoverBackground>().Single().Height, () => Is.EqualTo(0));
         }
 
         [Test]

--- a/osu.Game.Tournament/Models/TournamentUser.cs
+++ b/osu.Game.Tournament/Models/TournamentUser.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tournament.Models
         /// <summary>
         /// A URL to the player's profile cover.
         /// </summary>
-        public string CoverUrl { get; set; } = string.Empty;
+        public string? CoverUrl { get; set; } = string.Empty;
 
         public APIUser ToAPIUser()
         {

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -68,7 +68,6 @@ namespace osu.Game.Online.API.Requests.Responses
         public string AvatarUrl;
 
         [JsonProperty(@"cover_url")]
-        [CanBeNull]
         public string CoverUrl
         {
             get => Cover?.Url;

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -15,7 +15,7 @@ using osu.Game.Users;
 namespace osu.Game.Online.API.Requests.Responses
 {
     [JsonObject(MemberSerialization.OptIn)]
-    public class APIUser : IEquatable<APIUser>, IUser
+    public class APIUser : IEquatable<APIUser>, IUser, IHasCover
     {
         /// <summary>
         /// A user ID which can be used to represent any system user which is not attached to a user profile.
@@ -68,6 +68,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public string AvatarUrl;
 
         [JsonProperty(@"cover_url")]
+        [CanBeNull]
         public string CoverUrl
         {
             get => Cover?.Url;
@@ -75,14 +76,17 @@ namespace osu.Game.Online.API.Requests.Responses
         }
 
         [JsonProperty(@"cover")]
+        [CanBeNull]
         public UserCover Cover;
 
         public class UserCover
         {
             [JsonProperty(@"custom_url")]
+            [CanBeNull]
             public string CustomUrl;
 
             [JsonProperty(@"url")]
+            [CanBeNull]
             public string Url;
 
             [JsonProperty(@"id")]

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.Profile.Header
         [Resolved]
         private RankingsOverlay? rankingsOverlay { get; set; }
 
-        private UserCoverBackground cover = null!;
+        private CoverBackground cover = null!;
         private SupporterIcon supporterTag = null!;
         private UpdateableAvatar avatar = null!;
         private OsuSpriteText usernameText = null!;
@@ -241,7 +241,7 @@ namespace osu.Game.Overlays.Profile.Header
         {
             var user = data?.User;
 
-            cover.User = user;
+            cover.Item = user;
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
             openUserExternally.Link = $@"{api.Endpoints.WebsiteUrl}/users/{user?.Id ?? 0}";
@@ -277,7 +277,7 @@ namespace osu.Game.Overlays.Profile.Header
             flow.TransformTo(nameof(flow.Spacing), new Vector2(expanded ? 20f : 10f), transition_duration, Easing.OutQuint);
         }
 
-        private partial class ProfileCoverBackground : UserCoverBackground
+        private partial class ProfileCoverBackground : CoverBackground
         {
             protected override double LoadDelay => 0;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
@@ -164,13 +164,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                         RelativeSizeAxes = Axes.Both,
                         Colour = colourProvider?.Background5 ?? colours.Gray1
                     },
-                    background = new UserCoverBackground
+                    background = new CoverBackground
                     {
                         RelativeSizeAxes = Axes.Both,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Colour = colours.Gray7,
-                        User = User
+                        Item = User
                     },
                     new Container
                     {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private SpriteIcon crown = null!;
 
-        private UserCoverBackground userCover = null!;
+        private CoverBackground userCover = null!;
         private UpdateableAvatar userAvatar = null!;
         private UpdateableFlag userFlag = null!;
         private OsuSpriteText username = null!;
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = backgroundColour
                                 },
-                                userCover = new UserCoverBackground
+                                userCover = new CoverBackground
                                 {
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
@@ -240,7 +240,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         {
             var user = current.Value.User;
 
-            userCover.User = user;
+            userCover.Item = user;
             userAvatar.User = user;
             userFlag.CountryCode = user?.CountryCode ?? default;
             teamFlagContainer.Child = new UpdateableTeamFlag(user?.Team)

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -78,10 +78,10 @@ namespace osu.Game.Screens.Ranking.Contracted
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = Color4Extensions.FromHex("444")
                                 },
-                                new UserCoverBackground
+                                new CoverBackground
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    User = score.User,
+                                    Item = score.User,
                                     Colour = ColourInfo.GradientVertical(Color4.White.Opacity(0.5f), Color4Extensions.FromHex("#444").Opacity(0))
                                 },
                                 new FillFlowContainer

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -172,10 +172,10 @@ namespace osu.Game.Screens.Ranking
                                 Children = new[]
                                 {
                                     middleLayerBackground = new Box { RelativeSizeAxes = Axes.Both },
-                                    new UserCoverBackground
+                                    new CoverBackground
                                     {
                                         RelativeSizeAxes = Axes.Both,
-                                        User = Score.User,
+                                        Item = Score.User,
                                         Colour = ColourInfo.GradientVertical(Color4.White.Opacity(0.5f), Color4Extensions.FromHex("#444").Opacity(0))
                                     }
                                 }

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -196,10 +196,10 @@ namespace osu.Game.Screens.SelectV2
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = foregroundColour
                                 },
-                                new UserCoverBackground
+                                new CoverBackground
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    User = Score.User,
+                                    Item = Score.User,
                                     Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft,

--- a/osu.Game/Users/CoverBackground.cs
+++ b/osu.Game/Users/CoverBackground.cs
@@ -10,20 +10,19 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Online.API.Requests.Responses;
 using osuTK.Graphics;
 
 namespace osu.Game.Users
 {
-    public partial class UserCoverBackground : ModelBackedDrawable<APIUser?>
+    public partial class CoverBackground : ModelBackedDrawable<IHasCover?>
     {
-        public APIUser? User
+        public IHasCover? Item
         {
             get => Model;
             set => Model = value;
         }
 
-        protected override Drawable CreateDrawable(APIUser? user) => new Cover(user);
+        protected override Drawable CreateDrawable(IHasCover? item) => new Cover(item);
 
         protected override double LoadDelay => 300;
 
@@ -41,11 +40,11 @@ namespace osu.Game.Users
         [LongRunningLoad]
         private partial class Cover : CompositeDrawable
         {
-            private readonly APIUser? user;
+            private readonly IHasCover? item;
 
-            public Cover(APIUser? user)
+            public Cover(IHasCover? item)
             {
-                this.user = user;
+                this.item = item;
 
                 RelativeSizeAxes = Axes.Both;
             }
@@ -53,7 +52,7 @@ namespace osu.Game.Users
             [BackgroundDependencyLoader]
             private void load(LargeTextureStore textures)
             {
-                if (user == null)
+                if (item == null)
                 {
                     InternalChild = new Box
                     {
@@ -66,7 +65,7 @@ namespace osu.Game.Users
                     InternalChild = new Sprite
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Texture = textures.Get(user.CoverUrl),
+                        Texture = textures.Get(item.CoverUrl),
                         FillMode = FillMode.Fill,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre

--- a/osu.Game/Users/IHasCover.cs
+++ b/osu.Game/Users/IHasCover.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Users
+{
+    public interface IHasCover
+    {
+        string? CoverUrl { get; }
+    }
+}

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -114,12 +114,12 @@ namespace osu.Game.Users
         /// <summary>
         /// Panel background container. Can be null if a panel doesn't want a background under it's layout
         /// </summary>
-        protected virtual Drawable? CreateBackground() => Background = new UserCoverBackground
+        protected virtual Drawable? CreateBackground() => Background = new CoverBackground
         {
             RelativeSizeAxes = Axes.Both,
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
-            User = User
+            Item = User
         };
 
         protected OsuSpriteText CreateUsername() => new OsuSpriteText

--- a/osu.Game/Users/UserRankPanel.cs
+++ b/osu.Game/Users/UserRankPanel.cs
@@ -99,12 +99,12 @@ namespace osu.Game.Users
                         Masking = true,
                         Children = new Drawable[]
                         {
-                            new UserCoverBackground
+                            new CoverBackground
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                User = User,
+                                Item = User,
                                 Alpha = 0.3f
                             },
                             new GridContainer


### PR DESCRIPTION
Part of #32584.

Given that the user and team pages are very similar in layout, I decided to make this component reusable for use in the future team overlay.