### PR TITLE
Decrease realmAccess.Write() caused disk usage in starrating calculation and tag repopulating

### DIFF
--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -218,7 +218,6 @@ namespace osu.Game.Database
                 }
             }
 
-
             realmAccess.Write(r =>
             {
                 foreach ((Guid id, BeatmapInfo beatmap, double starRating) in buffer)


### PR DESCRIPTION
This increases the speed of sr calc (3-4 min faster on my SSD) and tag repopulating. The only change is that writes only happen after the calculations are complete.