### PR TITLE
Fix skin saving crashing if hashable files are not present

### DIFF
--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -474,8 +474,10 @@ namespace osu.Game.Database
 
             foreach (RealmNamedFileUsage file in item.Files.Where(f => HashableFileTypes.Any(ext => f.Filename.EndsWith(ext, StringComparison.OrdinalIgnoreCase))).OrderBy(f => f.Filename))
             {
-                using (Stream s = Files.Store.GetStream(file.File.GetStoragePath()))
-                    s.CopyTo(hashable);
+                using (Stream? s = Files.Store.GetStream(file.File.GetStoragePath()))
+                {
+                    s?.CopyTo(hashable);
+                }
             }
 
             if (hashable.Length > 0)


### PR DESCRIPTION
This ends up with a bit of an undefined behaviour, but it's already a bit of an edge case (files missing in the `files` folder that are references in the database).

First and foremost, let's stop the exception. If we allow it to throw, it's impossible to exit the skin editor in this state.

Closes https://github.com/ppy/osu/issues/36135.