### PR TITLE
Use `HotkeyDisplay` for toolbar buttons

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -180,16 +180,16 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override bool OnHover(HoverEvent e)
         {
-            HoverBackground.FadeIn(200);
-            tooltipContainer.FadeIn(100);
+            HoverBackground.FadeIn(300, Easing.OutQuint);
+            tooltipContainer.FadeIn(200, Easing.OutQuint);
 
             return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            HoverBackground.FadeOut(200);
-            tooltipContainer.FadeOut(100);
+            HoverBackground.FadeOut(200, Easing.Out);
+            tooltipContainer.FadeOut(100, Easing.Out);
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
-using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
@@ -36,14 +33,7 @@ namespace osu.Game.Overlays.Toolbar
             IconContainer.Show();
         }
 
-        [Resolved]
-        private ReadableKeyCombinationProvider keyCombinationProvider { get; set; } = null!;
-
-        public void SetIcon(IconUsage icon) =>
-            SetIcon(new SpriteIcon
-            {
-                Icon = icon,
-            });
+        public void SetIcon(IconUsage icon) => SetIcon(new SpriteIcon { Icon = icon });
 
         public LocalisableString TooltipMain
         {
@@ -66,15 +56,11 @@ namespace osu.Game.Overlays.Toolbar
         private readonly FillFlowContainer tooltipContainer;
         private readonly SpriteText tooltip1;
         private readonly SpriteText tooltip2;
-        private HotkeyDisplay keyBindingTooltip;
         protected FillFlowContainer Flow;
 
         protected readonly Container BackgroundContent;
 
-        private IDisposable? realmSubscription;
-
-        [Resolved]
-        private RealmAccess realm { get; set; } = null!;
+        private readonly FillFlowContainer subTooltipFlow;
 
         protected ToolbarButton()
         {
@@ -152,7 +138,7 @@ namespace osu.Game.Overlays.Toolbar
                             Shadow = true,
                             Font = OsuFont.GetFont(size: 22, weight: FontWeight.Bold),
                         },
-                        new FillFlowContainer
+                        subTooltipFlow = new FillFlowContainer
                         {
                             AutoSizeAxes = Axes.Both,
                             Anchor = TooltipAnchor,
@@ -161,11 +147,6 @@ namespace osu.Game.Overlays.Toolbar
                             Children = new Drawable[]
                             {
                                 tooltip2 = new OsuSpriteText { Shadow = true },
-                                keyBindingTooltip = new HotkeyDisplay()
-                                {
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                }
                             }
                         }
                     }
@@ -178,8 +159,13 @@ namespace osu.Game.Overlays.Toolbar
         {
             if (Hotkey != null)
             {
-                keyBindingTooltip.Hotkey = new Hotkey(Hotkey.Value);
-                keyBindingTooltip.Margin = new MarginPadding { Left = 3 };
+                subTooltipFlow.Add(new HotkeyDisplay
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Hotkey = new Hotkey(Hotkey.Value),
+                    Margin = new MarginPadding { Left = 3 },
+                });
             }
         }
 
@@ -219,13 +205,6 @@ namespace osu.Game.Overlays.Toolbar
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            realmSubscription?.Dispose();
         }
     }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -18,6 +17,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osuTK;
 using osuTK.Graphics;
@@ -66,7 +66,7 @@ namespace osu.Game.Overlays.Toolbar
         private readonly FillFlowContainer tooltipContainer;
         private readonly SpriteText tooltip1;
         private readonly SpriteText tooltip2;
-        private readonly SpriteText keyBindingTooltip;
+        private HotkeyDisplay keyBindingTooltip;
         protected FillFlowContainer Flow;
 
         protected readonly Container BackgroundContent;
@@ -158,10 +158,14 @@ namespace osu.Game.Overlays.Toolbar
                             Anchor = TooltipAnchor,
                             Origin = TooltipAnchor,
                             Direction = FillDirection.Horizontal,
-                            Children = new[]
+                            Children = new Drawable[]
                             {
                                 tooltip2 = new OsuSpriteText { Shadow = true },
-                                keyBindingTooltip = new OsuSpriteText { Shadow = true }
+                                keyBindingTooltip = new HotkeyDisplay()
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                }
                             }
                         }
                     }
@@ -174,8 +178,8 @@ namespace osu.Game.Overlays.Toolbar
         {
             if (Hotkey != null)
             {
-                realmSubscription = realm.SubscribeToPropertyChanged(r => r.All<RealmKeyBinding>().FirstOrDefault(rkb => rkb.RulesetName == null && rkb.ActionInt == (int)Hotkey.Value),
-                    kb => kb.KeyCombinationString, updateKeyBindingTooltip);
+                keyBindingTooltip.Hotkey = new Hotkey(Hotkey.Value);
+                keyBindingTooltip.Margin = new MarginPadding { Left = 3 };
             }
         }
 
@@ -215,15 +219,6 @@ namespace osu.Game.Overlays.Toolbar
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
-        }
-
-        private void updateKeyBindingTooltip(string keyCombination)
-        {
-            string keyBindingString = keyCombinationProvider.GetReadableString(keyCombination);
-
-            keyBindingTooltip.Text = !string.IsNullOrEmpty(keyBindingString)
-                ? $" ({keyBindingString})"
-                : string.Empty;
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Uses `HotkeyDisplay` for toolbar button tooltips rather than `SpriteText`

<img width="433" height="160" alt="image" src="https://github.com/user-attachments/assets/d74c4dd2-27fd-4e7c-881e-3c6152982dd6" />
