### PR TITLE
Fix changing combo colours in beatmap without custom samples opening new sample set popover

### DIFF
--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -101,7 +101,10 @@ namespace osu.Game.Screens.Edit
 
             string[] possiblePrefixes = possibleSounds.SelectMany(sound => possibleBanks.Select(bank => $@"{bank}-{sound}")).ToArray();
 
-            Dictionary<int, SampleSet> sampleSets = new Dictionary<int, SampleSet>();
+            Dictionary<int, SampleSet> sampleSets = new Dictionary<int, SampleSet>
+            {
+                [1] = new SampleSet(1),
+            };
 
             if (Skin.Samples != null)
             {

--- a/osu.Game/Screens/Edit/Setup/FormSampleSetChooser.cs
+++ b/osu.Game/Screens/Edit/Setup/FormSampleSetChooser.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.Edit.Setup
             if (beatmapSkin != null)
                 beatmapSkin.BeatmapSkinChanged += populateItems;
 
-            Current.Value = Items.FirstOrDefault(i => i?.SampleSetIndex > 0);
+            Current.Value = Items.First(i => i?.SampleSetIndex > 0);
             Current.BindValueChanged(val =>
             {
                 if (val.NewValue?.SampleSetIndex == -1)
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.Edit.Setup
 
         private void populateItems()
         {
-            var items = beatmapSkin?.GetAvailableSampleSets().ToList() ?? [];
+            var items = beatmapSkin?.GetAvailableSampleSets().ToList() ?? [new EditorBeatmapSkin.SampleSet(1)];
             items.Add(new EditorBeatmapSkin.SampleSet(-1, "Add new..."));
             Items = items;
         }


### PR DESCRIPTION
Reported [on reddit of all places](https://www.reddit.com/r/osugame/comments/1qhnfdn/every_time_i_make_an_adjustment_to_the_hitcircle/).

The reason that this is happening is as follows:

- Changing a combo colour raises `BeatmapSkinChanged`
- `BeatmapSkinChanged` getting raised triggers the sample chooser dropdown to repopulate its items (as intended and correctly)
- Setting items of a dropdown can also change its `Current.Value`, because the relevant logic attempts to ensure that `Current.Value` is valid in line with the new items
- Therefore the `Current.Value` of the dropdown changes from `null` to sample set `-1` which corresponds to the "Add new..." item as it's the only item in the dropdown...
- which is indistinguishable from the sequence of events that happens if the user manually opens the dropdown and clicks the "Add new..." item.

This change sidesteps this entire car crash by just ensuring that even beatmaps without custom samples have at least set number 1 initialised (even if it's empty and has no samples). This means that the initial value of the dropdown is never `null`, and that every time that the value changes to the set `-1` it actually is due to user action.

Should have known better than to play these dumb games.