### PR TITLE
Add a bunch of rhythm improvements

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -15,8 +15,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
     {
         private const int history_time_max = 5 * 1000; // 5 seconds
         private const int history_objects_max = 32;
-        private const double rhythm_overall_multiplier = 1.0;
-        private const double rhythm_ratio_multiplier = 28.0;
+        private const double rhythm_overall_multiplier = 0.9;
+        private const double rhythm_ratio_multiplier = 30.0;
 
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                         // bpm change was from a slider, this is easier typically than circle -> circle
                         // unintentional side effect is that bursts with kicksliders at the ends might have lower difficulty than bursts without sliders
                         if (prevObj.BaseObject is Slider)
-                            effectiveRatio *= 0.3;
+                            effectiveRatio *= 0.5;
 
                         // repeated island polarity (2 -> 4, 3 -> 5)
                         if (island.IsSimilarPolarity(previousIsland))
@@ -226,9 +226,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 if (DeltaCount <= 1 || other.DeltaCount <= 1)
                     return false;
 
-                // TODO: consider islands to be of similar polarity only if they're having the same average delta (we don't want to consider 3 singletaps similar to a triple)
-                //       naively adding delta check here breaks _a lot_ of maps because of the flawed ratio calculation
-                return DeltaCount % 2 == other.DeltaCount % 2;
+                return Math.Abs(Delta - other.Delta) < deltaDifferenceEpsilon &&
+                       DeltaCount % 2 == other.DeltaCount % 2;
             }
 
             public bool Equals(Island? other)

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const int history_time_max = 5 * 1000; // 5 seconds
         private const int history_objects_max = 32;
         private const double rhythm_overall_multiplier = 1.0;
-        private const double rhythm_ratio_multiplier = 30.0;
+        private const double rhythm_ratio_multiplier = 28.0;
 
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
@@ -55,6 +55,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             for (int i = rhythmStart; i > 0; i--)
             {
                 OsuDifficultyHitObject currObj = (OsuDifficultyHitObject)current.Previous(i - 1);
+                if (currObj.BaseObject is Spinner)
+                    continue;
 
                 // scales note 0 to 1 from history to now
                 double timeDecay = (history_time_max - (current.StartTime - currObj.StartTime)) / history_time_max;
@@ -62,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                 double currHistoricalDecay = Math.Min(noteDecay, timeDecay); // either we're limited by time or limited by object count.
 
-                // Use custom cap value to ensure that that at this point delta time is actually zero
+                // Use custom cap value to ensure that at this point delta time is actually zero
                 double currDelta = Math.Max(currObj.DeltaTime, 1e-7);
                 double prevDelta = Math.Max(prevObj.DeltaTime, 1e-7);
                 double lastDelta = Math.Max(lastObj.DeltaTime, 1e-7);
@@ -71,17 +73,23 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 // this function is meant to reduce rhythm bonus for deltas that are multiples of each other (i.e 100 and 200)
                 double deltaDifference = Math.Max(prevDelta, currDelta) / Math.Min(prevDelta, currDelta);
 
-                // Take only the fractional part of the value since we're only interested in punishing multiples
-                double deltaDifferenceFraction = deltaDifference - Math.Truncate(deltaDifference);
-
-                double currRatio = 1.0 + rhythm_ratio_multiplier * Math.Min(0.5, DifficultyCalculationUtils.SmoothstepBellCurve(deltaDifferenceFraction));
-
                 // reduce ratio bonus if delta difference is too big
                 double differenceMultiplier = Math.Clamp(2.0 - deltaDifference / 8.0, 0.0, 1.0);
 
                 double windowPenalty = Math.Min(1, Math.Max(0, Math.Abs(prevDelta - currDelta) - deltaDifferenceEpsilon) / deltaDifferenceEpsilon);
 
-                double effectiveRatio = windowPenalty * currRatio * differenceMultiplier;
+                double effectiveRatio = getEffectiveRatio(deltaDifference) * windowPenalty * differenceMultiplier;
+
+                // if previous object is a slider it might be easier to tap since you don't have to do a whole tapping motion
+                // while a full deltatime might end up some weird ratio the "unpress->tap" motion might be simple
+                // for example a slider-circle-circle pattern should be evaluated as a regular triple and not as a single->double
+                if (prevObj.BaseObject is Slider)
+                {
+                    double sliderEndDelta = currObj.MinimumJumpTime;
+                    double sliderDeltaDifference = Math.Max(sliderEndDelta, currDelta) / Math.Min(sliderEndDelta, currDelta);
+                    double sliderEffectiveRatio = getEffectiveRatio(sliderDeltaDifference);
+                    effectiveRatio = Math.Min(sliderEffectiveRatio, effectiveRatio);
+                }
 
                 if (firstDeltaSwitch)
                 {
@@ -177,6 +185,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             return Math.Sqrt(4 + rhythmComplexitySum * rhythm_overall_multiplier) / 2.0; // produces multiplier that can be applied to strain. range [1, infinity) (not really though);
         }
 
+        private static double getEffectiveRatio(double deltaDifference)
+        {
+            // Take only the fractional part of the value since we're only interested in punishing multiples
+            double deltaDifferenceFraction = deltaDifference - Math.Truncate(deltaDifference);
+
+            return 1.0 + rhythm_ratio_multiplier * Math.Min(0.5, DifficultyCalculationUtils.SmoothstepBellCurve(deltaDifferenceFraction));
+        }
+
         private class Island : IEquatable<Island>
         {
             private readonly double deltaDifferenceEpsilon;
@@ -206,6 +222,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             public bool IsSimilarPolarity(Island other)
             {
+                // single delta islands shouldn't be compared
+                if (DeltaCount <= 1 || other.DeltaCount <= 1)
+                    return false;
+
                 // TODO: consider islands to be of similar polarity only if they're having the same average delta (we don't want to consider 3 singletaps similar to a triple)
                 //       naively adding delta check here breaks _a lot_ of maps because of the flawed ratio calculation
                 return DeltaCount % 2 == other.DeltaCount % 2;

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -228,6 +228,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 TravelTime = Math.Max(LazyTravelTime / clockRate, MIN_DELTA_TIME);
             }
 
+            MinimumJumpTime = AdjustedDeltaTime;
+
             // We don't need to calculate either angle or distance when one of the last->curr objects is a spinner
             if (BaseObject is Spinner || LastObject is Spinner)
                 return;
@@ -239,7 +241,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             JumpDistance = (LastObject.StackedPosition - BaseObject.StackedPosition).Length * scalingFactor;
             LazyJumpDistance = (BaseObject.StackedPosition - lastCursorPosition).Length * scalingFactor;
-            MinimumJumpTime = AdjustedDeltaTime;
             MinimumJumpDistance = LazyJumpDistance;
 
             if (LastObject is Slider lastSlider && lastDifficultyObject != null)


### PR DESCRIPTION
This does a couple of things:

- Adds slider->circle effective ratio adjustment
- Removes same polarity nerf for single delta count islands (which are pretty much THE most unpredictable)
- Makes polarity nerf check actual deltas and not just the count
- Excludes spinners from ratio calculation

https://pp.huismetbenen.nl/rankings/players/minor-rhythm-improvements