### PR TITLE
Fix dropdown margins and animations being weird

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -104,9 +104,17 @@ namespace osu.Game.Graphics.UserInterface
                 }
             }
 
+            private Vector2? targetSize;
+
             // todo: this uses the same styling as OsuMenu. hopefully we can just use OsuMenu in the future with some refactoring
             protected override void UpdateSize(Vector2 newSize)
             {
+                // TODO: should probably fix this at a framework level (this method is running every frame which can spam transforms)
+                if (newSize == targetSize)
+                    return;
+
+                targetSize = newSize;
+
                 if (Direction == Direction.Vertical)
                 {
                     Width = newSize.X;

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -53,10 +53,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             header.Caption = Caption;
             header.HintText = HintText;
-
-            // there's bottom margin applied inside the header to give spacing between the header and the menu.
-            // however when the menu is closed the extra spacing remains present. to remove it, apply negative bottom padding here.
-            Margin = new MarginPadding { Bottom = -header_menu_spacing };
         }
 
         protected override void LoadComplete()
@@ -302,20 +298,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 base.AnimateOpen();
 
-                // there's negative bottom margin applied on the whole dropdown control to remove extra spacing when the menu is closed.
-                // however, when the menu is open, we want spacing between the menu and the next control below it. therefore apply bottom margin here.
-                // we use a transform to keep the open animation smooth while margin is adjusted.
                 this.TransformTo(nameof(Margin), new MarginPadding
                 {
                     Top = header_menu_spacing,
-                    Bottom = header_menu_spacing
-                }, 50, Easing.OutQuint);
+                }, 300, Easing.OutQuint);
             }
 
             protected override void AnimateClose()
             {
                 base.AnimateClose();
-                this.TransformTo(nameof(Margin), new MarginPadding { Bottom = 0 }, 300);
+                this.TransformTo(nameof(Margin), new MarginPadding(), 300, Easing.OutQuint);
             }
         }
     }


### PR DESCRIPTION
This was attempted to be fixed by frenzibyte using some hack workaround logic, but this is the true fix.

Things were never matching due to `UpdateSize` spamming `Resize` transforms every frame, causing the fade out to complete before transforms have reached a final state.

Before:

https://github.com/user-attachments/assets/49b1a5e5-02c0-4151-a141-1dc7dea9a767

After:

https://github.com/user-attachments/assets/154722e2-5263-455f-a46f-1447191b0bba

Pay attention to the end of the collapse animation.
