### PR TITLE
Adjust speed deviation scaling to be more harsh on low end

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -256,8 +256,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             speedValue *= speedHighDeviationMultiplier;
 
             // An effective hit window is created based on the speed SR. The higher the speed difficulty, the shorter the hit window.
-            // For example, a speed SR of 3.0 leads to an effective hit window of 20ms, which is OD 10.
-            double effectiveHitWindow = Math.Sqrt(30 * 60 / attributes.SpeedDifficulty);
+            // For example, a speed SR of 4.0 leads to an effective hit window of 20ms, which is OD 10.
+            double effectiveHitWindow = 20 * Math.Pow(4 / attributes.SpeedDifficulty, 0.35);
 
             // Find the proportion of 300s on speed notes assuming the hit window was the effective hit window.
             double effectiveAccuracy = DifficultyCalculationUtils.Erf(effectiveHitWindow / (double)speedDeviation);


### PR DESCRIPTION
This should buff raw speed plays like Ivaxa Violation, at the same time undoing part of the buff on the lower end scores like Save Me NM
Moved part of the multiplier out of the Pow to be more intuitive (it multiplies the 20 by Pow(difficulty/4), so it's more clear that it would be equal to 1 on difficulty = 4)
The scaling itself was adjusted to be more similar to live (so buffs/nerfs on 98% acc remains +- the same through the difficulty curve)

<img width="1917" height="834" alt="image" src="https://github.com/user-attachments/assets/8733f690-0d61-454b-b7af-7a399a469be3" />

<img width="1919" height="676" alt="image" src="https://github.com/user-attachments/assets/ef34c7da-b81c-43b4-bc1c-bc3b92120cc4" />
