### PR TITLE
Fix "ALL MODS" display not displaying in new playlist song select

### DIFF
--- a/osu.Game/Screens/OnlinePlay/FooterButtonFreeModsV2.cs
+++ b/osu.Game/Screens/OnlinePlay/FooterButtonFreeModsV2.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
@@ -13,21 +12,19 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.SelectV2;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay
 {
     public partial class FooterButtonFreeModsV2 : ScreenFooterButton
     {
-        private const float bar_height = 30f;
-
         public readonly Bindable<IReadOnlyList<Mod>> FreeMods = new Bindable<IReadOnlyList<Mod>>([]);
         public readonly Bindable<bool> Freestyle = new Bindable<bool>();
 
@@ -45,7 +42,7 @@ namespace osu.Game.Screens.OnlinePlay
         private Container modsWedge = null!;
         private ModDisplay modDisplay = null!;
         private Container modContainer = null!;
-        private ModCountText overflowModCountDisplay = null!;
+        private FooterButtonMods.ModCountText overflowModCountDisplay = null!;
 
         public FooterButtonFreeModsV2(ModSelectOverlay overlay)
             : base(overlay)
@@ -66,7 +63,7 @@ namespace osu.Game.Screens.OnlinePlay
                 Origin = Anchor.BottomLeft,
                 Shear = OsuGame.SHEAR,
                 CornerRadius = CORNER_RADIUS,
-                Size = new Vector2(BUTTON_WIDTH, bar_height),
+                Size = new Vector2(BUTTON_WIDTH, FooterButtonMods.BAR_HEIGHT),
                 Masking = true,
                 EdgeEffect = new EdgeEffectParameters
                 {
@@ -100,7 +97,7 @@ namespace osu.Game.Screens.OnlinePlay
                                 Current = { BindTarget = FreeMods },
                                 ExpansionMode = ExpansionMode.AlwaysContracted,
                             },
-                            overflowModCountDisplay = new ModCountText
+                            overflowModCountDisplay = new FooterButtonMods.ModCountText
                             {
                                 Mods = { BindTarget = FreeMods },
                                 Freestyle = { BindTarget = Freestyle }
@@ -144,57 +141,6 @@ namespace osu.Game.Screens.OnlinePlay
                 overflowModCountDisplay.Show();
             else
                 overflowModCountDisplay.Hide();
-        }
-
-        private partial class ModCountText : VisibilityContainer
-        {
-            public readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>();
-            public readonly Bindable<bool> Freestyle = new Bindable<bool>();
-
-            private OsuSpriteText text = null!;
-
-            [Resolved]
-            private OverlayColourProvider colourProvider { get; set; } = null!;
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                RelativeSizeAxes = Axes.Both;
-
-                InternalChildren = new Drawable[]
-                {
-                    new Box
-                    {
-                        Colour = colourProvider.Background3,
-                        Alpha = 0.8f,
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    text = new OsuSpriteText
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Font = OsuFont.Torus.With(size: 14f, weight: FontWeight.Bold),
-                        Shear = -OsuGame.SHEAR,
-                    }
-                };
-
-                Mods.BindValueChanged(_ => updateText());
-                Freestyle.BindValueChanged(_ => updateText());
-
-                updateText();
-            }
-
-            protected override void PopIn() => this.FadeIn(300, Easing.OutExpo);
-            protected override void PopOut() => this.FadeOut(300, Easing.OutExpo);
-
-            private void updateText()
-            {
-                if (Freestyle.Value)
-                    text.Text = ModSelectOverlayStrings.AllMods.ToUpper();
-                else
-                    text.Text = ModSelectOverlayStrings.Mods(Mods.Value.Count).ToUpper();
-            }
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/FooterButtonFreeModsV2.cs
+++ b/osu.Game/Screens/OnlinePlay/FooterButtonFreeModsV2.cs
@@ -5,11 +5,13 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
@@ -100,7 +102,6 @@ namespace osu.Game.Screens.OnlinePlay
                             overflowModCountDisplay = new FooterButtonMods.ModCountText
                             {
                                 Mods = { BindTarget = FreeMods },
-                                Freestyle = { BindTarget = Freestyle }
                             },
                         }
                     },
