### PR TITLE
Fix corner radius for user tag glow

### DIFF
--- a/osu.Game/Screens/Ranking/UserTagControl.DrawableUserTag.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.DrawableUserTag.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Ranking
             [BackgroundDependencyLoader]
             private void load()
             {
-                CornerRadius = 5;
+                CornerRadius = 11;
                 Masking = true;
 
                 EdgeEffect = new EdgeEffectParameters

--- a/osu.Game/Screens/Ranking/UserTagControl.DrawableUserTag.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.DrawableUserTag.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Ranking
             [BackgroundDependencyLoader]
             private void load()
             {
-                CornerRadius = 11;
+                CornerRadius = 10;
                 Masking = true;
 
                 EdgeEffect = new EdgeEffectParameters


### PR DESCRIPTION
Fixes incorrect glow corner radius around user tag buttons

Before:
<img width="267" height="123" alt="image" src="https://github.com/user-attachments/assets/3e602e84-bb13-46f7-942c-85ddf3954946" />
After:
<img width="227" height="102" alt="image" src="https://github.com/user-attachments/assets/4dca2e3d-80e2-4b6c-988e-d14f371cfbe8" />
