### PR TITLE
Change break timing to allow elements to be force transformed

### DIFF
--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Screens.Play
 
         private void updateDisplay(ValueChangedEvent<Period?> period)
         {
+            FinishTransforms(true);
             Scheduler.CancelDelayedTasks();
 
             if (period.NewValue == null)
@@ -165,7 +166,7 @@ namespace osu.Game.Screens.Play
                 info.MoveToX(50)
                     .MoveToX(0, BREAK_FADE_DURATION, Easing.OutQuint);
 
-                using (BeginDelayedSequence(b.Duration))
+                using (BeginDelayedSequence(b.Duration - BREAK_FADE_DURATION))
                 {
                     fadeContainer.FadeOut(BREAK_FADE_DURATION);
                     breakArrows.Hide(BREAK_FADE_DURATION);


### PR DESCRIPTION
This is a potential fix for #35900

My last change, #35566, broke replays because it was no longer forcing transforms. This meant that the positioning and transparency of some objects wouldn't reset when navigating a replay.

This pull request forces transitions when breaks are completed, however also changes the animations to happen sooner so as not to be cut off. The reason I call this a "potential fix" is because this changes how the animation looks in game. I figure this solution has less overhead and potential for issues, however if it doesn't look great I can spend some more time on other solutions.

See differences below

Before
https://github.com/user-attachments/assets/5bcfc904-a7c2-4e3d-8eac-8b8cc03a798c

After (note that the fadeout happens at the same time as the bar reaching 0 width)
https://github.com/user-attachments/assets/a552b225-bfd6-4d7e-8621-559ce36ba5d9

