### PR TITLE
Add early returns in `HarmonicSkill` and `OsuDifficultyCalculator`

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -146,6 +146,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         public static double SumCognitionDifficulty(double reading, double flashlight)
         {
+            if (reading <= 0)
+                return flashlight;
+
+            if (flashlight <= 0)
+                return reading;
+
             // Nerf flashlight value in cognition sum when reading is greater than flashlight
             return DifficultyCalculationUtils.Norm(OsuPerformanceCalculator.PERFORMANCE_NORM_EXPONENT, reading, flashlight * Math.Clamp(flashlight / reading, 0.25, 1.0));
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -51,9 +51,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
             const double reduced_difficulty_base_line = 0.0; // Assume the first seconds are completely memorised
 
-            if (difficulties.Length == 0)
-                return;
-
             int reducedNoteCount = calculateReducedNoteCount();
 
             for (int i = 0; i < Math.Min(difficulties.Length, reducedNoteCount); i++)

--- a/osu.Game/Rulesets/Difficulty/Skills/HarmonicSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/HarmonicSkill.cs
@@ -59,6 +59,9 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             // These notes will not contribute to the difficulty.
             double[] difficulties = ObjectDifficulties.Where(p => p > 0).ToArray();
 
+            if (difficulties.Length == 0)
+                return 0;
+
             ApplyDifficultyTransformation(difficulties);
 
             double difficulty = 0;


### PR DESCRIPTION
After https://github.com/ppy/osu/pull/36599 maps that had 0 reading difficulty were returning NaN for star rating, this fixes it.

`HarmonicSkill` early return in a micro-optimization for cases where every strain is 0 and no additional calculation is necessary