### PR TITLE
Add custom page up/down keyboard selection in song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -222,6 +222,8 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         protected void SelectPrevPanel() => AddStep("select prev panel", () => InputManager.Key(Key.Up));
         protected void SelectNextSet() => AddStep("select next set", () => InputManager.Key(Key.Right));
         protected void SelectPrevSet() => AddStep("select prev set", () => InputManager.Key(Key.Left));
+        protected void SelectPageDown() => AddStep("select page down", () => InputManager.Key(Key.PageDown));
+        protected void SelectPageUp() => AddStep("select page up", () => InputManager.Key(Key.PageUp));
 
         protected void Select() => AddStep("select", () => InputManager.Key(Key.Enter));
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselPageNavigation.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselPageNavigation.cs
@@ -1,0 +1,169 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Graphics.Carousel;
+using osu.Game.Screens.SelectV2;
+
+namespace osu.Game.Tests.Visual.SongSelectV2
+{
+    [TestFixture]
+    public partial class TestSceneBeatmapCarouselPageNavigation : BeatmapCarouselTestScene
+    {
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            RemoveAllBeatmaps();
+            CreateCarousel();
+
+            AddBeatmaps(20, fixedDifficultiesPerSet: 1);
+            WaitForDrawablePanels();
+        }
+
+        [Test]
+        public void TestPageDownMovesSelectionByMultipleItems()
+        {
+            SelectNextPanel();
+            WaitForScrolling();
+
+            CarouselItem? initialSelection = null;
+            int? initialIndex = null;
+
+            AddStep("save initial selection", () =>
+            {
+                initialSelection = GetKeyboardSelectedPanel()?.Item;
+                initialIndex = Carousel.GetCarouselItems()?.IndexOf(initialSelection!);
+            });
+
+            SelectPageDown();
+            WaitForScrolling();
+
+            AddAssert("selection moved forward", () =>
+            {
+                var currentSelection = GetKeyboardSelectedPanel()?.Item;
+                int? currentIndex = Carousel.GetCarouselItems()?.IndexOf(currentSelection!);
+
+                return currentIndex != null && initialIndex != null && currentIndex > initialIndex;
+            });
+
+            AddAssert("selection moved by more than one item", () =>
+            {
+                var currentSelection = GetKeyboardSelectedPanel()?.Item;
+                int? currentIndex = Carousel.GetCarouselItems()?.IndexOf(currentSelection!);
+
+                return currentIndex != null && initialIndex != null && currentIndex - initialIndex > 1;
+            });
+        }
+
+        [Test]
+        public void TestPageUpMovesSelectionByMultipleItems()
+        {
+            // Move to an item further down in the list first
+            AddRepeatStep("move selection down", () =>
+            {
+                SelectNextPanel();
+            }, 10);
+            WaitForScrolling();
+
+            CarouselItem? initialSelection = null;
+            int? initialIndex = null;
+
+            AddStep("save initial selection", () =>
+            {
+                initialSelection = GetKeyboardSelectedPanel()?.Item;
+                initialIndex = Carousel.GetCarouselItems()?.IndexOf(initialSelection!);
+            });
+
+            SelectPageUp();
+            WaitForScrolling();
+
+            AddAssert("selection moved backward", () =>
+            {
+                var currentSelection = GetKeyboardSelectedPanel()?.Item;
+                int? currentIndex = Carousel.GetCarouselItems()?.IndexOf(currentSelection!);
+
+                return currentIndex != null && initialIndex != null && currentIndex < initialIndex;
+            });
+
+            AddAssert("selection moved by more than one item", () =>
+            {
+                var currentSelection = GetKeyboardSelectedPanel()?.Item;
+                int? currentIndex = Carousel.GetCarouselItems()?.IndexOf(currentSelection!);
+
+                return currentIndex != null && initialIndex != null && initialIndex - currentIndex > 1;
+            });
+        }
+
+        [Test]
+        public void TestPageDownDoesNotWrapAround()
+        {
+            // Move to the end of the list
+            AddStep("scroll to end", () => Scroll.ScrollToEnd(false));
+
+            AddStep("select last item", () =>
+            {
+                var items = Carousel.GetCarouselItems();
+                if (items != null && items.Count > 0)
+                {
+                    var lastVisible = items.LastOrDefault(i => i.IsVisible);
+                    if (lastVisible != null)
+                    {
+                        // Click the last panel to select it
+                        var panel = Carousel.ChildrenOfType<ICarouselPanel>()
+                            .FirstOrDefault(p => p.Item == lastVisible);
+                        (panel as Panel)?.TriggerClick();
+                    }
+                }
+            });
+            WaitForScrolling();
+
+            CarouselItem? selectionBeforePageDown = null;
+
+            AddStep("save selection before page down", () =>
+            {
+                selectionBeforePageDown = GetKeyboardSelectedPanel()?.Item;
+            });
+
+            SelectPageDown();
+            WaitForScrolling();
+
+            AddAssert("selection did not wrap to beginning", () =>
+            {
+                var currentSelection = GetKeyboardSelectedPanel()?.Item;
+                int? currentIndex = Carousel.GetCarouselItems()?.IndexOf(currentSelection!);
+
+                // Selection should remain at or near the end, not wrap to beginning
+                return currentIndex >= (Carousel.GetCarouselItems()?.Count ?? 0) / 2;
+            });
+        }
+
+        [Test]
+        public void TestPageUpDoesNotWrapAround()
+        {
+            SelectNextPanel();
+            WaitForScrolling();
+
+            // We're at the first item
+            CarouselItem? selectionBeforePageUp = null;
+
+            AddStep("save selection before page up", () =>
+            {
+                selectionBeforePageUp = GetKeyboardSelectedPanel()?.Item;
+            });
+
+            SelectPageUp();
+            WaitForScrolling();
+
+            AddAssert("selection did not wrap to end", () =>
+            {
+                var currentSelection = GetKeyboardSelectedPanel()?.Item;
+                int? currentIndex = Carousel.GetCarouselItems()?.IndexOf(currentSelection!);
+
+                // Selection should remain at or near the beginning, not wrap to end
+                return currentIndex <= (Carousel.GetCarouselItems()?.Count ?? 0) / 2;
+            });
+        }
+    }
+}

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -704,7 +704,7 @@ namespace osu.Game.Graphics.Carousel
 
             // If we couldn't find a visible item in the desired direction,
             // try stepping backward from where we stopped.
