### PR TITLE
Fix score delete dialog not using user-facing rank terminology

### DIFF
--- a/osu.Game/Screens/Select/LocalScoreDeleteDialog.cs
+++ b/osu.Game/Screens/Select/LocalScoreDeleteDialog.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Scoring;
 
@@ -19,7 +20,7 @@ namespace osu.Game.Screens.Select
         [BackgroundDependencyLoader]
         private void load(ScoreManager scoreManager)
         {
-            BodyText = $"{score.User} ({score.DisplayAccuracy}, {score.Rank})";
+            BodyText = $"{score.User} ({score.DisplayAccuracy}, {score.Rank.GetLocalisableDescription()})";
             DangerousAction = () => scoreManager.Delete(score);
         }
     }


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/36859

| Before | After |
| --- | --- |
| <img width="187" height="41" alt="image" src="https://github.com/user-attachments/assets/4fd10043-38ba-46c3-a7be-3ee957652ef4" /> | <img width="241" height="43" alt="image" src="https://github.com/user-attachments/assets/94646620-536d-48ad-b09a-3fbf66dc1684" /> |

While we're here, should there be more statistics shown? At least score, and maybe max combo too. Not doing for now.

Proposed order: User (Score, Max Combo, Accuracy, Rank)

Order is derived from the leaderboard score left to right, but prioritizes score first as I believe that is the most important in differentiating what score is which.