### PR TITLE
Adjust all selected hold notes if they have the same StartTime and Duration

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Tests.Visual;
 using osuTK;
 using osuTK.Input;
@@ -17,12 +16,18 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
     {
         protected override Ruleset CreateEditorRuleset() => new ManiaRuleset();
 
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+            AddStep("Clear objects", () => EditorBeatmap.Clear());
+        }
+
         [Test]
         public void TestSimpleTailDragForward()
         {
             AddStep("Add hold note", () =>
             {
-                EditorBeatmap.Clear();
                 EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
             });
 
@@ -34,11 +39,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is higher", () =>
-            {
-                var holdNote = EditorBeatmap.HitObjects.First() as IHasDuration;
-                return holdNote!.Duration > 937.5f;
-            });
+            AddAssert("Duration is higher", () => ((HoldNote)EditorBeatmap.HitObjects.First())!.Duration > 937.5f);
         }
 
         [Test]
@@ -46,7 +47,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold note", () =>
             {
-                EditorBeatmap.Clear();
                 EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
             });
 
@@ -58,11 +58,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is lower", () =>
-            {
-                var holdNote = EditorBeatmap.HitObjects.First() as IHasDuration;
-                return holdNote!.Duration < 937.5f;
-            });
+            AddAssert("Duration is lower", () => ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f);
         }
 
         [Test]
@@ -70,7 +66,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.Clear();
                 EditorBeatmap.AddRange([
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
@@ -85,12 +80,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is higher, and the other is unchanged", () =>
-            {
-                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
-                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
-                return holdNote1!.Duration > 937.5f && holdNote2!.Duration == 937.5f;
-            });
+            AddAssert("Duration is higher, other is unchanged", () =>
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration > 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
+            );
         }
 
         [Test]
@@ -98,7 +91,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.Clear();
                 EditorBeatmap.AddRange([
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
@@ -113,12 +105,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is lower, and the other is unchanged", () =>
-            {
-                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
-                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
-                return holdNote1!.Duration < 937.5f && holdNote2!.Duration == 937.5f;
-            });
+            AddAssert("Duration is lower, other is unchanged", () =>
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
+            );
         }
 
         [Test]
@@ -126,7 +116,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.Clear();
                 EditorBeatmap.AddRange([
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
@@ -147,11 +136,9 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Both durations are higher", () =>
-            {
-                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
-                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
-                return holdNote1!.Duration > 937.5f && holdNote2!.Duration > 937.5f;
-            });
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration > 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration > 937.5f
+            );
         }
 
         [Test]
@@ -159,7 +146,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.Clear();
                 EditorBeatmap.AddRange([
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
@@ -180,11 +166,9 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Both durations are lower", () =>
-            {
-                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
-                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
-                return holdNote1!.Duration < 937.5f && holdNote2!.Duration < 937.5f;
-            });
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+            );
         }
 
         [Test]
