### PR TITLE
Add lazy difficulty attribute calculation

### DIFF
--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -154,10 +154,15 @@ namespace osu.Game.Rulesets.Difficulty
         /// a lazy-evaluated enumerable of <see cref="TimedDifficultyAttributes"/> representing the difficulty at every relevant time value in the beatmap.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The returned task represents the operations related to the initialisation of the difficulty calculation (pre-processing).
-        /// The pre-processing in question can be cancelled via <paramref name="cancellationToken"/>.
+        /// The task will block the calling thread; use <see cref="Task.Run(System.Action)"/> if this is not desired.
+        /// The task can be cancelled via <paramref name="cancellationToken"/>.
+        /// </para>
+        /// <para>
         /// Once the pre-processing is done, the returned enumerable no longer respects the <paramref name="cancellationToken"/>.
         /// Enumeration will be lazy and blocking; callers are expected to stop enumerating if they no longer wish to receive timed difficulty attributes.
+        /// </para>
         /// </remarks>
         /// <param name="mods">The mods that should be applied to the beatmap.</param>
         /// <param name="cancellationToken">The cancellation token for pre-processing.</param>

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -94,9 +94,6 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// Calculates the difficulty of the beatmap with no mods applied and returns a set of <see cref="TimedDifficultyAttributes"/> representing the difficulty at every relevant time value in the beatmap.
         /// </summary>
-        /// <remarks>
-        /// Unless a <paramref name="cancellationToken"/> is specified, calculation times out after 10 seconds.
-        /// </remarks>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The set of <see cref="TimedDifficultyAttributes"/>.</returns>
         public List<TimedDifficultyAttributes> CalculateTimed(CancellationToken cancellationToken = default)
@@ -105,75 +102,50 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// Calculates the difficulty of the beatmap using a specific mod combination and returns a set of <see cref="TimedDifficultyAttributes"/> representing the difficulty at every relevant time value in the beatmap.
         /// </summary>
-        /// <remarks>
-        /// Unless a <paramref name="cancellationToken"/> is specified, calculation times out after 10 seconds.
-        /// </remarks>
         /// <param name="mods">The mods that should be applied to the beatmap.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The set of <see cref="TimedDifficultyAttributes"/>.</returns>
         public List<TimedDifficultyAttributes> CalculateTimed([NotNull] IEnumerable<Mod> mods, CancellationToken cancellationToken = default)
         {
-            List<TimedDifficultyAttributes> attribs = [];
             using var timedCancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             if (!cancellationToken.CanBeCanceled)
                 cancellationToken = timedCancellationSource.Token;
 
-            foreach (var timedAttr in CalculateTimedLazy(mods, cancellationToken))
-            {
-                attribs.Add(timedAttr);
-            }
-
-            return attribs;
-        }
-
-        /// <summary>
-        /// Lazily calculates the difficulty of the beatmap on-demand using a specific mod combination and yields <see cref="TimedDifficultyAttributes"/> representing the difficulty until every relevant time value in the beatmap.
-        /// </summary>
-        /// <remarks>
-        /// 1. Pre-processing is done before this method returns.<br />
-        /// 2. Cancelling the <paramref name="cancellationToken"/> will throw while enumerating.
-        /// </remarks>
-        /// <param name="mods">The mods that should be applied to the beatmap.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The enumerated <see cref="TimedDifficultyAttributes"/>.</returns>
-        public IEnumerable<TimedDifficultyAttributes> CalculateTimedLazy([NotNull] IEnumerable<Mod> mods, CancellationToken cancellationToken = default)
-        {
             cancellationToken.ThrowIfCancellationRequested();
             // ReSharper disable once PossiblyMistakenUseOfCancellationToken
             preProcess(mods, cancellationToken);
 
+            var attribs = new List<TimedDifficultyAttributes>();
+
             if (!Beatmap.HitObjects.Any())
-                return [];
+                return attribs;
 
             var skills = CreateSkills(Beatmap, playableMods, clockRate);
             var progressiveBeatmap = new ProgressiveCalculationBeatmap(Beatmap);
             var difficultyObjects = getDifficultyHitObjects().ToArray();
 
-            return enumerate();
+            int currentIndex = 0;
 
-            IEnumerable<TimedDifficultyAttributes> enumerate()
+            foreach (var obj in Beatmap.HitObjects)
             {
-                int currentIndex = 0;
+                progressiveBeatmap.HitObjects.Add(obj);
 
-                foreach (var obj in Beatmap.HitObjects)
+                while (currentIndex < difficultyObjects.Length && difficultyObjects[currentIndex].BaseObject.GetEndTime() <= obj.GetEndTime())
                 {
-                    progressiveBeatmap.HitObjects.Add(obj);
-
-                    while (currentIndex < difficultyObjects.Length && difficultyObjects[currentIndex].BaseObject.GetEndTime() <= obj.GetEndTime())
+                    foreach (var skill in skills)
                     {
-                        foreach (var skill in skills)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            skill.Process(difficultyObjects[currentIndex]);
-                        }
-
-                        currentIndex++;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        skill.Process(difficultyObjects[currentIndex]);
                     }
 
-                    yield return new TimedDifficultyAttributes(obj.GetEndTime(), CreateDifficultyAttributes(progressiveBeatmap, playableMods, skills, clockRate));
+                    currentIndex++;
                 }
+
+                attribs.Add(new TimedDifficultyAttributes(obj.GetEndTime(), CreateDifficultyAttributes(progressiveBeatmap, playableMods, skills, clockRate)));
             }
+
+            return attribs;
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -150,10 +150,14 @@ namespace osu.Game.Rulesets.Difficulty
         }
 
         /// <summary>
-        /// Calculates the difficulty of the beatmap using a specific mod combination and returns enumerable <see cref="TimedDifficultyAttributes"/> representing the difficulty at every relevant time value in the beatmap.
+        /// Calculates the difficulty of the beatmap using a specific mod combination and returns
+        /// a lazy-evaluated enumerable of <see cref="TimedDifficultyAttributes"/> representing the difficulty at every relevant time value in the beatmap.
         /// </summary>
         /// <remarks>
-        /// The returned task represents the operations related to the initialization the difficulty calculation (pre-processing).<br />
+        /// The returned task represents the operations related to the initialisation of the difficulty calculation (pre-processing).
+        /// The pre-processing in question can be cancelled via <paramref name="cancellationToken"/>.
+        /// Once the pre-processing is done, the returned enumerable no longer respects the <paramref name="cancellationToken"/>.
+        /// Enumeration will be lazy and blocking; callers are expected to stop enumerating if they no longer wish to receive timed difficulty attributes.
         /// </remarks>
         /// <param name="mods">The mods that should be applied to the beatmap.</param>
         /// <param name="cancellationToken">The cancellation token for pre-processing.</param>


### PR DESCRIPTION
Second try at #36570 (continuing with their approval)

I've dissected the convoluted discussion that happened, and believe to have got the important things right:

1. The timed calculation logic was moved to `CalculateTimedLazy`
2. `CalculateTimed` calls `CalculateTimedLazy`, but continues to hold the 10 second timeout cancellation token, which is simply passed over
3. A cancellation of calculation will continue to throw in the inner loop (per-skill)
4. The behavior of `CalculateTimed` should be *identical*

I have also added a remark to the two `CalculateTimed` overloads, in order to highlight the timeout behavior that `CalculateTimedLazy` does not have. Whether the lazy method should actually hold the timeout logic can be discussed, but I personally don't see a need for it.