### PR TITLE
Add menu item to delete all beatmap sets in filter groups

### DIFF
--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
@@ -148,6 +148,11 @@ namespace osu.Game.Localisation
         /// "Restore all hidden"
         /// </summary>
         public static LocalisableString RestoreAllHidden => new TranslatableString(getKey(@"restore_all_hidden"), @"Restore all hidden");
+
+        /// <summary>
+        /// "Delete all in group"
+        /// </summary>
+        public static LocalisableString DeleteAllInGroup => new TranslatableString(getKey(@"delete_all_in_group"), @"Delete all in group");
 
         /// <summary>
         /// "{0} stars"

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -62,6 +62,15 @@ namespace osu.Game.Screens.Select
         /// Total number of beatmap difficulties displayed with the filter.
         /// </summary>
         public int MatchedBeatmapsCount => Filters.Last().BeatmapItemsCount;
+
+        /// <summary>
+        /// Retrieves all beatmap sets which are currently contained within the specified <see cref="GroupDefinition"/>.
+        /// </summary>
+        /// <param name="group">The group to retrieve beatmap sets for.</param>
+        public IEnumerable<BeatmapSetInfo> GetBeatmapSetsForGroup(GroupDefinition group)
+            => grouping.SetItems.Keys
+                       .Where(set => EqualityComparer<GroupDefinition?>.Default.Equals(set.Group, group))
+                       .Select(set => set.BeatmapSet);
 
         protected override float GetSpacingBetweenPanels(CarouselItem top, CarouselItem bottom)
         {

--- a/osu.Game/Screens/Select/BeatmapGroupDeleteDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapGroupDeleteDialog.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
+using osu.Game.Overlays.Dialog;
+
+namespace osu.Game.Screens.Select
+{
+    public partial class BeatmapGroupDeleteDialog : DeletionDialog
+    {
+        private readonly GroupDefinition group;
+        private readonly IReadOnlyList<BeatmapSetInfo> beatmapSets;
+
+        public BeatmapGroupDeleteDialog(GroupDefinition group, IReadOnlyList<BeatmapSetInfo> beatmapSets)
+        {
+            this.group = group;
+            this.beatmapSets = beatmapSets;
+
+            BodyText = group.Title;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(BeatmapManager beatmapManager)
+        {
+            DangerousAction = () =>
+            {
+                foreach (var set in beatmapSets)
+                    beatmapManager.Delete(set);
+            };
+        }
+    }
+}
+

--- a/osu.Game/Screens/Select/BeatmapGroupDeleteDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapGroupDeleteDialog.cs
@@ -10,14 +10,11 @@ namespace osu.Game.Screens.Select
 {
     public partial class BeatmapGroupDeleteDialog : DeletionDialog
     {
-        private readonly GroupDefinition group;
         private readonly IReadOnlyList<BeatmapSetInfo> beatmapSets;
 
         public BeatmapGroupDeleteDialog(GroupDefinition group, IReadOnlyList<BeatmapSetInfo> beatmapSets)
         {
-            this.group = group;
             this.beatmapSets = beatmapSets;
-
             BodyText = group.Title;
         }
 

--- a/osu.Game/Screens/Select/ISongSelect.cs
+++ b/osu.Game/Screens/Select/ISongSelect.cs
@@ -27,6 +27,12 @@ namespace osu.Game.Screens.Select
         void RestoreAllHidden(BeatmapSetInfo beatmapSet);
 
         /// <summary>
+        /// Requests the user for confirmation to delete all beatmap sets contained within the given group.
+        /// </summary>
+        /// <param name="group">The group whose contents should be deleted.</param>
+        void DeleteGroup(GroupDefinition group);
+
+        /// <summary>
         /// Opens the manage collections dialog.
         /// </summary>
         void ManageCollections();

--- a/osu.Game/Screens/Select/PanelGroup.cs
+++ b/osu.Game/Screens/Select/PanelGroup.cs
@@ -184,7 +184,6 @@ namespace osu.Game.Screens.Select
                     return new MenuItem[]
                     {
                         expandItem
-
                     };
                 }
 

--- a/osu.Game/Screens/Select/PanelGroup.cs
+++ b/osu.Game/Screens/Select/PanelGroup.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Screens.Select
                     new OsuMenuItem(
                         SongSelectStrings.DeleteAllInGroup,
                         MenuItemType.Destructive,
-                        () => songSelect.DeleteGroup(group))
+                        () => songSelect.DeleteGroup((GroupDefinition)Item.Model))
                 };
             }
         }

