### PR TITLE
Use new star rating text gradient for the difficulty name, "mapped by" text and difficulty bars

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.DifficultyDisplay.cs
@@ -24,7 +24,6 @@ using osu.Game.Online.Chat;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -303,13 +302,10 @@ namespace osu.Game.Screens.SelectV2
 
                 difficultyText.MaxWidth = Math.Max(nameLine.DrawWidth - mappedByText.DrawWidth - mapperText.DrawWidth - 20, 0);
 
-                // Use difficulty colour until it gets too dark to be visible against dark backgrounds.
-                Color4 col = starRatingDisplay.DisplayedStars.Value >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.Orange1 : starRatingDisplay.DisplayedDifficultyColour;
-
-                difficultyText.Colour = col;
-                mappedByText.Colour = col;
-                countStatisticsDisplay.AccentColour = col;
-                difficultyStatisticsDisplay.AccentColour = col;
+                difficultyText.Colour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
+                mappedByText.Colour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
+                countStatisticsDisplay.AccentColour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
+                difficultyStatisticsDisplay.AccentColour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
             }
 
             private partial class MapperLinkContainer : OsuHoverContainer

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.DifficultyDisplay.cs
@@ -24,6 +24,7 @@ using osu.Game.Online.Chat;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.SelectV2
 {
@@ -302,10 +303,13 @@ namespace osu.Game.Screens.SelectV2
 
                 difficultyText.MaxWidth = Math.Max(nameLine.DrawWidth - mappedByText.DrawWidth - mapperText.DrawWidth - 20, 0);
 
-                difficultyText.Colour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
-                mappedByText.Colour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
-                countStatisticsDisplay.AccentColour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
-                difficultyStatisticsDisplay.AccentColour = colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value);
+                // Use difficulty colour until it gets too dark to be visible against dark backgrounds.
+                Color4 col = starRatingDisplay.DisplayedStars.Value >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value) : starRatingDisplay.DisplayedDifficultyColour;
+
+                difficultyText.Colour = col;
+                mappedByText.Colour = col;
+                countStatisticsDisplay.AccentColour = col;
+                difficultyStatisticsDisplay.AccentColour = col;
             }
 
             private partial class MapperLinkContainer : OsuHoverContainer

--- a/osu.Game/Screens/SelectV2/BeatmapTitleWedge.DifficultyDisplay.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapTitleWedge.DifficultyDisplay.cs
@@ -48,9 +48,6 @@ namespace osu.Game.Screens.SelectV2
             [Resolved]
             private BeatmapDifficultyCache difficultyCache { get; set; } = null!;
 
-            [Resolved]
-            private OsuColour colours { get; set; } = null!;
-
             private StarRatingDisplay starRatingDisplay = null!;
             private FillFlowContainer nameLine = null!;
             private OsuSpriteText difficultyText = null!;
@@ -304,7 +301,7 @@ namespace osu.Game.Screens.SelectV2
                 difficultyText.MaxWidth = Math.Max(nameLine.DrawWidth - mappedByText.DrawWidth - mapperText.DrawWidth - 20, 0);
 
                 // Use difficulty colour until it gets too dark to be visible against dark backgrounds.
-                Color4 col = starRatingDisplay.DisplayedStars.Value >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.ForStarDifficultyText(starRatingDisplay.DisplayedStars.Value) : starRatingDisplay.DisplayedDifficultyColour;
+                Color4 col = starRatingDisplay.DisplayedStars.Value >= OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? starRatingDisplay.DisplayedDifficultyTextColour : starRatingDisplay.DisplayedDifficultyColour;
 
                 difficultyText.Colour = col;
                 mappedByText.Colour = col;


### PR DESCRIPTION
Fixes: #36312

I think that's exactly what needed to be done to fix this issue.

|master|this PR|
|:---:|:---:|
|<img width="943" height="272" alt="изображение" src="https://github.com/user-attachments/assets/e6fb57bd-8393-4476-ac73-a8b559365e6d" />|<img width="950" height="270" alt="изображение" src="https://github.com/user-attachments/assets/e09de911-0068-4a8b-9abb-f2aa04a87886" />|
|<img width="943" height="274" alt="изображение" src="https://github.com/user-attachments/assets/637a86f5-ad26-441d-8fa2-bdf113bb636d" />|<img width="936" height="272" alt="изображение" src="https://github.com/user-attachments/assets/d72f52a1-6c17-4156-a4eb-cca36e74f644" />|
|<img width="940" height="271" alt="изображение" src="https://github.com/user-attachments/assets/cf6a5f18-34c8-4f51-867a-ba1fc30b64a5" />|<img width="941" height="270" alt="изображение" src="https://github.com/user-attachments/assets/e21cda45-1a69-4623-b9a7-add3eb7c7013" />
|<img width="946" height="275" alt="изображение" src="https://github.com/user-attachments/assets/e29647bb-c4aa-4d03-a46d-3bbcd43181b6" />|<img width="932" height="271" alt="изображение" src="https://github.com/user-attachments/assets/1f777db2-d0f9-4c2a-91fa-e005b9704c9a" />


