### PR TITLE
Fix unhandled error when clicking difficulties rapidly

### DIFF
--- a/osu.Game/Screens/Select/Carousel/FilterableDifficultyIcon.cs
+++ b/osu.Game/Screens/Select/Carousel/FilterableDifficultyIcon.cs
@@ -28,6 +28,10 @@ namespace osu.Game.Screens.Select.Carousel
 
         protected override bool OnClick(ClickEvent e)
         {
+            // Avoid setting state on items that may be stale due to rapid selection changes
+            if (Item.State.Value == CarouselItemState.Collapsed)
+                return true;
+
             Item.State.Value = CarouselItemState.Selected;
             return true;
         }

--- a/osu.Game/Screens/Select/Carousel/GroupedDifficultyIcon.cs
+++ b/osu.Game/Screens/Select/Carousel/GroupedDifficultyIcon.cs
@@ -47,7 +47,13 @@ namespace osu.Game.Screens.Select.Carousel
 
         protected override bool OnClick(ClickEvent e)
         {
-            Items.First().State.Value = CarouselItemState.Selected;
+            var firstItem = Items.First();
+
+            // Avoid setting state on items that may be stale due to rapid selection changes
+            if (firstItem.State.Value == CarouselItemState.Collapsed)
+                return true;
+
+            firstItem.State.Value = CarouselItemState.Selected;
             return true;
         }
 


### PR DESCRIPTION
Prevents setting CarouselItemState.Selected on CarouselBeatmap items that are in a Collapsed state. This can occur during rapid clicking when panels are being recycled and the difficulty icons still hold stale references.