### PR TITLE
Return zero rhythm difficulty for `Swell` and `DrumRoll`

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// </summary>
         public static double EvaluateDifficultyOf(DifficultyHitObject hitObject, double hitWindow)
         {
-            if (hitObject.BaseObject is Swell or DrumRoll)
+            if (hitObject.BaseObject is not Hit)
                 return 0;
 
             TaikoRhythmData rhythmData = ((TaikoDifficultyHitObject)hitObject).RhythmData;

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm.Data;
+using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 {
@@ -18,6 +19,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// </summary>
         public static double EvaluateDifficultyOf(DifficultyHitObject hitObject, double hitWindow)
         {
+            if (hitObject.BaseObject is Swell or DrumRoll)
+                return 0;
+
             TaikoRhythmData rhythmData = ((TaikoDifficultyHitObject)hitObject).RhythmData;
             double difficulty = 0.0d;
 


### PR DESCRIPTION
Found in the middle of hitwindow usage refactor