### PR TITLE
Disable presenting scores in online song selects

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -23,6 +23,7 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Select;
 using osu.Game.Users;
@@ -30,7 +31,7 @@ using osu.Game.Utils;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
-    public partial class MultiplayerMatchSongSelect : SongSelect, IOnlinePlaySubScreen
+    public partial class MultiplayerMatchSongSelect : SongSelect, IOnlinePlaySubScreen, ISongSelect
     {
         public string ShortTitle => "song selection";
 
@@ -336,5 +337,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             base.Dispose(isDisposing);
             freeModSelectOverlayRegistration?.Dispose();
         }
+
+        bool ISongSelect.CanPresentScore => false;
+
+        void ISongSelect.PresentScore(ScoreInfo score, ScorePresentType presentType) { }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
@@ -11,12 +11,13 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
+using osu.Game.Scoring;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Select;
 
 namespace osu.Game.Screens.OnlinePlay
 {
-    public abstract partial class OnlinePlayFreestyleSelect : SongSelect, IHandlePresentBeatmap, IOnlinePlaySubScreen
+    public abstract partial class OnlinePlayFreestyleSelect : SongSelect, IHandlePresentBeatmap, IOnlinePlaySubScreen, ISongSelect
     {
         private readonly PlaylistItem item;
 
@@ -115,5 +116,9 @@ namespace osu.Game.Screens.OnlinePlay
         {
             // This screen cannot present beatmaps.
         }
+
+        bool ISongSelect.CanPresentScore => false;
+
+        void ISongSelect.PresentScore(ScoreInfo score, ScorePresentType presentType) { }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -17,13 +17,14 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Select;
 using osu.Game.Utils;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
 {
-    public partial class PlaylistsSongSelect : SongSelect, IOnlinePlaySubScreen
+    public partial class PlaylistsSongSelect : SongSelect, IOnlinePlaySubScreen, ISongSelect
     {
         public string ShortTitle => "song selection";
 
@@ -260,5 +261,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             base.Dispose(isDisposing);
             modSelectOverlayRegistration?.Dispose();
         }
+
+        bool ISongSelect.CanPresentScore => false;
+
+        void ISongSelect.PresentScore(ScoreInfo score, ScorePresentType presentType) { }
     }
 }

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -58,6 +58,7 @@ namespace osu.Game.Screens.Select
 
         public int? Rank { get; init; }
         public HighlightType? Highlight { get; init; }
+        public Action<ScoreInfo>? ShowReplay { get; init; }
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -630,7 +631,8 @@ namespace osu.Game.Screens.Select
                 if (items.Count > 0)
                     items.Add(new OsuMenuItemSpacer());
 
-                items.Add(new OsuMenuItem(SongSelectStrings.WatchReplay, MenuItemType.Standard, () => game?.PresentScore(Score, ScorePresentType.Gameplay)));
+                if (ShowReplay != null)
+                    items.Add(new OsuMenuItem(SongSelectStrings.WatchReplay, MenuItemType.Standard, () => ShowReplay.Invoke(Score)));
                 items.Add(new OsuMenuItem(CommonStrings.Export, MenuItemType.Standard, () => scoreManager.Export(Score)));
                 items.Add(new OsuMenuItem(Resources.Localisation.Web.CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => dialogOverlay?.Push(new LocalScoreDeleteDialog(Score))));
 

--- a/osu.Game/Screens/Select/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardWedge.cs
@@ -308,7 +308,12 @@ namespace osu.Game.Screens.Select
                     Rank = i + 1,
                     Highlight = highlightType,
                     SelectedMods = { BindTarget = mods },
-                    Action = () => onLeaderboardScoreClicked(s),
+                    Action = songSelect?.CanPresentScore == true
+                        ? () => songSelect.PresentScore(s)
+                        : null,
+                    ShowReplay = songSelect?.CanPresentScore == true
+                        ? info => songSelect.PresentScore(info, ScorePresentType.Gameplay)
+                        : null
                 };
             }), loadedScores =>
             {

--- a/osu.Game/Screens/Select/ISongSelect.cs
+++ b/osu.Game/Screens/Select/ISongSelect.cs
@@ -32,10 +32,16 @@ namespace osu.Game.Screens.Select
         void ManageCollections();
 
         /// <summary>
+        /// Whether <see cref="PresentScore"/> can be performed by this screen.
+        /// If <see langword="false"/>, <see cref="PresentScore"/> will have no effect.
+        /// </summary>
+        bool CanPresentScore { get; }
+
+        /// <summary>
         /// Opens results screen with the given score.
         /// This assumes active beatmap and ruleset selection matches the score.
         /// </summary>
-        void PresentScore(ScoreInfo score);
+        void PresentScore(ScoreInfo score, ScorePresentType presentType = ScorePresentType.Results);
 
         /// <summary>
         /// Set the current filter text query to the provided string.

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1148,12 +1148,23 @@ namespace osu.Game.Screens.Select
 
         void ISongSelect.Search(string query) => FilterControl.Search(query);
 
-        void ISongSelect.PresentScore(ScoreInfo score)
-        {
-            Debug.Assert(Beatmap.Value.BeatmapInfo.Equals(score.BeatmapInfo));
-            Debug.Assert(Ruleset.Value.Equals(score.Ruleset));
+        bool ISongSelect.CanPresentScore => true;
 
-            this.Push(new SoloResultsScreen(score));
+        void ISongSelect.PresentScore(ScoreInfo score, ScorePresentType presentType)
+        {
+            switch (presentType)
+            {
+                case ScorePresentType.Results:
+                    Debug.Assert(Beatmap.Value.BeatmapInfo.Equals(score.BeatmapInfo));
+                    Debug.Assert(Ruleset.Value.Equals(score.Ruleset));
+
+                    this.Push(new SoloResultsScreen(score));
+                    break;
+
+                case ScorePresentType.Gameplay:
+                    (game as OsuGame)?.PresentScore(score, presentType);
+                    break;
+            }
         }
 
         #endregion


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/36815 I guess.

Song select V1 completely disabled the ability to view a score outside of solo play in ways that are very easy to let fly under the radar:

https://github.com/ppy/osu/blob/5fc836d1f09cebf983313c9b91a5c252890c607a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs#L26 https://github.com/ppy/osu/blob/46db3ad96d0e1cd6ba4176b9b474cb79a338965d/osu.Game/Screens/Select/PlaySongSelect.cs#L47-L53

therefore the issue this is trying to close would never even manifest there.

The direct cause of the issue is that the results screen is pushed to the relevant online screen's *substack* of screens rather than the game-global parent stack. That means that when the back button is pressed, the following logic fires:

https://github.com/ppy/osu/blob/6fa4a7152f144ed2524f20ecf7cfd26492bbe61d/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs#L174-L189

This logic fires *on the parent screen* even though *the child screen* is the one the user is attempting to back out of. And none of the exemptions for the screen substack inside of the above method fire because the subscreen is not an `IOnlinePlaySubScreen` (it's `SoloResultsScreen` in this case).

Now the direct cause here is probably fixable, although possibly not without some significant pulling of footer-shaped teeth. *However*, I kind of question as to why viewing scores should be permitted on online song selects in the first place - it kind of distracts from the primary purpose of the screens which is to *just pick a map already*.