### PR TITLE
Extract common logic from `AddToPlaylistFooterButton`

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenFooterNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenFooterNavigation.cs
@@ -349,8 +349,8 @@ namespace osu.Game.Tests.Visual.Navigation
                         AutoSizeAxes = Axes.Both,
                         Children = new[]
                         {
-                            new ShearedButton(200) { Text = "Action #1", Action = () => { } },
-                            new ShearedButton(140) { Text = "Action #2", Action = () => { } },
+                            new ShearedButton { Width = 200, Text = "Action #1", Action = () => { } },
+                            new ShearedButton { Width = 140, Text = "Action #2", Action = () => { } },
                         }
                     };
                 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneButtonsInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneButtonsInput.cs
@@ -72,12 +72,13 @@ namespace osu.Game.Tests.Visual.UserInterface
                         Enabled = { Value = true },
                         Text = "Rounded button"
                     },
-                    shearedButton = new ShearedButton(width)
+                    shearedButton = new ShearedButton
                     {
                         Text = "Sheared button",
                         LighterColour = Colour4.FromHex("#FFFFFF"),
                         DarkerColour = Colour4.FromHex("#FFCC22"),
                         TextColour = Colour4.Black,
+                        Width = width,
                         Height = 40,
                         Enabled = { Value = true },
                         Padding = new MarginPadding(0)

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneScreenFooter.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneScreenFooter.cs
@@ -342,8 +342,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                         AutoSizeAxes = Axes.Both,
                         Children = new[]
                         {
-                            new ShearedButton(200) { Text = "Action #1", Action = () => { } },
-                            new ShearedButton(140) { Text = "Action #2", Action = () => { } },
+                            new ShearedButton { Width = 200, Text = "Action #1", Action = () => { } },
+                            new ShearedButton { Width = 140, Text = "Action #2", Action = () => { } },
                         }
                     };
                 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
