### PR TITLE
Add save filter result to collection

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
@@ -375,6 +375,133 @@ namespace osu.Game.Tests.Visual.SongSelect
             assertCollectionCount(1);
         }
 
+        [Test]
+        public void TestBatchAddButtonVisibility()
+        {
+            AddStep("add collection", () => Realm.Write(r => r.Add(new BeatmapCollection(name: "Test collection"))));
+
+            AddAssert("batch add button displayed", () =>
+                dialog.ChildrenOfType<DrawableCollectionListItem.BatchAddToCollectionButton>().Any());
+        }
+
+        [Test]
+        public void TestBatchAddButtonWithNoFilteredBeatmaps()
+        {
+            AddStep("add collection", () => Realm.Write(r => r.Add(new BeatmapCollection(name: "Test collection"))));
+            AddStep("set null filtered beatmaps provider", () => dialog.FilteredBeatmapsProvider = null);
+
+            AddStep("click batch add button", () =>
+            {
+                var button = dialog.ChildrenOfType<DrawableCollectionListItem.BatchAddToCollectionButton>().First();
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("no dialog shown", () => dialogOverlay.CurrentDialog == null);
+        }
+
+        [Test]
+        public void TestBatchAddAllBeatmaps()
+        {
+            BeatmapCollection collection = null!;
+
+            AddStep("add collection and set filtered beatmaps", () =>
+            {
+                Realm.Write(r => r.Add(collection = new BeatmapCollection(name: "Test collection")));
+                var beatmaps = beatmapManager.GetAllUsableBeatmapSets().SelectMany(s => s.Beatmaps).Take(5).ToList();
+                dialog.FilteredBeatmapsProvider = () => beatmaps;
+            });
+
+            AddStep("click batch add button", () =>
+            {
+                var button = dialog.ChildrenOfType<DrawableCollectionListItem.BatchAddToCollectionButton>().First();
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("add dialog shown", () => dialogOverlay.CurrentDialog != null && dialogOverlay.CurrentDialog.GetType().Name == "AddFilteredResultsDialog");
+            AddStep("confirm add all", () =>
+            {
+                InputManager.MoveMouseTo(dialogOverlay.CurrentDialog!.ChildrenOfType<PopupDialogButton>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("beatmaps added to collection", () =>
+                collection.BeatmapMD5Hashes.Count > 0);
+        }
+
+        [Test]
+        public void TestBatchRemoveAllBeatmaps()
+        {
+            BeatmapCollection collection = null!;
+
+            AddStep("add collection with all beatmaps", () =>
+            {
+                var beatmaps = beatmapManager.GetAllUsableBeatmapSets().SelectMany(s => s.Beatmaps).Take(5).ToList();
+                var hashes = beatmaps.Select(b => b.MD5Hash).Where(h => !string.IsNullOrEmpty(h)).ToList();
+                Realm.Write(r =>
+                {
+                    r.Add(collection = new BeatmapCollection(name: "Test collection"));
+                    foreach (string hash in hashes)
+                        collection.BeatmapMD5Hashes.Add(hash);
+                });
+                dialog.FilteredBeatmapsProvider = () => beatmaps;
+            });
+
+            AddStep("click batch add button", () =>
+            {
+                var button = dialog.ChildrenOfType<DrawableCollectionListItem.BatchAddToCollectionButton>().First();
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("remove dialog shown", () => dialogOverlay.CurrentDialog != null && dialogOverlay.CurrentDialog.GetType().Name == "RemoveFilteredResultsDialog");
+            AddStep("confirm remove all", () =>
+            {
+                InputManager.MoveMouseTo(dialogOverlay.CurrentDialog!.ChildrenOfType<PopupDialogButton>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("beatmaps removed from collection", () =>
+                collection.BeatmapMD5Hashes.Count == 0);
+        }
+
+        [Test]
+        public void TestBatchAddPartialOverlap()
+        {
+            BeatmapCollection collection;
+
+            AddStep("add collection with some beatmaps", () =>
+            {
+                var allBeatmaps = beatmapManager.GetAllUsableBeatmapSets().SelectMany(s => s.Beatmaps).Take(10).ToList();
+                var halfBeatmaps = allBeatmaps.Take(5).ToList();
+                var hashes = halfBeatmaps.Select(b => b.MD5Hash).Where(h => !string.IsNullOrEmpty(h)).ToList();
+                Realm.Write(r =>
+                {
+                    r.Add(collection = new BeatmapCollection(name: "Test collection"));
+                    foreach (string hash in hashes)
+                        collection.BeatmapMD5Hashes.Add(hash);
+                });
+                dialog.FilteredBeatmapsProvider = () => allBeatmaps;
+            });
+
+            AddStep("click batch add button", () =>
+            {
+                var button = dialog.ChildrenOfType<DrawableCollectionListItem.BatchAddToCollectionButton>().First();
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("partial overlap dialog shown", () => dialogOverlay.CurrentDialog != null && dialogOverlay.CurrentDialog.GetType().Name == "PartialOverlapFilteredResultsDialog");
+            AddStep("cancel operation", () =>
+            {
+                InputManager.MoveMouseTo(dialogOverlay.CurrentDialog!.ChildrenOfType<PopupDialogButton>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("dialog closed", () => dialogOverlay.CurrentDialog == null);
+        }
+
         private void assertCollectionCount(int count)
             => AddUntilStep($"{count} collections shown", () => dialog.ChildrenOfType<DrawableCollectionListItem>().Count(i => i.IsPresent) == count + 1); // +1 for placeholder
 

--- a/osu.Game/Collections/BatchAddToCollectionHandler.cs
+++ b/osu.Game/Collections/BatchAddToCollectionHandler.cs
@@ -1,0 +1,210 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Overlays.Dialog;
+
+namespace osu.Game.Collections
+{
+    internal static partial class BatchAddToCollectionHandler
+    {
+        public enum BatchAddOperation
+        {
+            Added,
+            Removed,
+        }
+
+        public readonly record struct BatchAddResult(Guid CollectionId, BatchAddOperation Operation, int Count);
+
+        public static event Action<BatchAddResult>? OperationCompleted;
+
+        private static readonly Dictionary<Guid, (BatchAddResult Result, DateTimeOffset Timestamp)> recent_results = new Dictionary<Guid, (BatchAddResult Result, DateTimeOffset Timestamp)>();
+        private static readonly object recent_results_lock = new object();
+        private static readonly TimeSpan recent_result_lifetime = TimeSpan.FromSeconds(6);
+
+        public static bool TryGetRecentResult(Guid collectionId, out BatchAddResult result)
+        {
+            lock (recent_results_lock)
+            {
+                cleanupExpiredResults();
+
+                if (recent_results.TryGetValue(collectionId, out var entry))
+                {
+                    result = entry.Result;
+                    return true;
+                }
+            }
+
+            result = default;
+            return false;
+        }
+
+        public static void RequestSaveToCollection(
+            Live<BeatmapCollection> collection,
+            Func<IEnumerable<BeatmapInfo>>? filteredBeatmapsProvider,
+            Action<PopupDialog> showDialog)
+        {
+            if (filteredBeatmapsProvider == null)
+                return;
+
+            var hashes = filteredBeatmapsProvider().Select(b => b.MD5Hash)
+                                                   .Where(h => !string.IsNullOrEmpty(h))
+                                                   .Distinct()
+                                                   .ToList();
+
+            if (hashes.Count == 0)
+                return;
+
+            var existing = collection.PerformRead(c => c.BeatmapMD5Hashes.ToList());
+            var intersection = existing.Intersect(hashes).ToList();
+            int overlapCount = intersection.Count;
+
+            if (overlapCount == hashes.Count)
+            {
+                showDialog(new RemoveFilteredResultsDialog(
+                    onRemove: () => runHashRemoval(collection, intersection, BatchAddOperation.Removed)));
+                return;
+            }
+
+            if (overlapCount > 0)
+            {
+                var toAdd = hashes.Except(existing).ToList();
+                var toRemove = intersection;
+
+                showDialog(new PartialOverlapFilteredResultsDialog(
+                    missingCount: toAdd.Count,
+                    duplicateCount: toRemove.Count,
+                    onAddDifference: () => runHashAddition(collection, toAdd, BatchAddOperation.Added),
+                    onRemoveIntersection: () => runHashRemoval(collection, toRemove, BatchAddOperation.Removed)));
+                return;
+            }
+
+            string collectionName = collection.PerformRead(c => c.Name);
+
+            showDialog(new AddFilteredResultsDialog(
+                collectionName,
+                hashes.Count,
+                onAddAll: () => runHashAddition(collection, hashes, BatchAddOperation.Added)));
+        }
+
+        private static void runHashAddition(Live<BeatmapCollection> collection, IReadOnlyList<string> hashes, BatchAddOperation operation)
+        {
+            if (hashes.Count == 0)
+                return;
+
+            Task.Run(() => collection.PerformWrite(c =>
+            {
+                int affected = 0;
+
+                foreach (string hash in hashes)
+                {
+                    if (c.BeatmapMD5Hashes.Contains(hash))
+                        continue;
+
+                    c.BeatmapMD5Hashes.Add(hash);
+                    affected++;
+                }
+
+                if (affected > 0)
+                    notifyOperationCompleted(c.ID, operation, affected);
+            }));
+        }
+
+        private static void runHashRemoval(Live<BeatmapCollection> collection, IReadOnlyList<string> hashes, BatchAddOperation operation)
+        {
+            Task.Run(() => collection.PerformWrite(c =>
+            {
+                int affected = 0;
+
+                foreach (string hash in hashes)
+                {
+                    if (c.BeatmapMD5Hashes.Remove(hash))
+                        affected++;
+                }
+
+                if (affected > 0)
+                    notifyOperationCompleted(c.ID, operation, affected);
+            }));
+        }
+
+        private static void notifyOperationCompleted(Guid collectionId, BatchAddOperation operation, int count)
+        {
+            var result = new BatchAddResult(collectionId, operation, count);
+
+            lock (recent_results_lock)
+            {
+                recent_results[collectionId] = (result, DateTimeOffset.UtcNow);
+                cleanupExpiredResults();
+            }
+
+            OperationCompleted?.Invoke(result);
+        }
+
+        private static void cleanupExpiredResults()
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            foreach (var entry in recent_results.ToArray())
+            {
+                if (now - entry.Value.Timestamp > recent_result_lifetime)
+                    recent_results.Remove(entry.Key);
+            }
+        }
+
+        private partial class AddFilteredResultsDialog : DangerousActionDialog
+        {
+            public AddFilteredResultsDialog(string collectionName, int beatmapCount, Action onAddAll)
+            {
+                Icon = FontAwesome.Solid.Check;
+                HeaderText = "Add all visible beatmaps to collection";
+                BodyText = $"Add {beatmapCount:#,0} beatmaps to \"{collectionName}\"?";
+                DangerousAction = onAddAll;
+            }
+        }
+
+        private partial class RemoveFilteredResultsDialog : DangerousActionDialog
+        {
+            public RemoveFilteredResultsDialog(Action onRemove)
+            {
+                Icon = FontAwesome.Solid.Trash;
+                HeaderText = "Remove all visible beatmaps from collection";
+                BodyText = "The collection already contains all the visible beatmaps, do you want to remove these beatmaps from the collection?";
+                DangerousAction = onRemove;
+            }
+        }
+
+        private partial class PartialOverlapFilteredResultsDialog : DangerousActionDialog
+        {
+            public PartialOverlapFilteredResultsDialog(int missingCount, int duplicateCount, Action onAddDifference, Action onRemoveIntersection)
+            {
+                Icon = FontAwesome.Solid.Question;
+                HeaderText = "Add or remove visible beatmaps";
+                BodyText = $"{missingCount:#,0} of the visible beatmaps are missing from this collection."
+                           + $"\n{duplicateCount:#,0} of the visible beatmaps already exist in this collection.";
+                Buttons = new PopupDialogButton[]
+                {
+                    new PopupDialogDangerousButton
+                    {
+                        Text = "Add missing beatmaps",
+                        Action = onAddDifference,
+                    },
+                    new PopupDialogDangerousButton
+                    {
+                        Text = "Remove existing beatmaps",
+                        Action = onRemoveIntersection,
+                    },
+                    new PopupDialogCancelButton
+                    {
+                        Text = "Cancel"
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -92,10 +92,19 @@ namespace osu.Game.Collections
                             IsTextBoxHovered = v => TextBox.ReceivePositionalInputAt(v)
                         }
                         : Empty(),
+                    collection.IsManaged
+                        ? new BatchAddToCollectionButton(collection)
+                        {
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.CentreRight,
+                            X = -button_width,
+                            IsTextBoxHovered = v => TextBox.ReceivePositionalInputAt(v),
+                        }
+                        : Empty(),
                     new Container
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Padding = new MarginPadding { Right = collection.IsManaged ? button_width : 0 },
+                        Padding = new MarginPadding { Right = collection.IsManaged ? button_width * 2 : 0 },
                         Children = new Drawable[]
                         {
                             TextBox = new ItemTextBox(collection)
@@ -134,6 +143,10 @@ namespace osu.Game.Collections
             private readonly Live<BeatmapCollection> collection;
 
             private OsuSpriteText countText = null!;
+            private OsuSpriteText actionText = null!;
+
+            private Color4 addedTextColour;
+            private Color4 removedTextColour;
 
             public ItemTextBox(Live<BeatmapCollection> collection)
             {
@@ -164,6 +177,19 @@ namespace osu.Game.Collections
                         Colour = colours.Yellow
                     });
 
+                    TextContainer.Add(actionText = new OsuSpriteText
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.TopLeft,
+                        Depth = float.MinValue,
+                        Font = OsuFont.Default.With(size: count_text_size, weight: FontWeight.SemiBold),
+                        Margin = new MarginPadding { Top = 2, Left = 2 },
+                        Alpha = 0,
+                    });
+
+                    addedTextColour = colours.Lime;
+                    removedTextColour = colours.Pink;
+
                     // interestingly, it is not required to subscribe to change notifications on this collection at all for this to work correctly.
                     // the reasoning for this is that `DrawableCollectionList` already takes out a subscription on the set of all `BeatmapCollection`s -
                     // but that subscription does not only cover *changes to the set of collections* (i.e. addition/removal/rearrangement of collections),
@@ -181,6 +207,57 @@ namespace osu.Game.Collections
                 {
                     PlaceholderText = CollectionsStrings.CreateNew;
                 }
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                if (collection.IsManaged)
+                {
+                    BatchAddToCollectionHandler.OperationCompleted += onBatchOperationCompleted;
+
+                    var collectionId = collection.PerformRead(c => c.ID);
+
+                    if (BatchAddToCollectionHandler.TryGetRecentResult(collectionId, out var recentResult))
+                        Schedule(() => showActionFeedback(recentResult));
+                }
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                if (collection.IsManaged)
+                    BatchAddToCollectionHandler.OperationCompleted -= onBatchOperationCompleted;
+            }
+
+            private void onBatchOperationCompleted(BatchAddToCollectionHandler.BatchAddResult result)
+            {
+                if (!collection.IsManaged)
+                    return;
+
+                if (collection.PerformRead(c => c.ID) != result.CollectionId)
+                    return;
+
+                Schedule(() => showActionFeedback(result));
+            }
+
+            private void showActionFeedback(BatchAddToCollectionHandler.BatchAddResult result)
+            {
+                actionText.Colour = result.Operation == BatchAddToCollectionHandler.BatchAddOperation.Added
+                    ? addedTextColour
+                    : removedTextColour;
+
+                actionText.Text = result.Operation == BatchAddToCollectionHandler.BatchAddOperation.Added
+                    ? $"{result.Count:#,0} items added"
+                    : $"{result.Count:#,0} items removed";
+
+                actionText.X = countText.DrawWidth + 8;
+                actionText.ClearTransforms();
+                actionText.FadeIn(120, Easing.OutQuint)
+                          .Delay(2000)
+                          .FadeOut(350, Easing.OutQuint);
             }
         }
 
@@ -201,7 +278,7 @@ namespace osu.Game.Collections
                 this.collection = collection;
                 RelativeSizeAxes = Axes.Y;
 
-                Width = button_width + item_height / 2; // add corner radius to cover with fill
+                Width = button_width + item_height / 4; // add corner radius to cover with fill
             }
 
             [BackgroundDependencyLoader]
@@ -238,7 +315,14 @@ namespace osu.Game.Collections
                 };
             }
 
-            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => base.ReceivePositionalInputAt(screenSpacePos) && !IsTextBoxHovered(screenSpacePos);
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+            {
+                if (!base.ReceivePositionalInputAt(screenSpacePos) || IsTextBoxHovered(screenSpacePos))
+                    return false;
+
+                float localX = ToLocalSpace(screenSpacePos).X;
+                return localX > item_height / 4;
+            }
 
             protected override bool OnHover(HoverEvent e)
             {
@@ -259,6 +343,77 @@ namespace osu.Game.Collections
             }
 
             private void deleteCollection() => collection.PerformWrite(c => c.Realm!.Remove(c));
+        }
+
+        public partial class BatchAddToCollectionButton : OsuClickableContainer
+        {
+            public Func<Vector2, bool> IsTextBoxHovered = null!;
+
+            private readonly Live<BeatmapCollection> collection;
+            private Color4 darkenedColour;
+            private Color4 normalColour;
+
+            private Drawable background = null!;
+
+            public BatchAddToCollectionButton(Live<BeatmapCollection> collection)
+            {
+                this.collection = collection;
+
+                RelativeSizeAxes = Axes.Y;
+                Width = button_width + item_height / 4;
+                TooltipText = "Add all visible beatmaps to collection";
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                normalColour = colours.Yellow;
+                darkenedColour = normalColour.Darken(0.9f);
+
+                Child = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 10,
+                    Children = new[]
+                    {
+                        background = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = darkenedColour,
+                        },
+                        new SpriteIcon
+                        {
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.Centre,
+                            X = -button_width * 0.6f,
+                            Size = new Vector2(10),
+                            Icon = FontAwesome.Solid.Plus,
+                        }
+                    }
+                };
+
+                Action = () => this.FindClosestParent<ManageCollectionsDialog>()?.RequestBatchAddToCollection(collection);
+            }
+
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => base.ReceivePositionalInputAt(screenSpacePos) && !IsTextBoxHovered(screenSpacePos);
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                background.FadeColour(normalColour, 100, Easing.Out);
+                return false;
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                background.FadeColour(darkenedColour, 100, Easing.Out);
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                background.FlashColour(Color4.White, 150);
+                return base.OnClick(e);
+            }
         }
 
         public IEnumerable<LocalisableString> FilterTerms => Model.PerformRead(m => m.IsValid ? new[] { (LocalisableString)m.Name } : []);

--- a/osu.Game/Collections/ManageCollectionsDialog.cs
+++ b/osu.Game/Collections/ManageCollectionsDialog.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -32,8 +34,13 @@ namespace osu.Game.Collections
         private BasicSearchTextBox searchTextBox = null!;
         private DrawableCollectionList list = null!;
 
+        public Func<IEnumerable<BeatmapInfo>>? FilteredBeatmapsProvider { get; set; }
+
         [Resolved]
         private MusicController? musicController { get; set; }
+
+        [Resolved(CanBeNull = true)]
+        private IDialogOverlay? dialogOverlay { get; set; }
 
         public ManageCollectionsDialog()
         {
@@ -217,6 +224,14 @@ namespace osu.Game.Collections
                     TextBox.Text = string.Empty;
                 };
             }
+        }
+
+        internal void RequestBatchAddToCollection(Live<BeatmapCollection> collection)
+        {
+            BatchAddToCollectionHandler.RequestSaveToCollection(
+                collection,
+                FilteredBeatmapsProvider,
+                dialog => Schedule(() => dialogOverlay?.Push(dialog)));
         }
     }
 }


### PR DESCRIPTION
Description
This feature adds a set of interactive controls to the Favorites Manager, allowing users to save filter results from the current screen directly to the target favorites.

Possible Improvements
Further refinements could be considered, such as:
- Batch removal of favorites
- Handling partially overlapping beatmaps: a pop-up could allow users to either add the remaining results or remove the overlapping parts
If these ideas are agreed upon, a TODO can be added for future iterations.
Testing & Performance
- Added test scenarios to validate functionality
- Performance impact has been assessed and should remain within acceptable limits
