### PR TITLE
Fix star rating no longer updating from mod setting changes after re-entering song select

### DIFF
--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -76,7 +76,10 @@ namespace osu.Game.Beatmaps
             currentMods.BindValueChanged(mods =>
             {
                 // A change in bindable here doesn't guarantee that mods have actually changed.
-                if (mods.OldValue.SequenceEqual(mods.NewValue))
+                // However, we *do* want to make sure that the mod *references* are the same;
+                // `SequenceEqual()` without a comparer would fall back to `IEquatable`.
+                // Failing to ensure reference equality can cause setting change tracking to fail later.
+                if (mods.OldValue.SequenceEqual(mods.NewValue, ReferenceEqualityComparer.Instance))
                     return;
 
                 modSettingChangeTracker?.Dispose();


### PR DESCRIPTION
As "reported" in https://osu.ppy.sh/comments/3929603.

On one hand, this *is* firmly a second-order failure stemming from all the stupid games we're playing by making mod select overlay instances always own the game-global references to mods, but on the other hand, isn't `IEquatable` and its silent pervasive nature just *awesome* to deal with sometimes?