### PR TITLE
Add safeties against exceptions in `OnlineLookupCache`

### DIFF
--- a/osu.Game/Database/OnlineLookupCache.cs
+++ b/osu.Game/Database/OnlineLookupCache.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.ExceptionExtensions;
+using osu.Framework.Logging;
 using osu.Game.Online.API;
 
 namespace osu.Game.Database
@@ -163,6 +165,14 @@ namespace osu.Game.Database
             }
         }
 
-        private void createNewTask() => pendingRequestTask = Task.Run(performLookup);
+        private void createNewTask()
+        {
+            var nextTask = Task.Run(performLookup);
+            nextTask.ContinueWith(t =>
+            {
+                Logger.Error(t.Exception.AsSingular(), $"{nameof(OnlineLookupCache<TLookup, TValue, TRequest>)} lookup request failed!");
+            }, TaskContinuationOptions.OnlyOnFaulted);
+            pendingRequestTask = nextTask;
+        }
     }
 }

--- a/osu.Game/Database/OnlineLookupCache.cs
+++ b/osu.Game/Database/OnlineLookupCache.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Database
                 pendingTasks.Enqueue((id, tcs));
 
                 // Create a request task if there's not already one.
-                if (pendingRequestTask == null)
+                if (pendingRequestTask == null || pendingRequestTask.IsFaulted)
                     createNewTask();
 
                 return tcs.Task;


### PR DESCRIPTION
Noticed in passing that an exception inside a lookup would cause the cache to never work again, and also not report this in logs at all.

🙈 