### PR TITLE
Make Difficulty Adjust and Target Practice mods incompatible

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -70,6 +72,8 @@ namespace osu.Game.Rulesets.Osu.Mods
                     yield return ("Approach rate", $"{ApproachRate.Value:N1}");
             }
         }
+
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModTargetPractice)).ToArray();
 
         protected override void ApplySettings(BeatmapDifficulty difficulty)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
@@ -48,7 +48,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             typeof(OsuModSpunOut),
             typeof(OsuModStrictTracking),
             typeof(OsuModSuddenDeath),
-            typeof(OsuModDepth)
+            typeof(OsuModDepth),
+            typeof(OsuModDifficultyAdjust),
         }).ToArray();
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/36490.

While I'm out here already taking heat for deleting mod combinations let me do more of that.

The main problem with the mod combination here, again, is that the application of the mods does not commute.

- The current behaviour is that TP is applied first, then DA. This is, again, "enforced" by the mod select overlay implicitly enforcing order of the mod instances in the global mod bindable to match the display order of mods inside it.

  Even this doesn't "work" correctly as is, because as the bug reporter points out, if they throw on DA with no changes expecting the map's default AR to be applied, it still gets halved. This is because DA works in a way wherein if you don't touch the AR slider, DA does not touch AR. Which means that the DA slider should *really* be at *half* of the map's base AR by default in this case because TP is active. How do you program this?

- The *alternative* behaviour would be that DA is applied first, then TP. This in turn would mean that the effective range of AR adjustment offered by DA when TP is active would be halved to [0, 5] (or [-5, 5.5] with extended ranges). How do you program this?

The above is just client-side concerns, while leaving out the other giant concern, which is "how do you get every single place in the game that may want to apply mods to a beatmap to apply them *in the same order*?". Then extend that to server-side components, then extend that to every external library that may want to re-implement SR/PP calculations, etc. etc.

One additional remark:
What the bug reporter *did not* say however, but I am saying, is that there's an elephant in the room, and that is the Easy mod, which *also* changes AR, but also *happens* to apply commutatively with Target Practice simply because both mods are implemented to halve the AR, which means that the order of application doesn't matter. If I were *really* bent on being a bad guy and just deleting mod combinations indiscriminately, I'd delete that one as well. But I'm not doing that.