@@ -192,7 +176,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.Clear();
                 EditorBeatmap.AddRange([
                     new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
                     new HoldNote { StartTime = 2404, Duration = 937.5, Column = 1 }
@@ -212,12 +195,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is lower, and the other is unchanged", () =>
-            {
-                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
-                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
-                return holdNote2!.Duration < 937.5f && holdNote1!.Duration == 937.5f;
-            });
+            AddAssert("Duration is unchanged, other is lower", () =>
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+            );
         }
 
         private void dragForward(DragArea dragArea)

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -1,0 +1,240 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Tests.Visual;
+using osuTK;
+using osuTK.Input;
+using DragArea = osu.Game.Screens.Edit.Compose.Components.Timeline.TimelineHitObjectBlueprint.DragArea;
+
+namespace osu.Game.Rulesets.Mania.Tests.Editor
+{
+    public partial class TestSceneHoldNoteTailDrag : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new ManiaRuleset();
+
+        [Test]
+        public void TestSimpleTailDragForward()
+        {
+            AddStep("Add hold note", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().Single();
+                dragForward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is higher", () =>
+            {
+                var holdNote = EditorBeatmap.HitObjects.First() as IHasDuration;
+                return holdNote!.Duration > 937.5f;
+            });
+        }
+
+        [Test]
+        public void TestSimpleTailDragBackwards()
+        {
+            AddStep("Add hold note", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().Single();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is lower", () =>
+            {
+                var holdNote = EditorBeatmap.HitObjects.First() as IHasDuration;
+                return holdNote!.Duration < 937.5f;
+            });
+        }
+
+        [Test]
+        public void TestSamePositionButNotSelectedDragForward()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragForward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is higher, and the other is unchanged", () =>
+            {
+                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
+                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
+                return holdNote1!.Duration > 937.5f && holdNote2!.Duration == 937.5f;
+            });
+        }
+
+        [Test]
+        public void TestSamePositionButNotSelectedDragBackward()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is lower, and the other is unchanged", () =>
+            {
+                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
+                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
+                return holdNote1!.Duration < 937.5f && holdNote2!.Duration == 937.5f;
+            });
+        }
+
+        [Test]
+        public void TestSamePositionSelectedDragForward()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
+
+            AddStep("Start select", selectAllNotes);
+            AddStep("End select", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragForward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Both durations are higher", () =>
+            {
+                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
+                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
+                return holdNote1!.Duration > 937.5f && holdNote2!.Duration > 937.5f;
+            });
+        }
+
+        [Test]
+        public void TestSamePositionSelectedDragBackward()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
+
+            AddStep("Start select", selectAllNotes);
+            AddStep("End select", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Both durations are lower", () =>
+            {
+                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
+                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
+                return holdNote1!.Duration < 937.5f && holdNote2!.Duration < 937.5f;
+            });
+        }
+
+        [Test]
+        public void TestSelectedButDifferentPositions()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2404, Duration = 937.5, Column = 1 }
+                ]);
+            });
+
+            AddStep("Start select", selectAllNotes);
+            AddStep("End select", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is lower, and the other is unchanged", () =>
+            {
+                var holdNote1 = EditorBeatmap.HitObjects.First() as IHasDuration;
+                var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
+                return holdNote2!.Duration < 937.5f && holdNote1!.Duration == 937.5f;
+            });
+        }
+
+        private void selectAllNotes()
+        {
+            InputManager.MoveMouseTo(new Vector2(1100, 110));
+            InputManager.PressButton(MouseButton.Left);
+            InputManager.MoveMouseTo(new Vector2(-50, 110));
+        }
+
+        private void dragForward(DragArea dragArea)
+        {
+            InputManager.MoveMouseTo(dragArea);
+            InputManager.PressKey(Key.LShift);
+            InputManager.PressButton(MouseButton.Left);
+            InputManager.MoveMouseTo(new Vector2(1100, 110));
+        }
+
+        private void dragBackward(DragArea dragArea)
+        {
+            InputManager.MoveMouseTo(dragArea);
+            InputManager.PressKey(Key.LShift);
+            InputManager.PressButton(MouseButton.Left);
+            InputManager.MoveMouseTo(new Vector2(-200, 110));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -201,6 +201,66 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             );
         }
 
