### PR TITLE
Handle mania-specific skill considerations explicitly through a new skill

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/Evaluators/IndividualStrainEvaluator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Evaluators/IndividualStrainEvaluator.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Mania.Objects;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Evaluators
 {
@@ -11,20 +12,23 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Evaluators
     {
         public static double EvaluateDifficultyOf(DifficultyHitObject current)
         {
+            if (current.BaseObject is TailNote)
+                return 0;
+
             var maniaCurrent = (ManiaDifficultyHitObject)current;
-            double startTime = maniaCurrent.StartTime;
-            double endTime = maniaCurrent.EndTime;
+            double currStartTime = maniaCurrent.StartTime;
+            double currEndTime = maniaCurrent.Tail?.EndTime ?? currStartTime;
 
             double holdFactor = 1.0; // Factor to all additional strains in case something else is held
 
             // We award a bonus if this note starts and ends before the end of another hold note.
-            foreach (var maniaPrevious in maniaCurrent.PreviousHitObjects)
+            foreach (var maniaPrevious in maniaCurrent.PreviousHeadObjects)
             {
-                if (maniaPrevious is null)
+                if (maniaPrevious is null || !maniaPrevious.IsHold)
                     continue;
 
-                if (Precision.DefinitelyBigger(maniaPrevious.EndTime, endTime, 1) &&
-                    Precision.DefinitelyBigger(startTime, maniaPrevious.StartTime, 1))
+                if (Precision.DefinitelyBigger(maniaPrevious.Tail!.ActualTime, currEndTime, 1) &&
+                    Precision.DefinitelyBigger(currStartTime, maniaPrevious.StartTime, 1))
                 {
                     holdFactor = 1.25;
                     break;

--- a/osu.Game.Rulesets.Mania/Difficulty/Evaluators/IndividualStrainEvaluator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Evaluators/IndividualStrainEvaluator.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
-using osu.Game.Rulesets.Mania.Objects;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Evaluators
 {
@@ -12,23 +11,20 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Evaluators
     {
         public static double EvaluateDifficultyOf(DifficultyHitObject current)
         {
-            if (current.BaseObject is TailNote)
-                return 0;
-
             var maniaCurrent = (ManiaDifficultyHitObject)current;
-            double currStartTime = maniaCurrent.StartTime;
-            double currEndTime = maniaCurrent.Tail?.EndTime ?? currStartTime;
+            double startTime = maniaCurrent.StartTime;
+            double endTime = maniaCurrent.EndTime;
 
             double holdFactor = 1.0; // Factor to all additional strains in case something else is held
 
             // We award a bonus if this note starts and ends before the end of another hold note.
             foreach (var maniaPrevious in maniaCurrent.PreviousHeadObjects)
             {
-                if (maniaPrevious is null || !maniaPrevious.IsHold)
+                if (maniaPrevious is null)
                     continue;
 
-                if (Precision.DefinitelyBigger(maniaPrevious.Tail!.ActualTime, currEndTime, 1) &&
-                    Precision.DefinitelyBigger(currStartTime, maniaPrevious.StartTime, 1))
+                if (Precision.DefinitelyBigger(maniaPrevious.EndTime, endTime, 1) &&
+                    Precision.DefinitelyBigger(startTime, maniaPrevious.StartTime, 1))
                 {
                     holdFactor = 1.25;
                     break;

--- a/osu.Game.Rulesets.Mania/Difficulty/Evaluators/OverallStrainEvaluator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Evaluators/OverallStrainEvaluator.cs
@@ -6,7 +6,6 @@ using osu.Framework.Utils;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
-using osu.Game.Rulesets.Mania.Objects;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Evaluators
 {
@@ -16,52 +15,31 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Evaluators
 
         public static double EvaluateDifficultyOf(DifficultyHitObject current)
         {
-            if (current.BaseObject is TailNote)
-                return 0;
-
             var maniaCurrent = (ManiaDifficultyHitObject)current;
-            double currStartTime = maniaCurrent.StartTime;
-            double currEndTime = maniaCurrent.Tail?.ActualTime ?? currStartTime;
+            double startTime = maniaCurrent.StartTime;
+            double endTime = maniaCurrent.EndTime;
             bool isOverlapping = false;
 
-            double closestEndTime = Math.Abs(currEndTime - currStartTime); // Lowest value we can assume with the current information
+            double closestEndTime = Math.Abs(endTime - startTime); // Lowest value we can assume with the current information
             double holdFactor = 1.0; // Factor to all additional strains in case something else is held
             double holdAddition = 0; // Addition to the current note in case it's a hold and has to be released awkwardly
 
-            // Bonus for interaction between LNs
             foreach (var maniaPrevious in maniaCurrent.PreviousHeadObjects)
             {
-                if (maniaPrevious is null || !maniaPrevious.IsHold)
-                {
-                    // This is wrong but yea match live woo hoo
-                    if (maniaPrevious is not null)
-                        closestEndTime = Math.Min(closestEndTime, Math.Abs(currEndTime - maniaPrevious.StartTime));
-
+                if (maniaPrevious is null)
                     continue;
-                }
 
-                // We count this note as overlapped if the current note is an LN and any other LN is arranged like this:
-                // Prev  Curr
-                //        O <- Current LN's tail comes after previous LN's tail
-                //  O     |
-                //  |     O <- Current LN's head intersects previous LN's body
-                //  O
-                if (maniaCurrent.IsHold)
-                {
-                    bool currentHeadIntersects = Precision.DefinitelyBigger(maniaPrevious.Tail!.ActualTime, currStartTime, 1)
-                                                 && Precision.DefinitelyBigger(currStartTime, maniaPrevious.StartTime, 1);
+                // The current note is overlapped if a previous note or end is overlapping the current note body
+                isOverlapping |= Precision.DefinitelyBigger(maniaPrevious.EndTime, startTime, 1) &&
+                                 Precision.DefinitelyBigger(endTime, maniaPrevious.EndTime, 1) &&
+                                 Precision.DefinitelyBigger(startTime, maniaPrevious.StartTime, 1);
 
-                    bool currentTailComesAfter = Precision.DefinitelyBigger(maniaCurrent.Tail!.ActualTime, maniaPrevious.Tail.ActualTime, 1);
-
-                    isOverlapping |= currentHeadIntersects && currentTailComesAfter;
-                }
-
-                // We also give a bonus to this note if an LN exists that starts before this note and ends after.
-                if (Precision.DefinitelyBigger(maniaPrevious.Tail!.ActualTime, currEndTime, 1) &&
-                    Precision.DefinitelyBigger(currStartTime, maniaPrevious.StartTime, 1))
+                // We give a slight bonus to everything if something is held meanwhile
+                if (Precision.DefinitelyBigger(maniaPrevious.EndTime, endTime, 1) &&
+                    Precision.DefinitelyBigger(startTime, maniaPrevious.StartTime, 1))
                     holdFactor = 1.25;
 
-                closestEndTime = Math.Min(closestEndTime, Math.Abs(currEndTime - maniaPrevious.Tail.ActualTime));
+                closestEndTime = Math.Min(closestEndTime, Math.Abs(endTime - maniaPrevious.EndTime));
             }
 
             // The hold addition is given if there was an overlap, however it is only valid if there are no other note with a similar ending.

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -41,6 +42,11 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
             HitWindows hitWindows = new ManiaHitWindows();
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
+
+            for (int i = 0; i < 5000; i++)
+            {
+                Console.Write(skills.OfType<Strain>().Single().GetObjectDifficulties()[i] + ", ");
+            }
 
             ManiaDifficultyAttributes attributes = new ManiaDifficultyAttributes
             {

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -76,34 +76,15 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             int totalColumns = ((ManiaBeatmap)beatmap).TotalColumns;
 
             List<DifficultyHitObject> objects = new List<DifficultyHitObject>();
-            List<ManiaDifficultyHitObject> headObjects = new List<ManiaDifficultyHitObject>();
-            List<ManiaDifficultyHitObject> tailObjects = new List<ManiaDifficultyHitObject>();
-            List<ManiaDifficultyHitObject>[] perColumnHeadObjects = new List<ManiaDifficultyHitObject>[totalColumns];
-            List<ManiaDifficultyHitObject>[] perColumnTailObjects = new List<ManiaDifficultyHitObject>[totalColumns];
-
-            for (int column = 0; column < totalColumns; column++)
-            {
-                perColumnHeadObjects[column] = new List<ManiaDifficultyHitObject>();
-                perColumnTailObjects[column] = new List<ManiaDifficultyHitObject>();
-            }
+            ManiaMapState mapState = new ManiaMapState(totalColumns);
 
             for (int i = 1; i < sortedObjects.Length; i++)
             {
                 var currentObject = new ManiaDifficultyHitObject(sortedObjects[i], sortedObjects[i - 1], clockRate,
-                    objects, headObjects, tailObjects, perColumnHeadObjects, perColumnTailObjects, objects.Count);
+                    objects, mapState, objects.Count);
 
                 objects.Add(currentObject);
-
-                if (currentObject.BaseObject is not TailNote)
-                {
-                    headObjects.Add(currentObject);
-                    perColumnHeadObjects[currentObject.Column].Add(currentObject);
-                }
-                else
-                {
-                    tailObjects.Add(currentObject);
-                    perColumnTailObjects[currentObject.Column].Add(currentObject);
-                }
+                mapState.Add(currentObject);
             }
 
             return objects;

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -42,11 +41,6 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
             HitWindows hitWindows = new ManiaHitWindows();
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
-
-            for (int i = 0; i < 5000; i++)
-            {
-                Console.Write(skills.OfType<Strain>().Single().GetObjectDifficulties()[i] + ", ");
-            }
 
             ManiaDifficultyAttributes attributes = new ManiaDifficultyAttributes
             {

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -89,7 +89,9 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
             for (int i = 1; i < sortedObjects.Length; i++)
             {
-                var currentObject = new ManiaDifficultyHitObject(sortedObjects[i], sortedObjects[i - 1], clockRate, objects, headObjects, tailObjects, perColumnHeadObjects, perColumnTailObjects, objects.Count);
+                var currentObject = new ManiaDifficultyHitObject(sortedObjects[i], sortedObjects[i - 1], clockRate,
+                    objects, headObjects, tailObjects, perColumnHeadObjects, perColumnTailObjects, objects.Count);
+
                 objects.Add(currentObject);
 
                 if (currentObject.BaseObject is not TailNote)

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -12,7 +11,6 @@ using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mania.Difficulty.Skills;
-using osu.Game.Rulesets.Mania.MathUtils;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Scoring;
@@ -64,22 +62,46 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
         protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)
         {
-            var sortedObjects = beatmap.HitObjects.ToArray();
+            List<HitObject> objectsList = new List<HitObject>();
+
+            foreach (var obj in beatmap.HitObjects)
+            {
+                if (obj is Note)
+                    objectsList.Add(obj);
+                else
+                    objectsList.AddRange(obj.NestedHitObjects.Where(o => o is not HoldNoteBody));
+            }
+
+            var sortedObjects = objectsList.OrderBy(o => o.StartTime).ToArray();
             int totalColumns = ((ManiaBeatmap)beatmap).TotalColumns;
 
-            LegacySortHelper<HitObject>.Sort(sortedObjects, Comparer<HitObject>.Create((a, b) => (int)Math.Round(a.StartTime) - (int)Math.Round(b.StartTime)));
-
             List<DifficultyHitObject> objects = new List<DifficultyHitObject>();
-            List<DifficultyHitObject>[] perColumnObjects = new List<DifficultyHitObject>[totalColumns];
+            List<ManiaDifficultyHitObject> headObjects = new List<ManiaDifficultyHitObject>();
+            List<ManiaDifficultyHitObject> tailObjects = new List<ManiaDifficultyHitObject>();
+            List<ManiaDifficultyHitObject>[] perColumnHeadObjects = new List<ManiaDifficultyHitObject>[totalColumns];
+            List<ManiaDifficultyHitObject>[] perColumnTailObjects = new List<ManiaDifficultyHitObject>[totalColumns];
 
             for (int column = 0; column < totalColumns; column++)
-                perColumnObjects[column] = new List<DifficultyHitObject>();
+            {
+                perColumnHeadObjects[column] = new List<ManiaDifficultyHitObject>();
+                perColumnTailObjects[column] = new List<ManiaDifficultyHitObject>();
+            }
 
             for (int i = 1; i < sortedObjects.Length; i++)
             {
-                var currentObject = new ManiaDifficultyHitObject(sortedObjects[i], sortedObjects[i - 1], clockRate, objects, perColumnObjects, objects.Count);
+                var currentObject = new ManiaDifficultyHitObject(sortedObjects[i], sortedObjects[i - 1], clockRate, objects, headObjects, tailObjects, perColumnHeadObjects, perColumnTailObjects, objects.Count);
                 objects.Add(currentObject);
-                perColumnObjects[currentObject.Column].Add(currentObject);
+
+                if (currentObject.BaseObject is not TailNote)
+                {
+                    headObjects.Add(currentObject);
+                    perColumnHeadObjects[currentObject.Column].Add(currentObject);
+                }
+                else
+                {
+                    tailObjects.Add(currentObject);
+                    perColumnTailObjects[currentObject.Column].Add(currentObject);
+                }
             }
 
             return objects;

--- a/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
@@ -28,23 +27,17 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
 
         public readonly int Column;
 
-        // Indices of the next notes
-        private readonly int nextHeadObjectIndex;
-        private readonly int nextTailObjectIndex;
+        // Note indices used to determine where to start searching the note index from this note
+        private readonly int prevHeadIndex;
+        private readonly int nextHeadIndex;
+        private readonly int prevTailIndex;
+        private readonly int nextTailIndex;
+        private readonly int columnPrevHeadIndex;
         private readonly int columnNextHeadIndex;
+        private readonly int columnPrevTailIndex;
         private readonly int columnNextTailIndex;
 
-        // Indices of the previous notes
-        private readonly int prevHeadObjectIndex;
-        private readonly int prevTailObjectIndex;
-        private readonly int columnPrevHeadIndex;
-        private readonly int columnPrevTailIndex;
-
-        // Lists of head and tail objects to make object-type specific traversal easier.
-        private readonly List<ManiaDifficultyHitObject> headObjects;
-        private readonly List<ManiaDifficultyHitObject> tailObjects;
-        private readonly List<ManiaDifficultyHitObject>[] perColumnHeadObjects;
-        private readonly List<ManiaDifficultyHitObject>[] perColumnTailObjects;
+        private readonly ManiaMapState mapState;
 
         /// <summary>
         /// The hit object earlier in time than this note in each column.
@@ -53,72 +46,69 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
 
         public readonly double ColumnHeadStrainTime;
 
-        public ManiaDifficultyHitObject(HitObject hitObject, HitObject lastObject, double clockRate, List<DifficultyHitObject> objects,
-                                        List<ManiaDifficultyHitObject> headObjects, List<ManiaDifficultyHitObject> tailObjects,
-                                        List<ManiaDifficultyHitObject>[] perColumnHeadObjects, List<ManiaDifficultyHitObject>[] perColumnTailObjects, int index)
+        public ManiaDifficultyHitObject(HitObject hitObject, HitObject lastObject, double clockRate,
+                                        List<DifficultyHitObject> objects, ManiaMapState mapState, int index)
             : base(hitObject, lastObject, clockRate, objects, index)
         {
-            int totalColumns = perColumnHeadObjects.Length;
-            this.headObjects = headObjects;
-            this.tailObjects = tailObjects;
-            this.perColumnHeadObjects = perColumnHeadObjects;
-            this.perColumnTailObjects = perColumnTailObjects;
-            Column = BaseObject.Column;
-            PreviousHeadObjects = new ManiaDifficultyHitObject[totalColumns];
+            this.mapState = mapState;
 
-            // Actual time is when the nested hit object takes place
+            Column = BaseObject.Column;
+            PreviousHeadObjects = new ManiaDifficultyHitObject[mapState.TotalColumns];
             ActualTime = base.StartTime;
 
-            int headObjectIndex = headObjects.Count;
-            int tailObjectIndex = tailObjects.Count;
-            int columnHeadIndex = perColumnHeadObjects[Column].Count;
-            int columnTailIndex = perColumnTailObjects[Column].Count;
+            int headCount = mapState.HeadCount;
+            int tailCount = mapState.TailCount;
+            int columnHeadCount = mapState.ColumnHeadCount(Column);
+            int columnTailCount = mapState.ColumnTailCount(Column);
 
-            prevHeadObjectIndex = headObjectIndex - 1;
-            prevTailObjectIndex = tailObjectIndex - 1;
-            columnPrevHeadIndex = columnHeadIndex - 1;
-            columnPrevTailIndex = columnTailIndex - 1;
-
-            // Add a reference to the related head/tail for long notes.
             if (BaseObject is TailNote)
             {
                 Tail = this;
-
-                // We process forward, so we need to set the tail value for the previous head while we process the tail for it.
-                Head = perColumnHeadObjects[Column].LastOrDefault();
+                Head = mapState.GetColumnHead(Column, columnHeadCount - 1);
 
                 if (Head is not null)
                 {
                     Head.Tail = this;
-                    Head.EndTime = Tail.ActualTime;
+                    Head.EndTime = ActualTime;
                 }
 
-                // We need to separate behaviour for future note indexing for heads and tails, since a tail's head index points to the next head, not itself.
-                nextHeadObjectIndex = headObjectIndex;
-                nextTailObjectIndex = tailObjectIndex + 1;
-                columnNextHeadIndex = columnHeadIndex;
-                columnNextTailIndex = columnTailIndex + 1;
+                // For a tail, the "next head" index is unchanged (this isn't a head),
+                // and the "next tail" index points past itself once added.
+                prevHeadIndex = headCount - 1;
+                nextHeadIndex = headCount;
+                prevTailIndex = tailCount - 1;
+                nextTailIndex = tailCount + 1;
+
+                columnPrevHeadIndex = columnHeadCount - 1;
+                columnNextHeadIndex = columnHeadCount;
+                columnPrevTailIndex = columnTailCount - 1;
+                columnNextTailIndex = columnTailCount + 1;
             }
             else
             {
                 Head = this;
 
-                // Same for heads
-                nextHeadObjectIndex = headObjectIndex + 1;
-                nextTailObjectIndex = tailObjectIndex;
-                columnNextHeadIndex = columnHeadIndex + 1;
-                columnNextTailIndex = columnTailIndex;
+                prevHeadIndex = headCount - 1;
+                nextHeadIndex = headCount + 1;
+                prevTailIndex = tailCount - 1;
+                nextTailIndex = tailCount;
+
+                columnPrevHeadIndex = columnHeadCount - 1;
+                columnNextHeadIndex = columnHeadCount + 1;
+                columnPrevTailIndex = columnTailCount - 1;
+                columnNextTailIndex = columnTailCount;
             }
 
             StartTime = Head?.ActualTime ?? ActualTime;
-            EndTime = ActualTime; // For LNs, we go back and populate this when we process the tail.
+            EndTime = ActualTime;
 
             HeadDeltaTime = StartTime - PrevHead(0)?.StartTime ?? StartTime;
             ColumnHeadStrainTime = StartTime - PrevHeadInColumn(0)?.StartTime ?? StartTime;
 
-            for (int i = 0; i < perColumnHeadObjects.Length; i++)
+            for (int i = 0; i < mapState.TotalColumns; i++)
             {
-                ManiaDifficultyHitObject? columnObject = perColumnHeadObjects[i].LastOrDefault();
+                int lastColumnHeadIndex = mapState.ColumnHeadCount(i) - 1;
+                ManiaDifficultyHitObject? columnObject = mapState.GetColumnHead(i, lastColumnHeadIndex);
 
                 if (columnObject is not null)
                 {
@@ -139,78 +129,42 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
             }
         }
 
-        public ManiaDifficultyHitObject? PrevHead(int backwardsIndex) => getNoteByIndex(headObjects, prevHeadObjectIndex - backwardsIndex);
-        public ManiaDifficultyHitObject? NextHead(int forwardsIndex) => getNoteByIndex(headObjects, nextHeadObjectIndex + forwardsIndex);
+        public ManiaDifficultyHitObject? PrevHead(int backwardsIndex) => mapState.GetHead(prevHeadIndex - backwardsIndex);
+        public ManiaDifficultyHitObject? NextHead(int forwardsIndex) => mapState.GetHead(nextHeadIndex + forwardsIndex);
 
-        public ManiaDifficultyHitObject? PrevTail(int backwardsIndex) => getNoteByIndex(tailObjects, prevTailObjectIndex - backwardsIndex);
-        public ManiaDifficultyHitObject? NextTail(int forwardsIndex) => getNoteByIndex(tailObjects, nextTailObjectIndex + forwardsIndex);
+        public ManiaDifficultyHitObject? PrevTail(int backwardsIndex) => mapState.GetTail(prevTailIndex - backwardsIndex);
+        public ManiaDifficultyHitObject? NextTail(int forwardsIndex) => mapState.GetTail(nextTailIndex + forwardsIndex);
 
         public ManiaDifficultyHitObject? PrevHeadInColumn(int backwardsIndex, int? column = null, bool inclusive = false)
         {
             if (column is null || column == Column)
-            {
-                return getNoteByIndex(perColumnHeadObjects[Column], columnPrevHeadIndex - backwardsIndex);
-            }
+                return mapState.GetColumnHead(Column, columnPrevHeadIndex - backwardsIndex);
 
-            return getNoteInColumn(perColumnHeadObjects, column.Value, backwardsIndex, inclusive, true);
+            return mapState.SearchColumnHead(column.Value, ActualTime, backwardsIndex, inclusive, backward: true);
         }
 
         public ManiaDifficultyHitObject? NextHeadInColumn(int forwardsIndex, int? column = null, bool inclusive = false)
         {
             if (column is null || column == Column)
-            {
-                return getNoteByIndex(perColumnHeadObjects[Column], columnNextHeadIndex + forwardsIndex);
-            }
+                return mapState.GetColumnHead(Column, columnNextHeadIndex + forwardsIndex);
 
-            return getNoteInColumn(perColumnHeadObjects, column.Value, forwardsIndex, inclusive, false);
+            return mapState.SearchColumnHead(column.Value, ActualTime, forwardsIndex, inclusive, backward: false);
         }
 
         public ManiaDifficultyHitObject? PrevTailInColumn(int backwardsIndex, int? column = null, bool inclusive = false)
         {
             if (column is null || column == Column)
-            {
-                return getNoteByIndex(perColumnTailObjects[Column], columnPrevTailIndex - backwardsIndex);
-            }
+                return mapState.GetColumnTail(Column, columnPrevTailIndex - backwardsIndex);
 
-            return getNoteInColumn(perColumnTailObjects, column.Value, backwardsIndex, inclusive, true);
+            return mapState.SearchColumnTail(column.Value, ActualTime, backwardsIndex, inclusive, backward: true);
         }
 
         public ManiaDifficultyHitObject? NextTailInColumn(int forwardsIndex, int? column = null, bool inclusive = false)
         {
             if (column is null || column == Column)
-            {
-                return getNoteByIndex(perColumnTailObjects[Column], columnNextTailIndex + forwardsIndex);
-            }
+                return mapState.GetColumnTail(Column, columnNextTailIndex + forwardsIndex);
 
-            return getNoteInColumn(perColumnTailObjects, column.Value, forwardsIndex, inclusive, false);
+            return mapState.SearchColumnTail(column.Value, ActualTime, forwardsIndex, inclusive, backward: false);
         }
-
-        private ManiaDifficultyHitObject? getNoteInColumn(List<ManiaDifficultyHitObject>[] columnLists, int column, int offset, bool inclusive, bool backward)
-        {
-            if (column < 0 || column >= columnLists.Length)
-                return null;
-
-            List<ManiaDifficultyHitObject> columnList = columnLists[column];
-
-            // The lists are ordered by ActualTime, so we can use binary search here.
-            int foundIndex = columnList.BinarySearch(this, Comparer<ManiaDifficultyHitObject>.Create((x, y) => x.ActualTime.CompareTo(y.ActualTime)));
-
-            if (foundIndex < 0) foundIndex = ~foundIndex;
-
-            if (backward)
-            {
-                // Binary search index is always either the same or greater, so we subtract 1 if not inclusive.
-                int baseIndex = inclusive && foundIndex < columnList.Count && columnList[foundIndex].ActualTime == ActualTime ? foundIndex : foundIndex - 1;
-                return getNoteByIndex(columnList, baseIndex - offset);
-            }
-            else
-            {
-                // Binary search index is always either the same or greater, so we only add 1 if not inclusive but there is a note at the same time.
-                int baseIndex = !inclusive && foundIndex < columnList.Count && columnList[foundIndex].ActualTime == ActualTime ? foundIndex + 1 : foundIndex;
-                return getNoteByIndex(columnList, baseIndex + offset);
-            }
-        }
-
-        private ManiaDifficultyHitObject? getNoteByIndex(List<ManiaDifficultyHitObject> list, int index) => index >= 0 && index < list.Count ? list[index] : null;
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
@@ -120,11 +120,17 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
         public ManiaDifficultyHitObject? PrevTail(int backwardsIndex) => getNoteByIndex(tailObjects, tailObjectIndex - (backwardsIndex + 1));
         public ManiaDifficultyHitObject? NextTail(int forwardsIndex) => getNoteByIndex(tailObjects, tailObjectIndex + forwardsIndex + 1);
 
-        public ManiaDifficultyHitObject? PrevHeadInColumn(int backwardsIndex, int? column = null, bool inclusive = false) => getRelative(perColumnHeadObjects, column, columnHeadIndex, -backwardsIndex - 1, inclusive, true);
-        public ManiaDifficultyHitObject? NextHeadInColumn(int forwardsIndex, int? column = null, bool inclusive = false) => getRelative(perColumnHeadObjects, column, columnHeadIndex, forwardsIndex + 1, inclusive, false);
+        public ManiaDifficultyHitObject? PrevHeadInColumn(int backwardsIndex, int? column = null, bool inclusive = false) =>
+            getRelative(perColumnHeadObjects, column, columnHeadIndex, -backwardsIndex - 1, inclusive, true);
 
-        public ManiaDifficultyHitObject? PrevTailInColumn(int backwardsIndex, int? column = null, bool inclusive = false) => getRelative(perColumnTailObjects, column, columnTailIndex, -backwardsIndex - 1, inclusive, true);
-        public ManiaDifficultyHitObject? NextTailInColumn(int forwardsIndex, int? column = null, bool inclusive = false) => getRelative(perColumnTailObjects, column, columnTailIndex, forwardsIndex + 1, inclusive, false);
+        public ManiaDifficultyHitObject? NextHeadInColumn(int forwardsIndex, int? column = null, bool inclusive = false) =>
+            getRelative(perColumnHeadObjects, column, columnHeadIndex, forwardsIndex + 1, inclusive, false);
+
+        public ManiaDifficultyHitObject? PrevTailInColumn(int backwardsIndex, int? column = null, bool inclusive = false) =>
+            getRelative(perColumnTailObjects, column, columnTailIndex, -backwardsIndex - 1, inclusive, true);
+
+        public ManiaDifficultyHitObject? NextTailInColumn(int forwardsIndex, int? column = null, bool inclusive = false) =>
+            getRelative(perColumnTailObjects, column, columnTailIndex, forwardsIndex + 1, inclusive, false);
 
         private ManiaDifficultyHitObject? getRelative(List<ManiaDifficultyHitObject>[] perColumnLists, int? column, int currIndex, int offset, bool inclusive, bool backward)
         {
@@ -147,16 +153,16 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
             // We don't add 1 to the offsets here, since it returns the index of the prev object already
             if (backward)
             {
-                int baseIndex = (inclusive && foundIndex < list.Count && list[foundIndex].StartTime == StartTime) ? foundIndex : foundIndex - 1;
+                int baseIndex = inclusive && foundIndex < list.Count && list[foundIndex].StartTime == StartTime ? foundIndex : foundIndex - 1;
                 return getNoteByIndex(list, baseIndex + offset);
             }
             else
             {
-                int baseIndex = (!inclusive && foundIndex < list.Count && list[foundIndex].StartTime == StartTime) ? foundIndex + 1 : foundIndex;
+                int baseIndex = !inclusive && foundIndex < list.Count && list[foundIndex].StartTime == StartTime ? foundIndex + 1 : foundIndex;
                 return getNoteByIndex(list, baseIndex + offset);
             }
         }
 
-        private ManiaDifficultyHitObject? getNoteByIndex(List<ManiaDifficultyHitObject> list, int index) => (index >= 0 && index < list.Count) ? list[index] : null;
+        private ManiaDifficultyHitObject? getNoteByIndex(List<ManiaDifficultyHitObject> list, int index) => index >= 0 && index < list.Count ? list[index] : null;
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
@@ -19,9 +19,6 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
         public new double StartTime { get; }
         public new double EndTime { get; private set; }
 
-        public int? HeadIndex => Head?.headObjectIndex;
-        public int? TailIndex => Tail?.headObjectIndex;
-
         /// <summary>
         /// The time difference to the last processed head note in any other column.
         /// </summary>

--- a/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaMapState.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaMapState.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mania.Objects;
+
+namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
+{
+    /// <summary>
+    /// Data processing class that makes it easy to traverse the whole map based on note type and column.
+    /// </summary>
+    public class ManiaMapState
+    {
+        private readonly List<ManiaDifficultyHitObject> heads = new List<ManiaDifficultyHitObject>();
+        private readonly List<ManiaDifficultyHitObject> tails = new List<ManiaDifficultyHitObject>();
+        private readonly List<ManiaDifficultyHitObject>[] columnHeads;
+        private readonly List<ManiaDifficultyHitObject>[] columnTails;
+
+        public int TotalColumns { get; }
+        public int HeadCount => heads.Count;
+        public int TailCount => tails.Count;
+
+        public ManiaMapState(int totalColumns)
+        {
+            TotalColumns = totalColumns;
+            columnHeads = new List<ManiaDifficultyHitObject>[totalColumns];
+            columnTails = new List<ManiaDifficultyHitObject>[totalColumns];
+
+            for (int i = 0; i < totalColumns; i++)
+            {
+                columnHeads[i] = new List<ManiaDifficultyHitObject>();
+                columnTails[i] = new List<ManiaDifficultyHitObject>();
+            }
+        }
+
+        public void Add(ManiaDifficultyHitObject obj)
+        {
+            if (obj.BaseObject is TailNote)
+            {
+                tails.Add(obj);
+                columnTails[obj.Column].Add(obj);
+            }
+            else
+            {
+                heads.Add(obj);
+                columnHeads[obj.Column].Add(obj);
+            }
+        }
+
+        public int ColumnHeadCount(int column) => columnHeads[column].Count;
+        public int ColumnTailCount(int column) => columnTails[column].Count;
+
+        public ManiaDifficultyHitObject? GetHead(int index) => GetByIndex(heads, index);
+        public ManiaDifficultyHitObject? GetTail(int index) => GetByIndex(tails, index);
+        public ManiaDifficultyHitObject? GetColumnHead(int column, int index) => GetByIndex(columnHeads[column], index);
+        public ManiaDifficultyHitObject? GetColumnTail(int column, int index) => GetByIndex(columnTails[column], index);
+
+        public ManiaDifficultyHitObject? SearchColumnHead(int column, double time, int offset, bool inclusive, bool backward)
+            => searchColumn(columnHeads, column, time, offset, inclusive, backward);
+
+        public ManiaDifficultyHitObject? SearchColumnTail(int column, double time, int offset, bool inclusive, bool backward)
+            => searchColumn(columnTails, column, time, offset, inclusive, backward);
+
+        private ManiaDifficultyHitObject? searchColumn(List<ManiaDifficultyHitObject>[] lists, int column, double time, int offset, bool inclusive, bool backward)
+        {
+            if (column < 0 || column >= TotalColumns)
+                return null;
+
+            var list = lists[column];
+            int found = list.BinarySearch(null!, Comparer<ManiaDifficultyHitObject>.Create((x, _) => x.ActualTime.CompareTo(time)));
+
+            if (found < 0) found = ~found;
+
+            if (backward)
+            {
+                int baseIndex = inclusive && found < list.Count && list[found].ActualTime == time ? found : found - 1;
+                return GetByIndex(list, baseIndex - offset);
+            }
+            else
+            {
+                int baseIndex = !inclusive && found < list.Count && list[found].ActualTime == time ? found + 1 : found;
+                return GetByIndex(list, baseIndex + offset);
+            }
+        }
+
+        public static ManiaDifficultyHitObject? GetByIndex(List<ManiaDifficultyHitObject> list, int index)
+            => index >= 0 && index < list.Count ? list[index] : null;
+    }
+}

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaSkill.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaSkill.cs
@@ -40,10 +40,10 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             this.lnProcessingMode = lnProcessingMode;
         }
 
-        protected override double ProcessInternal(DifficultyHitObject current)
+        public override void Process(DifficultyHitObject current)
         {
             if (!shouldProcess(current))
-                return 0;
+                return;
 
             ManiaDifficultyHitObject maniaCurrent = (ManiaDifficultyHitObject)current;
 
@@ -70,15 +70,15 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
                 chordPreprocessed = true;
             }
 
-            double strainValue = StrainValueAt(maniaCurrent);
+            FinalizeChord();
 
-            return strainValue;
+            double strainValue = ProcessInternal(maniaCurrent);
+
+            ObjectDifficulties.Add(strainValue);
         }
 
         protected abstract void PreprocessChordNote(ManiaDifficultyHitObject current);
         protected abstract void FinalizeChord();
-
-        protected abstract double StrainValueAt(ManiaDifficultyHitObject current);
 
         private void startNewChord(double newChordTime)
         {

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaSkill.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaSkill.cs
@@ -1,0 +1,118 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Mania.Difficulty.Skills
+{
+    public abstract class ManiaSkill : Skill
+    {
+        protected double CurrentChordTime { get; private set; }
+        protected double PreviousChordTime { get; private set; }
+        protected int ChordNoteCount { get; private set; }
+
+        protected readonly double[] PreviousColumnTimes;
+
+        // Used to update previousColumnTimes in a way unaffected by processing order.
+        private readonly double[] currentColumnTimes;
+
+        // Tracks if the chord starting at CurrentChordTime has already had PreprocessChordNote called for all notes
+        private bool chordPreprocessed;
+
+        public enum LnMode
+        {
+            Heads,
+            Tails,
+            Both
+        }
+
+        private readonly LnMode lnProcessingMode;
+
+        protected ManiaSkill(Mod[] mods, int columns, LnMode lnProcessingMode = LnMode.Heads)
+            : base(mods)
+        {
+            currentColumnTimes = new double[columns];
+            PreviousColumnTimes = new double[columns];
+            this.lnProcessingMode = lnProcessingMode;
+        }
+
+        protected override double ProcessInternal(DifficultyHitObject current)
+        {
+            if (!shouldProcess(current))
+                return 0;
+
+            ManiaDifficultyHitObject maniaCurrent = (ManiaDifficultyHitObject)current;
+
+            // If this is a new time stamp, reset state for the next chord.
+            if (maniaCurrent.StartTime > CurrentChordTime)
+            {
+                startNewChord(maniaCurrent.StartTime);
+                chordPreprocessed = false;
+            }
+
+            if (!chordPreprocessed)
+            {
+                ManiaDifficultyHitObject? chordNote = maniaCurrent;
+
+                // Look ahead and process all notes sharing this StartTime.
+                while (chordNote != null && chordNote.StartTime == CurrentChordTime)
+                {
+                    PreprocessChordNote(chordNote);
+                    currentColumnTimes[chordNote.Column] = chordNote.ActualTime;
+                    ChordNoteCount++;
+                    chordNote = getNext(chordNote);
+                }
+
+                chordPreprocessed = true;
+            }
+
+            double strainValue = StrainValueAt(maniaCurrent);
+
+            return strainValue;
+        }
+
+        protected abstract void PreprocessChordNote(ManiaDifficultyHitObject current);
+        protected abstract void FinalizeChord();
+
+        protected abstract double StrainValueAt(ManiaDifficultyHitObject current);
+
+        private void startNewChord(double newChordTime)
+        {
+            // Reset skill specific chord implementations
+            ResetChord();
+
+            PreviousChordTime = CurrentChordTime;
+            CurrentChordTime = newChordTime;
+            ChordNoteCount = 0;
+
+            for (int column = 0; column < currentColumnTimes.Length; column++)
+                PreviousColumnTimes[column] = currentColumnTimes[column];
+        }
+
+        protected abstract void ResetChord();
+
+        private bool shouldProcess(DifficultyHitObject current)
+        {
+            return current.BaseObject switch
+            {
+                TailNote => lnProcessingMode is LnMode.Tails or LnMode.Both,
+                _ => lnProcessingMode is not LnMode.Tails
+            };
+        }
+
+        private ManiaDifficultyHitObject? getNext(ManiaDifficultyHitObject curr)
+        {
+            return lnProcessingMode switch
+            {
+                LnMode.Heads => curr.NextHead(0),
+                LnMode.Tails => curr.NextTail(0),
+                LnMode.Both => (ManiaDifficultyHitObject?)curr.Next(0),
+                _ => (ManiaDifficultyHitObject?)curr.Next(0)
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaSkill.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaSkill.cs
@@ -67,10 +67,10 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
                     chordNote = getNext(chordNote);
                 }
 
+                FinalizeChord();
+
                 chordPreprocessed = true;
             }
-
-            FinalizeChord();
 
             double strainValue = ProcessInternal(maniaCurrent);
 
@@ -83,14 +83,14 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
         private void startNewChord(double newChordTime)
         {
             // Reset skill specific chord implementations
-            ResetChord();
-
             PreviousChordTime = CurrentChordTime;
             CurrentChordTime = newChordTime;
             ChordNoteCount = 0;
 
             for (int column = 0; column < currentColumnTimes.Length; column++)
                 PreviousColumnTimes[column] = currentColumnTimes[column];
+
+            ResetChord();
         }
 
         protected abstract void ResetChord();

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaStrainSkill.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaStrainSkill.cs
@@ -32,23 +32,26 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
         {
         }
 
+        protected sealed override void PreChordProcess(ManiaDifficultyHitObject current)
+        {
+            // The first object doesn't generate a strain, so we begin with an incremented section end
+            if (current.Index == 0)
+                currentSectionEnd = Math.Ceiling(current.ActualTime / SectionLength) * SectionLength;
+
+            while (current.ActualTime > currentSectionEnd)
+            {
+                saveCurrentPeak();
+                startNewSectionFrom(currentSectionEnd, current);
+                currentSectionEnd += SectionLength;
+            }
+        }
+
         /// <summary>
         /// Process a <see cref="DifficultyHitObject"/> and update current strain values accordingly.
         /// </summary>
         protected sealed override double ProcessInternal(DifficultyHitObject current)
         {
             ManiaDifficultyHitObject maniaCurrent = (ManiaDifficultyHitObject)current;
-
-            // The first object doesn't generate a strain, so we begin with an incremented section end
-            if (current.Index == 0)
-                currentSectionEnd = Math.Ceiling(maniaCurrent.ActualTime / SectionLength) * SectionLength;
-
-            while (maniaCurrent.ActualTime > currentSectionEnd)
-            {
-                saveCurrentPeak();
-                startNewSectionFrom(currentSectionEnd, maniaCurrent);
-                currentSectionEnd += SectionLength;
-            }
 
             double strain = StrainValueAt(maniaCurrent);
             currentSectionPeak = Math.Max(strain, currentSectionPeak);

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaStrainSkill.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/ManiaStrainSkill.cs
@@ -1,0 +1,136 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Mania.Difficulty.Skills
+{
+    public abstract class ManiaStrainSkill : ManiaSkill
+    {
+        /// <summary>
+        /// The weight by which each strain value decays.
+        /// </summary>
+        protected virtual double DecayWeight => 0.9;
+
+        /// <summary>
+        /// The length of each strain section.
+        /// </summary>
+        protected virtual int SectionLength => 400;
+
+        private double currentSectionPeak; // We also keep track of the peak strain level in the current section.
+        private double currentSectionEnd;
+
+        private readonly List<double> strainPeaks = new List<double>();
+
+        protected ManiaStrainSkill(Mod[] mods, int totalColumns, LnMode lnProcessingMode = LnMode.Heads)
+            : base(mods, totalColumns, lnProcessingMode)
+        {
+        }
+
+        /// <summary>
+        /// Returns the strain value at <see cref="DifficultyHitObject"/>. This value is calculated with or without respect to previous objects.
+        /// </summary>
+        protected abstract double StrainValueAt(DifficultyHitObject current);
+
+        /// <summary>
+        /// Process a <see cref="DifficultyHitObject"/> and update current strain values accordingly.
+        /// </summary>
+        protected sealed override double ProcessInternal(DifficultyHitObject current)
+        {
+            // The first object doesn't generate a strain, so we begin with an incremented section end
+            if (current.Index == 0)
+                currentSectionEnd = Math.Ceiling(current.StartTime / SectionLength) * SectionLength;
+
+            while (current.StartTime > currentSectionEnd)
+            {
+                saveCurrentPeak();
+                startNewSectionFrom(currentSectionEnd, current);
+                currentSectionEnd += SectionLength;
+            }
+
+            double strain = StrainValueAt(current);
+            currentSectionPeak = Math.Max(strain, currentSectionPeak);
+
+            return strain;
+        }
+
+        /// <summary>
+        /// Calculates the number of strains weighted against the top strain.
+        /// The result is scaled by clock rate as it affects the total number of strains.
+        /// </summary>
+        public virtual double CountTopWeightedStrains(double difficultyValue)
+        {
+            if (ObjectDifficulties.Count == 0)
+                return 0.0;
+
+            double consistentTopStrain = difficultyValue * (1 - DecayWeight); // What would the top strain be if all strain values were identical
+
+            if (consistentTopStrain == 0)
+                return ObjectDifficulties.Count;
+
+            // Use a weighted sum of all strains. Constants are arbitrary and give nice values
+            return ObjectDifficulties.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
+        }
+
+        /// <summary>
+        /// Saves the current peak strain level to the list of strain peaks, which will be used to calculate an overall difficulty.
+        /// </summary>
+        private void saveCurrentPeak()
+        {
+            strainPeaks.Add(currentSectionPeak);
+        }
+
+        /// <summary>
+        /// Sets the initial strain level for a new section.
+        /// </summary>
+        /// <param name="time">The beginning of the new section in milliseconds.</param>
+        /// <param name="current">The current hit object.</param>
+        private void startNewSectionFrom(double time, DifficultyHitObject current)
+        {
+            // The maximum strain of the new section is not zero by default
+            // This means we need to capture the strain level at the beginning of the new section, and use that as the initial peak level.
+            currentSectionPeak = CalculateInitialStrain(time, current);
+        }
+
+        /// <summary>
+        /// Retrieves the peak strain at a point in time.
+        /// </summary>
+        /// <param name="time">The time to retrieve the peak strain at.</param>
+        /// <param name="current">The current hit object.</param>
+        /// <returns>The peak strain.</returns>
+        protected abstract double CalculateInitialStrain(double time, DifficultyHitObject current);
+
+        /// <summary>
+        /// Returns a live enumerable of the peak strains for each <see cref="SectionLength"/> section of the beatmap,
+        /// including the peak of the current section.
+        /// </summary>
+        public IEnumerable<double> GetCurrentStrainPeaks() => strainPeaks.Append(currentSectionPeak);
+
+        /// <summary>
+        /// Returns the calculated difficulty value representing all <see cref="DifficultyHitObject"/>s that have been processed up to this point.
+        /// </summary>
+        public override double DifficultyValue()
+        {
+            double difficulty = 0;
+            double weight = 1;
+
+            // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
+            // These sections will not contribute to the difficulty.
+            var peaks = GetCurrentStrainPeaks().Where(p => p > 0).OrderDescending();
+
+            // Difficulty is the weighted sum of the highest strains from every section.
+            // We're sorting from highest to lowest strain.
+            foreach (double strain in peaks)
+            {
+                difficulty += strain * weight;
+                weight *= DecayWeight;
+            }
+
+            return difficulty;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -58,8 +58,8 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
         }
 
         protected override double ReadonlyStrainValueAt(double offset, ManiaDifficultyHitObject current) =>
-            applyDecay(maxIndividualStrain, offset - PreviousChordTime, individual_decay_base)
-            + applyDecay(chordStrain, offset - PreviousChordTime, chord_decay_base);
+            applyDecay(maxIndividualStrain, offset - CurrentChordTime, individual_decay_base)
+            + applyDecay(chordStrain, offset - CurrentChordTime, chord_decay_base);
 
         private double applyDecay(double value, double deltaTime, double decayBase)
             => value * Math.Pow(decayBase, deltaTime / 1000);

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -2,8 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
-using osu.Game.Rulesets.Difficulty.Skills;
+using System.Linq;
 using osu.Game.Rulesets.Mania.Difficulty.Evaluators;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mania.Objects;
@@ -11,48 +10,64 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Skills
 {
-    public class Strain : StrainSkill
+    public class Strain : ManiaSkill
     {
+        private const double chord_decay_base = 0.30;
         private const double individual_decay_base = 0.125;
-        private const double overall_decay_base = 0.30;
+
+        private double chordDifficulty;
+        private double chordStrain;
 
         private readonly double[] individualStrains;
-        private double highestIndividualStrain;
-        private double overallStrain;
 
         public Strain(Mod[] mods, int totalColumns)
-            : base(mods)
+            : base(mods, totalColumns)
         {
             individualStrains = new double[totalColumns];
-            overallStrain = 1;
+            chordStrain = 1;
         }
 
-        protected override double StrainValueAt(DifficultyHitObject current)
+        protected override void PreprocessChordNote(ManiaDifficultyHitObject current)
+        {
+            chordDifficulty += OverallStrainEvaluator.EvaluateDifficultyOf(current);
+        }
+
+        protected override void FinalizeChord()
+        {
+            double chordDelta = CurrentChordTime - PreviousChordTime;
+
+            chordStrain = applyDecay(chordStrain, chordDelta, chord_decay_base);
+            chordStrain += chordDifficulty;
+        }
+
+        protected override double StrainValueAt(ManiaDifficultyHitObject current)
         {
             if (current.BaseObject is TailNote)
                 return 0;
 
-            var maniaCurrent = (ManiaDifficultyHitObject)current;
+            double individualDelta = current.ActualTime - PreviousColumnTimes[current.Column];
 
-            individualStrains[maniaCurrent.Column] = applyDecay(individualStrains[maniaCurrent.Column], maniaCurrent.ColumnHeadStrainTime, individual_decay_base);
-            individualStrains[maniaCurrent.Column] += IndividualStrainEvaluator.EvaluateDifficultyOf(current);
+            individualStrains[current.Column] = applyDecay(individualStrains[current.Column], individualDelta, individual_decay_base);
+            individualStrains[current.Column] += IndividualStrainEvaluator.EvaluateDifficultyOf(current);
 
-            // Take the hardest individualStrain for notes that happen at the same time (in a chord).
-            // This is to ensure the order in which the notes are processed does not affect the resultant total strain.
-            highestIndividualStrain = maniaCurrent.HeadDeltaTime <= 1 ? Math.Max(highestIndividualStrain, individualStrains[maniaCurrent.Column]) : individualStrains[maniaCurrent.Column];
-
-            overallStrain = applyDecay(overallStrain, maniaCurrent.HeadDeltaTime, overall_decay_base);
-            overallStrain += OverallStrainEvaluator.EvaluateDifficultyOf(current);
-
-            // By subtracting CurrentStrain, this skill effectively only considers the maximum strain of any one hitobject within each strain section.
-            return highestIndividualStrain + overallStrain;
+            return individualStrains[current.Column] + chordStrain;
         }
 
-        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) =>
-            applyDecay(highestIndividualStrain, time - ((ManiaDifficultyHitObject)current).PrevHead(0)?.StartTime ?? 0, individual_decay_base)
-            + applyDecay(overallStrain, time - ((ManiaDifficultyHitObject)current).PrevHead(0)?.StartTime ?? 0, overall_decay_base);
+        protected override void ResetChord()
+        {
+            chordDifficulty = 0;
+        }
+
+        // protected override double CalculateInitialStrain(double offset, DifficultyHitObject current) =>
+        //     applyDecay(highestIndividualStrain, offset - current.Previous(0).StartTime, individual_decay_base)
+        //     + applyDecay(chordStrain, offset - current.Previous(0).StartTime, overall_decay_base);
 
         private double applyDecay(double value, double deltaTime, double decayBase)
             => value * Math.Pow(decayBase, deltaTime / 1000);
+
+        public override double DifficultyValue()
+        {
+            return ObjectDifficulties.Count > 0 ? ObjectDifficulties.Average() : 0;
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mania.Difficulty.Evaluators;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
@@ -19,6 +18,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
         private double chordStrain;
 
         private readonly double[] individualStrains;
+        private double maxIndividualStrain;
 
         public Strain(Mod[] mods, int totalColumns)
             : base(mods, totalColumns)
@@ -49,16 +49,19 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             individualStrains[maniaCurrent.Column] = applyDecay(individualStrains[maniaCurrent.Column], individualDelta, individual_decay_base);
             individualStrains[maniaCurrent.Column] += IndividualStrainEvaluator.EvaluateDifficultyOf(maniaCurrent);
 
-            return individualStrains[maniaCurrent.Column] + chordStrain;
+            maxIndividualStrain = Math.Max(maxIndividualStrain, individualStrains[maniaCurrent.Column]);
+
+            return maxIndividualStrain + chordStrain;
         }
 
         protected override void ResetChord()
         {
             chordDifficulty = 0;
+            maxIndividualStrain = 0;
         }
 
         protected override double CalculateInitialStrain(double offset, DifficultyHitObject current) =>
-            applyDecay(individualStrains.Max(), offset - ((ManiaDifficultyHitObject)current).PrevHead(0)?.StartTime ?? 0, individual_decay_base)
+            applyDecay(maxIndividualStrain, offset - ((ManiaDifficultyHitObject)current).PrevHead(0)?.StartTime ?? 0, individual_decay_base)
             + applyDecay(chordStrain, offset - ((ManiaDifficultyHitObject)current).PrevHead(0)?.StartTime ?? 0, chord_decay_base);
 
         private double applyDecay(double value, double deltaTime, double decayBase)

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -51,9 +51,9 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             return highestIndividualStrain + overallStrain - CurrentStrain;
         }
 
-        protected override double CalculateInitialStrain(double offset, DifficultyHitObject current) =>
-            applyDecay(highestIndividualStrain, offset - current.Previous(0).StartTime, individual_decay_base)
-            + applyDecay(overallStrain, offset - current.Previous(0).StartTime, overall_decay_base);
+        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) =>
+            applyDecay(highestIndividualStrain, time - ((ManiaDifficultyHitObject)current).PrevHead(0)?.StartTime ?? 0, individual_decay_base)
+            + applyDecay(overallStrain, time - ((ManiaDifficultyHitObject)current).PrevHead(0)?.StartTime ?? 0, overall_decay_base);
 
         private double applyDecay(double value, double deltaTime, double decayBase)
             => value * Math.Pow(decayBase, deltaTime / 1000);

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -2,8 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
-using osu.Game.Rulesets.Difficulty.Skills;
+using System.Linq;
 using osu.Game.Rulesets.Mania.Difficulty.Evaluators;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mania.Objects;
@@ -11,51 +10,64 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Skills
 {
-    public class Strain : StrainDecaySkill
+    public class Strain : ManiaSkill
     {
+        private const double chord_decay_base = 0.30;
         private const double individual_decay_base = 0.125;
-        private const double overall_decay_base = 0.30;
 
-        protected override double SkillMultiplier => 1;
-        protected override double StrainDecayBase => 1;
+        private double chordDifficulty;
+        private double chordStrain;
 
         private readonly double[] individualStrains;
-        private double highestIndividualStrain;
-        private double overallStrain;
 
         public Strain(Mod[] mods, int totalColumns)
-            : base(mods)
+            : base(mods, totalColumns)
         {
             individualStrains = new double[totalColumns];
-            overallStrain = 1;
+            chordStrain = 1;
         }
 
-        protected override double StrainValueOf(DifficultyHitObject current)
+        protected override void PreprocessChordNote(ManiaDifficultyHitObject current)
+        {
+            chordDifficulty += OverallStrainEvaluator.EvaluateDifficultyOf(current);
+        }
+
+        protected override void FinalizeChord()
+        {
+            double chordDelta = CurrentChordTime - PreviousChordTime;
+
+            chordStrain = applyDecay(chordStrain, chordDelta, chord_decay_base);
+            chordStrain += chordDifficulty;
+        }
+
+        protected override double StrainValueAt(ManiaDifficultyHitObject current)
         {
             if (current.BaseObject is TailNote)
                 return 0;
 
-            var maniaCurrent = (ManiaDifficultyHitObject)current;
+            double individualDelta = current.ActualTime - PreviousColumnTimes[current.Column];
 
-            individualStrains[maniaCurrent.Column] = applyDecay(individualStrains[maniaCurrent.Column], maniaCurrent.ColumnHeadStrainTime, individual_decay_base);
-            individualStrains[maniaCurrent.Column] += IndividualStrainEvaluator.EvaluateDifficultyOf(current);
+            individualStrains[current.Column] = applyDecay(individualStrains[current.Column], individualDelta, individual_decay_base);
+            individualStrains[current.Column] += IndividualStrainEvaluator.EvaluateDifficultyOf(current);
 
-            // Take the hardest individualStrain for notes that happen at the same time (in a chord).
-            // This is to ensure the order in which the notes are processed does not affect the resultant total strain.
-            highestIndividualStrain = maniaCurrent.HeadDeltaTime <= 1 ? Math.Max(highestIndividualStrain, individualStrains[maniaCurrent.Column]) : individualStrains[maniaCurrent.Column];
-
-            overallStrain = applyDecay(overallStrain, maniaCurrent.HeadDeltaTime, overall_decay_base);
-            overallStrain += OverallStrainEvaluator.EvaluateDifficultyOf(current);
-
-            // By subtracting CurrentStrain, this skill effectively only considers the maximum strain of any one hitobject within each strain section.
-            return highestIndividualStrain + overallStrain - CurrentStrain;
+            return individualStrains[current.Column] + chordStrain;
         }
 
-        protected override double CalculateInitialStrain(double offset, DifficultyHitObject current) =>
-            applyDecay(highestIndividualStrain, offset - current.Previous(0).StartTime, individual_decay_base)
-            + applyDecay(overallStrain, offset - current.Previous(0).StartTime, overall_decay_base);
+        protected override void ResetChord()
+        {
+            chordDifficulty = 0;
+        }
+
+        // protected override double CalculateInitialStrain(double offset, DifficultyHitObject current) =>
+        //     applyDecay(highestIndividualStrain, offset - current.Previous(0).StartTime, individual_decay_base)
+        //     + applyDecay(chordStrain, offset - current.Previous(0).StartTime, overall_decay_base);
 
         private double applyDecay(double value, double deltaTime, double decayBase)
             => value * Math.Pow(decayBase, deltaTime / 1000);
+
+        public override double DifficultyValue()
+        {
+            return ObjectDifficulties.Count > 0 ? ObjectDifficulties.Average() : 0;
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -6,6 +6,7 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mania.Difficulty.Evaluators;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Skills
@@ -31,16 +32,19 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
 
         protected override double StrainValueOf(DifficultyHitObject current)
         {
+            if (current.BaseObject is TailNote)
+                return 0;
+
             var maniaCurrent = (ManiaDifficultyHitObject)current;
 
-            individualStrains[maniaCurrent.Column] = applyDecay(individualStrains[maniaCurrent.Column], maniaCurrent.ColumnStrainTime, individual_decay_base);
+            individualStrains[maniaCurrent.Column] = applyDecay(individualStrains[maniaCurrent.Column], maniaCurrent.ColumnHeadStrainTime, individual_decay_base);
             individualStrains[maniaCurrent.Column] += IndividualStrainEvaluator.EvaluateDifficultyOf(current);
 
             // Take the hardest individualStrain for notes that happen at the same time (in a chord).
             // This is to ensure the order in which the notes are processed does not affect the resultant total strain.
-            highestIndividualStrain = maniaCurrent.DeltaTime <= 1 ? Math.Max(highestIndividualStrain, individualStrains[maniaCurrent.Column]) : individualStrains[maniaCurrent.Column];
+            highestIndividualStrain = maniaCurrent.HeadDeltaTime <= 1 ? Math.Max(highestIndividualStrain, individualStrains[maniaCurrent.Column]) : individualStrains[maniaCurrent.Column];
 
-            overallStrain = applyDecay(overallStrain, maniaCurrent.DeltaTime, overall_decay_base);
+            overallStrain = applyDecay(overallStrain, maniaCurrent.HeadDeltaTime, overall_decay_base);
             overallStrain += OverallStrainEvaluator.EvaluateDifficultyOf(current);
 
             // By subtracting CurrentStrain, this skill effectively only considers the maximum strain of any one hitobject within each strain section.

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -11,13 +11,10 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Skills
 {
-    public class Strain : StrainDecaySkill
+    public class Strain : StrainSkill
     {
         private const double individual_decay_base = 0.125;
         private const double overall_decay_base = 0.30;
-
-        protected override double SkillMultiplier => 1;
-        protected override double StrainDecayBase => 1;
 
         private readonly double[] individualStrains;
         private double highestIndividualStrain;
@@ -30,7 +27,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             overallStrain = 1;
         }
 
-        protected override double StrainValueOf(DifficultyHitObject current)
+        protected override double StrainValueAt(DifficultyHitObject current)
         {
             if (current.BaseObject is TailNote)
                 return 0;
@@ -48,7 +45,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             overallStrain += OverallStrainEvaluator.EvaluateDifficultyOf(current);
 
             // By subtracting CurrentStrain, this skill effectively only considers the maximum strain of any one hitobject within each strain section.
-            return highestIndividualStrain + overallStrain - CurrentStrain;
+            return highestIndividualStrain + overallStrain;
         }
 
         protected override double CalculateInitialStrain(double time, DifficultyHitObject current) =>

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double acute_angle_multiplier = 2.55;
         private const double slider_multiplier = 1.35;
         private const double velocity_change_multiplier = 0.75;
-        private const double wiggle_multiplier = 1.02;
+        private const double wiggle_multiplier = 1.02; // WARNING: Increasing this multiplier beyond 1.02 reduces difficulty as distance increases. Refer to the desmos link above the wiggle bonus calculation
 
         /// <summary>
         /// Evaluates the difficulty of aiming the current object, based on:

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -143,10 +143,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 velocityChangeBonus *= Math.Pow(Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) / Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime), 2);
             }
 
-            if (osuLastObj.BaseObject is Slider)
+            if (osuCurrObj.BaseObject is Slider)
             {
                 // Reward sliders based on velocity.
-                sliderBonus = osuLastObj.TravelDistance / osuLastObj.TravelTime;
+                sliderBonus = osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
             }
 
             aimStrain += wiggleBonus * wiggle_multiplier;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     public static class AimEvaluator
     {
         private const double wide_angle_multiplier = 1.5;
-        private const double acute_angle_multiplier = 2.55;
+        private const double acute_angle_multiplier = 2.3;
         private const double slider_multiplier = 1.35;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02; // WARNING: Increasing this multiplier beyond 1.02 reduces difficulty as distance increases. Refer to the desmos link above the wiggle bonus calculation

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -40,7 +40,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             const int diameter = OsuDifficultyHitObject.NORMALISED_DIAMETER;
 
             // Calculate the velocity to the current hitobject, which starts with a base distance / time assuming the last object is a hitcircle.
-            double currVelocity = osuCurrObj.LazyJumpDistance / osuCurrObj.AdjustedDeltaTime;
+            double currDistance = withSliderTravelDistance ? osuCurrObj.LazyJumpDistance : osuCurrObj.JumpDistance;
+            double currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
 
             // But if the last object is a slider, then we extend the travel velocity through the slider into the current object.
             if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
@@ -52,7 +53,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             }
 
             // As above, do the same for the previous hitobject.
-            double prevVelocity = osuLastObj.LazyJumpDistance / osuLastObj.AdjustedDeltaTime;
+            double prevDistance = withSliderTravelDistance ? osuLastObj.LazyJumpDistance : osuLastObj.JumpDistance;
+            double prevVelocity = prevDistance / osuLastObj.AdjustedDeltaTime;
 
             if (osuLastLastObj.BaseObject is Slider && withSliderTravelDistance)
             {
@@ -88,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
                     acuteAngleBonus *= angleBonus *
                                        DifficultyCalculationUtils.Smootherstep(DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.AdjustedDeltaTime, 2), 300, 400) *
-                                       DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, diameter, diameter * 2);
+                                       DifficultyCalculationUtils.Smootherstep(currDistance, diameter, diameter * 2);
                 }
 
                 wideAngleBonus = calcWideAngleBonus(currAngle);
@@ -97,16 +99,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 wideAngleBonus *= 1 - Math.Min(wideAngleBonus, Math.Pow(calcWideAngleBonus(lastAngle), 3));
 
                 // Apply full wide angle bonus for distance more than one diameter
-                wideAngleBonus *= angleBonus * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, 0, diameter);
+                wideAngleBonus *= angleBonus * DifficultyCalculationUtils.Smootherstep(currDistance, 0, diameter);
 
                 // Apply wiggle bonus for jumps that are [radius, 3*diameter] in distance, with < 110 angle
                 // https://www.desmos.com/calculator/dp0v0nvowc
                 wiggleBonus = angleBonus
-                              * DifficultyCalculationUtils.Smootherstep(osuCurrObj.LazyJumpDistance, radius, diameter)
-                              * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuCurrObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
+                              * DifficultyCalculationUtils.Smootherstep(currDistance, radius, diameter)
+                              * Math.Pow(DifficultyCalculationUtils.ReverseLerp(currDistance, diameter * 3, diameter), 1.8)
                               * DifficultyCalculationUtils.Smootherstep(currAngle, double.DegreesToRadians(110), double.DegreesToRadians(60))
-                              * DifficultyCalculationUtils.Smootherstep(osuLastObj.LazyJumpDistance, radius, diameter)
-                              * Math.Pow(DifficultyCalculationUtils.ReverseLerp(osuLastObj.LazyJumpDistance, diameter * 3, diameter), 1.8)
+                              * DifficultyCalculationUtils.Smootherstep(prevDistance, radius, diameter)
+                              * Math.Pow(DifficultyCalculationUtils.ReverseLerp(prevDistance, diameter * 3, diameter), 1.8)
                               * DifficultyCalculationUtils.Smootherstep(lastAngle, double.DegreesToRadians(110), double.DegreesToRadians(60));
 
                 if (osuLast2Obj != null)
@@ -127,9 +129,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             if (Math.Max(prevVelocity, currVelocity) != 0)
             {
-                // We want to use the average velocity over the whole object when awarding differences, not the individual jump and slider path velocities.
-                prevVelocity = (osuLastObj.LazyJumpDistance + osuLastLastObj.TravelDistance) / osuLastObj.AdjustedDeltaTime;
-                currVelocity = (osuCurrObj.LazyJumpDistance + osuLastObj.TravelDistance) / osuCurrObj.AdjustedDeltaTime;
+                if (withSliderTravelDistance)
+                {
+                    // We want to use the average velocity over the whole object when awarding differences, not the individual jump and slider path velocities.
+                    prevVelocity = (osuLastObj.LazyJumpDistance + osuLastLastObj.TravelDistance) / osuLastObj.AdjustedDeltaTime;
+                    currVelocity = (osuCurrObj.LazyJumpDistance + osuLastObj.TravelDistance) / osuCurrObj.AdjustedDeltaTime;
+                }
 
                 // Scale with ratio of difference compared to 0.5 * max dist.
                 double distRatio = DifficultyCalculationUtils.Smoothstep(Math.Abs(prevVelocity - currVelocity) / Math.Max(prevVelocity, currVelocity), 0, 1);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -162,8 +162,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             if (withSliderTravelDistance)
                 aimStrain += sliderBonus * slider_multiplier;
 
+            aimStrain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+
             return aimStrain;
         }
+
+        private static double highBpmBonus(double ms) => 1 / (1 - Math.Pow(0.15, ms / 1000));
 
         private static double calcWideAngleBonus(double angle) => DifficultyCalculationUtils.Smoothstep(angle, double.DegreesToRadians(40), double.DegreesToRadians(140));
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const double wide_angle_multiplier = 1.5;
         private const double acute_angle_multiplier = 2.3;
-        private const double slider_multiplier = 1.35;
+        private const double slider_multiplier = 1.5;
         private const double velocity_change_multiplier = 0.75;
         private const double wiggle_multiplier = 1.02; // WARNING: Increasing this multiplier beyond 1.02 reduces difficulty as distance increases. Refer to the desmos link above the wiggle bonus calculation
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/AimEvaluator.cs
@@ -160,12 +160,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Add in acute angle bonus or wide angle bonus, whichever is larger.
             aimStrain += Math.Max(acuteAngleBonus * acute_angle_multiplier, wideAngleBonus * wide_angle_multiplier);
 
-            // Apply high circle size bonus
-            aimStrain *= osuCurrObj.SmallCircleBonus;
-
             // Add in additional slider velocity bonus.
             if (withSliderTravelDistance)
                 aimStrain += sliderBonus * slider_multiplier;
+
+            // Apply high circle size bonus
+            aimStrain *= osuCurrObj.SmallCircleBonus;
 
             aimStrain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -2,8 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
@@ -28,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         /// <item><description>and whether the hidden mod is enabled.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool hidden)
+        public static double EvaluateDifficultyOf(DifficultyHitObject current, IReadOnlyList<Mod> mods)
         {
             if (current.BaseObject is Spinner)
                 return 0;
@@ -66,7 +70,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     double stackNerf = Math.Min(1.0, (currentObj.LazyJumpDistance / scalingFactor) / 25.0);
 
                     // Bonus based on how visible the object is.
-                    double opacityBonus = 1.0 + max_opacity_bonus * (1.0 - osuCurrent.OpacityAt(currentHitObject.StartTime, hidden));
+                    double opacityBonus = 1.0 + max_opacity_bonus * (1.0 - osuCurrent.OpacityAt(currentHitObject.StartTime, mods.OfType<OsuModHidden>().Any(m => !m.OnlyFadeApproachCircles.Value)));
 
                     result += stackNerf * opacityBonus * scalingFactor * jumpDistance / cumulativeStrainTime;
 
@@ -84,7 +88,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             result = Math.Pow(smallDistNerf * result, 2.0);
 
             // Additional bonus for Hidden due to there being no approach circles.
-            if (hidden)
+            if (mods.OfType<OsuModHidden>().Any())
                 result *= 1.0 + hidden_bonus;
 
             // Nerf patterns with repeated angles.

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -1,0 +1,244 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Utils;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
+{
+    public static class ReadingEvaluator
+    {
+        private const double reading_window_size = 3000; // 3 seconds
+        private const double distance_influence_threshold = OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.5; // 1.5 circles distance between centers
+        private const double hidden_multiplier = 0.28;
+        private const double density_multiplier = 2.4;
+        private const double density_difficulty_base = 2.5;
+        private const double preempt_balancing_factor = 140000;
+        private const double preempt_starting_point = 500; // AR 9.66 in milliseconds
+        private const double minimum_angle_relevancy_time = 2000; // 2 seconds
+        private const double maximum_angle_relevancy_time = 200;
+
+        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool hidden)
+        {
+            if (current.BaseObject is Spinner || current.Index == 0)
+                return 0;
+
+            var currObj = (OsuDifficultyHitObject)current;
+            var nextObj = (OsuDifficultyHitObject)current.Next(0);
+
+            double velocity = Math.Max(1, currObj.LazyJumpDistance / currObj.AdjustedDeltaTime); // Only allow velocity to buff
+
+            double currentVisibleObjectDensity = retrieveCurrentVisibleObjectDensity(currObj);
+            double pastObjectDifficultyInfluence = getPastObjectDifficultyInfluence(currObj);
+
+            double constantAngleNerfFactor = getConstantAngleNerfFactor(currObj);
+
+            double noteDensityDifficulty = calculateDensityDifficulty(nextObj, velocity, constantAngleNerfFactor, pastObjectDifficultyInfluence, currentVisibleObjectDensity);
+
+            double hiddenDifficulty = hidden
+                ? calculateHiddenDifficulty(currObj, pastObjectDifficultyInfluence, currentVisibleObjectDensity, velocity, constantAngleNerfFactor)
+                : 0;
+
+            double preemptDifficulty = calculatePreemptDifficulty(velocity, constantAngleNerfFactor, currObj.Preempt);
+
+            double difficulty = DifficultyCalculationUtils.Norm(1.5, preemptDifficulty, hiddenDifficulty, noteDensityDifficulty);
+
+            return difficulty;
+        }
+
+        /// <summary>
+        /// Calculates the density difficulty of the current object and how hard it is to aim it because of it based on:
+        /// <list type="bullet">
+        /// <item><description>cursor velocity to the current object,</description></item>
+        /// <item><description>how many times the current object's angle was repeated,</description></item>
+        /// <item><description>density of objects visible when the current object appears,</description></item>
+        /// <item><description>density of objects visible when the current object needs to be clicked,</description></item>
+        /// /// </list>
+        /// </summary>
+        private static double calculateDensityDifficulty(OsuDifficultyHitObject? nextObj, double velocity, double constantAngleNerfFactor,
+                                                         double pastObjectDifficultyInfluence, double currentVisibleObjectDensity)
+        {
+            // Consider future densities too because it can make the path the cursor takes less clear
+            double futureObjectDifficultyInfluence = Math.Sqrt(currentVisibleObjectDensity);
+
+            if (nextObj != null)
+            {
+                // Reduce difficulty if movement to next object is small
+                futureObjectDifficultyInfluence *= DifficultyCalculationUtils.Smootherstep(nextObj.LazyJumpDistance, 15, distance_influence_threshold);
+            }
+
+            // Value higher note densities exponentially
+            double noteDensityDifficulty = Math.Pow(pastObjectDifficultyInfluence + futureObjectDifficultyInfluence, 1.7) * 0.4 * constantAngleNerfFactor * velocity;
+
+            // Award only denser than average maps.
+            noteDensityDifficulty = Math.Max(0, noteDensityDifficulty - density_difficulty_base);
+
+            // Apply a soft cap to general density reading to account for partial memorization
+            noteDensityDifficulty = Math.Pow(noteDensityDifficulty, 0.45) * density_multiplier;
+
+            return noteDensityDifficulty;
+        }
+
+        /// <summary>
+        /// Calculates the difficulty of aiming the current object when the approach rate is very high based on:
+        /// <list type="bullet">
+        /// <item><description>cursor velocity to the current object,</description></item>
+        /// <item><description>how many times the current object's angle was repeated,</description></item>
+        /// <item><description>how many milliseconds elapse between the approach circle appearing and touching the inner circle</description></item>
+        /// </list>
+        /// </summary>
+        private static double calculatePreemptDifficulty(double velocity, double constantAngleNerfFactor, double preempt)
+        {
+            // Arbitrary curve for the base value preempt difficulty should have as approach rate increases.
+            // https://www.desmos.com/calculator/c175335a71
+            double preemptDifficulty = Math.Pow((preempt_starting_point - preempt + Math.Abs(preempt - preempt_starting_point)) / 2, 2.5) / preempt_balancing_factor;
+
+            preemptDifficulty *= constantAngleNerfFactor * velocity;
+
+            return preemptDifficulty;
+        }
+
+        /// <summary>
+        /// Calculates the difficulty of aiming the current object when the hidden mod is active based on:
+        /// <list type="bullet">
+        /// <item><description>cursor velocity to the current object,</description></item>
+        /// <item><description>time the current object spends invisible,</description></item>
+        /// <item><description>density of objects visible when the current object appears,</description></item>
+        /// <item><description>density of objects visible when the current object needs to be clicked,</description></item>
+        /// <item><description>how many times the current object's angle was repeated,</description></item>
+        /// <item><description>if the current object is perfectly stacked to the previous one</description></item>
+        /// </list>
+        /// </summary>
+        private static double calculateHiddenDifficulty(OsuDifficultyHitObject currObj, double pastObjectDifficultyInfluence, double currentVisibleObjectDensity, double velocity,
+                                                        double constantAngleNerfFactor)
+        {
+            double timeSpentInvisible = currObj.DurationSpentInvisible() / currObj.ClockRate;
+
+            // Value time spent invisible exponentially
+            double timeSpentInvisibleFactor = Math.Pow(timeSpentInvisible, 2.2) * 0.022;
+
+            // Account for both past and current densities
+            double densityFactor = Math.Pow(currentVisibleObjectDensity + pastObjectDifficultyInfluence, 3.3) * 3;
+
+            double hiddenDifficulty = (timeSpentInvisibleFactor + densityFactor) * constantAngleNerfFactor * velocity * 0.01;
+
+            // Apply a soft cap to general HD reading to account for partial memorization
+            hiddenDifficulty = Math.Pow(hiddenDifficulty, 0.4) * hidden_multiplier;
+
+            var previousObj = (OsuDifficultyHitObject)currObj.Previous(0);
+
+            // Buff perfect stacks only if current note is completely invisible at the time you click the previous note.
+            if (currObj.LazyJumpDistance == 0 && currObj.OpacityAt(previousObj.BaseObject.StartTime + previousObj.Preempt, true) == 0 && previousObj.StartTime + previousObj.Preempt > currObj.StartTime)
+                hiddenDifficulty += hidden_multiplier * 7500 / Math.Pow(currObj.AdjustedDeltaTime, 1.5); // Perfect stacks are harder the less time between notes
+
+            return hiddenDifficulty;
+        }
+
+        private static double getPastObjectDifficultyInfluence(OsuDifficultyHitObject currObj)
+        {
+            double pastObjectDifficultyInfluence = 0;
+
+            foreach (var loopObj in retrievePastVisibleObjects(currObj))
+            {
+                double loopDifficulty = currObj.OpacityAt(loopObj.BaseObject.StartTime, false);
+
+                // When aiming an object small distances mean previous objects may be cheesed, so it doesn't matter whether they were arranged confusingly.
+                loopDifficulty *= DifficultyCalculationUtils.Smootherstep(loopObj.LazyJumpDistance, 15, distance_influence_threshold);
+
+                // Account less for objects close to the max reading window
+                double timeBetweenCurrAndLoopObj = currObj.StartTime - loopObj.StartTime;
+                double timeNerfFactor = getTimeNerfFactor(timeBetweenCurrAndLoopObj);
+
+                loopDifficulty *= timeNerfFactor;
+                pastObjectDifficultyInfluence += loopDifficulty;
+            }
+
+            return pastObjectDifficultyInfluence;
+        }
+
+        // Returns a list of objects that are visible on screen at the point in time the current object becomes visible.
+        private static IEnumerable<OsuDifficultyHitObject> retrievePastVisibleObjects(OsuDifficultyHitObject current)
+        {
+            for (int i = 0; i < current.Index; i++)
+            {
+                OsuDifficultyHitObject hitObject = (OsuDifficultyHitObject)current.Previous(i);
+
+                if (hitObject.IsNull() ||
+                    current.StartTime - hitObject.StartTime > reading_window_size ||
+                    hitObject.StartTime + hitObject.Preempt < current.StartTime) // Current object not visible at the time object needs to be clicked
+                    break;
+
+                yield return hitObject;
+            }
+        }
+
+        // Returns the density of objects visible at the point in time the current object needs to be clicked capped by the reading window.
+        private static double retrieveCurrentVisibleObjectDensity(OsuDifficultyHitObject current)
+        {
+            double visibleObjectCount = 0;
+
+            OsuDifficultyHitObject? hitObject = (OsuDifficultyHitObject)current.Next(0);
+
+            while (hitObject != null)
+            {
+                if (hitObject.StartTime - current.StartTime > reading_window_size ||
+                    current.StartTime + hitObject.Preempt < hitObject.StartTime) // Object not visible at the time current object needs to be clicked.
+                    break;
+
+                double timeBetweenCurrAndLoopObj = hitObject.StartTime - current.StartTime;
+                double timeNerfFactor = getTimeNerfFactor(timeBetweenCurrAndLoopObj);
+
+                visibleObjectCount += hitObject.OpacityAt(current.BaseObject.StartTime, false) * timeNerfFactor;
+
+                hitObject = (OsuDifficultyHitObject?)hitObject.Next(0);
+            }
+
+            return visibleObjectCount;
+        }
+
+        // Returns a factor of how often the current object's angle has been repeated in a certain time frame.
+        // It does this by checking the difference in angle between current and past objects and sums them based on a range of similarity.
+        // https://www.desmos.com/calculator/eb057a4822
+        private static double getConstantAngleNerfFactor(OsuDifficultyHitObject current)
+        {
+            double constantAngleCount = 0;
+            int index = 0;
+            double currentTimeGap = 0;
+
+            while (currentTimeGap < minimum_angle_relevancy_time)
+            {
+                var loopObj = (OsuDifficultyHitObject)current.Previous(index);
+
+                if (loopObj.IsNull())
+                    break;
+
+                // Account less for objects that are close to the time limit.
+                double longIntervalFactor = 1 - DifficultyCalculationUtils.ReverseLerp(loopObj.AdjustedDeltaTime, maximum_angle_relevancy_time, minimum_angle_relevancy_time);
+
+                if (loopObj.Angle.IsNotNull() && current.Angle.IsNotNull())
+                {
+                    double angleDifference = Math.Abs(current.Angle.Value - loopObj.Angle.Value);
+                    double stackFactor = DifficultyCalculationUtils.Smootherstep(loopObj.LazyJumpDistance, 0, OsuDifficultyHitObject.NORMALISED_RADIUS);
+
+                    constantAngleCount += Math.Cos(3 * Math.Min(double.DegreesToRadians(30), angleDifference * stackFactor)) * longIntervalFactor;
+                }
+
+                currentTimeGap = current.StartTime - loopObj.StartTime;
+                index++;
+            }
+
+            return Math.Clamp(2 / constantAngleCount, 0.2, 1);
+        }
+
+        // Returns a nerfing factor for when objects are very distant in time, affecting reading less.
+        private static double getTimeNerfFactor(double deltaTime)
+        {
+            return Math.Clamp(2 - deltaTime / (reading_window_size / 2), 0, 1);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const int history_time_max = 5 * 1000; // 5 seconds
         private const int history_objects_max = 32;
         private const double rhythm_overall_multiplier = 1.0;
-        private const double rhythm_ratio_multiplier = 17.0;
+        private const double rhythm_ratio_multiplier = 30.0;
 
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const int history_time_max = 5 * 1000; // 5 seconds
         private const int history_objects_max = 32;
         private const double rhythm_overall_multiplier = 1.0;
-        private const double rhythm_ratio_multiplier = 15.0;
+        private const double rhythm_ratio_multiplier = 17.0;
 
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -26,8 +26,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             if (current.BaseObject is Spinner)
                 return 0;
 
-            var currentOsuObject = (OsuDifficultyHitObject)current;
-
             double rhythmComplexitySum = 0;
 
             double deltaDifferenceEpsilon = ((OsuDifficultyHitObject)current).HitWindowGreat * 0.3;
@@ -176,10 +174,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 prevObj = currObj;
             }
 
-            double rhythmDifficulty = Math.Sqrt(4 + rhythmComplexitySum * rhythm_overall_multiplier) / 2.0; // produces multiplier that can be applied to strain. range [1, infinity) (not really though)
-            rhythmDifficulty *= 1 - currentOsuObject.GetDoubletapness((OsuDifficultyHitObject)current.Next(0));
-
-            return rhythmDifficulty;
+            return Math.Sqrt(4 + rhythmComplexitySum * rhythm_overall_multiplier) / 2.0; // produces multiplier that can be applied to strain. range [1, infinity) (not really though);
         }
 
         private class Island : IEquatable<Island>

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedAimEvaluator.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
+{
+    public static class SpeedAimEvaluator
+    {
+        private const double single_spacing_threshold = OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25; // 1.25 circles distance between centers
+
+        /// <summary>
+        /// Evaluates the difficulty of aiming the current object, based on:
+        /// <list type="bullet">
+        /// <item><description>distance between the previous and current object</description></item>
+        /// </list>
+        /// </summary>
+        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        {
+            if (current.BaseObject is Spinner)
+                return 0;
+
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            var osuPrevObj = current.Index > 0 ? (OsuDifficultyHitObject)current.Previous(0) : null;
+
+            double travelDistance = osuPrevObj?.LazyTravelDistance ?? 0;
+            double distance = travelDistance + osuCurrObj.LazyJumpDistance;
+
+            // Cap distance at single_spacing_threshold
+            distance = Math.Min(distance, single_spacing_threshold);
+
+            // Max distance bonus is 1 * `distance_multiplier` at single_spacing_threshold
+            double distanceBonus = Math.Pow(distance / single_spacing_threshold, 3.95);
+
+            // Apply reduced small circle bonus because flow aim difficulty on small circles doesn't scale as hard as jumps
+            distanceBonus *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
+
+            double strain = distanceBonus * 1000 / osuCurrObj.AdjustedDeltaTime;
+
+            strain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+
+            return strain;
+        }
+
+        private static double highBpmBonus(double ms) => 1 / (1 - Math.Pow(0.3, ms / 1000));
+    }
+}

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -69,8 +69,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Base difficulty with all bonuses
             double difficulty = (1 + speedBonus + distanceBonus) * 1000 / strainTime;
 
+            difficulty *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+
             // Apply penalty if there's doubletappable doubles
             return difficulty * doubletapness;
         }
+
+        private static double highBpmBonus(double ms) => 1 / (1 - Math.Pow(0.3, ms / 1000));
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -2,40 +2,31 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
-using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 {
     public static class SpeedEvaluator
     {
-        private const double single_spacing_threshold = OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25; // 1.25 circles distance between centers
         private const double min_speed_bonus = 200; // 200 BPM 1/4th
         private const double speed_balancing_factor = 40;
-        private const double distance_multiplier = 0.8;
 
         /// <summary>
         /// Evaluates the difficulty of tapping the current object, based on:
         /// <list type="bullet">
         /// <item><description>time between pressing the previous and current object,</description></item>
-        /// <item><description>distance between those objects,</description></item>
         /// <item><description>and how easily they can be cheesed.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, IReadOnlyList<Mod> mods)
+        public static double EvaluateDifficultyOf(DifficultyHitObject current)
         {
             if (current.BaseObject is Spinner)
                 return 0;
 
-            // derive strainTime for calculation
             var osuCurrObj = (OsuDifficultyHitObject)current;
-            var osuPrevObj = current.Index > 0 ? (OsuDifficultyHitObject)current.Previous(0) : null;
 
             double strainTime = osuCurrObj.AdjustedDeltaTime;
             double doubletapness = 1.0 - osuCurrObj.GetDoubletapness((OsuDifficultyHitObject?)osuCurrObj.Next(0));
@@ -51,23 +42,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             if (DifficultyCalculationUtils.MillisecondsToBPM(strainTime) > min_speed_bonus)
                 speedBonus = 0.75 * Math.Pow((DifficultyCalculationUtils.BPMToMilliseconds(min_speed_bonus) - strainTime) / speed_balancing_factor, 2);
 
-            double travelDistance = osuPrevObj?.LazyTravelDistance ?? 0;
-            double distance = travelDistance + osuCurrObj.LazyJumpDistance;
-
-            // Cap distance at single_spacing_threshold
-            distance = Math.Min(distance, single_spacing_threshold);
-
-            // Max distance bonus is 1 * `distance_multiplier` at single_spacing_threshold
-            double distanceBonus = Math.Pow(distance / single_spacing_threshold, 3.95) * distance_multiplier;
-
-            // Apply reduced small circle bonus because flow aim difficulty on small circles doesn't scale as hard as jumps
-            distanceBonus *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
-
-            if (mods.OfType<OsuModAutopilot>().Any())
-                distanceBonus = 0;
-
             // Base difficulty with all bonuses
-            double difficulty = (1 + speedBonus + distanceBonus) * 1000 / strainTime;
+            double difficulty = (1 + speedBonus) * 1000 / strainTime;
 
             difficulty *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -51,8 +51,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             if (DifficultyCalculationUtils.MillisecondsToBPM(strainTime) > min_speed_bonus)
                 speedBonus = 0.75 * Math.Pow((DifficultyCalculationUtils.BPMToMilliseconds(min_speed_bonus) - strainTime) / speed_balancing_factor, 2);
 
-            double travelDistance = osuPrevObj?.TravelDistance ?? 0;
-            double distance = travelDistance + osuCurrObj.MinimumJumpDistance;
+            double travelDistance = osuPrevObj?.LazyTravelDistance ?? 0;
+            double distance = travelDistance + osuCurrObj.LazyJumpDistance;
 
             // Cap distance at single_spacing_threshold
             distance = Math.Min(distance, single_spacing_threshold);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -46,6 +46,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         public double FlashlightDifficulty { get; set; }
 
         /// <summary>
+        /// The difficulty corresponding to the reading skill.
+        /// </summary>
+        [JsonProperty("reading_difficulty")]
+        public double ReadingDifficulty { get; set; }
+
+        /// <summary>
         /// Describes how much of <see cref="AimDifficulty"/> is contributed to by hitcircles or sliders.
         /// A value closer to 1.0 indicates most of <see cref="AimDifficulty"/> is contributed by hitcircles.
         /// A value closer to 0.0 indicates most of <see cref="AimDifficulty"/> is contributed by sliders.
@@ -74,6 +80,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         [JsonProperty("speed_difficult_strain_count")]
         public double SpeedDifficultStrainCount { get; set; }
+
+        [JsonProperty("reading_difficult_note_count")]
+        public double ReadingDifficultNoteCount { get; set; }
 
         [JsonProperty("nested_score_per_object")]
         public double NestedScorePerObject { get; set; }
@@ -106,6 +115,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             yield return (ATTRIB_ID_AIM, AimDifficulty);
             yield return (ATTRIB_ID_SPEED, SpeedDifficulty);
+            yield return (ATTRIB_ID_READING, ReadingDifficulty);
             yield return (ATTRIB_ID_DIFFICULTY, StarRating);
 
             if (ShouldSerializeFlashlightDifficulty())
@@ -122,6 +132,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             yield return (ATTRIB_ID_NESTED_SCORE_PER_OBJECT, NestedScorePerObject);
             yield return (ATTRIB_ID_LEGACY_SCORE_BASE_MULTIPLIER, LegacyScoreBaseMultiplier);
             yield return (ATTRIB_ID_MAXIMUM_LEGACY_COMBO_SCORE, MaximumLegacyComboScore);
+            yield return (ATTRIB_ID_READING_DIFFICULT_NOTE_COUNT, ReadingDifficultNoteCount);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
@@ -130,6 +141,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             AimDifficulty = values[ATTRIB_ID_AIM];
             SpeedDifficulty = values[ATTRIB_ID_SPEED];
+            ReadingDifficulty = values[ATTRIB_ID_READING];
             StarRating = values[ATTRIB_ID_DIFFICULTY];
             FlashlightDifficulty = values.GetValueOrDefault(ATTRIB_ID_FLASHLIGHT);
             SliderFactor = values[ATTRIB_ID_SLIDER_FACTOR];
@@ -142,6 +154,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             NestedScorePerObject = values[ATTRIB_ID_NESTED_SCORE_PER_OBJECT];
             LegacyScoreBaseMultiplier = values[ATTRIB_ID_LEGACY_SCORE_BASE_MULTIPLIER];
             MaximumLegacyComboScore = values[ATTRIB_ID_MAXIMUM_LEGACY_COMBO_SCORE];
+            ReadingDifficultNoteCount = values[ATTRIB_ID_READING_DIFFICULT_NOTE_COUNT];
             HitCircleCount = onlineInfo.CircleCount;
             SliderCount = onlineInfo.SliderCount;
             SpinnerCount = onlineInfo.SpinnerCount;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -85,11 +85,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         public double MaximumLegacyComboScore { get; set; }
 
         /// <summary>
-        /// The beatmap's drain rate. This doesn't scale with rate-adjusting mods.
-        /// </summary>
-        public double DrainRate { get; set; }
-
-        /// <summary>
         /// The number of hitcircles in the beatmap.
         /// </summary>
         public int HitCircleCount { get; set; }
@@ -147,7 +142,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             NestedScorePerObject = values[ATTRIB_ID_NESTED_SCORE_PER_OBJECT];
             LegacyScoreBaseMultiplier = values[ATTRIB_ID_LEGACY_SCORE_BASE_MULTIPLIER];
             MaximumLegacyComboScore = values[ATTRIB_ID_MAXIMUM_LEGACY_COMBO_SCORE];
-            DrainRate = onlineInfo.DrainRate;
             HitCircleCount = onlineInfo.CircleCount;
             SliderCount = onlineInfo.SliderCount;
             SpinnerCount = onlineInfo.SpinnerCount;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -59,10 +59,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
             double speedDifficultyValue = speed.DifficultyValue();
 
-            double speedNotes = speed.RelevantNoteCount();
-
             double aimDifficultStrainCount = aim.CountTopWeightedStrains(aimDifficultyValue);
-            double speedDifficultStrainCount = speed.CountTopWeightedStrains(speedDifficultyValue);
+            double speedDifficultStrainCount = speed.CountTopWeightedObjectDifficulties(speedDifficultyValue);
+
+            double speedNotes = speed.RelevantNoteCount();
 
             double aimNoSlidersTopWeightedSliderCount = aimWithoutSliders.CountTopWeightedSliders(aimNoSlidersDifficultyValue);
             double aimNoSlidersDifficultStrainCount = aimWithoutSliders.CountTopWeightedStrains(aimNoSlidersDifficultyValue);
@@ -84,7 +84,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             int totalHits = beatmap.HitObjects.Count;
 
             double mechanicalDifficultyRating = calculateMechanicalDifficultyRating(aimDifficultyValue, speedDifficultyValue);
-            double sliderFactor = aimDifficultyValue > 0 ? OsuRatingCalculator.CalculateDifficultyRating(aimNoSlidersDifficultyValue) / OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue) : 1;
+            double sliderFactor = aimDifficultyValue > 0
+                ? OsuRatingCalculator.CalculateDifficultyRating(aimNoSlidersDifficultyValue) / OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue)
+                : 1;
 
             var osuRatingCalculator = new OsuRatingCalculator(mods, totalHits, approachRate, overallDifficulty, mechanicalDifficultyRating, sliderFactor);
 
@@ -103,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             var scoreAttributes = simulator.Simulate(WorkingBeatmap, beatmap);
 
             double baseAimPerformance = OsuStrainSkill.DifficultyToPerformance(aimRating);
-            double baseSpeedPerformance = OsuStrainSkill.DifficultyToPerformance(speedRating);
+            double baseSpeedPerformance = HarmonicSkill.DifficultyToPerformance(speedRating);
             double baseFlashlightPerformance = Flashlight.DifficultyToPerformance(flashlightRating);
 
             double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseFlashlightPerformance);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double baseSpeedPerformance = HarmonicSkill.DifficultyToPerformance(speedRating);
             double baseReadingPerformance = HarmonicSkill.DifficultyToPerformance(readingRating);
             double baseFlashlightPerformance = Flashlight.DifficultyToPerformance(flashlightRating);
-            double baseCognitionPerformance = DifficultyCalculationUtils.Norm(2, baseReadingPerformance, baseFlashlightPerformance);
+            double baseCognitionPerformance = SumCognitionDifficulty(baseReadingPerformance, baseFlashlightPerformance);
 
             double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseCognitionPerformance);
 
@@ -142,6 +142,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             };
 
             return attributes;
+        }
+
+        public static double SumCognitionDifficulty(double reading, double flashlight)
+        {
+            // Base LP summed value, accounting for map being partially memorized with FL
+            double cognition = DifficultyCalculationUtils.Norm(2, reading, flashlight);
+
+            // Inrease FL bonus when it's lower than reading to avoid situations where high reading difficulty makes FL give practically 0 bonus
+            return flashlight >= reading ? cognition : double.Lerp(reading + flashlight, cognition, flashlight / reading);
         }
 
         private double calculateStarRating(double basePerformance)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 flashlightRating = osuRatingCalculator.ComputeFlashlightRating(flashlight.DifficultyValue());
 
             double sliderNestedScorePerObject = LegacyScoreUtils.CalculateNestedScorePerObject(beatmap, totalHits);
-            double legacyScoreBaseMultiplier = LegacyScoreUtils.CalculateDifficultyPeppyStars(beatmap);
+            double legacyScoreBaseMultiplier = LegacyScoreUtils.CalculateDifficultyPeppyStars(WorkingBeatmap.Beatmap);
 
             var simulator = new OsuLegacyScoreSimulator();
             var scoreAttributes = simulator.Simulate(WorkingBeatmap, beatmap);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Difficulty.Skills;
@@ -107,12 +108,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double baseSpeedPerformance = OsuStrainSkill.DifficultyToPerformance(speedRating);
             double baseFlashlightPerformance = Flashlight.DifficultyToPerformance(flashlightRating);
 
-            double basePerformance =
-                Math.Pow(
-                    Math.Pow(baseAimPerformance, 1.1) +
-                    Math.Pow(baseSpeedPerformance, 1.1) +
-                    Math.Pow(baseFlashlightPerformance, 1.1), 1.0 / 1.1
-                );
+            double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseFlashlightPerformance);
 
             double starRating = calculateStarRating(basePerformance);
 
@@ -147,7 +143,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double aimValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue));
             double speedValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(speedDifficultyValue));
 
-            double totalValue = Math.Pow(Math.Pow(aimValue, 1.1) + Math.Pow(speedValue, 1.1), 1 / 1.1);
+            double totalValue = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, aimValue, speedValue);
 
             return calculateStarRating(totalValue);
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -110,8 +110,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double baseSpeedPerformance = HarmonicSkill.DifficultyToPerformance(speedRating);
             double baseReadingPerformance = HarmonicSkill.DifficultyToPerformance(readingRating);
             double baseFlashlightPerformance = Flashlight.DifficultyToPerformance(flashlightRating);
+            double baseCognitionPerformance = DifficultyCalculationUtils.Norm(2, baseReadingPerformance, baseFlashlightPerformance);
 
-            double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseReadingPerformance, baseFlashlightPerformance);
+            double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseCognitionPerformance);
 
             double starRating = calculateStarRating(basePerformance);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -54,13 +54,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             var aimWithoutSliders = skills.OfType<Aim>().Single(a => !a.IncludeSliders);
             var speed = skills.OfType<Speed>().Single();
             var flashlight = skills.OfType<Flashlight>().SingleOrDefault();
+            var reading = skills.OfType<Reading>().Single();
 
             double aimDifficultyValue = aim.DifficultyValue();
             double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
             double speedDifficultyValue = speed.DifficultyValue();
+            double readingDifficultyValue = reading.DifficultyValue();
 
             double aimDifficultStrainCount = aim.CountTopWeightedStrains(aimDifficultyValue);
             double speedDifficultStrainCount = speed.CountTopWeightedObjectDifficulties(speedDifficultyValue);
+            double readingDifficultNoteCount = reading.CountTopWeightedObjectDifficulties(readingDifficultyValue);
 
             double speedNotes = speed.RelevantNoteCount();
 
@@ -74,7 +77,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double difficultSliders = aim.GetDifficultSliders();
 
-            double approachRate = CalculateRateAdjustedApproachRate(beatmap.Difficulty.ApproachRate, clockRate);
             double overallDifficulty = CalculateRateAdjustedOverallDifficulty(beatmap.Difficulty.OverallDifficulty, clockRate);
 
             int hitCircleCount = beatmap.HitObjects.Count(h => h is HitCircle);
@@ -83,15 +85,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             int totalHits = beatmap.HitObjects.Count;
 
-            double mechanicalDifficultyRating = calculateMechanicalDifficultyRating(aimDifficultyValue, speedDifficultyValue);
             double sliderFactor = aimDifficultyValue > 0
                 ? OsuRatingCalculator.CalculateDifficultyRating(aimNoSlidersDifficultyValue) / OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue)
                 : 1;
 
-            var osuRatingCalculator = new OsuRatingCalculator(mods, totalHits, approachRate, overallDifficulty, mechanicalDifficultyRating, sliderFactor);
+            var osuRatingCalculator = new OsuRatingCalculator(mods, totalHits, overallDifficulty);
 
             double aimRating = osuRatingCalculator.ComputeAimRating(aimDifficultyValue);
             double speedRating = osuRatingCalculator.ComputeSpeedRating(speedDifficultyValue);
+            double readingRating = osuRatingCalculator.ComputeReadingRating(readingDifficultyValue);
 
             double flashlightRating = 0.0;
 
@@ -106,9 +108,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double baseAimPerformance = OsuStrainSkill.DifficultyToPerformance(aimRating);
             double baseSpeedPerformance = HarmonicSkill.DifficultyToPerformance(speedRating);
+            double baseReadingPerformance = HarmonicSkill.DifficultyToPerformance(readingRating);
             double baseFlashlightPerformance = Flashlight.DifficultyToPerformance(flashlightRating);
 
-            double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseFlashlightPerformance);
+            double basePerformance = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, baseAimPerformance, baseSpeedPerformance, baseReadingPerformance, baseFlashlightPerformance);
 
             double starRating = calculateStarRating(basePerformance);
 
@@ -121,9 +124,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 SpeedDifficulty = speedRating,
                 SpeedNoteCount = speedNotes,
                 FlashlightDifficulty = flashlightRating,
+                ReadingDifficulty = readingRating,
                 SliderFactor = sliderFactor,
                 AimDifficultStrainCount = aimDifficultStrainCount,
                 SpeedDifficultStrainCount = speedDifficultStrainCount,
+                ReadingDifficultNoteCount = readingDifficultNoteCount,
                 AimTopWeightedSliderFactor = aimTopWeightedSliderFactor,
                 SpeedTopWeightedSliderFactor = speedTopWeightedSliderFactor,
                 MaxCombo = beatmap.GetMaxCombo(),
@@ -136,16 +141,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             };
 
             return attributes;
-        }
-
-        private double calculateMechanicalDifficultyRating(double aimDifficultyValue, double speedDifficultyValue)
-        {
-            double aimValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue));
-            double speedValue = OsuStrainSkill.DifficultyToPerformance(OsuRatingCalculator.CalculateDifficultyRating(speedDifficultyValue));
-
-            double totalValue = DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, aimValue, speedValue);
-
-            return calculateStarRating(totalValue);
         }
 
         private double calculateStarRating(double basePerformance)
