### PR TITLE
Adjust RX-related multipliers

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -76,9 +76,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 readingRating = Math.Pow(readingRating, 0.8);
 
             if (mods.Any(m => m is OsuModRelax))
-                readingRating *= 0.7;
+                readingRating *= 0.6;
             else if (mods.Any(m => m is OsuModAutopilot))
-                readingRating *= 0.4;
+                readingRating *= 0.3;
 
             if (mods.Any(m => m is OsuModMagnetised))
             {

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -60,6 +60,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                 speedDifficulty = Math.Pow(speedDifficulty, 0.95);
             }
 
+            if (Mods.Any(m => m is OsuModRelax))
+            {
+                speedDifficulty *= 0.0;
+            }
+
             currentAimStrain *= decayAim;
             currentAimStrain += aimDifficulty * (1 - decayAim) * skillMultiplierAim;
 


### PR DESCRIPTION
<img width="1360" height="1191" alt="image" src="https://github.com/user-attachments/assets/223a76ef-06bc-4655-8acc-d5c4e42b213b" />
<img width="1360" height="1191" alt="image" src="https://github.com/user-attachments/assets/3044b389-23a2-408c-9706-4163abffaf8c" />
<img width="1360" height="1191" alt="image" src="https://github.com/user-attachments/assets/acde17fe-e673-426f-80d2-d5b1cc70e922" />

Mostly just keeping RX sane. I don't think we want to go too deep into the balancing here 