### PR TITLE
Add setting to request window focus when multiplayer match is about to start

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -239,7 +239,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.DashboardSortMode, UserSortCriteria.LastVisit);
             SetDefault(OsuSetting.DashboardDisplayStyle, OverlayPanelDisplayStyle.Card);
 
-            SetDefault(OsuSetting.RequestFocusOnMultiplayerGameplayStart, true);
+            SetDefault(OsuSetting.RequestFocusOnMultiplayerGameplayStart, false);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -238,6 +238,8 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.DashboardSortMode, UserSortCriteria.LastVisit);
             SetDefault(OsuSetting.DashboardDisplayStyle, OverlayPanelDisplayStyle.Card);
+
+            SetDefault(OsuSetting.RequestFocusOnMultiplayerGameplayStart, true);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -493,5 +495,7 @@ namespace osu.Game.Configuration
 
         DashboardSortMode,
         DashboardDisplayStyle,
+
+        RequestFocusOnMultiplayerGameplayStart,
     }
 }

--- a/osu.Game/Localisation/UserInterfaceStrings.cs
+++ b/osu.Game/Localisation/UserInterfaceStrings.cs
@@ -194,6 +194,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ShowHidden => new TranslatableString(getKey(@"show_hidden"), @"Show hidden");
 
+        /// <summary>
+        /// "Multiplayer"
+        /// </summary>
+        public static LocalisableString MultiplayerHeader => new TranslatableString(getKey(@"multiplayer"), @"Multiplayer");
+
+        /// <summary>
+        /// "Request window focus when multiplayer match is about to start"
+        /// </summary>
+        public static LocalisableString RequestFocusOnMultiplayerGameplayStart => new TranslatableString(getKey(@"request_focus_on_multiplayer_gameplay_start"), @"Request window focus when multiplayer match is about to start");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
@@ -10,7 +10,7 @@ using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
-    public class MultiplayerSettings : SettingsSubsection
+    public partial class MultiplayerSettings : SettingsSubsection
     {
         protected override LocalisableString Header => UserInterfaceStrings.MultiplayerHeader;
 

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+
+namespace osu.Game.Overlays.Settings.Sections.UserInterface
+{
+    public class MultiplayerSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => UserInterfaceStrings.MultiplayerHeader;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            Child = new SettingsItemV2(new FormCheckBox
+            {
+                Caption = UserInterfaceStrings.RequestFocusOnMultiplayerGameplayStart,
+                Current = config.GetBindable<bool>(OsuSetting.RequestFocusOnMultiplayerGameplayStart),
+            })
+            {
+                Keywords = new[] { "multiplayer", "match", "request", "focus", "window" }
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
@@ -16,15 +17,20 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            Child = new SettingsItemV2(new FormCheckBox
+            // This entire subsection is hidden on mobile platforms.
+            // If any settings are added which aren't available on all platforms, this must be undone in `UserInterfaceSection`.
+            if (RuntimeInfo.IsDesktop)
             {
-                Caption = UserInterfaceStrings.RequestFocusOnMultiplayerGameplayStart,
-                Current = config.GetBindable<bool>(OsuSetting.RequestFocusOnMultiplayerGameplayStart),
-            })
-            {
-                Keywords = new[] { "multiplayer", "match", "request", "focus", "window" },
-                ShowRevertToDefaultButton = true,
-            };
+                Add(new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = UserInterfaceStrings.RequestFocusOnMultiplayerGameplayStart,
+                    Current = config.GetBindable<bool>(OsuSetting.RequestFocusOnMultiplayerGameplayStart),
+                })
+                {
+                    Keywords = new[] { "multiplayer", "match", "request", "focus", "window" },
+                    ShowRevertToDefaultButton = true,
+                });
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MultiplayerSettings.cs
@@ -22,7 +22,8 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                 Current = config.GetBindable<bool>(OsuSetting.RequestFocusOnMultiplayerGameplayStart),
             })
             {
-                Keywords = new[] { "multiplayer", "match", "request", "focus", "window" }
+                Keywords = new[] { "multiplayer", "match", "request", "focus", "window" },
+                ShowRevertToDefaultButton = true,
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/UserInterfaceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterfaceSection.cs
@@ -25,7 +25,8 @@ namespace osu.Game.Overlays.Settings.Sections
             {
                 new GeneralSettings(),
                 new MainMenuSettings(),
-                new SongSelectSettings()
+                new SongSelectSettings(),
+                new MultiplayerSettings(),
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/UserInterfaceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterfaceSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -26,8 +27,14 @@ namespace osu.Game.Overlays.Settings.Sections
                 new GeneralSettings(),
                 new MainMenuSettings(),
                 new SongSelectSettings(),
-                new MultiplayerSettings(),
             };
+
+            // Currently, this subsection only adds 1 setting which is available on desktop platforms only,
+            // so the entire section is omitted on mobile platforms to avoid having a floating header without any settings.
+            if (RuntimeInfo.IsDesktop)
+            {
+                Add(new MultiplayerSettings());
+            }
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
@@ -48,7 +49,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.OnPlayerLoaded();
 
-            if (configManager != null && configManager.Get<bool>(OsuSetting.RequestFocusOnMultiplayerGameplayStart))
+            bool shouldRequestFocus = configManager?.Get<bool>(OsuSetting.RequestFocusOnMultiplayerGameplayStart) ?? false;
+
+            if (shouldRequestFocus && RuntimeInfo.IsDesktop)
                 game?.Window?.Raise();
             else
                 game?.Window?.Flash();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
+using osu.Game.Configuration;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.Play;
 
@@ -22,6 +23,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         [Resolved]
         private OsuGame? game { get; set; }
+
+        [Resolved]
+        private OsuConfigManager? configManager { get; set; }
 
         private Player? player;
 
@@ -44,7 +48,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.OnPlayerLoaded();
 
-            game?.Window?.Flash();
+            if (configManager != null && configManager.Get<bool>(OsuSetting.RequestFocusOnMultiplayerGameplayStart))
+                game?.Window?.Raise();
+            else
+                game?.Window?.Flash();
 
             multiplayerClient.ChangeState(MultiplayerUserState.Loaded)
                              .ContinueWith(task => failAndBail(task.Exception?.Message ?? "Server error"), TaskContinuationOptions.NotOnRanToCompletion);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private MultiplayerClient multiplayerClient { get; set; } = null!;
 
         [Resolved]
-        private OsuGame? game { get; set; }
+        private OsuGameBase? game { get; set; }
 
         [Resolved]
         private OsuConfigManager? configManager { get; set; }


### PR DESCRIPTION
Came up when test-playing for ranked play. RFC.

This adds the ability for the game window to request focus when a multiplayer match is about to start.
The behaviour is configurable (defaults to disabled), and if disabled will instead go back to the previous behaviour and make the window flash in the task bar.

<img width="641" height="257" alt="image" src="https://github.com/user-attachments/assets/5b02231e-a174-419c-a742-f0b17fbe08fc" />

Not 100% sure if the "user interface" settings section is the right place for this but felt like the one that was least incorrect.

Can be tested in visual test browser via `TestSceneMultiplayer.TestPlayStartsWithCorrectBeatmapWhileAtSongSelect`.
Tested myself on MacOS, was not able to test on other platforms currently. The setting item is hidden on mobile platforms.