-            newIndex = newIndex - direction;
+            newIndex -= direction;
             while (newIndex >= 0 && newIndex < carouselItems.Count && newIndex != originalIndex)
             {
                 var item = carouselItems[newIndex];

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -212,6 +212,9 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.Up }, GlobalAction.IncreaseModSpeed),
             new KeyBinding(new[] { InputKey.Control, InputKey.Down }, GlobalAction.DecreaseModSpeed),
             new KeyBinding(InputKey.None, GlobalAction.AbsoluteScrollSongList),
+
+            new KeyBinding(InputKey.PageUp, GlobalAction.SelectPageUp),
+            new KeyBinding(InputKey.PageDown, GlobalAction.SelectPageDown),
         };
 
         private static IEnumerable<KeyBinding> audioControlKeyBindings => new[]
@@ -520,6 +523,12 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleCurrentGroup))]
         ToggleCurrentGroup,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectPageUp))]
+        SelectPageUp,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectPageDown))]
+        SelectPageDown,
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -479,6 +479,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditorDiscardUnsavedChanges => new TranslatableString(getKey(@"editor_discard_unsaved_changes"), @"Discard unsaved changes");
 
+        /// <summary>
+        /// "Select page up"
+        /// </summary>
+        public static LocalisableString SelectPageUp => new TranslatableString(getKey(@"select_page_up"), @"Select page up");
+
+        /// <summary>
+        /// "Select page down"
+        /// </summary>
+        public static LocalisableString SelectPageDown => new TranslatableString(getKey(@"select_page_down"), @"Select page down");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }


### PR DESCRIPTION
This implements custom page up/down handling in song select like peppy mentioned in the issue. Instead of using the standard scroll container behavior which just scrolls the view by a page, it now changes the keyboard selection by multiple items at once.

The page navigation moves the selection by 5 visible items at a time (this is configurable via the `PageSelectionDistance` property if we want to tweak it later). The implementation doesn't wrap around at the ends of the list, so pressing Page Down at the bottom just stays at the bottom rather than jumping back to the start.

I've also added some basic tests to verify the page navigation moves the selection by more than one item and doesn't wrap around.

Closes #36099