### PR TITLE
Improve handling of account registration errors

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -428,10 +428,10 @@ namespace osu.Game.Online.API
                         // attempt to parse a non-form error message
                         var response = JObject.Parse(req.GetResponseString().AsNonNull());
 
-                        string redirect = (string)response.SelectToken(@"url", true);
+                        string redirect = (string)response.SelectToken(@"url", false);
                         string message = (string)response.SelectToken(@"error", false);
 
-                        if (!string.IsNullOrEmpty(redirect))
+                        if (!string.IsNullOrEmpty(redirect) || !string.IsNullOrEmpty(message))
                         {
                             return new RegistrationRequest.RegistrationRequestErrors
                             {

--- a/osu.Game/Online/API/RegistrationRequest.cs
+++ b/osu.Game/Online/API/RegistrationRequest.cs
@@ -14,9 +14,11 @@ namespace osu.Game.Online.API
 
         protected override void PrePerform()
         {
-            AddParameter("user[username]", Username);
-            AddParameter("user[user_email]", Email);
-            AddParameter("user[password]", Password);
+            AddParameter(@"user[username]", Username);
+            AddParameter(@"user[user_email]", Email);
+            AddParameter(@"user[password]", Password);
+
+            AddHeader(@"Accept", @"application/json");
 
             base.PrePerform();
         }

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -209,13 +209,11 @@ namespace osu.Game.Overlays.AccountCreation
                                 passwordDescription.AddErrors(errors.User.Password);
                             }
 
-                            if (!string.IsNullOrEmpty(errors.Redirect))
-                            {
-                                if (!string.IsNullOrEmpty(errors.Message))
-                                    passwordDescription.AddErrors(new[] { errors.Message });
+                            if (!string.IsNullOrEmpty(errors.Message))
+                                passwordDescription.AddErrors(new[] { errors.Message });
 
+                            if (!string.IsNullOrEmpty(errors.Redirect))
                                 game?.OpenUrlExternally($"{errors.Redirect}?username={usernameTextBox.Text}&email={emailTextBox.Text}", LinkWarnMode.NeverWarn);
-                            }
                         }
                         else
                         {


### PR DESCRIPTION
## [Specify `Accept` header in registration request](https://github.com/ppy/osu/commit/28edb788f78723cda23281a8801acc2065592840)

The lack of it meant that in specific scenarios web would respond with a chunk of HTML instead of JSON.

## [Allow showing registration error message even if no redirect is given](https://github.com/ppy/osu/commit/6ad49941ffd7cdf662ccd404836bb52fccec2142)

There are scenarios where this can happen, and if it did, previously the strict requirement to have both would cause the specific message to be discarded and replaced with the generic "something happened" one.