### PR TITLE
Standardise display order of playcount / favourites

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -72,6 +72,10 @@ namespace osu.Game.Tests.Visual.Online
                     Preview = @"https://b.ppy.sh/preview/12345.mp3",
                     PlayCount = 123,
                     FavouriteCount = 456,
+                    NominationStatus = new BeatmapSetNominationStatus
+                    {
+                        Current = 2,
+                    },
                     Submitted = DateTime.Now,
                     Ranked = DateTime.Now,
                     BPM = 111,

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
@@ -296,20 +296,20 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 return original;
             }
 
-            statisticsContainer.Content[0][0] = withMargin(new FavouritesStatistic(BeatmapSet)
-            {
-                Current = FavouriteState,
-            });
-
-            statisticsContainer.Content[1][0] = withMargin(new PlayCountStatistic(BeatmapSet));
-
             var hypesStatistic = HypesStatistic.CreateFor(BeatmapSet);
             if (hypesStatistic != null)
-                statisticsContainer.Content[0][1] = withMargin(hypesStatistic);
+                statisticsContainer.Content[0][0] = withMargin(hypesStatistic);
 
             var nominationsStatistic = NominationsStatistic.CreateFor(BeatmapSet);
             if (nominationsStatistic != null)
-                statisticsContainer.Content[1][1] = withMargin(nominationsStatistic);
+                statisticsContainer.Content[1][0] = withMargin(nominationsStatistic);
+
+            statisticsContainer.Content[0][1] = withMargin(new PlayCountStatistic(BeatmapSet));
+
+            statisticsContainer.Content[1][1] = withMargin(new FavouritesStatistic(BeatmapSet)
+            {
+                Current = FavouriteState,
+            });
 
             var dateStatistic = BeatmapCardDateStatistic.CreateFor(BeatmapSet);
             if (dateStatistic != null)

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -278,8 +278,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             if (nominationsStatistic != null)
                 yield return nominationsStatistic;
 
-            yield return new FavouritesStatistic(BeatmapSet) { Current = FavouriteState };
             yield return new PlayCountStatistic(BeatmapSet);
+            yield return new FavouritesStatistic(BeatmapSet) { Current = FavouriteState };
 
             var dateStatistic = BeatmapCardDateStatistic.CreateFor(BeatmapSet);
             if (dateStatistic != null)

--- a/osu.Game/Beatmaps/Drawables/Cards/Statistics/BeatmapCardDateStatistic.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Statistics/BeatmapCardDateStatistic.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Statistics
         {
             this.dateTime = dateTime;
 
-            Icon = FontAwesome.Regular.CheckCircle;
+            Icon = FontAwesome.Solid.CheckCircle;
             Text = dateTime.ToLocalisedMediumDate();
         }
 

--- a/osu.Game/Beatmaps/Drawables/Cards/Statistics/PlayCountStatistic.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Statistics/PlayCountStatistic.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Statistics
     {
         public PlayCountStatistic(IBeatmapSetOnlineInfo onlineInfo)
         {
-            Icon = FontAwesome.Regular.PlayCircle;
+            Icon = FontAwesome.Solid.PlayCircle;
             Text = onlineInfo.PlayCount.ToMetric(decimals: 1);
             TooltipText = BeatmapsStrings.PanelPlaycount(onlineInfo.PlayCount.ToLocalisableString(@"N0"));
         }

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
@@ -108,8 +109,14 @@ namespace osu.Game.Overlays.BeatmapSet
                             Margin = new MarginPadding { Top = 5 },
                             Children = new[]
                             {
-                                nominations = new Statistic(FontAwesome.Solid.ThumbsUp),
-                                plays = new Statistic(FontAwesome.Solid.PlayCircle),
+                                nominations = new Statistic(FontAwesome.Solid.ThumbsUp)
+                                {
+                                    TooltipText = BeatmapsetsStrings.ShowStatsNominations,
+                                },
+                                plays = new Statistic(FontAwesome.Solid.PlayCircle)
+                                {
+                                    TooltipText = BeatmapsetsStrings.ShowStatsPlaycount,
+                                },
                                 favourites = new Statistic(FontAwesome.Solid.Heart),
                             },
                         },
@@ -188,6 +195,7 @@ namespace osu.Game.Overlays.BeatmapSet
 
             plays.Value = BeatmapSet?.PlayCount ?? 0;
             favourites.Value = BeatmapSet?.FavouriteCount ?? 0;
+            favourites.TooltipText = BeatmapSet?.FavouriteCount > 0 ? BeatmapsetsStrings.ShowStatsFavourites : BeatmapsetsStrings.ShowStatsNoFavourites;
 
             updateDifficultyButtons();
         }
