### PR TITLE
Unimplement legacy compatibility method

### DIFF
--- a/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Threading.Tasks;
 
 namespace osu.Game.Online.Matchmaking
@@ -26,6 +27,7 @@ namespace osu.Game.Online.Matchmaking
         /// <remarks>
         /// Provided for compatibility with older clients - can be removed 20260825.
         /// </remarks>
+        [Obsolete]
         Task MatchmakingRoomInvited();
 
         /// <summary>

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -1085,8 +1085,8 @@ namespace osu.Game.Online.Multiplayer
 
         Task IMatchmakingClient.MatchmakingRoomInvited()
         {
-            // Compatibility with older servers.
-            return ((IMatchmakingClient)this).MatchmakingRoomInvitedWithParams(new MatchmakingRoomInvitationParams { Type = MatchmakingPoolType.QuickPlay });
+            // Not implemented (used by older clients).
+            return Task.CompletedTask;
         }
 
         Task IMatchmakingClient.MatchmakingRoomInvitedWithParams(MatchmakingRoomInvitationParams invitation)

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -75,7 +75,6 @@ namespace osu.Game.Online.Multiplayer
 
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueJoined), ((IMatchmakingClient)this).MatchmakingQueueJoined);
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueLeft), ((IMatchmakingClient)this).MatchmakingQueueLeft);
-                    connection.On(nameof(IMatchmakingClient.MatchmakingRoomInvited), ((IMatchmakingClient)this).MatchmakingRoomInvited);
                     connection.On<MatchmakingRoomInvitationParams>(nameof(IMatchmakingClient.MatchmakingRoomInvitedWithParams), ((IMatchmakingClient)this).MatchmakingRoomInvitedWithParams);
                     connection.On<long, string>(nameof(IMatchmakingClient.MatchmakingRoomReady), ((IMatchmakingClient)this).MatchmakingRoomReady);
                     connection.On<MatchmakingLobbyStatus>(nameof(IMatchmakingClient.MatchmakingLobbyStatusChanged), ((IMatchmakingClient)this).MatchmakingLobbyStatusChanged);


### PR DESCRIPTION
The spectator server invokes both legacy and non-legacy methods to keep compatibility with older clients:

https://github.com/ppy/osu-server-spectator/blob/fe0dad324587c8a12a2f203fd8289ce64182c2d9/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueueBackgroundService.cs#L292-L299

I thought that it'd be a good idea to implement the legacy method here, but it turns out to not be such a good idea because it means ranked-play clients will assume they're receiving a quick play invitation.