@@ -173,7 +168,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             {
                 new Aim(mods, true),
                 new Aim(mods, false),
-                new Speed(mods)
+                new Speed(mods),
+                new Reading(beatmap, mods, clockRate)
             };
 
             if (mods.Any(h => h is OsuModFlashlight))

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -22,8 +22,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 {
     public class OsuDifficultyCalculator : DifficultyCalculator
     {
-        private const double star_rating_multiplier = 0.0265;
-
         public override int Version => 20250306;
 
         public OsuDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
@@ -150,10 +148,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private double calculateStarRating(double basePerformance)
         {
-            if (basePerformance <= 0.00001)
-                return 0;
-
-            return Math.Cbrt(OsuPerformanceCalculator.PERFORMANCE_BASE_MULTIPLIER) * star_rating_multiplier * (Math.Cbrt(100000 / Math.Pow(2, 1 / 1.1) * basePerformance) + 4);
+            return Math.Cbrt(basePerformance * OsuPerformanceCalculator.PERFORMANCE_BASE_MULTIPLIER);
         }
 
         protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -55,17 +55,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             var speed = skills.OfType<Speed>().Single();
             var flashlight = skills.OfType<Flashlight>().SingleOrDefault();
 
+            double aimDifficultyValue = aim.DifficultyValue();
+            double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
+            double speedDifficultyValue = speed.DifficultyValue();
+
             double speedNotes = speed.RelevantNoteCount();
 
-            double aimDifficultStrainCount = aim.CountTopWeightedStrains();
-            double speedDifficultStrainCount = speed.CountTopWeightedStrains();
+            double aimDifficultStrainCount = aim.CountTopWeightedStrains(aimDifficultyValue);
+            double speedDifficultStrainCount = speed.CountTopWeightedStrains(speedDifficultyValue);
 
-            double aimNoSlidersTopWeightedSliderCount = aimWithoutSliders.CountTopWeightedSliders();
-            double aimNoSlidersDifficultStrainCount = aimWithoutSliders.CountTopWeightedStrains();
+            double aimNoSlidersTopWeightedSliderCount = aimWithoutSliders.CountTopWeightedSliders(aimNoSlidersDifficultyValue);
+            double aimNoSlidersDifficultStrainCount = aimWithoutSliders.CountTopWeightedStrains(aimNoSlidersDifficultyValue);
 
             double aimTopWeightedSliderFactor = aimNoSlidersTopWeightedSliderCount / Math.Max(1, aimNoSlidersDifficultStrainCount - aimNoSlidersTopWeightedSliderCount);
 
-            double speedTopWeightedSliderCount = speed.CountTopWeightedSliders();
+            double speedTopWeightedSliderCount = speed.CountTopWeightedSliders(speedDifficultyValue);
             double speedTopWeightedSliderFactor = speedTopWeightedSliderCount / Math.Max(1, speedDifficultStrainCount - speedTopWeightedSliderCount);
 
             double difficultSliders = aim.GetDifficultSliders();
@@ -78,10 +82,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             int spinnerCount = beatmap.HitObjects.Count(h => h is Spinner);
 
             int totalHits = beatmap.HitObjects.Count;
-
-            double aimDifficultyValue = aim.DifficultyValue();
-            double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
-            double speedDifficultyValue = speed.DifficultyValue();
 
             double mechanicalDifficultyRating = calculateMechanicalDifficultyRating(aimDifficultyValue, speedDifficultyValue);
             double sliderFactor = aimDifficultyValue > 0 ? OsuRatingCalculator.CalculateDifficultyRating(aimNoSlidersDifficultyValue) / OsuRatingCalculator.CalculateDifficultyRating(aimDifficultyValue) : 1;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -80,8 +80,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             int totalHits = beatmap.HitObjects.Count;
 
-            double drainRate = beatmap.Difficulty.DrainRate;
-
             double aimDifficultyValue = aim.DifficultyValue();
             double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
             double speedDifficultyValue = speed.DifficultyValue();
@@ -132,7 +130,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 SpeedDifficultStrainCount = speedDifficultStrainCount,
                 AimTopWeightedSliderFactor = aimTopWeightedSliderFactor,
                 SpeedTopWeightedSliderFactor = speedTopWeightedSliderFactor,
-                DrainRate = drainRate,
                 MaxCombo = beatmap.GetMaxCombo(),
                 HitCircleCount = hitCircleCount,
                 SliderCount = sliderCount,

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -115,9 +115,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double missCount = 0;
 
+            // If sliders in the map are hard - it's likely for player to drop sliderends
+            // If map has easy sliders - it's more likely for player to sliderbreak
+            double likelyMissedSliderendPortion = 0.04 + 0.06 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
+
             // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
-            // In classic scores we can't know the amount of dropped sliders so we estimate to 10% of all sliders on the map
-            double fullComboThreshold = attributes.MaxCombo - 0.1 * attributes.SliderCount;
+            // In classic scores we can't know the amount of dropped sliders so we estimate it
+            double fullComboThreshold = attributes.MaxCombo - Math.Min(4 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
 
             if (score.MaxCombo < fullComboThreshold)
                 missCount = Math.Pow(fullComboThreshold / Math.Max(1.0, score.MaxCombo), 2.5);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceAttributes.cs
@@ -21,6 +21,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         [JsonProperty("flashlight")]
         public double Flashlight { get; set; }
 
+        [JsonProperty("reading")]
+        public double Reading { get; set; }
+
         [JsonProperty("effective_miss_count")]
         public double EffectiveMissCount { get; set; }
 
@@ -48,6 +51,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             yield return new PerformanceDisplayAttribute(nameof(Speed), "Speed", Speed);
             yield return new PerformanceDisplayAttribute(nameof(Accuracy), "Accuracy", Accuracy);
             yield return new PerformanceDisplayAttribute(nameof(Flashlight), "Flashlight Bonus", Flashlight);
+            yield return new PerformanceDisplayAttribute(nameof(Reading), "Reading", Reading);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -337,9 +337,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (usingClassicSliderAccuracy)
             {
+                // If sliders in the map are hard - it's likely for player to drop sliderends
+                // If map has easy sliders - it's more likely for player to sliderbreak
+                double likelyMissedSliderendPortion = 0.04 + 0.06 * Math.Pow(Math.Min(attributes.AimTopWeightedSliderFactor, 1), 2);
+
                 // Consider that full combo is maximum combo minus dropped slider tails since they don't contribute to combo but also don't break it
-                // In classic scores we can't know the amount of dropped sliders so we estimate to 10% of all sliders on the map
-                double fullComboThreshold = attributes.MaxCombo - 0.1 * attributes.SliderCount;
+                // In classic scores we can't know the amount of dropped sliders so we estimate it
+                double fullComboThreshold = attributes.MaxCombo - Math.Min(4 + likelyMissedSliderendPortion * attributes.SliderCount, attributes.SliderCount);
 
                 if (scoreMaxCombo < fullComboThreshold)
                     missCount = fullComboThreshold / Math.Max(1.0, scoreMaxCombo);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -9,6 +9,7 @@ using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Osu.Difficulty.Skills;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -225,11 +226,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (score.Mods.Any(h => h is OsuModRelax) || speedDeviation == null)
                 return 0.0;
 
-            double speedValue = OsuStrainSkill.DifficultyToPerformance(attributes.SpeedDifficulty);
-
-            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                                 (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
-            speedValue *= lengthBonus;
+            double speedValue = HarmonicSkill.DifficultyToPerformance(attributes.SpeedDifficulty);
 
             if (effectiveMissCount > 0)
             {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double aimValue = OsuStrainSkill.DifficultyToPerformance(aimDifficulty);
 
-            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
+            double lengthBonus = 0.95 + 0.3 * Math.Min(1.0, totalHits / 2000.0) +
                                  (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
             aimValue *= lengthBonus;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -145,10 +145,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double aimValue = computeAimValue(score, osuAttributes);
             double speedValue = computeSpeedValue(score, osuAttributes);
             double accuracyValue = computeAccuracyValue(score, osuAttributes);
-            double flashlightValue = computeFlashlightValue(score, osuAttributes);
-            double readingValue = computeReadingValue(osuAttributes);
 
-            double totalValue = DifficultyCalculationUtils.Norm(PERFORMANCE_NORM_EXPONENT, aimValue, speedValue, accuracyValue, readingValue, flashlightValue) * multiplier;
+            double readingValue = computeReadingValue(osuAttributes);
+            double flashlightValue = computeFlashlightValue(score, osuAttributes);
+            double cognitionValue = DifficultyCalculationUtils.Norm(2, readingValue, flashlightValue);
+
+            double totalValue = DifficultyCalculationUtils.Norm(PERFORMANCE_NORM_EXPONENT, aimValue, speedValue, accuracyValue, cognitionValue) * multiplier;
 
             return new OsuPerformanceAttributes
             {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -253,15 +253,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedHighDeviationMultiplier = calculateSpeedHighDeviationNerf(attributes);
             speedValue *= speedHighDeviationMultiplier;
 
-            // Calculate accuracy assuming the worst case scenario
-            double relevantTotalDiff = Math.Max(0, totalHits - attributes.SpeedNoteCount);
-            double relevantCountGreat = Math.Max(0, countGreat - relevantTotalDiff);
-            double relevantCountOk = Math.Max(0, countOk - Math.Max(0, relevantTotalDiff - countGreat));
-            double relevantCountMeh = Math.Max(0, countMeh - Math.Max(0, relevantTotalDiff - countGreat - countOk));
-            double relevantAccuracy = attributes.SpeedNoteCount == 0 ? 0 : (relevantCountGreat * 6.0 + relevantCountOk * 2.0 + relevantCountMeh) / (attributes.SpeedNoteCount * 6.0);
+            // An effective hit window is created based on the speed SR. The higher the speed difficulty, the shorter the hit window.
+            // For example, a speed SR of 3.0 leads to an effective hit window of 20ms, which is OD 10.
+            double effectiveHitWindow = Math.Sqrt(30 * 60 / attributes.SpeedDifficulty);
 
-            // Scale the speed value with accuracy and OD.
-            speedValue *= Math.Pow((accuracy + relevantAccuracy) / 2.0, (14.5 - overallDifficulty) / 2);
+            // Find the proportion of 300s on speed notes assuming the hit window was the effective hit window.
+            double effectiveAccuracy = DifficultyCalculationUtils.Erf(effectiveHitWindow / (double)speedDeviation);
+
+            // Scale speed value by normalized accuracy.
+            speedValue *= Math.Pow(effectiveAccuracy, 2);
 
             return speedValue;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -50,8 +50,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         private double greatHitWindow;
         private double okHitWindow;
         private double mehHitWindow;
+
         private double overallDifficulty;
         private double approachRate;
+        private double drainRate;
 
         private double? speedDeviation;
 
@@ -95,6 +97,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             approachRate = OsuDifficultyCalculator.CalculateRateAdjustedApproachRate(difficulty.ApproachRate, clockRate);
             overallDifficulty = OsuDifficultyCalculator.CalculateRateAdjustedOverallDifficulty(difficulty.OverallDifficulty, clockRate);
+            drainRate = difficulty.DrainRate;
 
             double comboBasedEstimatedMissCount = calculateComboBasedEstimatedMissCount(osuAttributes);
             double? scoreBasedEstimatedMissCount = null;
@@ -211,7 +214,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // TC bonuses are excluded when blinds is present as the increased visual difficulty is unimportant when notes cannot be seen.
             if (score.Mods.Any(m => m is OsuModBlinds))
-                aimValue *= 1.3 + (totalHits * (0.0016 / (1 + 2 * effectiveMissCount)) * Math.Pow(accuracy, 16)) * (1 - 0.003 * attributes.DrainRate * attributes.DrainRate);
+                aimValue *= 1.3 + (totalHits * (0.0016 / (1 + 2 * effectiveMissCount)) * Math.Pow(accuracy, 16)) * (1 - 0.003 * drainRate * drainRate);
             else if (score.Mods.Any(m => m is OsuModTraceable))
             {
                 aimValue *= 1.0 + OsuRatingCalculator.CalculateVisibilityBonus(score.Mods, approachRate, sliderFactor: attributes.SliderFactor);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     public class OsuPerformanceCalculator : PerformanceCalculator
     {
         public const double PERFORMANCE_BASE_MULTIPLIER = 1.14; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
+        public const double PERFORMANCE_NORM_EXPONENT = 1.1;
 
         private bool usingClassicSliderAccuracy;
         private bool usingScoreV2;
@@ -145,13 +146,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double accuracyValue = computeAccuracyValue(score, osuAttributes);
             double flashlightValue = computeFlashlightValue(score, osuAttributes);
 
-            double totalValue =
-                Math.Pow(
-                    Math.Pow(aimValue, 1.1) +
-                    Math.Pow(speedValue, 1.1) +
-                    Math.Pow(accuracyValue, 1.1) +
-                    Math.Pow(flashlightValue, 1.1), 1.0 / 1.1
-                ) * multiplier;
+            double totalValue = DifficultyCalculationUtils.Norm(PERFORMANCE_NORM_EXPONENT, aimValue, speedValue, accuracyValue, flashlightValue) * multiplier;
 
             return new OsuPerformanceAttributes
             {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double readingValue = computeReadingValue(osuAttributes);
             double flashlightValue = computeFlashlightValue(score, osuAttributes);
-            double cognitionValue = DifficultyCalculationUtils.Norm(2, readingValue, flashlightValue);
+            double cognitionValue = OsuDifficultyCalculator.SumCognitionDifficulty(readingValue, flashlightValue);
 
             double totalValue = DifficultyCalculationUtils.Norm(PERFORMANCE_NORM_EXPONENT, aimValue, speedValue, accuracyValue, cognitionValue) * multiplier;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -146,8 +146,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedValue = computeSpeedValue(score, osuAttributes);
             double accuracyValue = computeAccuracyValue(score, osuAttributes);
             double flashlightValue = computeFlashlightValue(score, osuAttributes);
+            double readingValue = computeReadingValue(osuAttributes);
 
-            double totalValue = DifficultyCalculationUtils.Norm(PERFORMANCE_NORM_EXPONENT, aimValue, speedValue, accuracyValue, flashlightValue) * multiplier;
+            double totalValue = DifficultyCalculationUtils.Norm(PERFORMANCE_NORM_EXPONENT, aimValue, speedValue, accuracyValue, readingValue, flashlightValue) * multiplier;
 
             return new OsuPerformanceAttributes
             {
@@ -155,6 +156,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 Speed = speedValue,
                 Accuracy = accuracyValue,
                 Flashlight = flashlightValue,
+                Reading = readingValue,
                 EffectiveMissCount = effectiveMissCount,
                 ComboBasedEstimatedMissCount = comboBasedEstimatedMissCount,
                 ScoreBasedEstimatedMissCount = scoreBasedEstimatedMissCount,
@@ -213,7 +215,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.3 + (totalHits * (0.0016 / (1 + 2 * effectiveMissCount)) * Math.Pow(accuracy, 16)) * (1 - 0.003 * drainRate * drainRate);
             else if (score.Mods.Any(m => m is OsuModTraceable))
             {
-                aimValue *= 1.0 + OsuRatingCalculator.CalculateVisibilityBonus(score.Mods, approachRate, sliderFactor: attributes.SliderFactor);
+                aimValue *= 1.0 + calculateTraceableBonus(attributes.SliderFactor);
             }
 
             aimValue *= accuracy;
@@ -245,7 +247,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             }
             else if (score.Mods.Any(m => m is OsuModTraceable))
             {
-                speedValue *= 1.0 + OsuRatingCalculator.CalculateVisibilityBonus(score.Mods, approachRate);
+                speedValue *= 1.0 + calculateTraceableBonus();
             }
 
             double speedHighDeviationMultiplier = calculateSpeedHighDeviationNerf(attributes);
@@ -294,7 +296,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // Increasing the accuracy value by object count for Blinds isn't ideal, so the minimum buff is given.
             if (score.Mods.Any(m => m is OsuModBlinds))
                 accuracyValue *= 1.14;
-            else if (score.Mods.Any(m => m is OsuModHidden || m is OsuModTraceable))
+            else if (score.Mods.Any(m => m is OsuModTraceable))
             {
                 // Decrease bonus for AR > 10
                 accuracyValue *= 1 + 0.08 * DifficultyCalculationUtils.ReverseLerp(approachRate, 11.5, 10);
@@ -323,6 +325,19 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             flashlightValue *= 0.5 + accuracy / 2.0;
 
             return flashlightValue;
+        }
+
+        private double computeReadingValue(OsuDifficultyAttributes attributes)
+        {
+            double readingValue = HarmonicSkill.DifficultyToPerformance(attributes.ReadingDifficulty);
+
+            if (effectiveMissCount > 0)
+                readingValue *= calculateMissPenalty(effectiveMissCount + aimEstimatedSliderBreaks, attributes.ReadingDifficultNoteCount);
+
+            // Scale the reading value with accuracy _harshly_.
+            readingValue *= Math.Pow(accuracy, 3);
+
+            return readingValue;
         }
 
         private double calculateComboBasedEstimatedMissCount(OsuDifficultyAttributes attributes)
@@ -486,6 +501,28 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             adjustedSpeedValue = double.Lerp(adjustedSpeedValue, speedValue, lerp);
 
             return adjustedSpeedValue / speedValue;
+        }
+
+        /// <summary>
+        /// Calculates a visibility bonus that is applicable to Traceable.
+        /// </summary>
+        private double calculateTraceableBonus(double sliderFactor = 1)
+        {
+            // Start from normal curve, rewarding lower AR up to AR7
+            double traceableBonus = 0.025 * (12.0 - Math.Max(approachRate, 7));
+
+            // We want to reward slider aim on low AR less
+            double sliderVisibilityFactor = Math.Pow(sliderFactor, 3);
+
+            // For AR up to 0 - reduce reward for very low ARs when object is visible
+            if (approachRate < 7)
+                traceableBonus += 0.02 * (7.0 - Math.Max(approachRate, 0)) * sliderVisibilityFactor;
+
+            // Starting from AR0 - cap values so they won't grow to infinity
+            if (approachRate < 0)
+                traceableBonus += 0.01 * (1 - Math.Pow(1.5, approachRate)) * sliderVisibilityFactor;
+
+            return traceableBonus;
         }
 
         // Miss penalty assumes that a player will miss on the hardest parts of a map,

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double comboBasedEstimatedMissCount = calculateComboBasedEstimatedMissCount(osuAttributes);
             double? scoreBasedEstimatedMissCount = null;
 
-            if (usingClassicSliderAccuracy && score.LegacyTotalScore != null)
+            if (usingClassicSliderAccuracy && !usingScoreV2 && score.LegacyTotalScore != null)
             {
                 var legacyScoreMissCalculator = new OsuLegacyScoreMissCalculator(score, osuAttributes);
                 scoreBasedEstimatedMissCount = legacyScoreMissCalculator.Calculate();

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 {
     public class OsuPerformanceCalculator : PerformanceCalculator
     {
-        public const double PERFORMANCE_BASE_MULTIPLIER = 1.14; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
+        public const double PERFORMANCE_BASE_MULTIPLIER = 1.12; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
         public const double PERFORMANCE_NORM_EXPONENT = 1.1;
 
         private bool usingClassicSliderAccuracy;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -65,11 +65,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 speedRating *= 1.0 - magnetisedStrength * 0.3;
             }
 
-            double ratingMultiplier = 1.0;
-
-            ratingMultiplier *= 0.95 + Math.Pow(Math.Max(0, overallDifficulty), 2) / 750;
-
-            return speedRating * Math.Cbrt(ratingMultiplier);
+            return speedRating;
         }
 
         public double ComputeReadingRating(double readingDifficultyValue)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -15,19 +15,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private readonly Mod[] mods;
         private readonly int totalHits;
-        private readonly double approachRate;
         private readonly double overallDifficulty;
-        private readonly double mechanicalDifficultyRating;
-        private readonly double sliderFactor;
 
-        public OsuRatingCalculator(Mod[] mods, int totalHits, double approachRate, double overallDifficulty, double mechanicalDifficultyRating, double sliderFactor)
+        public OsuRatingCalculator(Mod[] mods, int totalHits, double overallDifficulty)
         {
             this.mods = mods;
             this.totalHits = totalHits;
-            this.approachRate = approachRate;
             this.overallDifficulty = overallDifficulty;
-            this.mechanicalDifficultyRating = mechanicalDifficultyRating;
-            this.sliderFactor = sliderFactor;
         }
 
         public double ComputeAimRating(double aimDifficultyValue)
@@ -50,26 +44,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             }
 
             double ratingMultiplier = 1.0;
-
-            double approachRateLengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                                             (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
-
-            double approachRateFactor = 0.0;
-            if (approachRate > 10.33)
-                approachRateFactor = 0.3 * (approachRate - 10.33);
-            else if (approachRate < 8.0)
-                approachRateFactor = 0.05 * (8.0 - approachRate);
-
-            if (mods.Any(h => h is OsuModRelax))
-                approachRateFactor = 0.0;
-
-            ratingMultiplier += approachRateFactor * approachRateLengthBonus; // Buff for longer maps with high AR.
-
-            if (mods.Any(m => m is OsuModHidden))
-            {
-                double visibilityFactor = calculateAimVisibilityFactor(approachRate);
-                ratingMultiplier += CalculateVisibilityBonus(mods, approachRate, visibilityFactor, sliderFactor);
-            }
 
             // It is important to consider accuracy difficulty when scaling with accuracy.
             ratingMultiplier *= 0.98 + Math.Pow(Math.Max(0, overallDifficulty), 2) / 2500;
@@ -96,27 +70,34 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double ratingMultiplier = 1.0;
 
-            double approachRateLengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                                             (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
-
-            double approachRateFactor = 0.0;
-            if (approachRate > 10.33)
-                approachRateFactor = 0.3 * (approachRate - 10.33);
-
-            if (mods.Any(m => m is OsuModAutopilot))
-                approachRateFactor = 0.0;
-
-            ratingMultiplier += approachRateFactor * approachRateLengthBonus; // Buff for longer maps with high AR.
-
-            if (mods.Any(m => m is OsuModHidden))
-            {
-                double visibilityFactor = calculateSpeedVisibilityFactor(approachRate);
-                ratingMultiplier += CalculateVisibilityBonus(mods, approachRate, visibilityFactor);
-            }
-
             ratingMultiplier *= 0.95 + Math.Pow(Math.Max(0, overallDifficulty), 2) / 750;
 
             return speedRating * Math.Cbrt(ratingMultiplier);
+        }
+
+        public double ComputeReadingRating(double readingDifficultyValue)
+        {
+            double readingRating = CalculateDifficultyRating(readingDifficultyValue);
+
+            if (mods.Any(m => m is OsuModTouchDevice))
+                readingRating = Math.Pow(readingRating, 0.8);
+
+            if (mods.Any(m => m is OsuModRelax))
+                readingRating *= 0.7;
+            else if (mods.Any(m => m is OsuModAutopilot))
+                readingRating *= 0.4;
+
+            if (mods.Any(m => m is OsuModMagnetised))
+            {
+                float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;
+                readingRating *= 1.0 - magnetisedStrength;
+            }
+
+            double ratingMultiplier = 1.0;
+
+            ratingMultiplier *= 0.75 + Math.Pow(Math.Max(0, overallDifficulty), 2.2) / 800;
+
+            return readingRating * Math.Cbrt(ratingMultiplier);
         }
 
         public double ComputeFlashlightRating(double flashlightDifficultyValue)
@@ -156,56 +137,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             ratingMultiplier *= 0.98 + Math.Pow(Math.Max(0, overallDifficulty), 2) / 2500;
 
             return flashlightRating * Math.Sqrt(ratingMultiplier);
-        }
-
-        private double calculateAimVisibilityFactor(double approachRate)
-        {
-            const double ar_factor_end_point = 11.5;
-
-            double mechanicalDifficultyFactor = DifficultyCalculationUtils.ReverseLerp(mechanicalDifficultyRating, 5, 10);
-            double arFactorStartingPoint = double.Lerp(9, 10.33, mechanicalDifficultyFactor);
-
-            return DifficultyCalculationUtils.ReverseLerp(approachRate, ar_factor_end_point, arFactorStartingPoint);
-        }
-
-        private double calculateSpeedVisibilityFactor(double approachRate)
-        {
-            const double ar_factor_end_point = 11.5;
-
-            double mechanicalDifficultyFactor = DifficultyCalculationUtils.ReverseLerp(mechanicalDifficultyRating, 5, 10);
-            double arFactorStartingPoint = double.Lerp(10, 10.33, mechanicalDifficultyFactor);
-
-            return DifficultyCalculationUtils.ReverseLerp(approachRate, ar_factor_end_point, arFactorStartingPoint);
-        }
-
-        /// <summary>
-        /// Calculates a visibility bonus that is applicable to Hidden and Traceable.
-        /// </summary>
-        public static double CalculateVisibilityBonus(Mod[] mods, double approachRate, double visibilityFactor = 1, double sliderFactor = 1)
-        {
-            // NOTE: TC's effect is only noticeable in performance calculations until lazer mods are accounted for server-side.
-            bool isAlwaysPartiallyVisible = mods.OfType<OsuModHidden>().Any(m => m.OnlyFadeApproachCircles.Value) || mods.OfType<OsuModTraceable>().Any();
-
-            // Start from normal curve, rewarding lower AR up to AR7
-            // TC forcefully requires a lower reading bonus for now as it's post-applied in PP which makes it multiplicative with the regular AR bonuses
-            // This means it has an advantage over HD, so we decrease the multiplier to compensate
-            // This should be removed once we're able to apply TC bonuses in SR (depends on real-time difficulty calculations being possible)
-            double readingBonus = (isAlwaysPartiallyVisible ? 0.025 : 0.04) * (12.0 - Math.Max(approachRate, 7));
-
-            readingBonus *= visibilityFactor;
-
-            // We want to reward slideraim on low AR less
-            double sliderVisibilityFactor = Math.Pow(sliderFactor, 3);
-
-            // For AR up to 0 - reduce reward for very low ARs when object is visible
-            if (approachRate < 7)
-                readingBonus += (isAlwaysPartiallyVisible ? 0.02 : 0.045) * (7.0 - Math.Max(approachRate, 0)) * sliderVisibilityFactor;
-
-            // Starting from AR0 - cap values so they won't grow to infinity
-            if (approachRate < 0)
-                readingBonus += (isAlwaysPartiallyVisible ? 0.01 : 0.1) * (1 - Math.Pow(1.5, approachRate)) * sliderVisibilityFactor;
-
-            return readingBonus;
         }
 
         public static double CalculateDifficultyRating(double difficultyValue) => Math.Sqrt(difficultyValue) * difficulty_multiplier;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -31,9 +31,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double aimRating = CalculateDifficultyRating(aimDifficultyValue);
 
-            if (mods.Any(m => m is OsuModTouchDevice))
-                aimRating = Math.Pow(aimRating, 0.8);
-
             if (mods.Any(m => m is OsuModRelax))
                 aimRating *= 0.9;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -242,15 +242,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             if (lastLastDifficultyObject != null && lastLastDifficultyObject.BaseObject is not Spinner)
             {
+                if (lastDifficultyObject!.BaseObject is Slider prevSlider && lastDifficultyObject.TravelDistance > 0)
+                    lastCursorPosition = prevSlider.HeadCircle.StackedPosition;
+
                 Vector2 lastLastCursorPosition = getEndCursorPosition(lastLastDifficultyObject);
 
-                Vector2 v1 = lastLastCursorPosition - LastObject.StackedPosition;
-                Vector2 v2 = BaseObject.StackedPosition - lastCursorPosition;
+                double angle = calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition);
+                double sliderAngle = calculateSliderAngle(lastDifficultyObject!, lastLastCursorPosition);
 
-                float dot = Vector2.Dot(v1, v2);
-                float det = v1.X * v2.Y - v1.Y * v2.X;
-
-                Angle = Math.Abs(Math.Atan2(det, dot));
+                Angle = Math.Min(angle, sliderAngle);
             }
         }
 
@@ -360,6 +360,30 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 if (i == nestedObjects.Count - 1)
                     LazyEndPosition = currCursorPosition;
             }
+        }
+
+        private double calculateSliderAngle(OsuDifficultyHitObject lastDifficultyObject, Vector2 lastLastCursorPosition)
+        {
+            Vector2 lastCursorPosition = getEndCursorPosition(lastDifficultyObject);
+
+            if (lastDifficultyObject.BaseObject is Slider prevSlider && lastDifficultyObject.TravelDistance > 0)
+            {
+                OsuHitObject secondLastNestedObject = (OsuHitObject)prevSlider.NestedHitObjects[^2];
+                lastLastCursorPosition = secondLastNestedObject.StackedPosition;
+            }
+
+            return calculateAngle(BaseObject.StackedPosition, lastCursorPosition, lastLastCursorPosition);
+        }
+
+        private double calculateAngle(Vector2 currentPosition, Vector2 lastPosition, Vector2 lastLastPosition)
+        {
+            Vector2 v1 = lastLastPosition - lastPosition;
+            Vector2 v2 = currentPosition - lastPosition;
+
+            float dot = Vector2.Dot(v1, v2);
+            float det = v1.X * v2.Y - v1.Y * v2.X;
+
+            return Math.Abs(Math.Atan2(det, dot));
         }
 
         private Vector2 getEndCursorPosition(OsuDifficultyHitObject difficultyHitObject)

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -47,6 +47,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         public readonly double ClockRate;
 
         /// <summary>
+        /// Normalised distance from the start position of the previous <see cref="OsuDifficultyHitObject"/> to the start position of this <see cref="OsuDifficultyHitObject"/>.
+        /// </summary>
+        public double JumpDistance { get; private set; }
+
+        /// <summary>
         /// Normalised distance from the "lazy" end position of the previous <see cref="OsuDifficultyHitObject"/> to the start position of this <see cref="OsuDifficultyHitObject"/>.
         /// <para>
         /// The "lazy" end position is the position at which the cursor ends up if the previous hitobject is followed with as minimal movement as possible (i.e. on the edge of slider follow circles).
@@ -232,7 +237,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             Vector2 lastCursorPosition = lastDifficultyObject != null ? getEndCursorPosition(lastDifficultyObject) : LastObject.StackedPosition;
 
-            LazyJumpDistance = (BaseObject.StackedPosition * scalingFactor - lastCursorPosition * scalingFactor).Length;
+            JumpDistance = (LastObject.StackedPosition - BaseObject.StackedPosition).Length * scalingFactor;
+            LazyJumpDistance = (BaseObject.StackedPosition - lastCursorPosition).Length * scalingFactor;
             MinimumJumpTime = AdjustedDeltaTime;
             MinimumJumpDistance = LazyJumpDistance;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -175,9 +175,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             {
                 double currDeltaTime = Math.Max(1, DeltaTime);
                 double nextDeltaTime = Math.Max(1, osuNextObj.DeltaTime);
+
                 double deltaDifference = Math.Abs(nextDeltaTime - currDeltaTime);
+
                 double speedRatio = currDeltaTime / Math.Max(currDeltaTime, deltaDifference);
-                double windowRatio = Math.Pow(Math.Min(1, currDeltaTime / HitWindowGreat), 2);
+                double windowRatio = Math.Pow(Math.Min(1, currDeltaTime / HitWindowGreat), 5);
+
                 return 1.0 - Math.Pow(speedRatio, 1 - windowRatio);
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -36,6 +36,17 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         public readonly double AdjustedDeltaTime;
 
         /// <summary>
+        /// Time (in ms) between the object first appearing and the time it needs to be clicked.
+        /// <see cref="OsuHitObject.TimePreempt"/> adjusted by clock rate.
+        /// </summary>
+        public readonly double Preempt;
+
+        /// <summary>
+        /// Beatmap playback rate.
+        /// </summary>
+        public readonly double ClockRate;
+
+        /// <summary>
         /// Normalised distance from the "lazy" end position of the previous <see cref="OsuDifficultyHitObject"/> to the start position of this <see cref="OsuDifficultyHitObject"/>.
         /// <para>
         /// The "lazy" end position is the position at which the cursor ends up if the previous hitobject is followed with as minimal movement as possible (i.e. on the edge of slider follow circles).
@@ -124,6 +135,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             SmallCircleBonus = Math.Max(1.0, 1.0 + (30 - BaseObject.Radius) / 40);
 
+            ClockRate = clockRate;
+            Preempt = BaseObject.TimePreempt / clockRate;
+
             if (BaseObject is Slider sliderObject)
             {
                 HitWindowGreat = 2 * sliderObject.HeadCircle.HitWindows.WindowFor(HitResult.Great) / clockRate;
@@ -148,7 +162,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             }
 
             double fadeInStartTime = BaseObject.StartTime - BaseObject.TimePreempt;
-            double fadeInDuration = BaseObject.TimeFadeIn;
+
+            // Equal to `OsuHitObject.TimeFadeIn` minus any adjustments from the HD mod.
+            double fadeInDuration = 400 * Math.Min(1, BaseObject.TimePreempt / OsuHitObject.PREEMPT_MIN);
 
             if (hidden)
             {
@@ -164,6 +180,17 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             }
 
             return Math.Clamp((time - fadeInStartTime) / fadeInDuration, 0.0, 1.0);
+        }
+
+        /// <summary>
+        /// Returns the amount of time a note spends invisible with the hidden mod at the current approach rate.
+        /// </summary>
+        public double DurationSpentInvisible()
+        {
+            double fadeOutStartTime = BaseObject.StartTime - BaseObject.TimePreempt + BaseObject.TimeFadeIn;
+            double fadeOutDuration = BaseObject.TimePreempt * OsuModHidden.FADE_OUT_DURATION_MULTIPLIER;
+
+            return (fadeOutStartTime + fadeOutDuration) - (BaseObject.StartTime - BaseObject.TimePreempt);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -60,6 +60,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return sliderStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxSliderStrain * 12.0 - 6.0))));
         }
 
-        public double CountTopWeightedSliders() => OsuStrainUtils.CountTopWeightedSliders(sliderStrains, DifficultyValue());
+        public double CountTopWeightedSliders(double difficultyValue)
+            => OsuStrainUtils.CountTopWeightedSliders(sliderStrains, difficultyValue);
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double skillMultiplierAim => 26.0;
         private double skillMultiplierSpeed => 1.3;
-        private double skillMultiplierTotal => 1.02;
+        private double skillMultiplierTotal => 1.01;
         private double meanExponent => 1.2;
 
         private readonly List<double> sliderStrains = new List<double>();

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double currentStrain;
 
-        private double skillMultiplier => 26;
+        private double skillMultiplier => 26.7;
         private double strainDecayBase => 0.15;
 
         private readonly List<double> sliderStrains = new List<double>();

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Difficulty.Utils;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
@@ -50,11 +51,20 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             double decayAim = strainDecayAim(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
             double decaySpeed = strainDecaySpeed(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
 
+            double aimDifficulty = AimEvaluator.EvaluateDifficultyOf(current, IncludeSliders);
+            double speedDifficulty = SpeedAimEvaluator.EvaluateDifficultyOf(current);
+
+            if (Mods.Any(m => m is OsuModTouchDevice))
+            {
+                aimDifficulty = Math.Pow(aimDifficulty, 0.8);
+                speedDifficulty = Math.Pow(speedDifficulty, 0.95);
+            }
+
             currentAimStrain *= decayAim;
-            currentAimStrain += AimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * (1 - decayAim) * skillMultiplierAim;
+            currentAimStrain += aimDifficulty * (1 - decayAim) * skillMultiplierAim;
 
             currentSpeedStrain *= decaySpeed;
-            currentSpeedStrain += SpeedAimEvaluator.EvaluateDifficultyOf(current) * (1 - decaySpeed) * skillMultiplierSpeed;
+            currentSpeedStrain += speedDifficulty * (1 - decaySpeed) * skillMultiplierSpeed;
 
             double totalStrain = DifficultyCalculationUtils.Norm(meanExponent, currentAimStrain, currentSpeedStrain);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double currentStrain;
 
-        private double skillMultiplier => 26.7;
+        private double skillMultiplier => 26.6;
         private double strainDecayBase => 0.15;
 
         private readonly List<double> sliderStrains = new List<double>();

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
@@ -26,28 +27,41 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             IncludeSliders = includeSliders;
         }
 
-        private double currentStrain;
+        private double currentAimStrain;
+        private double currentSpeedStrain;
 
-        private double skillMultiplier => 26.6;
-        private double strainDecayBase => 0.15;
+        private double skillMultiplierAim => 26.0;
+        private double skillMultiplierSpeed => 1.3;
+        private double skillMultiplierTotal => 1.02;
+        private double meanExponent => 1.2;
 
         private readonly List<double> sliderStrains = new List<double>();
 
-        private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
+        private double strainDecayAim(double ms) => Math.Pow(0.15, ms / 1000);
+        private double strainDecaySpeed(double ms) => Math.Pow(0.3, ms / 1000);
 
-        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) => currentStrain * strainDecay(time - current.Previous(0).StartTime);
+        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) =>
+            DifficultyCalculationUtils.Norm(meanExponent,
+                currentAimStrain * strainDecayAim(time - current.Previous(0).StartTime),
+                currentSpeedStrain * strainDecaySpeed(time - current.Previous(0).StartTime));
 
         protected override double StrainValueAt(DifficultyHitObject current)
         {
-            double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+            double decayAim = strainDecayAim(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+            double decaySpeed = strainDecaySpeed(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
 
-            currentStrain *= decay;
-            currentStrain += AimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * (1 - decay) * skillMultiplier;
+            currentAimStrain *= decayAim;
+            currentAimStrain += AimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * (1 - decayAim) * skillMultiplierAim;
+
+            currentSpeedStrain *= decaySpeed;
+            currentSpeedStrain += SpeedAimEvaluator.EvaluateDifficultyOf(current) * (1 - decaySpeed) * skillMultiplierSpeed;
+
+            double totalStrain = DifficultyCalculationUtils.Norm(meanExponent, currentAimStrain, currentSpeedStrain);
 
             if (current.BaseObject is Slider)
-                sliderStrains.Add(currentStrain);
+                sliderStrains.Add(totalStrain);
 
-            return currentStrain;
+            return totalStrain * skillMultiplierTotal;
         }
 
         public double GetDifficultSliders()

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Objects;
 
@@ -38,8 +39,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         protected override double StrainValueAt(DifficultyHitObject current)
         {
-            currentStrain *= strainDecay(current.DeltaTime);
-            currentStrain += AimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skillMultiplier;
+            double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+
+            currentStrain *= decay;
+            currentStrain += AimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * (1 - decay) * skillMultiplier;
 
             if (current.BaseObject is Slider)
                 sliderStrains.Add(currentStrain);

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
         }
 
-        private double skillMultiplier => 0.05512;
+        private double skillMultiplier => 0.056;
         private double strainDecayBase => 0.15;
 
         private double currentStrain;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -7,7 +7,6 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
-using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
@@ -16,12 +15,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public class Flashlight : StrainSkill
     {
-        private readonly bool hasHiddenMod;
-
         public Flashlight(Mod[] mods)
             : base(mods)
         {
-            hasHiddenMod = mods.Any(m => m is OsuModHidden);
         }
 
         private double skillMultiplier => 0.05512;
@@ -36,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         protected override double StrainValueAt(DifficultyHitObject current)
         {
             currentStrain *= strainDecay(current.DeltaTime);
-            currentStrain += FlashlightEvaluator.EvaluateDifficultyOf(current, hasHiddenMod) * skillMultiplier;
+            currentStrain += FlashlightEvaluator.EvaluateDifficultyOf(current, Mods) * skillMultiplier;
 
             return currentStrain;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -57,6 +57,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return difficulty;
         }
 
-        public static double DifficultyToPerformance(double difficulty) => Math.Pow(5.0 * Math.Max(1.0, difficulty / 0.0675) - 4.0, 3.0) / 100000.0;
+        public static double DifficultyToPerformance(double difficulty) => 4.0 * Math.Pow(difficulty, 3.0);
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -1,0 +1,107 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Difficulty.Utils;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
+using osu.Game.Rulesets.Osu.Mods;
+
+namespace osu.Game.Rulesets.Osu.Difficulty.Skills
+{
+    public class Reading : HarmonicSkill
+    {
+        private readonly IReadOnlyList<HitObject> objectList;
+
+        private readonly double clockRate;
+        private readonly bool hasHiddenMod;
+
+        public Reading(IBeatmap beatmap, Mod[] mods, double clockRate)
+            : base(mods)
+        {
+            this.clockRate = clockRate;
+            hasHiddenMod = mods.OfType<OsuModHidden>().Any(m => !m.OnlyFadeApproachCircles.Value);
+            objectList = beatmap.HitObjects;
+        }
+
+        private double currentDifficulty;
+
+        private double skillMultiplier => 2.5;
+        private double strainDecayBase => 0.8;
+
+        private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
+
+        protected override double ObjectDifficultyOf(DifficultyHitObject current)
+        {
+            currentDifficulty *= strainDecay(current.DeltaTime);
+
+            currentDifficulty += ReadingEvaluator.EvaluateDifficultyOf(current, hasHiddenMod) * skillMultiplier;
+
+            return currentDifficulty;
+        }
+
+        protected override void ApplyDifficultyTransformation(double[] difficulties)
+        {
+            const double reduced_difficulty_base_line = 0.0; // Assume the first seconds are completely memorised
+
+            if (difficulties.Length == 0)
+                return;
+
+            int reducedNoteCount = calculateReducedNoteCount();
+
+            for (int i = 0; i < Math.Min(difficulties.Length, reducedNoteCount); i++)
+            {
+                double scale = Math.Log10(Interpolation.Lerp(1, 10, Math.Clamp((double)i / reducedNoteCount, 0, 1)));
+                difficulties[i] *= Interpolation.Lerp(reduced_difficulty_base_line, 1.0, scale);
+            }
+        }
+
+        private int calculateReducedNoteCount()
+        {
+            const double reduced_difficulty_duration = 60 * 1000;
+
+            if (objectList.Count < 2)
+                return 0;
+
+            // We take the 2nd note to match `CreateDifficultyHitObjects`
+            HitObject firstDifficultyObject = objectList[1];
+
+            double reducedDuration = (firstDifficultyObject.StartTime / clockRate) + reduced_difficulty_duration;
+
+            int reducedNoteCount = 0;
+
+            foreach (var hitObject in objectList)
+            {
+                if (hitObject.StartTime / clockRate > reducedDuration)
+                    break;
+
+                reducedNoteCount++;
+            }
+
+            return reducedNoteCount;
+        }
+
+        public override double CountTopWeightedObjectDifficulties(double difficultyValue)
+        {
+            if (ObjectDifficulties.Count == 0)
+                return 0.0;
+
+            if (NoteWeightSum == 0)
+                return 0.0;
+
+            double consistentTopNote = difficultyValue / NoteWeightSum; // What would the top difficulty be if all object difficulties were identical
+
+            if (consistentTopNote == 0)
+                return 0;
+
+            return ObjectDifficulties.Sum(d => DifficultyCalculationUtils.Logistic(d / consistentTopNote, 1.15, 5, 1.1));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return ObjectStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxStrain * 12.0 - 6.0))));
         }
 
-        public double CountTopWeightedSliders() => OsuStrainUtils.CountTopWeightedSliders(sliderStrains, DifficultyValue());
+        public double CountTopWeightedSliders(double difficultyValue)
+            => OsuStrainUtils.CountTopWeightedSliders(sliderStrains, difficultyValue);
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -6,27 +6,29 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
-using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
 using System.Linq;
-using osu.Game.Rulesets.Osu.Difficulty.Utils;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Difficulty.Utils;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
     /// <summary>
     /// Represents the skill required to press keys with regards to keeping up with the speed at which objects need to be hit.
     /// </summary>
-    public class Speed : OsuStrainSkill
+    public class Speed : HarmonicSkill
     {
-        private double skillMultiplier => 1.47;
-        private double strainDecayBase => 0.3;
-
-        private double currentStrain;
-        private double currentRhythm;
+        private double skillMultiplier => 0.93;
 
         private readonly List<double> sliderStrains = new List<double>();
 
-        protected override int ReducedSectionCount => 5;
+        private double currentDifficulty;
+
+        private double strainDecayBase => 0.3;
+
+        protected override double HarmonicScale => 20;
+        protected override double DecayExponent => 0.85;
 
         public Speed(Mod[] mods)
             : base(mods)
@@ -35,23 +37,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
 
-        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) => (currentStrain * currentRhythm) * strainDecay(time - current.Previous(0).StartTime);
-
-        protected override double StrainValueAt(DifficultyHitObject current)
+        protected override double ObjectDifficultyOf(DifficultyHitObject current)
         {
             double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
 
-            currentStrain *= decay;
-            currentStrain += SpeedEvaluator.EvaluateDifficultyOf(current, Mods) * (1 - decay) * skillMultiplier;
+            currentDifficulty *= decay;
+            currentDifficulty += SpeedEvaluator.EvaluateDifficultyOf(current, Mods) * (1 - decay) * skillMultiplier;
 
-            currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
+            double currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
 
-            double totalStrain = currentStrain * currentRhythm;
+            double totalDifficulty = currentDifficulty * currentRhythm;
 
             if (current.BaseObject is Slider)
-                sliderStrains.Add(totalStrain);
+                sliderStrains.Add(totalDifficulty);
 
-            return totalStrain;
+            return totalDifficulty;
         }
 
         public double RelevantNoteCount()
@@ -60,6 +60,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                 return 0;
 
             double maxStrain = ObjectDifficulties.Max();
+
             if (maxStrain == 0)
                 return 0;
 
@@ -67,6 +68,20 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         }
 
         public double CountTopWeightedSliders(double difficultyValue)
-            => OsuStrainUtils.CountTopWeightedSliders(sliderStrains, difficultyValue);
+        {
+            if (sliderStrains.Count == 0)
+                return 0;
+
+            if (NoteWeightSum == 0)
+                return 0.0;
+
+            double consistentTopNote = difficultyValue / NoteWeightSum; // What would the top note be if all note values were identical
+
+            if (consistentTopNote == 0)
+                return 0;
+
+            // Use a weighted sum of all notes. Constants are arbitrary and give nice values
+            return sliderStrains.Sum(s => DifficultyCalculationUtils.Logistic(s / consistentTopNote, 0.88, 10, 1.1));
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -39,8 +39,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         protected override double StrainValueAt(DifficultyHitObject current)
         {
-            currentStrain *= strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
-            currentStrain += SpeedEvaluator.EvaluateDifficultyOf(current, Mods) * skillMultiplier;
+            double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+
+            currentStrain *= decay;
+            currentStrain += SpeedEvaluator.EvaluateDifficultyOf(current, Mods) * (1 - decay) * skillMultiplier;
 
             currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -54,14 +54,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public double RelevantNoteCount()
         {
-            if (ObjectStrains.Count == 0)
+            if (ObjectDifficulties.Count == 0)
                 return 0;
 
-            double maxStrain = ObjectStrains.Max();
+            double maxStrain = ObjectDifficulties.Max();
             if (maxStrain == 0)
                 return 0;
 
-            return ObjectStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxStrain * 12.0 - 6.0))));
+            return ObjectDifficulties.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxStrain * 12.0 - 6.0))));
         }
 
         public double CountTopWeightedSliders(double difficultyValue)

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public class Speed : HarmonicSkill
     {
-        private double skillMultiplier => 0.93;
+        private double skillMultiplier => 0.95;
 
         private readonly List<double> sliderStrains = new List<double>();
 
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
 
             currentDifficulty *= decay;
-            currentDifficulty += SpeedEvaluator.EvaluateDifficultyOf(current, Mods) * (1 - decay) * skillMultiplier;
+            currentDifficulty += SpeedEvaluator.EvaluateDifficultyOf(current) * (1 - decay) * skillMultiplier;
 
             double currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public class Speed : HarmonicSkill
     {
-        private double skillMultiplier => 0.95;
+        private double skillMultiplier => 1.03;
 
         private readonly List<double> sliderStrains = new List<double>();
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -108,14 +108,16 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             var stamina = skills.OfType<Stamina>().Single(s => !s.SingleColourStamina);
             var singleColourStamina = skills.OfType<Stamina>().Single(s => s.SingleColourStamina);
 
+            double staminaDifficultyValue = stamina.DifficultyValue();
+
             double rhythmSkill = rhythm.DifficultyValue() * rhythm_skill_multiplier;
             double readingSkill = reading.DifficultyValue() * reading_skill_multiplier;
             double colourSkill = colour.DifficultyValue() * colour_skill_multiplier;
-            double staminaSkill = stamina.DifficultyValue() * stamina_skill_multiplier;
+            double staminaSkill = staminaDifficultyValue * stamina_skill_multiplier;
             double monoStaminaSkill = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaFactor = staminaSkill == 0 ? 1 : Math.Pow(monoStaminaSkill / staminaSkill, 5);
 
-            double staminaDifficultStrains = stamina.CountTopWeightedStrains();
+            double staminaDifficultStrains = stamina.CountTopWeightedStrains(staminaDifficultyValue);
 
             // As we don't have pattern integration in osu!taiko, we apply the other two skills relative to rhythm.
             patternMultiplier = Math.Pow(staminaSkill * colourSkill, 0.10);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -186,10 +186,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             }
 
             List<double> hitObjectStrainPeaks = combinePeaks(
-                rhythm.GetObjectStrains().ToList(),
-                reading.GetObjectStrains().ToList(),
-                colour.GetObjectStrains().ToList(),
-                stamina.GetObjectStrains().ToList()
+                rhythm.GetObjectDifficulties(),
+                reading.GetObjectDifficulties(),
+                colour.GetObjectDifficulties(),
+                stamina.GetObjectDifficulties()
             );
 
             if (hitObjectStrainPeaks.Count == 0)
@@ -211,7 +211,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// <summary>
         /// Combines lists of peak strains from multiple skills into a list of single peak strains for each section.
         /// </summary>
-        private List<double> combinePeaks(List<double> rhythmPeaks, List<double> readingPeaks, List<double> colourPeaks, List<double> staminaPeaks)
+        private List<double> combinePeaks(IReadOnlyList<double> rhythmPeaks, IReadOnlyList<double> readingPeaks, IReadOnlyList<double> colourPeaks, IReadOnlyList<double> staminaPeaks)
         {
             var combinedPeaks = new List<double>();
 

--- a/osu.Game.Tests/NonVisual/TestSceneTimedDifficultyCalculation.cs
+++ b/osu.Game.Tests/NonVisual/TestSceneTimedDifficultyCalculation.cs
@@ -200,8 +200,9 @@ namespace osu.Game.Tests.NonVisual
                 {
                 }
 
-                public override void Process(DifficultyHitObject current)
+                protected override double ProcessInternal(DifficultyHitObject current)
                 {
+                    return 0;
                 }
 
                 public override double DifficultyValue() => 1;

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Rulesets.Difficulty
         protected const int ATTRIB_ID_MAXIMUM_LEGACY_COMBO_SCORE = 41;
         protected const int ATTRIB_ID_RHYTHM_DIFFICULTY = 43;
         protected const int ATTRIB_ID_CONSISTENCY_FACTOR = 45;
+        protected const int ATTRIB_ID_READING = 47;
+        protected const int ATTRIB_ID_READING_DIFFICULT_NOTE_COUNT = 49;
 
         /// <summary>
         /// The mods which were applied to the beatmap.

--- a/osu.Game/Rulesets/Difficulty/Skills/HarmonicSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/HarmonicSkill.cs
@@ -1,0 +1,102 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Utils;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Difficulty.Skills
+{
+    public abstract class HarmonicSkill : Skill
+    {
+        /// <summary>
+        /// The sum of note weights, calculated during summation.
+        /// Required for any calculations which need to normalise difficulty value.
+        /// </summary>
+        protected double NoteWeightSum;
+
+        /// <summary>
+        /// Scaling factor applied as HarmonicScale / (1 + index) during weight calculations.
+        /// A higher value will increase the influence of the hardest object difficulties during summation.
+        /// </summary>
+        protected virtual double HarmonicScale => 1.0;
+
+        /// <summary>
+        /// Exponent that controls the rate of which decay increases as the index increases.
+        /// Values closer to 1 decay faster whilst lower values give more weight to lower object difficulties.
+        /// </summary>
+        protected virtual double DecayExponent => 0.9;
+
+        protected HarmonicSkill(Mod[] mods)
+            : base(mods)
+        {
+        }
+
+        /// <summary>
+        /// Returns the difficulty value of the current <see cref="DifficultyHitObject"/>. This value is calculated with or without respect to previous objects.
+        /// </summary>
+        protected abstract double ObjectDifficultyOf(DifficultyHitObject current);
+
+        protected sealed override double ProcessInternal(DifficultyHitObject current)
+            => ObjectDifficultyOf(current);
+
+        /// <summary>
+        /// Transforms the object difficulties specifically for final difficulty summation.
+        /// This can be used to decrease weight of certain notes based on a skill-specific criteria.
+        /// </summary>
+        protected virtual void ApplyDifficultyTransformation(double[] difficulties)
+        {
+        }
+
+        public override double DifficultyValue()
+        {
+            if (ObjectDifficulties.Count == 0)
+                return 0;
+
+            // Notes with 0 difficulty are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
+            // These notes will not contribute to the difficulty.
+            double[] difficulties = ObjectDifficulties.Where(p => p > 0).ToArray();
+
+            ApplyDifficultyTransformation(difficulties);
+
+            double difficulty = 0;
+            int index = 0;
+
+            foreach (double note in difficulties.OrderDescending())
+            {
+                // Use a harmonic sum that considers each note of the map according to a predefined weight.
+                double weight = (1 + (HarmonicScale / (1 + index))) / (Math.Pow(index, DecayExponent) + 1 + (HarmonicScale / (1 + index)));
+
+                NoteWeightSum += weight;
+
+                difficulty += note * weight;
+                index += 1;
+            }
+
+            return difficulty;
+        }
+
+        /// <summary>
+        /// Calculates the number of object difficulties weighted against the top object difficulty.
+        /// </summary>
+        public virtual double CountTopWeightedObjectDifficulties(double difficultyValue)
+        {
+            if (ObjectDifficulties.Count == 0)
+                return 0.0;
+
+            if (NoteWeightSum == 0)
+                return 0.0;
+
+            double consistentTopNote = difficultyValue / NoteWeightSum; // What would the top difficulty be if all object difficulties were identical
+
+            if (consistentTopNote == 0)
+                return 0;
+
+            return ObjectDifficulties.Sum(d => DifficultyCalculationUtils.Logistic(d / consistentTopNote, 0.88, 10, 1.1));
+        }
+
+        public static double DifficultyToPerformance(double difficulty) => 4.0 * Math.Pow(difficulty, 3.0);
+    }
+}

--- a/osu.Game/Rulesets/Difficulty/Skills/Skill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/Skill.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// Process a <see cref="DifficultyHitObject"/>.
         /// </summary>
         /// <param name="current">The <see cref="DifficultyHitObject"/> to process.</param>
-        public void Process(DifficultyHitObject current)
+        public virtual void Process(DifficultyHitObject current)
         {
             double difficultyValue = ProcessInternal(current);
             ObjectDifficulties.Add(difficultyValue);

--- a/osu.Game/Rulesets/Difficulty/Skills/Skill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/Skill.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         protected IReadOnlyList<Mod> Mods => mods;
 
+        /// <summary>
+        /// List of calculated per-object difficulties, populated by Process
+        /// </summary>
+        protected readonly List<double> ObjectDifficulties = new List<double>();
+
         private readonly Mod[] mods;
 
         protected Skill(Mod[] mods)
@@ -31,11 +36,19 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// Process a <see cref="DifficultyHitObject"/>.
         /// </summary>
         /// <param name="current">The <see cref="DifficultyHitObject"/> to process.</param>
-        public abstract void Process(DifficultyHitObject current);
+        public void Process(DifficultyHitObject current)
+        {
+            double difficultyValue = ProcessInternal(current);
+            ObjectDifficulties.Add(difficultyValue);
+        }
+
+        protected abstract double ProcessInternal(DifficultyHitObject current);
 
         /// <summary>
         /// Returns the calculated difficulty value representing all <see cref="DifficultyHitObject"/>s that have been processed up to this point.
         /// </summary>
         public abstract double DifficultyValue();
+
+        public IReadOnlyList<double> GetObjectDifficulties() => ObjectDifficulties;
     }
 }

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -29,7 +29,6 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         private double currentSectionEnd;
 
         private readonly List<double> strainPeaks = new List<double>();
-        protected readonly List<double> ObjectStrains = new List<double>(); // Store individual strains
 
         protected StrainSkill(Mod[] mods)
             : base(mods)
@@ -44,7 +43,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// <summary>
         /// Process a <see cref="DifficultyHitObject"/> and update current strain values accordingly.
         /// </summary>
-        public sealed override void Process(DifficultyHitObject current)
+        protected sealed override double ProcessInternal(DifficultyHitObject current)
         {
             // The first object doesn't generate a strain, so we begin with an incremented section end
             if (current.Index == 0)
@@ -60,8 +59,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             double strain = StrainValueAt(current);
             currentSectionPeak = Math.Max(strain, currentSectionPeak);
 
-            // Store the strain value for the object
-            ObjectStrains.Add(strain);
+            return strain;
         }
 
         /// <summary>
@@ -70,16 +68,16 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public virtual double CountTopWeightedStrains(double difficultyValue)
         {
-            if (ObjectStrains.Count == 0)
+            if (ObjectDifficulties.Count == 0)
                 return 0.0;
 
             double consistentTopStrain = difficultyValue * (1 - DecayWeight); // What would the top strain be if all strain values were identical
 
             if (consistentTopStrain == 0)
-                return ObjectStrains.Count;
+                return ObjectDifficulties.Count;
 
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values
-            return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
+            return ObjectDifficulties.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
         }
 
         /// <summary>
@@ -115,8 +113,6 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// including the peak of the current section.
         /// </summary>
         public IEnumerable<double> GetCurrentStrainPeaks() => strainPeaks.Append(currentSectionPeak);
-
-        public IEnumerable<double> GetObjectStrains() => ObjectStrains;
 
         /// <summary>
         /// Returns the calculated difficulty value representing all <see cref="DifficultyHitObject"/>s that have been processed up to this point.

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             if (ObjectStrains.Count == 0)
                 return 0.0;
 
-            double consistentTopStrain = DifficultyValue() / 10; // What would the top strain be if all strain values were identical
+            double consistentTopStrain = DifficultyValue() * (1 - DecayWeight); // What would the top strain be if all strain values were identical
 
             if (consistentTopStrain == 0)
                 return ObjectStrains.Count;

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -68,12 +68,12 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// Calculates the number of strains weighted against the top strain.
         /// The result is scaled by clock rate as it affects the total number of strains.
         /// </summary>
-        public virtual double CountTopWeightedStrains()
+        public virtual double CountTopWeightedStrains(double difficultyValue)
         {
             if (ObjectStrains.Count == 0)
                 return 0.0;
 
-            double consistentTopStrain = DifficultyValue() * (1 - DecayWeight); // What would the top strain be if all strain values were identical
+            double consistentTopStrain = difficultyValue * (1 - DecayWeight); // What would the top strain be if all strain values were identical
 
             if (consistentTopStrain == 0)
                 return ObjectStrains.Count;


### PR DESCRIPTION
Soft depends on #36556, can remove the MDHO specific stuff without much trouble

This is part 2 of a multi-part series in trying to get live difficulty calculation structure to support the sunny rework as it stands. The new skill explicitly handles chords and provides suitable for adding custom strain and summation behaviour, as well as allowing you to filter which notes get processed by whatever the skill wants to see. Most skills don't want to process releases, so the default setting is to only process notes and long note heads.

StrainSkill is basically 1:1 copied into a new class ManiaStrainSkill, blame James (not really but he said living with it is my best option so any other suggestions are welcome).