### PR TITLE
Fall hub connections back to non-websocket transports if websocket persistently fails

### DIFF
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Online
         /// <summary>
         /// The current connection opened by this connector.
         /// </summary>
-        public new HubConnection? CurrentConnection => ((HubClient?)base.CurrentConnection)?.Connection;
+        private HubConnection? currentConnection => ((HubClient?)CurrentConnection)?.Connection;
 
         /// <summary>
         /// Constructs a new <see cref="HubClientConnector"/>.
@@ -79,20 +79,20 @@ namespace osu.Game.Online
 
         public Task InvokeAsync(string name, object?[]? args, CancellationToken cancellationToken = default)
         {
-            Debug.Assert(CurrentConnection != null);
-            return CurrentConnection.InvokeCoreAsync(name, args ?? [], cancellationToken);
+            Debug.Assert(currentConnection != null);
+            return currentConnection.InvokeCoreAsync(name, args ?? [], cancellationToken);
         }
 
         public Task<TResult> InvokeAsync<TResult>(string name, object?[]? args, CancellationToken cancellationToken = default)
         {
-            Debug.Assert(CurrentConnection != null);
-            return CurrentConnection.InvokeCoreAsync<TResult>(name, args ?? [], cancellationToken);
+            Debug.Assert(currentConnection != null);
+            return currentConnection.InvokeCoreAsync<TResult>(name, args ?? [], cancellationToken);
         }
 
         public Task SendAsync(string name, object?[]? args, CancellationToken cancellationToken = default)
         {
-            Debug.Assert(CurrentConnection != null);
-            return CurrentConnection.SendCoreAsync(name, args ?? [], cancellationToken);
+            Debug.Assert(currentConnection != null);
+            return currentConnection.SendCoreAsync(name, args ?? [], cancellationToken);
         }
 
         async Task IHubClientConnector.Disconnect()

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -74,6 +75,24 @@ namespace osu.Game.Online
             ConfigureConnection?.Invoke(newConnection);
 
             return Task.FromResult((PersistentEndpointClient)new HubClient(newConnection));
+        }
+
+        public Task InvokeAsync(string name, object?[]? args, CancellationToken cancellationToken = default)
+        {
+            Debug.Assert(CurrentConnection != null);
+            return CurrentConnection.InvokeCoreAsync(name, args ?? [], cancellationToken);
+        }
+
+        public Task<TResult> InvokeAsync<TResult>(string name, object?[]? args, CancellationToken cancellationToken = default)
+        {
+            Debug.Assert(CurrentConnection != null);
+            return CurrentConnection.InvokeCoreAsync<TResult>(name, args ?? [], cancellationToken);
+        }
+
+        public Task SendAsync(string name, object?[]? args, CancellationToken cancellationToken = default)
+        {
+            Debug.Assert(CurrentConnection != null);
+            return CurrentConnection.SendCoreAsync(name, args ?? [], cancellationToken);
         }
 
         async Task IHubClientConnector.Disconnect()

--- a/osu.Game/Online/IHubClientConnector.cs
+++ b/osu.Game/Online/IHubClientConnector.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Bindables;
@@ -15,11 +16,6 @@ namespace osu.Game.Online
     /// </summary>
     public interface IHubClientConnector : IDisposable
     {
-        /// <summary>
-        /// The current connection opened by this connector.
-        /// </summary>
-        HubConnection? CurrentConnection { get; }
-
         /// <summary>
         /// Whether this is connected to the hub, use <see cref="CurrentConnection"/> to access the connection, if this is <c>true</c>.
         /// </summary>
@@ -39,5 +35,9 @@ namespace osu.Game.Online
         /// Reconnect if already connected.
         /// </summary>
         Task Reconnect();
+
+        Task InvokeAsync(string name, object?[]? args = null, CancellationToken cancellationToken = default);
+        Task<TResult> InvokeAsync<TResult>(string name, object?[]? args = null, CancellationToken cancellationToken = default);
+        Task SendAsync(string name, object?[]? args = null, CancellationToken cancellationToken = default);
     }
 }

