### PR TITLE
Initial implementation of the team profile overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneClickableTeamFlag.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneClickableTeamFlag.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Graphics.Cursor;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Users.Drawables;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public partial class TestSceneClickableTeamFlag : OsuManualInputManagerTestScene
+    {
+        [SetUpSteps]
+        public void SetUp()
+        {
+            AddStep("create flags", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Spacing = new Vector2(10f),
+                    Children = new[]
+                    {
+                        new ClickableTeamFlag(
+                            new APITeam
+                            {
+                                Id = 1,
+                                Name = "Collective Wangs",
+                                ShortName = "WANG",
+                            }, showTooltipOnHover: false) { Width = 300, Height = 150 },
+                        new ClickableTeamFlag(
+                            new APITeam
+                            {
+                                Id = 2,
+                                Name = "mom?",
+                                ShortName = "MOM",
+                                FlagUrl = "https://assets.ppy.sh/teams/flag/1/b46fb10dbfd8a35dc50e6c00296c0dc6172dffc3ed3d3a4b379277ba498399fe.png",
+                            }, showTooltipOnHover: true) { Width = 300, Height = 150 },
+                    },
+                };
+            });
+        }
+
+        [Test]
+        public void TestHover()
+        {
+            AddStep("hover flag with no tooltip", () => InputManager.MoveMouseTo(this.ChildrenOfType<ClickableTeamFlag>().ElementAt(0)));
+            AddWaitStep("wait", 3);
+            AddAssert("tooltip is not visible", () => this.ChildrenOfType<OsuTooltipContainer.OsuTooltip>().FirstOrDefault()?.State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddStep("hover flag with tooltip", () => InputManager.MoveMouseTo(this.ChildrenOfType<ClickableTeamFlag>().ElementAt(1)));
+            AddUntilStep("wait for tooltip to show", () => this.ChildrenOfType<OsuTooltipContainer.OsuTooltip>().FirstOrDefault()?.State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneReportPopover.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneReportPopover.cs
@@ -1,0 +1,118 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Net.Http;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Overlays.Chat;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public partial class TestSceneReportPopover : OsuTestScene
+    {
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        private ReportPopoverContainer popover = null!;
+
+        [SetUpSteps]
+        public void SetUp()
+        {
+            AddStep("create popover", () =>
+            {
+                Child = new PopoverContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = popover = new ReportPopoverContainer(),
+                };
+            });
+        }
+
+        [Test]
+        public void TestSuccess()
+        {
+            ChatReportRequest pendingRequest = null!;
+
+            AddStep("setup request handling", () =>
+            {
+                dummyAPI.HandleRequest += request =>
+                {
+                    if (request is ChatReportRequest chatReportRequest)
+                    {
+                        pendingRequest = chatReportRequest;
+                        return true;
+                    }
+
+                    return false;
+                };
+            });
+            AddStep("show popover", () => popover.ShowPopover());
+            AddStep("input reason", () => this.ChildrenOfType<OsuTextBox>().First().Text = "reason");
+            AddStep("send report", () => this.ChildrenOfType<Button>().First().TriggerClick());
+            AddUntilStep("wait for loading layer to hide", () => this.ChildrenOfType<LoadingLayer>().First().IsPresent, () => Is.True);
+            AddWaitStep("wait some", 3);
+            AddStep("complete request", () => pendingRequest.TriggerSuccess());
+            AddUntilStep("wait for loading layer to hide", () => this.ChildrenOfType<LoadingLayer>().First().IsPresent, () => Is.False);
+            AddAssert("ensure form is not present", () => this.ChildrenOfType<ReverseChildIDFillFlowContainer<Drawable>>().First().IsPresent, () => Is.False);
+            AddAssert("ensure confirmation is present", () => this.ChildrenOfType<ReportPopover<ChatReportReason>.ReportConfirmation>().First().IsPresent, () => Is.True);
+            AddUntilStep("wait for popover to hide", () => this.ChildrenOfType<ReportPopoverContainer.TestReportPopover>().First().IsPresent, () => Is.False);
+        }
+
+        [Test]
+        public void TestFailure()
+        {
+            ChatReportRequest pendingRequest = null!;
+
+            AddStep("setup request handling", () =>
+            {
+                dummyAPI.HandleRequest += request =>
+                {
+                    if (request is ChatReportRequest chatReportRequest)
+                    {
+                        pendingRequest = chatReportRequest;
+                        return true;
+                    }
+
+                    return false;
+                };
+            });
+            AddStep("show popover", () => popover.ShowPopover());
+            AddStep("input reason", () => this.ChildrenOfType<OsuTextBox>().First().Text = "reason");
+            AddStep("send report", () => this.ChildrenOfType<Button>().First().TriggerClick());
+            AddUntilStep("wait for loading layer to hide", () => this.ChildrenOfType<LoadingLayer>().First().IsPresent, () => Is.True);
+            AddWaitStep("wait some", 3);
+            AddStep("fail request", () => pendingRequest.TriggerFailure(new APIException("test error", new HttpRequestException("test error"))));
+            AddUntilStep("wait for loading layer to hide", () => this.ChildrenOfType<LoadingLayer>().First().IsPresent, () => Is.False);
+            AddAssert("ensure form is present", () => this.ChildrenOfType<ReverseChildIDFillFlowContainer<Drawable>>().First().IsPresent, () => Is.True);
+            AddAssert("ensure error is present", () => this.ChildrenOfType<ErrorTextFlowContainer>().First().IsPresent, () => Is.True);
+            AddAssert("ensure confirmation is not present", () => this.ChildrenOfType<ReportPopover<ChatReportReason>.ReportConfirmation>().First().IsPresent, () => Is.False);
+        }
+
+        protected partial class ReportPopoverContainer : Drawable, IHasPopover
+        {
+            public Popover GetPopover() => new TestReportPopover("test");
+
+            public partial class TestReportPopover : ReportPopover<ChatReportReason>
+            {
+                private IAPIProvider api { get; set; } = null!;
+
+                public TestReportPopover(string name)
+                    : base($"Report {name}?")
+                {
+                }
+
+                protected override APIRequest GetRequest(ChatReportReason reason, string comment) => new ChatReportRequest(1, reason, comment);
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneTeamProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneTeamProfileHeader.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Testing;
+using osu.Game.Graphics.Containers;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Team;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public partial class TestSceneTeamProfileHeader : OsuTestScene
+    {
+        private TeamProfileHeader header = null!;
+
+        [SetUpSteps]
+        public void SetUp()
+        {
+            AddStep("create header", () =>
+            {
+                header = new TeamProfileHeader();
+
+                Child = new DependencyProvidingContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    CachedDependencies = new (Type, object)[]
+                    {
+                        (typeof(TeamProfileHeader), header),
+                        (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Pink))
+                    },
+                    Child = new OsuScrollContainer(Direction.Vertical)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new PopoverContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Child = header,
+                        },
+                    },
+                };
+            });
+        }
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("show team", () => header.TeamData.Value = new TeamProfileData(TEST_TEAM, new OsuRuleset().RulesetInfo));
+        }
+
+        [Test]
+        public void TestMissingImages()
+        {
+            AddStep("show team with no flag", () =>
+            {
+                header.TeamData.Value = new TeamProfileData(new APITeam
+                {
+                    Name = "mom?",
+                    Id = 1,
+                    ShortName = "MOM",
+                    CoverUrl = TestResources.COVER_IMAGE_1,
+                }, new OsuRuleset().RulesetInfo);
+            });
+            AddStep("show team with no cover", () =>
+            {
+                header.TeamData.Value = new TeamProfileData(new APITeam
+                {
+                    Name = "mom?",
+                    Id = 1,
+                    ShortName = "MOM",
+                    FlagUrl = "https://assets.ppy.sh/teams/flag/1/b46fb10dbfd8a35dc50e6c00296c0dc6172dffc3ed3d3a4b379277ba498399fe.png",
+                }, new OsuRuleset().RulesetInfo);
+            });
+        }
+
+        public static readonly APITeam TEST_TEAM = new APITeam
+        {
+            Name = "mom?",
+            Id = 1,
+            ShortName = "MOM",
+            CoverUrl = TestResources.COVER_IMAGE_1,
+            FlagUrl = "https://assets.ppy.sh/teams/flag/1/b46fb10dbfd8a35dc50e6c00296c0dc6172dffc3ed3d3a4b379277ba498399fe.png",
+        };
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneTeamProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneTeamProfileHeader.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
@@ -10,7 +11,9 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Overlays.Team;
+using osu.Game.Overlays.Team.Header;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Tests.Resources;
 
@@ -18,6 +21,8 @@ namespace osu.Game.Tests.Visual.Online
 {
     public partial class TestSceneTeamProfileHeader : OsuTestScene
     {
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
         private TeamProfileHeader header = null!;
 
         [SetUpSteps]
@@ -78,6 +83,27 @@ namespace osu.Game.Tests.Visual.Online
                     FlagUrl = "https://assets.ppy.sh/teams/flag/1/b46fb10dbfd8a35dc50e6c00296c0dc6172dffc3ed3d3a4b379277ba498399fe.png",
                 }, new OsuRuleset().RulesetInfo);
             });
+        }
+
+        [Test]
+        public void TestOwnTeam()
+        {
+            AddStep("set user team", () => dummyAPI.LocalUser.Value.Team = TEST_TEAM);
+            AddStep("show team", () => header.TeamData.Value = new TeamProfileData(TEST_TEAM, new OsuRuleset().RulesetInfo));
+            AddWaitStep("wait for header to load", 3);
+            AddAssert("team chat button is present", () => this.ChildrenOfType<BottomHeaderContainer.TeamChatButton>().FirstOrDefault()?.IsPresent, () => Is.True);
+            AddAssert("actions button is not present", () => this.ChildrenOfType<ProfileActionsButton>().FirstOrDefault()?.IsPresent, () => Is.False);
+            AddStep("unset user team", () => dummyAPI.LocalUser.Value.Team = null);
+        }
+
+        [Test]
+        public void TestOtherTeam()
+        {
+            AddStep("show team", () => header.TeamData.Value = new TeamProfileData(TEST_TEAM, new OsuRuleset().RulesetInfo));
+            AddWaitStep("wait for header to load", 3);
+            AddAssert("team chat button is not present", () => this.ChildrenOfType<BottomHeaderContainer.TeamChatButton>().FirstOrDefault()?.IsPresent, () => Is.False);
+            AddAssert("actions button is present", () => this.ChildrenOfType<ProfileActionsButton>().FirstOrDefault()?.IsPresent, () => Is.True);
+            AddStep("unset user team", () => dummyAPI.LocalUser.Value.Team = null);
         }
 
         public static readonly APITeam TEST_TEAM = new APITeam

