### PR TITLE
Add user role to `MultiplayerRoomUser`

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
@@ -55,6 +55,12 @@ namespace osu.Game.Online.Multiplayer
         [Key(7)]
         public bool VotedToSkipIntro;
 
+        /// <summary>
+        /// The role of this user in the room.
+        /// </summary>
+        [Key(8)]
+        public MultiplayerRoomUserRole Role;
+
         [IgnoreMember]
         public APIUser? User { get; set; }
 

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomUserRole.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomUserRole.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Online.Multiplayer
+{
+    public enum MultiplayerRoomUserRole
+    {
+        Player,
+        Referee,
+    }
+}


### PR DESCRIPTION
- Related to https://github.com/ppy/osu-server-spectator/issues/406

Adding this field to this model has several vague reasons that I can't fully formulate yet, but I can't really see myself going forward *without* this.

- People were very excited about having referees displayed on the room participants' list, and so adding the referees as real `MultiplayerRoomUser`s helps this. Having the role could even be used client-side to show a special icon or other status on the participants list. (Which isn't done yet, could be as an aesthetic follow-up after the basics are in place.)
- Server-side, having this field is convenient for things like permission checks or just plain logic, as with two hubs you just need to do different *stuff* on a `MultiplayerRoomUser`.