### PR TITLE
Undo slider high cs bonus hotfix

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -160,12 +160,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Add in acute angle bonus or wide angle bonus, whichever is larger.
             aimStrain += Math.Max(acuteAngleBonus * acute_angle_multiplier, wideAngleBonus * wide_angle_multiplier);
 
-            // Apply high circle size bonus
-            aimStrain *= osuCurrObj.SmallCircleBonus;
-
             // Add in additional slider velocity bonus.
             if (withSliderTravelDistance)
                 aimStrain += sliderBonus * slider_multiplier;
+
+            // Apply high circle size bonus
+            aimStrain *= osuCurrObj.SmallCircleBonus;
 
             aimStrain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
 


### PR DESCRIPTION
It existed for one map and now that that map is fine there's no need to do it anymore.

+71pp
<img width="1294" height="140" alt="image" src="https://github.com/user-attachments/assets/4ffe0af7-15d9-4bd9-abfe-a30dd1f99ad8" />

+36pp
<img width="1297" height="127" alt="image" src="https://github.com/user-attachments/assets/b58e4d13-58af-406f-a7b6-1c52a29603f3" />
