### PR TITLE
Prevent tagging when on Target Practice

### DIFF
--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -258,6 +258,9 @@ namespace osu.Game.Screens.Ranking.Statistics
                     preventTaggingReason = "Play the beatmap in its original ruleset to contribute to beatmap tags!";
                 else if (localUserScore.Rank < ScoreRank.C)
                     preventTaggingReason = "Set a better score to contribute to beatmap tags!";
+                else if (newScore.Ruleset.OnlineID == 0 && newScore.APIMods.Any(m => m.Acronym == "TP"))
+                    // Target Practice completely changes the gameplay, so it makes no sense to be able to add gameplay tags about the map
+                    preventTaggingReason = "Play without Target Practice to contribute to beatmap tags!";
 
                 if (preventTaggingReason == null)
                 {


### PR DESCRIPTION
closes #36553

i put the change in core code (as opposed to ruleset-specific) because all of the other reasons to prevent tagging are there, but an argument can be made that this should be handled in the ruleset. not sure how much of an issue this is, but seeing as this change is incredibly small, i don't currently see the need for a larger refactor solely for "reasons to prevent tagging"

`APIMods.Any(m => m.Acronym == "TP")` this pattern might seem a bit strange/hardcoded but it's also seen in osu.Game/Database/RealmAccess.cs, line 1099