### PR TITLE
Fix ordering of skins not working as expected

### DIFF
--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -158,11 +158,11 @@ namespace osu.Game.Skinning
 
                 var userSkins = realm.All<SkinInfo>()
                                      .Where(s => !s.DeletePending && !s.Protected)
-                                     .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
                                      .AsEnumerable()
+                                     .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
                                      .Select(s => s.ToLive(Realm));
 
-                foreach (var s in userSkins.Where(s => !s.Value.Protected))
+                foreach (var s in userSkins)
                     skins.Add(s);
             });
 


### PR DESCRIPTION
As mentioned [here](https://github.com/ppy/osu/pull/11536#issuecomment-3977314909).

Realm ordering is weird/broken so let's just do it at our end.