### PR TITLE
Use better text structure for `ScreenshotSaved` notification

### DIFF
--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -236,9 +236,11 @@ Click to see what's new!", version);
         public static LocalisableString ElevatedPrivileges(LocalisableString user) => new TranslatableString(getKey(@"elevated_privileges"), @"Running osu! as {0} does not improve performance, may break integrations and poses a security risk. Please run the game as a normal user.", user);
 
         /// <summary>
-        /// "Screenshot {0} saved!"
+        /// "Screenshot saved!
+        /// {0}"
         /// </summary>
-        public static LocalisableString ScreenshotSaved(string filename) => new TranslatableString(getKey(@"screenshot_saved"), @"Screenshot {0} saved!", filename);
+        public static LocalisableString ScreenshotSaved(string filename) => new TranslatableString(getKey(@"screenshot_saved"), @"Screenshot saved!
+{0}", filename);
 
         /// <summary>
         /// "The multiplayer server will be right back..."

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -236,10 +236,10 @@ Click to see what's new!", version);
         public static LocalisableString ElevatedPrivileges(LocalisableString user) => new TranslatableString(getKey(@"elevated_privileges"), @"Running osu! as {0} does not improve performance, may break integrations and poses a security risk. Please run the game as a normal user.", user);
 
         /// <summary>
-        /// "Screenshot saved!
+        /// "Screenshot saved! Click to view.
         /// {0}"
         /// </summary>
-        public static LocalisableString ScreenshotSaved(string filename) => new TranslatableString(getKey(@"screenshot_saved"), @"Screenshot saved!
+        public static LocalisableString ScreenshotSaved(string filename) => new TranslatableString(getKey(@"screenshot_saved"), @"Screenshot saved! Click to view.
 {0}", filename);
 
         /// <summary>


### PR DESCRIPTION
reads a bit better when filename isn't in main text

also added "click to view" text by analogy with `LogsExportFinished`

| master | pr |
|-|-|
| <img width="336" height="114" alt="image" src="https://github.com/user-attachments/assets/2555390c-1299-43ae-9be5-cb8d091b3387" /> | <img width="336" height="108" alt="image" src="https://github.com/user-attachments/assets/a8f18d9f-fa11-4d8f-82af-c88b0f82576c" /> |