### PR TITLE
Fix random selection not showing selection when all groups are collapsed

### DIFF
--- a/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/BeatmapCarouselTestScene.cs
@@ -222,6 +222,7 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         protected void SelectPrevPanel() => AddStep("select prev panel", () => InputManager.Key(Key.Up));
         protected void SelectNextSet() => AddStep("select next set", () => InputManager.Key(Key.Right));
         protected void SelectPrevSet() => AddStep("select prev set", () => InputManager.Key(Key.Left));
+        protected void SelectRandomSet() => AddStep("select random set", () => Carousel.NextRandom());
 
         protected void Select() => AddStep("select", () => InputManager.Key(Key.Enter));
 

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -254,6 +254,19 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestGroupDoesExpandAfterRandomTraversal()
+        {
+            SelectNextSet();
+
+            ToggleGroupCollapse();
+            AddAssert("group not expanded", () => Carousel.ExpandedGroup, () => Is.Null);
+
+            SelectRandomSet();
+
+            AddAssert("group expanded", () => Carousel.ExpandedGroup, () => Is.Not.Null);
+        }
+
+        [Test]
         public void TestGroupDoesNotExpandAgainOnRefilterIfManuallyCollapsed()
         {
             ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneBeatmapCarouselArtistGrouping.cs
@@ -267,6 +267,41 @@ namespace osu.Game.Tests.Visual.SongSelectV2
         }
 
         [Test]
+        public void TestFilterWhileCollapsedUpdatesVisualStateConnectly()
+        {
+            SelectNextSet();
+
+            CheckHasSelection();
+            AddAssert("group expanded", () => Carousel.ExpandedGroup, () => Is.Not.Null);
+            AddAssert("has expanded set", () => Carousel.ExpandedBeatmapSet != null);
+
+            AddAssert("has visible beatmaps", () => Carousel.GetCarouselItems()!.Count(item => item.Model is GroupedBeatmap && item.IsVisible), () => Is.EqualTo(3));
+            AddAssert("has visually expanded set", () => Carousel.GetCarouselItems()!.Count(item => item.Model is GroupedBeatmapSet && item.IsExpanded && item.IsVisible), () => Is.EqualTo(1));
+
+            ToggleGroupCollapse();
+
+            CheckHasSelection();
+            AddAssert("group not expanded", () => Carousel.ExpandedGroup, () => Is.Null);
+            AddAssert("has expanded set", () => Carousel.ExpandedBeatmapSet != null);
+
+            AddAssert("has no visible beatmaps", () => Carousel.GetCarouselItems()!.Count(item => item.Model is GroupedBeatmap && item.IsVisible), () => Is.Zero);
+            AddAssert("has no visually expanded set", () => Carousel.GetCarouselItems()!.Count(item => item.Model is GroupedBeatmapSet && item.IsExpanded && item.IsVisible), () => Is.Zero);
+
+            // filter while collapsed.
+            ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = Carousel.SelectedBeatmapSet!.Metadata.Title);
+
+            // then expand.
+            ToggleGroupCollapse();
+
+            CheckHasSelection();
+            AddAssert("group expanded", () => Carousel.ExpandedGroup, () => Is.Not.Null);
+            AddAssert("has expanded set", () => Carousel.ExpandedBeatmapSet != null);
+
+            AddAssert("has visible beatmaps", () => Carousel.GetCarouselItems()!.Count(item => item.Model is GroupedBeatmap && item.IsVisible), () => Is.EqualTo(3));
+            AddAssert("has visually expanded set", () => Carousel.GetCarouselItems()!.Count(item => item.Model is GroupedBeatmapSet && item.IsExpanded && item.IsVisible), () => Is.EqualTo(1));
+        }
+
+        [Test]
         public void TestGroupDoesNotExpandAgainOnRefilterIfManuallyCollapsed()
         {
             ApplyToFilterAndWaitForFilter("filter", c => c.SearchText = BeatmapSets[2].Metadata.Title);

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -32,7 +32,6 @@ using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select;
-using osu.Game.Screens.Select.Filter;
 using Realms;
 
 namespace osu.Game.Screens.SelectV2
@@ -495,8 +494,9 @@ namespace osu.Game.Screens.SelectV2
 
             if (groupingRemainsOff || groupStillValid)
             {
-                // Only update the visual state of the selected item.
-                HandleItemSelected(currentGroupedBeatmap);
+                // Update the visual state of the selected item if it should still be expanded post filter.
+                if (currentGroupedBeatmap != null && currentGroupedBeatmap.Group == groupForReselection)
+                    setExpandedSet(new GroupedBeatmapSet(currentGroupedBeatmap.Group, currentGroupedBeatmap.Beatmap.BeatmapSet!));
             }
             else if (currentGroupedBeatmap != null)
             {

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -378,7 +378,7 @@ namespace osu.Game.Screens.SelectV2
 
                         if (userCollapsedGroup)
                         {
-                            if (grouping.BeatmapSetsGroupedTogether && CurrentGroupedBeatmap != null && CheckModelEquality(group, CurrentGroupedBeatmap.Group))
+                            if (grouping.BeatmapSetsGroupedTogether && CurrentGroupedBeatmap != null)
                                 setExpandedSet(new GroupedBeatmapSet(CurrentGroupedBeatmap.Group, CurrentGroupedBeatmap.Beatmap.BeatmapSet!));
                             userCollapsedGroup = false;
                         }

--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -352,12 +352,6 @@ namespace osu.Game.Screens.SelectV2
             }
         }
 
