### PR TITLE
Fix reversing straight perfect curve sliders positioning them weirdly

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
@@ -3,10 +3,13 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Tests.Beatmaps;
@@ -58,13 +61,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         [TestCase(0, 250)]
         [TestCase(0, 200)]
-        [TestCase(1, 120, false)]
-        [TestCase(1, 80, false)]
+        [TestCase(1, 120, false, false)]
+        [TestCase(1, 80, false, false)]
         [TestCase(2, 250)]
         [TestCase(2, 190)]
         [TestCase(3, 250)]
         [TestCase(3, 190)]
-        public void TestSliderReversal(int pathIndex, double length, bool assertEqualDistances = true)
+        public void TestSliderReversal(int pathIndex, double length, bool assertEqualDistances = true, bool assertSliderReduction = true)
         {
             var controlPoints = paths[pathIndex];
 
@@ -146,6 +149,67 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
                 return oldControlPointTypes.Take(newControlPointTypes.Length).SequenceEqual(newControlPointTypes);
             });
+
+            if (assertSliderReduction)
+            {
+                AddStep("Move to marker", () =>
+                {
+                    var marker = this.ChildrenOfType<SliderEndDragMarker>().Single();
+                    var position = (marker.ScreenSpaceDrawQuad.TopRight + marker.ScreenSpaceDrawQuad.BottomRight) / 2;
+                    InputManager.MoveMouseTo(position);
+                });
+                AddStep("Click", () => InputManager.PressButton(MouseButton.Left));
+                AddStep("Reduce slider", () =>
+                {
+                    var middleControlPoint = this.ChildrenOfType<PathControlPointPiece<Slider>>().ToArray()[^2];
+                    InputManager.MoveMouseTo(middleControlPoint);
+                });
+                AddStep("Release click", () => InputManager.ReleaseButton(MouseButton.Left));
+
+                AddStep("Save half slider info", () =>
+                {
+                    oldStartPos = selectedSlider.Position;
+                    oldEndPos = selectedSlider.EndPosition;
+                    oldDistance = selectedSlider.Path.Distance;
+                });
+
+                AddStep("Reverse slider", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.G);
+                    InputManager.ReleaseKey(Key.LControl);
+                });
+
+                AddAssert("Middle control point has the same distance from start to end", () =>
+                {
+                    var pathControlPoints = selectedSlider.Path.ControlPoints;
+                    float middleToStart = Vector2.Distance(pathControlPoints[^2].Position, pathControlPoints[0].Position);
+                    float middleToEnd = Vector2.Distance(pathControlPoints[^2].Position, pathControlPoints[^1].Position);
+
+                    return Precision.AlmostEquals(middleToStart, middleToEnd, 1f);
+                });
+
+                AddAssert("Middle control point is not at start or end", () =>
+                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldStartPos) > 1 &&
+                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldEndPos) > 1
+                );
+
+                AddAssert("Slider has correct length", () =>
+                    Precision.AlmostEquals(selectedSlider.Path.Distance, oldDistance));
+
+                AddAssert("Slider has correct start position", () =>
+                    Vector2.Distance(selectedSlider.Position, oldEndPos) < 1);
+
+                AddAssert("Slider has correct end position", () =>
+                    Vector2.Distance(selectedSlider.EndPosition, oldStartPos) < 1);
+
+                AddAssert("Control points have correct types", () =>
+                {
+                    var newControlPointTypes = selectedSlider.Path.ControlPoints.Select(p => p.Type).ToArray();
+
+                    return oldControlPointTypes.Take(newControlPointTypes.Length).SequenceEqual(newControlPointTypes);
+                });
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             createPathSegment(
                 PathType.PERFECT_CURVE,
                 new Vector2(100.009f, -50),
-                new Vector2(200, -100)
+                new Vector2(200.0089f, -100)
             )
         };
 
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [TestCase(1, 120)]
         [TestCase(1, 80)]
         [TestCase(2, 250)]
-        [TestCase(2, 200)]
+        [TestCase(2, 190)]
         public void TestSliderReversal(int pathIndex, double length)
         {
             var controlPoints = paths[pathIndex];
@@ -105,6 +105,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                     InputManager.Key(Key.G);
                     InputManager.ReleaseKey(Key.LControl);
                 }, 2);
