### PR TITLE
Fix initial solo gameplay leaderboard position and color

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
+++ b/osu.Game/Screens/Select/Leaderboards/SoloGameplayLeaderboardProvider.cs
@@ -58,6 +58,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             scores.AddRange(newScores);
 
+            sort();
             Scheduler.AddDelayed(sort, 1000, true);
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/35743

Matches playlists. Multiplayer seems to not have it, but I think that's expected (i.e. there's no past scores, so having the initial position be "-" and no initial green color seems right).

| Before | After |
| --- | --- |
| ![Kapture 2026-01-27 at 15 49 29](https://github.com/user-attachments/assets/39ad2cda-87e4-49e4-a872-4588ec07cae1) | ![Kapture 2026-01-27 at 15 47 30](https://github.com/user-attachments/assets/1b8f1e42-5468-4634-8397-ba455c453761) |
| ![Kapture 2026-01-27 at 15 51 57](https://github.com/user-attachments/assets/29b0a4b9-551a-4ac0-9b83-c8eb853422ae) | ![Kapture 2026-01-27 at 15 52 45](https://github.com/user-attachments/assets/7b4b4c9b-4353-4845-9be1-8467326d3f6b) |