### PR TITLE
Use web localisation on `LeaderboardScopeSelector` to match `osu-web`

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/LeaderboardScopeSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/LeaderboardScopeSelector.cs
@@ -46,10 +46,6 @@ namespace osu.Game.Overlays.BeatmapSet
             {
                 switch (Value)
                 {
-                    case BeatmapLeaderboardScope.Local:
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(Value), Value, null);
-
                     case BeatmapLeaderboardScope.Global:
                         return BeatmapsetsStrings.ShowScoreboardGlobal;
 
@@ -61,6 +57,9 @@ namespace osu.Game.Overlays.BeatmapSet
 
                     case BeatmapLeaderboardScope.Team:
                         return BeatmapsetsStrings.ShowScoreboardTeam;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
                 }
             }
 

--- a/osu.Game/Overlays/BeatmapSet/LeaderboardScopeSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/LeaderboardScopeSelector.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Graphics.UserInterface;
 using osu.Framework.Allocation;
 using osuTK.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.Play.Leaderboards;
 
 namespace osu.Game.Overlays.BeatmapSet
@@ -37,6 +40,28 @@ namespace osu.Game.Overlays.BeatmapSet
             public ScopeSelectorTabItem(BeatmapLeaderboardScope value)
                 : base(value)
             {
+            }
+
+            protected override LocalisableString CreateText()
+            {
+                switch (Value)
+                {
+                    case BeatmapLeaderboardScope.Local:
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(Value), Value, null);
+
+                    case BeatmapLeaderboardScope.Global:
+                        return BeatmapsetsStrings.ShowScoreboardGlobal;
+
+                    case BeatmapLeaderboardScope.Country:
+                        return BeatmapsetsStrings.ShowScoreboardCountry;
+
+                    case BeatmapLeaderboardScope.Friend:
+                        return BeatmapsetsStrings.ShowScoreboardFriend;
+
+                    case BeatmapLeaderboardScope.Team:
+                        return BeatmapsetsStrings.ShowScoreboardTeam;
+                }
             }
 
             protected override bool OnHover(HoverEvent e)


### PR DESCRIPTION
- regressed in https://github.com/ppy/osu/commit/1f052bb195bfc5a2681b1b324bf34764641a1c40
- also see https://github.com/ppy/osu/pull/34074#discussion_r2211853662

did it by analogy with https://github.com/ppy/osu/blob/a0ecbd7c8704d6beee3e5c54c2ccb5f735872fb0/osu.Game/Overlays/BeatmapSet/Scores/NoScoresPlaceholder.cs#L27-L49

| master | pr | `osu-web` |
|-|-|-|
| <img width="1625" height="188" alt="osu_2026-03-04_18-26-44" src="https://github.com/user-attachments/assets/9bd2690a-2ddf-4f03-9ca6-22003efbd895" /> | ![osu_2026-03-04_18-36-12](https://github.com/user-attachments/assets/1498c4a9-7188-4e97-a6bd-3553b9befa5e) | <img width="990" height="139" alt="Снимок экрана 2026-03-04 182558" src="https://github.com/user-attachments/assets/1bf14bee-3097-478d-936b-6ecb7d912be2" /> |