+
+                AddAssert("Middle control point is not at start or end", () =>
+                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldStartPos) >= 1 &&
+                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldEndPos) >= 1
+                );
             }
 
             AddAssert("Slider has correct length", () =>

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             ),
             createPathSegment(
                 PathType.PERFECT_CURVE,
-                new Vector2(100.009f, -50),
+                new Vector2(100.009f, -50.0009f),
                 new Vector2(200.0089f, -100)
             )
         };

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
@@ -30,6 +30,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 PathType.LINEAR,
                 new Vector2(100, 0),
                 new Vector2(100, 100)
+            ),
+            createPathSegment(
+                PathType.PERFECT_CURVE,
+                new Vector2(100.009f, -50),
+                new Vector2(200, -100)
             )
         };
 
@@ -50,6 +55,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [TestCase(0, 200)]
         [TestCase(1, 120)]
         [TestCase(1, 80)]
+        [TestCase(2, 250)]
+        [TestCase(2, 200)]
         public void TestSliderReversal(int pathIndex, double length)
         {
             var controlPoints = paths[pathIndex];
@@ -89,6 +96,16 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 InputManager.Key(Key.G);
                 InputManager.ReleaseKey(Key.LControl);
             });
+
+            if (pathIndex == 2)
+            {
+                AddRepeatStep("Reverse slider again", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.G);
+                    InputManager.ReleaseKey(Key.LControl);
+                }, 2);
+            }
 
             AddAssert("Slider has correct length", () =>
                 Precision.AlmostEquals(selectedSlider.Path.Distance, oldDistance));

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
@@ -35,6 +35,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 PathType.PERFECT_CURVE,
                 new Vector2(100.009f, -50.0009f),
                 new Vector2(200.0089f, -100)
+            ),
+            createPathSegment(
+                PathType.PERFECT_CURVE,
+                new Vector2(25, -50),
+                new Vector2(100, 75)
             )
         };
 
@@ -53,11 +58,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         [TestCase(0, 250)]
         [TestCase(0, 200)]
-        [TestCase(1, 120)]
-        [TestCase(1, 80)]
+        [TestCase(1, 120, false)]
+        [TestCase(1, 80, false)]
         [TestCase(2, 250)]
         [TestCase(2, 190)]
-        public void TestSliderReversal(int pathIndex, double length)
+        [TestCase(3, 250)]
+        [TestCase(3, 190)]
+        public void TestSliderReversal(int pathIndex, double length, bool assertEqualDistances = true)
         {
             var controlPoints = paths[pathIndex];
 
@@ -105,6 +112,18 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                     InputManager.Key(Key.G);
                     InputManager.ReleaseKey(Key.LControl);
                 }, 2);
+            }
+
+            if (assertEqualDistances)
+            {
+                AddAssert("Middle control point has the same distance from start to end", () =>
+                {
+                    var pathControlPoints = selectedSlider.Path.ControlPoints;
+                    float middleToStart = Vector2.Distance(pathControlPoints[^2].Position, pathControlPoints[0].Position);
+                    float middleToEnd = Vector2.Distance(pathControlPoints[^2].Position, pathControlPoints[^1].Position);
+
+                    return Precision.AlmostEquals(middleToStart, middleToEnd, 1f);
+                });
             }
 
             AddAssert("Middle control point is not at start or end", () =>

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
@@ -105,12 +105,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                     InputManager.Key(Key.G);
                     InputManager.ReleaseKey(Key.LControl);
                 }, 2);
-
-                AddAssert("Middle control point is not at start or end", () =>
-                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldStartPos) > 1 &&
-                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldEndPos) > 1
-                );
             }
