### PR TITLE
Locally schedule beatmap skin change callbacks to ensure they fire at valid times

### DIFF
--- a/osu.Game/Screens/Edit/Components/FormSampleSet.cs
+++ b/osu.Game/Screens/Edit/Components/FormSampleSet.cs
@@ -284,7 +284,7 @@ namespace osu.Game.Screens.Edit.Components
                 triangles.Colour = ColourInfo.GradientVertical(triangleGradientSecondColour.Value, BackgroundColour);
             }
 
-            private void recycleSamples()
+            private void recycleSamples() => Schedule(() =>
             {
                 if (hoverSounds?.Parent == this)
                 {
@@ -306,7 +306,7 @@ namespace osu.Game.Screens.Edit.Components
                 {
                     sample = null;
                 }
-            }
+            });
 
             protected override bool OnHover(HoverEvent e)
             {

--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -20,6 +20,12 @@ namespace osu.Game.Screens.Edit
     /// </summary>
     public class EditorBeatmapSkin : ISkin, IDisposable
     {
+        /// <summary>
+        /// Invoked when the beatmap skin changes.
+        /// This event is not locally scheduled to update thread or otherwise marshalled
+        /// in a way that would prevent invocation of a callback registered by a potentially-now-disposed caller.
+        /// Callers are expected to schedule locally as required.
+        /// </summary>
         public event Action? BeatmapSkinChanged;
 
         /// <summary>

--- a/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
+++ b/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.Edit
             base.LoadComplete();
 
             if (beatmapSkin != null)
-                beatmapSkin.BeatmapSkinChanged += TriggerSourceChanged;
+                beatmapSkin.BeatmapSkinChanged += triggerSourceChanged;
         }
 
         protected override void Dispose(bool isDisposing)
@@ -32,7 +32,9 @@ namespace osu.Game.Screens.Edit
             base.Dispose(isDisposing);
 
             if (beatmapSkin != null)
-                beatmapSkin.BeatmapSkinChanged -= TriggerSourceChanged;
+                beatmapSkin.BeatmapSkinChanged -= triggerSourceChanged;
         }
+
+        private void triggerSourceChanged() => Schedule(TriggerSourceChanged);
     }
 }

--- a/osu.Game/Screens/Edit/Setup/FormSampleSetChooser.cs
+++ b/osu.Game/Screens/Edit/Setup/FormSampleSetChooser.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Edit.Setup
 
             populateItems();
             if (beatmapSkin != null)
-                beatmapSkin.BeatmapSkinChanged += populateItems;
+                beatmapSkin.BeatmapSkinChanged += scheduleItemPopulation;
 
             Current.Value = Items.First(i => i?.SampleSetIndex > 0);
             Current.BindValueChanged(val =>
@@ -53,6 +53,8 @@ namespace osu.Game.Screens.Edit.Setup
             items.Add(new EditorBeatmapSkin.SampleSet(-1, "Add new..."));
             Items = items;
         }
+
+        private void scheduleItemPopulation() => Schedule(populateItems);
 
         protected override LocalisableString GenerateItemText(EditorBeatmapSkin.SampleSet? item)
         {
@@ -88,7 +90,7 @@ namespace osu.Game.Screens.Edit.Setup
         protected override void Dispose(bool isDisposing)
         {
             if (beatmapSkin != null)
-                beatmapSkin.BeatmapSkinChanged -= populateItems;
+                beatmapSkin.BeatmapSkinChanged -= scheduleItemPopulation;
 
             base.Dispose(isDisposing);
         }


### PR DESCRIPTION
See CI failures like https://github.com/ppy/osu/actions/runs/21238110652/job/61110112412?pr=36404#step:5:21.

Last attempt was https://github.com/ppy/osu/pull/36424 wherein I claimed "missing disposal" but I forgot that `EditorBeatmap` is a component and is `AddInternal`'d:

https://github.com/ppy/osu/blob/7cc025d8f4a579a6b109330d5fe80d8dee94639c/osu.Game/Screens/Edit/Editor.cs#L300

Hopefully works this time. Sample size of n=1 from my fork says maybe.