--- a/osu.Game/Screens/Select/PanelGroup.cs
+++ b/osu.Game/Screens/Select/PanelGroup.cs
@@ -172,29 +172,17 @@ namespace osu.Game.Screens.Select
                 if (Item == null)
                     return Array.Empty<MenuItem>();
 
-                var group = (GroupDefinition)Item.Model;
-
-                var expandItem = new OsuMenuItem(
-                    Expanded.Value ? WebCommonStrings.ButtonsCollapse.ToSentence() : WebCommonStrings.ButtonsExpand.ToSentence(),
-                    MenuItemType.Highlighted,
-                    () => TriggerClick());
-
-                if (songSelect == null)
-                {
-                    return new MenuItem[]
-                    {
-                        expandItem
-                    };
-                }
-
                 return new MenuItem[]
                 {
-                    expandItem,
+                    new OsuMenuItem(
+                        Expanded.Value ? WebCommonStrings.ButtonsCollapse.ToSentence() : WebCommonStrings.ButtonsExpand.ToSentence(),
+                        MenuItemType.Highlighted,
+                        () => TriggerClick()),
                     new OsuMenuItemSpacer(),
                     new OsuMenuItem(
                         SongSelectStrings.DeleteAllInGroup,
                         MenuItemType.Destructive,
-                        () => songSelect.DeleteGroup((GroupDefinition)Item.Model))
+                        () => songSelect?.DeleteGroup((GroupDefinition)Item.Model))
                 };
             }
         }

--- a/osu.Game/Screens/Select/PanelGroup.cs
+++ b/osu.Game/Screens/Select/PanelGroup.cs
@@ -17,6 +17,7 @@ using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -37,6 +38,9 @@ namespace osu.Game.Screens.Select
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private ISongSelect? songSelect { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -168,9 +172,30 @@ namespace osu.Game.Screens.Select
                 if (Item == null)
                     return Array.Empty<MenuItem>();
 
+                var group = (GroupDefinition)Item.Model;
+
+                var expandItem = new OsuMenuItem(
+                    Expanded.Value ? WebCommonStrings.ButtonsCollapse.ToSentence() : WebCommonStrings.ButtonsExpand.ToSentence(),
+                    MenuItemType.Highlighted,
+                    () => TriggerClick());
+
+                if (songSelect == null)
+                {
+                    return new MenuItem[]
+                    {
+                        expandItem
+
+                    };
+                }
+
                 return new MenuItem[]
                 {
-                    new OsuMenuItem(Expanded.Value ? WebCommonStrings.ButtonsCollapse.ToSentence() : WebCommonStrings.ButtonsExpand.ToSentence(), MenuItemType.Highlighted, () => TriggerClick())
+                    expandItem,
+                    new OsuMenuItemSpacer(),
+                    new OsuMenuItem(
+                        SongSelectStrings.DeleteAllInGroup,
+                        MenuItemType.Destructive,
+                        () => songSelect.DeleteGroup(group))
                 };
             }
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1246,6 +1246,19 @@ namespace osu.Game.Screens.Select
 
         public void Delete(BeatmapSetInfo beatmapSet) => dialogOverlay?.Push(new BeatmapDeleteDialog(beatmapSet));
 
+        public void DeleteGroup(GroupDefinition group)
+        {
+            if (dialogOverlay == null)
+                return;
+
+            var beatmapSets = carousel.GetBeatmapSetsForGroup(group).ToArray();
+
+            if (beatmapSets.Length == 0)
+                return;
+
+            dialogOverlay.Push(new BeatmapGroupDeleteDialog(group, beatmapSets));
+        }
+
         public void RestoreAllHidden(BeatmapSetInfo beatmapSet)
         {
             foreach (var b in beatmapSet.Beatmaps)


### PR DESCRIPTION
As requested in #36825, this adds a menu item to delete all beatmap sets in whichever group you right click. It will make it easier to mass delete maps and save some precious storage. Considering the spike in SSD prices recently, I for one would like more options to mass delete maps.

<img width="2560" height="1438" alt="image" src="https://github.com/user-attachments/assets/bc7de3cc-8196-4f9e-8aa8-89dfca690037" />

Things that should maybe be addressed, hence why this is a draft:
- When grouping by last played, if a subset of difficulties appear and you hit delete, it will delete the whole map set, which might be unexpected for some people. Though, this also happens when you hit delete on the difficulty itself so it doesn't diverge from how things are currently done
- Write tests?