### PR TITLE
Change difficulty range slider colors to match star rating more closely

### DIFF
--- a/osu.Game/Screens/SelectV2/FilterControl.DifficultyRangeSlider.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.DifficultyRangeSlider.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
 using osu.Framework.Localisation;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
@@ -165,7 +166,10 @@ namespace osu.Game.Screens.SelectV2
                 {
                     Colour4 nubColour = ColourUtils.SampleFromLinearGradient(spectrum, (float)Math.Round(value, 2, MidpointRounding.AwayFromZero));
 
-                    if (value >= 8.0)
+                    // Handle edge case colors for color harmony
+                    if (value >= 7.5 && value < 8.0)
+                        nubColour = Interpolation.ValueAt<Colour4>(value, nubColour, colours.Gray4, 7.5, 8.0);
+                    else if (value >= 8.0)
                         nubColour = colours.Gray4;
 
                     Nub.AccentColour = nubColour;

--- a/osu.Game/Screens/SelectV2/FilterControl.DifficultyRangeSlider.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.DifficultyRangeSlider.cs
@@ -164,15 +164,17 @@ namespace osu.Game.Screens.SelectV2
                 protected override void UpdateDisplay(double value)
                 {
                     Colour4 nubColour = ColourUtils.SampleFromLinearGradient(spectrum, (float)Math.Round(value, 2, MidpointRounding.AwayFromZero));
-                    nubColour = nubColour.Lighten(0.4f);
 
                     if (value >= 8.0)
                         nubColour = colours.Gray4;
 
                     Nub.AccentColour = nubColour;
-                    Nub.GlowingAccentColour = nubColour.Lighten(0.2f);
+                    Nub.GlowingAccentColour = nubColour.Lighten(0.1f);
                     Nub.ShadowColour = Color4.Black.Opacity(0.2f);
-                    NubText.Colour = OsuColour.ForegroundTextColourFor(nubColour);
+                    NubText.Colour = colours.ForStarDifficultyText(value);
+                    // Except for infinity, which should be white
+                    if (Current.IsDefault && isUpper)
+                        NubText.Colour = OsuColour.ForegroundTextColourFor(nubColour);
 
                     base.UpdateDisplay(value);
                 }


### PR DESCRIPTION
my attempt at #36452: changes difficulty range slider in song select V2 to use the new star difficulty text gradient colors from #36292.

closes #36405

https://github.com/user-attachments/assets/134ace54-a8f8-4024-a32e-f1604c868232

to match star rating more closely for sr <= 7.5 (where i don't think the colors are so intense that they break harmony with the rest of the design), i removed the Lighten by 0.4f on color update

also improved the transition from 7.9 to 8.0 which is quite abrupt in the current version

https://github.com/ppy/osu/pull/33425#issuecomment-2951914385 is relevant here