### PR TITLE
Clean up `HubClientConnector` configuration

### DIFF
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -66,8 +66,6 @@ namespace osu.Game.Online
                     }
 
                     options.AccessTokenProvider = () => Task.FromResult<string?>(API.AccessToken);
-                    // non-standard header name kept for backwards compatibility, can be removed after server side has migrated to `VERSION_HASH_HEADER`
-                    options.Headers.Add(@"OsuVersionHash", versionHash);
                     options.Headers.Add(VERSION_HASH_HEADER, versionHash);
                     options.Headers.Add(CLIENT_SESSION_ID_HEADER, API.SessionIdentifier.ToString());
                 });

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -57,13 +57,7 @@ namespace osu.Game.Online
                 {
                     // Configuring proxies is not supported on iOS, see https://github.com/xamarin/xamarin-macios/issues/14632.
                     if (RuntimeInfo.OS != RuntimeInfo.Platform.iOS)
-                    {
-                        // Use HttpClient.DefaultProxy once on net6 everywhere.
-                        // The credential setter can also be removed at this point.
-                        options.Proxy = WebRequest.DefaultWebProxy;
-                        if (options.Proxy != null)
-                            options.Proxy.Credentials = CredentialCache.DefaultCredentials;
-                    }
+                        options.Proxy = HttpClient.DefaultProxy;
 
                     options.AccessTokenProvider = () => Task.FromResult<string?>(API.AccessToken);
                     options.Headers.Add(VERSION_HASH_HEADER, versionHash);

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Online
                             options.Proxy.Credentials = CredentialCache.DefaultCredentials;
                     }
 
-                    options.Headers.Add(@"Authorization", @$"Bearer {API.AccessToken}");
+                    options.AccessTokenProvider = () => Task.FromResult<string?>(API.AccessToken);
                     // non-standard header name kept for backwards compatibility, can be removed after server side has migrated to `VERSION_HASH_HEADER`
                     options.Headers.Add(@"OsuVersionHash", versionHash);
                     options.Headers.Add(VERSION_HASH_HEADER, versionHash);


### PR DESCRIPTION
This is a bunch of assorted minor changes that fell out from me looking into SignalR authentication for the refereeing client implementation. If anything here offends, relevant commits or the PR in its entirety can be dropped - any known functional concerns that these changes would fix are at most theoretical.

## [Replace manual specification of `Authorization` header with SignalR-provided provider property](https://github.com/ppy/osu/commit/d5aa5b61ad2eac7eb9c06b7b67d4309a8ea07d7c)

The property used here [is listed in SignalR documentation](https://learn.microsoft.com/en-us/aspnet/core/signalr/authn-and-authz?view=aspnetcore-10.0#bearer-token-authentication). Not sure why it hasn't been used from the start, it's at least 8 years old.

While in practice this probably has zero bearing on anything, theoretically the way proposed in this commit is more correct. As the documentation states, with some transports the token may need to be renewed if it expires, which providing it via a header as done previously would not achieve, while going through `API.AccessToken` via the accessor every time will perform a token refresh if one is needed.

## [Remove no longer needed header alias for version hash](https://github.com/ppy/osu/commit/5abc0f93fe67b424a97ae5869535535ae8af330a)
 
Clean-up from an old change (see https://github.com/ppy/osu/pull/28892#discussion_r1681136250).

## [Simplify proxy configuration](https://github.com/ppy/osu/commit/9c8d6e63a7473dec0bf80f35fa9e76a89e57ac34) 

More clean-up while I'm here. Can't say I tested this at all.