### PR TITLE
Show first two slider repeats with the rest of the combo in Freeze Frame mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -60,14 +60,22 @@ namespace osu.Game.Rulesets.Osu.Mods
                 if (osuObject is not Spinner)
                     osuObject.TimePreempt += osuObject.StartTime - lastNewComboTime;
 
+                int repeatCount = 0;
+
                 foreach (var nested in osuObject.NestedHitObjects.OfType<OsuHitObject>())
                 {
                     switch (nested)
                     {
-                        //Freezing the SliderTicks doesnt play well with snaking sliders
+                        // Freezing the SliderTicks doesnt play well with snaking sliders
                         case SliderTick:
-                        //SliderRepeat wont layer correctly if preempt is changed.
+                            break;
+
                         case SliderRepeat:
+                            if (repeatCount > 2)
+                                break;
+
+                            applyFadeInAdjustment(nested);
+                            repeatCount++;
                             break;
 
                         default:


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/95b19bdb-12c5-4ee7-b7e2-f9098aecd2fa

After:

https://github.com/user-attachments/assets/937081c5-92cb-4bea-a774-e53afbdbb1fb

---

This is a subjective diff and can be closed on the spot with no discussion if deemed incorrect. I mostly just want to get it off my list of unresolved forum threads.

The catalyst for this change is [this thread](https://osu.ppy.sh/community/forums/topics/2171493?n=1), wherein the complaint is that you can get jumpscared by a slider repeat in a combo because the slider repeats do not fade in with the rest of the combo. Which means that you don't immediately know whether a slider will need to be repeated or not and you have to watch out for potential slider repeats fading in, which could happen at an *arbitrary* time because it's still dependent on the map's original AR.

This seems pretty anti-user so I made it fade in with the rest of the combo. The original comment cited "broken layering" which I guess refers to the fact that sliders can repeat *more* than once and the second repeat will show *under the slider head*. It's pretty broken, sure, but I don't think it's *that* bad, and I *do* think that it's better than the current behaviour.

The reason it shows only the first two repeats is that there's no point in showing more for reasons that are hopefully obvious.