--- a/osu.Game.Tests/Visual/Online/TestSceneTeamProfileInfoSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneTeamProfileInfoSection.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Graphics.Containers;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Team;
+using osu.Game.Overlays.Team.Sections;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public partial class TestSceneTeamProfileInfoSection : OsuTestScene
+    {
+        private InfoSection section = null!;
+
+        [SetUpSteps]
+        public void SetUp()
+        {
+            AddStep("create section", () =>
+            {
+                Child = new DependencyProvidingContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    CachedDependencies = new (Type, object)[]
+                    {
+                        (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Pink))
+                    },
+                    Child = new OsuScrollContainer(Direction.Vertical)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding(20),
+                        Child = section = new InfoSection(),
+                    },
+                };
+            });
+        }
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("show team", () => section.TeamData.Value = GenerateTeam(new OsuRuleset().RulesetInfo));
+        }
+
+        [Test]
+        public void TestEmpty()
+        {
+        }
+
+        [Test]
+        public void TestRulesets()
+        {
+            AddStep("osu", () => section.TeamData.Value = GenerateTeam(new OsuRuleset().RulesetInfo));
+            AddStep("taiko", () => section.TeamData.Value = GenerateTeam(new TaikoRuleset().RulesetInfo));
+            AddStep("mania", () => section.TeamData.Value = GenerateTeam(new ManiaRuleset().RulesetInfo));
+            AddStep("catch", () => section.TeamData.Value = GenerateTeam(new CatchRuleset().RulesetInfo));
+        }
+
+        public static TeamProfileData GenerateTeam(RulesetInfo ruleset) => new TeamProfileData(new APITeam
+        {
+            Id = 1,
+            CreatedAt = new DateTimeOffset(2026, 1, 1, 13, 6, 0, TimeSpan.Zero),
+            IsOpen = true,
+            DefaultRulesetId = ruleset.OnlineID,
+            MembersCount = 1,
+            EmptySlots = 8,
+            Leader = new APIUser
+            {
+                Id = 2,
+                Username = "peppy",
+                CoverUrl = TestResources.COVER_IMAGE_3,
+            },
+            Statistics = new APITeamStatistics
+            {
+                Rank = RNG.Next(1, 10000),
+                Performance = RNG.Next(0, 100000),
+                PlayCount = RNG.Next(0, 1000000),
+                RankedScore = RNG.Next(0, 1000000000),
+            },
+        }, ruleset);
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneTeamProfileMembersSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneTeamProfileMembersSection.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Team;
+using osu.Game.Overlays.Team.Sections;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public partial class TestSceneTeamProfileMembersSection : OsuTestScene
+    {
+        private const int per_page = 51;
+
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        private MembersSection section = null!;
+
+        [SetUpSteps]
+        public void SetUp()
+        {
+            AddStep("create section", () =>
+            {
+                Child = new DependencyProvidingContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    CachedDependencies = new (Type, object)[]
+                    {
+                        (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Pink))
+                    },
+                    Child = new OsuScrollContainer(Direction.Vertical)
+                    {
+                        Width = 890,
+                        RelativeSizeAxes = Axes.Y,
+                        Padding = new MarginPadding(20),
+                        Child = section = new MembersSection(),
+                    },
+                };
+            });
+        }
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("setup request handling", () =>
+            {
+                const int member_count = 80;
+                IEnumerable<APITeamMember> members = from i in Enumerable.Range(1, member_count) select GenerateMember(i);
+
+                dummyAPI.HandleRequest = req =>
+                {
+                    if (req is GetTeamMembersRequest getTeamMembersRequest)
+                    {
+                        getTeamMembersRequest.TriggerSuccess(new TeamMembersResponse
+                        {
+                            Items = members.Take(per_page).ToArray(),
+                            Total = member_count,
+                        });
+
+                        members = members.Skip(per_page);
+
+                        return true;
+                    }
+
+                    return false;
+                };
+            });
+            AddStep("show", () => section.TeamData.Value = GenerateTeam());
+        }
+
+        [Test]
+        public void TestShowMore()
+        {
+            AddStep("setup request handling", () =>
+            {
+                const int member_count = 180;
+                IEnumerable<APITeamMember> members = from i in Enumerable.Range(1, member_count) select GenerateMember(i);
+
+                dummyAPI.HandleRequest = req =>
+                {
+                    if (req is GetTeamMembersRequest getTeamMembersRequest)
+                    {
+                        getTeamMembersRequest.TriggerSuccess(new TeamMembersResponse
+                        {
+                            Items = members.Take(per_page).ToArray(),
+                            Total = member_count,
+                        });
+
+                        members = members.Skip(per_page);
+
+                        return true;
+                    }
+
+                    return false;
+                };
+            });
+            AddStep("show", () => section.TeamData.Value = GenerateTeam());
+            AddRepeatStep("click show more", () => this.ChildrenOfType<ShowMoreButton>().First().TriggerClick(), 3);
+            AddUntilStep("wait for button to hide", () => this.ChildrenOfType<ShowMoreButton>().First().IsPresent, () => Is.False);
+        }
+
+        public static APITeamMember GenerateMember(int id) => new APITeamMember
+        {
+            CreatedAt = "2026-01-22T019:05:15+00:00",
+            User = GenerateUser(id),
+        };
+
+        public static readonly string[] COVERS =
+        {
+            TestResources.COVER_IMAGE_1,
+            TestResources.COVER_IMAGE_2,
+            TestResources.COVER_IMAGE_3,
+            TestResources.COVER_IMAGE_4,
+        };
+
+        public static APIUser GenerateUser(int id)
+        {
+            return new APIUser
+            {
+                Id = id,
+                Username = $"user{id}",
+                CoverUrl = COVERS[RNG.Next(0, COVERS.Length - 1)],
+            };
+        }
+
+        public static TeamProfileData GenerateTeam() => new TeamProfileData(new APITeam
+        {
+            Leader = new APIUser
+            {
+                Id = 2,
+                Username = "peppy",
+                CoverUrl = TestResources.COVER_IMAGE_3,
+            },
+        }, new OsuRuleset().RulesetInfo);
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneTeamProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneTeamProfileOverlay.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -57,6 +58,15 @@ namespace osu.Game.Tests.Visual.Online
                         return true;
                     }
 
+                    if (req is GetTeamMembersRequest getTeamMembersRequest)
+                    {
+                        getTeamMembersRequest.TriggerSuccess(new TeamMembersResponse
+                        {
+                            Items = (from i in Enumerable.Range(1, 10) select GenerateMember(i)).ToArray(),
+                            Total = 10,
+                        });
+                    }
+
                     return false;
                 };
             });
@@ -76,6 +86,15 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         pendingRequest = getTeamRequest;
                         return true;
+                    }
+
+                    if (req is GetTeamMembersRequest getTeamMembersRequest)
+                    {
+                        getTeamMembersRequest.TriggerSuccess(new TeamMembersResponse
+                        {
+                            Items = (from i in Enumerable.Range(1, 10) select GenerateMember(i)).ToArray(),
+                            Total = 10,
+                        });
                     }
 
                     return false;
@@ -108,6 +127,15 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         pendingRequest = getTeamRequest;
                         return true;
+                    }
+
+                    if (req is GetTeamMembersRequest getTeamMembersRequest)
+                    {
+                        getTeamMembersRequest.TriggerSuccess(new TeamMembersResponse
+                        {
+                            Items = (from i in Enumerable.Range(1, 10) select GenerateMember(i)).ToArray(),
+                            Total = 10,
+                        });
                     }
 
                     return false;
@@ -158,5 +186,29 @@ namespace osu.Game.Tests.Visual.Online
                 RankedScore = 546346745,
             },
         };
+
+        public static APITeamMember GenerateMember(int id) => new APITeamMember
+        {
+            CreatedAt = "2026-01-22T019:05:15+00:00",
+            User = GenerateUser(id),
+        };
+
+        public static readonly string[] COVERS =
+        {
+            TestResources.COVER_IMAGE_1,
+            TestResources.COVER_IMAGE_2,
+            TestResources.COVER_IMAGE_3,
+            TestResources.COVER_IMAGE_4,
+        };
+
+        public static APIUser GenerateUser(int id)
+        {
+            return new APIUser
+            {
+                Id = id,
+                Username = $"user{id}",
+                CoverUrl = COVERS[RNG.Next(0, COVERS.Length - 1)],
+            };
+        }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneUpdateableTeamFlag.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUpdateableTeamFlag.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Users.Drawables;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    [TestFixture]
+    public partial class TestSceneUpdateableTeamFlag : OsuTestScene
+    {
+        [Test]
+        public void TestHideOnNull()
+        {
+            UpdateableTeamFlag flag = null!;
+
+            AddStep("create flag with team", () => Child = flag = new UpdateableTeamFlag(createTeam(), hideOnNull: true) { Width = 300, Height = 150 });
+            AddAssert("flag is present", () => flag.IsPresent, () => Is.True);
+            AddStep("set team to null", () => flag.Team = null);
+            AddAssert("flag is not present", () => flag.IsPresent, () => Is.False);
+        }
+
+        [Test]
+        public void DontHideOnNull()
+        {
+            UpdateableTeamFlag flag = null!;
+
+            AddStep("create flag with team", () => Child = flag = new UpdateableTeamFlag(createTeam(), hideOnNull: false) { Width = 300, Height = 150 });
+            AddAssert("flag is present", () => flag.IsPresent, () => Is.True);
+            AddStep("set team to null", () => flag.Team = null);
+            AddAssert("flag is present", () => flag.IsPresent, () => Is.True);
+        }
+
+        private static APITeam createTeam() => new APITeam
+        {
+            Id = 2,
+            Name = "mom?",
+            ShortName = "MOM",
+            FlagUrl = @"https://assets.ppy.sh/teams/flag/1/b46fb10dbfd8a35dc50e6c00296c0dc6172dffc3ed3d3a4b379277ba498399fe.png",
+        };
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Set cover to expanded", () => configManager.SetValue(OsuSetting.ProfileCoverExpanded, true));
             AddStep("Show example user", () => header.User.Value = new UserProfileData(TestSceneUserProfileOverlay.TEST_USER, new OsuRuleset().RulesetInfo));
-            AddUntilStep("Cover is expanded", () => header.ChildrenOfType<UserCoverBackground>().Single().Height, () => Is.GreaterThan(0));
+            AddUntilStep("Cover is expanded", () => header.ChildrenOfType<CoverBackground>().Single().Height, () => Is.GreaterThan(0));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Set cover to collapsed", () => configManager.SetValue(OsuSetting.ProfileCoverExpanded, false));
             AddStep("Show example user", () => header.User.Value = new UserProfileData(TestSceneUserProfileOverlay.TEST_USER, new OsuRuleset().RulesetInfo));
-            AddUntilStep("Cover is collapsed", () => header.ChildrenOfType<UserCoverBackground>().Single().Height, () => Is.EqualTo(0));
+            AddUntilStep("Cover is collapsed", () => header.ChildrenOfType<CoverBackground>().Single().Height, () => Is.EqualTo(0));
         }
 
         [Test]

--- a/osu.Game.Tournament/Models/TournamentUser.cs
+++ b/osu.Game.Tournament/Models/TournamentUser.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tournament.Models
         /// <summary>
         /// A URL to the player's profile cover.
         /// </summary>
-        public string CoverUrl { get; set; } = string.Empty;
+        public string? CoverUrl { get; set; } = string.Empty;
 
         public APIUser ToAPIUser()
         {

--- a/osu.Game/Online/API/Requests/GetTeamMembersRequest.cs
+++ b/osu.Game/Online/API/Requests/GetTeamMembersRequest.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetTeamMembersRequest : PaginatedAPIRequest<TeamMembersResponse>
+    {
+        public readonly int TeamId;
+
+        public GetTeamMembersRequest(int teamId, PaginationParameters pagination)
+            : base(pagination)
+        {
+            TeamId = teamId;
+        }
+
+        protected override string Target => $"teams/{TeamId}/members";
+    }
+}

