### PR TITLE
Update production endpoints in an attempt to fix Russian player connections

### DIFF
--- a/osu.Game/Online/ProductionEndpointConfiguration.cs
+++ b/osu.Game/Online/ProductionEndpointConfiguration.cs
@@ -10,9 +10,9 @@ namespace osu.Game.Online
             WebsiteUrl = APIUrl = @"https://osu.ppy.sh";
             APIClientSecret = @"FGc9GAtyHzeQDshWP5Ah7dega8hJACAJpQtw6OXk";
             APIClientID = "5";
-            SpectatorUrl = "https://spectator.ppy.sh/spectator";
-            MultiplayerUrl = "https://spectator.ppy.sh/multiplayer";
-            MetadataUrl = "https://spectator.ppy.sh/metadata";
+            SpectatorUrl = "https://spectator.osu.ppy.sh/spectator";
+            MultiplayerUrl = "https://spectator.osu.ppy.sh/multiplayer";
+            MetadataUrl = "https://spectator.osu.ppy.sh/metadata";
             BeatmapSubmissionServiceUrl = "https://bss.ppy.sh";
         }
     }


### PR DESCRIPTION
Mostly making the PR for changelog coverage.

This change was proposed by a user and seems to work in limited testing, so it's worth a try.

Importantly, if this works we probably want to move `bss` as well before the next major release.