+        [Test]
+        public void TestSelectedSameStartTimeDifferentDurations()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 1171.8, Column = 1 }
+                ]);
+            });
+
+            AddStep("Select all", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is unchanged, other is lower", () =>
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+            );
+        }
+
+        [Test]
+        public void TestSelectedSameDurationDifferentStartTimes()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2638.7, Duration = 937.5, Column = 1 }
+                ]);
+            });
+
+            AddStep("Select all", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is unchanged, other is lower", () =>
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+            );
+        }
+
         private void dragForward(DragArea dragArea)
         {
             InputManager.MoveMouseTo(dragArea);

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -26,101 +27,75 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         [Test]
         public void TestSimpleTailDragForward()
         {
-            AddStep("Add hold note", () =>
-            {
-                EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
-            });
+            AddStep("Add hold note", () => EditorBeatmap.Add(getMatchingNotes()[0]));
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().Single();
-                dragForward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().Single();
+                dragForward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is higher", () => ((HoldNote)EditorBeatmap.HitObjects.First())!.Duration > 937.5f);
+            AddAssert("Duration is higher", () => getFirstNote().Duration > 937.5f);
         }
 
         [Test]
         public void TestSimpleTailDragBackwards()
         {
-            AddStep("Add hold note", () =>
-            {
-                EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
-            });
+            AddStep("Add hold note", () => EditorBeatmap.Add(getMatchingNotes()[0]));
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().Single();
-                dragBackward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().Single();
+                dragBackward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is lower", () => ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f);
+            AddAssert("Duration is lower", () => getFirstNote().Duration < 937.5f);
         }
 
         [Test]
         public void TestSamePositionButNotSelectedDragForward()
         {
-            AddStep("Add hold notes", () =>
-            {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
-                ]);
-            });
+            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragForward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragForward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is higher, other is unchanged", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration > 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
+                getFirstNote().Duration > 937.5f && Precision.AlmostEquals(getLastNote().Duration, 937.5f)
             );
         }
 
         [Test]
         public void TestSamePositionButNotSelectedDragBackward()
         {
-            AddStep("Add hold notes", () =>
-            {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
-                ]);
-            });
+            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is lower, other is unchanged", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
+                getFirstNote().Duration < 937.5f && Precision.AlmostEquals(getLastNote().Duration, 937.5f)
             );
         }
 
         [Test]
         public void TestSamePositionSelectedDragForward()
         {
-            AddStep("Add hold notes", () =>
-            {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
-                ]);
-            });
+            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
 
             AddStep("Select all", () =>
             {
@@ -129,28 +104,21 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragForward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragForward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Both durations are higher", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration > 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration > 937.5f
+                getFirstNote().Duration > 937.5f && getLastNote().Duration > 937.5f
             );
         }
 
         [Test]
         public void TestSamePositionSelectedDragBackward()
         {
-            AddStep("Add hold notes", () =>
-            {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
-                ]);
-            });
+            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
 
             AddStep("Select all", () =>
             {
@@ -159,15 +127,14 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Both durations are lower", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+                getFirstNote().Duration < 937.5f && getLastNote().Duration < 937.5f
             );
         }
 
@@ -176,10 +143,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2404, Duration = 937.5, Column = 1 }
-                ]);
+                var unmatchingNotes = getMatchingNotes();
+                unmatchingNotes[^1].StartTime = 2404;
+
+                EditorBeatmap.AddRange(unmatchingNotes);
             });
 
             AddStep("Select all", () =>
@@ -189,15 +156,14 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is unchanged, other is lower", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+                Precision.AlmostEquals(getFirstNote().Duration, 937.5f) && getLastNote().Duration < 937.5f
             );
         }
 
@@ -206,10 +172,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2170, Duration = 1171.8, Column = 1 }
-                ]);
+                var unmatchingNotes = getMatchingNotes();
+                unmatchingNotes[^1].Duration = 1171.8;
+
+                EditorBeatmap.AddRange(unmatchingNotes);
             });
 
             AddStep("Select all", () =>
@@ -219,24 +185,22 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag until both match", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                InputManager.MoveMouseTo(blueprintDragArea);
-                InputManager.PressKey(Key.LShift);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                InputManager.MoveMouseTo(noteDragArea);
                 InputManager.PressButton(MouseButton.Left);
                 InputManager.MoveMouseTo(new Vector2(1000, 110));
             });
 
             AddStep("Continue the drag", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is unchanged, other is lower", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+                Precision.AlmostEquals(getFirstNote().Duration, 937.5f) && getLastNote().Duration < 937.5f
             );
         }
 