--- a/osu.Game/Online/IHubClientConnector.cs
+++ b/osu.Game/Online/IHubClientConnector.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Online
     public interface IHubClientConnector : IDisposable
     {
         /// <summary>
-        /// Whether this is connected to the hub, use <see cref="CurrentConnection"/> to access the connection, if this is <c>true</c>.
+        /// Whether the user is connected.
         /// </summary>
         IBindable<bool> IsConnected { get; }
 

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -44,8 +44,6 @@ namespace osu.Game.Online.Metadata
         private IBindable<UserStatus> userStatus = null!;
         private IBindable<UserActivity?> userActivity = null!;
 
-        private HubConnection? connection => connector?.CurrentConnection;
-
         public OnlineMetadataClient(EndpointConfiguration endpoints)
         {
             endpoint = endpoints.MetadataUrl;
@@ -179,9 +177,9 @@ namespace osu.Game.Online.Metadata
 
             Logger.Log($"Requesting any changes since last known queue id {queueId}");
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync<BeatmapUpdates>(nameof(IMetadataServer.GetChangesSince), queueId);
+            return connector.InvokeAsync<BeatmapUpdates>(nameof(IMetadataServer.GetChangesSince), [queueId]);
         }
 
         public override Task UpdateActivity(UserActivity? activity)
@@ -189,8 +187,7 @@ namespace osu.Game.Online.Metadata
             if (connector?.IsConnected.Value != true)
                 return Task.FromCanceled(new CancellationToken(true));
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMetadataServer.UpdateActivity), activity);
+            return connector.InvokeAsync(nameof(IMetadataServer.UpdateActivity), [activity]);
         }
 
         public override Task UpdateStatus(UserStatus? status)
@@ -198,8 +195,7 @@ namespace osu.Game.Online.Metadata
             if (connector?.IsConnected.Value != true)
                 return Task.FromCanceled(new CancellationToken(true));
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMetadataServer.UpdateStatus), status);
+            return connector.InvokeAsync(nameof(IMetadataServer.UpdateStatus), [status]);
         }
 
         protected override Task BeginWatchingUserPresenceInternal()
@@ -209,8 +205,7 @@ namespace osu.Game.Online.Metadata
 
             Logger.Log($@"{nameof(OnlineMetadataClient)} began watching user presence", LoggingTarget.Network);
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMetadataServer.BeginWatchingUserPresence));
+            return connector.InvokeAsync(nameof(IMetadataServer.BeginWatchingUserPresence));
         }
 
         protected override Task EndWatchingUserPresenceInternal()
@@ -223,8 +218,7 @@ namespace osu.Game.Online.Metadata
             // must be scheduled before any remote calls to avoid mis-ordering.
             Schedule(() => userPresences.Clear());
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMetadataServer.EndWatchingUserPresence));
+            return connector.InvokeAsync(nameof(IMetadataServer.EndWatchingUserPresence));
         }
 
         public override Task UserPresenceUpdated(int userId, UserPresence? presence)
@@ -272,8 +266,7 @@ namespace osu.Game.Online.Metadata
             if (connector?.IsConnected.Value != true)
                 throw new OperationCanceledException();
 
-            Debug.Assert(connection != null);
-            var result = await connection.InvokeAsync<MultiplayerPlaylistItemStats[]>(nameof(IMetadataServer.BeginWatchingMultiplayerRoom), id).ConfigureAwait(false);
+            var result = await connector.InvokeAsync<MultiplayerPlaylistItemStats[]>(nameof(IMetadataServer.BeginWatchingMultiplayerRoom), [id]).ConfigureAwait(false);
             Logger.Log($@"{nameof(OnlineMetadataClient)} began watching multiplayer room with ID {id}", LoggingTarget.Network);
             return result;
         }
@@ -283,8 +276,7 @@ namespace osu.Game.Online.Metadata
             if (connector?.IsConnected.Value != true)
                 throw new OperationCanceledException();
 
