### PR TITLE
Fix random spin sample playing multiple times in the same frame

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapCarousel.cs
@@ -959,7 +959,9 @@ namespace osu.Game.Screens.SelectV2
         private readonly List<GroupedBeatmap> randomHistory = new List<GroupedBeatmap>();
 
         private Sample? spinSample;
+        private SampleChannel? spinSampleChannel;
         private Sample? randomSelectSample;
+        private SampleChannel? randomSelectSampleChannel;
 
         public bool NextRandom()
         {
@@ -1142,15 +1144,17 @@ namespace osu.Game.Screens.SelectV2
 
         private void playSpinSample(double distance)
         {
-            var chan = spinSample?.GetChannel();
+            spinSampleChannel?.Stop();
+            spinSampleChannel = spinSample?.GetChannel();
 
-            if (chan != null)
+            if (spinSampleChannel != null)
             {
-                chan.Frequency.Value = 1f + Math.Clamp(distance / 200, 0, 1);
-                chan.Play();
+                spinSampleChannel.Frequency.Value = 1f + Math.Clamp(distance / 200, 0, 1);
+                spinSampleChannel.Play();
             }
 
-            randomSelectSample?.Play();
+            randomSelectSampleChannel?.Stop();
+            randomSelectSampleChannel = randomSelectSample?.Play();
         }
 
         #endregion


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26497

When pressing the random button (F2) rapidly in song select, the spin/select samples could play multiple times in the same frame, causing the sound to stack and become louder.

Fixes the issue by stopping any currently playing sample channel before starting a new one.