### PR TITLE
First pass adjustments to new settings design

### DIFF
--- a/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
+++ b/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
 
 namespace osu.Game.Graphics.Cursor
 {
@@ -93,10 +94,10 @@ namespace osu.Game.Graphics.Cursor
             protected override void PopIn()
             {
                 instantMovement |= !IsPresent;
-                this.FadeIn(500, Easing.OutQuint);
+                this.FadeIn(300, Easing.OutQuint);
             }
 
-            protected override void PopOut() => this.Delay(150).FadeOut(500, Easing.OutQuint);
+            protected override void PopOut() => this.Delay(150).FadeOut(300, Easing.OutQuint);
 
             public override void Move(Vector2 pos)
             {
@@ -107,7 +108,8 @@ namespace osu.Game.Graphics.Cursor
                 }
                 else
                 {
-                    this.MoveTo(pos, 200, Easing.OutQuint);
+                    // This method is called every frame so we can do this safely here.
+                    Position = Interpolation.ValueAt(Time.Elapsed, Position, pos, 0, 120, Easing.OutQuint);
                 }
             }
         }

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -1,13 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
@@ -21,10 +18,8 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public partial class HoverClickSounds : HoverSounds
     {
-        public Bindable<bool> Enabled = new Bindable<bool>(true);
-
-        private Sample sampleClick;
-        private Sample sampleClickDisabled;
+        private Sample? sampleClick;
+        private Sample? sampleClickDisabled;
 
         private readonly MouseButton[] buttons;
 
@@ -36,7 +31,7 @@ namespace osu.Game.Graphics.UserInterface
         /// Array of button codes which should trigger the click sound.
         /// If this optional parameter is omitted or set to <code>null</code>, the click sound will only be played on left click.
         /// </param>
-        public HoverClickSounds(HoverSampleSet sampleSet = HoverSampleSet.Default, MouseButton[] buttons = null)
+        public HoverClickSounds(HoverSampleSet sampleSet = HoverSampleSet.Default, MouseButton[]? buttons = null)
             : base(sampleSet)
         {
             this.buttons = buttons ?? new[] { MouseButton.Left };
@@ -58,14 +53,6 @@ namespace osu.Game.Graphics.UserInterface
                 PlayClickSample();
 
             return base.OnClick(e);
-        }
-
-        public override void PlayHoverSample()
-        {
-            if (!Enabled.Value)
-                return;
-
-            base.PlayHoverSample();
         }
 
         public void PlayClickSample()

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -6,6 +6,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
@@ -18,6 +19,8 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public partial class HoverSounds : HoverSampleDebounceComponent
     {
+        public readonly Bindable<bool> Enabled = new Bindable<bool>(true);
+
         private Sample sampleHover;
 
         protected readonly HoverSampleSet SampleSet;
@@ -37,6 +40,9 @@ namespace osu.Game.Graphics.UserInterface
 
         public override void PlayHoverSample()
         {
+            if (!Enabled.Value)
+                return;
+
             sampleHover.Frequency.Value = 0.98 + RNG.NextDouble(0.04);
             sampleHover.Play();
         }

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Graphics.UserInterface
             Margin = new MarginPadding { Left = 2 },
         };
 
+        protected bool DrawBorder { get; init; }
+
         private OsuCaret? caret;
 
         private bool selectionStarted;
@@ -256,7 +258,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void OnFocus(FocusEvent e)
         {
-            if (Masking)
+            if (DrawBorder)
                 BorderThickness = 3;
 
             base.OnFocus(e);
@@ -268,7 +270,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void OnFocusLost(FocusLostEvent e)
         {
-            if (Masking)
+            if (DrawBorder)
                 BorderThickness = 0;
 
             base.OnFocusLost(e);

--- a/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
@@ -9,11 +9,9 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
-using osu.Framework.Utils;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -70,8 +68,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
-        private Container content = null!;
-        private Box background = null!;
+        private FormControlBackground background = null!;
         private OsuTextFlowContainer text = null!;
         private Button button = null!;
 
@@ -81,7 +78,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            InternalChild = content = new Container
+            InternalChild = new Container
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
@@ -90,17 +87,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 CornerExponent = 2.5f,
                 Children = new Drawable[]
                 {
-                    background = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colourProvider.Background5,
-                    },
-                    new TrianglesV2
-                    {
-                        SpawnRatio = 0.5f,
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = ColourInfo.GradientVertical(colourProvider.Background4, colourProvider.Background5),
-                    },
+                    background = new FormControlBackground(),
                     new HoverClickSounds(HoverSampleSet.Button)
                     {
                         Enabled = { BindTarget = Enabled },
@@ -175,7 +162,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             if (Enabled.Value)
             {
-                background.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
+                background.Flash();
                 button.TriggerClick();
             }
 
@@ -186,19 +173,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             text.Colour = Enabled.Value ? colourProvider.Content1 : colourProvider.Background1;
 
-            background.FadeColour(IsHovered
-                ? ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4)
-                : colourProvider.Background5, 200, Easing.OutQuint);
+            background.StyleHovered = IsHovered;
+            background.StyleDisabled = !Enabled.Value;
 
-            content.BorderThickness = IsHovered ? 2 : 0;
-
-            if (BackgroundColour != null)
-            {
-                button.BackgroundColour = BackgroundColour.Value;
-                content.BorderColour = Enabled.Value ? BackgroundColour.Value : Interpolation.ValueAt(0.75, BackgroundColour.Value, colourProvider.Dark1, 0, 1);
-            }
-            else
-                content.BorderColour = Enabled.Value ? colourProvider.Light4 : colourProvider.Dark1;
+            // TODO: Support BackgroundColour?
         }
 
         public partial class Button : OsuButton

--- a/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
@@ -88,10 +88,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Children = new Drawable[]
                 {
                     background = new FormControlBackground(),
-                    new HoverClickSounds(HoverSampleSet.Button)
-                    {
-                        Enabled = { BindTarget = Enabled },
-                    },
                     new Container
                     {
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
@@ -169,8 +169,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             text.Colour = Enabled.Value ? colourProvider.Content1 : colourProvider.Background1;
 
-            background.StyleHovered = IsHovered;
-            background.StyleDisabled = !Enabled.Value;
+            if (!Enabled.Value)
+                background.VisualStyle = VisualStyle.Disabled;
+            else if (IsHovered)
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
 
             // TODO: Support BackgroundColour?
         }

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -15,10 +15,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Localisation;
 using osu.Game.Overlays;
-using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -44,7 +41,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private Box background = null!;
         private FormFieldCaption caption = null!;
-        private OsuSpriteText text = null!;
 
         private Sample? sampleChecked;
         private Sample? sampleUnchecked;
@@ -77,23 +73,19 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     Padding = new MarginPadding(9),
                     Children = new Drawable[]
                     {
-                        new FillFlowContainer
+                        new Container
                         {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Direction = FillDirection.Vertical,
                             Padding = new MarginPadding { Right = SwitchButton.WIDTH + 5 },
-                            Spacing = new Vector2(0f, 4f),
                             Children = new Drawable[]
                             {
                                 caption = new FormFieldCaption
                                 {
                                     Caption = Caption,
                                     TooltipText = HintText,
-                                },
-                                text = new OsuSpriteText
-                                {
-                                    RelativeSizeAxes = Axes.X,
                                 },
                             },
                         },
@@ -159,9 +151,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void updateState()
         {
             caption.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
-            text.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
-
-            text.Text = Current.Value ? CommonStrings.Enabled : CommonStrings.Disabled;
 
             // use FadeColour to override any existing colour transform (i.e. FlashColour on click).
             background.FadeColour(IsHovered

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -9,9 +9,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
@@ -39,7 +37,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public LocalisableString HintText { get; init; }
 
-        private Box background = null!;
+        private FormControlBackground background = null!;
         private FormFieldCaption caption = null!;
 
         private Sample? sampleChecked;
@@ -55,17 +53,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Masking = true;
-            CornerRadius = 5;
-            CornerExponent = 2.5f;
-
             InternalChildren = new Drawable[]
             {
-                background = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
+                background = new FormControlBackground(),
                 new Container
                 {
                     RelativeSizeAxes = Axes.X,
@@ -111,7 +101,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 updateState();
                 playSamples();
-                background.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
+                background.Flash();
 
                 ValueChanged?.Invoke();
             });
@@ -151,14 +141,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void updateState()
         {
             caption.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
-
-            // use FadeColour to override any existing colour transform (i.e. FlashColour on click).
-            background.FadeColour(IsHovered
-                ? ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4)
-                : colourProvider.Background5);
-
-            BorderThickness = IsHovered ? 2 : 0;
-            BorderColour = Current.Disabled ? colourProvider.Dark1 : colourProvider.Light4;
+            background.StyleHovered = IsHovered;
+            background.StyleDisabled = IsDisabled;
         }
 
         public IEnumerable<LocalisableString> FilterTerms => Caption.Yield();

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -141,8 +141,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void updateState()
         {
             caption.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
-            background.StyleHovered = IsHovered;
-            background.StyleDisabled = IsDisabled;
+
+            if (IsDisabled)
+                background.VisualStyle = VisualStyle.Disabled;
+            else if (IsHovered)
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
         }
 
         public IEnumerable<LocalisableString> FilterTerms => Caption.Yield();

--- a/osu.Game/Graphics/UserInterfaceV2/FormColourPalette.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormColourPalette.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public BindableBool CanAdd { get; } = new BindableBool(true);
 
-        private Box background = null!;
+        private FormControlBackground background = null!;
         private FormFieldCaption caption = null!;
         private FillFlowContainer flow = null!;
         private RoundedButton addButton = null!;
@@ -47,16 +47,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Masking = true;
-            CornerRadius = 5;
-
             InternalChildren = new Drawable[]
             {
-                background = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
+                background = new FormControlBackground(),
                 new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
@@ -140,13 +133,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateState()
         {
-            background.Colour = colourProvider.Background5;
             caption.Colour = colourProvider.Content2;
 
-            BorderThickness = IsHovered ? 2 : 0;
-
-            if (IsHovered)
-                BorderColour = colourProvider.Light4;
+            background.StyleHovered = IsHovered;
         }
 
         private void updateColours()

--- a/osu.Game/Graphics/UserInterfaceV2/FormColourPalette.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormColourPalette.cs
@@ -135,7 +135,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             caption.Colour = colourProvider.Content2;
 
-            background.StyleHovered = IsHovered;
+            if (IsHovered)
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
         }
 
         private void updateColours()

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK.Graphics;
 
@@ -52,6 +53,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private readonly Box box;
 
+        private readonly HoverSounds sounds;
+
         public FormControlBackground()
         {
             RelativeSizeAxes = Axes.Both;
@@ -69,6 +72,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     Colour = Color4.White,
                     RelativeSizeAxes = Axes.Both,
                 },
+                sounds = new HoverSounds(),
             };
         }
 
@@ -87,6 +91,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateStyling()
         {
+            sounds.Enabled.Value = !styleDisabled;
+
             ColourInfo colour = colourProvider.Background4.Darken(0.1f);
             ColourInfo borderColour = colourProvider.Light4;
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -59,6 +60,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
             CornerRadius = 5;
             CornerExponent = 2.5f;
 
+            BorderThickness = 2.5f;
+
             InternalChildren = new Drawable[]
             {
                 box = new Box
@@ -84,8 +87,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateStyling()
         {
-            ColourInfo colour = colourProvider.Background5;
+            ColourInfo colour = colourProvider.Background4.Darken(0.1f);
             ColourInfo borderColour = colourProvider.Light4;
+
             bool border = false;
 
             if (styleDisabled)
@@ -105,10 +109,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 border = true;
             }
 
-            BorderThickness = border ? 2 : 0;
-            BorderColour = borderColour;
+            this.TransformTo(nameof(BorderColour), border ? borderColour : colour, 250, Easing.OutQuint);
 
-            box.FadeColour(colour, 500, Easing.OutQuint);
+            box.FadeColour(colour, 250, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -18,36 +19,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public const float CORNER_EXPONENT = 2.5f;
         public const float BORDER_THICKNESS = 2.5f;
 
-        private bool styleDisabled;
+        private VisualStyle visualStyle;
 
-        public bool StyleDisabled
+        public VisualStyle VisualStyle
         {
+            get => visualStyle;
             set
             {
-                styleDisabled = value;
-                updateStyling();
-            }
-        }
-
-        private bool styleFocused;
-
-        public bool StyleFocused
-        {
-            set
-            {
-                styleFocused = value;
-                updateStyling();
-            }
-        }
-
-        private bool styleHovered;
-
-        public bool StyleHovered
-        {
-            set
-            {
-                styleHovered = value;
-                updateStyling();
+                visualStyle = value;
+                updateStyle();
             }
         }
 
@@ -83,7 +63,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             base.LoadComplete();
 
-            updateStyling();
+            updateStyle();
             FinishTransforms(true);
         }
 
@@ -92,35 +72,54 @@ namespace osu.Game.Graphics.UserInterfaceV2
             box.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
         }
 
-        private void updateStyling()
+        private void updateStyle()
         {
-            sounds.Enabled.Value = !styleDisabled;
+            sounds.Enabled.Value = visualStyle != VisualStyle.Disabled;
 
-            ColourInfo colour = colourProvider.Background4.Darken(0.1f);
-            ColourInfo borderColour = colourProvider.Light4;
+            ColourInfo colour;
+            ColourInfo borderColour;
 
             bool border = false;
 
-            if (styleDisabled)
+            switch (visualStyle)
             {
-                colour = colourProvider.Background4;
-                borderColour = colourProvider.Dark1;
-            }
-            else if (styleFocused)
-            {
-                colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
-                border = true;
-                borderColour = colourProvider.Highlight1;
-            }
-            else if (styleHovered)
-            {
-                colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
-                border = true;
+                case VisualStyle.Normal:
+                    colour = colourProvider.Background4.Darken(0.1f);
+                    borderColour = colourProvider.Light4;
+                    break;
+
+                case VisualStyle.Disabled:
+                    colour = colourProvider.Background4;
+                    borderColour = colourProvider.Dark1;
+                    break;
+
+                case VisualStyle.Hovered:
+                    colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
+                    borderColour = colourProvider.Light4;
+                    border = true;
+                    break;
+
+                case VisualStyle.Focused:
+                    colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
+                    border = true;
+                    borderColour = colourProvider.Highlight1;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
 
             this.TransformTo(nameof(BorderColour), border ? borderColour : colour, 250, Easing.OutQuint);
 
             box.FadeColour(colour, 250, Easing.OutQuint);
         }
+    }
+
+    public enum VisualStyle
+    {
+        Normal,
+        Disabled,
+        Hovered,
+        Focused
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class FormControlBackground : CompositeDrawable
     {
+        public const float CORNER_EXPONENT = 2.5f;
+        public const float BORDER_THICKNESS = 2.5f;
+
         private bool styleDisabled;
 
         public bool StyleDisabled
@@ -61,9 +64,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             Masking = true;
             CornerRadius = 5;
-            CornerExponent = 2.5f;
 
-            BorderThickness = 2.5f;
+            CornerExponent = CORNER_EXPONENT;
+            BorderThickness = BORDER_THICKNESS;
 
             InternalChildren = new Drawable[]
             {

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Overlays;
+using osuTK.Graphics;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public partial class FormControlBackground : CompositeDrawable
+    {
+        private bool styleDisabled;
+
+        public bool StyleDisabled
+        {
+            set
+            {
+                styleDisabled = value;
+                updateStyling();
+            }
+        }
+
+        private bool styleFocused;
+
+        public bool StyleFocused
+        {
+            set
+            {
+                styleFocused = value;
+                updateStyling();
+            }
+        }
+
+        private bool styleHovered;
+
+        public bool StyleHovered
+        {
+            set
+            {
+                styleHovered = value;
+                updateStyling();
+            }
+        }
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private readonly Box box;
+
+        public FormControlBackground()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            Masking = true;
+            CornerRadius = 5;
+            CornerExponent = 2.5f;
+
+            InternalChildren = new Drawable[]
+            {
+                box = new Box
+                {
+                    Colour = Color4.White,
+                    RelativeSizeAxes = Axes.Both,
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            updateStyling();
+            FinishTransforms(true);
+        }
+
+        public void Flash()
+        {
+            box.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
+        }
+
+        private void updateStyling()
+        {
+            ColourInfo colour = colourProvider.Background5;
+            ColourInfo borderColour = colourProvider.Light4;
+            bool border = false;
+
+            if (styleDisabled)
+            {
+                colour = colourProvider.Background4;
+                borderColour = colourProvider.Dark1;
+            }
+            else if (styleFocused)
+            {
+                colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
+                border = true;
+                borderColour = colourProvider.Highlight1;
+            }
+            else if (styleHovered)
+            {
+                colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
+                border = true;
+            }
+
+            BorderThickness = border ? 2 : 0;
+            BorderColour = borderColour;
+
+            box.FadeColour(colour, 500, Easing.OutQuint);
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -246,9 +246,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 else
                     label.Alpha = 1;
 
-                background.StyleDisabled = Dropdown.Current.Disabled;
-                background.StyleHovered = IsHovered;
-                background.StyleFocused = dropdownOpen;
+                if (Dropdown.Current.Disabled)
+                    background.VisualStyle = VisualStyle.Disabled;
+                else if (dropdownOpen)
+                    background.VisualStyle = VisualStyle.Focused;
+                else if (IsHovered)
+                    background.VisualStyle = VisualStyle.Hovered;
+                else
+                    background.VisualStyle = VisualStyle.Normal;
             }
 
             private void updateChevron()

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -156,8 +156,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Masking = true;
                 CornerRadius = 5;
 
-                Margin = new MarginPadding { Bottom = header_menu_spacing };
-
                 // We use our own background for more control.
                 Background.Alpha = 0;
 
@@ -290,7 +288,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 ItemsContainer.Padding = new MarginPadding(9);
 
-                MaskingContainer.BorderThickness = 2;
+                MaskingContainer.BorderThickness = FormControlBackground.BORDER_THICKNESS;
+                MaskingContainer.CornerExponent = FormControlBackground.CORNER_EXPONENT;
                 MaskingContainer.BorderColour = colourProvider.Highlight1;
             }
 
@@ -301,13 +300,17 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 // there's negative bottom margin applied on the whole dropdown control to remove extra spacing when the menu is closed.
                 // however, when the menu is open, we want spacing between the menu and the next control below it. therefore apply bottom margin here.
                 // we use a transform to keep the open animation smooth while margin is adjusted.
-                this.TransformTo(nameof(Margin), new MarginPadding { Bottom = header_menu_spacing }, 300, Easing.OutQuint);
+                this.TransformTo(nameof(Margin), new MarginPadding
+                {
+                    Top = header_menu_spacing,
+                    Bottom = header_menu_spacing
+                }, 50, Easing.OutQuint);
             }
 
             protected override void AnimateClose()
             {
                 base.AnimateClose();
-                this.TransformTo(nameof(Margin), new MarginPadding { Bottom = 0 }, 300, Easing.OutQuint);
+                this.TransformTo(nameof(Margin), new MarginPadding { Bottom = 0 }, 300);
             }
         }
     }

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             private FormFieldCaption caption = null!;
             private OsuSpriteText label = null!;
             private SpriteIcon chevron = null!;
+            private FormControlBackground background = null!;
 
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -157,37 +158,49 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                 Margin = new MarginPadding { Bottom = header_menu_spacing };
 
-                Foreground.Padding = new MarginPadding(9);
+                // We use our own background for more control.
+                Background.Alpha = 0;
+
                 Foreground.Children = new Drawable[]
                 {
-                    new FillFlowContainer
+                    background = new FormControlBackground(),
+                    new Container
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(0, 4),
+                        Padding = new MarginPadding(9),
                         Children = new Drawable[]
                         {
-                            caption = new FormFieldCaption
-                            {
-                                Caption = Caption,
-                                TooltipText = HintText,
-                            },
-                            label = new TruncatingSpriteText
+                            new FillFlowContainer
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Padding = new MarginPadding { Right = 25 },
-                                AlwaysPresent = true,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(0, 4),
+                                Children = new Drawable[]
+                                {
+                                    caption = new FormFieldCaption
+                                    {
+                                        Caption = Caption,
+                                        TooltipText = HintText,
+                                    },
+                                    label = new TruncatingSpriteText
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        Padding = new MarginPadding { Right = 25 },
+                                        AlwaysPresent = true,
+                                    },
+                                }
+                            },
+                            chevron = new SpriteIcon
+                            {
+                                Icon = FontAwesome.Solid.ChevronDown,
+                                Anchor = Anchor.BottomRight,
+                                Origin = Anchor.BottomRight,
+                                Size = new Vector2(16),
+                                Margin = new MarginPadding { Right = 5 },
                             },
                         }
-                    },
-                    chevron = new SpriteIcon
-                    {
-                        Icon = FontAwesome.Solid.ChevronDown,
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Size = new Vector2(16),
-                        Margin = new MarginPadding { Right = 5 },
                     },
                 };
 
@@ -240,25 +253,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 else
                     label.Alpha = 1;
 
-                BorderThickness = IsHovered || dropdownOpen ? 2 : 0;
-
-                if (Dropdown.Current.Disabled)
-                    BorderColour = colourProvider.Dark1;
-                else
-                    BorderColour = dropdownOpen ? colourProvider.Highlight1 : colourProvider.Light4;
-
-                if (dropdownOpen)
-                    Background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
-                else if (IsHovered)
-                    Background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
-                else
-                    Background.Colour = colourProvider.Background5;
+                background.StyleDisabled = Dropdown.Current.Disabled;
+                background.StyleHovered = IsHovered;
+                background.StyleFocused = dropdownOpen;
             }
 
             private void updateChevron()
             {
                 bool open = Dropdown.Menu.State == MenuState.Open;
                 chevron.ScaleTo(open ? new Vector2(1f, -1f) : Vector2.One, 300, Easing.OutQuint);
+                chevron.MoveToY(open ? -chevron.DrawHeight : 0, 300, Easing.OutQuint);
             }
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -203,11 +203,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                         }
                     },
                 };
