### PR TITLE
Fix transient user stats animation changing speed after first display

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -45,12 +45,6 @@ namespace osu.Game.Overlays.Toolbar
                 Icon = icon,
             });
 
-        public LocalisableString Text
-        {
-            get => DrawableText.Text;
-            set => DrawableText.Text = value;
-        }
-
         public LocalisableString TooltipMain
         {
             get => tooltip1.Text;
@@ -67,7 +61,6 @@ namespace osu.Game.Overlays.Toolbar
 
         protected readonly Container ButtonContent;
         protected ConstrainedIconContainer IconContainer;
-        protected SpriteText DrawableText;
         protected Box HoverBackground;
         private readonly Box flashBackground;
         private readonly FillFlowContainer tooltipContainer;
@@ -138,11 +131,6 @@ namespace osu.Game.Overlays.Toolbar
                                     Origin = Anchor.CentreLeft,
                                     Size = new Vector2(20),
                                     Alpha = 0,
-                                },
-                                DrawableText = new OsuSpriteText
-                                {
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.CentreLeft,
                                 },
                             },
                         },

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -117,7 +117,6 @@ namespace osu.Game.Overlays.Toolbar
                         Flow = new FillFlowContainer
                         {
                             Direction = FillDirection.Horizontal,
-                            Spacing = new Vector2(5),
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Padding = new MarginPadding { Left = Toolbar.HEIGHT / 2, Right = Toolbar.HEIGHT / 2 },

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Overlays.Toolbar
                 Origin = Anchor.CentreLeft,
                 Width = 3f,
                 Height = IconContainer.Height,
-                Margin = new MarginPadding { Horizontal = 2.5f },
+                Margin = new MarginPadding { Left = 7.5f, Right = 2.5f },
                 Masking = true,
                 Children = new[]
                 {

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
@@ -32,6 +33,8 @@ namespace osu.Game.Overlays.Toolbar
 
         private IBindable<APIState> apiState = null!;
 
+        private OsuSpriteText usernameText = null!;
+
         public ToolbarUserButton()
         {
             ButtonContent.AutoSizeAxes = Axes.X;
@@ -42,6 +45,12 @@ namespace osu.Game.Overlays.Toolbar
         {
             Flow.AddRange(new Drawable[]
             {
+                usernameText = new OsuSpriteText
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding { Right = 5 },
+                },
                 new Container
                 {
                     Masking = true,
@@ -80,7 +89,7 @@ namespace osu.Game.Overlays.Toolbar
                         },
                     }
                 },
-                new TransientUserStatisticsUpdateDisplay(),
+                new TransientUserStatisticsUpdateDisplay()
             });
 
             apiState = api.State.GetBoundCopy();
@@ -94,7 +103,7 @@ namespace osu.Game.Overlays.Toolbar
 
         private void userChanged(ValueChangedEvent<APIUser> user) => Schedule(() =>
         {
-            Text = user.NewValue.Username;
+            usernameText.Text = user.NewValue.Username;
             avatar.User = user.NewValue;
         });
 

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -89,7 +89,10 @@ namespace osu.Game.Overlays.Toolbar
                         },
                     }
                 },
