### PR TITLE
File selector localisation and root dir name change

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FileSelection/HiddenFilesToggleCheckbox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelection/HiddenFilesToggleCheckbox.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -22,7 +23,7 @@ namespace osu.Game.Graphics.UserInterfaceV2.FileSelection
             Origin = Anchor.CentreLeft;
             LabelTextFlowContainer.Anchor = Anchor.CentreLeft;
             LabelTextFlowContainer.Origin = Anchor.CentreLeft;
-            LabelText = @"Show hidden";
+            LabelText = UserInterfaceStrings.ShowHidden;
 
             Scale = new Vector2(0.8f);
         }

--- a/osu.Game/Graphics/UserInterfaceV2/FileSelection/OsuDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelection/OsuDirectorySelectorBreadcrumbDisplay.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -26,7 +27,7 @@ namespace osu.Game.Graphics.UserInterfaceV2.FileSelection
             d.Alpha = 0;
         });
 
-        protected override DirectorySelectorDirectory CreateRootDirectoryItem() => new OsuBreadcrumbDisplayComputer();
+        protected override DirectorySelectorDirectory CreateRootDirectoryItem() => new OsuBreadcrumbDisplayDevice();
 
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string? displayName = null) => new OsuBreadcrumbDisplayDirectory(directory, displayName);
 
@@ -47,12 +48,12 @@ namespace osu.Game.Graphics.UserInterfaceV2.FileSelection
             });
         }
 
-        private partial class OsuBreadcrumbDisplayComputer : OsuBreadcrumbDisplayDirectory
+        private partial class OsuBreadcrumbDisplayDevice : OsuBreadcrumbDisplayDirectory
         {
             protected override IconUsage? Icon => null;
 
-            public OsuBreadcrumbDisplayComputer()
-                : base(null, "Computer")
+            public OsuBreadcrumbDisplayDevice()
+                : base(null, UserInterfaceStrings.Device.ToString())
             {
             }
         }

--- a/osu.Game/Localisation/UserInterfaceStrings.cs
+++ b/osu.Game/Localisation/UserInterfaceStrings.cs
@@ -174,6 +174,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString SelectedMods => new TranslatableString(getKey(@"selected_mods"), @"Selected Mods");
 
+        /// <summary>
+        /// "Device"
+        /// </summary>
+        public static LocalisableString Device => new TranslatableString(getKey(@"device"), @"Device");
+
+        /// <summary>
+        /// "Show hidden"
+        /// </summary>
+        public static LocalisableString ShowHidden => new TranslatableString(getKey(@"show_hidden"), @"Show hidden");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }


### PR DESCRIPTION
Resolves #36340

As discussed in this issue, the root name is now localisable and has been changed from ‘Computer’ to ‘Device’. The ‘Show hidden’ option in the file selection field is now localisable as well.
I added the strings to UserInterfaceStrings.cs because I didn't think it was necessary to create a new file for two strings, especially since there are no other strings in the file selector interface that could potentially be added.

<img width="1081" height="726" alt="image" src="https://github.com/user-attachments/assets/940a374a-0554-4eca-8f0d-ede9f6136643" />