### PR TITLE
Add info about damage dealt to ranked play user state

### DIFF
--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
+{
+    [Serializable]
+    [MessagePackObject]
+    public class RankedPlayDamageInfo : IEquatable<RankedPlayDamageInfo>
+    {
+        /// <summary>
+        /// Total amount of damage dealt.
+        /// </summary>
+        [Key(0)]
+        public required int Damage { get; init; }
+
+        /// <summary>
+        /// Damage dealt before multipliers are applied.
+        /// </summary>
+        [Key(1)]
+        public required int RawDamage { get; init; }
+
+        /// <summary>
+        /// Life before damage was applied.
+        /// </summary>
+        [Key(2)]
+        public required int OldLife { get; init; }
+
+        /// <summary>
+        /// Life after damage was applied.
+        /// </summary>
+        [Key(3)]
+        public required int NewLife { get; init; }
+
+        public bool Equals(RankedPlayDamageInfo? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Damage == other.Damage && RawDamage == other.RawDamage && OldLife == other.OldLife && NewLife == other.NewLife;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+
+            return Equals((RankedPlayDamageInfo)obj);
+        }
+
+        public override int GetHashCode() => HashCode.Combine(Damage, RawDamage, OldLife, NewLife);
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
@@ -34,5 +34,14 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// </summary>
         [Key(3)]
         public int RatingAfter { get; set; }
+
+        /// <summary>
+        /// Information about damage being applied in the current stage.
+        /// </summary>
+        /// <remarks>
+        /// This value is only expected to be populated during the <see cref="RankedPlayStage.Results"/> stage.
+        /// </remarks>
+        [Key(4)]
+        public RankedPlayDamageInfo? DamageInfo;
     }
 }


### PR DESCRIPTION
Adds a `DamageInfo` property to `RankedPlayDamageInfo` to be used by the result screen.

The issue this is trying to solve is that once the result screen initializes, the HP value of each player has already been updated in the room state so the previous values are no longer accessible. Doing this without the state exposing it would require some kinda setup to keep the previous MatchState's HP values around on the client which would introduce a lot of unnecessary weirdness.