### PR TITLE
Fix some text boxes no longer having borders

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Graphics.UserInterface
             Margin = new MarginPadding { Left = 2 },
         };
 
-        protected bool DrawBorder { get; init; }
+        protected bool DrawBorder { get; init; } = true;
 
         private OsuCaret? caret;
 

--- a/osu.Game/Overlays/Comments/CommentEditor.cs
+++ b/osu.Game/Overlays/Comments/CommentEditor.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Overlays.Comments
 
             public EditorTextBox()
             {
-                Masking = false;
+                Masking = DrawBorder = false;
                 TextContainer.Height = 0.4f;
             }
 


### PR DESCRIPTION
Regressed in d6bf4fd90d51b9978a20dacd3959a20f609c91fe.

One very visible instance of this regression is the login form.

https://github.com/user-attachments/assets/5ba10ac5-4cb1-49af-b55c-89cf58ca0b44

The `CommentEditor` usage was discovered with one of my favourite tricks which is doing

```diff
diff --git a/osu.Game/Graphics/UserInterface/OsuTextBox.cs b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
index fefe776b01..c17cca726b 100644
--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -42,6 +42,12 @@ public partial class OsuTextBox : BasicTextBox
             Margin = new MarginPadding { Left = 2 },
         };
 
+        public new bool Masking
+        {
+            get => base.Masking;
+            set => base.Masking = value;
+        }
+
         protected bool DrawBorder { get; init; } = true;
 
         private OsuCaret? caret;

```

and then looking for usages of the setter. That's all due diligence you're getting here, I'm not auditing every single text box in the game.

And yes, the `CommentEditor` usage is OMEGA dodgy but the change applied here is the only one that preserves its visual appearance. I'm not putting in time to fix it.