### PR TITLE
Fix two mod presets having key binding of `1`

### DIFF
--- a/osu.Game/Overlays/Mods/ModPresetColumn.cs
+++ b/osu.Game/Overlays/Mods/ModPresetColumn.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Overlays.Mods
 
                 panels.Add(new ModPresetPanel(preset.ToLive(realm))
                 {
-                    Index = i <= 10 ? (i + 1) % 10 : null,
+                    Index = i < 10 ? (i + 1) % 10 : null,
                     Shear = Vector2.Zero
                 });
             }


### PR DESCRIPTION
Fixes #36562 

Currently there exists a bug where the mod preset hotkeys will wrap outside of the intended bounds.

Fix is making sure the preset index is < 10

Before:
<img width="486" height="358" alt="image" src="https://github.com/user-attachments/assets/77f1ca9e-4fd0-4b29-b9f5-f53e652db42d" />

After:
<img width="1007" height="1295" alt="image" src="https://github.com/user-attachments/assets/ca81cc39-2f86-462c-a26b-002aceed77f4" />
