### PR TITLE
Add pool type to matchmaking room invited event

### DIFF
--- a/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
@@ -23,7 +23,18 @@ namespace osu.Game.Online.Matchmaking
         /// <see cref="IMatchmakingServer.MatchmakingDeclineInvitation">declined</see>,
         /// or ignored - in which case it will automatically be declined after a short timeout period.
         /// </summary>
+        /// <remarks>
+        /// Provided for compatibility with older clients - can be removed 20260825.
+        /// </remarks>
         Task MatchmakingRoomInvited();
+
+        /// <summary>
+        /// Signals that a match has been found and the local user is invited to it.
+        /// The invitation may be <see cref="IMatchmakingServer.MatchmakingAcceptInvitation">accepted</see>,
+        /// <see cref="IMatchmakingServer.MatchmakingDeclineInvitation">declined</see>,
+        /// or ignored - in which case it will automatically be declined after a short timeout period.
+        /// </summary>
+        Task MatchmakingRoomInvitedWithParams(MatchmakingRoomInvitationParams invitation);
 
         /// <summary>
         /// Signals that the matchmaking room is ready to be opened.

--- a/osu.Game/Online/Matchmaking/MatchmakingRoomInvitationParams.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingRoomInvitationParams.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingRoomInvitationParams
+    {
+        [Key(0)]
+        public MatchmakingPoolType Type { get; set; }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Online.Multiplayer
 
         public event Action? MatchmakingQueueJoined;
         public event Action? MatchmakingQueueLeft;
-        public event Action? MatchmakingRoomInvited;
+        public event Action<MatchmakingRoomInvitationParams>? MatchmakingRoomInvited;
         public event Action<long, string>? MatchmakingRoomReady;
         public event Action<MatchmakingLobbyStatus>? MatchmakingLobbyStatusChanged;
         public event Action<MatchmakingQueueStatus>? MatchmakingQueueStatusChanged;
@@ -1085,7 +1085,13 @@ namespace osu.Game.Online.Multiplayer
 
         Task IMatchmakingClient.MatchmakingRoomInvited()
         {
-            Scheduler.Add(() => MatchmakingRoomInvited?.Invoke());
+            // Compatibility with older servers.
+            return ((IMatchmakingClient)this).MatchmakingRoomInvitedWithParams(new MatchmakingRoomInvitationParams { Type = MatchmakingPoolType.QuickPlay });
+        }
+
+        Task IMatchmakingClient.MatchmakingRoomInvitedWithParams(MatchmakingRoomInvitationParams invitation)
+        {
+            Scheduler.Add(() => MatchmakingRoomInvited?.Invoke(invitation));
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Online.Multiplayer
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueJoined), ((IMatchmakingClient)this).MatchmakingQueueJoined);
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueLeft), ((IMatchmakingClient)this).MatchmakingQueueLeft);
                     connection.On(nameof(IMatchmakingClient.MatchmakingRoomInvited), ((IMatchmakingClient)this).MatchmakingRoomInvited);
+                    connection.On<MatchmakingRoomInvitationParams>(nameof(IMatchmakingClient.MatchmakingRoomInvitedWithParams), ((IMatchmakingClient)this).MatchmakingRoomInvitedWithParams);
                     connection.On<long, string>(nameof(IMatchmakingClient.MatchmakingRoomReady), ((IMatchmakingClient)this).MatchmakingRoomReady);
                     connection.On<MatchmakingLobbyStatus>(nameof(IMatchmakingClient.MatchmakingLobbyStatusChanged), ((IMatchmakingClient)this).MatchmakingLobbyStatusChanged);
                     connection.On<MatchmakingQueueStatus>(nameof(IMatchmakingClient.MatchmakingQueueStatusChanged), ((IMatchmakingClient)this).MatchmakingQueueStatusChanged);


### PR DESCRIPTION
Rebase of https://github.com/smoogipoo/osu/pull/193

Going forward, the client will have to know the type of pool being invited to so that it can enter the appropriate screen when clicking the notification.

Unfortunately, SignalR does not support overloading methods, or even adding parameters to them, so this PR deprecates the `MatchmakingRoomInvited` event and adds its replacement `MatchmakingRoomInvitedWithParams` with a complex `invitation` parameter that we _can_ extend in the future if required (such as potentially adding the name of the pool).

This also prepares the notification by extracting some code to a `Complete` method receiving said `invitation` parameter. This part of code will be further modified to enter the correct screen:

https://github.com/smoogipoo/osu/blob/0a4018045b9d908f66c63dee65d0059d05b26e43/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs#L200

In particular, I have tested that new clients continue to work with the old server (dev.ppy.sh) in quick play

|         | Old Server           | New Server  |
| ------------- |:-------------:| :-----:|
| Old Client      | :green_circle:  | :green_circle: |
| New Client      | :green_circle:  | :green_circle: |