### PR TITLE
Add Noto CJK font with weights

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -486,6 +486,11 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Inter/Inter-Bold");
             AddFont(Resources, @"Fonts/Inter/Inter-BoldItalic");
 
+            AddFont(Resources, @"Fonts/NotoSansKR/NotoSansKR-Regular");
+            AddFont(Resources, @"Fonts/NotoSansKR/NotoSansKR-Bold");
+            AddFont(Resources, @"Fonts/NotoSansKR/NotoSansKR-SemiBold");
+            AddFont(Resources, @"Fonts/NotoSansKR/NotoSansKR-Light");
+
             AddFont(Resources, @"Fonts/Noto/Noto-Basic");
             AddFont(Resources, @"Fonts/Noto/Noto-Bopomofo");
             AddFont(Resources, @"Fonts/Noto/Noto-CJK-Basic");


### PR DESCRIPTION
- Depends on ppy/osu-resources#410

This PR adds Noto CJK font with regular, light, semi bold, and bold weight.

|master|This PR|
|---|---|
|![osu_2026-03-07_20-08-18](https://github.com/user-attachments/assets/fd5f7a61-0826-4b86-b1a1-0e6e780f55ea)|<img width="286" height="368" alt="osu_2026-03-07_20-07-14" src="https://github.com/user-attachments/assets/9d2ebb0d-35ce-476b-8ecf-6602e126c31c" />|