### PR TITLE
Ranked Play: Fix casing inconsistency in results screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.ScoreStatisticsDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.ScoreStatisticsDisplay.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Scoring;
@@ -48,7 +49,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             Children = score.GetStatisticsForDisplay().Select(it => new BeatmapTitleWedge.StatisticDifficulty
                             {
                                 Width = 80,
-                                Value = new BeatmapTitleWedge.StatisticDifficulty.Data(it.DisplayName, it.Count, it.Count, it.MaxCount ?? it.Count),
+                                Value = new BeatmapTitleWedge.StatisticDifficulty.Data(it.DisplayName.ToTitle(), it.Count, it.Count, it.MaxCount ?? it.Count),
                                 AccentColour = colours.PrimaryDarker,
                             }).ToArray(),
                         }


### PR DESCRIPTION
This is kind of annoying...

Some hit results are given custom names (e.g. "slider tick"):

https://github.com/ppy/osu/blob/87b37fd3860d75c0a90f7a67adb94e3267d1779b/osu.Game.Rulesets.Osu/OsuRuleset.cs#L301-L320

While others go through that `base` call which uses the enum descriptions (e.g. "Great"):

https://github.com/ppy/osu/blob/87b37fd3860d75c0a90f7a67adb94e3267d1779b/osu.Game/Rulesets/Scoring/HitResult.cs#L53-L56