@@ -112,7 +113,11 @@ namespace osu.Game.Screens.OnlinePlay
         {
             base.LoadComplete();
 
-            Freestyle.BindValueChanged(f => Enabled.Value = !f.NewValue, true);
+            Freestyle.BindValueChanged(f =>
+            {
+                Enabled.Value = !f.NewValue;
+                overflowModCountDisplay.CustomText = f.NewValue ? ModSelectOverlayStrings.AllMods.ToUpper() : (LocalisableString?)null;
+            }, true);
             FreeMods.BindValueChanged(m =>
             {
                 if (m.NewValue.Count == 0 && !Freestyle.Value)

--- a/osu.Game/Screens/OnlinePlay/FooterButtonFreeModsV2.cs
+++ b/osu.Game/Screens/OnlinePlay/FooterButtonFreeModsV2.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.OnlinePlay
             Freestyle.BindValueChanged(f => Enabled.Value = !f.NewValue, true);
             FreeMods.BindValueChanged(m =>
             {
-                if (m.NewValue.Count == 0)
+                if (m.NewValue.Count == 0 && !Freestyle.Value)
                     modsWedge.FadeOut(200);
                 else
                     modsWedge.FadeIn(200);
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.OnlinePlay
         {
             base.Update();
 
-            if (modDisplay.DrawWidth * modDisplay.Scale.X > modContainer.DrawWidth)
+            if (Freestyle.Value || modDisplay.DrawWidth * modDisplay.Scale.X > modContainer.DrawWidth)
                 overflowModCountDisplay.Show();
             else
                 overflowModCountDisplay.Hide();

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -36,7 +36,8 @@ namespace osu.Game.Screens.SelectV2
     {
         public Action? RequestDeselectAllMods { get; init; }
 
-        private const float bar_height = 30f;
+        public const float BAR_HEIGHT = 30f;
+
         private const float mod_display_portion = 0.65f;
 
         private readonly BindableWithCurrent<IReadOnlyList<Mod>> current = new BindableWithCurrent<IReadOnlyList<Mod>>(Array.Empty<Mod>());
@@ -92,7 +93,7 @@ namespace osu.Game.Screens.SelectV2
                     Origin = Anchor.BottomLeft,
                     Shear = OsuGame.SHEAR,
                     CornerRadius = CORNER_RADIUS,
-                    Size = new Vector2(BUTTON_WIDTH, bar_height),
+                    Size = new Vector2(BUTTON_WIDTH, BAR_HEIGHT),
                     Masking = true,
                     EdgeEffect = new EdgeEffectParameters
                     {
@@ -257,9 +258,10 @@ namespace osu.Game.Screens.SelectV2
                 overflowModCountDisplay.Hide();
         }
 
-        private partial class ModCountText : CompositeDrawable, IHasCustomTooltip<IReadOnlyList<Mod>>
+        public partial class ModCountText : VisibilityContainer, IHasCustomTooltip<IReadOnlyList<Mod>>
         {
             public readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>();
+            public readonly Bindable<bool> Freestyle = new Bindable<bool>();
 
             private OsuSpriteText text = null!;
 
@@ -289,12 +291,24 @@ namespace osu.Game.Screens.SelectV2
                     }
                 };
 
-                Mods.BindValueChanged(v => text.Text = ModSelectOverlayStrings.Mods(v.NewValue.Count).ToUpper(), true);
+                Freestyle.BindValueChanged(_ => updateText());
+                Mods.BindValueChanged(_ => updateText(), true);
             }
 
             public ITooltip<IReadOnlyList<Mod>> GetCustomTooltip() => new ModOverflowTooltip(colourProvider);
 
             public IReadOnlyList<Mod>? TooltipContent => Mods.Value;
+
+            protected override void PopIn() => this.FadeIn(300, Easing.OutExpo);
+            protected override void PopOut() => this.FadeOut(300, Easing.OutExpo);
+
+            private void updateText()
+            {
+                if (Freestyle.Value)
+                    text.Text = ModSelectOverlayStrings.AllMods.ToUpper();
+                else
+                    text.Text = ModSelectOverlayStrings.Mods(Mods.Value.Count).ToUpper();
+            }
 
             public partial class ModOverflowTooltip : VisibilityContainer, ITooltip<IReadOnlyList<Mod>>
             {
@@ -356,7 +370,7 @@ namespace osu.Game.Screens.SelectV2
                 Shear = OsuGame.SHEAR;
                 CornerRadius = CORNER_RADIUS;
                 AutoSizeAxes = Axes.X;
-                Height = bar_height;
+                Height = BAR_HEIGHT;
                 Masking = true;
                 BorderColour = Color4.White;
                 BorderThickness = 2f;

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -312,7 +312,7 @@ namespace osu.Game.Screens.SelectV2
 
             public partial class ModOverflowTooltip : VisibilityContainer, ITooltip<IReadOnlyList<Mod>>
             {
-                private ModDisplay extendedModDisplay = null!;
+                private ModFlowDisplay extendedModDisplay = null!;
 
                 [Cached]
                 private OverlayColourProvider colourProvider;
@@ -336,11 +336,12 @@ namespace osu.Game.Screens.SelectV2
                             RelativeSizeAxes = Axes.Both,
                             Colour = colourProvider.Background5,
                         },
-                        extendedModDisplay = new ModDisplay
+                        extendedModDisplay = new ModFlowDisplay
                         {
+                            AutoSizeAxes = Axes.Both,
+                            MaximumSize = new Vector2(400, 0),
                             Margin = new MarginPadding { Vertical = 2f, Horizontal = 10f },
                             Scale = new Vector2(0.6f),
-                            ExpansionMode = ExpansionMode.AlwaysExpanded,
                         },
                     };
                 }

--- a/osu.Game/Screens/SelectV2/FooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/FooterButtonMods.cs
@@ -261,7 +261,22 @@ namespace osu.Game.Screens.SelectV2
         public partial class ModCountText : VisibilityContainer, IHasCustomTooltip<IReadOnlyList<Mod>>
         {
             public readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>();
-            public readonly Bindable<bool> Freestyle = new Bindable<bool>();
+
+            private LocalisableString? customText;
+
+            /// <summary>
+            /// When set, this will be shown instead of a mod count.
+            /// </summary>
+            public LocalisableString? CustomText
+            {
+                get => customText;
+                set
+                {
+                    customText = value;
+                    if (IsLoaded)
+                        updateText();
+                }
+            }
 
             private OsuSpriteText text = null!;
 
@@ -291,7 +306,6 @@ namespace osu.Game.Screens.SelectV2
                     }
                 };
 
-                Freestyle.BindValueChanged(_ => updateText());
                 Mods.BindValueChanged(_ => updateText(), true);
             }
 
@@ -304,8 +318,8 @@ namespace osu.Game.Screens.SelectV2
 
             private void updateText()
             {
-                if (Freestyle.Value)
-                    text.Text = ModSelectOverlayStrings.AllMods.ToUpper();
+                if (CustomText != null)
+                    text.Text = CustomText.Value;
                 else
                     text.Text = ModSelectOverlayStrings.Mods(Mods.Value.Count).ToUpper();
             }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/36411.
- Closes https://github.com/ppy/osu/issues/36412

Also fixes some visual glitching which I noticed on the way:

### Tooltip can get very long

| Before | After |
| :---: | :---: |
| <img width="1118" height="211" alt="osu! 2026-01-28 at 07 10 25" src="https://github.com/user-attachments/assets/ddb2aab3-7b35-4798-91f5-d2ad01c1371a" /> | <img width="1118" height="211" alt="osu! 2026-01-28 at 07 11 35" src="https://github.com/user-attachments/assets/4cb0c9dd-287b-426c-a812-a7b2655d7e5b" /> |

### Display flashed when switching freestyle on/off

Adjusted via 0c90cf3. Hard to show but basically it was updating the background dim overlay to be hidden while the overflow was empty for one frame.