-        /// <summary>
-        /// Tracks whether the user has manually requested to collapse an open group.
-        /// In this case, refilters should not forcibly expand groups until the user expands a group again themselves.
-        /// </summary>
-        private bool userCollapsedGroup;
-
         protected override void HandleItemActivated(CarouselItem item)
         {
             try
@@ -370,18 +364,10 @@ namespace osu.Game.Screens.SelectV2
                         {
                             setExpansionStateOfGroup(ExpandedGroup, false);
                             ExpandedGroup = null;
-                            userCollapsedGroup = true;
                             return;
                         }
 
                         setExpandedGroup(group);
-
-                        if (userCollapsedGroup)
-                        {
-                            if (grouping.BeatmapSetsGroupedTogether && CurrentGroupedBeatmap != null)
-                                setExpandedSet(new GroupedBeatmapSet(CurrentGroupedBeatmap.Group, CurrentGroupedBeatmap.Beatmap.BeatmapSet!));
-                            userCollapsedGroup = false;
-                        }
 
                         // If the active selection is within this group, it should get keyboard focus immediately.
                         if (CurrentSelectionItem?.IsVisible == true && CurrentSelection is GroupedBeatmap gb)
@@ -421,9 +407,6 @@ namespace osu.Game.Screens.SelectV2
                     throw new InvalidOperationException("Groups should never become selected");
 
                 case GroupedBeatmap groupedBeatmap:
-                    if (userCollapsedGroup)
-                        break;
-
                     setExpandedGroup(groupedBeatmap.Group);
 
                     if (grouping.BeatmapSetsGroupedTogether)
@@ -797,9 +780,6 @@ namespace osu.Game.Screens.SelectV2
             bool resetDisplay = grouping.BeatmapSetsGroupedTogether != BeatmapCarouselFilterGrouping.ShouldGroupBeatmapsTogether(criteria);
 
             Criteria = criteria;
-
-            if (criteria.Group == GroupMode.None)
-                userCollapsedGroup = false;
 
             loadingDebounce ??= Scheduler.AddDelayed(() =>
             {


### PR DESCRIPTION
Closes #36365.

This reverts a previous fix (https://github.com/ppy/osu/pull/35163 plus follow-up regression fix) and applies a hopefully more permanent fix which doesn't affect other scenarios.

I also did some refactoring, which is in the last commit. It can be skipped or applied separately as preferred (but without it I have trouble understanding the fix I made here).

Note that I'm still dealing with surrounding flaky tests and only pushing this PR out to see how production CI responds. It should be considered a functional RFC.