--- a/osu.Game/Online/API/Requests/GetTeamRequest.cs
+++ b/osu.Game/Online/API/Requests/GetTeamRequest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetTeamRequest : APIRequest<APITeam>
+    {
+        public readonly string Lookup;
+        public readonly IRulesetInfo? Ruleset;
+
+        public GetTeamRequest(long? teamId = null, IRulesetInfo? ruleset = null)
+        {
+            Lookup = teamId.ToString()!;
+            Ruleset = ruleset;
+        }
+
+        public GetTeamRequest(string shortName, IRulesetInfo? ruleset = null)
+        {
+            Lookup = $"@{shortName}";
+            Ruleset = ruleset;
+        }
+
+        protected override string Target => $@"teams/{Lookup}/{Ruleset?.ShortName}";
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/APITeam.cs
+++ b/osu.Game/Online/API/Requests/Responses/APITeam.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public int PlayCount { get; set; }
 
         [JsonProperty(@"ranked_score")]
-        public int RankedScore { get; set; }
+        public long RankedScore { get; set; }
 
         [JsonProperty(@"performance")]
         public int Performance { get; set; }

--- a/osu.Game/Online/API/Requests/Responses/APITeam.cs
+++ b/osu.Game/Online/API/Requests/Responses/APITeam.cs
@@ -1,12 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
+using osu.Game.Teams;
+using osu.Game.Users;
 
 namespace osu.Game.Online.API.Requests.Responses
 {
     [JsonObject(MemberSerialization.OptIn)]
-    public class APITeam
+    public class APITeam : ITeam, IHasCover
     {
         [JsonProperty(@"id")]
         public int Id { get; set; } = 1;
@@ -18,6 +21,50 @@ namespace osu.Game.Online.API.Requests.Responses
         public string ShortName { get; set; } = string.Empty;
 
         [JsonProperty(@"flag_url")]
-        public string FlagUrl = string.Empty;
+        public string? FlagUrl { get; set; }
+
+        [JsonProperty(@"cover_url")]
+        public string? CoverUrl { get; set; }
+
+        [JsonProperty(@"default_ruleset_id")]
+        public int DefaultRulesetId { get; set; }
+
+        [JsonProperty(@"created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty(@"description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonProperty(@"leader")]
+        public APIUser Leader { get; set; } = new APIUser();
+
+        [JsonProperty(@"is_open")]
+        public bool IsOpen { get; set; }
+
+        [JsonProperty(@"members_count")]
+        public int MembersCount { get; set; }
+
+        [JsonProperty(@"empty_slots")]
+        public int EmptySlots { get; set; }
+
+        [JsonProperty(@"statistics")]
+        public APITeamStatistics Statistics { get; set; } = new APITeamStatistics();
+
+        public int OnlineID => Id;
+    }
+
+    public class APITeamStatistics
+    {
+        [JsonProperty(@"play_count")]
+        public int PlayCount { get; set; }
+
+        [JsonProperty(@"ranked_score")]
+        public int RankedScore { get; set; }
+
+        [JsonProperty(@"performance")]
+        public int Performance { get; set; }
+
+        [JsonProperty(@"rank")]
+        public int? Rank { get; set; }
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APITeamMember.cs
+++ b/osu.Game/Online/API/Requests/Responses/APITeamMember.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class APITeamMember
+    {
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; } = string.Empty;
+
+        [JsonProperty("user")]
+        public required APIUser User { get; set; } = new APIUser();
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -68,7 +68,6 @@ namespace osu.Game.Online.API.Requests.Responses
         public string AvatarUrl;
 
         [JsonProperty(@"cover_url")]
-        [CanBeNull]
         public string CoverUrl
         {
             get => Cover?.Url;

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -15,7 +15,7 @@ using osu.Game.Users;
 namespace osu.Game.Online.API.Requests.Responses
 {
     [JsonObject(MemberSerialization.OptIn)]
-    public class APIUser : IEquatable<APIUser>, IUser
+    public class APIUser : IEquatable<APIUser>, IUser, IHasCover
     {
         /// <summary>
         /// A user ID which can be used to represent any system user which is not attached to a user profile.
@@ -68,6 +68,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public string AvatarUrl;
 
         [JsonProperty(@"cover_url")]
+        [CanBeNull]
         public string CoverUrl
         {
             get => Cover?.Url;
@@ -75,14 +76,17 @@ namespace osu.Game.Online.API.Requests.Responses
         }
 
         [JsonProperty(@"cover")]
+        [CanBeNull]
         public UserCover Cover;
 
         public class UserCover
         {
             [JsonProperty(@"custom_url")]
+            [CanBeNull]
             public string CustomUrl;
 
             [JsonProperty(@"url")]
+            [CanBeNull]
             public string Url;
 
             [JsonProperty(@"id")]

--- a/osu.Game/Online/API/Requests/Responses/TeamMembersResponse.cs
+++ b/osu.Game/Online/API/Requests/Responses/TeamMembersResponse.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class TeamMembersResponse
+    {
+        [JsonProperty("items")]
+        public ICollection<APITeamMember> Items { get; set; } = Array.Empty<APITeamMember>();
+
+        [JsonProperty("total")]
+        public int Total { get; set; }
+    }
+}

--- a/osu.Game/Online/API/Requests/TeamReportRequest.cs
+++ b/osu.Game/Online/API/Requests/TeamReportRequest.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Net.Http;
+using osu.Framework.IO.Network;
+using osu.Game.Overlays.Team;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class TeamReportRequest : APIRequest
+    {
+        public readonly long TeamID;
+        public readonly TeamReportReason Reason;
+        public readonly string Comment;
+
+        public TeamReportRequest(long teamID, TeamReportReason reason, string comment)
+        {
+            TeamID = teamID;
+            Reason = reason;
+            Comment = comment;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+            req.Method = HttpMethod.Post;
+
+            req.AddParameter(@"reportable_type", @"team");
+            req.AddParameter(@"reportable_id", $"{TeamID}");
+            req.AddParameter(@"reason", Reason.ToString());
+            req.AddParameter(@"comments", Comment);
+
+            return req;
+        }
+
+        protected override string Target => @"reports";
+    }
+}

--- a/osu.Game/Online/API/Requests/UserReportRequest.cs
+++ b/osu.Game/Online/API/Requests/UserReportRequest.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Net.Http;
+using osu.Framework.IO.Network;
+using osu.Game.Overlays.Profile;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class UserReportRequest : APIRequest
+    {
+        public readonly int UserID;
+        public readonly UserReportReason Reason;
+        public readonly string Comment;
+
+        public UserReportRequest(int userID, UserReportReason reason, string comment)
+        {
+            UserID = userID;
+            Reason = reason;
+            Comment = comment;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var request = base.CreateWebRequest();
+            request.Method = HttpMethod.Post;
+
+            request.AddParameter(@"reportable_type", @"user");
+            request.AddParameter(@"reportable_id", $"{UserID}");
+            request.AddParameter(@"reason", Reason.ToString());
+            request.AddParameter(@"comments", Comment);
+
+            return request;
+        }
+
+        protected override string Target => @"reports";
+    }
+}

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -204,6 +204,7 @@ namespace osu.Game.Online.Leaderboards
                                                             Anchor = Anchor.CentreLeft,
                                                             Origin = Anchor.CentreLeft,
                                                             Size = new Vector2(40, 20),
+                                                            CornerRadius = 2.5f,
                                                         },
                                                         new DateLabel(Score.Date)
                                                         {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -74,6 +74,7 @@ using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Seasonal;
 using osu.Game.Skinning;
+using osu.Game.Teams;
 using osu.Game.Updater;
 using osu.Game.Users;
 using osu.Game.Utils;
@@ -592,6 +593,12 @@ namespace osu.Game
         /// </summary>
         /// <param name="user">The user to display.</param>
         public void ShowUser(IUser user) => waitForReady(() => userProfile, _ => userProfile.ShowUser(user));
+
+        /// <summary>
+        /// Show a team's profile as an overlay.
+        /// </summary>
+        /// <param name="team">The team to display.</param>
+        public void ShowTeam(ITeam team) => waitForReady(() => teamProfileOverlay, _ => teamProfileOverlay.ShowTeam(team));
 
         /// <summary>
         /// Show a beatmap's set as an overlay, displaying the given beatmap.

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -134,6 +134,8 @@ namespace osu.Game
 
         private UserProfileOverlay userProfile;
 
+        private TeamProfileOverlay teamProfileOverlay;
+
         private BeatmapSetOverlay beatmapSetOverlay;
 
         private WikiOverlay wikiOverlay;
@@ -1241,6 +1243,7 @@ namespace osu.Game
             loadComponentSingleFile(Settings = new SettingsOverlay(), leftFloatingOverlayContent.Add, true);
             loadComponentSingleFile(changelogOverlay = new ChangelogOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(userProfile = new UserProfileOverlay(), overlayContent.Add, true);
+            loadComponentSingleFile(teamProfileOverlay = new TeamProfileOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(beatmapSetOverlay = new BeatmapSetOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(wikiOverlay = new WikiOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(skinEditor = new SkinEditorOverlay(ScreenContainer), overlayContent.Add, true);
@@ -1284,7 +1287,7 @@ namespace osu.Game
             }
 
             // eventually informational overlays should be displayed in a stack, but for now let's only allow one to stay open at a time.
-            var informationalOverlays = new OverlayContainer[] { beatmapSetOverlay, userProfile };
+            var informationalOverlays = new OverlayContainer[] { beatmapSetOverlay, userProfile, teamProfileOverlay };
 
             foreach (var overlay in informationalOverlays)
             {

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -170,6 +170,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         new UpdateableTeamFlag(score.User.Team)
                         {
                             Size = new Vector2(28, 14),
+                            CornerRadius = 1.75f,
                         },
                         username,
                     }

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -135,6 +135,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                         Anchor = Anchor.CentreLeft,
                                         Origin = Anchor.CentreLeft,
                                         Size = new Vector2(28, 14),
+                                        CornerRadius = 1.75f,
                                         Margin = new MarginPadding { Top = 3 }, // makes spacing look more even
                                     },
                                 }

--- a/osu.Game/Overlays/Chat/ReportChatPopover.cs
+++ b/osu.Game/Overlays/Chat/ReportChatPopover.cs
@@ -13,9 +13,6 @@ namespace osu.Game.Overlays.Chat
     public partial class ReportChatPopover : ReportPopover<ChatReportReason>
     {
         [Resolved]
-        private IAPIProvider api { get; set; } = null!;
-
-        [Resolved]
         private ChannelManager channelManager { get; set; } = null!;
 
         private readonly Message message;
@@ -24,16 +21,12 @@ namespace osu.Game.Overlays.Chat
             : base(ReportStrings.UserTitle(message.Sender?.Username ?? @"Someone"))
         {
             this.message = message;
-            Action = report;
         }
 
-        protected override bool IsCommentRequired(ChatReportReason reason) => reason == ChatReportReason.Other;
-
-        private void report(ChatReportReason reason, string comments)
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            var request = new ChatReportRequest(message.Id, reason, comments);
-
-            request.Success += () =>
+            Success += () =>
             {
                 string thanksMessage;
 
@@ -41,10 +34,10 @@ namespace osu.Game.Overlays.Chat
                 {
                     case ChannelType.PM:
                         thanksMessage = """
-                                  Chat moderators have been alerted. You have reported a private message so they will not be able to read history to maintain your privacy. Please make sure to include as much details as you can.
-                                  You can submit a second report with more details if required, or contact abuse@ppy.sh if a user is being extremely offensive.
-                                  You can also block a user via the block button on their user profile, or by right-clicking on their name in the chat and selecting "Block".
-                                  """;
+                                        Chat moderators have been alerted. You have reported a private message so they will not be able to read history to maintain your privacy. Please make sure to include as much details as you can.
+                                        You can submit a second report with more details if required, or contact abuse@ppy.sh if a user is being extremely offensive.
+                                        You can also block a user via the block button on their user profile, or by right-clicking on their name in the chat and selecting "Block".
+                                        """;
                         break;
 
                     default:
@@ -54,8 +47,10 @@ namespace osu.Game.Overlays.Chat
 
                 channelManager.CurrentChannel.Value.AddNewMessages(new InfoMessage(thanksMessage));
             };
-
-            api.Queue(request);
         }
+
+        protected override APIRequest GetRequest(ChatReportReason reason, string comments) => new ChatReportRequest(message.Id, reason, comments);
+
+        protected override bool IsCommentRequired(ChatReportReason reason) => reason == ChatReportReason.Other;
     }
 }

--- a/osu.Game/Overlays/Chat/ReportChatPopover.cs
+++ b/osu.Game/Overlays/Chat/ReportChatPopover.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Overlays.Chat
         private readonly Message message;
 
         public ReportChatPopover(Message message)
-            : base(ReportStrings.UserTitle(message.Sender?.Username ?? @"Someone"))
+            : base(ReportStrings.UserTitle(message.Sender?.Username ?? @"Someone"), false)
         {
             this.message = message;
         }

--- a/osu.Game/Overlays/Comments/ReportCommentPopover.cs
+++ b/osu.Game/Overlays/Comments/ReportCommentPopover.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Overlays.Comments
         private readonly Comment comment;
 
         public ReportCommentPopover(Comment comment)
-            : base(ReportStrings.CommentTitle(comment.User?.Username ?? comment.LegacyName ?? @"Someone"))
+            : base(ReportStrings.CommentTitle(comment.User?.Username ?? comment.LegacyName ?? @"Someone"), false)
         {
             this.comment = comment;
         }

--- a/osu.Game/Overlays/Comments/ReportCommentPopover.cs
+++ b/osu.Game/Overlays/Comments/ReportCommentPopover.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
 
@@ -9,9 +11,14 @@ namespace osu.Game.Overlays.Comments
 {
     public partial class ReportCommentPopover : ReportPopover<CommentReportReason>
     {
-        public ReportCommentPopover(Comment? comment)
-            : base(ReportStrings.CommentTitle(comment?.User?.Username ?? comment?.LegacyName ?? @"Someone"))
+        private readonly Comment comment;
+
+        public ReportCommentPopover(Comment comment)
+            : base(ReportStrings.CommentTitle(comment.User?.Username ?? comment.LegacyName ?? @"Someone"))
         {
+            this.comment = comment;
         }
+
+        protected override APIRequest GetRequest(CommentReportReason reason, string comments) => new CommentReportRequest(comment.Id, reason, comments);
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileActionPopover.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileActionPopover.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Overlays.Profile.Header.Components
+{
+    public abstract partial class ProfileActionPopover : OsuPopover
+    {
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private FillFlowContainer container = null!;
+
+        protected ProfileActionPopover()
+            : base(false)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Background.Colour = colourProvider.Background6;
+
+            AllowableAnchors = [Anchor.BottomCentre, Anchor.TopCentre];
+
+            Child = container = new FillFlowContainer
+            {
+                Width = 160,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding { Horizontal = 5, Vertical = 10 },
+            };
+        }
+
+        public ProfilePopoverAction[] Actions { set => container.Children = value; }
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileActionsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileActionsButton.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.Containers;
+using osuTK;
+
+namespace osu.Game.Overlays.Profile.Header.Components
+{
+    public abstract partial class ProfileActionsButton : OsuHoverContainer, IHasPopover
+    {
+        private Box background = null!;
+
+        protected override IEnumerable<Drawable> EffectTargets => [background];
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            IdleColour = colourProvider.Background2;
+            HoverColour = colourProvider.Background1;
+
+            Size = new Vector2(40);
+            Masking = true;
+            CornerRadius = 20;
+
+            Child = new CircularContainer
+            {
+                Masking = true,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new SpriteIcon
+                    {
+                        Size = new Vector2(12),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Icon = FontAwesome.Solid.EllipsisV,
+                    },
+                }
+            };
+
+            Action = this.ShowPopover;
+        }
+
+        public abstract Popover GetPopover();
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/ProfilePopoverAction.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfilePopoverAction.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Overlays.Profile.Header.Components
+{
+    public partial class ProfilePopoverAction : OsuClickableContainer
+    {
+        private readonly IconUsage icon;
+        private readonly LocalisableString caption;
+
+        private Box background = null!;
+        private CircularContainer indicator = null!;
+
+        public ProfilePopoverAction(IconUsage icon, LocalisableString caption)
+        {
+            this.icon = icon;
+            this.caption = caption;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            RelativeSizeAxes = Content.RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Content.AutoSizeAxes = Axes.Y;
+
+            Masking = true;
+            CornerRadius = 4;
+            Children = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background5,
+                    Alpha = 0,
+                },
+                indicator = new Circle
+                {
+                    Width = 4,
+                    Height = 14,
+                    X = 10,
+                    Colour = colourProvider.Highlight1,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.Centre,
+                    Alpha = 0,
+                },
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Y,
+                    RelativeSizeAxes = Axes.X,
+                    Padding = new MarginPadding { Horizontal = 25, Vertical = 5 },
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(5, 0),
+                    Children = new Drawable[]
+                    {
+                        new SpriteIcon
+                        {
+                            Icon = icon,
+                            Size = new Vector2(11),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = caption,
+                            Font = OsuFont.Style.Body,
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            UseFullGlyphHeight = false,
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateState();
+            return true;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            updateState();
+            base.OnHoverLost(e);
+        }
+
+        private void updateState()
+        {
+            background.Alpha = indicator.Alpha = IsHovered ? 1 : 0;
+        }
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             new OsuSpriteText
                             {
                                 Text = caption,
-                                Font = OsuFont.Style.Body,
+                                Font = OsuFont.Style.Caption1,
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                                 UseFullGlyphHeight = false,

--- a/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -9,34 +8,20 @@ using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
-using osu.Framework.Localisation;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
-using osuTK;
 
 namespace osu.Game.Overlays.Profile.Header.Components
 {
-    public partial class UserActionsButton : OsuHoverContainer, IHasPopover
+    public partial class UserActionsButton : ProfileActionsButton
     {
         public readonly Bindable<UserProfileData?> User = new Bindable<UserProfileData?>();
 
-        private Box background = null!;
         private UserReportPopoverTarget reportPopoverTarget = null!;
-
-        protected override IEnumerable<Drawable> EffectTargets => [background];
-
-        [Resolved]
-        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -44,45 +29,18 @@ namespace osu.Game.Overlays.Profile.Header.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            IdleColour = colourProvider.Background2;
-            HoverColour = colourProvider.Background1;
-
-            Size = new Vector2(40);
-            Masking = true;
-            CornerRadius = 20;
-
-            Child = new CircularContainer
+            // This is a bit of a dirty hack. Because `ReportUserPopover` is spawned from `UserActionsPopover`,
+            // and that they both share the same `PopoverContainer`, the former will get destroyed when the latter
+            // is opened, causing it to get destroyed as well.
+            //
+            // This is worked around by having an additional dummy popover target on the actions button,
+            // which is then passed to `UserActionsPopover` and the user report action. This way the popover
+            // can remain attached to it once the actions popover is destroyed.
+            reportPopoverTarget = new UserReportPopoverTarget
             {
-                Masking = true,
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
-                {
-                    background = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    // This is a bit of a dirty hack. Because `ReportUserPopover` is spawned from `UserActionsPopover`,
-                    // and that they both share the same `PopoverContainer`, the former will get destroyed when the latter
-                    // is opened, causing it to get destroyed as well.
-                    //
-                    // This is worked around by having an additional dummy popover target on the actions button,
-                    // which is then passed to `UserActionsPopover` and the user report action. This way the popover
-                    // can remain attached to it once the actions popover is destroyed.
-                    reportPopoverTarget = new UserReportPopoverTarget
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    new SpriteIcon
-                    {
-                        Size = new Vector2(12),
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Icon = FontAwesome.Solid.EllipsisV,
-                    },
-                }
+                RelativeSizeAxes = Axes.Both
             };
-
-            Action = this.ShowPopover;
+            Add(reportPopoverTarget);
         }
 
         protected override void LoadComplete()
@@ -96,142 +54,44 @@ namespace osu.Game.Overlays.Profile.Header.Components
             }, true);
         }
 
-        public Popover GetPopover() => new UserActionPopover(User.Value!.User, reportPopoverTarget);
+        public override Popover GetPopover() => new UserActionPopover(User.Value!.User, reportPopoverTarget);
 
-        private partial class UserActionPopover : OsuPopover
+        private partial class UserActionPopover : ProfileActionPopover
         {
             private readonly APIUser user;
 
             private readonly IHasPopover reportPopoverTarget;
 
             public UserActionPopover(APIUser user, IHasPopover reportPopoverTarget)
-                : base(false)
             {
                 this.user = user;
                 this.reportPopoverTarget = reportPopoverTarget;
             }
 
             [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider, IAPIProvider api, IDialogOverlay? dialogOverlay)
+            private void load(IAPIProvider api, IDialogOverlay? dialogOverlay)
             {
-                Background.Colour = colourProvider.Background6;
-
                 bool userBlocked = api.LocalUserState.Blocks.Any(b => b.TargetID == user.Id);
 
-                AllowableAnchors = [Anchor.BottomCentre, Anchor.TopCentre];
-
-                Child = new FillFlowContainer
+                Actions = new[]
                 {
-                    Width = 160,
-                    AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = 5, Vertical = 10 },
-                    Children = new Drawable[]
+                    new ProfilePopoverAction(FontAwesome.Solid.Ban, userBlocked ? UsersStrings.BlocksButtonUnblock : UsersStrings.BlocksButtonBlock)
                     {
-                        new UserAction(FontAwesome.Solid.Ban, userBlocked ? UsersStrings.BlocksButtonUnblock : UsersStrings.BlocksButtonBlock)
+                        Action = () =>
                         {
-                            Action = () =>
-                            {
-                                dialogOverlay?.Push(userBlocked ? ConfirmBlockActionDialog.Unblock(user) : ConfirmBlockActionDialog.Block(user));
-                                this.HidePopover();
-                            }
-                        },
-                        new UserAction(FontAwesome.Solid.ExclamationTriangle, ReportStrings.UserButton)
-                        {
-                            Action = () =>
-                            {
-                                this.HidePopover();
-                                reportPopoverTarget.ShowPopover();
-                            },
+                            dialogOverlay?.Push(userBlocked ? ConfirmBlockActionDialog.Unblock(user) : ConfirmBlockActionDialog.Block(user));
+                            this.HidePopover();
                         }
-                    }
-                };
-            }
-        }
-
-        private partial class UserAction : OsuClickableContainer
-        {
-            private readonly IconUsage icon;
-            private readonly LocalisableString caption;
-
-            private Box background = null!;
-            private CircularContainer indicator = null!;
-
-            public UserAction(IconUsage icon, LocalisableString caption)
-            {
-                this.icon = icon;
-                this.caption = caption;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                RelativeSizeAxes = Content.RelativeSizeAxes = Axes.X;
-                AutoSizeAxes = Content.AutoSizeAxes = Axes.Y;
-
-                Masking = true;
-                CornerRadius = 4;
-                Children = new Drawable[]
-                {
-                    background = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colourProvider.Background5,
-                        Alpha = 0,
                     },
-                    indicator = new Circle
+                    new ProfilePopoverAction(FontAwesome.Solid.ExclamationTriangle, ReportStrings.UserButton)
                     {
-                        Width = 4,
-                        Height = 14,
-                        X = 10,
-                        Colour = colourProvider.Highlight1,
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.Centre,
-                        Alpha = 0,
-                    },
-                    new FillFlowContainer
-                    {
-                        AutoSizeAxes = Axes.Y,
-                        RelativeSizeAxes = Axes.X,
-                        Padding = new MarginPadding { Horizontal = 25, Vertical = 5 },
-                        Direction = FillDirection.Horizontal,
-                        Spacing = new Vector2(5, 0),
-                        Children = new Drawable[]
+                        Action = () =>
                         {
-                            new SpriteIcon
-                            {
-                                Icon = icon,
-                                Size = new Vector2(11),
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                            },
-                            new OsuSpriteText
-                            {
-                                Text = caption,
-                                Font = OsuFont.Style.Caption1,
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                                UseFullGlyphHeight = false,
-                            }
+                            this.HidePopover();
+                            reportPopoverTarget.ShowPopover();
                         }
-                    }
+                    },
                 };
-            }
-
-            protected override bool OnHover(HoverEvent e)
-            {
-                updateState();
-                return true;
-            }
-
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                updateState();
-                base.OnHoverLost(e);
-            }
-
-            private void updateState()
-            {
-                background.Alpha = indicator.Alpha = IsHovered ? 1 : 0;
             }
         }
 

--- a/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/UserActionsButton.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         public readonly Bindable<UserProfileData?> User = new Bindable<UserProfileData?>();
 
         private Box background = null!;
+        private UserReportPopoverTarget reportPopoverTarget = null!;
 
         protected override IEnumerable<Drawable> EffectTargets => [background];
 
@@ -60,6 +61,17 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     {
                         RelativeSizeAxes = Axes.Both,
                     },
+                    // This is a bit of a dirty hack. Because `ReportUserPopover` is spawned from `UserActionsPopover`,
+                    // and that they both share the same `PopoverContainer`, the former will get destroyed when the latter
+                    // is opened, causing it to get destroyed as well.
+                    //
+                    // This is worked around by having an additional dummy popover target on the actions button,
+                    // which is then passed to `UserActionsPopover` and the user report action. This way the popover
+                    // can remain attached to it once the actions popover is destroyed.
+                    reportPopoverTarget = new UserReportPopoverTarget
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
                     new SpriteIcon
                     {
                         Size = new Vector2(12),
@@ -77,19 +89,26 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             base.LoadComplete();
 
-            User.BindValueChanged(_ => Alpha = User.Value?.User.OnlineID == api.LocalUser.Value.OnlineID ? 0 : 1, true);
+            User.BindValueChanged(_ =>
+            {
+                Alpha = User.Value?.User.OnlineID == api.LocalUser.Value.OnlineID ? 0 : 1;
+                reportPopoverTarget.User = User.Value?.User;
+            }, true);
         }
 
-        public Popover GetPopover() => new UserActionPopover(User.Value!.User);
+        public Popover GetPopover() => new UserActionPopover(User.Value!.User, reportPopoverTarget);
 
         private partial class UserActionPopover : OsuPopover
         {
             private readonly APIUser user;
 
-            public UserActionPopover(APIUser user)
+            private readonly IHasPopover reportPopoverTarget;
+
+            public UserActionPopover(APIUser user, IHasPopover reportPopoverTarget)
                 : base(false)
             {
                 this.user = user;
+                this.reportPopoverTarget = reportPopoverTarget;
             }
 
             [BackgroundDependencyLoader]
@@ -115,6 +134,14 @@ namespace osu.Game.Overlays.Profile.Header.Components
                                 dialogOverlay?.Push(userBlocked ? ConfirmBlockActionDialog.Unblock(user) : ConfirmBlockActionDialog.Block(user));
                                 this.HidePopover();
                             }
+                        },
+                        new UserAction(FontAwesome.Solid.ExclamationTriangle, ReportStrings.UserButton)
+                        {
+                            Action = () =>
+                            {
+                                this.HidePopover();
+                                reportPopoverTarget.ShowPopover();
+                            },
                         }
                     }
                 };
@@ -206,6 +233,13 @@ namespace osu.Game.Overlays.Profile.Header.Components
             {
                 background.Alpha = indicator.Alpha = IsHovered ? 1 : 0;
             }
+        }
+
+        private partial class UserReportPopoverTarget : Container, IHasPopover
+        {
+            public APIUser? User;
+
+            public Popover? GetPopover() => User != null ? new ReportUserPopover(User) : null;
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -199,6 +199,7 @@ namespace osu.Game.Overlays.Profile.Header
                                                                 teamFlag = new UpdateableTeamFlag
                                                                 {
                                                                     Size = new Vector2(40, 20),
+                                                                    CornerRadius = 2.5f,
                                                                 },
                                                                 teamText = new OsuSpriteText
                                                                 {

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.Profile.Header
         [Resolved]
         private RankingsOverlay? rankingsOverlay { get; set; }
 
-        private UserCoverBackground cover = null!;
+        private CoverBackground cover = null!;
         private SupporterIcon supporterTag = null!;
         private UpdateableAvatar avatar = null!;
         private OsuSpriteText usernameText = null!;
@@ -241,7 +241,7 @@ namespace osu.Game.Overlays.Profile.Header
         {
             var user = data?.User;
 
-            cover.User = user;
+            cover.Item = user;
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
             openUserExternally.Link = $@"{api.Endpoints.WebsiteUrl}/users/{user?.Id ?? 0}";
@@ -277,7 +277,7 @@ namespace osu.Game.Overlays.Profile.Header
             flow.TransformTo(nameof(flow.Spacing), new Vector2(expanded ? 20f : 10f), transition_duration, Easing.OutQuint);
         }
 
-        private partial class ProfileCoverBackground : UserCoverBackground
+        private partial class ProfileCoverBackground : CoverBackground
         {
             protected override double LoadDelay => 0;
 

--- a/osu.Game/Overlays/Profile/ReportUserPopover.cs
+++ b/osu.Game/Overlays/Profile/ReportUserPopover.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Overlays.Profile
+{
+    public partial class ReportUserPopover : ReportPopover<UserReportReason>
+    {
+        private readonly APIUser user;
+
+        public ReportUserPopover(APIUser user)
+            : base(ReportStrings.UserTitle(user.Username))
+        {
+            this.user = user;
+        }
+
+        protected override APIRequest GetRequest(UserReportReason reason, string comments) => new UserReportRequest(user.Id, reason, comments);
+    }
+}

--- a/osu.Game/Overlays/Profile/UserReportReason.cs
+++ b/osu.Game/Overlays/Profile/UserReportReason.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Overlays.Profile
+{
+    public enum UserReportReason
+    {
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.ReportOptionsCheating))]
+        Cheating,
+
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.ReportOptionsMultipleAccounts))]
+        MultipleAccounts,
+
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.ReportOptionsInappropriateChat))]
+        InappropriateChat,
+
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.ReportOptionsUnwantedContent))]
+        UnwantedContent,
+
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.ReportOptionsOther))]
+        Other,
+    }
+}

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Overlays.Rankings.Tables
                 TextAnchor = Anchor.CentreLeft
             };
             username.AddUserLink(item.User);
-            return [new UpdateableTeamFlag(item.User.Team) { Size = new Vector2(40, 20) }, username];
+            return [new UpdateableTeamFlag(item.User.Team) { Size = new Vector2(40, 20), CornerRadius = 2.5f }, username];
         }
 
         protected sealed override Drawable[] CreateAdditionalContent(UserStatistics item) => new[]

--- a/osu.Game/Overlays/Team/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Team/Header/BottomHeaderContainer.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API;
+using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Overlays.Team.Header.Components;
+using osu.Game.Resources.Localisation.Web;
+using osuTK;
+
+namespace osu.Game.Overlays.Team.Header
+{
+    public partial class BottomHeaderContainer : CompositeDrawable
+    {
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        private TeamChatButton chatButton = null!;
+        private TeamActionsButton actionsButton = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        public BottomHeaderContainer()
+        {
+            Height = 60;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background3,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Horizontal,
+                    Child = new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Padding = new MarginPadding { Vertical = 10 },
+                        Margin = new MarginPadding { Right = WaveOverlayContainer.HORIZONTAL_PADDING },
+                        Spacing = new Vector2(10, 0),
+                        Children = new Drawable[]
+                        {
+                            chatButton = new TeamChatButton { TeamData = { BindTarget = TeamData }, Alpha = 0 },
+                            actionsButton = new TeamActionsButton { TeamData = { BindTarget = TeamData }, Alpha = 1 },
+                        }
+                    }
+                }
+            };
+
+            TeamData.ValueChanged += _ => updateDisplay();
+        }
+
+        private void updateDisplay()
+        {
+            if (api.LocalUser.Value.Team?.Id != TeamData.Value?.Team.Id)
+            {
+                chatButton.Alpha = 0;
+                actionsButton.Alpha = 1;
+            }
+            else
+            {
+                chatButton.Alpha = 1;
+                actionsButton.Alpha = 0;
+            }
+        }
+
+        public partial class TeamChatButton : ProfileHeaderButton
+        {
+            public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+            public TeamChatButton()
+            {
+                Content.Padding = new MarginPadding { Vertical = 10, Horizontal = 30 };
+
+                Child = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = TeamsStrings.ShowBarChat,
+                    Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
+                };
+
+                Action = () =>
+                {
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Team/Header/BottomHeaderContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -9,6 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API;
+using osu.Game.Online.Chat;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Overlays.Team.Header.Components;
 using osu.Game.Resources.Localisation.Web;
@@ -85,6 +87,15 @@ namespace osu.Game.Overlays.Team.Header
         {
             public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
 
+            [Resolved]
+            private TeamProfileOverlay? teamProfileOverlay { get; set; }
+
+            [Resolved]
+            private ChatOverlay? chatOverlay { get; set; }
+
+            [Resolved]
+            private ChannelManager? channelManager { get; set; }
+
             public TeamChatButton()
             {
                 Content.Padding = new MarginPadding { Vertical = 10, Horizontal = 30 };
@@ -99,6 +110,16 @@ namespace osu.Game.Overlays.Team.Header
 
                 Action = () =>
                 {
+                    // This assumes that a user is only in one team at once,
+                    // and that osu-web will provide that channel in the presence response.
+                    var channel = channelManager?.JoinedChannels.FirstOrDefault(c => c.Type == ChannelType.Team);
+
+                    if (channel == null || channelManager == null)
+                        return;
+
+                    channelManager.CurrentChannel.Value = channel;
+                    teamProfileOverlay?.Hide();
+                    chatOverlay?.Show();
                 };
             }
         }

--- a/osu.Game/Overlays/Team/Header/Components/TeamActionsButton.cs
+++ b/osu.Game/Overlays/Team/Header/Components/TeamActionsButton.cs
@@ -3,8 +3,13 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Resources.Localisation.Web;
 
@@ -14,10 +19,45 @@ namespace osu.Game.Overlays.Team.Header.Components
     {
         public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
 
-        public override Popover GetPopover() => new TeamActionPopover();
+        private TeamReportPopoverTarget reportPopoverTarget = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            // This is a bit of a dirty hack. Because `ReportTeamPopover` is spawned from `TeamActionsPopover`,
+            // and that they both share the same `PopoverContainer`, the former will get destroyed when the latter
+            // is opened, causing it to get destroyed as well.
+            //
+            // This is worked around by having an additional dummy popover target on the actions button,
+            // which is then passed to `TeamActionsPopover` and the user report action. This way the popover
+            // can remain attached to it once the actions popover is destroyed.
+            reportPopoverTarget = new TeamReportPopoverTarget
+            {
+                RelativeSizeAxes = Axes.Both,
+            };
+            Add(reportPopoverTarget);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            TeamData.BindValueChanged(_ =>
+            {
+                reportPopoverTarget.Team = TeamData.Value?.Team;
+            });
+        }
+
+        public override Popover GetPopover() => new TeamActionPopover(reportPopoverTarget);
 
         private partial class TeamActionPopover : ProfileActionPopover
         {
+            private readonly IHasPopover reportPopoverTarget;
+
+            public TeamActionPopover(IHasPopover reportPopoverTarget)
+            {
+                this.reportPopoverTarget = reportPopoverTarget;
+            }
+
             [BackgroundDependencyLoader]
             private void load()
             {
@@ -27,10 +67,19 @@ namespace osu.Game.Overlays.Team.Header.Components
                     {
                         Action = () =>
                         {
+                            this.HidePopover();
+                            reportPopoverTarget.ShowPopover();
                         }
                     }
                 };
             }
+        }
+
+        private partial class TeamReportPopoverTarget : Container, IHasPopover
+        {
+            public APITeam? Team;
+
+            public Popover? GetPopover() => Team != null ? new ReportTeamPopover(Team) : null;
         }
     }
 }

--- a/osu.Game/Overlays/Team/Header/Components/TeamActionsButton.cs
+++ b/osu.Game/Overlays/Team/Header/Components/TeamActionsButton.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Overlays.Team.Header.Components
+{
+    public partial class TeamActionsButton : ProfileActionsButton
+    {
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        public override Popover GetPopover() => new TeamActionPopover();
+
+        private partial class TeamActionPopover : ProfileActionPopover
+        {
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Actions = new[]
+                {
+                    new ProfilePopoverAction(FontAwesome.Solid.ExclamationTriangle, ReportStrings.TeamButton)
+                    {
+                        Action = () =>
+                        {
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/Header/Components/TeamRulesetSelector.cs
+++ b/osu.Game/Overlays/Team/Header/Components/TeamRulesetSelector.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Extensions;
+using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Overlays.Team.Header.Components
+{
+    public partial class TeamRulesetSelector : OverlayRulesetSelector
+    {
+        [Resolved]
+        private TeamProfileOverlay? profileOverlay { get; set; }
+
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            TeamData.BindValueChanged(data => updateState(data.NewValue));
+            Current.BindValueChanged(ruleset =>
+            {
+                if (TeamData.Value != null && !ruleset.NewValue.Equals(TeamData.Value.Ruleset))
+                    profileOverlay?.ShowTeam(TeamData.Value.Team, ruleset.NewValue);
+            });
+        }
+
+        private void updateState(TeamProfileData? data)
+        {
+            Current.Value = Items.SingleOrDefault(ruleset => data?.Ruleset.MatchesOnlineID(ruleset) == true);
+            setDefaultRuleset(Rulesets.GetRuleset(data?.Team.DefaultRulesetId ?? 0).AsNonNull());
+        }
+
+        private void setDefaultRuleset(RulesetInfo ruleset)
+        {
+            foreach (var tabItem in TabContainer)
+                ((ProfileRulesetTabItem)tabItem).IsDefault = ((ProfileRulesetTabItem)tabItem).Value.Equals(ruleset);
+        }
+
+        protected override TabItem<RulesetInfo> CreateTabItem(RulesetInfo value) => new ProfileRulesetTabItem(value);
+    }
+}

--- a/osu.Game/Overlays/Team/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Team/Header/TopHeaderContainer.cs
@@ -9,6 +9,8 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Users;
 using osu.Game.Users.Drawables;
@@ -20,10 +22,14 @@ namespace osu.Game.Overlays.Team.Header
     {
         public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
 
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
         private ProfileCoverBackground cover = null!;
         private UpdateableTeamFlag teamFlag = null!;
         private OsuSpriteText teamName = null!;
         private OsuSpriteText shortName = null!;
+        private ExternalLinkButton showTeamExternal = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -84,9 +90,23 @@ namespace osu.Game.Overlays.Team.Header
                                     Spacing = new Vector2(0, 5),
                                     Children = new Drawable[]
                                     {
-                                        teamName = new OsuSpriteText
+                                        new FillFlowContainer
                                         {
-                                            Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular),
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Horizontal,
+                                            Spacing = new Vector2(5, 0),
+                                            Children = new Drawable[]
+                                            {
+                                                teamName = new OsuSpriteText
+                                                {
+                                                    Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular),
+                                                },
+                                                showTeamExternal = new ExternalLinkButton
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                },
+                                            },
                                         },
                                         shortName = new OsuSpriteText
                                         {
@@ -114,6 +134,7 @@ namespace osu.Game.Overlays.Team.Header
             teamFlag.Team = team;
             teamName.Text = team?.Name ?? string.Empty;
             shortName.Text = team != null ? $"[{team.ShortName}]" : string.Empty;
+            showTeamExternal.Link = $@"{api.Endpoints.WebsiteUrl}/teams/{team?.Id ?? 0}";
         }
 
         private partial class ProfileCoverBackground : CoverBackground

--- a/osu.Game/Overlays/Team/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Team/Header/TopHeaderContainer.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Users;
+using osu.Game.Users.Drawables;
+using osuTK;
+
+namespace osu.Game.Overlays.Team.Header
+{
+    public partial class TopHeaderContainer : CompositeDrawable
+    {
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        private ProfileCoverBackground cover = null!;
+        private UpdateableTeamFlag teamFlag = null!;
+        private OsuSpriteText teamName = null!;
+        private OsuSpriteText shortName = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background4,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        cover = new ProfileCoverBackground
+                        {
+                            RelativeSizeAxes = Axes.X,
+                        },
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Direction = FillDirection.Horizontal,
+                            Height = 85,
+                            Spacing = new Vector2(20, 0),
+                            Padding = new MarginPadding
+                            {
+                                Left = WaveOverlayContainer.HORIZONTAL_PADDING,
+                                Vertical = 10,
+                            },
+                            Children = new Drawable[]
+                            {
+                                teamFlag = new UpdateableTeamFlag(isInteractive: false, hideOnNull: false)
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Width = 240,
+                                    Height = 120,
+                                    CornerRadius = 40,
+                                    EdgeEffect = new EdgeEffectParameters
+                                    {
+                                        Type = EdgeEffectType.Shadow,
+                                        Offset = new Vector2(0, 1),
+                                        Radius = 3,
+                                        Colour = Colour4.Black.Opacity(0.25f),
+                                    },
+                                },
+                                new FillFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(0, 5),
+                                    Children = new Drawable[]
+                                    {
+                                        teamName = new OsuSpriteText
+                                        {
+                                            Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular),
+                                        },
+                                        shortName = new OsuSpriteText
+                                        {
+                                            Font = OsuFont.GetFont(size: 20, weight: FontWeight.Regular),
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            TeamData.BindValueChanged(data => updateTeam(data.NewValue?.Team), true);
+        }
+
+        private void updateTeam(APITeam? team)
+        {
+            cover.Item = team;
+            teamFlag.Team = team;
+            teamName.Text = team?.Name ?? string.Empty;
+            shortName.Text = team != null ? $"[{team.ShortName}]" : string.Empty;
+        }
+
+        private partial class ProfileCoverBackground : CoverBackground
+        {
+            protected override double LoadDelay => 0;
+
+            public ProfileCoverBackground()
+            {
+                Masking = true;
+                Height = 250;
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/ReportTeamPopover.cs
+++ b/osu.Game/Overlays/Team/ReportTeamPopover.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Overlays.Team
+{
+    public partial class ReportTeamPopover : ReportPopover<TeamReportReason>
+    {
+        private readonly APITeam team;
+
+        public ReportTeamPopover(APITeam team)
+            : base(ReportStrings.TeamTitle(team.Leader.Username))
+        {
+            this.team = team;
+        }
+
+        protected override APIRequest GetRequest(TeamReportReason reason, string comments) => new TeamReportRequest(team.Id, reason, comments);
+    }
+}

--- a/osu.Game/Overlays/Team/Sections/Info/InfoValueDisplay.cs
+++ b/osu.Game/Overlays/Team/Sections/Info/InfoValueDisplay.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Overlays.Team.Sections.Info
+{
+    public partial class InfoValueDisplay : CompositeDrawable
+    {
+        private readonly OsuSpriteText title;
+        public OsuSpriteText Content { get; }
+
+        public LocalisableString Title
+        {
+            set => title.Text = value;
+        }
+
+        public InfoValueDisplay(InfoValueSize size = InfoValueSize.Small)
+        {
+            AutoSizeAxes = Axes.Both;
+            InternalChild = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                AutoSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    title = new OsuSpriteText
+                    {
+                        Font = OsuFont.GetFont(size: 12),
+                    },
+                    Content = new OsuSpriteText
+                    {
+                        Font = OsuFont.GetFont(
+                            size: size switch
+                            {
+                                InfoValueSize.Small => 12,
+                                InfoValueSize.Large => 30,
+                                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
+                            },
+                            weight: FontWeight.Regular
+                        ),
+                    },
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            title.Colour = colourProvider.Content1;
+            Content.Colour = colourProvider.Content2;
+        }
+    }
+
+    public enum InfoValueSize
+    {
+        Small,
+        Large,
+    }
+}

--- a/osu.Game/Overlays/Team/Sections/Info/LeaderValueDisplay.cs
+++ b/osu.Game/Overlays/Team/Sections/Info/LeaderValueDisplay.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Overlays.Team.Sections.Info
                     if (user == null)
                         return;
 
-                    container.AddLink(user.Username, LinkAction.OpenUserProfile, user.Id);
+                    container.AddLink(user.Username, LinkAction.OpenUserProfile, user);
                 });
         }
     }

--- a/osu.Game/Overlays/Team/Sections/Info/LeaderValueDisplay.cs
+++ b/osu.Game/Overlays/Team/Sections/Info/LeaderValueDisplay.cs
@@ -1,0 +1,80 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Chat;
+
+namespace osu.Game.Overlays.Team.Sections.Info
+{
+    public partial class LeaderValueDisplay : CompositeDrawable
+    {
+        private readonly OsuSpriteText title;
+        private readonly Container container;
+
+        private APIUser? user;
+
+        public LocalisableString Title
+        {
+            set => title.Text = value;
+        }
+
+        public APIUser? User
+        {
+            get => user;
+            set
+            {
+                if (user == value)
+                    return;
+
+                user = value;
+                Scheduler.AddOnce(updateLink);
+            }
+        }
+
+        public LeaderValueDisplay()
+        {
+            AutoSizeAxes = Axes.Both;
+            InternalChild = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                AutoSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    title = new OsuSpriteText
+                    {
+                        Font = OsuFont.GetFont(size: 12),
+                    },
+                    container = new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                    },
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            title.Colour = colourProvider.Content1;
+        }
+
+        private void updateLink()
+        {
+            container.Child = new LinkFlowContainer(sprite => sprite.Font = OsuFont.GetFont(size: 12, weight: FontWeight.Light))
+                .With(container =>
+                {
+                    if (user == null)
+                        return;
+
+                    container.AddLink(user.Username, LinkAction.OpenUserProfile, user.Id);
+                });
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/Sections/Info/RulesetValueDisplay.cs
+++ b/osu.Game/Overlays/Team/Sections/Info/RulesetValueDisplay.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.Overlays.Team.Sections.Info
+{
+    public partial class RulesetValueDisplay : CompositeDrawable
+    {
+        private readonly OsuSpriteText title;
+        private readonly ConstrainedIconContainer iconContainer;
+        private readonly OsuSpriteText rulesetName;
+
+        private RulesetInfo? ruleset;
+
+        public LocalisableString Title
+        {
+            set => title.Text = value;
+        }
+
+        public RulesetInfo? Ruleset
+        {
+            get => ruleset;
+            set
+            {
+                if (ruleset != null && ruleset.Equals(value))
+                    return;
+
+                ruleset = value;
+                Scheduler.AddOnce(updateRuleset);
+            }
+        }
+
+        public RulesetValueDisplay()
+        {
+            AutoSizeAxes = Axes.Both;
+            InternalChild = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                AutoSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    title = new OsuSpriteText
+                    {
+                        Font = OsuFont.GetFont(size: 12),
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Spacing = new Vector2(2, 0),
+                        Children = new Drawable[]
+                        {
+                            iconContainer = new ConstrainedIconContainer
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Size = new Vector2(10),
+                            },
+                            rulesetName = new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Font = OsuFont.GetFont(size: 12),
+                            }
+                        },
+                    },
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            title.Colour = colourProvider.Content1;
+            rulesetName.Colour = colourProvider.Content2;
+        }
+
+        private void updateRuleset()
+        {
+            if (ruleset == null)
+                return;
+
+            rulesetName.Text = ruleset.Name;
+            iconContainer.Icon = ruleset.CreateInstance().CreateIcon();
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/Sections/InfoSection.cs
+++ b/osu.Game/Overlays/Team/Sections/InfoSection.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Overlays.Profile;
+using osu.Game.Overlays.Team.Sections.Info;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.Overlays.Team.Sections
+{
+    public partial class InfoSection : ProfileSection
+    {
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        private InfoValueDisplay createdAt = null!;
+        private RulesetValueDisplay defaultRuleset = null!;
+        private InfoValueDisplay teamApplication = null!;
+        private LeaderValueDisplay leader = null!;
+        private InfoValueDisplay rank = null!;
+        private InfoValueDisplay performance = null!;
+        private InfoValueDisplay rankedScore = null!;
+        private InfoValueDisplay playCount = null!;
+        private InfoValueDisplay members = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        public override LocalisableString Title => TeamsStrings.ShowSectionsInfo;
+
+        public override string Identifier => @"info";
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            Children = new[]
+            {
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(maxSize: 280),
+                        new Dimension(GridSizeMode.Absolute, size: 2),
+                        new Dimension(),
+                    },
+                    RowDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.AutoSize),
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(0, 10),
+                                Margin = new MarginPadding { Right = 20 },
+                                Children = new Drawable[]
+                                {
+                                    createdAt = new InfoValueDisplay(size: InfoValueSize.Small) { Title = TeamsStrings.ShowInfoCreated },
+                                    defaultRuleset = new RulesetValueDisplay { Title = ModelValidationStrings.TeamAttributesDefaultRulesetId },
+                                    teamApplication = new InfoValueDisplay(size: InfoValueSize.Small) { Title = ModelValidationStrings.TeamAttributesIsOpen },
+                                    leader = new LeaderValueDisplay { Title = TeamsStrings.ShowMembersOwner },
+                                },
+                            },
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = colourProvider.Background6,
+                            },
+                            new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(0, 10),
+                                Margin = new MarginPadding { Left = 20 },
+                                Children = new[]
+                                {
+                                    rank = new InfoValueDisplay(size: InfoValueSize.Large) { Title = TeamsStrings.ShowStatisticsRank },
+                                    performance = new InfoValueDisplay(size: InfoValueSize.Small) { Title = RankingsStrings.StatPerformance },
+                                    rankedScore = new InfoValueDisplay(size: InfoValueSize.Small) { Title = RankingsStrings.StatRankedScore },
+                                    playCount = new InfoValueDisplay(size: InfoValueSize.Small) { Title = RankingsStrings.StatPlayCount },
+                                    members = new InfoValueDisplay(size: InfoValueSize.Small) { Title = RankingsStrings.StatMembers },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            TeamData.BindValueChanged(onTeamChanged, true);
+        }
+
+        private void onTeamChanged(ValueChangedEvent<TeamProfileData?> teamData)
+        {
+            createdAt.Content.Text = (TeamData.Value?.Team.CreatedAt.Date ?? new DateTime(2025, 2, 20)) // teams release date as per lazer updates video
+                .ToLocalisableString(@"MMMM yyyy");
+            defaultRuleset.Ruleset = rulesets.GetRuleset(TeamData.Value?.Team.DefaultRulesetId ?? 0);
+            // TOOD: add empty slot count once pluralization is merged framework-side
+            teamApplication.Content.Text = (TeamData.Value?.Team.IsOpen ?? false)
+                ? TeamsStrings.EditSettingsApplicationStateState1
+                : TeamsStrings.EditSettingsApplicationStateState0;
+            leader.User = TeamData.Value?.Team.Leader;
+
+            rank.Content.Text = $"#{TeamData.Value?.Team.Statistics.Rank ?? 0}";
+            performance.Content.Text = (TeamData.Value?.Team.Statistics.Performance ?? 0).ToLocalisableString(@"N0");
+            rankedScore.Content.Text = (TeamData.Value?.Team.Statistics.RankedScore ?? 0).ToLocalisableString(@"N0");
+            playCount.Content.Text = (TeamData.Value?.Team.Statistics.PlayCount ?? 0).ToLocalisableString(@"N0");
+            members.Content.Text = (TeamData.Value?.Team.MembersCount ?? 0).ToLocalisableString(@"N0");
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/Sections/Members/LeaderGroup.cs
+++ b/osu.Game/Overlays/Team/Sections/Members/LeaderGroup.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Game.Overlays.Team.Sections.Members
+{
+    public partial class LeaderGroup : CompositeDrawable
+    {
+        public APIUser? User
+        {
+            set => cardContainer.Child = value != null ? new UserGridPanel(value) { RelativeSizeAxes = Axes.X } : Empty();
+        }
+
+        private Container cardContainer = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Masking = true;
+            CornerRadius = 10;
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.Orange1,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding(5),
+                    Spacing = new Vector2(0, 5),
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                            Colour = colours.Orange4,
+                            Shadow = false,
+                            Text = TeamsStrings.ShowMembersOwner,
+                            Padding = new MarginPadding { Left = 10 },
+                        },
+                        cardContainer = new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                        },
+                    },
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/Sections/Members/MembersGroup.cs
+++ b/osu.Game/Overlays/Team/Sections/Members/MembersGroup.cs
@@ -1,0 +1,163 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Game.Overlays.Team.Sections.Members
+{
+    public partial class MembersGroup : CompositeDrawable
+    {
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        private OsuSpriteText memberCount = null!;
+        private FillFlowContainer membersContainer = null!;
+        private ShowMoreButton showMoreButton = null!;
+
+        private const int per_page = 51;
+        private PaginationParameters paginationParameters;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Masking = true;
+            CornerRadius = 10;
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colourProvider.Background2,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding(5),
+                    Spacing = new Vector2(0, 5),
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Padding = new MarginPadding { Horizontal = 10 },
+                            Children = new Drawable[]
+                            {
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                                    Colour = colourProvider.Content1,
+                                    Shadow = false,
+                                    Text = TeamsStrings.ShowMembersMembers,
+                                },
+                                memberCount = new OsuSpriteText
+                                {
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                                    Colour = colourProvider.Content1,
+                                    Shadow = false,
+                                    Text = @"0",
+                                },
+                            }
+                        },
+                        membersContainer = new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Spacing = new Vector2(5),
+                        },
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Children = new Drawable[]
+                            {
+                                showMoreButton = new ShowMoreButton
+                                {
+                                    Alpha = 0,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Action = fetchMembers,
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            TeamData.ValueChanged += data =>
+            {
+                if (data.OldValue?.Team.Id != data.NewValue?.Team.Id)
+                    onTeamChanged(data.NewValue?.Team);
+            };
+            onTeamChanged(null);
+        }
+
+        private void onTeamChanged(APITeam? team)
+        {
+            paginationParameters = new PaginationParameters(0, per_page);
+            membersContainer.Clear();
+
+            if (team == null)
+                return;
+
+            fetchMembers();
+        }
+
+        private void fetchMembers()
+        {
+            if (TeamData.Value == null)
+                return;
+
+            var request = new GetTeamMembersRequest(TeamData.Value.Team.Id, paginationParameters);
+            request.Success += res => Schedule(() => onSuccess(res));
+
+            api.Queue(request);
+        }
+
+        private void onSuccess(TeamMembersResponse response)
+        {
+            memberCount.Text = $"{response.Total}";
+
+            membersContainer.AddRange(response.Items.Select(createUserPanel));
+            paginationParameters = paginationParameters.TakeNext(response.Items.Count);
+
+            showMoreButton.IsLoading = false;
+            showMoreButton.Alpha = membersContainer.Children.Count == response.Total ? 0 : 1;
+        }
+
+        private UserGridPanel createUserPanel(APITeamMember member) => new UserGridPanel(member.User)
+        {
+            Width = 250,
+        };
+    }
+}

--- a/osu.Game/Overlays/Team/Sections/MembersSection.cs
+++ b/osu.Game/Overlays/Team/Sections/MembersSection.cs
@@ -12,7 +12,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.Team.Sections
 {
-    public class MembersSection : ProfileSection
+    public partial class MembersSection : ProfileSection
     {
         public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
 
@@ -33,6 +33,7 @@ namespace osu.Game.Overlays.Team.Sections
                 Children = new Drawable[]
                 {
                     leaderGroup = new LeaderGroup(),
+                    new MembersGroup { TeamData = { BindTarget = TeamData } },
                 },
             };
         }

--- a/osu.Game/Overlays/Team/Sections/MembersSection.cs
+++ b/osu.Game/Overlays/Team/Sections/MembersSection.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Overlays.Profile;
+using osu.Game.Overlays.Team.Sections.Members;
+using osu.Game.Resources.Localisation.Web;
+using osuTK;
+
+namespace osu.Game.Overlays.Team.Sections
+{
+    public class MembersSection : ProfileSection
+    {
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        private readonly LeaderGroup leaderGroup;
+
+        public override LocalisableString Title => TeamsStrings.ShowSectionsMembers;
+
+        public override string Identifier => @"members";
+
+        public MembersSection()
+        {
+            Child = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 10),
+                Children = new Drawable[]
+                {
+                    leaderGroup = new LeaderGroup(),
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            TeamData.ValueChanged += data =>
+            {
+                if (data.OldValue?.Team.Id == data.NewValue?.Team.Id)
+                    return;
+
+                leaderGroup.User = data.NewValue?.Team.Leader;
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/TeamProfileData.cs
+++ b/osu.Game/Overlays/Team/TeamProfileData.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Overlays.Team
+{
+    /// <summary>
+    /// Contains data about a profile presented on the <see cref="TeamProfileOverlay"/>.
+    /// </summary>
+    public class TeamProfileData
+    {
+        /// <summary>
+        /// The team whose profile is being presented.
+        /// </summary>
+        public APITeam Team { get; }
+
+        /// <summary>
+        /// The ruleset that the team profile is being shown with.
+        /// </summary>
+        public RulesetInfo Ruleset { get; }
+
+        public TeamProfileData(APITeam team, RulesetInfo ruleset)
+        {
+            Team = team;
+            Ruleset = ruleset;
+        }
+    }
+}

--- a/osu.Game/Overlays/Team/TeamProfileHeader.cs
+++ b/osu.Game/Overlays/Team/TeamProfileHeader.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Overlays.Team
                     RelativeSizeAxes = Axes.X,
                     TeamData = { BindTarget = TeamData },
                 },
+                new BottomHeaderContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    TeamData = { BindTarget = TeamData },
+                },
             }
         };
 

--- a/osu.Game/Overlays/Team/TeamProfileHeader.cs
+++ b/osu.Game/Overlays/Team/TeamProfileHeader.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Overlays.Team
+{
+    public partial class TeamProfileHeader : TabControlOverlayHeader<TeamTabs>
+    {
+        public readonly Bindable<TeamProfileData?> TeamData = new Bindable<TeamProfileData?>();
+
+        protected override OverlayTitle CreateTitle() => new TeamHeaderTitle();
+
+        protected override Drawable CreateBackground() => Empty();
+
+        private partial class TeamHeaderTitle : OverlayTitle
+        {
+            public TeamHeaderTitle()
+            {
+                Title = PageTitleStrings.MainTeamsControllerShow;
+                Icon = OsuIcon.Team;
+            }
+        }
+    }
+
+    public enum TeamTabs
+    {
+        [LocalisableDescription(typeof(TeamsStrings), nameof(TeamsStrings.HeaderLinksShow))]
+        Info,
+    }
+}

--- a/osu.Game/Overlays/Team/TeamProfileHeader.cs
+++ b/osu.Game/Overlays/Team/TeamProfileHeader.cs
@@ -3,8 +3,10 @@
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
+using osu.Game.Overlays.Team.Header;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Team
@@ -16,6 +18,21 @@ namespace osu.Game.Overlays.Team
         protected override OverlayTitle CreateTitle() => new TeamHeaderTitle();
 
         protected override Drawable CreateBackground() => Empty();
+
+        protected override Drawable CreateContent() => new FillFlowContainer
+        {
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Direction = FillDirection.Vertical,
+            Children = new Drawable[]
+            {
+                new TopHeaderContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    TeamData = { BindTarget = TeamData },
+                },
+            }
+        };
 
         private partial class TeamHeaderTitle : OverlayTitle
         {

--- a/osu.Game/Overlays/Team/TeamProfileHeader.cs
+++ b/osu.Game/Overlays/Team/TeamProfileHeader.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Overlays.Team.Header;
+using osu.Game.Overlays.Team.Header.Components;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Team
@@ -37,6 +38,11 @@ namespace osu.Game.Overlays.Team
                     TeamData = { BindTarget = TeamData },
                 },
             }
+        };
+
+        protected override Drawable CreateTabControlContent() => new TeamRulesetSelector
+        {
+            TeamData = { BindTarget = TeamData },
         };
 
         private partial class TeamHeaderTitle : OverlayTitle

--- a/osu.Game/Overlays/Team/TeamReportReason.cs
+++ b/osu.Game/Overlays/Team/TeamReportReason.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Overlays.Team
+{
+    /// <remarks>
+    /// References:
+    /// https://github.com/ppy/osu-web/blob/4579103d681d98851e40f51d50f7243d999968b0/app/Models/UserReport.php#L54
+    /// </remarks>
+    public enum TeamReportReason
+    {
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.ReportOptionsUnwantedContent))]
+        UnwantedContent,
+
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.ReportOptionsOther))]
+        Other,
+    }
+}

--- a/osu.Game/Overlays/TeamProfileOverlay.cs
+++ b/osu.Game/Overlays/TeamProfileOverlay.cs
@@ -88,6 +88,7 @@ namespace osu.Game.Overlays
                             Children = new Drawable[]
                             {
                                 new InfoSection { TeamData = { BindTarget = teamData } },
+                                new MembersSection { TeamData = { BindTarget = teamData } },
                             },
                         },
                     },

--- a/osu.Game/Overlays/TeamProfileOverlay.cs
+++ b/osu.Game/Overlays/TeamProfileOverlay.cs
@@ -13,8 +13,10 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Team;
+using osu.Game.Overlays.Team.Sections;
 using osu.Game.Rulesets;
 using osu.Game.Teams;
+using osuTK;
 
 namespace osu.Game.Overlays
 {
@@ -76,6 +78,18 @@ namespace osu.Game.Overlays
                     Children = new Drawable[]
                     {
                         Header,
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0, 10),
+                            Padding = new MarginPadding(10),
+                            Children = new Drawable[]
+                            {
+                                new InfoSection { TeamData = { BindTarget = teamData } },
+                            },
+                        },
                     },
                 },
             };

--- a/osu.Game/Overlays/TeamProfileOverlay.cs
+++ b/osu.Game/Overlays/TeamProfileOverlay.cs
@@ -1,0 +1,119 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays.Team;
+using osu.Game.Rulesets;
+using osu.Game.Teams;
+
+namespace osu.Game.Overlays
+{
+    public partial class TeamProfileOverlay : FullscreenOverlay<TeamProfileHeader>
+    {
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        private readonly OnlineViewContainer onlineViewContainer;
+        private readonly LoadingLayer loadingLayer;
+
+        private GetTeamRequest? req;
+
+        private IBindable<APIUser> apiUser = new Bindable<APIUser>();
+
+        private readonly Bindable<TeamProfileData?> teamData = new Bindable<TeamProfileData?>();
+        private (ITeam team, IRulesetInfo? ruleset)? lastLookup;
+
+        protected override Container<Drawable> Content => onlineViewContainer;
+
+        public TeamProfileOverlay()
+            : base(OverlayColourScheme.Pink)
+        {
+            base.Content.Add(new PopoverContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    onlineViewContainer = new OnlineViewContainer($"Sign in to view the {Header.Title.Title}")
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    loadingLayer = new LoadingLayer(true),
+                },
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            apiUser = api.LocalUser.GetBoundCopy();
+            apiUser.ValueChanged += _ => Schedule(() =>
+            {
+                if (api.IsLoggedIn)
+                    Scheduler.AddOnce(fetchAndSetContent);
+            });
+            Child = new OverlayScrollContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                ScrollbarVisible = false,
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        Header,
+                    },
+                },
+            };
+        }
+
+        protected override TeamProfileHeader CreateHeader() => new TeamProfileHeader { TeamData = { BindTarget = teamData } };
+
+        public void ShowTeam(ITeam teamToShow, IRulesetInfo? teamRuleset = null)
+        {
+            lastLookup = (teamToShow, teamRuleset);
+
+            Show();
+            fetchAndSetContent();
+        }
+
+        private void fetchAndSetContent()
+        {
+            if (lastLookup == null)
+                return;
+
+            req?.Cancel();
+
+            if (!api.IsLoggedIn)
+                return;
+
+            req = new GetTeamRequest(lastLookup.Value.team.OnlineID, lastLookup.Value.ruleset);
+            req.Success += team => teamLoadComplete(team, lastLookup.Value.ruleset);
+
+            API.Queue(req);
+            loadingLayer.Show();
+        }
+
+        private void teamLoadComplete(APITeam team, IRulesetInfo? ruleset)
+        {
+            var actualRuleset = rulesets.GetRuleset(ruleset?.OnlineID ?? team.DefaultRulesetId).AsNonNull();
+
+            teamData.Value = new TeamProfileData(team, actualRuleset);
+            loadingLayer.Hide();
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/PlayerPanel.cs
@@ -164,13 +164,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match
                         RelativeSizeAxes = Axes.Both,
                         Colour = colourProvider?.Background5 ?? colours.Gray1
                     },
-                    background = new UserCoverBackground
+                    background = new CoverBackground
                     {
                         RelativeSizeAxes = Axes.Both,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Colour = colours.Gray7,
-                        User = User
+                        Item = User
                     },
                     new Container
                     {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private SpriteIcon crown = null!;
 
-        private UserCoverBackground userCover = null!;
+        private CoverBackground userCover = null!;
         private UpdateableAvatar userAvatar = null!;
         private UpdateableFlag userFlag = null!;
         private OsuSpriteText username = null!;
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = backgroundColour
                                 },
-                                userCover = new UserCoverBackground
+                                userCover = new CoverBackground
                                 {
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
@@ -240,7 +240,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         {
             var user = current.Value.User;
 
-            userCover.User = user;
+            userCover.Item = user;
             userAvatar.User = user;
             userFlag.CountryCode = user?.CountryCode ?? default;
             teamFlagContainer.Child = new UpdateableTeamFlag(user?.Team)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -245,7 +245,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             userFlag.CountryCode = user?.CountryCode ?? default;
             teamFlagContainer.Child = new UpdateableTeamFlag(user?.Team)
             {
-                Size = new Vector2(40, 20)
+                Size = new Vector2(40, 20),
+                CornerRadius = 2.5f,
             };
             username.Text = user?.Username ?? string.Empty;
 

--- a/osu.Game/Screens/Play/HUD/PlayerTeamFlag.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerTeamFlag.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Screens.Play.HUD
             InternalChild = flag = new UpdateableTeamFlag
             {
                 RelativeSizeAxes = Axes.Both,
+                CornerRadius = default_size / 16f,
             };
         }
 

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -78,10 +78,10 @@ namespace osu.Game.Screens.Ranking.Contracted
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = Color4Extensions.FromHex("444")
                                 },
-                                new UserCoverBackground
+                                new CoverBackground
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    User = score.User,
+                                    Item = score.User,
                                     Colour = ColourInfo.GradientVertical(Color4.White.Opacity(0.5f), Color4Extensions.FromHex("#444").Opacity(0))
                                 },
                                 new FillFlowContainer

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -172,10 +172,10 @@ namespace osu.Game.Screens.Ranking
                                 Children = new[]
                                 {
                                     middleLayerBackground = new Box { RelativeSizeAxes = Axes.Both },
-                                    new UserCoverBackground
+                                    new CoverBackground
                                     {
                                         RelativeSizeAxes = Axes.Both,
-                                        User = Score.User,
+                                        Item = Score.User,
                                         Colour = ColourInfo.GradientVertical(Color4.White.Opacity(0.5f), Color4Extensions.FromHex("#444").Opacity(0))
                                     }
                                 }

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -196,10 +196,10 @@ namespace osu.Game.Screens.SelectV2
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = foregroundColour
                                 },
-                                new UserCoverBackground
+                                new CoverBackground
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    User = Score.User,
+                                    Item = Score.User,
                                     Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft,

--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -288,6 +288,7 @@ namespace osu.Game.Screens.SelectV2
                                                                 Anchor = Anchor.CentreLeft,
                                                                 Origin = Anchor.CentreLeft,
                                                                 Size = new Vector2(30, 15),
+                                                                CornerRadius = 1.875f,
                                                             },
                                                             new DateLabel(Score.Date)
                                                             {

--- a/osu.Game/Teams/ITeam.cs
+++ b/osu.Game/Teams/ITeam.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Database;
+
+namespace osu.Game.Teams
+{
+    public interface ITeam : IHasOnlineID<int>, IEquatable<ITeam>
+    {
+        string ShortName { get; }
+
+        bool IEquatable<ITeam>.Equals(ITeam? other)
+        {
+            if (other == null)
+                return false;
+
+            return OnlineID == other.OnlineID && ShortName == other.ShortName;
+        }
+    }
+}

--- a/osu.Game/Users/CoverBackground.cs
+++ b/osu.Game/Users/CoverBackground.cs
@@ -10,20 +10,19 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Online.API.Requests.Responses;
 using osuTK.Graphics;
 
 namespace osu.Game.Users
 {
-    public partial class UserCoverBackground : ModelBackedDrawable<APIUser?>
+    public partial class CoverBackground : ModelBackedDrawable<IHasCover?>
     {
-        public APIUser? User
+        public IHasCover? Item
         {
             get => Model;
             set => Model = value;
         }
 
-        protected override Drawable CreateDrawable(APIUser? user) => new Cover(user);
+        protected override Drawable CreateDrawable(IHasCover? item) => new Cover(item);
 
         protected override double LoadDelay => 300;
 
@@ -41,11 +40,11 @@ namespace osu.Game.Users
         [LongRunningLoad]
         private partial class Cover : CompositeDrawable
         {
-            private readonly APIUser? user;
+            private readonly IHasCover? item;
 
-            public Cover(APIUser? user)
+            public Cover(IHasCover? item)
             {
-                this.user = user;
+                this.item = item;
 
                 RelativeSizeAxes = Axes.Both;
             }
@@ -53,7 +52,7 @@ namespace osu.Game.Users
             [BackgroundDependencyLoader]
             private void load(LargeTextureStore textures)
             {
-                if (user == null)
+                if (item == null)
                 {
                     InternalChild = new Box
                     {
@@ -66,7 +65,7 @@ namespace osu.Game.Users
                     InternalChild = new Sprite
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Texture = textures.Get(user.CoverUrl),
+                        Texture = textures.Get(item.CoverUrl),
                         FillMode = FillMode.Fill,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre

--- a/osu.Game/Users/Drawables/ClickableTeamFlag.cs
+++ b/osu.Game/Users/Drawables/ClickableTeamFlag.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Users.Drawables
+{
+    public partial class ClickableTeamFlag : OsuClickableContainer
+    {
+        private readonly APITeam? team;
+
+        [Resolved]
+        private OsuGame? game { get; set; }
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        /// <summary>
+        /// A clickable flag component for the specified team, with UI sounds and a tooltip.
+        /// </summary>
+        /// <param name="team">The team. A null value will show a placeholder background.</param>
+        /// <param name="showTooltipOnHover">If set to true, the team's name is displayed in the tooltip.</param>
+        public ClickableTeamFlag(APITeam? team, bool showTooltipOnHover = true)
+        {
+            this.team = team;
+
+            if (team == null)
+                return;
+
+            Action = openProfile;
+
+            if (showTooltipOnHover)
+                TooltipText = team.Name;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            LoadComponentAsync(new DrawableTeamFlag(team) { RelativeSizeAxes = Axes.Both }, Add);
+        }
+
+        private void openProfile()
+        {
+            if (team != null)
+                game?.OpenUrlExternally($@"{api.Endpoints.WebsiteUrl}/teams/{team.Id}");
+        }
+    }
+}

--- a/osu.Game/Users/Drawables/ClickableTeamFlag.cs
+++ b/osu.Game/Users/Drawables/ClickableTeamFlag.cs
@@ -1,10 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Users.Drawables
@@ -16,8 +16,11 @@ namespace osu.Game.Users.Drawables
         [Resolved]
         private OsuGame? game { get; set; }
 
-        [Resolved]
-        private IAPIProvider api { get; set; } = null!;
+        /// <summary>
+        /// Perform an action in addition to showing the team profile.
+        /// This should be used to perform auxiliary tasks and not as a primary action for clicking a flag (to maintain a consistent UX).
+        /// </summary>
+        public new Action? Action;
 
         /// <summary>
         /// A clickable flag component for the specified team, with UI sounds and a tooltip.
@@ -31,7 +34,11 @@ namespace osu.Game.Users.Drawables
             if (team == null)
                 return;
 
-            Action = openProfile;
+            base.Action = () =>
+            {
+                openProfile();
+                Action?.Invoke();
+            };
 
             if (showTooltipOnHover)
                 TooltipText = team.Name;
@@ -46,7 +53,7 @@ namespace osu.Game.Users.Drawables
         private void openProfile()
         {
             if (team != null)
-                game?.OpenUrlExternally($@"{api.Endpoints.WebsiteUrl}/teams/{team.Id}");
+                game?.ShowTeam(team);
         }
     }
 }

--- a/osu.Game/Users/Drawables/DrawableTeamFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableTeamFlag.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Users.Drawables
+{
+    [LongRunningLoad]
+    public partial class DrawableTeamFlag : CompositeDrawable
+    {
+        private readonly APITeam? team;
+
+        private readonly Sprite sprite;
+
+        /// <summary>
+        /// A simple, non-interactable flag sprite for the specified user.
+        /// </summary>
+        /// <param name="team">The team. A null value will show a placeholder background.</param>
+        public DrawableTeamFlag(APITeam? team)
+        {
+            this.team = team;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Colour4.FromHex("333"),
+                },
+                sprite = new Sprite
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    FillMode = FillMode.Fit,
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(LargeTextureStore textures)
+        {
+            if (team != null)
+                sprite.Texture = textures.Get(team.FlagUrl);
+        }
+    }
+}

--- a/osu.Game/Users/Drawables/UpdateableTeamFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableTeamFlag.cs
@@ -1,17 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Framework.Input.Events;
-using osu.Framework.Localisation;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Online.API;
+using osu.Framework.Graphics.Effects;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Users.Drawables
@@ -31,10 +23,46 @@ namespace osu.Game.Users.Drawables
             }
         }
 
+        public new bool Masking
+        {
+            get => base.Masking;
+            set => base.Masking = value;
+        }
+
+        public new float CornerRadius
+        {
+            get => base.CornerRadius;
+            set => base.CornerRadius = value;
+        }
+
+        public new EdgeEffectParameters EdgeEffect
+        {
+            get => base.EdgeEffect;
+            set => base.EdgeEffect = value;
+        }
+
         protected override double LoadDelay => 200;
 
-        public UpdateableTeamFlag(APITeam? team = null)
+        private readonly bool isInteractive;
+        private readonly bool hideOnNull;
+        private readonly bool showTooltipOnHover;
+
+        /// <summary>
+        /// Construct a new UpdateableTeamFlag.
+        /// </summary>
+        /// <param name="team">The initial team to display.</param>
+        /// <param name="isInteractive">If set to true, hover/click sounds will play and clicking the flag will open the team's profile.</param>
+        /// <param name="showTooltipOnHover">
+        /// If set to true, the team's name is displayed in the tooltip.
+        /// Only has an effect if <see cref="isInteractive"/> is true.
+        /// </param>
+        /// <param name="hideOnNull">Whether to hide the flag when the provided team is null.</param>
+        public UpdateableTeamFlag(APITeam? team = null, bool isInteractive = true, bool hideOnNull = true, bool showTooltipOnHover = true)
         {
+            this.isInteractive = isInteractive;
+            this.hideOnNull = hideOnNull;
+            this.showTooltipOnHover = showTooltipOnHover;
+
             Team = team;
 
             Masking = true;
@@ -42,69 +70,25 @@ namespace osu.Game.Users.Drawables
 
         protected override Drawable? CreateDrawable(APITeam? team)
         {
-            if (team == null)
+            if (team == null && hideOnNull)
                 return Empty();
 
-            return new TeamFlag(team) { RelativeSizeAxes = Axes.Both };
+            if (isInteractive)
+            {
+                return new ClickableTeamFlag(team, showTooltipOnHover)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+
+            return new DrawableTeamFlag(team)
+            {
+                RelativeSizeAxes = Axes.Both,
+            };
         }
 
         // Generally we just want team flags to disappear if the user doesn't have one.
         // This also handles fill flow cases and avoids spacing being added for non-displaying flags.
-        public override bool IsPresent => base.IsPresent && Team != null;
-
-        protected override void Update()
-        {
-            base.Update();
-
-            CornerRadius = DrawHeight / 8;
-        }
-
-        [LongRunningLoad]
-        public partial class TeamFlag : CompositeDrawable, IHasTooltip
-        {
-            private readonly APITeam team;
-
-            public LocalisableString TooltipText { get; }
-
-            [Resolved]
-            private OsuGame? game { get; set; }
-
-            [Resolved]
-            private IAPIProvider api { get; set; } = null!;
-
-            public TeamFlag(APITeam team)
-            {
-                this.team = team;
-                TooltipText = team.Name;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(LargeTextureStore textures)
-            {
-                InternalChildren = new Drawable[]
-                {
-                    new HoverClickSounds(),
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Colour4.FromHex("333"),
-                    },
-                    new Sprite
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Texture = textures.Get(team.FlagUrl),
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        FillMode = FillMode.Fit,
-                    }
-                };
-            }
-
-            protected override bool OnClick(ClickEvent e)
-            {
-                game?.OpenUrlExternally($"{api.Endpoints.WebsiteUrl}/teams/{team.Id}");
-                return true;
-            }
-        }
+        public override bool IsPresent => base.IsPresent && (Team != null || !hideOnNull);
     }
 }

--- a/osu.Game/Users/Drawables/UpdateableTeamFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableTeamFlag.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
@@ -41,6 +42,13 @@ namespace osu.Game.Users.Drawables
             set => base.EdgeEffect = value;
         }
 
+        /// <summary>
+        /// Perform an action in addition to showing the team profile.
+        /// This should be used to perform auxiliary tasks and not as a primary action for clicking a flag (to maintain a consistent UX).
+        /// Ignored if `isInteractive` is false.
+        /// </summary>
+        public Action? Action;
+
         protected override double LoadDelay => 200;
 
         private readonly bool isInteractive;
@@ -78,6 +86,7 @@ namespace osu.Game.Users.Drawables
                 return new ClickableTeamFlag(team, showTooltipOnHover)
                 {
                     RelativeSizeAxes = Axes.Both,
+                    Action = Action,
                 };
             }
 

--- a/osu.Game/Users/IHasCover.cs
+++ b/osu.Game/Users/IHasCover.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Users
+{
+    public interface IHasCover
+    {
+        string? CoverUrl { get; }
+    }
+}

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -114,12 +114,12 @@ namespace osu.Game.Users
         /// <summary>
         /// Panel background container. Can be null if a panel doesn't want a background under it's layout
         /// </summary>
-        protected virtual Drawable? CreateBackground() => Background = new UserCoverBackground
+        protected virtual Drawable? CreateBackground() => Background = new CoverBackground
         {
             RelativeSizeAxes = Axes.Both,
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
-            User = User
+            Item = User
         };
 
         protected OsuSpriteText CreateUsername() => new OsuSpriteText

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Users
         protected Drawable CreateTeamLogo() => new UpdateableTeamFlag(User.Team)
         {
             Size = new Vector2(52, 26),
+            CornerRadius = 3.25f,
         };
 
         public MenuItem[] ContextMenuItems

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -141,6 +141,7 @@ namespace osu.Game.Users
         {
             Size = new Vector2(52, 26),
             CornerRadius = 3.25f,
+            Action = Action,
         };
 
         public MenuItem[] ContextMenuItems

--- a/osu.Game/Users/UserRankPanel.cs
+++ b/osu.Game/Users/UserRankPanel.cs
@@ -99,12 +99,12 @@ namespace osu.Game.Users
                         Masking = true,
                         Children = new Drawable[]
                         {
-                            new UserCoverBackground
+                            new CoverBackground
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                User = User,
+                                Item = User,
                                 Alpha = 0.3f
                             },
                             new GridContainer


### PR DESCRIPTION
Resolves #32584. ~~It's still missing the plumbing to connect the open team chat button (which should be simple), and the members list is pending API implementation web-side. This PR is also pretty big already, so I'll probably send it in in a separate one.~~ It's all in the PR now. Will decide how to handle it after the prereq PRs (including the web one) are dealt with.

This PR is currently based on all the prerequisite PRs for #32584. I will rebase it or remake the PR once they're all merged.

The actual changes are split and can be reviewed commit by commit.

<img width="1628" height="1222" alt="image" src="https://github.com/user-attachments/assets/8ff27543-7a1b-4775-993a-efe19a33bfb9" />
