### PR TITLE
Fix previous usernames display showing underneath other elements

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -240,6 +240,7 @@ namespace osu.Game.Tests.Visual.Online
             CoverUrl = TestResources.COVER_IMAGE_1,
             JoinDate = DateTimeOffset.Now.AddDays(-1),
             LastVisit = DateTimeOffset.Now,
+            PreviousUsernames = ["ForgetMe", "MySpaceLover", "i once was a man named enis", "mr anderson"],
             Groups = new[]
             {
                 new APIUserGroup { Colour = "#EB47D0", ShortName = "DEV", Name = "Developers" },

--- a/osu.Game/Overlays/Profile/Header/Components/PreviousUsernamesDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/PreviousUsernamesDisplay.cs
@@ -127,6 +127,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
             Hide();
         }
 
+        protected override bool OnHover(HoverEvent e) => true;
+        protected override bool OnClick(ClickEvent e) => true;
+
         protected override void OnHoverLost(HoverLostEvent e)
         {
             base.OnHoverLost(e);

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -48,7 +48,8 @@ namespace osu.Game.Overlays.Profile.Header
         private OsuSpriteText teamText = null!;
         private GroupBadgeFlow groupBadgeFlow = null!;
         private ToggleCoverButton coverToggle = null!;
-        private PreviousUsernamesDisplay previousUsernamesDisplay = null!;
+
+        public PreviousUsernamesDisplay PreviousUsernamesDisplay = new PreviousUsernamesDisplay();
 
         private Bindable<bool> coverExpanded = null!;
 
@@ -149,7 +150,7 @@ namespace osu.Game.Overlays.Profile.Header
                                                         new Container
                                                         {
                                                             // Intentionally use a zero-size container, else the fill flow will adjust to (and cancel) the upwards animation.
-                                                            Child = previousUsernamesDisplay = new PreviousUsernamesDisplay(),
+                                                            Child = PreviousUsernamesDisplay,
                                                         }
                                                     }
                                                 },
@@ -254,7 +255,7 @@ namespace osu.Game.Overlays.Profile.Header
             titleText.Text = user?.Title ?? string.Empty;
             titleText.Colour = Color4Extensions.FromHex(user?.Colour ?? "fff");
             groupBadgeFlow.User.Value = user;
-            previousUsernamesDisplay.User.Value = user;
+            PreviousUsernamesDisplay.User.Value = user;
         }
 
         private void updateCoverState()

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Overlays.Profile.Header
         private GroupBadgeFlow groupBadgeFlow = null!;
         private ToggleCoverButton coverToggle = null!;
 
-        public PreviousUsernamesDisplay PreviousUsernamesDisplay = new PreviousUsernamesDisplay();
+        public PreviousUsernamesDisplay PreviousUsernamesDisplay { get; } = new PreviousUsernamesDisplay();
 
         private Bindable<bool> coverExpanded = null!;
 

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Overlays.Profile
         private CentreHeaderContainer centreHeaderContainer;
         private DetailHeaderContainer detailHeaderContainer;
 
+        private TopHeaderContainer topHeaderContainer = null!;
+
         public ProfileHeader()
         {
             ContentSidePadding = WaveOverlayContainer.HORIZONTAL_PADDING;
@@ -43,7 +45,7 @@ namespace osu.Game.Overlays.Profile
             Direction = FillDirection.Vertical,
             Children = new Drawable[]
             {
-                new TopHeaderContainer
+                topHeaderContainer = new TopHeaderContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     User = { BindTarget = User },
@@ -74,6 +76,15 @@ namespace osu.Game.Overlays.Profile
                 },
             }
         };
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // This is basically a tooltip display on hover, so we should display above everything.
+            // If this ever breaks let's just trash the design and make it a standard tooltip.
+            AddInternal(topHeaderContainer.PreviousUsernamesDisplay.CreateProxy());
+        }
 
         protected override OverlayTitle CreateTitle() => new ProfileHeaderTitle();
 


### PR DESCRIPTION
Closes #36379.

Notably, does not resolve elements beneath it potentially getting input preference (proxy doesn't affect input handling).

<img width="721" height="291" alt="osu Game Tests 2026-01-26 at 06 39 44" src="https://github.com/user-attachments/assets/ad902bfa-2264-40c0-853e-8582e32c7bae" />

Can't see a simple way around this.