@@ -36,8 +36,10 @@ namespace osu.Game.Tests.Visual.UserInterface
 
                 if (bigButton)
                 {
-                    Child = button = new ShearedButton(400, 80)
+                    Child = button = new ShearedButton
                     {
+                        Width = 400,
+                        Height = 80,
                         LighterColour = Colour4.FromHex("#FFFFFF"),
                         DarkerColour = Colour4.FromHex("#FFCC22"),
                         TextColour = Colour4.Black,
@@ -50,8 +52,10 @@ namespace osu.Game.Tests.Visual.UserInterface
                 }
                 else
                 {
-                    Child = button = new ShearedButton(200, 80)
+                    Child = button = new ShearedButton
                     {
+                        Width = 200,
+                        Height = 80,
                         LighterColour = Colour4.FromHex("#FF86DD"),
                         DarkerColour = Colour4.FromHex("#DE31AE"),
                         TextColour = Colour4.White,
@@ -79,8 +83,9 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("create button", () =>
             {
-                Child = button = new ShearedToggleButton(200)
+                Child = button = new ShearedToggleButton
                 {
+                    Width = 200,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Text = "Toggle me",
@@ -96,8 +101,9 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             ShearedToggleButton toggleButton = null;
 
-            AddStep("create fixed width button", () => Child = toggleButton = new ShearedToggleButton(200)
+            AddStep("create fixed width button", () => Child = toggleButton = new ShearedToggleButton
             {
+                Width = 200,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Text = "Fixed width"
@@ -109,6 +115,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("create auto-sizing button", () => Child = toggleButton = new ShearedToggleButton
             {
+                AutoSizeAxes = Axes.X,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Text = "This button autosizes to its text!"
@@ -130,8 +137,9 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("create button", () =>
             {
-                Child = button = new ShearedToggleButton(200)
+                Child = button = new ShearedToggleButton
                 {
+                    Width = 200,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Text = "Toggle me",
@@ -186,6 +194,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         new ShearedButton
                         {
+                            AutoSizeAxes = Axes.X,
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
                             Text = "Button",
@@ -194,6 +203,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                         },
                         new ShearedButton
                         {
+                            AutoSizeAxes = Axes.X,
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
                             Text = "Button",
@@ -202,6 +212,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                         },
                         new ShearedButton
                         {
+                            AutoSizeAxes = Axes.X,
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
                             Text = "Button",

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
@@ -11,8 +11,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Screens.Footer;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -94,6 +96,41 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddToggleStep("toggle button", active => button.Active.Value = active);
             AddToggleStep("toggle disabled", disabled => button.Active.Disabled = disabled);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestShearedFooterButton(bool withIcon)
+        {
+            var colours = new OsuColour();
+
+            ShearedFooterButton button = null!;
+            bool actionFired = false;
+
+            AddStep("create button", () =>
+            {
+                Child = button = new ShearedFooterButton
+                {
+                    Width = 220,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    LighterColour = colours.Blue1,
+                    DarkerColour = colours.Blue3,
+                    Text = "Add to playlist",
+                    Action = () => actionFired = true,
+                };
+
+                if (withIcon)
+                    button.Icon = OsuIcon.Add;
+            });
+
+            AddStep("set disabled", () => button.Enabled.Value = false);
+            AddStep("press button", () => button.TriggerClick());
+            AddAssert("action not fired", () => !actionFired);
+
+            AddStep("set enabled", () => button.Enabled.Value = true);
+            AddStep("press button", () => button.TriggerClick());
+            AddAssert("action fired", () => actionFired);
         }
 
         [Test]

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -90,6 +90,8 @@ namespace osu.Game.Graphics
         public static IconUsage Twitter => get(OsuIconMapping.Twitter);
         public static IconUsage UserInterface => get(OsuIconMapping.UserInterface);
         public static IconUsage Wiki => get(OsuIconMapping.Wiki);
+        public static IconUsage Add => get(OsuIconMapping.Add);
+        public static IconUsage Remove => get(OsuIconMapping.Remove);
         public static IconUsage EditorAddControlPoint => get(OsuIconMapping.EditorAddControlPoint);
         public static IconUsage EditorConvertToStream => get(OsuIconMapping.EditorConvertToStream);
         public static IconUsage EditorDistanceSnap => get(OsuIconMapping.EditorDistanceSnap);
@@ -395,6 +397,12 @@ namespace osu.Game.Graphics
 
             [Description(@"wiki")]
             Wiki,
+
+            [Description(@"add")]
+            Add,
+
+            [Description(@"remove")]
+            Remove,
 
             [Description(@"Editor/add-control-point")]
             EditorAddControlPoint = 1000,

--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -75,19 +75,11 @@ namespace osu.Game.Graphics.UserInterface
         protected readonly Container ButtonContent;
 
         /// <summary>
-        /// Creates a new <see cref="ShearedToggleButton"/>
+        /// Creates a new <see cref="ShearedButton"/>
         /// </summary>
-        /// <param name="width">
-        /// The width of the button.
-        /// <list type="bullet">
-        /// <item>If a non-<see langword="null"/> value is provided, this button will have a fixed width equal to the provided value.</item>
-        /// <item>If a <see langword="null"/> value is provided (or the argument is omitted entirely), the button will autosize in width to fit the text.</item>
-        /// </list>
-        /// </param>
-        /// <param name="height">The height of the button.</param>
-        public ShearedButton(float? width = null, float height = DEFAULT_HEIGHT)
+        public ShearedButton()
         {
-            Height = height;
+            Height = DEFAULT_HEIGHT;
 
             Shear = OsuGame.SHEAR;
 
@@ -99,27 +91,25 @@ namespace osu.Game.Graphics.UserInterface
             {
                 backgroundLayer = new Container
                 {
-                    RelativeSizeAxes = Axes.Y,
+                    RelativeSizeAxes = Axes.Both,
                     CornerRadius = CORNER_RADIUS,
                     Masking = true,
                     BorderThickness = BORDER_THICKNESS,
-                    Children = new Drawable[]
+                    Child = background = new Box
                     {
-                        background = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both
-                        },
-                        ButtonContent = new Container
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            AutoSizeAxes = Axes.Both,
-                            Shear = -OsuGame.SHEAR,
-                            Child = text = new OsuSpriteText
-                            {
-                                Font = OsuFont.TorusAlternate.With(size: 17),
-                            }
-                        },
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                },
+                ButtonContent = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Shear = -OsuGame.SHEAR,
+                    Child = text = new OsuSpriteText
+                    {
+                        Font = OsuFont.TorusAlternate.With(size: 17),
+                        Margin = new MarginPadding { Horizontal = 15 },
                     }
                 },
                 flashLayer = new Box
@@ -130,18 +120,6 @@ namespace osu.Game.Graphics.UserInterface
                     Alpha = 0,
                 },
             };
-
-            if (width != null)
-            {
-                Width = width.Value;
-                backgroundLayer.RelativeSizeAxes = Axes.Both;
-            }
-            else
-            {
-                AutoSizeAxes = Axes.X;
-                backgroundLayer.AutoSizeAxes = Axes.X;
-                text.Margin = new MarginPadding { Horizontal = 15 };
-            }
         }
 
         protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet) { Enabled = { BindTarget = Enabled } };

--- a/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
@@ -24,21 +24,6 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         public BindableBool Active { get; } = new BindableBool();
 
-        /// <summary>
-        /// Creates a new <see cref="ShearedToggleButton"/>
-        /// </summary>
-        /// <param name="width">
-        /// The width of the button.
-        /// <list type="bullet">
-        /// <item>If a non-<see langword="null"/> value is provided, this button will have a fixed width equal to the provided value.</item>
-        /// <item>If a <see langword="null"/> value is provided (or the argument is omitted entirely), the button will autosize in width to fit the text.</item>
-        /// </list>
-        /// </param>
-        public ShearedToggleButton(float? width = null)
-            : base(width)
-        {
-        }
-
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Overlays.Mods
         private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
 
         public AddPresetButton()
-            : base(1)
         {
             RelativeSizeAxes = Axes.X;
             Height = ModSelectPanel.HEIGHT;

--- a/osu.Game/Overlays/Mods/AddPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/AddPresetPopover.cs
@@ -74,11 +74,12 @@ namespace osu.Game.Overlays.Mods
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            createButton = new ShearedButton(content_width)
+                            createButton = new ShearedButton
                             {
                                 // todo: for some very odd reason, this needs to be anchored to topright for the fill flow to be correctly sized to the AABB of the sheared button
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
+                                Width = content_width,
                                 Text = ModSelectOverlayStrings.AddPreset,
                                 Action = createPreset
                             }

--- a/osu.Game/Overlays/Mods/DeselectAllModsButton.cs
+++ b/osu.Game/Overlays/Mods/DeselectAllModsButton.cs
@@ -15,8 +15,9 @@ namespace osu.Game.Overlays.Mods
         private readonly Bindable<IReadOnlyList<Mod>> selectedMods = new Bindable<IReadOnlyList<Mod>>();
 
         public DeselectAllModsButton(ModSelectOverlay modSelectOverlay)
-            : base(ModSelectOverlay.BUTTON_WIDTH)
         {
+            Width = ModSelectOverlay.BUTTON_WIDTH;
+
             Text = CommonStrings.DeselectAll;
             Action = modSelectOverlay.DeselectAll;
 

--- a/osu.Game/Overlays/Mods/EditPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/EditPresetPopover.cs
@@ -114,22 +114,24 @@ namespace osu.Game.Overlays.Mods
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            useCurrentModsButton = new ShearedButton(content_width)
+                            useCurrentModsButton = new ShearedButton
                             {
                                 // todo: for some very odd reason, this needs to be anchored to topright for the fill flow to be correctly sized to the AABB of the sheared button
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
+                                Width = content_width,
                                 Text = ModSelectOverlayStrings.UseCurrentMods,
                                 DarkerColour = colours.Blue1,
                                 LighterColour = colours.Blue0,
                                 TextColour = colourProvider.Background6,
                                 Action = useCurrentMods,
                             },
-                            saveButton = new ShearedButton(content_width)
+                            saveButton = new ShearedButton
                             {
                                 // todo: for some very odd reason, this needs to be anchored to topright for the fill flow to be correctly sized to the AABB of the sheared button
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
+                                Width = content_width,
                                 Text = Resources.Localisation.Web.CommonStrings.ButtonsSave,
                                 DarkerColour = colours.Orange1,
                                 LighterColour = colours.Orange0,

--- a/osu.Game/Overlays/Mods/SelectAllModsButton.cs
+++ b/osu.Game/Overlays/Mods/SelectAllModsButton.cs
@@ -18,8 +18,9 @@ namespace osu.Game.Overlays.Mods
         private readonly Bindable<string> searchTerm = new Bindable<string>();
 
         public SelectAllModsButton(FreeModSelectOverlay modSelectOverlay)
-            : base(ModSelectOverlay.BUTTON_WIDTH)
         {
+            Width = ModSelectOverlay.BUTTON_WIDTH;
+
             Text = CommonStrings.SelectAll;
             Action = modSelectOverlay.SelectAll;
 

--- a/osu.Game/Overlays/WizardOverlay.cs
+++ b/osu.Game/Overlays/WizardOverlay.cs
@@ -245,10 +245,9 @@ namespace osu.Game.Overlays
 
                 Padding = new MarginPadding { Right = OsuGame.SCREEN_EDGE_MARGIN };
 
-                InternalChild = NextButton = new ShearedButton(0)
+                InternalChild = NextButton = new ShearedButton
                 {
                     RelativeSizeAxes = Axes.X,
-                    Width = 1,
                     Text = FirstRunSetupOverlayStrings.GetStarted,
                     DarkerColour = colourProvider.Colour3,
                     LighterColour = colourProvider.Colour2,

--- a/osu.Game/Screens/Footer/ScreenBackButton.cs
+++ b/osu.Game/Screens/Footer/ScreenBackButton.cs
@@ -32,14 +32,11 @@ namespace osu.Game.Screens.Footer
             return inputRectangle.Contains(ToLocalSpace(screenSpacePos));
         }
 
-        public ScreenBackButton()
-            : base(BUTTON_WIDTH)
-        {
-        }
-
         [BackgroundDependencyLoader]
         private void load()
         {
+            Width = BUTTON_WIDTH;
+
             ButtonContent.Child = new FillFlowContainer
             {
                 X = -10f,

--- a/osu.Game/Screens/Footer/ShearedFooterButton.cs
+++ b/osu.Game/Screens/Footer/ShearedFooterButton.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+
+namespace osu.Game.Screens.Footer
+{
+    /// <summary>
+    /// A <see cref="ShearedButton"/> intended to be used on the <see cref="ScreenFooter"/>
+    /// Allows displaying an additional icon displayed on the right hand side of the button.
+    /// </summary>
+    public partial class ShearedFooterButton : ShearedButton
+    {
+        public new LocalisableString Text
+        {
+            get => text.Text;
+            set => text.Text = value;
+        }
+
+        public IconUsage Icon
+        {
+            get => icon.Icon;
+            set
+            {
+                icon.Icon = value;
+                icon.Alpha = icon.Icon.Equals(default) ? 0 : 1;
+            }
+        }
+
+        public Vector2 IconSize
+        {
+            get => icon.Size;
+            set => icon.Size = value;
+        }
+
+        private readonly OsuSpriteText text;
+        private readonly SpriteIcon icon;
+
+        public ShearedFooterButton()
+        {
+            ButtonContent.AutoSizeAxes = Axes.None;
+            ButtonContent.RelativeSizeAxes = Axes.Both;
+            ButtonContent.Padding = new MarginPadding { Horizontal = 15 };
+
+            ButtonContent.Child = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                ColumnDimensions = new[]
+                {
+                    new Dimension(),
+                    new Dimension(GridSizeMode.AutoSize),
+                },
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Child = text = new OsuSpriteText
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Font = OsuFont.TorusAlternate.With(size: 17),
+                            },
+                        },
+                        icon = new SpriteIcon
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(20),
+                            Shadow = true,
+                            ShadowOffset = new Vector2(0.8f, 0.8f),
+                            Alpha = 0,
+                        },
+                    },
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -269,12 +269,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                 AvailablePools = { BindTarget = availablePools },
                                 SelectedPool = { BindTarget = selectedPool }
                             },
-                            new BeginQueueingButton(200)
+                            new BeginQueueingButton
                             {
                                 DarkerColour = colours.Blue2,
                                 LighterColour = colours.Blue1,
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
+                                Width = 200,
                                 SelectedPool = { BindTarget = selectedPool },
                                 Action = () =>
                                 {
@@ -308,12 +309,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                             {
                                 State = { Value = Visibility.Visible },
                             },
-                            new ShearedButton(200)
+                            new ShearedButton
                             {
                                 DarkerColour = colours.Red3,
                                 LighterColour = colours.Red4,
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
+                                Width = 200,
                                 Text = "Stop queueing",
                                 Action = () => client.MatchmakingLeaveQueue().FireAndForget()
                             }
@@ -430,11 +432,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         {
             public readonly IBindable<MatchmakingPool?> SelectedPool = new Bindable<MatchmakingPool?>();
 
-            public BeginQueueingButton(float? width = null)
-                : base(width)
-            {
-            }
-
             protected override void LoadComplete()
             {
                 base.LoadComplete();
@@ -445,11 +442,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private partial class SelectionButton : ShearedButton, IKeyBindingHandler<GlobalAction>
         {
-            protected SelectionButton(float? width = null, float height = DEFAULT_HEIGHT)
-                : base(width, height)
-            {
-            }
-
             public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
             {
                 if (e.Action == GlobalAction.Select && !e.Repeat)

--- a/osu.Game/Screens/OnlinePlay/Playlists/AddToPlaylistFooterButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/AddToPlaylistFooterButton.cs
@@ -13,14 +13,11 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 {
     public partial class AddToPlaylistFooterButton : ShearedButton
     {
-        public AddToPlaylistFooterButton()
-            : base(width: 220)
-        {
-        }
-
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
+            Width = 220;
+
             DarkerColour = colours.Blue3;
             LighterColour = colours.Blue1;
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/AddToPlaylistFooterButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/AddToPlaylistFooterButton.cs
@@ -5,13 +5,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
+using osu.Game.Screens.Footer;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
 {
-    public partial class AddToPlaylistFooterButton : ShearedButton
+    public partial class AddToPlaylistFooterButton : ShearedFooterButton
     {
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -21,28 +20,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             DarkerColour = colours.Blue3;
             LighterColour = colours.Blue1;
 
-            ButtonContent.Children = new Drawable[]
-            {
-                new OsuSpriteText
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    X = -10,
-                    Font = OsuFont.TorusAlternate.With(size: 17),
-                    Text = OnlinePlayStrings.FooterButtonPlaylistAdd,
-                    UseFullGlyphHeight = false,
-                },
-                new OsuSpriteText
-                {
-                    Anchor = Anchor.CentreRight,
-                    Origin = Anchor.CentreRight,
-                    X = 35,
-                    Font = OsuFont.TorusAlternate.With(size: 20),
-                    Shadow = false,
-                    Text = "+",
-                    UseFullGlyphHeight = false,
-                },
-            };
+            Text = OnlinePlayStrings.FooterButtonPlaylistAdd;
+            Icon = OsuIcon.Add;
         }
 
         public void Appear()

--- a/osu.Game/Screens/SelectV2/BeatmapDetailsArea.Header.cs
+++ b/osu.Game/Screens/SelectV2/BeatmapDetailsArea.Header.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Screens.SelectV2
                                     {
                                         Anchor = Anchor.CentreRight,
                                         Origin = Anchor.CentreRight,
+                                        AutoSizeAxes = Axes.X,
                                         Text = UserInterfaceStrings.SelectedMods,
                                         Height = 30f,
                                         // Eyeballed to make spacing match. Because shear is silly and implemented in different ways between dropdown and button.

--- a/osu.Game/Screens/SelectV2/FilterControl.ScopedBeatmapSetDisplay.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.ScopedBeatmapSetDisplay.cs
@@ -73,10 +73,11 @@ namespace osu.Game.Screens.SelectV2
                                 Colour = colourProvider.Background6,
                                 Padding = new MarginPadding { Right = 80, Vertical = 5 }
                             },
-                            new ShearedButton(80)
+                            new ShearedButton
                             {
                                 Anchor = Anchor.CentreRight,
                                 Origin = Anchor.CentreRight,
+                                Width = 80,
                                 Text = CommonStrings.Back,
                                 RelativeSizeAxes = Axes.Y,
                                 Height = 1,

--- a/osu.Game/Screens/SelectV2/FilterControl.cs
+++ b/osu.Game/Screens/SelectV2/FilterControl.cs
@@ -152,6 +152,7 @@ namespace osu.Game.Screens.SelectV2
                                     {
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.Centre,
+                                        AutoSizeAxes = Axes.X,
                                         Text = UserInterfaceStrings.ShowConverts,
                                         Height = 30f,
                                     },


### PR DESCRIPTION
Depends on https://github.com/ppy/osu/pull/36802 and https://github.com/ppy/osu-resources/pull/408.

This moves out the common layout from `AddToPlaylistFooterButton` to
a separate `ShearedFooterButton`, that is intended to be used
in other screens which I'm currently working on migrating to the
new footer.

It also adds a new 'add' icon to be used on the playlists button.

Pushing this ahead of time (without any other buttons using it yet)
mostly to get the new icon on the add to playlist button.

I've set the icon size to `20`. Could get it smaller, howvever
I think it should be a *bit* taller than the button label.

| Before | After |
|--------|--------|
| <img width="407" height="112" alt="image" src="https://github.com/user-attachments/assets/5d077cb6-4189-456d-a061-8b0a4bda3253" /> | <img width="374" height="86" alt="image" src="https://github.com/user-attachments/assets/8bea232a-c3e7-4a88-b061-372752e529be" />| 