### PR TITLE
Fix toasts showing "no key bound" for operations which can't have keys bound

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         private partial class EmptyToast : Toast
         {
             public EmptyToast()
-                : base("", "", "")
+                : base("", "")
             {
             }
         }
@@ -104,8 +104,9 @@ namespace osu.Game.Tests.Visual.UserInterface
         private partial class LengthyToast : Toast
         {
             public LengthyToast()
-                : base("Toast with a very very very long text", "A very very very very very very long text also", "A very very very very very long shortcut")
+                : base("Toast with a very very very long text", "A very very very very very very long text also")
             {
+                ExtraText = "A very very very very very long shortcut";
             }
         }
 

--- a/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
+++ b/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -86,7 +85,7 @@ namespace osu.Game.Overlays.Music
             private readonly GlobalAction action;
 
             public MusicActionToast(LocalisableString value, GlobalAction action)
-                : base(ToastStrings.MusicPlayback, value, string.Empty)
+                : base(ToastStrings.MusicPlayback, value)
             {
                 this.action = action;
             }
@@ -94,7 +93,7 @@ namespace osu.Game.Overlays.Music
             [BackgroundDependencyLoader]
             private void load(RealmKeyBindingStore keyBindingStore)
             {
-                ShortcutText.Text = keyBindingStore.GetBindingsStringFor(action).ToUpper();
+                ExtraText = keyBindingStore.GetBindingsStringFor(action);
             }
         }
     }

--- a/osu.Game/Overlays/OSD/CopiedToClipboardToast.cs
+++ b/osu.Game/Overlays/OSD/CopiedToClipboardToast.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Overlays.OSD
     public partial class CopiedToClipboardToast : Toast
     {
         public CopiedToClipboardToast()
-            : base(CommonStrings.General, ToastStrings.CopiedToClipboard, "")
+            : base(CommonStrings.General, ToastStrings.CopiedToClipboard)
         {
         }
     }

--- a/osu.Game/Overlays/OSD/SpeedChangeToast.cs
+++ b/osu.Game/Overlays/OSD/SpeedChangeToast.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
@@ -9,9 +10,15 @@ namespace osu.Game.Overlays.OSD
 {
     public partial class SpeedChangeToast : Toast
     {
-        public SpeedChangeToast(RealmKeyBindingStore keyBindingStore, double newSpeed)
-            : base(ModSelectOverlayStrings.ModCustomisation, ToastStrings.SpeedChangedTo(newSpeed), keyBindingStore.GetBindingsStringFor(GlobalAction.IncreaseModSpeed) + " / " + keyBindingStore.GetBindingsStringFor(GlobalAction.DecreaseModSpeed))
+        public SpeedChangeToast(double newSpeed)
+            : base(ModSelectOverlayStrings.ModCustomisation, ToastStrings.SpeedChangedTo(newSpeed))
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(RealmKeyBindingStore keyBindingStore)
+        {
+            ExtraText = keyBindingStore.GetBindingsStringFor(GlobalAction.IncreaseModSpeed) + " / " + keyBindingStore.GetBindingsStringFor(GlobalAction.DecreaseModSpeed);
         }
     }
 }

--- a/osu.Game/Overlays/OSD/Toast.cs
+++ b/osu.Game/Overlays/OSD/Toast.cs
@@ -10,23 +10,30 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
-using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.OSD
 {
     public abstract partial class Toast : Container
     {
+        /// <summary>
+        /// Extra text to be shown at the bottom of the toast. Usually a key binding if available.
+        /// </summary>
+        public LocalisableString ExtraText
+        {
+            get => extraText.Text;
+            set => extraText.Text = value.ToUpper();
+        }
+
         private const int toast_minimum_width = 240;
 
         private readonly Container content;
 
         protected override Container<Drawable> Content => content;
 
-        protected readonly OsuSpriteText ValueText;
+        protected readonly OsuSpriteText ValueSpriteText;
+        private readonly OsuSpriteText extraText;
 
-        protected readonly OsuSpriteText ShortcutText;
-
-        protected Toast(LocalisableString description, LocalisableString value, LocalisableString shortcut)
+        protected Toast(LocalisableString description, LocalisableString value)
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -65,7 +72,7 @@ namespace osu.Game.Overlays.OSD
                     Origin = Anchor.TopCentre,
                     Text = description.ToUpper()
                 },
-                ValueText = new OsuSpriteText
+                ValueSpriteText = new OsuSpriteText
                 {
                     Font = OsuFont.GetFont(size: 24, weight: FontWeight.Light),
                     Padding = new MarginPadding { Horizontal = 10 },
@@ -74,15 +81,14 @@ namespace osu.Game.Overlays.OSD
                     Origin = Anchor.Centre,
                     Text = value
                 },
-                ShortcutText = new OsuSpriteText
+                extraText = new OsuSpriteText
                 {
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.BottomCentre,
-                    Name = "Shortcut",
+                    Name = "Extra Text",
                     Alpha = 0.3f,
                     Margin = new MarginPadding { Bottom = 15, Horizontal = 10 },
                     Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                    Text = string.IsNullOrEmpty(shortcut.ToString()) ? ToastStrings.NoKeyBound.ToUpper() : shortcut.ToUpper()
                 },
             };
         }