-
-                AddInternal(new HoverClickSounds
-                {
-                    Enabled = { BindTarget = Enabled },
-                });
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterfaceV2/FormFieldCaption.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFieldCaption.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            InternalChild = textFlow = new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(size: 12, weight: FontWeight.SemiBold))
+            InternalChild = textFlow = new OsuTextFlowContainer(t => t.Font = OsuFont.Style.Caption1)
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,

--- a/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
@@ -11,7 +11,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
@@ -70,7 +69,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public Container PreviewContainer { get; private set; } = null!;
 
-        private Box background = null!;
+        private FormControlBackground background = null!;
 
         private FormFieldCaption caption = null!;
         private OsuSpriteText placeholderText = null!;
@@ -93,16 +92,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Masking = true;
-            CornerRadius = 5;
-
             InternalChildren = new Drawable[]
             {
-                background = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
+                background = new FormControlBackground(),
                 PreviewContainer = new Container
                 {
                     RelativeSizeAxes = Axes.X,
@@ -194,7 +186,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             initialChooserPath = Current.Value?.DirectoryName;
             placeholderText.Alpha = Current.Value == null ? 1 : 0;
             filenameText.Text = Current.Value?.Name ?? string.Empty;
-            background.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
+            background.Flash();
         }
 
         protected override bool OnClick(ClickEvent e)
@@ -220,22 +212,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             caption.Colour = Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;
             filenameText.Colour = Current.Disabled || Current.Value == null ? colourProvider.Foreground1 : colourProvider.Content1;
 
-            if (!Current.Disabled)
-            {
-                BorderThickness = IsHovered || popoverState.Value == Visibility.Visible ? 2 : 0;
-                BorderColour = popoverState.Value == Visibility.Visible ? colourProvider.Highlight1 : colourProvider.Light4;
-
-                if (popoverState.Value == Visibility.Visible)
-                    background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
-                else if (IsHovered)
-                    background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
-                else
-                    background.Colour = colourProvider.Background5;
-            }
-            else
-            {
-                background.Colour = colourProvider.Background4;
-            }
+            background.StyleDisabled = Current.Disabled;
+            background.StyleFocused = popoverState.Value == Visibility.Visible;
+            background.StyleHovered = IsHovered;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
@@ -212,9 +212,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
             caption.Colour = Current.Disabled ? colourProvider.Foreground1 : colourProvider.Content2;
             filenameText.Colour = Current.Disabled || Current.Value == null ? colourProvider.Foreground1 : colourProvider.Content1;
 
-            background.StyleDisabled = Current.Disabled;
-            background.StyleFocused = popoverState.Value == Visibility.Visible;
-            background.StyleHovered = IsHovered;
+            if (Current.Disabled)
+                background.VisualStyle = VisualStyle.Disabled;
+            else if (popoverState.Value == Visibility.Visible)
+                background.VisualStyle = VisualStyle.Focused;
+            else if (IsHovered)
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -451,7 +451,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
             private Box leftBox = null!;
             private Box rightBox = null!;
             private InnerSliderNub nub = null!;
-            private HoverClickSounds sounds = null!;
             public const float NUB_WIDTH = 10;
 
             [Resolved]
@@ -496,7 +495,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             ResetToDefault = ResetToDefault,
                         }
                     },
