### PR TITLE
Add note lock function to beatmap editor

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -26,24 +26,24 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestGridToggles()
         {
-            AddStep("enable distance snap grid", () => InputManager.Key(Key.Y));
+            AddStep("enable distance snap grid", () => InputManager.Key(Key.U));
             AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
 
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
             gridActive<RectangularPositionSnapGrid>(false);
 
-            AddStep("enable rectangular grid", () => InputManager.Key(Key.T));
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
 
             AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
             AddUntilStep("distance snap grid still visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
             gridActive<RectangularPositionSnapGrid>(true);
 
-            AddStep("disable distance snap grid", () => InputManager.Key(Key.Y));
+            AddStep("disable distance snap grid", () => InputManager.Key(Key.U));
             AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
             AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
             gridActive<RectangularPositionSnapGrid>(true);
 
-            AddStep("disable rectangular grid", () => InputManager.Key(Key.T));
+            AddStep("disable rectangular grid", () => InputManager.Key(Key.Y));
             AddUntilStep("distance snap grid still hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
             gridActive<RectangularPositionSnapGrid>(false);
         }
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("release alt", () => InputManager.ReleaseKey(Key.AltLeft));
             AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
 
-            AddStep("enable distance snap grid", () => InputManager.Key(Key.Y));
+            AddStep("enable distance snap grid", () => InputManager.Key(Key.U));
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
             AddStep("hold alt", () => InputManager.PressKey(Key.AltLeft));
             AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             double distanceSnap = double.PositiveInfinity;
 
-            AddStep("enable distance snap grid", () => InputManager.Key(Key.Y));
+            AddStep("enable distance snap grid", () => InputManager.Key(Key.U));
 
             AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
@@ -174,7 +174,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestGridSizeToggling()
         {
-            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.U));
             AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
             gridSizeIs(4);
 
@@ -197,7 +197,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestGridTypeToggling()
         {
-            AddStep("enable rectangular grid", () => InputManager.Key(Key.T));
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
             AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
             gridActive<RectangularPositionSnapGrid>(true);
 
@@ -220,7 +220,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestGridPlacementTool()
         {
-            AddStep("enable rectangular grid", () => InputManager.Key(Key.T));
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
 
             AddStep("start grid placement", () => InputManager.Key(Key.Number5));
             AddStep("move cursor to slider head + (1, 1)", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -765,5 +765,50 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("release alt", () => InputManager.ReleaseKey(Key.AltLeft));
         }
+
+        [Test]
+        public void TestNoteLock()
+        {
+            HitCircle addedCircle = null!;
+
+            AddStep("add hitobjects", () =>
+            {
+                EditorBeatmap.Add(addedCircle = new HitCircle { StartTime = 100, Position = new Vector2(150, 150) });
+            });
+
+            AddStep("enable notelock", () =>
+            {
+                blueprintContainer.NoteLock.Value = TernaryState.True;
+            });
+
+            AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.Add(addedCircle));
+
+            moveMouseToObject(() => addedCircle);
+
+            AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
+
+            AddAssert("circle didn't move", () => addedCircle.Position == new Vector2(150, 150));
+
+            AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("disable notelock", () =>
+            {
+                blueprintContainer.NoteLock.Value = TernaryState.False;
+            });
+
+            AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.Add(addedCircle));
+
+            moveMouseToObject(() => addedCircle);
+
+            AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
+
+            AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("circle moved", () => addedCircle.Position != new Vector2(150, 150));
+        }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
@@ -17,6 +17,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Tests.Beatmaps;
 using osuTK;
@@ -433,5 +434,50 @@ namespace osu.Game.Tests.Visual.Editing
 
         private void assertSelectionIs(IEnumerable<HitObject> hitObjects)
             => AddAssert("correct hitobjects selected", () => EditorBeatmap.SelectedHitObjects.OrderBy(h => h.StartTime).SequenceEqual(hitObjects));
+
+        [Test]
+        public void TestNoteLock()
+        {
+            HitCircle addedCircle = null!;
+
+            AddStep("add hitobjects", () =>
+            {
+                EditorBeatmap.Add(addedCircle = new HitCircle { StartTime = 100, Position = new Vector2(150, 150) });
+            });
+
+            AddStep("enable notelock", () =>
+            {
+                Editor.ChildrenOfType<ComposeBlueprintContainer>().First().NoteLock.Value = TernaryState.True;
+            });
+
+            AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.Add(addedCircle));
+
+            moveMouseToObject(() => addedCircle);
+
+            AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
+
+            AddAssert("circle didn't move", () => addedCircle.StartTime == 100);
+
+            AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("disable notelock", () =>
+            {
+                Editor.ChildrenOfType<ComposeBlueprintContainer>().First().NoteLock.Value = TernaryState.False;
+            });
+
+            AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.Add(addedCircle));
+
+            moveMouseToObject(() => addedCircle);
+
+            AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
+
+            AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("circle moved", () => addedCircle.StartTime != 100);
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -585,13 +585,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected virtual IEnumerable<SelectionBlueprint<T>> SortForMovement(IReadOnlyList<SelectionBlueprint<T>> blueprints) => blueprints;
 
         /// <summary>