@@ -245,10 +209,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2638.7, Duration = 937.5, Column = 1 }
-                ]);
+                var unmatchingNotes = getMatchingNotes();
+                unmatchingNotes[^1].StartTime = 2638.7;
+
+                EditorBeatmap.AddRange(unmatchingNotes);
             });
 
             AddStep("Select all", () =>
@@ -258,28 +222,21 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is unchanged, other is lower", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
+                Precision.AlmostEquals(getFirstNote().Duration, 937.5f) && getLastNote().Duration < 937.5f
             );
         }
 
         [Test]
         public void TestDragNoteOutsideOfSelection()
         {
-            AddStep("Add hold notes", () =>
-            {
-                EditorBeatmap.AddRange([
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
-                ]);
-            });
+            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
 
             AddStep("Select the back stack slider", () =>
             {
@@ -288,16 +245,34 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(blueprintDragArea);
+                var noteDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(noteDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is lower, other is unchanged", () =>
-                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
-                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
+                getFirstNote().Duration < 937.5f && Precision.AlmostEquals(getLastNote().Duration, 937.5f)
             );
+        }
+
+        private HoldNote getFirstNote()
+        {
+            return (HoldNote)EditorBeatmap.HitObjects[0];
+        }
+
+        private HoldNote getLastNote()
+        {
+            return (HoldNote)EditorBeatmap.HitObjects[^1];
+        }
+
+        private HoldNote[] getMatchingNotes()
+        {
+            return
+            [
+                new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+            ];
         }
 
         private void dragForward(DragArea dragArea)

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -27,75 +26,101 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         [Test]
         public void TestSimpleTailDragForward()
         {
-            AddStep("Add hold note", () => EditorBeatmap.Add(getMatchingNotes()[0]));
+            AddStep("Add hold note", () =>
+            {
+                EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
+            });
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().Single();
-                dragForward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().Single();
+                dragForward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is higher", () => getFirstNote().Duration > 937.5f);
+            AddAssert("Duration is higher", () => ((HoldNote)EditorBeatmap.HitObjects.First())!.Duration > 937.5f);
         }
 
         [Test]
         public void TestSimpleTailDragBackwards()
         {
-            AddStep("Add hold note", () => EditorBeatmap.Add(getMatchingNotes()[0]));
+            AddStep("Add hold note", () =>
+            {
+                EditorBeatmap.Add(new HoldNote { StartTime = 2170, Duration = 937.5 });
+            });
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().Single();
-                dragBackward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().Single();
+                dragBackward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("Duration is lower", () => getFirstNote().Duration < 937.5f);
+            AddAssert("Duration is lower", () => ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f);
         }
 
         [Test]
         public void TestSamePositionButNotSelectedDragForward()
         {
-            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragForward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragForward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is higher, other is unchanged", () =>
-                getFirstNote().Duration > 937.5f && Precision.AlmostEquals(getLastNote().Duration, 937.5f)
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration > 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
             );
         }
 
         [Test]
         public void TestSamePositionButNotSelectedDragBackward()
         {
-            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is lower, other is unchanged", () =>
-                getFirstNote().Duration < 937.5f && Precision.AlmostEquals(getLastNote().Duration, 937.5f)
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
             );
         }
 
         [Test]
         public void TestSamePositionSelectedDragForward()
         {
-            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
 
             AddStep("Select all", () =>
             {
@@ -104,21 +129,28 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragForward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragForward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Both durations are higher", () =>
-                getFirstNote().Duration > 937.5f && getLastNote().Duration > 937.5f
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration > 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration > 937.5f
             );
         }
 
         [Test]
         public void TestSamePositionSelectedDragBackward()
         {
-            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
 
             AddStep("Select all", () =>
             {
@@ -127,14 +159,15 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Both durations are lower", () =>
-                getFirstNote().Duration < 937.5f && getLastNote().Duration < 937.5f
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
             );
         }
 
@@ -143,10 +176,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                var unmatchingNotes = getMatchingNotes();
-                unmatchingNotes[^1].StartTime = 2404;
-
-                EditorBeatmap.AddRange(unmatchingNotes);
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2404, Duration = 937.5, Column = 1 }
+                ]);
             });
 
             AddStep("Select all", () =>
@@ -156,14 +189,15 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is unchanged, other is lower", () =>
-                Precision.AlmostEquals(getFirstNote().Duration, 937.5f) && getLastNote().Duration < 937.5f
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
             );
         }
 
