### PR TITLE
Expand settings in `ReplayPlayer` by default

### DIFF
--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class PlayerSettingsOverlay : ExpandingContainer
     {
-        public VisualSettings VisualSettings { get; private set; }
-
         private const float padding = 10;
 
         public const float EXPANDED_WIDTH = player_settings_width + padding * 2;
@@ -66,11 +64,7 @@ namespace osu.Game.Screens.Play.HUD
                 Direction = FillDirection.Vertical,
                 Spacing = new Vector2(0, 20),
                 Margin = new MarginPadding(padding),
-                Children = new PlayerSettingsGroup[]
-                {
-                    VisualSettings = new VisualSettings { Expanded = { Value = false } },
-                    new AudioSettings { Expanded = { Value = false } }
-                }
+                Children = new PlayerSettingsGroup[] { new VisualSettings(), new AudioSettings() }
             });
 
             // For future consideration, this icon should probably not exist.

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -77,11 +77,7 @@ namespace osu.Game.Screens.Play
         /// Add a settings group to the HUD overlay. Intended to be used by rulesets to add replay-specific settings.
         /// </summary>
         /// <param name="settings">The settings group to be shown.</param>
-        public void AddSettings(PlayerSettingsGroup settings) => Schedule(() =>
-        {
-            settings.Expanded.Value = false;
-            HUDOverlay.PlayerSettingsOverlay.Add(settings);
-        });
+        public void AddSettings(PlayerSettingsGroup settings) => Schedule(() => HUDOverlay.PlayerSettingsOverlay.Add(settings));
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)


### PR DESCRIPTION
~i recently saw an suggestion to do this, but don't remember where~

- addresses https://github.com/ppy/osu/discussions/36189

i think it's logical, since the settings have been displayed in a separate overlay for more than six months, and not on top of the gameplay itself, and for example, it can be difficult to expand section on phones

| master | pr |
|-|-|
| <img width="1920" height="1080" alt="osu_2026-01-12_09-40-23" src="https://github.com/user-attachments/assets/35d15ce6-ce12-4a9a-be4e-d72043dfb91a" /> | <img width="1920" height="1080" alt="osu_2026-01-12_09-39-40" src="https://github.com/user-attachments/assets/225d75db-1719-48dc-a65f-16272cca8295" /> |