-                    sounds = new HoverClickSounds()
                 };
             }
 
@@ -558,7 +556,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             private void updateState()
             {
-                sounds.Enabled.Value = !Current.Disabled;
                 rightBox.Colour = colourProvider.Background5;
 
                 Color4 leftColour = colourProvider.Light4;

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -22,6 +22,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
+using osuTK.Graphics;
 using Vector2 = osuTK.Vector2;
 
 namespace osu.Game.Graphics.UserInterfaceV2
@@ -325,8 +326,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             currentNumberInstantaneous.TriggerChange();
             current.Value = currentNumberInstantaneous.Value;
 
-            flashLayer.Colour = ColourInfo.GradientVertical(colourProvider.Dark2.Opacity(0), colourProvider.Dark2);
-            flashLayer.FadeOutFromOne(800, Easing.OutQuint);
+            background.Flash();
         }
 
         private void tryUpdateSliderFromTextBox()
@@ -502,7 +502,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             protected override void LoadComplete()
             {
                 base.LoadComplete();
+
                 Current.BindDisabledChanged(_ => updateState(), true);
+                FinishTransforms(true);
             }
 
             protected override void UpdateAfterChildren()
@@ -558,16 +560,22 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 sounds.Enabled.Value = !Current.Disabled;
                 rightBox.Colour = colourProvider.Background6;
 
