### PR TITLE
Fix flashlight having near-zero bonus when reading difficulty is much higher

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double baseSpeedPerformance = HarmonicSkill.DifficultyToPerformance(speedRating);
             double baseReadingPerformance = HarmonicSkill.DifficultyToPerformance(readingRating);
             double baseFlashlightPerformance = Flashlight.DifficultyToPerformance(flashlightRating);
-            double baseCognitionPerformance = DifficultyCalculationUtils.Norm(2, baseReadingPerformance, baseFlashlightPerformance);
+            double baseCognitionPerformance = SumCognitionDifficulty(baseReadingPerformance, baseFlashlightPerformance);
 
             double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseCognitionPerformance);
 
@@ -142,6 +142,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             };
 
             return attributes;
+        }
+
+        public static double SumCognitionDifficulty(double reading, double flashlight)
+        {
+            // Base LP summed value, accounting for map being partially memorized with FL
+            double cognition = DifficultyCalculationUtils.Norm(2, reading, flashlight);
+
+            // Inrease FL bonus when it's lower than reading to avoid situations where high reading difficulty makes FL give practically 0 bonus
+            return flashlight >= reading ? cognition : double.Lerp(reading + flashlight, cognition, flashlight / reading);
         }
 
         private double calculateStarRating(double basePerformance)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double readingValue = computeReadingValue(osuAttributes);
             double flashlightValue = computeFlashlightValue(score, osuAttributes);
-            double cognitionValue = DifficultyCalculationUtils.Norm(2, readingValue, flashlightValue);
+            double cognitionValue = OsuDifficultyCalculator.SumCognitionDifficulty(readingValue, flashlightValue);
 
             double totalValue = DifficultyCalculationUtils.Norm(PERFORMANCE_NORM_EXPONENT, aimValue, speedValue, accuracyValue, cognitionValue) * multiplier;
 


### PR DESCRIPTION
There was a recent PR (https://github.com/ppy/osu/pull/36464) that was aimed on accounting for the fact that getting your map partially memorized with FL makes reading easier, so those bonuses shouldn't reward full pp to each other.
But in cases where FL pp is significantly lower than reading it have lead to cases where FL adds practically 0 additional pp.
This PR is adjusting a formula to account for cases like this.

FL reward on this map - https://osu.ppy.sh/beatmapsets/1487999#osu/3259719 with EZHDHT(FL):
Full bonus: 408pp -> 486pp (+78pp)
Current: 408pp -> 424pp (+16pp)
This PR: 408pp -> 478pp (+70pp)