### PR TITLE
Refactor `DifficultyHitObject` to include `ClockRate` and `HitWindows`

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -22,8 +22,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty
     {
         private const double difficulty_multiplier = 4.59;
 
-        private float halfCatcherWidth;
-
         public override int Version => 20250306;
 
         public CatchDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
@@ -52,6 +50,11 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             List<DifficultyHitObject> objects = new List<DifficultyHitObject>();
 
+            float halfCatcherWidth = Catcher.CalculateCatchWidth(beatmap.Difficulty) * 0.5f;
+
+            // For circle sizes above 5.5, reduce the catcher width further to simulate imperfect gameplay.
+            halfCatcherWidth *= 1 - (Math.Max(0, beatmap.Difficulty.CircleSize - 5.5f) * 0.0625f);
+
             // In 2B beatmaps, it is possible that a normal Fruit is placed in the middle of a JuiceStream.
             foreach (var hitObject in CatchBeatmap.GetPalpableObjects(beatmap.HitObjects))
             {
@@ -70,14 +73,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
         protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
         {
-            halfCatcherWidth = Catcher.CalculateCatchWidth(beatmap.Difficulty) * 0.5f;
-
-            // For circle sizes above 5.5, reduce the catcher width further to simulate imperfect gameplay.
-            halfCatcherWidth *= 1 - (Math.Max(0, beatmap.Difficulty.CircleSize - 5.5f) * 0.0625f);
-
             return new Skill[]
             {
-                new Movement(mods, halfCatcherWidth, clockRate),
+                new Movement(mods),
             };
         }
 

--- a/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
@@ -11,11 +11,15 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Evaluators
     {
         private const double direction_change_bonus = 21.0;
 
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, double catcherSpeedMultiplier)
+        public static double EvaluateDifficultyOf(DifficultyHitObject current)
         {
             var catchCurrent = (CatchDifficultyHitObject)current;
             var catchLast = (CatchDifficultyHitObject)current.Previous(0);
             var catchLastLast = (CatchDifficultyHitObject)current.Previous(1);
+
+            // In catch, clockrate adjustments do not only affect the timings of hitobjects,
+            // but also the speed of the player's catcher, which has an impact on difficulty
+            double catcherSpeedMultiplier = current.ClockRate;
 
             double weightedStrainTime = catchCurrent.StrainTime + 13 + (3 / catcherSpeedMultiplier);
 

--- a/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
@@ -17,28 +17,14 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
 
         protected override int SectionLength => 750;
 
-        protected readonly float HalfCatcherWidth;
-
-        /// <summary>
-        /// The speed multiplier applied to the player's catcher.
-        /// </summary>
-        private readonly double catcherSpeedMultiplier;
-
-        public Movement(Mod[] mods, float halfCatcherWidth, double clockRate)
+        public Movement(Mod[] mods)
             : base(mods)
         {
-            HalfCatcherWidth = halfCatcherWidth;
-
-            // In catch, clockrate adjustments do not only affect the timings of hitobjects,
-            // but also the speed of the player's catcher, which has an impact on difficulty
-            // TODO: Support variable clockrates caused by mods such as ModTimeRamp
-            //  (perhaps by using IApplicableToRate within the CatchDifficultyHitObject constructor to set a catcher speed for each object before processing)
-            catcherSpeedMultiplier = clockRate;
         }
 
         protected override double StrainValueOf(DifficultyHitObject current)
         {
-            return MovementEvaluator.EvaluateDifficultyOf(current, catcherSpeedMultiplier);
+            return MovementEvaluator.EvaluateDifficultyOf(current);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 {
@@ -28,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             double rhythmComplexitySum = 0;
 
-            double deltaDifferenceEpsilon = ((OsuDifficultyHitObject)current).HitWindowGreat * 0.3;
+            double deltaDifferenceEpsilon = ((OsuDifficultyHitObject)current).HitWindow(HitResult.Great) * 0.3;
 
             var island = new Island(deltaDifferenceEpsilon);
             var previousIsland = new Island(deltaDifferenceEpsilon);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -6,6 +6,7 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 {
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             // Cap deltatime to the OD 300 hitwindow.
             // 0.93 is derived from making sure 260bpm OD8 streams aren't nerfed harshly, whilst 0.92 limits the effect of the cap.
-            strainTime /= Math.Clamp((strainTime / osuCurrObj.HitWindowGreat) / 0.93, 0.92, 1);
+            strainTime /= Math.Clamp((strainTime / osuCurrObj.HitWindow(HitResult.Great)) / 0.93, 0.92, 1);
 
             // speedBonus will be 0.0 for BPM < 200
             double speedBonus = 0.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 new Aim(mods, true),
                 new Aim(mods, false),
                 new Speed(mods),
-                new Reading(beatmap, mods, clockRate)
+                new Reading(mods)
             };
 
             if (mods.Any(h => h is OsuModFlashlight))

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -47,11 +47,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         public readonly double Preempt;
 
         /// <summary>
-        /// Beatmap playback rate.
-        /// </summary>
-        public readonly double ClockRate;
-
-        /// <summary>
         /// Normalised distance from the start position of the previous <see cref="OsuDifficultyHitObject"/> to the start position of this <see cref="OsuDifficultyHitObject"/>.
         /// </summary>
         public double JumpDistance { get; private set; }
@@ -122,11 +117,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         public double? Angle { get; private set; }
 
         /// <summary>
-        /// Retrieves the full hit window for a Great <see cref="HitResult"/>.
-        /// </summary>
-        public double HitWindowGreat { get; private set; }
-
-        /// <summary>
         /// Selective bonus for maps with higher circle size.
         /// </summary>
         public double SmallCircleBonus { get; private set; }
@@ -146,17 +136,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 
             SmallCircleBonus = Math.Max(1.0, 1.0 + (30 - BaseObject.Radius) / 40);
 
-            ClockRate = clockRate;
             Preempt = BaseObject.TimePreempt / clockRate;
-
-            if (BaseObject is Slider sliderObject)
-            {
-                HitWindowGreat = 2 * sliderObject.HeadCircle.HitWindows.WindowFor(HitResult.Great) / clockRate;
-            }
-            else
-            {
-                HitWindowGreat = 2 * BaseObject.HitWindows.WindowFor(HitResult.Great) / clockRate;
-            }
 
             computeSliderCursorPosition();
             setDistances(clockRate);
@@ -206,7 +186,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 double deltaDifference = Math.Abs(nextDeltaTime - currDeltaTime);
 
                 double speedRatio = currDeltaTime / Math.Max(currDeltaTime, deltaDifference);
-                double windowRatio = Math.Pow(Math.Min(1, currDeltaTime / HitWindowGreat), 5);
+                double windowRatio = Math.Pow(Math.Min(1, currDeltaTime / HitWindow(HitResult.Great)), 5);
 
                 return 1.0 - Math.Pow(speedRatio, 1 - windowRatio);
             }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -5,12 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Utils;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
 using osu.Game.Rulesets.Osu.Mods;
 
@@ -18,17 +16,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
     public class Reading : HarmonicSkill
     {
-        private readonly IReadOnlyList<HitObject> objectList;
+        private readonly List<DifficultyHitObject> objectList = new List<DifficultyHitObject>();
 
-        private readonly double clockRate;
         private readonly bool hasHiddenMod;
 
-        public Reading(IBeatmap beatmap, Mod[] mods, double clockRate)
+        public Reading(Mod[] mods)
             : base(mods)
         {
-            this.clockRate = clockRate;
             hasHiddenMod = mods.OfType<OsuModHidden>().Any(m => !m.OnlyFadeApproachCircles.Value);
-            objectList = beatmap.HitObjects;
         }
 
         private double currentDifficulty;
@@ -40,6 +35,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         protected override double ObjectDifficultyOf(DifficultyHitObject current)
         {
+            objectList.Add(current);
+
             currentDifficulty *= strainDecay(current.DeltaTime);
 
             currentDifficulty += ReadingEvaluator.EvaluateDifficultyOf(current, hasHiddenMod) * skillMultiplier;
@@ -67,19 +64,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
             const double reduced_difficulty_duration = 60 * 1000;
 
-            if (objectList.Count < 2)
+            if (objectList.Count == 0)
                 return 0;
 
-            // We take the 2nd note to match `CreateDifficultyHitObjects`
-            HitObject firstDifficultyObject = objectList[1];
-
-            double reducedDuration = (firstDifficultyObject.StartTime / clockRate) + reduced_difficulty_duration;
+            double reducedDuration = objectList.First().StartTime + reduced_difficulty_duration;
 
             int reducedNoteCount = 0;
 
             foreach (var hitObject in objectList)
             {
-                if (hitObject.StartTime / clockRate > reducedDuration)
+                if (hitObject.StartTime > reducedDuration)
                     break;
 
                 reducedNoteCount++;

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm.Data;
+using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 {
@@ -16,14 +18,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <summary>
         /// Evaluate the difficulty of a hitobject considering its interval change.
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject hitObject, double hitWindow)
+        public static double EvaluateDifficultyOf(DifficultyHitObject hitObject)
         {
+            if (hitObject.BaseObject is not Hit)
+                return 0;
+
             TaikoRhythmData rhythmData = ((TaikoDifficultyHitObject)hitObject).RhythmData;
             double difficulty = 0.0d;
 
             double sameRhythm = 0;
             double samePattern = 0;
             double intervalPenalty = 0;
+
+            double hitWindow = hitObject.HitWindow(HitResult.Great);
 
             if (rhythmData.SameRhythmGroupedHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmGroupedHitObjects
             {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double samePattern = 0;
             double intervalPenalty = 0;
 
-            double hitWindow = hitObject.HitWindow(HitResult.Great);
+            double hitWindow = hitObject.HitWindow(HitResult.Great) / 2.0; // this is practically incorrect, but kept as is for balancing
 
             if (rhythmData.SameRhythmGroupedHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmGroupedHitObjects
             {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
@@ -3,17 +3,14 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Difficulty.Evaluators;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Colour;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm;
 using osu.Game.Rulesets.Taiko.Difficulty.Utils;
 using osu.Game.Rulesets.Taiko.Objects;
-using osu.Game.Rulesets.Taiko.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
 {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
@@ -3,14 +3,17 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Difficulty.Evaluators;
-using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Colour;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm;
 using osu.Game.Rulesets.Taiko.Difficulty.Utils;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
 {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Rhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Rhythm.cs
@@ -17,17 +17,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         protected override double SkillMultiplier => 1.0;
         protected override double StrainDecayBase => 0.4;
 
-        private readonly double greatHitWindow;
-
-        public Rhythm(Mod[] mods, double greatHitWindow)
+        public Rhythm(Mod[] mods)
             : base(mods)
         {
-            this.greatHitWindow = greatHitWindow;
         }
 
         protected override double StrainValueOf(DifficultyHitObject current)
         {
-            double difficulty = RhythmEvaluator.EvaluateDifficultyOf(current, greatHitWindow);
+            double difficulty = RhythmEvaluator.EvaluateDifficultyOf(current);
 
             // To prevent abuse of exceedingly long intervals between awkward rhythms, we penalise its difficulty.
             double staminaDifficulty = StaminaEvaluator.EvaluateDifficultyOf(current) - 0.5; // Remove base strain

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -10,13 +10,11 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Colour;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm;
 using osu.Game.Rulesets.Taiko.Difficulty.Skills;
 using osu.Game.Rulesets.Taiko.Mods;
-using osu.Game.Rulesets.Taiko.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty
 {
@@ -43,15 +41,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
         {
-            HitWindows hitWindows = new TaikoHitWindows();
-            hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
-
             isConvert = beatmap.BeatmapInfo.Ruleset.OnlineID == 0;
             isRelax = mods.Any(h => h is TaikoModRelax);
 
             return new Skill[]
             {
-                new Rhythm(mods, hitWindows.WindowFor(HitResult.Great) / clockRate),
+                new Rhythm(mods),
                 new Reading(mods),
                 new Colour(mods),
                 new Stamina(mods, false, isConvert),

--- a/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
+++ b/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
@@ -4,7 +4,9 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Difficulty.Preprocessing
 {
@@ -46,6 +48,11 @@ namespace osu.Game.Rulesets.Difficulty.Preprocessing
         public readonly double EndTime;
 
         /// <summary>
+        /// Beatmap playback rate.
+        /// </summary>
+        public readonly double ClockRate;
+
+        /// <summary>
         /// Creates a new <see cref="DifficultyHitObject"/>.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> which this <see cref="DifficultyHitObject"/> wraps.</param>
@@ -62,6 +69,7 @@ namespace osu.Game.Rulesets.Difficulty.Preprocessing
             DeltaTime = (hitObject.StartTime - lastObject.StartTime) / clockRate;
             StartTime = hitObject.StartTime / clockRate;
             EndTime = hitObject.GetEndTime() / clockRate;
+            ClockRate = clockRate;
         }
 
         public DifficultyHitObject Previous(int backwardsIndex)
@@ -74,6 +82,27 @@ namespace osu.Game.Rulesets.Difficulty.Preprocessing
         {
             int index = Index + (forwardsIndex + 1);
             return index >= 0 && index < difficultyHitObjects.Count ? difficultyHitObjects[index] : default;
+        }
+
+        /// <summary>
+        /// Retrieves the full hit window for a <see cref="HitResult"/>.
+        /// </summary>
+        public virtual double HitWindow(HitResult hitResult)
+        {
+            // Try to get HitWindows from nested hit objects
+            // This is important for objects such as Slider in osu! where the object itself has HitWindows set to Empty, but the nested SliderHead has proper hit windows
+            if (BaseObject.HitWindows == HitWindows.Empty)
+            {
+                foreach (var nestedHitObject in BaseObject.NestedHitObjects)
+                {
+                    if (nestedHitObject.HitWindows == HitWindows.Empty)
+                        continue;
+
+                    return 2 * nestedHitObject.HitWindows.WindowFor(hitResult) / ClockRate;
+                }
+            }
+
+            return 2 * BaseObject.HitWindows.WindowFor(hitResult) / ClockRate;
         }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
+++ b/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Linq;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 


### PR DESCRIPTION
- [x] Requires https://github.com/ppy/osu/pull/36628

This changes difficulty calculations to use `ClockRate` and `HitWindows` from `DifficultyHitObjects` instead of providing them manually. It's main purpose is unifying all the calculations to use the same source of truth, and also allowing future work on supporting variable clockrates.

Potential value-affecting changes:
- osu: Reading strain reduction was changed from using `HitObjects` to `DifficultyHitObjects`. 
- taiko: None. Rhythm hit window retrieval was kept incorrect to keep the values the same.
- mania: None.
- catch: None.