### PR TITLE
Fix possible exception

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -183,7 +184,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
                     this.ScaleTo(1.02f, EXPAND_DURATION, Easing.In)
                         .Then()
-                        .ScaleTo(1f, beatLength - EXPAND_DURATION, new CubicBezierEasingFunction(easeIn: 0.1f, easeOut: 1f));
+                        .ScaleTo(1f, Math.Max(0, beatLength - EXPAND_DURATION), new CubicBezierEasingFunction(easeIn: 0.1f, easeOut: 1f));
                 }
             }
 


### PR DESCRIPTION
Randomly encountered this one. Not sure how it behaves in practice/whether this is the correct fix, but it should be quite rare?

```
System.ArgumentOutOfRangeException: duration ('-199.99999999999955') must be a non-negative value. (Parameter 'duration')
Actual value was -199.99999999999955.
   at System.ArgumentOutOfRangeException.ThrowNegative[T](T value, String paramName)
   at System.ArgumentOutOfRangeException.ThrowIfNegative[T](T value, String paramName)
   at osu.Framework.Graphics.TransformableExtensions.PopulateTransform[TValue,TEasing,TThis](TThis t, Transform`3 transform, TValue newValue, Double duration, TEasing& easing)
   at osu.Framework.Graphics.TransformableExtensions.MakeTransform[TThis,TEasing,TValue](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping)
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis,TValue,TEasing](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping)
   at osu.Framework.Graphics.TransformableExtensions.ScaleTo[T,TEasing](T drawable, Vector2 newScale, Double duration, TEasing& easing)
   at osu.Framework.Graphics.TransformableExtensions.ScaleTo[T,TEasing](T drawable, Single newScale, Double duration, TEasing& easing)
   at osu.Framework.Graphics.TransformSequenceExtensions.<>c__DisplayClass42_0`2.<ScaleTo>b__0(T o)
   at osu.Framework.Graphics.Transforms.TransformSequence`1.Append(Generator childGenerator)
   at osu.Framework.Graphics.TransformSequenceExtensions.ScaleTo[T,TEasing](TransformSequence`1 t, Single newScale, Double duration, TEasing easing)
   at osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card.RankedPlayCard.SongPreviewContainer.PulseContainer.OnNewBeat(Int32 beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
```