### PR TITLE
Add a game state server using SignalR

### DIFF
--- a/osu.Desktop/GameState/GameStateHub.cs
+++ b/osu.Desktop/GameState/GameStateHub.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+
+namespace osu.Desktop.GameState
+{
+    public class GameStateHub : Hub<IGameStateClient>;
+
+    public interface IGameStateClient
+    {
+        Task SoloGameplayStarted(int ruleset, string name);
+
+        Task SoloGameplayEnded();
+    }
+}

--- a/osu.Desktop/GameState/GameStateIntegration.cs
+++ b/osu.Desktop/GameState/GameStateIntegration.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.AspNetCore.SignalR;
+using osu.Desktop.GameState.Handlers;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Threading;
+using osu.Game.Configuration;
+
+namespace osu.Desktop.GameState
+{
+    public partial class GameStateIntegration : Container
+    {
+        private Bindable<bool> integrationEnabled = null!;
+        private Bindable<string?> serverUrl = null!;
+
+        private ScheduledDelegate? toggleServerDelegate;
+
+        private GameStateServer server = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config, SessionStatics session)
+        {
+            integrationEnabled = config.GetBindable<bool>(OsuSetting.GameStateIntegration);
+            serverUrl = session.GetBindable<string?>(Static.GameStateServerUrl);
+
+            server = new GameStateServer();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            integrationEnabled.ValueChanged += onEnabledChanged;
+
+            server.OnReady += onReady;
+            server.OnStopped += onStopped;
+
+            if (integrationEnabled.Value)
+                server.Start();
+        }
+
+        private void onEnabledChanged(ValueChangedEvent<bool> e)
+        {
+            toggleServerDelegate?.Cancel();
+
+            toggleServerDelegate = Scheduler.AddDelayed(() =>
+            {
+                if (e.NewValue)
+                    server.Start();
+                else
+                    server.Stop();
+            }, 1000);
+        }
+
+        private void onReady(string serverUrl, IHubContext<GameStateHub, IGameStateClient> hubContext)
+        {
+            this.serverUrl.Value = serverUrl;
+
+            Scheduler.Add(() => Add(new GameplayStateHandler(hubContext)));
+        }
+
+        private void onStopped()
+        {
+            Scheduler.Add(Clear);
+            serverUrl.Value = null;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (!server.IsRunning)
+                server.Stop();
+        }
+    }
+}

--- a/osu.Desktop/GameState/GameStateServer.cs
+++ b/osu.Desktop/GameState/GameStateServer.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using osu.Framework.Logging;
+
+namespace osu.Desktop.GameState
+{
+    public class GameStateServer
+    {
+        private WebApplication? app;
+
+        private IHubContext<GameStateHub, IGameStateClient>? hubContext;
+
+        public bool IsRunning { get; private set; }
+
+        public OnServerReady? OnReady;
+
+        public OnServerStopped? OnStopped;
+
+        public void Start()
+        {
+            if (IsRunning)
+            {
+                Logger.Log("Attempted to start game state server while it was already running.");
+                return;
+            }
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Services.AddSignalR();
+
+            // block chosen arbitrarily from list of unassigned ports
+            // at https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
+            int port = findOpenPort(31000, 10);
+            string serverUrl = $"http://localhost:{port}";
+            builder.WebHost.UseUrls(serverUrl);
+
+            app = builder.Build();
+            app.MapHub<GameStateHub>("/gamestate");
+
+            hubContext = app.Services.GetService<IHubContext<GameStateHub, IGameStateClient>>();
+
+            var thread = new Thread(() => app.Run())
+            {
+                Name = "GameStateServer",
+                IsBackground = true,
+            };
+
+            app.Lifetime.ApplicationStarted.Register(() =>
+            {
+                IsRunning = true;
+                OnReady?.Invoke(serverUrl, hubContext!);
+            });
+
+            thread.Start();
+        }
+
+        public void Stop()
+        {
+            if (!IsRunning || app == null)
+            {
+                Logger.Log("Attempted to stop game state server while it was not running.");
+                return;
+            }
+
+            Task.Run(() =>
+            {
+                app.Lifetime.StopApplication();
+
+                IsRunning = false;
+                OnStopped?.Invoke();
+            });
+        }
+
+        private int findOpenPort(int start, int count)
+        {
+            IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
+            List<int> tcpEndpoints = properties.GetActiveTcpListeners().Select(endpoint => endpoint.Port).ToList();
+            List<int> udpEndpoints = properties.GetActiveUdpListeners().Select(endpoint => endpoint.Port).ToList();
+
+            int? port = Enumerable.Range(start, count).FirstOrDefault(port => !tcpEndpoints.Contains(port) && !udpEndpoints.Contains(port));
+
+            return port ?? throw new InvalidOperationException($"No open port was found in the range provided ({start}-{start + count}.");
+        }
+    }
+
+    public delegate void OnServerReady(string serverUrl, IHubContext<GameStateHub, IGameStateClient> hubContext);
+
+    public delegate void OnServerStopped();
+}

