### PR TITLE
Fix event handler leaks in DrawableEditorRulesetWrapper

### DIFF
--- a/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -22,6 +23,9 @@ namespace osu.Game.Rulesets.Edit
         public Playfield Playfield => drawableRuleset.Playfield;
 
         private readonly DrawableRuleset<TObject> drawableRuleset;
+
+        private Action? onStateChange;
+        private Action<HitObject>? onHitObjectUpdated;
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; } = null!;
@@ -55,11 +59,13 @@ namespace osu.Game.Rulesets.Edit
             if (changeHandler != null)
             {
                 // for now only regenerate replay on a finalised state change, not HitObjectUpdated.
-                changeHandler.OnStateChange += () => Scheduler.AddOnce(regenerateAutoplay);
+                onStateChange = () => Scheduler.AddOnce(regenerateAutoplay);
+                changeHandler.OnStateChange += onStateChange;
             }
             else
             {
-                beatmap.HitObjectUpdated += _ => Scheduler.AddOnce(regenerateAutoplay);
+                onHitObjectUpdated = _ => Scheduler.AddOnce(regenerateAutoplay);
+                beatmap.HitObjectUpdated += onHitObjectUpdated;
             }
 
             Scheduler.AddOnce(regenerateAutoplay);
@@ -97,7 +103,11 @@ namespace osu.Game.Rulesets.Edit
             {
                 beatmap.HitObjectAdded -= addHitObject;
                 beatmap.HitObjectRemoved -= removeHitObject;
+                beatmap.HitObjectUpdated -= onHitObjectUpdated;
             }
+
+            if (changeHandler != null)
+                changeHandler.OnStateChange -= onStateChange;
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Fix memory leak**: `changeHandler.OnStateChange` and `beatmap.HitObjectUpdated` event handlers were subscribed as anonymous lambdas in `LoadComplete()` but never unsubscribed in `Dispose()`, causing leaked references and ghost callbacks on disposed objects during editor sessions.
- **Solution**: Store delegates in fields (`onStateChange`, `onHitObjectUpdated`) so they can be properly unsubscribed in `Dispose()`.

## Details

In `DrawableEditorRulesetWrapper`, four event handlers are subscribed in `LoadComplete()`:

| Event | Previously unsubscribed in Dispose? |
|-------|-------------------------------------|
| `beatmap.HitObjectAdded` | ✅ Yes |
| `beatmap.HitObjectRemoved` | ✅ Yes |
| `changeHandler.OnStateChange` | ❌ **No — fixed** |
| `beatmap.HitObjectUpdated` | ❌ **No — fixed** |

The two missing unsubscriptions meant that every time the editor wrapper was disposed and recreated, old handlers would accumulate — keeping disposed objects alive and potentially invoking `regenerateAutoplay` on them.

## Test plan

- [ ] Open the beatmap editor, make changes (add/remove/move hit objects), undo/redo, and verify autoplay regeneration still works correctly
- [ ] Verify no unexpected exceptions in editor after extended editing sessions
- [ ] Run existing editor tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)