### PR TITLE
Rework `DrawableSliderRepeat` to not rely on slider current curve

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -268,7 +268,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             SliderBody?.UpdateProgress(HeadCircle.IsHit ? completionProgress : 0);
 
             foreach (DrawableSliderRepeat repeat in repeatContainer)
-                repeat.UpdateSnakingPosition(HitObject.Path.PositionAt(SliderBody?.SnakedStart ?? 0), HitObject.Path.PositionAt(SliderBody?.SnakedEnd ?? 0));
+                repeat.UpdateSnakingPosition(SliderBody?.SnakedStart ?? 0, SliderBody?.SnakedEnd ?? 0);
 
             Size = SliderBody?.Size ?? Vector2.Zero;
             OriginPosition = SliderBody?.PathOffset ?? Vector2.Zero;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -115,35 +114,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private bool hasRotation;
 
-        public void UpdateSnakingPosition(Vector2 start, Vector2 end)
+        public void UpdateSnakingPosition(double progressStart, double progressEnd)
         {
             // When the repeat is hit, the arrow should fade out on spot rather than following the slider
             if (IsHit) return;
 
             bool isRepeatAtEnd = HitObject.RepeatIndex % 2 == 0;
-            List<Vector2> curve = ((PlaySliderBody)DrawableSlider.Body.Drawable).CurrentCurve;
+            double progress = isRepeatAtEnd ? progressEnd : progressStart;
 
-            Position = isRepeatAtEnd ? end : start;
+            Position = Slider?.Path.PositionAt(progress) ?? Vector2.Zero;
+            Vector2 direction = Slider?.Path.DirectionAtProgress(progress, !isRepeatAtEnd) ?? (isRepeatAtEnd ? -Vector2.UnitX : Vector2.UnitX);
 
-            if (curve.Count < 2)
-                return;
-
-            int searchStart = isRepeatAtEnd ? curve.Count - 1 : 0;
-            int direction = isRepeatAtEnd ? -1 : 1;
-
-            Vector2 aimRotationVector = Vector2.Zero;
-
-            // find the next vector2 in the curve which is not equal to our current position to infer a rotation.
-            for (int i = searchStart; i >= 0 && i < curve.Count; i += direction)
-            {
-                if (Precision.AlmostEquals(curve[i], Position))
-                    continue;
-
-                aimRotationVector = curve[i];
-                break;
-            }
-
-            float aimRotation = float.RadiansToDegrees(MathF.Atan2(aimRotationVector.Y - Position.Y, aimRotationVector.X - Position.X));
+            float aimRotation = float.RadiansToDegrees(MathF.Atan2(direction.Y, direction.X));
             while (Math.Abs(aimRotation - Arrow.Rotation) > 180)
                 aimRotation += aimRotation < Arrow.Rotation ? 360 : -360;
 

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -198,6 +198,33 @@ namespace osu.Game.Rulesets.Objects
             return interpolateVertices(indexOfDistance(d), d);
         }
 
+        public Vector2 DirectionAtProgress(double progress, bool forward)
+        {
+            ensureValid();
+
+            int step = forward ? 1 : -1;
+            if (calculatedPath.Count == 0)
+                return Vector2.UnitX * step;
+
+            int segmentIndex = Math.Clamp(indexOfDistance(progressToDistance(progress)), forward ? 0 : 1, calculatedPath.Count - (forward ? 2 : 1));
+
+            int i = segmentIndex + step;
+            Vector2 p0 = calculatedPath[segmentIndex];
+
+            while (i < calculatedPath.Count && i >= 0)
+            {
+                Vector2 p1 = calculatedPath[i];
+                Vector2 dir = p1 - p0;
+
+                if (dir.X * dir.X + dir.Y * dir.Y > 0.01f)
+                    return dir;
+
+                i += step;
+            }
+
+            return Vector2.UnitX * step;
+        }
+
         /// <summary>
         /// Returns the control points belonging to the same segment as the one given.
         /// The first point has a PathType which all other points inherit.


### PR DESCRIPTION
With preparation for native start/end progress, `SnakingSliderBody.CurrentCurve` will be removed as not needed, thus we need a way to compute the angle of `DrawableSliderRepeat` without relying on that.
This pr introduces `SliderPath.DirectionAtProgress()` which covers that need.