### PR TITLE
Added preselection support for presets in mod overlay

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Spacing = new Vector2(0, 5),
-                ChildrenEnumerable = createTestPresets().Select(preset => new ModPresetPanel(preset.ToLiveUnmanaged()))
+                ChildrenEnumerable = createTestPresets().Select(preset => new ModPresetPanel(new ModPresetState(preset.ToLiveUnmanaged())))
             });
         }
 
@@ -51,11 +51,15 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             ModPresetPanel? panel = null;
 
-            AddStep("create panel", () => Child = panel = new ModPresetPanel(createTestPresets().First().ToLiveUnmanaged())
+            AddStep("create panel", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Width = 0.5f
+                var presetState = new ModPresetState(createTestPresets().First().ToLiveUnmanaged());
+                Child = panel = new ModPresetPanel(presetState)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 0.5f
+                };
             });
             AddAssert("panel is not active", () => !panel.AsNonNull().Active.Value);
 
@@ -97,11 +101,15 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             ModPresetPanel? panel = null;
 
-            AddStep("create panel", () => Child = panel = new ModPresetPanel(createTestPresets().First().ToLiveUnmanaged())
+            AddStep("create panel", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Width = 0.5f
+                var presetState = new ModPresetState(createTestPresets().First().ToLiveUnmanaged());
+                Child = panel = new ModPresetPanel(presetState)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 0.5f
+                };
             });
 
             AddStep("activate panel", () => panel.AsNonNull().TriggerClick());
@@ -128,20 +136,25 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             ModPresetPanel? panel = null;
 
-            AddStep("create panel", () => Child = panel = new ModPresetPanel(new ModPreset
+            AddStep("create panel", () =>
             {
-                Name = "Autopilot included",
-                Description = "no way",
-                Mods = new Mod[]
+                var presetState = new ModPresetState(new ModPreset
                 {
-                    new OsuModAutopilot()
-                },
-                Ruleset = new OsuRuleset().RulesetInfo
-            }.ToLiveUnmanaged())
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Width = 0.5f
+                    Name = "Autopilot included",
+                    Description = "no way",
+                    Mods = new Mod[]
+                    {
+                        new OsuModAutopilot()
+                    },
+                    Ruleset = new OsuRuleset().RulesetInfo
+                }.ToLiveUnmanaged());
+
+                Child = panel = new ModPresetPanel(presetState)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 0.5f
+                };
             });
 
             AddStep("Add touch device to selected mods", () => SelectedMods.Value = new Mod[] { new OsuModTouchDevice() });

--- a/osu.Game/Overlays/Mods/ModPresetState.cs
+++ b/osu.Game/Overlays/Mods/ModPresetState.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Database;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Overlays.Mods
+{
+    /// <summary>
+    /// Wrapper class used to store the current state of a mod preset shown on the <see cref="ModSelectOverlay"/>.
+    /// Used primarily to decouple data from drawable logic.
+    /// </summary>
+    public class ModPresetState
+    {
+        /// <summary>
+        /// The live database object representing the preset this state wraps.
+        /// </summary>
+        public Live<ModPreset> Preset { get; }
+
+        /// <summary>
+        /// Whether the preset is currently selected (i.e., all its mods are selected).
+        /// </summary>
+        public BindableBool Active { get; } = new BindableBool();
+
+        public BindableBool Preselected { get; } = new BindableBool();
+
+        public ModPresetState(Live<ModPreset> preset)
+        {
+            Preset = preset;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #35713 

**Changes:**
- Added ModPresetState class (similar to ModState, but for presets)
Introduced a new state wrapper for mod presets (ModPresetState) to decouple the data from drawable logic in ModSelectOverlay.
- Updated the mod selection logic to also handle preset preselection:
  - `preselectMod` → `preselectModOrPreset`
  - **Mods are checked first:** if a match for a mod acronym or name exists, that mod is preselected and presets are ignored.
  - **Preset fallback:** if no mod matches,  presets are filtered using all search words from the input (split by spaces).
    - Each preset matches if all search words appear in any of its terms, including:
    Preset name and description
    - Names, acronyms, or descriptions of the mods in the preset
  - Only one preset is preselected at a time.
  - I chose this approach because if you have the  “Easy” Mod for example, and you search for "Eas", a preset with the "Easy" Mod will always be selected first. If you have a lot of presets, the mod will almost never selected.
- Prevents presets from being preselected if a mod already matches the search.
Presets can be preselected via multi-word search (e.g., "Easy Half Time" or "[preset name] Easy" selects the corresponding preset).

**Result:**

https://github.com/user-attachments/assets/43b2d931-e2e4-4969-b7ae-8e1c2354ab88