--- a/osu.Desktop/GameState/Handlers/GameplayStateHandler.cs
+++ b/osu.Desktop/GameState/Handlers/GameplayStateHandler.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.AspNetCore.SignalR;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Rulesets;
+using osu.Game.Users;
+
+namespace osu.Desktop.GameState.Handlers
+{
+    public partial class GameplayStateHandler : Component
+    {
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+        [Resolved]
+
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        private readonly IHubContext<GameStateHub, IGameStateClient> hubContext;
+
+        private IBindable<UserActivity?> userActivity = null!;
+
+        public GameplayStateHandler(IHubContext<GameStateHub, IGameStateClient> hubContext)
+        {
+            this.hubContext = hubContext;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(SessionStatics session)
+        {
+            userActivity = session.GetBindable<UserActivity?>(Static.UserOnlineActivity);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            userActivity.ValueChanged += onUserActivityChanged;
+        }
+
+        private void onUserActivityChanged(ValueChangedEvent<UserActivity?> e)
+        {
+            if (e.NewValue is UserActivity.InSoloGame)
+            {
+                hubContext.Clients.All.SoloGameplayStarted(ruleset.Value.OnlineID, $"{beatmap.Value.BeatmapInfo.GetDisplayTitle()}").FireAndForget();
+            }
+            else if (e.OldValue is UserActivity.InSoloGame)
+            {
+                hubContext.Clients.All.SoloGameplayEnded().FireAndForget();
+            }
+        }
+    }
+}

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.Win32;
+using osu.Desktop.GameState;
 using osu.Desktop.Performance;
 using osu.Desktop.Security;
 using osu.Framework.Platform;
@@ -132,6 +133,7 @@ namespace osu.Desktop
             base.LoadComplete();
 
             LoadComponentAsync(new DiscordRichPresence(), Add);
+            LoadComponentAsync(new GameStateIntegration(), Add);
 
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
                 LoadComponentAsync(new GameplayWinKeyBlocker(), Add);

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -15,6 +15,9 @@
   <PropertyGroup>
     <StartupObject>osu.Desktop.Program</StartupObject>
   </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game.Tournament\osu.Game.Tournament.csproj" />
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -196,6 +196,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Sometimes);
 
             SetDefault(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Full);
+            SetDefault(OsuSetting.GameStateIntegration, false);
 
             SetDefault(OsuSetting.EditorDim, 0.25f, 0f, 0.75f, 0.25f);
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f, 0f, 1f, 0.25f);
@@ -440,6 +441,7 @@ namespace osu.Game.Configuration
         EditorShowHitMarkers,
         EditorAutoSeekOnPlacement,
         DiscordRichPresence,
+        GameStateIntegration,
 
         ShowOnlineExplicitContent,
         LastProcessedMetadataId,

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Configuration
             SetDefault<ScoreInfo?>(Static.LastLocalUserScore, null);
             SetDefault<ScoreInfo?>(Static.LastAppliedOffsetScore, null);
             SetDefault<UserActivity?>(Static.UserOnlineActivity, null);
+            SetDefault<string?>(Static.GameStateServerUrl, null);
             SetDefault<APITag[]?>(Static.AllBeatmapTags, null);
         }
 
@@ -107,6 +108,12 @@ namespace osu.Game.Configuration
         /// The activity for the current user to broadcast to other players.
         /// </summary>
         UserOnlineActivity,
+
+        /// <summary>
+        /// The URL at which the game state integration server is present,
+        /// or <c>null</c> if the server is not running.
+        /// </summary>
+        GameStateServerUrl,
 
         AllBeatmapTags,
     }

--- a/osu.Game/Localisation/OnlineSettingsStrings.cs
+++ b/osu.Game/Localisation/OnlineSettingsStrings.cs
@@ -50,6 +50,21 @@ namespace osu.Game.Localisation
         public static LocalisableString DiscordRichPresence => new TranslatableString(getKey(@"discord_rich_presence"), @"Discord Rich Presence");
 
         /// <summary>
