### PR TITLE
only nerf total cognition sum when reading > flashlight

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -146,11 +146,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         public static double SumCognitionDifficulty(double reading, double flashlight)
         {
-            // Base LP summed value, accounting for map being partially memorized with FL
-            double cognition = DifficultyCalculationUtils.Norm(2, reading, flashlight);
-
-            // Inrease FL bonus when it's lower than reading to avoid situations where high reading difficulty makes FL give practically 0 bonus
-            return flashlight >= reading ? cognition : double.Lerp(reading + flashlight, cognition, flashlight / reading);
+            // Nerf flashlight value in cognition sum when reading is greater than flashlight
+            return DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, reading, flashlight * Math.Clamp(flashlight / reading, 0.25, 1.0));
         }
 
         private double calculateStarRating(double basePerformance)


### PR DESCRIPTION
Alternative to #36464 and #36487.

Reading and flashlight should be treated much more separately, since the flashlight skill only accounts for object visibility and repetition, but reading accounts for overlaps, high/low AR, etc. However, for certain scores with very high reading (to the point of memorisation), the skill indeed overlaps with flashlight.

This PR uses the normal strain sum exponent for reading and flashlight (for player expectations), with an extra factor on flashlight to account for the ease of adding flashlight to a partially memorised map when reading is the dominant skill.