-            Debug.Assert(connection != null);
-            await connection.InvokeAsync(nameof(IMetadataServer.EndWatchingMultiplayerRoom), id).ConfigureAwait(false);
+            await connector.InvokeAsync(nameof(IMetadataServer.EndWatchingMultiplayerRoom), [id]).ConfigureAwait(false);
             Logger.Log($@"{nameof(OnlineMetadataClient)} stopped watching multiplayer room with ID {id}", LoggingTarget.Network);
         }
 
@@ -293,8 +285,7 @@ namespace osu.Game.Online.Metadata
             if (connector?.IsConnected.Value != true)
                 throw new OperationCanceledException();
 
-            Debug.Assert(connection != null);
-            await connection.InvokeAsync(nameof(IMetadataServer.RefreshFriends)).ConfigureAwait(false);
+            await connector.InvokeAsync(nameof(IMetadataServer.RefreshFriends)).ConfigureAwait(false);
         }
 
         public override async Task DisconnectRequested()

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -29,8 +29,6 @@ namespace osu.Game.Online.Multiplayer
 
         public override IBindable<bool> IsConnected { get; } = new BindableBool();
 
-        private HubConnection? connection => connector?.CurrentConnection;
-
         public OnlineMultiplayerClient(EndpointConfiguration endpoints)
         {
             endpoint = endpoints.MultiplayerUrl;
@@ -94,18 +92,16 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 throw new OperationCanceledException();
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
             try
             {
-                return await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.CreateRoom), room).ConfigureAwait(false);
+                return await connector.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.CreateRoom), [room]).ConfigureAwait(false);
             }
             catch (HubException exception)
             {
                 if (exception.GetHubExceptionMessage() == HubClientConnector.SERVER_SHUTDOWN_MESSAGE)
                 {
-                    Debug.Assert(connector != null);
-
                     await connector.Reconnect().ConfigureAwait(false);
                     return await CreateRoomInternal(room).ConfigureAwait(false);
                 }
@@ -119,18 +115,16 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 throw new OperationCanceledException();
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
             try
             {
-                return await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), roomId, password ?? string.Empty).ConfigureAwait(false);
+                return await connector.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), [roomId, password ?? string.Empty]).ConfigureAwait(false);
             }
             catch (HubException exception)
             {
                 if (exception.GetHubExceptionMessage() == HubClientConnector.SERVER_SHUTDOWN_MESSAGE)
                 {
-                    Debug.Assert(connector != null);
-
                     await connector.Reconnect().ConfigureAwait(false);
                     return await JoinRoomInternal(roomId, password).ConfigureAwait(false);
                 }
@@ -144,9 +138,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.FromCanceled(new CancellationToken(true));
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.LeaveRoom));
+            return connector.InvokeAsync(nameof(IMultiplayerServer.LeaveRoom));
         }
 
         public override async Task InvitePlayer(int userId)
@@ -154,11 +148,11 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
             try
             {
-                await connection.InvokeAsync(nameof(IMultiplayerServer.InvitePlayer), userId).ConfigureAwait(false);
+                await connector.InvokeAsync(nameof(IMultiplayerServer.InvitePlayer), [userId]).ConfigureAwait(false);
             }
             catch (HubException exception)
             {
@@ -180,9 +174,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.TransferHost), userId);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.TransferHost), [userId]);
         }
 
         public override Task KickUser(int userId)
@@ -190,9 +184,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.KickUser), userId);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.KickUser), [userId]);
         }
 
         public override Task ChangeSettings(MultiplayerRoomSettings settings)
@@ -200,9 +194,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeSettings), settings);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.ChangeSettings), [settings]);
         }
 
         public override Task ChangeState(MultiplayerUserState newState)
@@ -210,9 +204,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeState), newState);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.ChangeState), [newState]);
         }
 
         public override Task ChangeBeatmapAvailability(BeatmapAvailability newBeatmapAvailability)
@@ -220,9 +214,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeBeatmapAvailability), newBeatmapAvailability);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.ChangeBeatmapAvailability), [newBeatmapAvailability]);
         }
 
         public override Task ChangeUserStyle(int? beatmapId, int? rulesetId)