+
+            AddAssert("Middle control point is not at start or end", () =>
+                Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldStartPos) > 1 &&
+                Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldEndPos) > 1
+            );
 
             AddAssert("Slider has correct length", () =>
                 Precision.AlmostEquals(selectedSlider.Path.Distance, oldDistance));

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderReversal.cs
@@ -107,8 +107,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 }, 2);
 
                 AddAssert("Middle control point is not at start or end", () =>
-                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldStartPos) >= 1 &&
-                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldEndPos) >= 1
+                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldStartPos) > 1 &&
+                    Vector2.Distance(selectedSlider.Path.ControlPoints[^2].Position, oldEndPos) > 1
                 );
             }
 

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -55,12 +55,7 @@ namespace osu.Game.Rulesets.Objects
             if (controlPoints.Count >= 3 && controlPoints[^3].Type == PathType.PERFECT_CURVE && controlPoints[^2].Type == null && segmentEnds.Any())
             {
                 double lastSegmentStart = segmentEnds.Length > 1 ? segmentEnds[^2] : 0;
-                double lastSegmentEnd = segmentEnds[^1] > 1 ? 1 : segmentEnds[^1];
-
-                if (controlPoints.Count == 3 && lastSegmentEnd < 1)
-                    lastSegmentEnd = 1;
-
-                controlPoints[^2].Position = sliderPath.PositionAt((lastSegmentStart + lastSegmentEnd) / 2);
+                controlPoints[^2].Position = sliderPath.PositionAt((lastSegmentStart + 1) / 2);
             }
 
             sliderPath.reverseControlPoints(out positionalOffset);

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects.Types;
@@ -55,25 +53,7 @@ namespace osu.Game.Rulesets.Objects
 
             // Recalculate middle perfect curve control points at the end of the slider path.
             if (controlPoints.Count >= 3 && controlPoints[^3].Type == PathType.PERFECT_CURVE && controlPoints[^2].Type == null && segmentEnds.Any())
-            {
-                double lastSegmentStart = segmentEnds.Length > 1 ? segmentEnds[^2] : 0;
-                double lastSegmentEnd = segmentEnds[^1];
-
-                var circleArcPath = new List<Vector2>();
-                sliderPath.GetPathToProgress(circleArcPath, lastSegmentStart / lastSegmentEnd, 1);
-
-                // If the arc path only contains 2 unique values the slider is not an arc
-                controlPoints[^2].Position = circleArcPath
-                                             .Select(v => (
-                                                 (int)Math.Round(v.X / 0.1f),
-                                                 (int)Math.Round(v.Y / 0.1f)
-                                             ))
-                                             .Distinct()
-                                             .Take(3)
-                                             .Count() > 2
-                    ? circleArcPath[circleArcPath.Count / 2]
-                    : Vector2.Divide(circleArcPath[^1], 2);
-            }
+                controlPoints[^2].Position = sliderPath.PositionAt(0.5);
 
             sliderPath.reverseControlPoints(out positionalOffset);
         }

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -53,7 +53,15 @@ namespace osu.Game.Rulesets.Objects
 
             // Recalculate middle perfect curve control points at the end of the slider path.
             if (controlPoints.Count >= 3 && controlPoints[^3].Type == PathType.PERFECT_CURVE && controlPoints[^2].Type == null && segmentEnds.Any())
-                controlPoints[^2].Position = sliderPath.PositionAt(0.5);
+            {
+                double lastSegmentStart = segmentEnds.Length > 1 ? segmentEnds[^2] : 0;
+                double lastSegmentEnd = segmentEnds[^1] > 1 ? 1 : segmentEnds[^1];
+
+                if (controlPoints.Count == 3 && lastSegmentEnd < 1)
+                    lastSegmentEnd = 1;
+
+                controlPoints[^2].Position = sliderPath.PositionAt((lastSegmentStart + lastSegmentEnd) / 2);
+            }
 
             sliderPath.reverseControlPoints(out positionalOffset);
         }

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Edit;
@@ -61,7 +62,19 @@ namespace osu.Game.Rulesets.Objects
                 var circleArcPath = new List<Vector2>();
                 sliderPath.GetPathToProgress(circleArcPath, lastSegmentStart / lastSegmentEnd, 1);
 