-                new TransientUserStatisticsUpdateDisplay()
+                new TransientUserStatisticsUpdateDisplay
+                {
+                    Alpha = 0,
+                }
             });
 
             apiState = api.State.GetBoundCopy();

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -40,51 +40,48 @@ namespace osu.Game.Overlays.Toolbar
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, IAPIProvider api, LoginOverlay? login)
         {
-            Flow.Add(new Container
+            Flow.AddRange(new Drawable[]
             {
-                Masking = true,
-                CornerRadius = 4,
-                Size = new Vector2(32),
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                EdgeEffect = new EdgeEffectParameters
+                new Container
                 {
-                    Type = EdgeEffectType.Shadow,
-                    Radius = 4,
-                    Colour = Color4.Black.Opacity(0.1f),
+                    Masking = true,
+                    CornerRadius = 4,
+                    Size = new Vector2(32),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Radius = 4,
+                        Colour = Color4.Black.Opacity(0.1f),
+                    },
+                    Children = new Drawable[]
+                    {
+                        avatar = new UpdateableAvatar(isInteractive: false)
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        spinner = new LoadingLayer(dimBackground: true, withBox: false)
+                        {
+                            BlockPositionalInput = false,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        failingIcon = new SpriteIcon
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Alpha = 0,
+                            Size = new Vector2(0.3f),
+                            Icon = FontAwesome.Solid.ExclamationTriangle,
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colours.YellowLight,
+                        },
+                    }
                 },
-                Children = new Drawable[]
-                {
-                    avatar = new UpdateableAvatar(isInteractive: false)
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    spinner = new LoadingLayer(dimBackground: true, withBox: false)
-                    {
-                        BlockPositionalInput = false,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    failingIcon = new SpriteIcon
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Alpha = 0,
-                        Size = new Vector2(0.3f),
-                        Icon = FontAwesome.Solid.ExclamationTriangle,
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colours.YellowLight,
-                    },
-                }
+                new TransientUserStatisticsUpdateDisplay(),
             });
-
-            Flow.Add(new TransientUserStatisticsUpdateDisplay
-            {
-                Alpha = 0
-            });
-            Flow.AutoSizeEasing = Easing.OutQuint;
-            Flow.AutoSizeDuration = 250;
 
             apiState = api.State.GetBoundCopy();
             apiState.BindValueChanged(onlineStateChanged, true);

--- a/osu.Game/Overlays/Toolbar/TransientUserStatisticsUpdateDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/TransientUserStatisticsUpdateDisplay.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Overlays.Toolbar
         private void load(UserStatisticsWatcher? userStatisticsWatcher)
         {
             RelativeSizeAxes = Axes.Y;
-            Alpha = 0;
 
             InternalChild = new FillFlowContainer
             {

--- a/osu.Game/Overlays/Toolbar/TransientUserStatisticsUpdateDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/TransientUserStatisticsUpdateDisplay.cs
@@ -26,11 +26,12 @@ namespace osu.Game.Overlays.Toolbar
         private Statistic<int> globalRank = null!;
         private Statistic<int> pp = null!;
 
+        private ScheduledDelegate? shrinkDelegate;
+
         [BackgroundDependencyLoader]
         private void load(UserStatisticsWatcher? userStatisticsWatcher)
         {
             RelativeSizeAxes = Axes.Y;
-            AutoSizeAxes = Axes.X;
             Alpha = 0;
 
             InternalChild = new FillFlowContainer
@@ -40,7 +41,7 @@ namespace osu.Game.Overlays.Toolbar
                 Padding = new MarginPadding { Horizontal = 10 },
                 Spacing = new Vector2(10),
                 Direction = FillDirection.Horizontal,
-                Children = new Drawable[]
+                Children = new[]
                 {
                     globalRank = new Statistic<int>(UsersStrings.ShowRankGlobalSimple, @"#", Comparer<int>.Create((before, after) => before - after)),
                     pp = new Statistic<int>(RankingsStrings.StatPerformance, string.Empty, Comparer<int>.Create((before, after) => Math.Sign(after - before))),
@@ -71,8 +72,7 @@ namespace osu.Game.Overlays.Toolbar
                     return;
 
                 FinishTransforms(true);
-
-                this.FadeIn(500, Easing.OutQuint);
+                shrinkDelegate?.Cancel();
 
                 if (update.After.GlobalRank != null)
                 {
@@ -90,7 +90,21 @@ namespace osu.Game.Overlays.Toolbar
                     pp.Display(before, delta, after);
                 }
 
-                this.Delay(5000).FadeOut(500, Easing.OutQuint);
+                this.FadeIn(500, Easing.OutQuint);
+
+                AutoSizeAxes = Axes.X;
+                AutoSizeDuration = 500;
+                AutoSizeEasing = Easing.OutQuint;
+
+                using (BeginDelayedSequence(5000))
+                {
+                    this.FadeOut(500, Easing.OutQuint);
+                    shrinkDelegate = Schedule(() =>
+                    {
+                        AutoSizeAxes = Axes.None;
+                        this.ResizeWidthTo(0, 500, Easing.OutQuint);
+                    });
+                }
             });
         }
 


### PR DESCRIPTION
This is a bit of an annoying one. The actual issue is that the first time this control is displayed, the transient component is *moving* from `x=0` to its final location, which makes the animation look smoother on first display. Subsequent displays already have the correct `x` location so only the width resize part animates, causing a much faster animation.

As a solution, I've moved the animation to not use `FlowDuration` / `AutoSizeDuration` at the outer level. This also means there's less custom stuff on the `ToolbarButton.Flow` which is a win.

To make things work well, I had to remove the `Spacing` because as we know, `Spacing` doesn't work well with fill flow animations. See individual commits for the "unrelated" refactors required to make this happen sanely.

Closes https://github.com/ppy/osu/issues/36477