+                Color4 leftColour;
+                Color4 nubColour;
+
                 if (Current.Disabled)
                 {
-                    leftBox.Colour = colourProvider.Dark3;
-                    nub.Colour = colourProvider.Dark1;
+                    leftColour = colourProvider.Dark3;
+                    nubColour = colourProvider.Dark1;
                 }
                 else
                 {
-                    leftBox.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Highlight1.Opacity(0.3f);
-                    nub.Colour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1 : colourProvider.Light4;
+                    leftColour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Highlight1.Opacity(0.3f);
+                    nubColour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1 : colourProvider.Light4;
                 }
+
+                leftBox.FadeColour(leftColour, 250, Easing.OutQuint);
+                nub.FadeColour(nubColour, 250, Easing.OutQuint);
             }
 
             protected override void UpdateValue(float value)

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -200,6 +200,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             Masking = true;
             CornerRadius = 5;
+            CornerExponent = 2.5f;
 
             InternalChildren = new Drawable[]
             {
@@ -558,20 +559,20 @@ namespace osu.Game.Graphics.UserInterfaceV2
             private void updateState()
             {
                 sounds.Enabled.Value = !Current.Disabled;
-                rightBox.Colour = colourProvider.Background6;
+                rightBox.Colour = colourProvider.Background5;
 
-                Color4 leftColour;
+                Color4 leftColour = colourProvider.Light4;
                 Color4 nubColour;
+
+                if (IsHovered || HasFocus || IsDragged)
+                    nubColour = colourProvider.Highlight1;
+                else
+                    nubColour = colourProvider.Highlight1.Darken(0.1f);
 
                 if (Current.Disabled)
                 {
-                    leftColour = colourProvider.Dark3;
-                    nubColour = colourProvider.Dark1;
-                }
-                else
-                {
-                    leftColour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Highlight1.Opacity(0.3f);
-                    nubColour = HasFocus || IsHovered || IsDragged ? colourProvider.Highlight1 : colourProvider.Light4;
+                    nubColour = nubColour.Darken(0.4f);
+                    leftColour = leftColour.Darken(0.4f);
                 }
 
                 leftBox.FadeColour(leftColour, 250, Easing.OutQuint);
@@ -580,7 +581,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             protected override void UpdateValue(float value)
             {
-                nub.MoveToX(value, 200, Easing.OutPow10);
+                nub.MoveToX(value, 250, Easing.OutElasticQuarter);
             }
 
             protected override bool Commit()
@@ -603,6 +604,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             [BackgroundDependencyLoader]
             private void load()
             {
+                CornerExponent = 2.5f;
                 Width = InnerSlider.NUB_WIDTH;
                 RelativeSizeAxes = Axes.Y;
                 RelativePositionAxes = Axes.X;

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public Func<T, LocalisableString> TooltipFormat { get; init; }
 
-        private Box background = null!;
+        private FormControlBackground background = null!;
         private Box flashLayer = null!;
         private FormTextBox.InnerTextBox textBox = null!;
         private OsuSpriteText valueLabel = null!;
@@ -202,11 +202,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             InternalChildren = new Drawable[]
             {
-                background = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
+                background = new FormControlBackground(),
                 flashLayer = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -398,19 +394,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             textBox.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content1;
             valueLabel.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content1;
 
-            BorderThickness = childHasFocus || IsHovered || slider.IsDragging.Value ? 2 : 0;
-
-            if (Current.Disabled)
-                BorderColour = colourProvider.Dark1;
-            else
-                BorderColour = childHasFocus ? colourProvider.Highlight1 : colourProvider.Light4;
-
-            if (childHasFocus)
-                background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
-            else if (IsHovered || slider.IsDragging.Value)
-                background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
-            else
-                background.Colour = colourProvider.Background5;
+            background.StyleDisabled = Current.Disabled;
+            background.StyleFocused = childHasFocus;
+            background.StyleHovered = IsHovered || slider.IsDragging.Value;
         }
 
         private void updateValueDisplay()

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -395,9 +395,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
             textBox.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content1;
             valueLabel.Colour = currentNumberInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content1;
 
-            background.StyleDisabled = Current.Disabled;
-            background.StyleFocused = childHasFocus;
-            background.StyleHovered = IsHovered || slider.IsDragging.Value;
+            if (Current.Disabled)
+                background.VisualStyle = VisualStyle.Disabled;
+            else if (childHasFocus)
+                background.VisualStyle = VisualStyle.Focused;
+            else if (IsHovered || slider.IsDragging.Value)
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
         }
 
         private void updateValueDisplay()

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -185,9 +185,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
             caption.Colour = disabled ? colourProvider.Background1 : colourProvider.Content2;
             textBox.Colour = disabled ? colourProvider.Foreground1 : colourProvider.Content1;
 
-            background.StyleDisabled = Current.Disabled;
-            background.StyleFocused = textBox.Focused.Value;
-            background.StyleHovered = IsHovered;
+            if (Current.Disabled)
+                background.VisualStyle = VisualStyle.Disabled;
+            else if (textBox.Focused.Value)
+                background.VisualStyle = VisualStyle.Focused;
+            else if (IsHovered)
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
         }
 
         internal partial class InnerTextBox : OsuTextBox

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public LocalisableString PlaceholderText { get; init; }
 
-        private Box background = null!;
+        private FormControlBackground background = null!;
         private Box flashLayer = null!;
         private InnerTextBox textBox = null!;
         private FormFieldCaption caption = null!;
@@ -92,17 +92,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Masking = true;
-            CornerRadius = 5;
-            CornerExponent = 2.5f;
-
             InternalChildren = new Drawable[]
             {
-                background = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
+                background = new FormControlBackground(),
                 flashLayer = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -193,19 +185,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             caption.Colour = disabled ? colourProvider.Background1 : colourProvider.Content2;
             textBox.Colour = disabled ? colourProvider.Foreground1 : colourProvider.Content1;
 
-            BorderThickness = IsHovered || textBox.Focused.Value ? 2 : 0;
-
-            if (disabled)
-                BorderColour = colourProvider.Dark1;
-            else
-                BorderColour = textBox.Focused.Value ? colourProvider.Highlight1 : colourProvider.Light4;
-
-            if (textBox.Focused.Value)
-                background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark3);
-            else if (IsHovered)
-                background.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark4);
-            else
-                background.Colour = colourProvider.Background5;
+            background.StyleDisabled = Current.Disabled;
+            background.StyleFocused = textBox.Focused.Value;
+            background.StyleHovered = IsHovered;
         }
 
         internal partial class InnerTextBox : OsuTextBox
