### PR TITLE
Add explanations for scoring mode used in ranked & total score tooltips

### DIFF
--- a/osu.Game/Localisation/RankingStatisticsStrings.cs
+++ b/osu.Game/Localisation/RankingStatisticsStrings.cs
@@ -34,6 +34,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString NotAvailable => new TranslatableString(getKey(@"not_available"), @"(not available)");
 
+        /// <summary>
+        /// "Classic scoring mode is always used for this statistic."
+        /// </summary>
+        public static LocalisableString ClassicScoringAlwaysUsed => new TranslatableString(getKey(@"classic_scoring_always_used"), @"Classic scoring mode is always used for this statistic.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Ranking/Statistics/User/RankedScoreChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/RankedScoreChangeRow.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
+using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Ranking.Statistics.User
@@ -15,6 +16,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
         }
 
         protected override LocalisableString Label => UsersStrings.ShowStatsRankedScore;
+        public override LocalisableString TooltipText => RankingStatisticsStrings.ClassicScoringAlwaysUsed;
 
         protected override LocalisableString FormatCurrentValue(long current) => current.ToLocalisableString(@"N0");
 

--- a/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -17,7 +18,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Ranking.Statistics.User
 {
-    public abstract partial class RankingChangeRow<T> : CompositeDrawable
+    public abstract partial class RankingChangeRow<T> : CompositeDrawable, IHasTooltip
     {
         public Bindable<ScoreBasedUserStatisticsUpdate?> StatisticsUpdate { get; } = new Bindable<ScoreBasedUserStatisticsUpdate?>();
 
@@ -153,6 +154,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
         }
 
         protected abstract LocalisableString Label { get; }
+        public virtual LocalisableString TooltipText => default;
 
         protected abstract LocalisableString FormatCurrentValue(T current);
         protected abstract int CalculateDifference(T previous, T current, out LocalisableString formattedDifference);

--- a/osu.Game/Screens/Ranking/Statistics/User/TotalScoreChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/TotalScoreChangeRow.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
+using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Ranking.Statistics.User
@@ -15,6 +16,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
         }
 
         protected override LocalisableString Label => UsersStrings.ShowStatsTotalScore;
+        public override LocalisableString TooltipText => RankingStatisticsStrings.ClassicScoringAlwaysUsed;
 
         protected override LocalisableString FormatCurrentValue(long current) => current.ToLocalisableString(@"N0");
 


### PR DESCRIPTION
Because people get confused by how this works.

Shows on results screen where the post-play statistics updates go.

https://github.com/user-attachments/assets/ef3a91d1-86dd-4029-8f0f-bdf0b727ca6c