### PR TITLE
Fix beatmap samples with incorrect 1 sample set suffix in the filename being shown in setup tab as belonging to custom sample bank 1

### DIFF
--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Screens.Edit
 
                         if (string.IsNullOrEmpty(indexString))
                             index = 1;
-                        if (int.TryParse(indexString, out int parsed))
+                        if (int.TryParse(indexString, out int parsed) && parsed >= 2)
                             index = parsed;
 
                         if (!index.HasValue)


### PR DESCRIPTION
To explain on the wordy and probably incoherent title: The patient zero for this was the following discord report: https://discord.com/channels/188630481301012481/1097318920991559880/1463029073998774375

After information extraction, it turned out that the user manually used the "Edit externally..." feature to rename a sample to `normal-hitnormal1.mp3`, thinking (logically, to be fair), that the 1 bank works the same way that all the others do.

It doesn't, samples in the 1 bank do not have a numerical suffix in the filename - but the logic retrieving the sample sets to display in the setup tab was not checking that, leading to confusion wherein a sample would only "work" in the setup tab but not in the actual editor composer.

Can be tested with [the beatmap provided by the user](https://discord.com/channels/188630481301012481/1097318920991559880/1463110516573470774).