### PR TITLE
Mute warning samples during stage fast forwards

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -46,11 +46,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private const int card_play_samples = 2;
         private Sample?[]? cardPlaySamples;
 
-        private bool timeRunningOutWarningActive;
+        /// <summary>
+        /// Whether the local user has discarded cards.
+        /// </summary>
+        private bool hasDiscardedCards;
+
         private Sample? timeRunningOutSample;
         private SampleChannel? timeRunningOutSampleChannel;
 
         private DateTimeOffset stageEndTime;
+        private TimeSpan stageDuration;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
@@ -143,13 +148,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             onSelectionChanged();
         }
 
+        private bool shouldPlayWarningSample
+            => matchInfo.Stage.Value == RankedPlayStage.CardDiscard
+               && stageDuration > TimeSpan.FromSeconds(warning_time_threshold)
+               && stageEndTime - DateTimeOffset.Now < TimeSpan.FromSeconds(warning_time_threshold)
+               && !hasDiscardedCards;
+
         protected override void Update()
         {
             base.Update();
 
-            TimeSpan remainingTime = stageEndTime - DateTimeOffset.Now;
-
-            if (timeRunningOutWarningActive && remainingTime.TotalSeconds < warning_time_threshold)
+            if (shouldPlayWarningSample)
             {
                 timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
 
@@ -160,6 +169,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 timeRunningOutSampleChannel.Looping = true;
                 timeRunningOutSampleChannel.Play();
             }
+            else
+                timeRunningOutSampleChannel?.Stop();
         }
 
         public override void OnEntering(RankedPlaySubScreen? previous)
@@ -187,11 +198,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
-            if (countdown is not RankedPlayStageCountdown stageCountdown)
+            if (countdown is not RankedPlayStageCountdown)
                 return;
 
             stageEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
-            timeRunningOutWarningActive = stageCountdown.Stage == RankedPlayStage.CardDiscard;
+            stageDuration = countdown.TimeRemaining;
         });
 
         private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
@@ -199,10 +210,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             if (countdown is not RankedPlayStageCountdown)
                 return;
 
-            timeRunningOutSampleChannel?.Stop();
-
             stageEndTime = DateTimeOffset.Now;
-            timeRunningOutWarningActive = false;
+            stageDuration = TimeSpan.Zero;
         });
 
         private void onSelectionChanged()
@@ -219,6 +228,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             Client.DiscardCards(playerHand.Selection.Select(it => it.Card).ToArray()).FireAndForget();
             playerHand.SelectionMode = HandSelectionMode.Disabled;
+
+            hasDiscardedCards = true;
         }
 
         private readonly List<RankedPlayCardWithPlaylistItem> discardedCards = new List<RankedPlayCardWithPlaylistItem>();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -38,12 +38,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private const int card_play_samples = 2;
         private Sample?[]? cardPlaySamples;
 
-        private bool timeRunningOutWarningActive;
         private Sample? timeRunningOutSample;
         private SampleChannel? timeRunningOutSampleChannel;
         private Sample? timeUpBuzzerSample;
 
         private DateTimeOffset stageEndTime;
+        private TimeSpan stageDuration;
 
         /// <summary>
         /// Whether the local user has played a card themselves.
@@ -122,13 +122,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             }
         }
 
+        private bool shouldPlayWarningSample
+            => matchInfo.Stage.Value == RankedPlayStage.CardPlay
+               && stageDuration > TimeSpan.FromSeconds(warning_time_threshold)
+               && stageEndTime - DateTimeOffset.Now < TimeSpan.FromSeconds(warning_time_threshold)
+               && !hasPlayedCard;
+
         protected override void Update()
         {
             base.Update();
 
-            TimeSpan remainingTime = stageEndTime - DateTimeOffset.Now;
-
-            if (timeRunningOutWarningActive && remainingTime.TotalSeconds < warning_time_threshold)
+            if (shouldPlayWarningSample)
             {
                 timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
 
@@ -139,6 +143,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 timeRunningOutSampleChannel.Looping = true;
                 timeRunningOutSampleChannel.Play();
             }
+            else
+                timeRunningOutSampleChannel?.Stop();
         }
 
         public override void OnEntering(RankedPlaySubScreen? previous)
@@ -184,11 +190,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
-            if (countdown is not RankedPlayStageCountdown stageCountdown)
+            if (countdown is not RankedPlayStageCountdown)
                 return;
 
             stageEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
-            timeRunningOutWarningActive = stageCountdown.Stage == RankedPlayStage.CardPlay;
+            stageDuration = countdown.TimeRemaining;
         });
 
         private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
@@ -196,10 +202,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             if (countdown is not RankedPlayStageCountdown stageCountdown)
                 return;
 
-            timeRunningOutSampleChannel?.Stop();
-
             stageEndTime = DateTimeOffset.Now;
-            timeRunningOutWarningActive = false;
+            stageDuration = TimeSpan.Zero;
 
             if (stageCountdown.Stage == RankedPlayStage.CardPlay && !hasPlayedCard)
                 timeUpBuzzerSample?.Play();


### PR DESCRIPTION
In particular, the discard stage fast forwards using a 3s timer: https://github.com/ppy/osu-server-spectator/blob/9cb1dd35c677f216a7cf93b04fd490c68a76f632/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/CardDiscardStage.cs#L46-L48

Play stage changes are only to conform to this new implementation.