@@ -172,10 +206,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                var unmatchingNotes = getMatchingNotes();
-                unmatchingNotes[^1].Duration = 1171.8;
-
-                EditorBeatmap.AddRange(unmatchingNotes);
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 1171.8, Column = 1 }
+                ]);
             });
 
             AddStep("Select all", () =>
@@ -185,22 +219,24 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag until both match", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                InputManager.MoveMouseTo(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                InputManager.MoveMouseTo(blueprintDragArea);
+                InputManager.PressKey(Key.LShift);
                 InputManager.PressButton(MouseButton.Left);
                 InputManager.MoveMouseTo(new Vector2(1000, 110));
             });
 
             AddStep("Continue the drag", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is unchanged, other is lower", () =>
-                Precision.AlmostEquals(getFirstNote().Duration, 937.5f) && getLastNote().Duration < 937.5f
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
             );
         }
 
@@ -209,10 +245,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("Add hold notes", () =>
             {
-                var unmatchingNotes = getMatchingNotes();
-                unmatchingNotes[^1].StartTime = 2638.7;
-
-                EditorBeatmap.AddRange(unmatchingNotes);
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2638.7, Duration = 937.5, Column = 1 }
+                ]);
             });
 
             AddStep("Select all", () =>
@@ -222,21 +258,28 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is unchanged, other is lower", () =>
-                Precision.AlmostEquals(getFirstNote().Duration, 937.5f) && getLastNote().Duration < 937.5f
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration == 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration < 937.5f
             );
         }
 
         [Test]
         public void TestDragNoteOutsideOfSelection()
         {
-            AddStep("Add hold notes", () => EditorBeatmap.AddRange(getMatchingNotes()));
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
 
             AddStep("Select the back stack slider", () =>
             {
@@ -245,34 +288,16 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("Drag tail", () =>
             {
-                var noteDragArea = this.ChildrenOfType<DragArea>().First();
-                dragBackward(noteDragArea);
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
             });
 
             AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddAssert("Duration is lower, other is unchanged", () =>
-                getFirstNote().Duration < 937.5f && Precision.AlmostEquals(getLastNote().Duration, 937.5f)
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
             );
-        }
-
-        private HoldNote getFirstNote()
-        {
-            return (HoldNote)EditorBeatmap.HitObjects[0];
-        }
-
-        private HoldNote getLastNote()
-        {
-            return (HoldNote)EditorBeatmap.HitObjects[^1];
-        }
-
-        private HoldNote[] getMatchingNotes()
-        {
-            return
-            [
-                new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
-                new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
-            ];
         }
 
         private void dragForward(DragArea dragArea)

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -217,7 +217,16 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                 EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
             });
 
-            AddStep("Drag tail", () =>
+            AddStep("Drag until both match", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                InputManager.MoveMouseTo(blueprintDragArea);
+                InputManager.PressKey(Key.LShift);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.MoveMouseTo(new Vector2(1000, 110));
+            });
+
+            AddStep("Continue the drag", () =>
             {
                 var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
                 dragBackward(blueprintDragArea);
@@ -264,7 +273,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         private void dragForward(DragArea dragArea)
         {
             InputManager.MoveMouseTo(dragArea);
-            InputManager.PressKey(Key.LShift);
             InputManager.PressButton(MouseButton.Left);
             InputManager.MoveMouseTo(new Vector2(1100, 110));
         }
@@ -272,9 +280,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         private void dragBackward(DragArea dragArea)
         {
             InputManager.MoveMouseTo(dragArea);
-            InputManager.PressKey(Key.LShift);
             InputManager.PressButton(MouseButton.Left);
-            InputManager.MoveMouseTo(new Vector2(-200, 110));
+            InputManager.MoveMouseTo(new Vector2(700, 110));
         }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -133,8 +133,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                 ]);
             });
 
-            AddStep("Start select", selectAllNotes);
-            AddStep("End select", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddStep("Select all", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
 
             AddStep("Drag tail", () =>
             {
@@ -164,8 +166,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                 ]);
             });
 
-            AddStep("Start select", selectAllNotes);
-            AddStep("End select", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddStep("Select all", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
 
             AddStep("Drag tail", () =>
             {
@@ -195,8 +199,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                 ]);
             });
 