-                controlPoints[^2].Position = circleArcPath[circleArcPath.Count / 2];
+                // If there is only 2 unique values in the path the slider is straight,
+                // and we can just use the last control point's position divided by 2 to center.
+                if (circleArcPath
+                    .Select(v => (
+                        (int)Math.Round(v.X / 0.1f),
+                        (int)Math.Round(v.Y / 0.1f)
+                    ))
+                    .Distinct()
+                    .Take(3)
+                    .Count() > 2)
+                    controlPoints[^2].Position = circleArcPath[circleArcPath.Count / 2];
+                else
+                    controlPoints[^2].Position = new Vector2(circleArcPath[^1].X / 2, circleArcPath[^1].Y / 2);
             }
 
             sliderPath.reverseControlPoints(out positionalOffset);

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Rulesets.Objects
             if (controlPoints.Count >= 3 && controlPoints[^3].Type == PathType.PERFECT_CURVE && controlPoints[^2].Type == null && segmentEnds.Any())
             {
                 double lastSegmentStart = segmentEnds.Length > 1 ? segmentEnds[^2] : 0;
+
+                // we want to shorten the last perfect segment, preserving its shape, so that its end is consistent with the slider path's end.
+                // therefore we also reposition the middle point of the segment to be ideally halfway through its arc.
+                // the end of the segment is assumed to be at path position 1 at all times,
+                // but the start of the segment cannot be assumed to be at 0 because multi-segment sliders exist.
                 controlPoints[^2].Position = sliderPath.PositionAt((lastSegmentStart + 1) / 2);
             }
 

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Objects
                     .Count() > 2)
                     controlPoints[^2].Position = circleArcPath[circleArcPath.Count / 2];
                 else
-                    controlPoints[^2].Position = new Vector2(circleArcPath[^1].X / 2, circleArcPath[^1].Y / 2);
+                    controlPoints[^2].Position = Vector2.Divide(circleArcPath[^1], 2);
             }
 
             sliderPath.reverseControlPoints(out positionalOffset);

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -62,19 +62,17 @@ namespace osu.Game.Rulesets.Objects
                 var circleArcPath = new List<Vector2>();
                 sliderPath.GetPathToProgress(circleArcPath, lastSegmentStart / lastSegmentEnd, 1);
 
-                // If there is only 2 unique values in the path the slider is straight,
-                // and we can just use the last control point's position divided by 2 to center.
-                if (circleArcPath
-                    .Select(v => (
-                        (int)Math.Round(v.X / 0.1f),
-                        (int)Math.Round(v.Y / 0.1f)
-                    ))
-                    .Distinct()
-                    .Take(3)
-                    .Count() > 2)
-                    controlPoints[^2].Position = circleArcPath[circleArcPath.Count / 2];
-                else
-                    controlPoints[^2].Position = Vector2.Divide(circleArcPath[^1], 2);
+                // If the arc path only contains 2 unique values the slider is not an arc
+                controlPoints[^2].Position = circleArcPath
+                                             .Select(v => (
+                                                 (int)Math.Round(v.X / 0.1f),
+                                                 (int)Math.Round(v.Y / 0.1f)
+                                             ))
+                                             .Distinct()
+                                             .Take(3)
+                                             .Count() > 2
+                    ? circleArcPath[circleArcPath.Count / 2]
+                    : Vector2.Divide(circleArcPath[^1], 2);
             }
 
             sliderPath.reverseControlPoints(out positionalOffset);


### PR DESCRIPTION
Closes #35919

To find the right position for the middle control point the code currently retrieves the slider's path to the end, saves it at `circleArcPath` and uses the middle index with `circleArcPath.Count / 2` to reposition the middle control point.

If the slider is perfectly straight aligned its `circleArcPath` can look like:

```
0 (0,0)
1 (0,0)
2 (-107.337265, -47.14827)
3 (-107.337265, -47.14827)
```
or 
```
0 (0,0)
1 (0,0)
2 (-0.00012207031, 0)
3 (-107.337265, -47.14827)
4 (-107.337265, -47.14827)
```
In example 1 the picked index is the end of the slider
In example 2 the picked index is the start of the slider

This PR adds a check to see if there are more than two unique values in the `circleArcPath`, rounding the coordinates to deal with a possible float number. 

If we have more than two the behavior is kept unchanged, if we don't have more than 2 unique coordinates the slider does not have an arc and we can use the last control point's coordinates divided by 2 to find the middle of the slider.


https://github.com/user-attachments/assets/23e283f1-25ff-456f-8cc4-b217c158b3c7

https://github.com/user-attachments/assets/c3556199-87ea-4cad-9cf6-47ca610997f7