### PR TITLE
Migrate daily challenge screen to footer v2

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestSceneAddToPlaylistFooterButton.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestSceneAddToPlaylistFooterButton.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.Playlists
         {
             AddStep("appear", () => button.Appear());
             AddWaitStep("wait for animation", 3);
-            AddStep("disappear", () => button.Disappear());
+            AddStep("disappear", () => button.Disappear(false));
             AddWaitStep("wait for animation", 3);
             AddStep("appear", () => button.Appear());
         }

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneScreenFooter.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneScreenFooter.cs
@@ -55,6 +55,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
                 new FooterButtonRandom(),
                 new FooterButtonOptions(),
             });
+
+            screenFooter.SetPrimaryButton(new FooterButton(240)
+            {
+                Text = "Primary",
+                Action = () => { },
+            });
         });
 
         [SetUpSteps]
@@ -116,10 +122,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("show overlay", () => externalOverlay.Show());
             contentDisplayed();
             AddUntilStep("other buttons hidden", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.Child.Parent!.Y > 0));
+            AddAssert("primary button hidden", () => screenFooter.ChildrenOfType<FooterButton>().First().Y, () => Is.GreaterThan(0));
 
             AddStep("hide overlay", () => externalOverlay.Hide());
             contentHidden();
             AddUntilStep("other buttons returned", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.ChildrenOfType<Container>().First().Y == 0));
+            AddAssert("primary button returned", () => screenFooter.ChildrenOfType<FooterButton>().First().Y, () => Is.EqualTo(0));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelectV2/TestSceneScreenFooter.cs
+++ b/osu.Game.Tests/Visual/SongSelectV2/TestSceneScreenFooter.cs
@@ -122,12 +122,12 @@ namespace osu.Game.Tests.Visual.SongSelectV2
             AddStep("show overlay", () => externalOverlay.Show());
             contentDisplayed();
             AddUntilStep("other buttons hidden", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.Child.Parent!.Y > 0));
-            AddAssert("primary button hidden", () => screenFooter.ChildrenOfType<FooterButton>().First().Y, () => Is.GreaterThan(0));
+            AddAssert("primary button hidden", () => screenFooter.ChildrenOfType<FooterButton>().First().ChildrenOfType<Container>().ElementAt(1).Y, () => Is.GreaterThan(0));
 
             AddStep("hide overlay", () => externalOverlay.Hide());
             contentHidden();
             AddUntilStep("other buttons returned", () => screenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.ChildrenOfType<Container>().First().Y == 0));
-            AddAssert("primary button returned", () => screenFooter.ChildrenOfType<FooterButton>().First().Y, () => Is.EqualTo(0));
+            AddAssert("primary button returned", () => screenFooter.ChildrenOfType<FooterButton>().First().ChildrenOfType<Container>().ElementAt(1).Y, () => Is.EqualTo(0));
         }
 
         [Test]

--- a/osu.Game/Localisation/DailyChallengeStrings.cs
+++ b/osu.Game/Localisation/DailyChallengeStrings.cs
@@ -10,12 +10,16 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.DailyChallenge";
 
         /// <summary>
+        /// "Play!"
+        /// </summary>
+        public static LocalisableString Play => new TranslatableString(getKey(@"play"), @"Play!");
+
+        /// <summary>
         /// "Today&#39;s daily challenge has concluded – thanks for playing!
         ///
         /// Tomorrow&#39;s challenge is now being prepared and will appear soon."
         /// </summary>