@@ -230,9 +224,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeUserStyle), beatmapId, rulesetId);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.ChangeUserStyle), [beatmapId, rulesetId]);
         }
 
         public override Task ChangeUserMods(IEnumerable<APIMod> newMods)
@@ -240,9 +234,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeUserMods), newMods);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.ChangeUserMods), [newMods]);
         }
 
         public override Task SendMatchRequest(MatchUserRequest request)
@@ -250,9 +244,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.SendMatchRequest), request);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.SendMatchRequest), [request]);
         }
 
         public override Task StartMatch()
@@ -260,9 +254,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.StartMatch));
+            return connector.InvokeAsync(nameof(IMultiplayerServer.StartMatch));
         }
 
         public override Task AbortGameplay()
@@ -270,9 +264,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.AbortGameplay));
+            return connector.InvokeAsync(nameof(IMultiplayerServer.AbortGameplay));
         }
 
         public override Task AbortMatch()
@@ -280,9 +274,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.AbortMatch));
+            return connector.InvokeAsync(nameof(IMultiplayerServer.AbortMatch));
         }
 
         public override Task AddPlaylistItem(MultiplayerPlaylistItem item)
@@ -290,9 +284,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.AddPlaylistItem), item);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.AddPlaylistItem), [item]);
         }
 
         public override Task EditPlaylistItem(MultiplayerPlaylistItem item)
@@ -300,9 +294,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.EditPlaylistItem), item);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.EditPlaylistItem), [item]);
         }
 
         public override Task RemovePlaylistItem(long playlistItemId)
@@ -310,9 +304,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.RemovePlaylistItem), playlistItemId);
+            return connector.InvokeAsync(nameof(IMultiplayerServer.RemovePlaylistItem), [playlistItemId]);
         }
 
         public override Task VoteToSkipIntro()
@@ -320,9 +314,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.VoteToSkipIntro));
+            return connector.InvokeAsync(nameof(IMultiplayerServer.VoteToSkipIntro));
         }
 
         public override Task DisconnectInternal()
@@ -338,8 +332,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.FromResult(Array.Empty<MatchmakingPool>());
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync<MatchmakingPool[]>(nameof(IMatchmakingServer.GetMatchmakingPoolsOfType), type);
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync<MatchmakingPool[]>(nameof(IMatchmakingServer.GetMatchmakingPoolsOfType), [type]);
         }
 
         public override Task MatchmakingJoinLobby()
@@ -347,8 +341,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingJoinLobby));
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingJoinLobby));
         }
 
         public override Task MatchmakingLeaveLobby()
@@ -356,8 +350,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingLeaveLobby));
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingLeaveLobby));
         }
 
         public override Task MatchmakingJoinQueue(int poolId)
@@ -365,8 +359,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingJoinQueue), poolId);
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingJoinQueue), [poolId]);
         }
 
         public override Task MatchmakingLeaveQueue()
@@ -374,8 +368,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingLeaveQueue));
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingLeaveQueue));
         }
 
         public override Task MatchmakingAcceptInvitation()
@@ -383,8 +377,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingAcceptInvitation));
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingAcceptInvitation));
         }
 
         public override Task MatchmakingDeclineInvitation()
@@ -392,8 +386,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingDeclineInvitation));
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingDeclineInvitation));
         }
 
         public override Task MatchmakingToggleSelection(long playlistItemId)
@@ -401,8 +395,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingToggleSelection), playlistItemId);
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingToggleSelection), [playlistItemId]);
         }
 
         public override Task MatchmakingSkipToNextStage()
