### PR TITLE
Standardise ruleset error logging to always include exception in logs

### DIFF
--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -57,8 +56,6 @@ namespace osu.Game.Beatmaps
 
                     var working = workingBeatmapCache.GetWorkingBeatmap(beatmap);
                     var ruleset = working.BeatmapInfo.Ruleset.CreateInstance();
-
-                    Debug.Assert(ruleset != null);
 
                     var calculator = ruleset.CreateDifficultyCalculator(working);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -648,16 +648,16 @@ namespace osu.Game
 
             Ruleset instance = null;
 
-            try
+            if (r.NewValue?.Available == true)
             {
-                if (r.NewValue?.Available == true)
+                try
                 {
                     instance = r.NewValue.CreateInstance();
                 }
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e, "Ruleset load failed and has been rolled back");
+                catch (Exception e)
+                {
+                    Rulesets.RulesetStore.LogRulesetFailure(r.NewValue, e);
+                }
             }
 
             if (instance == null)
@@ -682,7 +682,7 @@ namespace osu.Game
             }
             catch (Exception e)
             {
-                Logger.Error(e, $"Could not load mods for \"{instance.RulesetInfo.Name}\" ruleset. Current ruleset has been rolled back.");
+                Rulesets.RulesetStore.LogRulesetFailure(r.NewValue, e);
                 revertRulesetChange();
                 return;
             }

--- a/osu.Game/Overlays/Settings/Sections/RulesetSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/RulesetSection.cs
@@ -1,12 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Framework.Logging;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Rulesets;
@@ -34,9 +34,9 @@ namespace osu.Game.Overlays.Settings.Sections
                     if (section != null)
                         Add(section);
                 }
-                catch
+                catch (Exception e)
                 {
-                    Logger.Log($"Failed to load ruleset settings for {ruleset.RulesetInfo.Name}. Please check for an update from the developer.", level: LogLevel.Error);
+                    RulesetStore.LogRulesetFailure(ruleset.RulesetInfo, e);
                 }
             }
         }

--- a/osu.Game/Overlays/Settings/SettingsFooter.cs
+++ b/osu.Game/Overlays/Settings/SettingsFooter.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Logging;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -72,9 +72,9 @@ namespace osu.Game.Overlays.Settings
 
                     modes.Add(icon);
                 }
-                catch
+                catch (Exception e)
                 {
-                    Logger.Log($"Could not create ruleset icon for {ruleset.Name}. Please check for an update from the developer.", level: LogLevel.Error);
+                    RulesetStore.LogRulesetFailure(ruleset, e);
                 }
             }
         }

--- a/osu.Game/Rulesets/RealmRulesetStore.cs
+++ b/osu.Game/Rulesets/RealmRulesetStore.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets
                     catch (Exception ex)
                     {
                         r.Available = false;
-                        LogFailedLoad(r.Name, ex);
+                        LogRulesetFailure(r, ex);
                     }
                 }
 

--- a/osu.Game/Rulesets/RulesetSelector.cs
+++ b/osu.Game/Rulesets/RulesetSelector.cs
@@ -3,9 +3,9 @@
 
 #nullable disable
 
-using osu.Framework.Graphics.UserInterface;
+using System;
 using osu.Framework.Allocation;
-using osu.Framework.Logging;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Extensions;
 
 namespace osu.Game.Rulesets
@@ -31,9 +31,9 @@ namespace osu.Game.Rulesets
                 {
                     AddItem(ruleset);
                 }
-                catch
+                catch (Exception e)
                 {
-                    Logger.Log($"Could not create ruleset icon for {ruleset.Name}. Please check for an update from the developer.", level: LogLevel.Error);
+                    RulesetStore.LogRulesetFailure(ruleset, e);
                 }
             }
         }

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Rulesets
             }
             catch (Exception e)
             {
-                LogFailedLoad(filename, e);
+                logRulesetFailure(filename, e);
             }
 
             return null;
@@ -169,7 +169,7 @@ namespace osu.Game.Rulesets
             }
             catch (Exception e)
             {
-                LogFailedLoad(assembly.GetName().Name!.Split('.').Last(), e);
+                logRulesetFailure(assembly.GetName().Name!.Split('.').Last(), e);
             }
         }
 
@@ -184,10 +184,12 @@ namespace osu.Game.Rulesets
             AppDomain.CurrentDomain.AssemblyResolve -= resolveRulesetDependencyAssembly;
         }
 
-        protected void LogFailedLoad(string name, Exception exception)
+        public static void LogRulesetFailure(RulesetInfo ruleset, Exception e) => logRulesetFailure(ruleset.Name, e);
+
+        private static void logRulesetFailure(string name, Exception exception)
         {
-            Logger.Log($"Could not load ruleset \"{name}\". Please check for an update from the developer.", level: LogLevel.Error);
-            Logger.Log($"Ruleset load failed: {exception}");
+            Logger.Log($"An issue with ruleset \"{name}\" occurred. Please check for an update from the developer.", level: LogLevel.Error);
+            Logger.Log(exception.ToString());
         }
 
         #region Implementation of IRulesetStore

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Framework.Timing;
 using osu.Framework.Utils;
@@ -342,9 +341,9 @@ namespace osu.Game.Screens.Menu
 
                             Add(icon);
                         }
-                        catch
+                        catch (Exception e)
                         {
-                            Logger.Log($"Could not create ruleset icon for {ruleset.Name}. Please check for an update from the developer.", level: LogLevel.Error);
+                            RulesetStore.LogRulesetFailure(ruleset, e);
                         }
                     }
                 }


### PR DESCRIPTION
Supersedes and closes https://github.com/ppy/osu/pull/36420.

Intentionally not using error output level because that would surface to user/sentry.