-            AddStep("Start select", selectAllNotes);
-            AddStep("End select", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddStep("Select all", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
 
             AddStep("Drag tail", () =>
             {
@@ -212,13 +218,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                 var holdNote2 = EditorBeatmap.HitObjects.Last() as IHasDuration;
                 return holdNote2!.Duration < 937.5f && holdNote1!.Duration == 937.5f;
             });
-        }
-
-        private void selectAllNotes()
-        {
-            InputManager.MoveMouseTo(new Vector2(1100, 110));
-            InputManager.PressButton(MouseButton.Left);
-            InputManager.MoveMouseTo(new Vector2(-50, 110));
         }
 
         private void dragForward(DragArea dragArea)

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -270,6 +270,36 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             );
         }
 
+        [Test]
+        public void TestDragNoteOutsideOfSelection()
+        {
+            AddStep("Add hold notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 1 }
+                ]);
+            });
+
+            AddStep("Select the back stack slider", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.Last());
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Duration is lower, other is unchanged", () =>
+                ((HoldNote)EditorBeatmap.HitObjects[0]).Duration < 937.5f &&
+                ((HoldNote)EditorBeatmap.HitObjects[^1]).Duration == 937.5f
+            );
+        }
+
         private void dragForward(DragArea dragArea)
         {
             InputManager.MoveMouseTo(dragArea);

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneHoldNoteTailDrag.cs
@@ -300,6 +300,40 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             );
         }
 