-        public static LocalisableString ChallengeEndedNotification => new TranslatableString(getKey(@"todays_daily_challenge_has_concluded"),
-            @"Today's daily challenge has concluded – thanks for playing!
+        public static LocalisableString ChallengeEndedNotification => new TranslatableString(getKey(@"todays_daily_challenge_has_concluded"), @"Today's daily challenge has concluded – thanks for playing!
 
 Tomorrow's challenge is now being prepared and will appear soon.");
 

--- a/osu.Game/Screens/Footer/FooterButton.cs
+++ b/osu.Game/Screens/Footer/FooterButton.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Footer
+{
+    public partial class FooterButton : ShearedButton
+    {
+        public FooterButton(float? width)
+            : base(width)
+        {
+        }
+
+        public void Appear()
+        {
+            FinishTransforms();
+
+            Content.MoveToY(150f)
+                   .FadeOut()
+                   .MoveToY(0f, 240, Easing.OutCubic)
+                   .FadeIn(240, Easing.OutCubic);
+        }
+
+        public void Disappear(bool expire)
+        {
+            FinishTransforms();
+
+            Content.FadeOut(240, Easing.InOutCubic)
+                   .MoveToY(150f, 240, Easing.InOutCubic);
+
+            if (expire)
+                this.Delay(Content.LatestTransformEndTime - Time.Current).Expire();
+        }
+    }
+}

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -52,6 +52,7 @@ namespace osu.Game.Screens.Footer
         private FillFlowContainer<ScreenFooterButton> buttonsFlow = null!;
         private Container overlayContentContainer = null!;
         private Container<ScreenFooterButton> hiddenButtonsContainer = null!;
+        private Container<FooterButton> primaryButtonContainer = null!;
 
         private LogoTrackingContainer logoTrackingContainer = null!;
         private IDisposable? logoTracking;
@@ -134,6 +135,16 @@ namespace osu.Game.Screens.Footer
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     AutoSizeAxes = Axes.Both,
+                },
+                primaryButtonContainer = new Container<FooterButton>
+                {
+                    Name = "Primary button container",
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding
+                    {
+                        Bottom = OsuGame.SCREEN_EDGE_MARGIN,
+                        Right = OsuGame.SCREEN_EDGE_MARGIN * 2,
+                    },
                 },
                 (logoTrackingContainer = new LogoTrackingContainer
                 {
@@ -235,6 +246,24 @@ namespace osu.Game.Screens.Footer
             }
         }
 
+        public void SetPrimaryButton(FooterButton? button)
+        {
+            if (primaryButtonContainer.Count == 1)
+                primaryButtonContainer.Child.Disappear(true);
+
+            if (button == null)
+                return;
+
+            Debug.Assert(!button.IsLoaded);
+            primaryButtonContainer.Child = button.With(p =>
+            {
+                p.Anchor = Anchor.BottomRight;
+                p.Origin = Anchor.BottomRight;
+            });
+
+            button.OnLoadComplete += _ => button.Appear();
+        }
+
         public ShearedOverlayContainer? ActiveOverlay { get; private set; }
 
         private VisibilityContainer? activeOverlayContent;
@@ -267,6 +296,9 @@ namespace osu.Game.Screens.Footer
 
                 makeButtonDisappearToBottom(button, 0, 0, false);
             }
+
+            if (primaryButtonContainer.Count == 1)
+                primaryButtonContainer.Child.Disappear(false);
 
             updateColourScheme(overlay.ColourProvider.Hue);
 
@@ -312,6 +344,9 @@ namespace osu.Game.Screens.Footer
             }
 
             temporarilyHiddenButtons.Clear();
+
+            if (primaryButtonContainer.Count == 1)
+                primaryButtonContainer.Child.Appear();
 
             updateColourScheme(OverlayColourScheme.Aquamarine.GetHue());
 

--- a/osu.Game/Screens/Footer/ScreenStackFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenStackFooter.cs
@@ -93,6 +93,7 @@ namespace osu.Game.Screens.Footer
                 ((BindableBool)backButtonVisibility).Value = true;
 
                 Footer.SetButtons([]);
+                Footer.SetPrimaryButton(null);
                 Footer.Hide();
                 return;
             }
@@ -111,6 +112,7 @@ namespace osu.Game.Screens.Footer
                 {
                     // ensure the current buttons are immediately disabled on screen change (so they can't be pressed).
                     Footer.SetButtons([]);
+                    Footer.SetPrimaryButton(null);
 
                     osuScreen.OnLoadComplete += _ => updateFooterButtons();
                 }