@@ -410,8 +404,8 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingSkipToNextStage));
+            Debug.Assert(connector != null);
+            return connector.InvokeAsync(nameof(IMatchmakingServer.MatchmakingSkipToNextStage));
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Online/PersistentEndpointClientConnector.cs
+++ b/osu.Game/Online/PersistentEndpointClientConnector.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Online
                     }
                     catch (Exception e)
                     {
-                        await handleErrorAndDelay(e, cancellationToken).ConfigureAwait(false);
+                        await HandleErrorAndDelay(e, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -141,7 +141,7 @@ namespace osu.Game.Online
         /// <summary>
         /// Handles an exception and delays an async flow.
         /// </summary>
-        private async Task handleErrorAndDelay(Exception exception, CancellationToken cancellationToken)
+        protected virtual async Task HandleErrorAndDelay(Exception exception, CancellationToken cancellationToken)
         {
             // random stagger factor to avoid mass incidental synchronisation
             // compare: https://github.com/peppy/osu-stable-reference/blob/013c3010a9d495e3471a9c59518de17006f9ad89/osu!/Online/BanchoClient.cs#L331
@@ -167,7 +167,7 @@ namespace osu.Game.Online
             await disconnect(true).ConfigureAwait(false);
 
             if (ex != null)
-                await handleErrorAndDelay(ex, CancellationToken.None).ConfigureAwait(false);
+                await HandleErrorAndDelay(ex, CancellationToken.None).ConfigureAwait(false);
             else
                 Logger.Log($"{ClientName} disconnected", LoggingTarget.Network);
 

--- a/osu.Game/Online/PersistentEndpointClientConnector.cs
+++ b/osu.Game/Online/PersistentEndpointClientConnector.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Online
         /// <summary>
         /// The current connection opened by this connector.
         /// </summary>
-        public PersistentEndpointClient? CurrentConnection { get; private set; }
+        protected PersistentEndpointClient? CurrentConnection { get; private set; }
 
         protected readonly IAPIProvider API;
 

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -20,8 +20,6 @@ namespace osu.Game.Online.Spectator
 
         public override IBindable<bool> IsConnected { get; } = new BindableBool();
 
-        private HubConnection? connection => connector?.CurrentConnection;
-
         public OnlineSpectatorClient(EndpointConfiguration endpoints)
         {
             endpoint = endpoints.SpectatorUrl;
@@ -56,11 +54,11 @@ namespace osu.Game.Online.Spectator
             if (!IsConnected.Value)
                 return;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
             try
             {
-                await connection.InvokeAsync(nameof(ISpectatorServer.BeginPlaySession), scoreToken, state).ConfigureAwait(false);
+                await connector.InvokeAsync(nameof(ISpectatorServer.BeginPlaySession), [scoreToken, state]).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -82,9 +80,9 @@ namespace osu.Game.Online.Spectator
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.SendAsync(nameof(ISpectatorServer.SendFrameData), bundle);
+            return connector.SendAsync(nameof(ISpectatorServer.SendFrameData), [bundle]);
         }
 
         protected override Task EndPlayingInternal(SpectatorState state)
@@ -92,9 +90,9 @@ namespace osu.Game.Online.Spectator
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(ISpectatorServer.EndPlaySession), state);
+            return connector.InvokeAsync(nameof(ISpectatorServer.EndPlaySession), [state]);
         }
 
         protected override Task WatchUserInternal(int userId)
@@ -102,9 +100,9 @@ namespace osu.Game.Online.Spectator
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(ISpectatorServer.StartWatchingUser), userId);
+            return connector.InvokeAsync(nameof(ISpectatorServer.StartWatchingUser), [userId]);
         }
 
         protected override Task StopWatchingUserInternal(int userId)
@@ -112,9 +110,9 @@ namespace osu.Game.Online.Spectator
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            Debug.Assert(connection != null);
+            Debug.Assert(connector != null);
 
-            return connection.InvokeAsync(nameof(ISpectatorServer.EndWatchingUser), userId);
+            return connector.InvokeAsync(nameof(ISpectatorServer.EndWatchingUser), [userId]);
         }
 
         protected override async Task DisconnectInternal()


### PR DESCRIPTION
In a theoretical scenario wherein client & server go through transport negotiation, agree to use websockets, but then websockets get killed persistently but other transports might not be getting killed persistently, this theoretically maybe allows said users to connect to spectator server.

I've only vaguely tested that this vaguely does what I wrote above. I don't know whether this diff is going to help a single user. Would need users currently affected by spectator server blocks to test and say.