### PR TITLE
Fix exiting via footer back button from a subscreen stack exiting the top level stack instead

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenFooterNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenFooterNavigation.cs
@@ -84,6 +84,23 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         /// <summary>
+        /// Pressing the back button when a subscreen is present should exit on the subscreen stack, not the top-level stack.
+        /// </summary>
+        [Test]
+        public void TestExitSubScreenFromBackButton()
+        {
+            TestScreenWithSubScreen screen = null!;
+
+            PushAndConfirm(() => screen = new TestScreenWithSubScreen());
+            pushSubScreenAndConfirm(() => screen, () => new TestScreenOne());
+
+            AddStep("press back button", () => screenFooter.BackButton.TriggerClick());
+            AddUntilStep("current screen still correct", () => Game.ScreenStack.CurrentScreen, () => Is.EqualTo(screen));
+
+            AddUntilStep("subscreen stack empty", () => screen.SubScreenStack.CurrentScreen, () => Is.Null);
+        }
+
+        /// <summary>
         /// Tests pushing a new parenting screen while the footer is displayed from a subscreen.
         /// </summary>
         [Test]

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1324,9 +1324,21 @@ namespace osu.Game
             // TODO: this is SUPER SUPER bad.
             // It can potentially exit the wrong screen if screens are not loaded yet.
             // ScreenFooter / ScreenBackButton should be aware of which screen it is currently being handled by.
-            if (!(ScreenStack.CurrentScreen is IOsuScreen currentScreen)) return;
+            if (ScreenStack.CurrentScreen is not IOsuScreen currentScreen) return;
 
-            if (!((Drawable)currentScreen).IsLoaded || (currentScreen.AllowUserExit && !currentScreen.OnBackButton())) ScreenStack.Exit();
+            // We expect exists to always be performed on the innermost screen stack.
+            if (currentScreen is IHasSubScreenStack subScreen)
+            {
+                performExit((IOsuScreen)subScreen.SubScreenStack.CurrentScreen);
+                return;
+            }
+
+            performExit(currentScreen);
+
+            void performExit(IOsuScreen screen)
+            {
+                if (!((Drawable)screen).IsLoaded || (screen.AllowUserExit && !screen.OnBackButton())) screen.Exit();
+            }
         }
 
         private void handleStartupImport()


### PR DESCRIPTION
cc @LiquidPL for visibility