### PR TITLE
Fix crash when clicking panels during recycling

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -96,6 +96,23 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestClickExpiredPanel()
+        {
+            CreateCarousel();
+
+            AddStep("set eager loading very low", () =>
+            {
+                Carousel.DistanceOffscreenToPreload = -100;
+            });
+
+            AddBeatmaps(50, 10);
+
+            AddUntilStep("wait for panels", () => Carousel.ChildrenOfType<Panel>().Any());
+
+            AddRepeatStep("click last panel", () => Carousel.ChildrenOfType<Panel>().FirstOrDefault()?.TriggerClick(), 20);
+        }
+
+        [Test]
         public void TestHighChurnUpdatesStillShowsPanels()
         {
             ScheduledDelegate updateTask = null!;

--- a/osu.Game/Screens/Select/Panel.cs
+++ b/osu.Game/Screens/Select/Panel.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Screens.Select
 
         protected const float DURATION = 400;
 
+        public override bool HandlePositionalInput => Item != null;
+
         protected float PanelXOffset { get; init; }
 
         private Container backgroundContainer = null!;

--- a/osu.Game/Screens/Select/Panel.cs
+++ b/osu.Game/Screens/Select/Panel.cs
@@ -364,7 +364,8 @@ namespace osu.Game.Screens.Select
                 if (ReferenceEquals(item, value))
                     return;
 
-                // If a new item is set and we already have an item, this is a case of reuse.
+                // If a new item is set and we already have an item, this is a special case of reuse.
+                // See https://github.com/ppy/osu/blob/033e13cb3b79e6195ddcd9f659b04095aa52fd2f/osu.Game/Graphics/Carousel/Carousel.cs#L1071
                 // To keep things simple, assume that we need to do a full refresh.
                 //
                 // In the future, this could be more contextual and check whether the associated model has actually changed.

--- a/osu.Game/Screens/Select/Panel.cs
+++ b/osu.Game/Screens/Select/Panel.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Screens.Select
 
         protected const float DURATION = 400;
 
-        public override bool HandlePositionalInput => Item != null;
-
         protected float PanelXOffset { get; init; }
 
         private Container backgroundContainer = null!;
@@ -267,7 +265,12 @@ namespace osu.Game.Screens.Select
 
         protected override bool OnClick(ClickEvent e)
         {
-            carousel?.Activate(Item!);
+            // Item may be set to null before actual `FreeAfterUse`.
+            // This is because Carousel knows to do this ahead of time and let the drawable fade/animate away.
+            // See https://github.com/ppy/osu/blob/033e13cb3b79e6195ddcd9f659b04095aa52fd2f/osu.Game/Graphics/Carousel/Carousel.cs#L1132-L1135.
+            if (item != null)
+                carousel?.Activate(item);
+
             return true;
         }
 


### PR DESCRIPTION
Closes #36246

This PR overrides `HandlePositionalInput` to reject all positional input when `Item` is null.