### PR TITLE
Fix input settings being interactive even when collapsed

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
@@ -35,8 +35,6 @@ namespace osu.Game.Overlays.Settings.Sections
         public InputSubsection(InputHandler handler)
         {
             this.handler = handler;
-
-            FlowContent.AlwaysPresent = true;
         }
 
         protected override Drawable CreateHeader() => header = new ToggleableHeader(Header, IsToggleable)
@@ -50,6 +48,9 @@ namespace osu.Game.Overlays.Settings.Sections
 
             handlerEnabled.BindTo(handler.Enabled);
             handlerEnabled.BindValueChanged(updateEnabledState, true);
+
+            // We use masking to hide the content of these sections.
+            FlowContent.Masking = true;
         }
 
         private void updateEnabledState(ValueChangedEvent<bool> state)
@@ -66,8 +67,6 @@ namespace osu.Game.Overlays.Settings.Sections
             {
                 FlowContent.AutoSizeAxes = Axes.None;
                 FlowContent.ResizeHeightTo(0, 300, Easing.OutQuint);
-
-                FlowContent.FadeOut(200, Easing.OutQuint);
             }
             else
             {
@@ -77,9 +76,8 @@ namespace osu.Game.Overlays.Settings.Sections
                 FlowContent.AutoSizeDuration = state.NewValue == state.OldValue ? 0 : 300;
                 FlowContent.AutoSizeEasing = Easing.OutQuint;
                 FlowContent.AutoSizeAxes = Axes.Y;
-                ScheduleAfterChildren(() => FlowContent.AutoSizeDuration = 0);
 
-                FlowContent.FadeIn(300, Easing.OutQuint);
+                ScheduleAfterChildren(() => FlowContent.AutoSizeDuration = 0);
             }
         }
 

--- a/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
@@ -49,15 +49,17 @@ namespace osu.Game.Overlays.Settings.Sections
             base.LoadComplete();
 
             handlerEnabled.BindTo(handler.Enabled);
-            handlerEnabled.BindValueChanged(v => updateEnabledState(), true);
+            handlerEnabled.BindValueChanged(updateEnabledState, true);
         }
 
-        private void updateEnabledState()
+        private void updateEnabledState(ValueChangedEvent<bool> state)
         {
             // set negative bottom margin to not have too much vertical gap between disabled input subsections.
             bool negativeBottomMargin = !handlerEnabled.Value || FlowContent.Count == 0;
             header.TransformTo(nameof(Margin), new MarginPadding { Bottom = negativeBottomMargin ? -VERTICAL_PADDING : 0 }, 300, Easing.OutQuint);
 
+            // Avoid crashes from toggling `AutoSizeAxes` while active `AutoSizeDuration` transforms are still running.
+            // This is probably a framework bug.
             FlowContent.ClearTransforms();
 
             if (!handlerEnabled.Value)
@@ -72,7 +74,7 @@ namespace osu.Game.Overlays.Settings.Sections
                 // enable auto size transform momentarily for smooth pop in animation, and disable it right after the transform is added.
                 // we don't want this specification to apply when a dropdown in the input settings is being open, it causes too slow animation.
                 // (try removing the schedule below then watch a settings dropdown menu opening animation).
-                FlowContent.AutoSizeDuration = 300;
+                FlowContent.AutoSizeDuration = state.NewValue == state.OldValue ? 0 : 300;
                 FlowContent.AutoSizeEasing = Easing.OutQuint;
                 FlowContent.AutoSizeAxes = Axes.Y;
                 ScheduleAfterChildren(() => FlowContent.AutoSizeDuration = 0);

--- a/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSubsection.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private readonly BindableBool handlerEnabled = new BindableBool();
 
+        private ToggleableHeader header = null!;
+
         public InputSubsection(InputHandler handler)
         {
             this.handler = handler;
@@ -37,14 +39,10 @@ namespace osu.Game.Overlays.Settings.Sections
             FlowContent.AlwaysPresent = true;
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override Drawable CreateHeader() => header = new ToggleableHeader(Header, IsToggleable)
         {
-            HeaderContainer.Child = new ToggleableHeader(Header, IsToggleable)
-            {
-                Current = { BindTarget = handlerEnabled },
-            };
-        }
+            Current = { BindTarget = handlerEnabled },
+        };
 
         protected override void LoadComplete()
         {
@@ -58,7 +56,7 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             // set negative bottom margin to not have too much vertical gap between disabled input subsections.
             bool negativeBottomMargin = !handlerEnabled.Value || FlowContent.Count == 0;
-            HeaderContainer.TransformTo(nameof(Margin), new MarginPadding { Bottom = negativeBottomMargin ? -15 : 0 }, 300, Easing.OutQuint);
+            header.TransformTo(nameof(Margin), new MarginPadding { Bottom = negativeBottomMargin ? -VERTICAL_PADDING : 0 }, 300, Easing.OutQuint);
 
             FlowContent.ClearTransforms();
 
@@ -92,6 +90,11 @@ namespace osu.Game.Overlays.Settings.Sections
 
             public ToggleableHeader(LocalisableString text, bool toggleable)
             {
+                Padding = SettingsPanel.CONTENT_PADDING;
+
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+
                 this.text = text;
                 this.toggleable = toggleable;
             }
@@ -105,8 +108,6 @@ namespace osu.Game.Overlays.Settings.Sections
             [BackgroundDependencyLoader]
             private void load()
             {
-                AutoSizeAxes = Axes.Both;
-
                 InternalChildren = new Drawable[]
                 {
                     switchButton = new SwitchButton

--- a/osu.Game/Overlays/Settings/SettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSubsection.cs
@@ -14,11 +14,11 @@ namespace osu.Game.Overlays.Settings
 {
     public abstract partial class SettingsSubsection : FillFlowContainer, IFilterable
     {
+        public const float VERTICAL_PADDING = (header_height - header_font_size) * 0.5f;
+
         protected override Container<Drawable> Content => FlowContent;
 
         protected readonly FillFlowContainer FlowContent;
-
-        protected Container HeaderContainer { get; private set; } = null!;
 
         protected abstract LocalisableString Header { get; }
 
@@ -53,25 +53,22 @@ namespace osu.Game.Overlays.Settings
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddRangeInternal(new Drawable[]
+            AddRangeInternal(new[]
             {
-                HeaderContainer = new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Padding = SettingsPanel.CONTENT_PADDING,
-                    Children = new[]
-                    {
-                        new OsuSpriteText
-                        {
-                            Text = Header,
-                            Font = OsuFont.GetFont(size: header_font_size),
-                            Margin = new MarginPadding { Vertical = (header_height - header_font_size) * 0.5f },
-                        },
-                    },
-                },
+                CreateHeader(),
                 FlowContent
             });
+        }
+
+        protected virtual Drawable CreateHeader()
+        {
+            return new OsuSpriteText
+            {
+                Text = Header,
+                Font = OsuFont.GetFont(size: header_font_size),
+                Margin = new MarginPadding { Vertical = VERTICAL_PADDING },
+                Padding = SettingsPanel.CONTENT_PADDING,
+            };
         }
     }
 }


### PR DESCRIPTION
Comes with a bit of clean-up, see individual commits. The remaining autosize adjustment logic is ugly but I'm not touching it.