### PR TITLE
Fix missing `EditorBeatmap` disposal in editor

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -499,6 +499,8 @@ namespace osu.Game.Screens.Edit
 
         protected override void Dispose(bool isDisposing)
         {
+            editorBeatmap?.Dispose();
+
             base.Dispose(isDisposing);
 
             // redundant (should have happened via a `resetTrack()` call in `OnExiting()`), but done for safety


### PR DESCRIPTION
Missed in https://github.com/ppy/osu/pull/36190.

Caught through CI failures like [this one](https://github.com/ppy/osu/actions/runs/21238110652/job/61110112412?pr=36404#step:5:21) or [this one](https://github.com/ppy/osu/actions/runs/21216676973/job/61039650053#step:5:21).

I'd hope this is enough and I don't have to dig further.

I have a distinct feeling of checking whether anything was calling that disposal but it might be a confabulation, or it also might have been me getting confused because F12'ing a `Dispose()` method is completely useless due to it being an override of `Drawable`'s virtual disposal and therefore it pulls up a gazillion irrelevant usages, and you can't even do the `new` trick for whatever reason.