+        /// "Expose game state to external applications"
+        /// </summary>
+        public static LocalisableString GameStateIntegration => new TranslatableString(getKey(@"game_state_integration"), @"Expose game state to external applications");
+
+        /// <summary>
+        /// "This will allow external applications (eg. score/PP overlays) to read the current state of the game."
+        /// </summary>
+        public static LocalisableString GameStateIntegrationTooltip => new TranslatableString(getKey(@"game_state_integration_tooltip"), @"This will allow external applications (eg. score/PP overlays) to read the current state of the game.");
+
+        /// <summary>
+        /// "The game state server is running at {0}."
+        /// </summary>
+        public static LocalisableString GameStateIntegrationCurrentServer(string serverUrl) => new TranslatableString(getKey(@"game_state_integration_current_server"), @"The game state server is running at {0}.", serverUrl);
+
+        /// <summary>
         /// "Web"
         /// </summary>
         public static LocalisableString WebHeader => new TranslatableString(getKey(@"web_header"), @"Web");

--- a/osu.Game/Overlays/Settings/Sections/Online/IntegrationSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/IntegrationSettings.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
@@ -14,9 +16,14 @@ namespace osu.Game.Overlays.Settings.Sections.Online
     {
         protected override LocalisableString Header => OnlineSettingsStrings.IntegrationsHeader;
 
+        private Bindable<string?> gameStateServerUrl = null!;
+        private readonly Bindable<SettingsNote.Data?> gameStateServerNote = new Bindable<SettingsNote.Data?>();
+
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, SessionStatics session)
         {
+            gameStateServerUrl = session.GetBindable<string?>(Static.GameStateServerUrl);
+
             Children = new Drawable[]
             {
                 new SettingsItemV2(new FormEnumDropdown<DiscordRichPresenceMode>
@@ -24,7 +31,37 @@ namespace osu.Game.Overlays.Settings.Sections.Online
                     Caption = OnlineSettingsStrings.DiscordRichPresence,
                     Current = config.GetBindable<DiscordRichPresenceMode>(OsuSetting.DiscordRichPresence)
                 }),
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = OnlineSettingsStrings.GameStateIntegration,
+                    HintText = OnlineSettingsStrings.GameStateIntegrationTooltip,
+                    Current = config.GetBindable<bool>(OsuSetting.GameStateIntegration),
+                })
+                {
+                    CanBeShown = { Value = RuntimeInfo.IsDesktop },
+                    Note = { BindTarget = gameStateServerNote }
+                }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            gameStateServerUrl.BindValueChanged(e => Schedule(() =>
+            {
+                if (e.NewValue == null)
+                {
+                    gameStateServerNote.Value = null;
+                }
+                else
+                {
+                    gameStateServerNote.Value = new SettingsNote.Data(
+                        OnlineSettingsStrings.GameStateIntegrationCurrentServer(e.NewValue),
+                        SettingsNote.Type.Informational
+                    );
+                }
+            }), true);
         }
     }
 }


### PR DESCRIPTION
This commit adds a SignalR server intended to expose realtime game state (eg. scores, PP, misses) to be used by external applications.

It only includes a very simple, non-real-world example of such state being implemented, as the focus of this PR is the server itself.

In contrast to #18129 this implementation decides to use SignalR instead of WebSockets. Given that SignalR is already intensively used in both the game and spectator-server, stuff like existing models (and MessagePack encoding) could be reused here as well.

MessagePack isn't enabled at the moment, but that shouldn't be too much work.

There's a few concerns I have about this though.

### Build size increase 

Right now this PR makes `osu.Desktop` pull in the entire `Microsoft.AspNetCore.App` framework. I suppose this could be reduced to some individual packages, but I don't have enough knowledge about aspnet, so I left it as is for now. The actual build size doesn't appear to increase much though, at least according to my very unscientific tests (checking `osu.Desktop/bin/Release` size after removing all build artifacts, forcing a nuget restore, and rebuilding):

| Branch | Size |
|--------|--------|
| current `master`| 610,1 MiB (639 695 476 bytes) |
| this PR| 610,1 MiB (639 697 883 bytes) |

According to this the size change is pretty negligible, although I might me missing something with how production builds are being made, so this could still be worth verifying further.

### Server lifecycle

Right now the server can be started and fully shut down based on the state of the checkbox in the settings. Since this means that the it can be created and disposed multiple times over the process' runtime, I had handle some cases where the user could break stuff by repeatedly toggling the server on and off.

I investigated keeping the server running indefinitely instead, and just switching off the handlers sending state events, but ultimately decided against it, as users would probably prefer not having anything running at all if the setting for the server is disabled.

### Minor integration stuff

This is mainly about the fact that the server is using native .NET logging facilities instead of osu!framework's, causing the logs to look out of place.

<img width="752" height="232" alt="image" src="https://github.com/user-attachments/assets/fe9a7174-ec8e-4d62-969e-01c6f15b9ff5" />

This could be dealt with by implementing a custom handler that forwards all the logging events to `Logger.Log()` but I decided not make this PR any larger by adding this right now.