### PR TITLE
Attempt to fix "copy labels from issues" workflow permissions again

### DIFF
--- a/.github/workflows/pull-request-copy-labels.yml
+++ b/.github/workflows/pull-request-copy-labels.yml
@@ -5,8 +5,8 @@ on:
     types: [opened]
 
 permissions:
-  issues: write # to read the labels of any linked issue(s), and to put the found labels if any on the PR
-  # not granting any `pull_requests` permissions because in github's modeling pull requests are a subset of issues. it's confusing.
+  issues: read # to read the labels of any linked issue(s)
+  pull-requests: write # to put the found labels if any on the PR
 
 jobs:
   copy-labels:


### PR DESCRIPTION
It's [still broken](https://github.com/ppy/osu/actions/runs/22310482792/job/64540909415) and I'm not sure what else it could be other than this, so I'm giving it one more honest try before I throw up hands.

For better or worse, there's [github documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) which explicitly lists that the `pull-requests` permission allows tagging PRs, so I'm holding out hope that this is it. Still terrible marks for documentation here, both to the github action, as well as everything to do with `GITHUB_TOKEN`.