### PR TITLE
Consider comments in wiki's front matter YAML

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
@@ -130,6 +130,20 @@ outdated: true  # not sure about the format for ""list of mods"".
         }
 
         [Test]
+        public void TestCommentedOutFrontMatter()
+        {
+            AddStep("Add commented out front matter", () =>
+            {
+                markdownContainer.Text = @"---
+#outdated: true
+# stub: true
+---";
+            });
+
+            AddAssert("No notice box visible", () => !markdownContainer.ChildrenOfType<Container>().Any());
+        }
+
+        [Test]
         public void TestAbsoluteImage()
         {
             AddStep("Add absolute image", () =>

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
@@ -117,6 +117,19 @@ needs_cleanup: true
         }
 
         [Test]
+        public void TestOutdatedNoticeBoxWithComments()
+        {
+            AddStep("Add outdated yaml with comments", () =>
+            {
+                markdownContainer.Text = @"---
+outdated: true  # not sure about the format for ""list of mods"".
+---";
+            });
+
+            AddAssert("Outdated notice box visible", () => markdownContainer.ChildrenOfType<Container>().Any());
+        }
+
+        [Test]
         public void TestAbsoluteImage()
         {
             AddStep("Add absolute image", () =>

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
@@ -117,7 +117,7 @@ needs_cleanup: true
         }
 
         [Test]
-        public void TestOutdatedNoticeBoxWithComments()
+        public void TestOutdatedNoticeBoxWithSuffixComments()
         {
             AddStep("Add outdated yaml with comments", () =>
             {
@@ -136,7 +136,7 @@ outdated: true  # not sure about the format for ""list of mods"".
             {
                 markdownContainer.Text = @"---
 #outdated: true
-# stub: true
+# outdated: true
 ---";
             });
 

--- a/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
@@ -29,7 +29,9 @@ namespace osu.Game.Overlays.Wiki.Markdown
 
             foreach (object line in yamlFrontMatterBlock.Lines)
             {
-                string? cleaned = line.ToString()?.Split('#')[0].Trim();
+                // Not considering more complex usages here.
+                // For parsing simple tags like those below, matching " #" is enough.
+                string? cleaned = line.ToString()?.Split(" #")[0].Trim();
 
                 switch (cleaned)
                 {

--- a/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
@@ -29,7 +29,9 @@ namespace osu.Game.Overlays.Wiki.Markdown
 
             foreach (object line in yamlFrontMatterBlock.Lines)
             {
-                switch (line.ToString())
+                string? cleaned = line.ToString()?.Split('#')[0].Trim();
+
+                switch (cleaned)
                 {
                     case @"outdated: true":
                         isOutdated = true;

--- a/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using Markdig.Extensions.Yaml;
+using Markdig.Helpers;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -27,12 +29,15 @@ namespace osu.Game.Overlays.Wiki.Markdown
             Direction = FillDirection.Vertical;
             Spacing = new Vector2(10);
 
-            foreach (object line in yamlFrontMatterBlock.Lines)
+            foreach (StringLine line in yamlFrontMatterBlock.Lines)
             {
-                // Not considering more complex usages here.
-                // For parsing simple tags like those below, matching " #" is enough.
-                string? cleaned = line.ToString()?.Split(" #")[0].Trim();
+                // Commonly, comments are added to the end of lines.
+                // There are cases of '#' used inside frontmatter, ie for url content, so matching with the prefix space is important.
+                string cleaned = line.ToString().Split(" #").First().Trim();
 
+                // Exact text matching should hopefully be enough as a certain degree of linting is applied at
+                // the wiki side. Note that this will ensure cases of the whole line being commented out are not actioned
+                // on, covering cases not caught by the above check.
                 switch (cleaned)
                 {
                     case @"outdated: true":


### PR DESCRIPTION
This PR makes front matter items with comments able to be parsed correctly by the client, for example:

```markdown
---
tags:
  - keyboard
  - tap
  - hybrid
  - play style
needs_cleanup: true  # https://github.com/ppy/osu-wiki/issues/9919
---

# Hybrid

...
```

The front matter YAML used by osu!wiki not complicated, so simply splitting with `#` is possible.
