### PR TITLE
Add star rating text gradient

### DIFF
--- a/osu.Game.Tests/Visual/Colours/TestSceneStarDifficultyColours.cs
+++ b/osu.Game.Tests/Visual/Colours/TestSceneStarDifficultyColours.cs
@@ -7,7 +7,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK;
@@ -31,7 +33,7 @@ namespace osu.Game.Tests.Visual.Colours
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(5f),
-                    ChildrenEnumerable = Enumerable.Range(0, 10).Select(i => new FillFlowContainer
+                    ChildrenEnumerable = Enumerable.Range(0, 15).Select(i => new FillFlowContainer
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -40,7 +42,9 @@ namespace osu.Game.Tests.Visual.Colours
                         Spacing = new Vector2(10f),
                         ChildrenEnumerable = Enumerable.Range(0, 10).Select(j =>
                         {
-                            var colour = colours.ForStarDifficulty(1f * i + 0.1f * j);
+                            float difficulty = 1f * i + 0.1f * j;
+                            var colour = colours.ForStarDifficulty(difficulty);
+                            var textColour = colours.ForStarDifficultyText(difficulty);
 
                             return new FillFlowContainer
                             {
@@ -48,36 +52,27 @@ namespace osu.Game.Tests.Visual.Colours
                                 Origin = Anchor.Centre,
                                 AutoSizeAxes = Axes.Both,
                                 Direction = FillDirection.Vertical,
-                                Spacing = new Vector2(0f, 10f),
+                                Spacing = new Vector2(0f, 5f),
                                 Children = new Drawable[]
                                 {
-                                    new CircularContainer
+                                    new OsuSpriteText
                                     {
-                                        Masking = true,
                                         Anchor = Anchor.TopCentre,
                                         Origin = Anchor.TopCentre,
-                                        Size = new Vector2(75f, 25f),
-                                        Children = new Drawable[]
-                                        {
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Colour = colour,
-                                            },
-                                            new OsuSpriteText
-                                            {
-                                                Anchor = Anchor.Centre,
-                                                Origin = Anchor.Centre,
-                                                Colour = OsuColour.ForegroundTextColourFor(colour),
-                                                Text = colour.ToHex(),
-                                            },
-                                        }
+                                        Font = FontUsage.Default.With(size: 10),
+                                        Text = $"BG: {colour.ToHex()}",
                                     },
                                     new OsuSpriteText
                                     {
                                         Anchor = Anchor.TopCentre,
                                         Origin = Anchor.TopCentre,
-                                        Text = $"*{(1f * i + 0.1f * j):0.00}",
+                                        Font = FontUsage.Default.With(size: 10),
+                                        Text = $"Text: {textColour.ToHex()}",
+                                    },
+                                    new StarRatingDisplay(new StarDifficulty(difficulty, 0))
+                                    {
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
                                     }
                                 }
                             };

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -59,9 +59,6 @@ namespace osu.Game.Beatmaps.Drawables
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
-        [Resolved]
-        private OverlayColourProvider? colourProvider { get; set; }
-
         /// <summary>
         /// Creates a new <see cref="StarRatingDisplay"/> using an already computed <see cref="StarDifficulty"/>.
         /// </summary>

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -42,6 +41,12 @@ namespace osu.Game.Beatmaps.Drawables
         /// Can be used to have other components match the spectrum animation.
         /// </summary>
         public Color4 DisplayedDifficultyColour => background.Colour;
+
+        /// <summary>
+        /// The difficulty text colour currently displayed.
+        /// Can be used to have other components match the spectrum animation.
+        /// </summary>
+        public Color4 DisplayedDifficultyTextColour => starsText.Colour;
 
         private readonly Bindable<double> displayedStars = new BindableDouble();
 
@@ -160,8 +165,8 @@ namespace osu.Game.Beatmaps.Drawables
 
                 background.Colour = colours.ForStarDifficulty(s.NewValue);
 
-                starIcon.Colour = s.NewValue >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : colourProvider?.Background5 ?? Color4Extensions.FromHex("303d47");
-                starsText.Colour = s.NewValue >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : colourProvider?.Background5 ?? Color4.Black.Opacity(0.75f);
+                starIcon.Colour = colours.ForStarDifficultyText(s.NewValue);
+                starsText.Colour = colours.ForStarDifficultyText(s.NewValue);
             }, true);
         }
     }

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Overlays;
 using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Graphics
         /// </summary>
         public const float STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF = 6.5f;
 
+        /// <summary>
+        /// Star rating at which display text switches from static colours to a gradient.
+        /// </summary>
+        public const float STAR_DIFFICULTY_TEXT_GRADIENT_CUTOFF = 9.0f;
+
         public static readonly (float, Color4)[] STAR_DIFFICULTY_SPECTRUM =
         {
             (0.1f, Color4Extensions.FromHex("aaaaaa")),
@@ -42,10 +47,33 @@ namespace osu.Game.Graphics
             (10.0f, Color4.Black),
         };
 
