### PR TITLE
Fix offset slider no longer showing explanatory tooltip correctly

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 Current = currentNumberInstantaneous,
                 OnCommit = () => current.Value = currentNumberInstantaneous.Value,
-                TooltipFormat = TooltipFormat,
+                TooltipFormat = s => TooltipFormat(s),
                 DisplayAsPercentage = DisplayAsPercentage,
                 PlaySamplesOnAdjust = PlaySamplesOnAdjust,
                 ResetToDefault = () =>


### PR DESCRIPTION
Closes #36793.