### PR TITLE
Fix multiplayer team display becoming inconsistent

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -106,14 +106,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 clickableContent.TooltipText = "Change team";
             }
 
-            // reset to ensure samples don't play
-            DisplayedTeam = null;
-            updateState();
+            updateState(false);
         }
 
-        private void onRoomUpdated() => Scheduler.AddOnce(updateState);
+        private void onRoomUpdated() => Scheduler.AddOnce(() => updateState(true));
 
-        private void updateState()
+        private void updateState(bool playSamples)
         {
             // we don't have a way of knowing when an individual user's state has updated, so just handle on RoomUpdated for now.
 
@@ -129,7 +127,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             // only play the sample if an already valid team changes to another valid team.
             // this avoids playing a sound for each user if the match type is changed to/from a team mode.
-            if (newTeam != null && DisplayedTeam != null)
+            if (playSamples && newTeam != null && DisplayedTeam != null)
                 sampleTeamSwap?.Play();
 
             DisplayedTeam = newTeam;


### PR DESCRIPTION
Supersedes / closes https://github.com/ppy/osu/pull/36509
Fixes https://github.com/ppy/osu/issues/35844

This is pooling related - this component is contained within `ParticipantPanel`, which is the pooled component. The `Current` value is the user, so if it so happens that the user is changed (i.e. on scroll) and a room update happens simultaneously, then this condition will prevent the visual state from being updated:

https://github.com/ppy/osu/blob/9bf52034d7d259cab3f6edcdbd810dadff4fa99a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs#L127-L128

It's a very weird sequence of events so I don't know how to write a test for this, a practical one will have to do?

```diff
diff --git a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
index 50c4c3439b..b9c092e2af 100644
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -234,6 +235,43 @@ public void TestKickButtonKicks()
             AddUntilStep("second user kicked", () => MultiplayerClient.ClientRoom?.Users.Single().UserID == API.LocalUser.Value.Id);
         }
 
+        [Test]
+        [Solo]
+        public void TestBroken()
+        {
+            const int users_count = 200;
+
+            AddStep("add many users", () =>
+            {
+                for (int i = 0; i < users_count; i++)
+                {
+                    MultiplayerClient.AddUser(new APIUser
+                    {
+                        Id = i,
+                        Username = $"User {i}",
+                        RulesetsStatistics = new Dictionary<string, UserStatistics>
+                        {
+                            {
+                                Ruleset.Value.ShortName,
+                                new UserStatistics { GlobalRank = RNG.Next(1, 100000), }
+                            }
+                        },
+                        CoverUrl = TestResources.COVER_IMAGE_3,
+                    });
+                }
+            });
+
+            AddStep("set team versus", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings
+            {
+                MatchType = MatchType.TeamVersus
+            }).WaitSafely());
+
+            AddStep("set head to head", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings
+            {
+                MatchType = MatchType.HeadToHead
+            }).WaitSafely());
+        }
+
         [Test]
         public void TestManyUsers()
         {

```

The test procedure is to scroll while toggling the team state, but it is not consistent:

https://github.com/user-attachments/assets/ce7d64ae-e4fd-4768-9f72-822b895125cc