### PR TITLE
Preserve bookmarks when creating a new difficulty from scratch

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Tests.Visual.Editing
                 var effectPoint = EditorBeatmap.ControlPointInfo.EffectPoints.Single();
                 return effectPoint.Time == 500 && effectPoint.KiaiMode && effectPoint.ScrollSpeedBindable.IsDefault;
             });
-            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks.Count == 2);
             AddAssert("created difficulty has no objects", () => EditorBeatmap.HitObjects.Count == 0);
 
             AddAssert("status is modified", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified);
@@ -256,7 +256,7 @@ namespace osu.Game.Tests.Visual.Editing
                 return timingPoint.Time == 0 && timingPoint.BeatLength == 1000;
             });
 
-            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks.Count == 2);
 
             AddAssert("created difficulty has effect points", () =>
             {
@@ -317,7 +317,7 @@ namespace osu.Game.Tests.Visual.Editing
                 return timingPoint.Time == 0 && timingPoint.BeatLength == 1000;
             });
 
-            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks.Count == 2);
 
             AddAssert("created difficulty has effect points", () =>
             {
@@ -403,7 +403,7 @@ namespace osu.Game.Tests.Visual.Editing
                 return timingPoint.Time == 0 && timingPoint.BeatLength == 1000;
             });
             AddAssert("created difficulty has objects", () => EditorBeatmap.HitObjects.Count == 2);
-            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks.Count == 2);
             AddAssert("approach rate correctly copied", () => EditorBeatmap.Difficulty.ApproachRate == 4);
             AddAssert("combo colours correctly copied", () => EditorBeatmap.BeatmapSkin.AsNonNull().ComboColours.Count == 2);
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -132,6 +132,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = firstDifficultyName);
             AddStep("add timing point", () => EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 }));
             AddStep("add effect point", () => EditorBeatmap.ControlPointInfo.Add(500, new EffectControlPoint { KiaiMode = true }));
+            AddStep("add bookmarks", () => EditorBeatmap.Bookmarks.AddRange([500, 1000]));
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[]
             {
                 new HitCircle
@@ -185,6 +186,7 @@ namespace osu.Game.Tests.Visual.Editing
                 var effectPoint = EditorBeatmap.ControlPointInfo.EffectPoints.Single();
                 return effectPoint.Time == 500 && effectPoint.KiaiMode && effectPoint.ScrollSpeedBindable.IsDefault;
             });
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
             AddAssert("created difficulty has no objects", () => EditorBeatmap.HitObjects.Count == 0);
 
             AddAssert("status is modified", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified);
@@ -223,6 +225,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = previousDifficultyName = Guid.NewGuid().ToString());
             AddStep("add timing point", () => EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 }));
+            AddStep("add bookmarks", () => EditorBeatmap.Bookmarks.AddRange([500, 1000]));
             AddStep("add effect points", () =>
             {
                 EditorBeatmap.ControlPointInfo.Add(250, new EffectControlPoint { KiaiMode = false, ScrollSpeed = 0.05 });
@@ -252,6 +255,8 @@ namespace osu.Game.Tests.Visual.Editing
                 var timingPoint = EditorBeatmap.ControlPointInfo.TimingPoints.Single();
                 return timingPoint.Time == 0 && timingPoint.BeatLength == 1000;
             });
+
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
 
             AddAssert("created difficulty has effect points", () =>
             {
@@ -284,6 +289,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = firstDifficultyName);
             AddStep("add timing point", () => EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 }));
+            AddStep("add bookmarks", () => EditorBeatmap.Bookmarks.AddRange([500, 1000]));
             AddStep("add effect points", () =>
             {
                 EditorBeatmap.ControlPointInfo.Add(250, new EffectControlPoint { KiaiMode = false, ScrollSpeed = 0.05 });
@@ -310,6 +316,8 @@ namespace osu.Game.Tests.Visual.Editing
                 var timingPoint = EditorBeatmap.ControlPointInfo.TimingPoints.Single();
                 return timingPoint.Time == 0 && timingPoint.BeatLength == 1000;
             });
+
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
 
             AddAssert("created difficulty has effect points", () =>
             {
@@ -344,6 +352,7 @@ namespace osu.Game.Tests.Visual.Editing
                     StartTime = 1000
                 }
             }));
+            AddStep("add bookmarks", () => EditorBeatmap.Bookmarks.AddRange([500, 1000]));
             AddStep("set approach rate", () => EditorBeatmap.Difficulty.ApproachRate = 4);
             AddStep("set combo colours", () =>
             {
@@ -394,6 +403,7 @@ namespace osu.Game.Tests.Visual.Editing
                 return timingPoint.Time == 0 && timingPoint.BeatLength == 1000;
             });
             AddAssert("created difficulty has objects", () => EditorBeatmap.HitObjects.Count == 2);
+            AddAssert("created difficulty has bookmarks", () => EditorBeatmap.Bookmarks[0] == 500 && EditorBeatmap.Bookmarks[^1] == 1000);
             AddAssert("approach rate correctly copied", () => EditorBeatmap.Difficulty.ApproachRate == 4);
             AddAssert("combo colours correctly copied", () => EditorBeatmap.BeatmapSkin.AsNonNull().ComboColours.Count == 2);
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Beatmaps
             var newBeatmap = new Beatmap
             {
                 BeatmapInfo = newBeatmapInfo,
-                Bookmarks = referenceWorkingBeatmap.Beatmap.Bookmarks
+                Bookmarks = referenceWorkingBeatmap.Beatmap.Bookmarks.ToArray()
             };
 
             foreach (var timingPoint in referenceWorkingBeatmap.Beatmap.ControlPointInfo.TimingPoints)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -154,7 +154,11 @@ namespace osu.Game.Beatmaps
             {
                 DifficultyName = NamingUtils.GetNextBestName(targetBeatmapSet.Beatmaps.Select(b => b.DifficultyName), "New Difficulty")
             };
-            var newBeatmap = new Beatmap { BeatmapInfo = newBeatmapInfo };
+            var newBeatmap = new Beatmap
+            {
+                BeatmapInfo = newBeatmapInfo,
+                Bookmarks = referenceWorkingBeatmap.Beatmap.Bookmarks
+            };
 
             foreach (var timingPoint in referenceWorkingBeatmap.Beatmap.ControlPointInfo.TimingPoints)
                 newBeatmap.ControlPointInfo.Add(timingPoint.Time, timingPoint.DeepClone());


### PR DESCRIPTION
Closes #33395

Copies the bookmarks from `referenceWorkingBeatmap` while creating a new difficulty from scratch. I adapted the tests in `TestSceneEditorBeatmapCreation` to include the bookmark checks.