--- a/osu.Game/Overlays/OSD/TrackedSettingToast.cs
+++ b/osu.Game/Overlays/OSD/TrackedSettingToast.cs
@@ -35,8 +35,10 @@ namespace osu.Game.Overlays.OSD
         private Bindable<double?> lastPlaybackTime;
 
         public TrackedSettingToast(SettingDescription description)
-            : base(description.Name, description.Value, description.Shortcut)
+            : base(description.Name, description.Value)
         {
+            ExtraText = description.Shortcut;
+
             FillFlowContainer<OptionLight> optionLights;
 
             Children = new Drawable[]
@@ -75,7 +77,7 @@ namespace osu.Game.Overlays.OSD
                     break;
             }
 
-            ValueText.Origin = optionCount > 0 ? Anchor.BottomCentre : Anchor.Centre;
+            ValueSpriteText.Origin = optionCount > 0 ? Anchor.BottomCentre : Anchor.Centre;
 
             for (int i = 0; i < optionCount; i++)
                 optionLights.Add(new OptionLight { Glowing = i == selectedOption });

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -769,8 +769,9 @@ namespace osu.Game.Overlays.SkinEditor
         private partial class SkinEditorToast : Toast
         {
             public SkinEditorToast(LocalisableString value, string skinDisplayName)
-                : base(SkinSettingsStrings.SkinLayoutEditor, value, skinDisplayName)
+                : base(SkinSettingsStrings.SkinLayoutEditor, value)
             {
+                ExtraText = skinDisplayName;
             }
         }
 

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -308,7 +308,7 @@ namespace osu.Game.Rulesets.Edit
             private readonly ValueChangedEvent<double> change;
 
             public DistanceSpacingToast(LocalisableString value, ValueChangedEvent<double> change)
-                : base(getAction(change).GetLocalisableDescription(), value, string.Empty)
+                : base(getAction(change).GetLocalisableDescription(), value)
             {
                 this.change = change;
             }
@@ -316,7 +316,7 @@ namespace osu.Game.Rulesets.Edit
             [BackgroundDependencyLoader]
             private void load(RealmKeyBindingStore keyBindingStore)
             {
-                ShortcutText.Text = keyBindingStore.GetBindingsStringFor(getAction(change)).ToUpper();
+                ExtraText = keyBindingStore.GetBindingsStringFor(getAction(change));
             }
 
             private static GlobalAction getAction(ValueChangedEvent<double> change) => change.NewValue - change.OldValue > 0

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1620,8 +1620,9 @@ namespace osu.Game.Screens.Edit
         private partial class BeatmapEditorToast : Toast
         {
             public BeatmapEditorToast(LocalisableString value, string beatmapDisplayName)
-                : base(InputSettingsStrings.EditorSection, value, beatmapDisplayName)
+                : base(InputSettingsStrings.EditorSection, value)
             {
+                ExtraText = beatmapDisplayName;
             }
         }
 

--- a/osu.Game/Screens/Select/ModSpeedHotkeyHandler.cs
+++ b/osu.Game/Screens/Select/ModSpeedHotkeyHandler.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
-using osu.Game.Input;
 using osu.Game.Overlays;
 using osu.Game.Overlays.OSD;
 using osu.Game.Rulesets.Mods;
@@ -20,9 +19,6 @@ namespace osu.Game.Screens.Select
     {
         [Resolved]
         private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
-
-        [Resolved]
-        private RealmKeyBindingStore keyBindingStore { get; set; } = null!;
 
         [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
@@ -56,7 +52,7 @@ namespace osu.Game.Screens.Select
             if (Precision.AlmostEquals(targetSpeed, 1, 0.005))
             {
                 selectedMods.Value = selectedMods.Value.Where(m => m is not ModRateAdjust).ToList();
-                onScreenDisplay?.Display(new SpeedChangeToast(keyBindingStore, targetSpeed));
+                onScreenDisplay?.Display(new SpeedChangeToast(targetSpeed));
                 return true;
             }
 
@@ -109,7 +105,7 @@ namespace osu.Game.Screens.Select
                 return false;
 
             selectedMods.Value = intendedMods;
-            onScreenDisplay?.Display(new SpeedChangeToast(keyBindingStore, targetMod.SpeedChange.Value));
+            onScreenDisplay?.Display(new SpeedChangeToast(targetMod.SpeedChange.Value));
             return true;
         }
     }


### PR DESCRIPTION
Supersedes and closes https://github.com/ppy/osu/pull/35781.
Closes https://github.com/ppy/osu/issues/36294.
