### PR TITLE
[Taiko] Add a toggle to disable animation when an object is hit

### DIFF
--- a/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
@@ -18,11 +18,13 @@ namespace osu.Game.Rulesets.Taiko.Configuration
             base.InitialiseDefaults();
 
             SetDefault(TaikoRulesetSetting.TouchControlScheme, TaikoTouchControlScheme.KDDK);
+            SetDefault(TaikoRulesetSetting.HitAnimation, true);
         }
     }
 
     public enum TaikoRulesetSetting
     {
-        TouchControlScheme
+        TouchControlScheme,
+        HitAnimation
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -171,7 +171,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     if (!configHitAnimation.Value)
                     {
                         // Make the object instantly invisible when hit
-                        ClearTransforms();
                         Alpha = 0;
                         this.Delay(StrongNestedHit.SECOND_HIT_WINDOW).Expire();
                         break;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -7,11 +7,13 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Configuration;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
@@ -39,6 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private double? lastPressHandleTime;
 
         private readonly Bindable<HitType> type = new Bindable<HitType>();
+        private readonly Bindable<bool> configHitAnimation = new BindableBool();
 
         public DrawableHit()
             : this(null)
@@ -49,6 +52,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             : base(hit)
         {
             FillMode = FillMode.Fit;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(TaikoRulesetConfigManager rulesetConfig)
+        {
+            rulesetConfig.BindWith(TaikoRulesetSetting.HitAnimation, configHitAnimation);
         }
 
         protected override void OnApply()
@@ -159,6 +168,15 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     break;
 
                 case ArmedState.Hit:
+                    if (!configHitAnimation.Value)
+                    {
+                        // Make the object instantly invisible when hit
+                        ClearTransforms();
+                        Alpha = 0;
+                        this.Delay(StrongNestedHit.SECOND_HIT_WINDOW).Expire();
+                        break;
+                    }
+
                     // If we're far enough away from the left stage, we should bring ourselves in front of it
                     ProxyContent();
 

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     Caption = RulesetSettingsStrings.TouchControlScheme,
                     Current = config.GetBindable<TaikoTouchControlScheme>(TaikoRulesetSetting.TouchControlScheme)
+                }),
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = RulesetSettingsStrings.HitAnimation,
+                    Current = config.GetBindable<bool>(TaikoRulesetSetting.HitAnimation)
                 })
             };
         }

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -114,6 +114,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString TouchOverlay => new TranslatableString(getKey(@"touch_overlay"), @"Touch overlay");
 
+        /// <summary>
+        /// "Hit animation"
+        /// </summary>
+        public static LocalisableString HitAnimation => new TranslatableString(getKey(@"hit_animation"), @"Hit animation");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }


### PR DESCRIPTION
(Hopefully) first real code contribution. Supersedes https://github.com/ppy/osu/pull/32945 and in the process fixes a lifetime (?) related bug in my previous implementation where in certain cases you'd be stuck in the beatmap and the result screen would never show up. This time I've also sanity checked the feature on a few different maps to make sure I didn't add this bug again.

This was a long awaited feature by me and other taiko players as some players prefer to play without the animations because they're either used to the circles going into the HP bar or no animation at all.

The feature works as expected, though in terms of code quality? I had to do a weird workaround. I initially wanted to implement this similarly like the hidden mod and just use `FadeOut()`, but with no arguments passed or just the value being too low it would cause the bug I've talked about above, so I had to do it in a weird, alternative way to avoid lifetime related bugs, or maybe I just lack the knowledge about how it all works. *Maybe* there's a better way to do this, but that works as well.


https://github.com/user-attachments/assets/5507bcc4-2633-40fb-a915-0dcbefdf2476