@@ -221,7 +203,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 Height = 16;
                 TextContainer.Height = 1;
-                Masking = false;
                 BackgroundUnfocused = BackgroundFocused = BackgroundCommit = Colour4.Transparent;
             }
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -198,6 +198,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             protected override float LeftRightPadding => 0;
 
+            public InnerTextBox()
+            {
+                DrawBorder = false;
+            }
+
             [BackgroundDependencyLoader]
             private void load()
             {

--- a/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
@@ -121,7 +121,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
             fill.FadeColour(fillColour, 250, Easing.OutQuint);
 
             content.TransformTo(nameof(BorderColour), (ColourInfo)borderColour, 250, Easing.OutQuint);
-            content.ResizeWidthTo(ExpandOnCurrent && Current.Value ? 1 : 0.75f, 250, Easing.OutQuint);
+
+            if (ExpandOnCurrent && Current.Value)
+                content.ResizeWidthTo(1f, 200, Easing.OutElasticQuarter);
+            else
+                content.ResizeWidthTo(0.75f, 120, Easing.OutExpo);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
@@ -19,20 +19,22 @@ namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class SwitchButton : Checkbox
     {
-        public const float WIDTH = 60;
+        public const float WIDTH = 56;
 
         private readonly Box fill;
-        private readonly CircularContainer content;
+        private readonly Container content;
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        public bool ExpandOnCurrent { get; init; } = true;
 
         private Sample? sampleChecked;
         private Sample? sampleUnchecked;
 
         public SwitchButton()
         {
-            Size = new Vector2(WIDTH, 20);
+            Size = new Vector2(WIDTH, 16);
 
             InternalChild = content = new CircularContainer
             {
@@ -40,8 +42,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
                 BorderColour = Color4.White,
-                BorderThickness = 4,
+                BorderThickness = 3.2f,
                 Masking = true,
+                CornerExponent = 2.5f,
                 Children = new Drawable[]
                 {
                     fill = new Box
@@ -98,7 +101,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateState()
         {
-            Color4 fillColour = colourProvider.Background6;
+            Color4 fillColour = colourProvider.Background5.Opacity(0);
             Color4 borderColour = colourProvider.Light4;
 
             if (IsHovered)
@@ -118,7 +121,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             fill.FadeColour(fillColour, 250, Easing.OutQuint);
 
             content.TransformTo(nameof(BorderColour), (ColourInfo)borderColour, 250, Easing.OutQuint);
-            content.ResizeWidthTo(Current.Value ? 1 : 0.75f, 250, Easing.OutQuint);
+            content.ResizeWidthTo(ExpandOnCurrent && Current.Value ? 1 : 0.75f, 250, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
@@ -19,14 +19,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class SwitchButton : Checkbox
     {
-        public const float WIDTH = 45;
-
-        private const float border_thickness = 4.5f;
-        private const float padding = 1.25f;
+        public const float WIDTH = 60;
 
         private readonly Box fill;
-        private readonly Container nubContainer;
-        private readonly Drawable nub;
         private readonly CircularContainer content;
 
         [Resolved]
@@ -41,9 +36,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             InternalChild = content = new CircularContainer
             {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
                 BorderColour = Color4.White,
-                BorderThickness = border_thickness,
+                BorderThickness = 4,
                 Masking = true,
                 Children = new Drawable[]
                 {
@@ -52,21 +49,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                         RelativeSizeAxes = Axes.Both,
                         AlwaysPresent = true,
                     },
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Padding = new MarginPadding(border_thickness + padding),
-                        Child = nubContainer = new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Child = nub = new Circle
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                FillMode = FillMode.Fit,
-                                Masking = true,
-                            }
-                        }
-                    }
                 }
             };
         }
@@ -82,28 +64,21 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             base.LoadComplete();
 
-            Current.BindDisabledChanged(_ => updateColours());
+            Current.BindDisabledChanged(_ => updateState());
             Current.BindValueChanged(_ => updateState(), true);
 
             FinishTransforms(true);
         }
 
-        private void updateState()
-        {
-            nub.MoveToX(Current.Value ? nubContainer.DrawWidth - nub.DrawWidth : 0, 200, Easing.OutQuint);
-
-            updateColours();
-        }
-
         protected override bool OnHover(HoverEvent e)
         {
-            updateColours();
+            updateState();
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            updateColours();
+            updateState();
             base.OnHoverLost(e);
         }
 
@@ -121,35 +96,29 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 sampleUnchecked?.Play();
         }
 
-        private void updateColours()
+        private void updateState()
         {
-            ColourInfo borderColour;
-            ColourInfo switchColour;
+            Color4 fillColour = colourProvider.Background6;
+            Color4 borderColour = colourProvider.Light4;
+
+            if (IsHovered)
+                borderColour = colourProvider.Highlight1;
+            else if (Current.Value)
+                borderColour = colourProvider.Highlight1.Darken(0.1f);
+
+            if (Current.Value)
+                fillColour = borderColour;
 
             if (Current.Disabled)
             {
-                borderColour = colourProvider.Dark2;
-                switchColour = colourProvider.Dark1;
-                fill.Colour = colourProvider.Dark5;
-            }
-            else
-            {
-                bool hover = IsHovered && !Current.Disabled;
-
-                borderColour = hover ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Highlight1.Opacity(0.3f);
-                switchColour = hover || Current.Value ? colourProvider.Highlight1 : colourProvider.Light4;
-
-                if (!Current.Value)
-                {
-                    borderColour = borderColour.MultiplyAlpha(0.8f);
-                    switchColour = switchColour.MultiplyAlpha(0.8f);
-                }
-
-                fill.Colour = Current.Value ? colourProvider.Colour4.Darken(0.2f) : colourProvider.Background6;
+                fillColour = fillColour.Darken(0.4f);
+                borderColour = borderColour.Darken(0.4f);
             }
 
-            nubContainer.FadeColour(switchColour, 250, Easing.OutQuint);
-            content.TransformTo(nameof(BorderColour), borderColour, 250, Easing.OutQuint);
+            fill.FadeColour(fillColour, 250, Easing.OutQuint);
+
+            content.TransformTo(nameof(BorderColour), (ColourInfo)borderColour, 250, Easing.OutQuint);
+            content.ResizeWidthTo(Current.Value ? 1 : 0.75f, 250, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Localisation/BindingSettingsStrings.cs
+++ b/osu.Game/Localisation/BindingSettingsStrings.cs
@@ -10,9 +10,9 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.BindingSettings";
 
         /// <summary>
-        /// "Shortcut and gameplay bindings"
+        /// "Shortcuts and gameplay bindings"
         /// </summary>
-        public static LocalisableString ShortcutAndGameplayBindings => new TranslatableString(getKey(@"shortcut_and_gameplay_bindings"), @"Shortcut and gameplay bindings");
+        public static LocalisableString ShortcutAndGameplayBindings => new TranslatableString(getKey(@"shortcut_and_gameplay_bindings"), @"Shortcuts and gameplay bindings");
 
         /// <summary>
         /// "Configure"

--- a/osu.Game/Localisation/InputSettingsStrings.cs
+++ b/osu.Game/Localisation/InputSettingsStrings.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Localisation
         public static LocalisableString InputSectionHeader => new TranslatableString(getKey(@"input_section_header"), @"Input");
 
         /// <summary>
+        /// "Device: {0}"
+        /// </summary>
+        public static LocalisableString Device(LocalisableString text) => new TranslatableString(getKey(@"device"), @"Device: {0}", text);
+
+        /// <summary>
         /// "Global"
         /// </summary>
         public static LocalisableString GlobalKeyBindingHeader => new TranslatableString(getKey(@"global_key_binding_header"), @"Global");
@@ -72,7 +77,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "The binding you&#39;ve selected conflicts with another existing binding."
         /// </summary>
-        public static LocalisableString KeyBindingConflictDetected => new TranslatableString(getKey(@"key_binding_conflict_detected"), @"The binding you've selected conflicts with another existing binding.");
+        public static LocalisableString KeyBindingConflictDetected =>
+            new TranslatableString(getKey(@"key_binding_conflict_detected"), @"The binding you've selected conflicts with another existing binding.");
 
         /// <summary>
         /// "Keep existing"

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
@@ -16,6 +16,7 @@ using osu.Game.Extensions;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Screens.Play.PlayerSettings;
+using osuTK;
 
 namespace osu.Game.Overlays.Settings.Sections.Audio
 {
@@ -52,6 +53,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
+                Spacing = new Vector2(SettingsSection.ITEM_SPACING_V2),
                 Children = new Drawable[]
                 {
                     new SettingsItemV2(new FormSliderBar<double>
@@ -67,30 +69,23 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Padding = new MarginPadding
-                        {
-                            Left = SettingsPanel.CONTENT_PADDING.Left + 9,
-                            Right = SettingsPanel.CONTENT_PADDING.Right + 5
-                        },
-                        Child = notchContainer = new Container<Circle>
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Width = 0.5f,
-                            Height = 10,
-                            Margin = new MarginPadding { Top = 2 },
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight,
-                            Padding = new MarginPadding
-                            {
-                                Horizontal = FormSliderBar<double>.InnerSlider.NUB_WIDTH / 2
-                            },
-                        },
-                    },
-                    hintNote = new SettingsNote
-                    {
-                        RelativeSizeAxes = Axes.X,
                         Padding = SettingsPanel.CONTENT_PADDING,
-                        TextAnchor = Anchor.TopCentre,
+                        Children = new Drawable[]
+                        {
+                            notchContainer = new Container<Circle>
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Width = 0.5f,
+                                Height = 10,
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                Padding = new MarginPadding
+                                {
+                                    Horizontal = FormSliderBar<double>.InnerSlider.NUB_WIDTH / 2
+                                },
+                            },
+                            hintNote = new SettingsNote { RelativeSizeAxes = Axes.X },
+                        }
                     },
                     applySuggestion = new RoundedButton
                     {
@@ -166,18 +161,23 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 applySuggestion.Enabled.Value = false;
                 notchContainer.Hide();
                 hintNote.Current.Value = new SettingsNote.Data(AudioSettingsStrings.SuggestedOffsetNote, SettingsNote.Type.Informational);
+                hintNote.MoveToY(0, 200, Easing.OutQuint);
             }
             else if (Math.Abs(SuggestedOffset.Value.Value - current.Value) < 1)
             {
                 applySuggestion.Enabled.Value = false;
                 notchContainer.Show();
                 hintNote.Current.Value = new SettingsNote.Data(AudioSettingsStrings.SuggestedOffsetCorrect(averageHitErrorHistory.Count), SettingsNote.Type.Informational);
+                hintNote.MoveToY(10, 200, Easing.OutQuint);
             }
             else
             {
                 applySuggestion.Enabled.Value = true;
                 notchContainer.Show();
-                hintNote.Current.Value = new SettingsNote.Data(AudioSettingsStrings.SuggestedOffsetValueReceived(averageHitErrorHistory.Count, SuggestedOffset.Value.Value.ToStandardFormattedString(0)), SettingsNote.Type.Informational);
+                hintNote.Current.Value =
+                    new SettingsNote.Data(AudioSettingsStrings.SuggestedOffsetValueReceived(averageHitErrorHistory.Count, SuggestedOffset.Value.Value.ToStandardFormattedString(0)),
+                        SettingsNote.Type.Informational);
+                hintNote.MoveToY(10, 200, Easing.OutQuint);
             }
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
@@ -23,7 +23,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Text = BindingSettingsStrings.Configure,
                     TooltipText = BindingSettingsStrings.ChangeBindingsButton,
-                    Action = keyConfig.ToggleVisibility
+                    Action = keyConfig.ToggleVisibility,
+                    Height = 60
                 },
             };
         }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -136,7 +136,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
