### PR TITLE
Add metadata endpoint to refresh friend listing

### DIFF
--- a/osu.Game/Online/Metadata/IMetadataServer.cs
+++ b/osu.Game/Online/Metadata/IMetadataServer.cs
@@ -53,5 +53,10 @@ namespace osu.Game.Online.Metadata
         /// Signals to the server that the current user would like to stop receiving updates about the state of the multiplayer room with the given <paramref name="id"/>.
         /// </summary>
         Task EndWatchingMultiplayerRoom(long id);
+
+        /// <summary>
+        /// Refresh this user's friend listing.
+        /// </summary>
+        Task RefreshFriends();
     }
 }

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Users;
 
@@ -20,6 +21,16 @@ namespace osu.Game.Online.Metadata
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
+
+        private readonly IBindableList<APIRelation> localFriends = new BindableList<APIRelation>();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            localFriends.BindTo(api.LocalUserState.Friends);
+            localFriends.BindCollectionChanged((_, _) => RefreshFriends().FireAndForget());
+        }
 
         #region Beatmap metadata updates
 

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -152,6 +152,8 @@ namespace osu.Game.Online.Metadata
 
         public abstract Task EndWatchingMultiplayerRoom(long id);
 
+        public abstract Task RefreshFriends();
+
         public event Action<MultiplayerRoomScoreSetEvent>? MultiplayerRoomScoreSet;
 
         Task IMetadataClient.MultiplayerRoomScoreSet(MultiplayerRoomScoreSetEvent roomScoreSetEvent)

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -288,6 +288,15 @@ namespace osu.Game.Online.Metadata
             Logger.Log($@"{nameof(OnlineMetadataClient)} stopped watching multiplayer room with ID {id}", LoggingTarget.Network);
         }
 
+        public override async Task RefreshFriends()
+        {
+            if (connector?.IsConnected.Value != true)
+                throw new OperationCanceledException();
+
+            Debug.Assert(connection != null);
+            await connection.InvokeAsync(nameof(IMetadataServer.RefreshFriends)).ConfigureAwait(false);
+        }
+
         public override async Task DisconnectRequested()
         {
             await base.DisconnectRequested().ConfigureAwait(false);

--- a/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
+++ b/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
@@ -128,6 +128,8 @@ namespace osu.Game.Tests.Visual.Metadata
 
         public override Task EndWatchingMultiplayerRoom(long id) => Task.CompletedTask;
 
+        public override Task RefreshFriends() => Task.CompletedTask;
+
         public void Disconnect()
         {
             isConnected.Value = false;


### PR DESCRIPTION
Alternative to / closes https://github.com/ppy/osu/pull/36341
See also: https://github.com/ppy/osu-server-spectator/pull/415

This is a simple solution by adding a spectator endpoint to refresh the friend listing. A more complicated form of this is to make adding/removing friends only via spectator, but that would require osu-web changes too.

