### PR TITLE
Make grouped friend notifications Transient and not important

### DIFF
--- a/osu.Game/Online/FriendPresenceNotifier.cs
+++ b/osu.Game/Online/FriendPresenceNotifier.cs
@@ -221,6 +221,8 @@ namespace osu.Game.Online
         {
             public MultipleFriendsOnlineNotification(ICollection<APIUser> users)
             {
+                Transient = true;
+                IsImportant = false;
                 Text = NotificationsStrings.FriendOnline(string.Join(@", ", users.Select(u => u.Username)));
             }
 
@@ -258,6 +260,8 @@ namespace osu.Game.Online
         {
             public MultipleFriendsOfflineNotification(ICollection<APIUser> users)
             {
+                Transient = true;
+                IsImportant = false;
                 Text = NotificationsStrings.FriendOffline(string.Join(@", ", users.Select(u => u.Username)));
             }
 


### PR DESCRIPTION
Grouped notifications for more than 1 person were added in https://github.com/ppy/osu/pull/36180 but it looks like they forgot to add the Transient and IsImportant flags, which means the grouped notifications would still stay in the notification list/flash the taskbar.

Before:

https://github.com/user-attachments/assets/8a34bbc0-2b5c-4086-b2ee-1daa6d1e6e10



After:

https://github.com/user-attachments/assets/03c25ba6-7c8e-464c-bbb1-688ab9da6bb6