@@ -118,10 +120,15 @@ namespace osu.Game.Screens.Footer
                 void updateFooterButtons()
                 {
                     var buttons = osuScreen.CreateFooterButtons();
+                    var primary = osuScreen.CreateFooterPrimaryButton();
 
                     osuScreen.LoadComponentsAgainstScreenDependencies(buttons);
 
+                    if (primary != null)
+                        osuScreen.LoadComponentsAgainstScreenDependencies([primary]);
+
                     Footer.SetButtons(buttons);
+                    Footer.SetPrimaryButton(primary);
                     Footer.Show();
                 }
             }
@@ -130,6 +137,7 @@ namespace osu.Game.Screens.Footer
                 backButtonVisibility.BindTo(osuScreen.BackButtonVisibility);
 
                 Footer.SetButtons([]);
+                Footer.SetPrimaryButton(null);
                 Footer.Hide();
             }
         }

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -104,6 +104,13 @@ namespace osu.Game.Screens
         IReadOnlyList<ScreenFooterButton> CreateFooterButtons();
 
         /// <summary>
+        /// The primary button displayed on the right hand side of the game's footer toolbar.
+        /// Note that this is separate from the osu! logo, which is handled separately.
+        /// </summary>
+        /// <returns>The primary button drawable, or <c>null</c> if this screen doesn't have one.</returns>
+        FooterButton? CreateFooterPrimaryButton();
+
+        /// <summary>
         /// Whether mod track adjustments should be applied on entering this screen.
         /// A <see langword="null"/> value means that the parent screen's value of this setting will be used.
         /// </summary>

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
     public partial class DailyChallengeIntro : OsuScreen
     {
+        public override bool ShowFooter => true;
+
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
         public override bool? ApplyModTrackAdjustments => true;

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/PlayFooterButton.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/PlayFooterButton.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
+using osu.Game.Screens.Footer;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.DailyChallenge
+{
+    public partial class PlayFooterButton : FooterButton
+    {
+        public PlayFooterButton()
+            : base(220)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            DarkerColour = colours.Green3;
+            LighterColour = colours.Green1;
+
+            ButtonContent.Children = new Drawable[]
+            {
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    X = -10,
+                    Font = OsuFont.TorusAlternate.With(size: 17),
+                    Text = DailyChallengeStrings.Play,
+                    UseFullGlyphHeight = false,
+                },
+                new SpriteIcon
+                {
+                    Icon = OsuIcon.Play,
+                    Size = new Vector2(24),
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    X = 70,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Playlists/AddToPlaylistFooterButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/AddToPlaylistFooterButton.cs
@@ -3,15 +3,14 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Transforms;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
+using osu.Game.Screens.Footer;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
 {
-    public partial class AddToPlaylistFooterButton : ShearedButton
+    public partial class AddToPlaylistFooterButton : FooterButton
     {
         public AddToPlaylistFooterButton()
             : base(width: 220)
@@ -46,24 +45,6 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     UseFullGlyphHeight = false,
                 },
             };
-        }
-
-        public void Appear()
-        {
-            FinishTransforms();
-
-            this.MoveToY(150f)
-                .FadeOut()
-                .MoveToY(0f, 240, Easing.OutCubic)
-                .FadeIn(240, Easing.OutCubic);
-        }
-
-        public TransformSequence<AddToPlaylistFooterButton> Disappear()
-        {
-            FinishTransforms();
-
-            return this.FadeOut(240, Easing.InOutCubic)
-                       .MoveToY(150f, 240, Easing.InOutCubic);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelectV2.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelectV2.cs
@@ -8,8 +8,6 @@ using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Screens;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
@@ -35,7 +33,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         [Resolved]
         private IOverlayManager? overlayManager { get; set; }
 
-        private readonly AddToPlaylistFooterButton addToPlaylistFooterButton;
+        private AddToPlaylistFooterButton addToPlaylistFooterButton = null!;
 
         private readonly Room room;
         private ModSelectOverlay modSelect = null!;
@@ -51,19 +49,6 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             Padding = new MarginPadding { Horizontal = HORIZONTAL_OVERFLOW_PADDING };
             LeftPadding = new MarginPadding { Top = CORNER_RADIUS_HIDE_OFFSET + Header.HEIGHT };
-
-            addToPlaylistFooterButton = new AddToPlaylistFooterButton
-            {
-                Anchor = Anchor.BottomRight,
-                Origin = Anchor.BottomRight,
-                Margin = new MarginPadding
-                {
-                    Bottom = OsuGame.SCREEN_EDGE_MARGIN,
-                    Right = OsuGame.SCREEN_EDGE_MARGIN * 2
-                },
-                Alpha = 0,
-                Action = AddNewItem
-            };
         }
 
         [BackgroundDependencyLoader]
@@ -93,29 +78,16 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             modSelectOverlayRegistration = overlayManager?.RegisterBlockingOverlay(freeModSelect);
 
-            modSelect.State.BindValueChanged(onModSelectStateChanged, true);
-            freeModSelect.State.BindValueChanged(onModSelectStateChanged, true);
-
             Mods.BindValueChanged(onGlobalModsChanged);
             Ruleset.BindValueChanged(onRulesetChanged);
             Freestyle.BindValueChanged(onFreestyleChanged);
 
             updateValidMods();
-
-            Footer?.Add(addToPlaylistFooterButton);
         }
 
         public void AddNewItem()
         {
             room.Playlist = room.Playlist.Append(createItem()).ToArray();
-        }
-
-        private void onModSelectStateChanged(ValueChangedEvent<Visibility> state)
-        {
-            if (state.NewValue == Visibility.Visible)
-                addToPlaylistFooterButton.Disappear();
-            else
-                addToPlaylistFooterButton.Appear();
         }
 
         private void onGlobalModsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
@@ -173,36 +145,6 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             addToPlaylistFooterButton.TriggerClick();
         }
 
-        public override void OnEntering(ScreenTransitionEvent e)
-        {
-            base.OnEntering(e);
-
-            addToPlaylistFooterButton.Appear();
-        }
-
-        public override void OnResuming(ScreenTransitionEvent e)
-        {
-            base.OnResuming(e);
-
-            addToPlaylistFooterButton.Appear();
-        }
-
-        public override void OnSuspending(ScreenTransitionEvent e)
-        {
-            base.OnSuspending(e);
-
-            addToPlaylistFooterButton.Disappear();
-        }
-
-        public override bool OnExiting(ScreenExitEvent e)
-        {
-            if (base.OnExiting(e))
-                return true;
-
-            addToPlaylistFooterButton.Disappear().Expire();
-            return false;
-        }
-
         public override IReadOnlyList<ScreenFooterButton> CreateFooterButtons()
         {
             var buttons = base.CreateFooterButtons().ToList();
@@ -224,6 +166,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             return buttons;
         }
+
+        public override FooterButton CreateFooterPrimaryButton() => addToPlaylistFooterButton = new AddToPlaylistFooterButton { Action = AddNewItem };
 
         protected override ModSelectOverlay CreateModSelectOverlay() => modSelect = new UserModSelectOverlay(OverlayColourScheme.Plum)
         {

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -321,6 +321,8 @@ namespace osu.Game.Screens
 
         public virtual IReadOnlyList<ScreenFooterButton> CreateFooterButtons() => Array.Empty<ScreenFooterButton>();
 
+        public virtual FooterButton CreateFooterPrimaryButton() => null;
+
         public virtual bool OnBackButton() => false;
     }
 }


### PR DESCRIPTION
Resolves #35710.

The first commit deals with refactoring the footer to allow adding a "primary" button on the right-hand side, and migrating the playlist song select to use that. I'm not sure if this the right way to do it, but at least it feels better than copy-pasting the relevant code across the playlists and daily challenge screens.

The second commit refactors the daily challenge screen to use the new footer. Since the mods button extends a fair bit above the footer especially with the selected mods indicator, the main container resizes a bit to accommodate when said indicator is present.

https://github.com/user-attachments/assets/51e876b5-3dda-4baa-814f-bbed649ec823