+        [Test]
+        public void TestDragHoldNoteWithNotes()
+        {
+            AddStep("Add notes", () =>
+            {
+                EditorBeatmap.AddRange([
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 0 },
+                    new Note { StartTime = 2170, Column = 1 },
+                    new Note { StartTime = 3107.5, Column = 2 },
+                    new HoldNote { StartTime = 2170, Duration = 937.5, Column = 3 }
+                ]);
+            });
+
+            AddStep("Select all", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Drag tail", () =>
+            {
+                var blueprintDragArea = this.ChildrenOfType<DragArea>().First();
+                dragBackward(blueprintDragArea);
+            });
+
+            AddStep("Release tail", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("Both durations are lower", () =>
+                {
+                    var holdNotes = EditorBeatmap.HitObjects.OfType<HoldNote>();
+                    return holdNotes.First().Duration < 937.5f && holdNotes.Last().Duration < 937.5f;
+                }
+            );
+        }
+
         private void dragForward(DragArea dragArea)
         {
             InputManager.MoveMouseTo(dragArea);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -460,26 +460,25 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 if (endTimeHitObject.EndTime == snappedTime)
                                     return;
 
-                                List<HitObject> objectsToAdjust = new List<HitObject>();
+                                List<HitObject> objsToAdjust = new List<HitObject>();
 
                                 foreach (var item in blueprintContainer.SelectionHandler.SelectedItems)
                                 {
-                                    if (item is IHasDuration durationItem &&
-                                        durationItem.Duration == endTimeHitObject.Duration &&
-                                        item.StartTime == hitObject.StartTime
-                                       )
+                                    var durationItem = item as IHasDuration;
+
+                                    if (durationItem!.Duration == endTimeHitObject.Duration && item.StartTime == hitObject.StartTime)
                                     {
-                                        objectsToAdjust.Add(item);
+                                        objsToAdjust.Add(item);
                                     }
                                 }
 
-                                // If nothing is selected it means the user is just dragging a slider end
-                                if (objectsToAdjust.Count == 0)
-                                    objectsToAdjust.Add(hitObject);
+                                // If nothing has been added to the list, the user has not selected anything and is just performing a simple drag.
+                                if (objsToAdjust.Count == 0)
+                                    objsToAdjust.Add(hitObject);
 
-                                foreach (var obj in objectsToAdjust)
+                                foreach (var obj in objsToAdjust)
                                 {
-                                    (obj as IHasDuration).Duration = snappedTime - obj.StartTime;
+                                    (obj as IHasDuration)!.Duration = snappedTime - obj.StartTime;
                                     beatmap.Update(obj);
                                 }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -313,7 +313,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             private readonly HitObject? hitObject;
 
-            private List<HitObject> objsToAdjust = new List<HitObject>();
+            private readonly List<HitObject> objsToAdjust = new List<HitObject>();
 
             [Resolved]
             private EditorBeatmap beatmap { get; set; } = null!;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -461,9 +461,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                     return;
 
                                 List<HitObject> objsToAdjust = new List<HitObject>();
+                                var selectedObjects = blueprintContainer.SelectionHandler.SelectedItems;
 
-                                foreach (var item in blueprintContainer.SelectionHandler.SelectedItems)
+                                foreach (var item in selectedObjects)
                                 {
+                                    // If the dragged object is not in the selection we ignore the selected items
+                                    if (!selectedObjects.Contains(hitObject))
+                                        break;
+
                                     var durationItem = item as IHasDuration;
 
                                     if (Precision.AlmostEquals(durationItem!.Duration, endTimeHitObject.Duration) &&

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -419,8 +419,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                     var durationItem = item as IHasDuration;
 
-                    if (Precision.AlmostEquals(durationItem!.Duration, (hitObject as IHasDuration)!.Duration) &&
-                        Precision.AlmostEquals(item.StartTime, hitObject!.StartTime))
+                    if (Precision.AlmostEquals(durationItem!.Duration, (hitObject as IHasDuration)!.Duration, 1) &&
+                        Precision.AlmostEquals(item.StartTime, hitObject!.StartTime, 1))
                     {
                         objsToAdjust.Add(item);
                     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -466,7 +466,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 {
                                     var durationItem = item as IHasDuration;
 
-                                    if (durationItem!.Duration == endTimeHitObject.Duration && item.StartTime == hitObject.StartTime)
+                                    if (Precision.AlmostEquals(durationItem!.Duration, endTimeHitObject.Duration) &&
+                                        Precision.AlmostEquals(item.StartTime, hitObject.StartTime))
                                     {
                                         objsToAdjust.Add(item);
                                     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -411,7 +411,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 changeHandler?.BeginChange();
 
-                foreach (var item in blueprintContainer.SelectionHandler.SelectedItems)
+                var selectionItems = blueprintContainer.SelectionHandler.SelectedItems;
+
+                if (!selectionItems.Contains(hitObject))
+                    return true;
+
+                foreach (var item in selectionItems)
                 {
                     if (item == hitObject) continue;
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -325,9 +325,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             private Timeline timeline { get; set; } = null!;
 
             [Resolved]
-            private TimelineBlueprintContainer blueprintContainer { get; set; } = null!;
-
-            [Resolved]
             private IEditorChangeHandler? changeHandler { get; set; }
 
             private ScheduledDelegate? dragOperation;
@@ -411,7 +408,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 changeHandler?.BeginChange();
 
-                var selectionItems = blueprintContainer.SelectionHandler.SelectedItems;
+                var selectionItems = beatmap.SelectedHitObjects;
 
                 if (!selectionItems.Contains(hitObject))
                     return true;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -478,7 +478,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 if (endTimeHitObject.EndTime == snappedTime)
                                     return;
 
-                                objsToAdjust.Add(hitObject);
+                                if (!objsToAdjust.Contains(hitObject))
+                                    objsToAdjust.Add(hitObject);
 
                                 foreach (var obj in objsToAdjust)
                                 {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -415,11 +415,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 foreach (var item in selectionItems)
                 {
-                    if (item == hitObject) continue;
+                    if (item == hitObject || item is not IHasDuration durationItem) continue;
 
-                    var durationItem = item as IHasDuration;
-
-                    if (Precision.AlmostEquals(durationItem!.Duration, (hitObject as IHasDuration)!.Duration, 1) &&
+                    if (Precision.AlmostEquals(durationItem.Duration, (hitObject as IHasDuration)!.Duration, 1) &&
                         Precision.AlmostEquals(item.StartTime, hitObject!.StartTime, 1))
                     {
                         objsToAdjust.Add(item);


### PR DESCRIPTION
Addresses #36267

The drag now checks all the selected objects in the blueprint container to see if they have the same `StartTime` and `Duration` as the dragged note, and if so, adjust them accordingly.