### PR TITLE
Fix "copy labels from issues" workflow not having the appropriate permissions to do what it claims to do

### DIFF
--- a/.github/workflows/pull-request-copy-labels.yml
+++ b/.github/workflows/pull-request-copy-labels.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write # to read the labels of any linked issue(s), and to put the found labels if any on the PR
+  # not granting any `pull_requests` permissions because in github's modeling pull requests are a subset of issues. it's confusing.
+
 jobs:
   copy-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-copy-labels.yml
+++ b/.github/workflows/pull-request-copy-labels.yml
@@ -1,3 +1,5 @@
+name: Copy labels from linked issues
+
 on:
   pull_request:
     types: [opened]
@@ -7,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Copy labels from linked issues
     steps:
-      - name: copy-labels
+      - name: Copy labels
         uses: michalvankodev/copy-issue-labels@v1.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
While the record of this check [looks green enough](https://github.com/ppy/osu/actions/workflows/pull-request-copy-labels.yml), there was only one run thus far that actually needed to copy a label from an issue to a PR and [it failed on "resource not accessible by integration"](https://github.com/ppy/osu/actions/runs/21672797894/job/62484800067#step:2:5), so I'm going to call this workflow broken. This matches with my understanding which is that:

> The token has `write` permissions to a number of API endpoints except in the case of pull requests from forks which are always `read`.

([source](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/))

Note that granting the `issues: write` scope could potentially permit the action used here to execute [any of the following endpoints](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-issues).

If that's uncomfortable then maybe the workflow needs to be reconsidered. For what it's worth I spent 5 minutes auditing the action code at the tag it was pinned to and could not find anything suspicious, but it *was* 5 minutes.

Not sure why the README of the action doesn't mention a peep of any of this either.

Untested, mostly guesstimated based off source inspection of the relevant action.