### PR TITLE
Fix logs failing to export after multiple failure attempts on file locks

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/General/QuickActionSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/QuickActionSettings.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 using (var zip = ZipArchive.Create())
                 {
                     foreach (string? f in logStorage.GetFiles(string.Empty, "*.log"))
-                        FileUtils.AttemptOperation(z => z.AddEntry(f, logStorage.GetStream(f), false), zip);
+                        FileUtils.AttemptOperation(z => z.AddEntry(f, logStorage.GetStream(f), closeStream: true), zip, throwOnFailure: false);
 
                     zip.SaveTo(outStream);
                 }

--- a/osu.Game/Overlays/Settings/Sections/General/QuickActionSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/QuickActionSettings.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 using (var zip = ZipArchive.Create())
                 {
                     foreach (string? f in logStorage.GetFiles(string.Empty, "*.log"))
-                        FileUtils.AttemptOperation(z => z.AddEntry(f, logStorage.GetStream(f), true), zip);
+                        FileUtils.AttemptOperation(z => z.AddEntry(f, logStorage.GetStream(f), false), zip);
 
                     zip.SaveTo(outStream);
                 }


### PR DESCRIPTION
Even if one file fails, we usually don't care and still want the archive to finish exporting.

Closes https://github.com/ppy/osu/issues/36446