+        /// Indicates whether the selected blueprint can be moved.
+        /// </summary>
+        protected virtual bool AllowSelectionMovement => true;
+
+        /// <summary>
         /// Moves the current selected blueprints.
         /// </summary>
         /// <param name="e">The <see cref="DragEvent"/> defining the movement event.</param>
         /// <returns>Whether a movement was active.</returns>
         private bool moveCurrentSelection(DragEvent e)
         {
-            if (movementBlueprints == null)
+            if (movementBlueprints == null || !AllowSelectionMovement)
                 return false;
 
             return TryMoveBlueprints(e, movementBlueprints);

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [Resolved(canBeNull: true)]
         private EditorScreenWithTimeline editorScreen { get; set; }
 
+        protected override bool AllowSelectionMovement => NoteLock.Value == TernaryState.False;
+
         /// <remarks>
         /// Positional input must be received outside the container's bounds,
         /// in order to handle composer blueprints which are partially offscreen.
@@ -174,6 +176,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public readonly Bindable<TernaryState> NewCombo = new Bindable<TernaryState> { Description = "New Combo" };
 
+        public readonly Bindable<TernaryState> NoteLock = new Bindable<TernaryState> { Description = "Note Lock" };
+
         /// <summary>
         /// A collection of states which will be displayed to the user in the toolbox.
         /// </summary>
@@ -198,6 +202,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     CreateIcon = () => GetIconForSample(kvp.Key),
                 };
             }
+
+            yield return new DrawableTernaryButton
+            {
+                Current = NoteLock,
+                Description = "Note lock",
+                TooltipText = "Lock time and position of note",
+                CreateIcon = () => new SpriteIcon { Icon = FontAwesome.Solid.Lock }
+            };
         }
 
         private IEnumerable<SampleBankTernaryButton> createSampleBankTernaryButtons()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -48,6 +48,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// </remarks>
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => timeline.ReceivePositionalInputAt(screenSpacePos);
 
+        private readonly Bindable<TernaryState> noteLock = new Bindable<TernaryState>();
+
+        protected override bool AllowSelectionMovement => noteLock.Value == TernaryState.False;
+
         public TimelineBlueprintContainer(HitObjectComposer composer)
             : base(composer)
         {
@@ -72,6 +76,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            noteLock.BindTo(Composer.BlueprintContainer.NoteLock);
 
             placement = Beatmap.PlacementObject.GetBoundCopy();
             placement.ValueChanged += placementChanged;


### PR DESCRIPTION
Add a new property to `BlueprintContainer` to control whether the current selection can be moved.

this editor note lock behaviour consistent with stable by preventing drag movement of selected hitobjects in both the compose area and the timeline, including start time changes from timeline dragging.

https://github.com/user-attachments/assets/7c39268e-2a97-4806-88b8-d0f44f1e9472