@@ -377,7 +385,7 @@ namespace osu.Game.Overlays.BeatmapSet
             }
         }
 
-        private partial class Statistic : FillFlowContainer
+        private partial class Statistic : FillFlowContainer, IHasTooltip
         {
             private readonly OsuSpriteText text;
 
@@ -417,6 +425,8 @@ namespace osu.Game.Overlays.BeatmapSet
                     },
                 };
             }
+
+            public LocalisableString TooltipText { get; set; }
         }
 
         public enum DifficultySelectorState

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
@@ -32,7 +33,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private const float tile_spacing = 2;
 
         private readonly LinkFlowContainer infoContainer;
-        private readonly Statistic plays, favourites;
+        private readonly Statistic nominations, plays, favourites;
 
         public readonly DifficultiesContainer Difficulties;
 
@@ -107,6 +108,7 @@ namespace osu.Game.Overlays.BeatmapSet
                             Margin = new MarginPadding { Top = 5 },
                             Children = new[]
                             {
+                                nominations = new Statistic(FontAwesome.Solid.ThumbsUp),
                                 plays = new Statistic(FontAwesome.Solid.PlayCircle),
                                 favourites = new Statistic(FontAwesome.Solid.Heart),
                             },
@@ -175,6 +177,14 @@ namespace osu.Game.Overlays.BeatmapSet
 
             // Else just choose the first available difficulty for now.
             Beatmap.Value ??= Difficulties.FirstOrDefault()?.Beatmap;
+
+            if (beatmapSet?.Status == BeatmapOnlineStatus.Pending && beatmapSet.NominationStatus != null)
+            {
+                nominations.Show();
+                nominations.Value = beatmapSet.NominationStatus.Current;
+            }
+            else
+                nominations.Hide();
 
             plays.Value = BeatmapSet?.PlayCount ?? 0;
             favourites.Value = BeatmapSet?.FavouriteCount ?? 0;


### PR DESCRIPTION
- To be in line with https://github.com/ppy/osu-web/pull/12648

The last two commits are also side additions to match web.

| Before | After | Web |
| --- | --- | --- |
| <img width="455" height="115" alt="Screenshot 2026-03-02 at 11 01 14 PM" src="https://github.com/user-attachments/assets/95c618b6-b18c-4276-8f03-e302c6d5f976" /> | <img width="457" height="122" alt="Screenshot 2026-03-02 at 10 45 14 PM" src="https://github.com/user-attachments/assets/d4d9b343-45ff-40a5-9e0b-04f030c0ce53" /> | <img width="491" height="115" alt="Screenshot 2026-03-02 at 10 56 09 PM" src="https://github.com/user-attachments/assets/956cacc9-13ae-45b6-bc4c-4784b699bed7" /> |
| <img width="454" height="154" alt="Screenshot 2026-03-02 at 11 01 20 PM" src="https://github.com/user-attachments/assets/194313b1-282a-43aa-bb7d-c64144122198" /> | <img width="450" height="158" alt="Screenshot 2026-03-02 at 10 45 21 PM" src="https://github.com/user-attachments/assets/26a8a2b2-f081-49db-9891-41e3cefe1c2d" /> | <img width="489" height="154" alt="Screenshot 2026-03-02 at 10 56 15 PM" src="https://github.com/user-attachments/assets/75ff2864-32dd-4289-9855-2890e149379c" /> |
| <img width="450" height="115" alt="Screenshot 2026-03-02 at 11 01 32 PM" src="https://github.com/user-attachments/assets/d7457c14-729c-46ef-a4ba-d311336d1578" /> | <img width="453" height="116" alt="Screenshot 2026-03-02 at 10 45 36 PM" src="https://github.com/user-attachments/assets/f82e9410-5adc-4dc5-b1a3-057e788ffa02" /> | <img width="490" height="113" alt="Screenshot 2026-03-02 at 10 56 32 PM" src="https://github.com/user-attachments/assets/c73cd1bf-d65a-45ae-b707-7b5b43b2b304" /> |
| <img width="454" height="156" alt="Screenshot 2026-03-02 at 11 01 38 PM" src="https://github.com/user-attachments/assets/89bb7083-9871-4bf4-8f54-c2a9c0cee193" /> | <img width="455" height="160" alt="Screenshot 2026-03-02 at 10 45 28 PM" src="https://github.com/user-attachments/assets/1e128482-0f48-48b8-8f78-ae350607c6c4" /> | <img width="492" height="155" alt="Screenshot 2026-03-02 at 10 56 25 PM" src="https://github.com/user-attachments/assets/c184706b-3caf-4883-a350-cf47704dd3b9" /> |