### PR TITLE
Penalise aim strain for repeated angles

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -127,9 +127,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     }
                 }
 
-                double repetitionRatio = (lastAngle == double.DegreesToRadians(180)) ? 0 : Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 2);
+                double repetitionRatio = (lastAngle == double.DegreesToRadians(180)) ? 0 : Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 4);
                 repetitionRatio = repetitionRatio > 1 ? 1 / repetitionRatio : repetitionRatio;
-                angleRepetitionPenalty = 0.1 * repetitionRatio;
+                angleRepetitionPenalty = 0.2 * repetitionRatio;
             }
 
             if (Math.Max(prevVelocity, currVelocity) != 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 {
     public static class AimEvaluator
     {
-        private const double wide_angle_multiplier = 1.35;
+        private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.3;
         private const double slider_multiplier = 1.5;
         private const double velocity_change_multiplier = 0.75;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     }
                 }
 
-                double repetitionRatio = (lastAngle == Math.PI) ? 0 : Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 2);
+                double repetitionRatio = (lastAngle == double.DegreesToRadians(180)) ? 0 : Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 2);
                 repetitionRatio = repetitionRatio > 1 ? 1 / repetitionRatio : repetitionRatio;
                 angleRepetitionPenalty = 0.1 * repetitionRatio;
             }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 {
     public static class AimEvaluator
     {
-        private const double wide_angle_multiplier = 1.5;
+        private const double wide_angle_multiplier = 1.35;
         private const double acute_angle_multiplier = 2.3;
         private const double slider_multiplier = 1.5;
         private const double velocity_change_multiplier = 0.75;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -69,6 +69,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             double sliderBonus = 0;
             double velocityChangeBonus = 0;
             double wiggleBonus = 0;
+            double angleRepetitionPenalty = 0;
 
             double aimStrain = currVelocity; // Start strain with regular velocity.
 
@@ -125,6 +126,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                         wideAngleBonus *= 1 - 0.35 * (1 - distance);
                     }
                 }
+
+                double repetitionRatio = lastAngle == Math.PI ? 0 : 
+                                        Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 2);
+                repetitionRatio = repetitionRatio > 1 ? 1 / repetitionRatio : repetitionRatio;
+                angleRepetitionPenalty = 0.1 * repetitionRatio;
             }
 
             if (Math.Max(prevVelocity, currVelocity) != 0)
@@ -153,6 +159,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 // Reward sliders based on velocity.
                 sliderBonus = osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
             }
+            
+            // Nerf aim strain for repeated angles
+            aimStrain *= (1 - angleRepetitionPenalty);
 
             aimStrain += wiggleBonus * wiggle_multiplier;
             aimStrain += velocityChangeBonus * velocity_change_multiplier;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -127,8 +127,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     }
                 }
 
-                double repetitionRatio = lastAngle == Math.PI ? 0 :
-                                        Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 2);
+                double repetitionRatio = (lastAngle == Math.PI) ? 0 : Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 2);
                 repetitionRatio = repetitionRatio > 1 ? 1 / repetitionRatio : repetitionRatio;
                 angleRepetitionPenalty = 0.1 * repetitionRatio;
             }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     }
                 }
 
-                double repetitionRatio = lastAngle == Math.PI ? 0 : 
+                double repetitionRatio = lastAngle == Math.PI ? 0 :
                                         Math.Pow(Math.Cos(currAngle / 2) / Math.Cos(lastAngle / 2), 2);
                 repetitionRatio = repetitionRatio > 1 ? 1 / repetitionRatio : repetitionRatio;
                 angleRepetitionPenalty = 0.1 * repetitionRatio;
@@ -159,7 +159,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 // Reward sliders based on velocity.
                 sliderBonus = osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
             }
-            
+
             // Nerf aim strain for repeated angles
             aimStrain *= (1 - angleRepetitionPenalty);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentAimStrain;
         private double currentSpeedStrain;
 
-        private double skillMultiplierAim => 27.14;
+        private double skillMultiplierAim => 28.4;
         private double skillMultiplierSpeed => 1.35;
         private double skillMultiplierTotal => 1.0;
         private double meanExponent => 1.2;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentAimStrain;
         private double currentSpeedStrain;
 
-        private double skillMultiplierAim => 26.0;
+        private double skillMultiplierAim => 27.3;
         private double skillMultiplierSpeed => 1.3;
         private double skillMultiplierTotal => 1.01;
         private double meanExponent => 1.2;


### PR DESCRIPTION
Current aim is velocity + angle bonus, this becomes velocity * angle repetitiveness + angle bonus.
Has a minor aim mult bump since this only nerfs out of the box.
Deltas are about expected - very few things are actually buffed, and maps with very repetitive angles like PikA and Nymphe's aim maps are most nerfed.
Largest issue is doubletap maps which tend to gain a lot, but I don't think there's any way to cleanly address them with this, and they really need their own fixes for all angle bonuses.