-                    IconSize = 12,
                     Action = RestoreDefaults,
                 },
                 new Container

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -136,8 +136,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
-                    Height = 1,
-                    RelativeSizeAxes = Axes.Y,
                     IconSize = 12,
                     Action = RestoreDefaults,
                 },

--- a/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
@@ -12,7 +12,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Settings.Sections
@@ -85,14 +84,14 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private partial class ToggleableHeader : CompositeDrawable
         {
-            private readonly LocalisableString header;
+            private readonly LocalisableString text;
             private readonly bool toggleable;
 
             public readonly BindableBool Current = new BindableBool(true);
 
-            public ToggleableHeader(LocalisableString header, bool toggleable)
+            public ToggleableHeader(LocalisableString text, bool toggleable)
             {
-                this.header = header;
+                this.text = text;
                 this.toggleable = toggleable;
             }
 
@@ -119,7 +118,7 @@ namespace osu.Game.Overlays.Settings.Sections
                     },
                     headerText = new OsuSpriteText
                     {
-                        Text = header,
+                        Text = $"Device: {text}",
                         Font = OsuFont.Style.Heading2,
                         Margin = new MarginPadding { Vertical = 12 },
                         X = 18,

--- a/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
@@ -111,18 +111,19 @@ namespace osu.Game.Overlays.Settings.Sections
                 {
                     switchButton = new SwitchButton
                     {
-                        Anchor = Anchor.TopLeft,
-                        Origin = Anchor.TopLeft,
-                        Scale = new Vector2(0.6f),
-                        Position = new Vector2(12, 8),
-                        Rotation = 90,
+                        ExpandOnCurrent = false,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Width = 15,
+                        Height = 22,
                     },
                     headerText = new OsuSpriteText
                     {
                         Text = header,
-                        Font = OsuFont.GetFont(size: 20),
+                        Font = OsuFont.Style.Heading2,
                         Margin = new MarginPadding { Vertical = 12 },
-                        X = 20,
+                        X = 18,
+                        Y = -1,
                     },
                     new HoverSounds(),
                 };

--- a/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK.Graphics;
+using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
@@ -118,7 +119,7 @@ namespace osu.Game.Overlays.Settings.Sections
                     },
                     headerText = new OsuSpriteText
                     {
-                        Text = $"Device: {text}",
+                        Text = InputSettingsStrings.Device(text),
                         Font = OsuFont.Style.Heading2,
                         Margin = new MarginPadding { Vertical = 12 },
                         X = 18,

--- a/osu.Game/Overlays/Settings/SettingsButtonV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsButtonV2.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Overlays.Settings
         public SettingsButtonV2()
         {
             RelativeSizeAxes = Axes.X;
-            Margin = new MarginPadding { Vertical = -1.5f };
             Padding = SettingsPanel.CONTENT_PADDING;
         }
 

--- a/osu.Game/Overlays/Settings/SettingsHeader.cs
+++ b/osu.Game/Overlays/Settings/SettingsHeader.cs
@@ -37,8 +37,7 @@ namespace osu.Game.Overlays.Settings
                     {
                         Left = SettingsPanel.CONTENT_PADDING.Left,
                         Right = SettingsPanel.CONTENT_PADDING.Right,
-                        Top = Toolbar.Toolbar.TOOLTIP_HEIGHT,
-                        Bottom = 30
+                        Vertical = 20,
                     }
                 }.With(flow =>
                 {

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -86,6 +86,12 @@ namespace osu.Game.Overlays.Settings
             controlDefault.BindValueChanged(_ => updateDefaultState());
             controlEnabled.BindValueChanged(_ => updateDefaultState(), true);
             FinishTransforms(true);
+
+            ScheduleAfterChildren(() =>
+            {
+                revertButton.RelativeSizeAxes = Axes.None;
+                revertButton.Height = ((Drawable)Control).DrawHeight;
+            });
         }
 
         private void updateDefaultState()

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -70,7 +70,6 @@ namespace osu.Game.Overlays.Settings
                     {
                         RelativeSizeAxes = Axes.X,
                         Current = { BindTarget = Note },
-                        Depth = 1,
                     },
                 },
             };

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -70,6 +70,7 @@ namespace osu.Game.Overlays.Settings
                     {
                         RelativeSizeAxes = Axes.X,
                         Current = { BindTarget = Note },
+                        Depth = 1,
                     },
                 },
             };

