### PR TITLE
Fix spectator player cells not having initial shadow edge effect set

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.Cell.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.Cell.cs
@@ -47,6 +47,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
                 Masking = true;
                 CornerRadius = 5;
+
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Shadow,
+                    Radius = 10,
+                    Colour = Colour4.Black.Opacity(0.2f),
+                };
             }
 
             protected override void Update()


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/36727

Copies/sets the non-maximised edge effect initially:

https://github.com/ppy/osu/blob/c144cf188a37ebc965b25818938527c02013efc4/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.Cell.cs#L83-L88