### PR TITLE
Fix underline size at song select details panel not matching after changing language

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapDetailsArea.WedgeSelector.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapDetailsArea.WedgeSelector.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -13,6 +14,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -24,6 +26,8 @@ namespace osu.Game.Screens.SelectV2
             where T : struct, Enum
         {
             private Circle strip = null!;
+
+            private Bindable<Language> currentLanguage = null!;
 
             protected override Dropdown<T>? CreateDropdown() => null;
 
@@ -37,7 +41,7 @@ namespace osu.Game.Screens.SelectV2
             }
 
             [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
+            private void load(OverlayColourProvider colourProvider, OsuGameBase game)
             {
                 AddInternal(strip = new Circle
                 {
@@ -49,6 +53,8 @@ namespace osu.Game.Screens.SelectV2
 
                 foreach (var type in Enum.GetValues<T>())
                     AddItem(type);
+
+                currentLanguage = game.CurrentLanguage.GetBoundCopy();
             }
 
             protected override void LoadComplete()
@@ -57,26 +63,14 @@ namespace osu.Game.Screens.SelectV2
 
                 Current.BindValueChanged(_ => updateDisplay());
 
-                // Update the underlining for the active tab item when the text changes (e.g., due to language change).
-                foreach (var drawable in TabContainer.Children)
+                currentLanguage.BindValueChanged(_ =>
                 {
-                    if (drawable is not TabItem wedgeTab)
-                        continue;
-
-                    wedgeTab.Text.Current.BindValueChanged(_ =>
+                    ScheduleAfterChildren(() =>
                     {
-                        if (wedgeTab == SelectedTab)
-                        {
-                            ScheduleAfterChildren(updateDisplay);
-                        }
+                        updateDisplay();
+                        FinishTransforms(true);
                     });
-                }
-
-                ScheduleAfterChildren(() =>
-                {
-                    updateDisplay();
-                    FinishTransforms(true);
-                });
+                }, true);
             }
 
             private void updateDisplay()

--- a/osu.Game/Screens/SelectV2/BeatmapDetailsArea.WedgeSelector.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapDetailsArea.WedgeSelector.cs
@@ -57,6 +57,21 @@ namespace osu.Game.Screens.SelectV2
 
                 Current.BindValueChanged(_ => updateDisplay());
 
+                // Update the underlining for the active tab item when the text changes (e.g., due to language change).
+                foreach (var drawable in TabContainer.Children)
+                {
+                    if (drawable is not TabItem wedgeTab)
+                        continue;
+
+                    wedgeTab.Text.Current.BindValueChanged(_ =>
+                    {
+                        if (wedgeTab == SelectedTab)
+                        {
+                            ScheduleAfterChildren(updateDisplay);
+                        }
+                    });
+                }
+
                 ScheduleAfterChildren(() =>
                 {
                     updateDisplay();


### PR DESCRIPTION
Fixes #36274 

**Change:**
Registered a `BindValueChanged` callback on each TabItem’s `Text.Current` to ensure the underline indicator (strip) updates whenever the displayed tab text changes and calling `updateDisplay` accordingly to update the underline.

**Result:**

https://github.com/user-attachments/assets/6fb95a46-c768-46ec-a68a-a5e394e08a78

