### PR TITLE
Make Hidden and Freeze Frame mods incompatible

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -27,8 +27,10 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override LocalisableString Description => "Burn the notes into your memory.";
 
-        //Alters the transforms of the approach circles, breaking the effects of these mods.
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModApproachDifferent), typeof(OsuModTransform), typeof(OsuModDepth) }).ToArray();
+        /// <remarks>
+        /// Incompatible with all mods that directly modify or indirectly depend on <see cref="OsuHitObject.TimePreempt"/>, or alter the behaviour of approach circles.
+        /// </remarks>
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModApproachDifferent), typeof(OsuModTransform), typeof(OsuModDepth), typeof(OsuModHidden) }).ToArray();
 
         public override ModType Type => ModType.Fun;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => @"Play with no approach circles and fading circles/sliders.";
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn), typeof(OsuModDepth) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn), typeof(OsuModDepth), typeof(OsuModFreezeFrame) };
 
         public const double FADE_IN_DURATION_MULTIPLIER = 0.4;
         public const double FADE_OUT_DURATION_MULTIPLIER = 0.3;


### PR DESCRIPTION
Effectively closing https://github.com/ppy/osu/issues/21471 as a wontfix.

The issue is demonstrated by the following test case:

<details>
<summary>patch</summary>

```diff
diff --git a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFreezeFrame.cs b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFreezeFrame.cs
index 31498295da..36b4fe5122 100644
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFreezeFrame.cs
@@ -55,5 +55,49 @@ public void TestSkipToFirstSpinnerNotSuppressed()
                 PassCondition = () => Player.GameplayClockContainer.GameplayStartTime > 0
             });
         }
+
+        [Test]
+        public void TestFreezeFrameAppliedBeforeHidden()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mods =
+                [
+                    new OsuModFreezeFrame(),
+                    new OsuModHidden(),
+                ],
+                CreateBeatmap = () => new OsuBeatmap
+                {
+                    HitObjects =
+                    {
+                        new HitCircle { StartTime = 3000, Position = OsuPlayfield.BASE_SIZE / 2, NewCombo = true },
+                        new HitCircle { StartTime = 5000, Position = OsuPlayfield.BASE_SIZE / 2 },
+                    }
+                },
+                PassCondition = () => ((HitCircle)Player.GameplayState.Beatmap.HitObjects[1]).TimeFadeIn == 480
+            });
+        }
+
+        [Test]
+        public void TestFreezeFrameAppliedAfterHidden()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mods =
+                [
+                    new OsuModHidden(),
+                    new OsuModFreezeFrame(),
+                ],
+                CreateBeatmap = () => new OsuBeatmap
+                {
+                    HitObjects =
+                    {
+                        new HitCircle { StartTime = 3000, Position = OsuPlayfield.BASE_SIZE / 2, NewCombo = true },
+                        new HitCircle { StartTime = 5000, Position = OsuPlayfield.BASE_SIZE / 2 },
+                    }
+                },
+                PassCondition = () => ((HitCircle)Player.GameplayState.Beatmap.HitObjects[1]).TimeFadeIn == 480
+            });
+        }
     }
 }

```

</details>

The reason that this is happening is a data dependency. Freeze Frame modifies `TimePreempt` of hitobjects:

https://github.com/ppy/osu/blob/54c0b2c20c3209f1f17be81b8883ef66ec8a83bb/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs#L53

while Hidden uses `TimePreempt` to set `TimeFadeIn`:

https://github.com/ppy/osu/blob/54c0b2c20c3209f1f17be81b8883ef66ec8a83bb/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs#L45

Therefore the final value of `TimeFadeIn` with these two mods active depends on the order of application.

The reason why I'm bothering to do this is that I was pinged from the PP development server about this again in the context of some ongoing 'rework' and I wish to get ahead of this before it becomes a bigger problem than it already is.

The current order of application of these mods as done in `Player` is constant, but essentially undefined. I'm not even sure what even enforces the current order. It's currently Hidden, then Freeze Frame. If I were to guess, the thing "enforcing" (insert 400 tonne solid lead air quotes) it is probably the mod select overlay with its "I need to own all of the mod instances in the global bindable" substitution logic.

I'm already getting pushback for this from the PP server crowd who are attempting to justify the current "behaviour" by saying that the player base wants this or by saying that it's already broken so it should remain that way forever. I am however not willing to accept [stable-taiko-tier stupidity again](https://github.com/ppy/osu/pull/27136#issuecomment-1957055402) and am not willing to accept the complexity this would invite everywhere else.

I do not see any other easy way of fixing this problem at this point in time. I had hoped that I could inline the `TimePreempt` read in `OsuModHidden`, but it's not that easy because it's set in multiple places.

Existing HDFF scores would probably need to be delisted from the leaderboards. I'm not even sure I can get myself to pretend to care.