### PR TITLE
fix(macOS): reapply cursor confinement each frame as workaround for input loss

### DIFF
--- a/osu.Desktop/LegacyIpc/LegacyIpcMessage.cs
+++ b/osu.Desktop/LegacyIpc/LegacyIpcMessage.cs
@@ -1,8 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Platform;
 using Newtonsoft.Json.Linq;
+using osu.Framework.Platform;
 
 namespace osu.Desktop.LegacyIpc
 {
@@ -12,13 +12,13 @@ namespace osu.Desktop.LegacyIpc
     /// In order to deserialise types at either end, types must be serialised as their <see cref="System.Type.AssemblyQualifiedName"/>,
     /// however this cannot be done since osu!stable and osu!lazer live in two different assemblies.
     /// <br />
-    /// To get around this, this class exists which serialises a payload (<see cref="LegacyIpcMessage.Data"/>) as an <see cref="System.Object"/> type,
+    /// To get around this, this class exists which serialises a payload (<see cref="Data"/>) as an <see cref="object"/> type,
     /// which can be deserialised at either end because it is part of the core library (mscorlib / System.Private.CorLib).
     /// The payload contains the data to be sent over the IPC channel.
     /// <br />
-    /// At either end, Json.NET deserialises the payload into a <see cref="JObject"/> which is manually converted back into the expected <see cref="LegacyIpcMessage.Data"/> type,
+    /// At either end, Json.NET deserialises the payload into a <see cref="JObject"/> which is manually converted back into the expected <see cref="Data"/> type,
     /// which then further contains another <see cref="JObject"/> representing the data sent over the IPC channel whose type can likewise be lazily matched through
-    /// <see cref="LegacyIpcMessage.Data.MessageType"/>.
+    /// <see cref="Data.MessageType"/>.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/osu.Desktop/NVAPI.cs
+++ b/osu.Desktop/NVAPI.cs
@@ -119,11 +119,13 @@ namespace osu.Desktop
                 if (!IsLaptop)
                     return false;
 
-                if (!getProfile(out nint profileHandle, out _, out bool _))
+                IntPtr profileHandle;
+                if (!getProfile(out profileHandle, out _, out bool _))
                     return false;
 
                 // Get the optimus setting
-                if (!getSetting(NvSettingID.SHIM_RENDERING_MODE_ID, profileHandle, out var setting))
+                NvSetting setting;
+                if (!getSetting(NvSettingID.SHIM_RENDERING_MODE_ID, profileHandle, out setting))
                     return false;
 
                 return (setting.U32CurrentValue & (uint)NvShimSetting.SHIM_RENDERING_MODE_ENABLE) > 0;
@@ -162,11 +164,13 @@ namespace osu.Desktop
                 if (!Available)
                     return NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
 
-                if (!getProfile(out nint profileHandle, out _, out bool _))
+                IntPtr profileHandle;
+                if (!getProfile(out profileHandle, out _, out bool _))
                     return NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
 
                 // Get the threaded optimisations setting
-                if (!getSetting(NvSettingID.OGL_THREAD_CONTROL_ID, profileHandle, out var setting))
+                NvSetting setting;
+                if (!getSetting(NvSettingID.OGL_THREAD_CONTROL_ID, profileHandle, out setting))
                     return NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
 
                 return (NvThreadControlSetting)setting.U32CurrentValue;
@@ -286,7 +290,10 @@ namespace osu.Desktop
 
         private static bool setSetting(NvSettingID settingId, uint settingValue)
         {
-            if (!getProfile(out nint profileHandle, out var application, out bool isApplicationSpecific))
+            NvApplication application;
+            IntPtr profileHandle;
+            bool isApplicationSpecific;
+            if (!getProfile(out profileHandle, out application, out isApplicationSpecific))
                 return false;
 
             if (!isApplicationSpecific)
@@ -371,8 +378,8 @@ namespace osu.Desktop
                     return;
                 }
 
-                getDelegate(0x0150E828, out
-                InitializeDelegate initialize);
+                InitializeDelegate initialize;
+                getDelegate(0x0150E828, out initialize);
 
                 if (initialize?.Invoke() == NvStatus.OK)
                 {

--- a/osu.Desktop/NVAPI.cs
+++ b/osu.Desktop/NVAPI.cs
@@ -119,13 +119,11 @@ namespace osu.Desktop
                 if (!IsLaptop)
                     return false;
 
-                IntPtr profileHandle;
-                if (!getProfile(out profileHandle, out _, out bool _))
+                if (!getProfile(out nint profileHandle, out _, out bool _))
                     return false;
 
                 // Get the optimus setting
-                NvSetting setting;
-                if (!getSetting(NvSettingID.SHIM_RENDERING_MODE_ID, profileHandle, out setting))
+                if (!getSetting(NvSettingID.SHIM_RENDERING_MODE_ID, profileHandle, out var setting))
                     return false;
 
                 return (setting.U32CurrentValue & (uint)NvShimSetting.SHIM_RENDERING_MODE_ENABLE) > 0;
@@ -164,13 +162,11 @@ namespace osu.Desktop
                 if (!Available)
                     return NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
 
-                IntPtr profileHandle;
-                if (!getProfile(out profileHandle, out _, out bool _))
+                if (!getProfile(out nint profileHandle, out _, out bool _))
                     return NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
 
                 // Get the threaded optimisations setting
-                NvSetting setting;
-                if (!getSetting(NvSettingID.OGL_THREAD_CONTROL_ID, profileHandle, out setting))
+                if (!getSetting(NvSettingID.OGL_THREAD_CONTROL_ID, profileHandle, out var setting))
                     return NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
 
                 return (NvThreadControlSetting)setting.U32CurrentValue;
@@ -290,10 +286,7 @@ namespace osu.Desktop
 
         private static bool setSetting(NvSettingID settingId, uint settingValue)
         {
-            NvApplication application;
-            IntPtr profileHandle;
-            bool isApplicationSpecific;
-            if (!getProfile(out profileHandle, out application, out isApplicationSpecific))
+            if (!getProfile(out nint profileHandle, out var application, out bool isApplicationSpecific))
                 return false;
 
             if (!isApplicationSpecific)
@@ -378,8 +371,8 @@ namespace osu.Desktop
                     return;
                 }
 
-                InitializeDelegate initialize;
-                getDelegate(0x0150E828, out initialize);
+                getDelegate(0x0150E828, out
+                InitializeDelegate initialize);
 
                 if (initialize?.Invoke() == NvStatus.OK)
                 {

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -9,19 +9,19 @@ using System.Threading.Tasks;
 using Microsoft.Win32;
 using osu.Desktop.Performance;
 using osu.Desktop.Security;
+using osu.Desktop.Updater;
+using osu.Desktop.Windows;
+using osu.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game;
-using osu.Desktop.Updater;
-using osu.Framework;
-using osu.Framework.Logging;
-using osu.Game.Updater;
-using osu.Desktop.Windows;
-using osu.Framework.Allocation;
 using osu.Game.Configuration;
 using osu.Game.IO;
 using osu.Game.IPC;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Performance;
+using osu.Game.Updater;
 using osu.Game.Utils;
 
 namespace osu.Desktop

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Layout;
 using osu.Framework.Platform;
+using RuntimeInfo = osu.Framework.RuntimeInfo;
 using osu.Framework.Screens;
 using osu.Game.Configuration;
 using osu.Game.Screens;
@@ -281,11 +282,19 @@ namespace osu.Game.Graphics.Containers
             {
                 base.Update();
 
-                if (confineHostCursor && !cursorRectCache.IsValid)
+                if (!confineHostCursor) return;
+
+                if (!cursorRectCache.IsValid)
                 {
                     updateHostCursorConfineRect();
                     cursorRectCache.Validate();
                 }
+
+                // On macOS, cursor confinement/capture can sometimes be lost after certain
+                // interactions (eg. repeated slider clicks). Reapply the confine rect each
+                // frame as a defensive workaround to ensure the host receives mouse input.
+                if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
+                    updateHostCursorConfineRect();
             }
 
             private void updateHostCursorConfineRect()


### PR DESCRIPTION
Haii!!

On macOS, cursor confinement can randomly be lost during gameplay. This causes the cursor to escape the window when moving it downward while holding a key - which breaks slider tracking
Reapplying the confine rect each frame on macOS prevents this from happening.
happens randomly, roughly once every few restarts. (???)

tl;dr - a held key on the keyboard with a 40% chance = loss of mouse input