### PR TITLE
Fix seeking to previous bookmark not working when song is playing

### DIFF
--- a/osu.Game/Screens/Edit/BookmarkController.cs
+++ b/osu.Game/Screens/Edit/BookmarkController.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Timing;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
@@ -106,8 +107,12 @@ namespace osu.Game.Screens.Edit
 
         private void seekBookmark(int direction)
         {
+            // In the case of a backwards seek while playing, it can be hard to jump before a bookmark.
+            // Adding some lenience here makes it more user-friendly.
+            double seekLenience = clock.IsRunning ? 1000 * ((IAdjustableClock)clock).Rate : 0;
+
             int? targetBookmark = direction < 1
-                ? bookmarks.Cast<int?>().LastOrDefault(b => b < clock.CurrentTimeAccurate)
+                ? bookmarks.Cast<int?>().LastOrDefault(b => b < clock.CurrentTimeAccurate - seekLenience)
                 : bookmarks.Cast<int?>().FirstOrDefault(b => b > clock.CurrentTimeAccurate);
 
             if (targetBookmark != null)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/35389

Same as:
https://github.com/ppy/osu/blob/2efe0c95e63817f312f5fb12cc60dd56bee0023b/osu.Game/Screens/Edit/Editor.cs#L1173-L1180

There's also seeking hit objects and sample points, but the seeks are relatively close to each other and probably useless when playing(?). If we want to make those cases not stuck at the same point in time, I believe the leniency should be lower than 1000 ms.

With the above, that is why I just copy-pasted the code, as we may want to have different leniencies.

Edit: forgot the automated label thing, will not label next time