### PR TITLE
Specialise mod setting hover text in song select scoreboard

### DIFF
--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -59,21 +59,24 @@ namespace osu.Game.Rulesets.Mods
                     if (bindable.IsDefault)
                         continue;
 
-                    string valueText;
-
-                    switch (bindable)
-                    {
-                        case Bindable<bool> b:
-                            valueText = b.Value ? "On" : "Off";
-                            break;
-
-                        default:
-                            valueText = bindable.ToString() ?? string.Empty;
-                            break;
-                    }
-
-                    yield return (attr.Label, valueText);
+                    yield return (attr.Label, GetSettingTooltipText(bindable));
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets the tooltip text for a specific mod setting.
+        /// Can be overridden to provide custom formatting for specific settings.
+        /// </summary>
+        protected virtual LocalisableString GetSettingTooltipText(IBindable bindable)
+        {
+            switch (bindable)
+            {
+                case Bindable<bool> b:
+                    return b.Value ? "On" : "Off";
+
+                default:
+                    return bindable.ToString() ?? string.Empty;
             }
         }
 

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -96,10 +96,23 @@ namespace osu.Game.Rulesets.Mods
         }
 
         public ScoreRank AdjustRank(ScoreRank rank, double accuracy) => rank;
+
+        protected override LocalisableString GetSettingTooltipText(IBindable bindable)
+        {
+            if (ReferenceEquals(bindable, MuteComboCount))
+                return MuteComboSlider.FormatMuteComboValue(MuteComboCount.Value);
+
+            return base.GetSettingTooltipText(bindable);
+        }
     }
 
     public partial class MuteComboSlider : RoundedSliderBar<int>
     {
-        public override LocalisableString TooltipText => Current.Value == 0 ? "always muted" : base.TooltipText;
+        public override LocalisableString TooltipText => FormatMuteComboValue(Current.Value);
+
+        public static LocalisableString FormatMuteComboValue(int value)
+        {
+            return value == 0 ? "always muted" : value.ToString();
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -62,10 +62,23 @@ namespace osu.Game.Rulesets.Mods
                 ComboBasedAlpha = Math.Max(MIN_ALPHA, 1 - (float)combo.NewValue / HiddenComboCount.Value);
             }, true);
         }
+
+        protected override LocalisableString GetSettingTooltipText(IBindable bindable)
+        {
+            if (ReferenceEquals(bindable, HiddenComboCount))
+                return HiddenComboSlider.FormatHiddenComboValue(HiddenComboCount.Value);
+
+            return base.GetSettingTooltipText(bindable);
+        }
     }
 
     public partial class HiddenComboSlider : RoundedSliderBar<int>
     {
-        public override LocalisableString TooltipText => Current.Value == 0 ? "always hidden" : base.TooltipText;
+        public override LocalisableString TooltipText => FormatHiddenComboValue(Current.Value);
+
+        public static LocalisableString FormatHiddenComboValue(int value)
+        {
+            return value == 0 ? "always hidden" : value.ToString();
+        }
     }
 }


### PR DESCRIPTION
- resolves #35992

**Changes**

Introduced GetSettingTooltipText, which returns the value of the respective setting. The function can be overwritten, allowing to implement specific behavior. This allows you to define that a value of 0 for the “Muted” mod will instead display “always muted.”
In the same step, I also adjusted the "NoScope" mod, where we had the same problem.
Wherever we want to implement specialization like this, we can simply overwrite GetSettingTooltipText to customize the behavior for the mod settings of the mod.

**Result**
<img width="2560" height="1440" alt="2026-01-19-122307_hyprshot" src="https://github.com/user-attachments/assets/20e3aa9a-aa6f-4284-9cf1-3092f52c021d" />
<img width="2560" height="1440" alt="2026-01-19-122324_hyprshot" src="https://github.com/user-attachments/assets/6f3fac5b-2a5d-4dd9-a56c-4b09c02cbcca" />
<img width="2560" height="1440" alt="2026-01-19-155307_hyprshot" src="https://github.com/user-attachments/assets/f9ee75d3-c200-4536-9ee9-d20ddbd9fa44" />