+        public static readonly (float, Color4)[] STAR_DIFFICULTY_TEXT_SPECTRUM =
+        {
+            (9.0f, Color4Extensions.FromHex("f6f05c")),
+            (9.9f, Color4Extensions.FromHex("ff8068")),
+            (10.6f, Color4Extensions.FromHex("ff4e6f")),
+            (11.5f, Color4Extensions.FromHex("c645b8")),
+            (12.4f, Color4Extensions.FromHex("6563de")),
+        };
+
         /// <summary>
         /// Retrieves the colour for a given point in the star range.
         /// </summary>
         public Color4 ForStarDifficulty(double starDifficulty) => ColourUtils.SampleFromLinearGradient(STAR_DIFFICULTY_SPECTRUM, (float)Math.Round(starDifficulty, 2, MidpointRounding.AwayFromZero));
+
+        /// <summary>
+        /// Retrieves the colour for the text inside the star rating display.
+        /// </summary>
+        public Color4 ForStarDifficultyText(double starDifficulty)
+        {
+            if (starDifficulty < STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF)
+                return Color4.Black.Opacity(0.75f);
+
+            if (starDifficulty < STAR_DIFFICULTY_TEXT_GRADIENT_CUTOFF)
+                return Orange1;
+
+            return ColourUtils.SampleFromLinearGradient(STAR_DIFFICULTY_TEXT_SPECTRUM, (float)Math.Round(starDifficulty, 2, MidpointRounding.AwayFromZero));
+        }
 
         /// <summary>
         /// Retrieves the colour for a <see cref="ScoreRank"/>.

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -54,12 +54,6 @@ namespace osu.Game.Screens.SelectV2
         private IRulesetStore rulesets { get; set; } = null!;
 
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; } = null!;
-
-        [Resolved]
-        private OsuColour colours { get; set; } = null!;
-
-        [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; } = null!;
 
         [Resolved]

--- a/osu.Game/Screens/SelectV2/PanelBeatmap.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmap.cs
@@ -278,9 +278,12 @@ namespace osu.Game.Screens.SelectV2
                 backgroundBorder.Colour = diffColour;
                 backgroundDifficultyTint.Colour = ColourInfo.GradientHorizontal(diffColour.Opacity(0.25f), diffColour.Opacity(0f));
 
-                difficultyIcon.Colour = starRatingDisplay.DisplayedStars.Value > OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : colourProvider.Background5;
-
                 triangles.Colour = ColourInfo.GradientVertical(diffColour.Opacity(0.25f), diffColour.Opacity(0f));
+            }
+
+            if (difficultyIcon.Colour != starRatingDisplay.DisplayedDifficultyTextColour)
+            {
+                difficultyIcon.Colour = starRatingDisplay.DisplayedDifficultyTextColour;
             }
         }
 

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -46,9 +46,6 @@ namespace osu.Game.Screens.SelectV2
         private BeatmapManager beatmaps { get; set; } = null!;
 
         [Resolved]
-        private OsuColour colours { get; set; } = null!;
-
-        [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; } = null!;
 
         private IBindable<StarDifficulty>? starDifficultyBindable;

--- a/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/SelectV2/PanelBeatmapStandalone.cs
@@ -293,7 +293,7 @@ namespace osu.Game.Screens.SelectV2
             spreadDisplay.Current.Colour = diffColour;
 
             backgroundBorder.Colour = diffColour;
-            difficultyIcon.Colour = starRatingDisplay.DisplayedStars.Value > OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : colourProvider.Background5;
+            difficultyIcon.Colour = starRatingDisplay.DisplayedDifficultyTextColour;
         }
 
         private void updateKeyCount()


### PR DESCRIPTION
Implements https://github.com/ppy/osu-web/pull/12363

There's one less colour in the spectrum than in the [web code](https://github.com/ppy/osu-web/pull/12363/changes#diff-a9bdefd7233ca98f7f89cd76213aba5d869ae0424c8e79d1e322abd3e43462fbR31) because the spectrum was actually defined incorrectly and has [one less domain entry than it should](https://github.com/ppy/osu-web/pull/12363/changes#diff-a9bdefd7233ca98f7f89cd76213aba5d869ae0424c8e79d1e322abd3e43462fbR29). I've chose to not add it because of consistency with the web and because it looked pretty ugly (it was pretty much unreadable)

<img width="1361" height="814" alt="image" src="https://github.com/user-attachments/assets/5f9d7a93-3e28-4b8c-952c-0abd6f8c2cc3" />
<img width="805" height="647" alt="image" src="https://github.com/user-attachments/assets/b060cba7-3beb-4bb5-8d50-6210e8417715" />

