### PR TITLE
Adjust padding and text size in editor inspector

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
@@ -35,14 +35,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected void AddHeader(string header) => InspectorText.AddParagraph($"{header}: ", s =>
         {
-            s.Padding = new MarginPadding { Top = 2 };
-            s.Font = s.Font.With(size: 12);
+            s.Font = OsuFont.Style.Caption1;
             s.Colour = colourProvider.Content2;
         });
 
         protected void AddValue(string value) => InspectorText.AddParagraph(value, s =>
         {
-            s.Font = s.Font.With(weight: FontWeight.SemiBold);
+            s.Padding = new MarginPadding { Top = -5 };
+            s.Font = OsuFont.Style.Body;
             s.Colour = colourProvider.Content1;
         });
     }


### PR DESCRIPTION
It was taking up way too much vertical space previously.

I'm using the same font specs that are in the new dropdown header, which seem to work quite well. Negative padding because without it everything is way too vertically sparse.

Why? I was looking at [this discussion](https://github.com/ppy/osu/discussions/36708) and like "we need to have SV visible here" but there's really not much room with all this text in the way.