--- a/osu.Game/Overlays/Settings/SettingsNote.cs
+++ b/osu.Game/Overlays/Settings/SettingsNote.cs
@@ -26,14 +26,6 @@ namespace osu.Game.Overlays.Settings
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
-        public new MarginPadding Padding
-        {
-            get => base.Padding;
-            set => base.Padding = value;
-        }
-
-        public Anchor TextAnchor { get; init; } = Anchor.TopLeft;
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -61,7 +53,6 @@ namespace osu.Game.Overlays.Settings
                         },
                         text = new OsuTextFlowContainer(s => s.Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold))
                         {
-                            TextAnchor = TextAnchor,
                             Padding = new MarginPadding(8),
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
@@ -76,12 +67,14 @@ namespace osu.Game.Overlays.Settings
             base.LoadComplete();
 
             Current.BindValueChanged(_ => updateDisplay(), true);
+            FinishTransforms(true);
         }
 
         private void updateDisplay()
         {
             // Explicitly use ClearTransforms to clear any existing auto-size transform before modifying size / flag.
-            ClearTransforms();
+            // TODO: This is dodgy as hell and needs to go.
+            ClearTransforms(false, @"baseSize");
 
             if (Current.Value == null)
             {

--- a/osu.Game/Overlays/Settings/SettingsNote.cs
+++ b/osu.Game/Overlays/Settings/SettingsNote.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Overlays.Settings
             // Explicitly use ClearTransforms to clear any existing auto-size transform before modifying size / flag.
             // TODO: This is dodgy as hell and needs to go.
             ClearTransforms(false, @"baseSize");
+            ClearTransforms(false, nameof(Height));
 
             if (Current.Value == null)
             {

--- a/osu.Game/Overlays/Settings/SettingsNote.cs
+++ b/osu.Game/Overlays/Settings/SettingsNote.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Overlays.Settings
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Padding = new MarginPadding { Top = 5, Bottom = 5 },
+                Padding = new MarginPadding { Top = SettingsSection.ITEM_SPACING_V2 },
                 Child = new Container
                 {
                     RelativeSizeAxes = Axes.X,
@@ -74,8 +74,8 @@ namespace osu.Game.Overlays.Settings
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
             Current.BindValueChanged(_ => updateDisplay(), true);
-            FinishTransforms(true);
         }
 
         private void updateDisplay()

--- a/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
@@ -31,7 +31,8 @@ namespace osu.Game.Overlays.Settings
 
         public SettingsRevertToDefaultButton()
         {
-            Size = new Vector2(WIDTH, 50);
+            RelativeSizeAxes = Axes.Y;
+            Width = WIDTH;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsRevertToDefaultButton.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Localisation;
 using osuTK;
@@ -16,9 +15,9 @@ namespace osu.Game.Overlays.Settings
 {
     public partial class SettingsRevertToDefaultButton : OsuClickableContainer
     {
-        public const float WIDTH = 32;
+        public const float WIDTH = 28;
 
-        public float IconSize { get; init; } = 14;
+        public float IconSize { get; init; } = 10;
 
         private Box background = null!;
         private SpriteIcon spriteIcon = null!;
@@ -54,7 +53,7 @@ namespace osu.Game.Overlays.Settings
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Colour = colourProvider.Light1,
-                    Icon = OsuIcon.Undo,
+                    Icon = FontAwesome.Solid.Undo,
                     Margin = new MarginPadding { Left = 12, Right = 5 },
                     Size = new Vector2(IconSize),
                 }

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.Settings
         public const int ITEM_SPACING_V2 = 4;
 
         private const int header_size = 24;
-        private const int border_size = 4;
+        private const int border_size = 2;
 
         private bool matchingFilter = true;
 

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.Settings
         public virtual IEnumerable<LocalisableString> FilterTerms => new[] { Header };
 
         public const int ITEM_SPACING = 14;
-        public const int ITEM_SPACING_V2 = 7;
+        public const int ITEM_SPACING_V2 = 4;
 
         private const int header_size = 24;
         private const int border_size = 4;

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays
         public const float CONTENT_MARGINS = 20;
 
         // extra right padding to give room to the revert-to-default button in settings controls.
-        public static readonly MarginPadding CONTENT_PADDING = new MarginPadding { Left = 20, Right = 30 };
+        public static readonly MarginPadding CONTENT_PADDING = new MarginPadding { Left = 12, Right = 22 };
 
         public const float TRANSITION_LENGTH = 600;
 
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays
                         AutoSizeAxes = Axes.Y,
                         Padding = new MarginPadding
                         {
-                            Vertical = 20,
+                            Vertical = 6,
                             Left = CONTENT_PADDING.Left,
                             Right = CONTENT_PADDING.Right,
                         },
@@ -324,7 +324,7 @@ namespace osu.Game.Overlays
             {
                 HeaderBackground = new Box
                 {
-                    Colour = colourProvider.Background4,
+                    Colour = colourProvider.Background5,
                     RelativeSizeAxes = Axes.Both
                 };
 

--- a/osu.Game/Screens/Edit/Components/FormSampleSet.cs
+++ b/osu.Game/Screens/Edit/Components/FormSampleSet.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
@@ -48,7 +47,7 @@ namespace osu.Game.Screens.Edit.Components
         private readonly BindableWithCurrent<EditorBeatmapSkin.SampleSet?> current = new BindableWithCurrent<EditorBeatmapSkin.SampleSet?>();
         private readonly Dictionary<(string name, string bank), SampleButton> buttons = new Dictionary<(string, string), SampleButton>();
 
-        private Box background = null!;
+        private FormControlBackground background = null!;
         private FormFieldCaption caption = null!;
 
         [Resolved]
@@ -62,13 +61,13 @@ namespace osu.Game.Screens.Edit.Components
 
             Masking = true;
             CornerRadius = 5;
+            CornerExponent = 2.5f;
 
             InternalChildren = new Drawable[]
             {
-                background = new Box
+                background = new FormControlBackground
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
                 },
                 new FillFlowContainer
                 {
@@ -167,13 +166,9 @@ namespace osu.Game.Screens.Edit.Components
 
         private void updateState()
         {
-            background.Colour = colourProvider.Background5;
             caption.Colour = colourProvider.Content2;
 
-            BorderThickness = IsHovered ? 2 : 0;
-
-            if (IsHovered)
-                BorderColour = colourProvider.Light4;
+            background.VisualStyle = IsHovered ? VisualStyle.Hovered : VisualStyle.Normal;
         }
 
         public partial class SampleButton : OsuButton, IHasPopover, IHasContextMenu


### PR DESCRIPTION
See individual commits for what has changed. I have more changes coming but these seem to stand alone quite amicably.

| Release | Tachyon | This PR
| :---: | :---: | :---: |
| <img width="987" height="1304" alt="osu! 2026-01-27 at 07 54 54" src="https://github.com/user-attachments/assets/ea7aa3c5-f478-4937-8457-6360d5f37c33" /> | <img width="987" height="1304" alt="osu! 2026-01-27 at 07 54 06" src="https://github.com/user-attachments/assets/8f022d0e-0258-4153-8d90-d8b9465768e2" /> | <img width="987" height="1304" alt="osu! 2026-01-27 at 07 53 19" src="https://github.com/user-attachments/assets/d1d1f2f4-d7b3-4eff-87f0-9aad97972f44" /> |
| <img width="1689" height="1130" alt="osu! 2026-01-27 at 07 57 48" src="https://github.com/user-attachments/assets/e6fcc43a-69bf-48ae-8066-cf9e4b846923" /> |<img width="1689" height="1130" alt="osu! 2026-01-27 at 07 58 36" src="https://github.com/user-attachments/assets/27ac0053-d4df-436c-b1bd-c4342537eeae" /> |<img width="1689" height="1130" alt="osu! 2026-01-27 at 08 06 44" src="https://github.com/user-attachments/assets/d5adf8dd-17b4-4d08-b500-6efa2e07d6d3" />
<img width="1387" height="1099" alt="osu Game Tests 2026-01-27 at 08 09 54" src="https://github.com/user-attachments/assets/3e5dcca5-58e2-4dfd-834d-3c45a4d83c77" /> | <img width="1387" height="1099" alt="osu Game Tests 2026-01-27 at 08 09 01" src="https://github.com/user-attachments/assets/fd9b82f8-84d4-416f-b16f-47bdb23e4b15" /> | <img width="1387" height="1099" alt="osu Game Tests 2026-01-27 at 08 08 25" src="https://github.com/user-attachments/assets/e70e7ca1-c518-4223-b7d7-ff716e4c5657" />