### PR TITLE
Fix loose spacers at top of leaderboard score context menu

### DIFF
--- a/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapLeaderboardScore.cs
@@ -628,7 +628,9 @@ namespace osu.Game.Screens.SelectV2
 
                 if (Score.Files.Count <= 0) return items.ToArray();
 
-                items.Add(new OsuMenuItemSpacer());
+                if (items.Count > 0)
+                    items.Add(new OsuMenuItemSpacer());
+
                 items.Add(new OsuMenuItem(SongSelectStrings.WatchReplay, MenuItemType.Standard, () => game?.PresentScore(Score, ScorePresentType.Gameplay)));
                 items.Add(new OsuMenuItem(CommonStrings.Export, MenuItemType.Standard, () => scoreManager.Export(Score)));
                 items.Add(new OsuMenuItem(Resources.Localisation.Web.CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => dialogOverlay?.Push(new LocalScoreDeleteDialog(Score))));


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/36777.