### PR TITLE
Fix double-clicking form slider bar not propagating default to other bindables when `TransferValueOnCommit` is true

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
@@ -67,6 +67,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestNubDoubleClickRevertToDefault()
         {
+            OsuSpriteText text;
             FormSliderBar<float> slider = null!;
 
             AddStep("create content", () =>
@@ -81,6 +82,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Spacing = new Vector2(10),
                     Children = new Drawable[]
                     {
+                        text = new OsuSpriteText(),
                         slider = new FormSliderBar<float>
                         {
                             Caption = "Slider",
@@ -94,7 +96,26 @@ namespace osu.Game.Tests.Visual.UserInterface
                         },
                     }
                 };
+                slider.Current.BindValueChanged(_ => text.Text = $"Current value is: {slider.Current.Value}", true);
             });
+            AddStep("set slider to 1", () => slider.Current.Value = 1);
+
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));
+
+            AddStep("double click nub", () =>
+            {
+                InputManager.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("slider is default", () => slider.Current.IsDefault);
+
+            AddStep("set transfer value on commit to true", () =>
+            {
+                if (slider.IsNotNull())
+                    slider.TransferValueOnCommit = true;
+            });
+
             AddStep("set slider to 1", () => slider.Current.Value = 1);
 
             AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
@@ -64,8 +64,9 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
         }
 
-        [Test]
-        public void TestNubDoubleClickRevertToDefault()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestNubDoubleClickRevertToDefault(bool transferValueOnCommit)
         {
             OsuSpriteText text;
             FormSliderBar<float> slider = null!;
@@ -86,6 +87,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                         slider = new FormSliderBar<float>
                         {
                             Caption = "Slider",
+                            TransferValueOnCommit = transferValueOnCommit,
                             Current = new BindableFloat
                             {
                                 MinValue = 0,
@@ -98,24 +100,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                 };
                 slider.Current.BindValueChanged(_ => text.Text = $"Current value is: {slider.Current.Value}", true);
             });
-            AddStep("set slider to 1", () => slider.Current.Value = 1);
-
-            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));
-
-            AddStep("double click nub", () =>
-            {
-                InputManager.Click(MouseButton.Left);
-                InputManager.Click(MouseButton.Left);
-            });
-
-            AddAssert("slider is default", () => slider.Current.IsDefault);
-
-            AddStep("set transfer value on commit to true", () =>
-            {
-                if (slider.IsNotNull())
-                    slider.TransferValueOnCommit = true;
-            });
-
             AddStep("set slider to 1", () => slider.Current.Value = 1);
 
             AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -403,13 +403,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private partial class InnerSlider : OsuSliderBar<T>
         {
-            public Action? ResetToDefault { get; set; }
-
             public BindableBool Focused { get; } = new BindableBool();
 
-            public BindableBool IsDragging { get; set; } = new BindableBool();
+            public BindableBool IsDragging { get; } = new BindableBool();
 
-            public Action? OnCommit { get; set; }
+            public Action? ResetToDefault { get; init; }
+
+            public Action? OnCommit { get; init; }
 
             public sealed override LocalisableString TooltipText => base.TooltipText;
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -233,6 +233,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             TooltipFormat = TooltipFormat,
                             DisplayAsPercentage = DisplayAsPercentage,
                             PlaySamplesOnAdjust = PlaySamplesOnAdjust,
+                            ResetToDefault = () =>
+                            {
+                                if (!IsDisabled)
+                                    SetDefault();
+                            }
                         }
                     },
                 },
@@ -398,6 +403,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private partial class InnerSlider : OsuSliderBar<T>
         {
+            public Action? ResetToDefault { get; set; }
+
             public BindableBool Focused { get; } = new BindableBool();
 
             public BindableBool IsDragging { get; set; } = new BindableBool();
@@ -453,11 +460,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                         Padding = new MarginPadding { Horizontal = RangePadding, },
                         Child = nub = new InnerSliderNub
                         {
-                            ResetToDefault = () =>
-                            {
-                                if (!Current.Disabled)
-                                    Current.SetDefault();
-                            }
+                            ResetToDefault = ResetToDefault,
                         }
                     },
                     sounds = new HoverClickSounds()


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/pull/36346#discussion_r2692322683

The inner slider bar binds its `Current` to `currentNumberInstantaneous`:

https://github.com/ppy/osu/blob/1add946db486c866cc214c5eb3d728f308aad637/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs#L225-L236

But the current bindable of the form component doesn't update because of this.

https://github.com/ppy/osu/blob/1add946db486c866cc214c5eb3d728f308aad637/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs#L285-L293

Fixed it by just moving the `ResetToDefault` action up another level.