### PR TITLE
Fix song select carousel being initially invalidated unnecessarily

### DIFF
--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -411,11 +411,13 @@ namespace osu.Game.Graphics.Carousel
 
                 HandleFilterCompleted();
 
+                NewItemsPresented?.Invoke(carouselItems);
+
                 refreshAfterSelection();
                 if (!Scroll.UserScrolling)
                     ScrollToSelection(immediate: true);
 
-                NewItemsPresented?.Invoke(carouselItems);
+                selectionValid.Validate();
             });
 
             return items;


### PR DESCRIPTION
This is not a full fix for animation issues. Any number of things can trigger this invalidation and each one may have adverse effects on the animation. Both horizontal and vertical positioning is quite unstable.

But this does fix the obvious frame jump *every time* song select is entered.

Closes #36762.

Before:

https://github.com/user-attachments/assets/f9f15066-6717-4ff3-9497-ed2e3ae06328

After:

https://github.com/user-attachments/assets/2344ec5c-fce4-49aa-9011-ab1e2a6df6fe

Note: no single frame glitching.
