### PR TITLE
Save current editor screen mode for restoration

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -114,6 +114,25 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestScreenModePreservedAfterSwitch()
+        {
+            BeatmapInfo targetDifficulty = null;
+
+            AddStep("switch to timing screen", () => Editor.Mode.Value = EditorScreenMode.Timing);
+
+            AddStep("set target difficulty", () => targetDifficulty = importedBeatmapSet.Beatmaps.Last(beatmap => !beatmap.Equals(Beatmap.Value.BeatmapInfo)));
+            switchToDifficulty(() => targetDifficulty);
+            confirmEditingBeatmap(() => targetDifficulty);
+
+            AddAssert("timing screen displayed", () => Editor.Mode.Value == EditorScreenMode.Timing);
+
+            AddStep("exit editor", () => Stack.Exit());
+
+            // ensure editor loader didn't resume.
+            AddAssert("stack empty", () => Stack.CurrentScreen == null);
+        }
+
+        [Test]
         public void TestPreventSwitchDueToUnsavedChanges()
         {
             BeatmapInfo targetDifficulty = null;

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Edit.Compose
 
         private Bindable<string> clipboard { get; set; }
 
-        private HitObjectComposer composer;
+        public HitObjectComposer Composer { get; private set; }
 
         public ComposeScreen()
             : base(EditorScreenMode.Compose)
@@ -50,26 +50,26 @@ namespace osu.Game.Screens.Edit.Compose
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
             ruleset = parent.Get<IBindable<WorkingBeatmap>>().Value.BeatmapInfo.Ruleset.CreateInstance();
-            composer = ruleset?.CreateHitObjectComposer();
+            Composer = ruleset?.CreateHitObjectComposer();
 
             // make the composer available to the timeline and other components in this screen.
-            if (composer != null)
-                dependencies.CacheAs(composer);
+            if (Composer != null)
+                dependencies.CacheAs(Composer);
 
             return dependencies;
         }
 
         protected override Drawable CreateMainContent()
         {
-            if (ruleset == null || composer == null)
+            if (ruleset == null || Composer == null)
                 return new ScreenWhiteBox.UnderConstructionMessage(ruleset == null ? "This beatmap" : $"{ruleset.Description}'s composer");
 
-            return wrapSkinnableContent(composer);
+            return wrapSkinnableContent(Composer);
         }
 
         protected override Drawable CreateTimelineContent()
         {
-            if (ruleset == null || composer == null)
+            if (ruleset == null || Composer == null)
                 return base.CreateTimelineContent();
 
             TimelineBreakDisplay breakDisplay = new TimelineBreakDisplay
@@ -88,7 +88,7 @@ namespace osu.Game.Screens.Edit.Compose
                     // We want to display this below hitobjects to better expose placement objects visually.
                     // It needs to be above the blueprint container to handle drags on breaks though.
                     breakDisplay.CreateProxy(),
-                    new TimelineBlueprintContainer(composer),
+                    new TimelineBlueprintContainer(Composer),
                     breakDisplay
                 }
             });
@@ -112,12 +112,12 @@ namespace osu.Game.Screens.Edit.Compose
             base.LoadComplete();
 
             // May be null in the case of a ruleset that doesn't have editor support, see CreateMainContent().
-            if (composer == null)
+            if (Composer == null)
                 return;
 
             EditorBeatmap.SelectedHitObjects.BindCollectionChanged((_, _) => updateClipboardActionAvailability());
             clipboard.BindValueChanged(_ => updateClipboardActionAvailability());
-            composer.OnLoadComplete += _ => updateClipboardActionAvailability();
+            Composer.OnLoadComplete += _ => updateClipboardActionAvailability();
             updateClipboardActionAvailability();
         }
 
@@ -173,16 +173,16 @@ namespace osu.Game.Screens.Edit.Compose
         private void updateClipboardActionAvailability()
         {
             CanCut.Value = CanCopy.Value = EditorBeatmap.SelectedHitObjects.Any();
-            CanPaste.Value = composer.IsLoaded && !string.IsNullOrEmpty(clipboard.Value);
+            CanPaste.Value = Composer.IsLoaded && !string.IsNullOrEmpty(clipboard.Value);
         }
 
         private string getTimestamp()
         {
-            if (composer == null)
+            if (Composer == null)
                 return string.Empty;
 
             double displayTime = EditorBeatmap.SelectedHitObjects.MinBy(h => h.StartTime)?.StartTime ?? clock.CurrentTime;
-            string selectionAsString = composer.ConvertSelectionToString();
+            string selectionAsString = Composer.ConvertSelectionToString();
 
             return !string.IsNullOrEmpty(selectionAsString)
                 ? $"{displayTime.ToEditorFormattedString()} ({selectionAsString}) - "

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -516,6 +516,7 @@ namespace osu.Game.Screens.Edit
         /// </param>
         public EditorState GetState([CanBeNull] RulesetInfo nextRuleset = null) => new EditorState
         {
+            ScreenMode = Mode.Value,
             Time = clock.CurrentTimeAccurate,
             ClipboardContent = nextRuleset == null || editorBeatmap.BeatmapInfo.Ruleset.ShortName == nextRuleset.ShortName ? Clipboard.Content.Value : string.Empty
         };
@@ -526,6 +527,7 @@ namespace osu.Game.Screens.Edit
         /// <param name="state">The state to restore.</param>
         public void RestoreState([NotNull] EditorState state) => Schedule(() =>
         {
+            Mode.Value = state.ScreenMode;
             clock.Seek(state.Time);
             Clipboard.Content.Value = state.ClipboardContent;
         });

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -487,7 +487,8 @@ namespace osu.Game.Screens.Edit
             base.LoadComplete();
             setUpClipboardActionAvailability();
 
-            Mode.Value = isNewBeatmap ? EditorScreenMode.SongSetup : EditorScreenMode.Compose;
+            if (Mode.Value == EditorScreenMode.SongSetup && !isNewBeatmap)
+                Mode.Value = EditorScreenMode.Compose;
 
             // AddOnce here ensures we don't unnecessarily load multiple modes when entering the editor.
             // See case where Mode is restored via `RestoreState`.

--- a/osu.Game/Screens/Edit/EditorState.cs
+++ b/osu.Game/Screens/Edit/EditorState.cs
@@ -9,6 +9,11 @@ namespace osu.Game.Screens.Edit
     public class EditorState
     {
         /// <summary>
+        /// The current editor screen being displayed.
+        /// </summary>
+        public EditorScreenMode ScreenMode { get; set; }
+
+        /// <summary>
         /// The current audio time.
         /// </summary>
         public double Time { get; set; }


### PR DESCRIPTION
This PR added the function to store the editor's current screen via `EditorState`.

When the difficulty is changed (either new or existing difficulty), the editor will come back with the same screen instead of the Compose screen by default. This is convenient in some cases, like checking metadata consistency across difficulties and looking for detected errors.

This only affects difficulty changes inside the editor. i.e. the specified screen would still be displayed when entering the editor from outside.
