### PR TITLE
Fix Simplified Rhythm mod breaking diffcalc when applied to some maps

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
@@ -122,6 +122,8 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     }
                 }
             }
+
+            taikoBeatmap.HitObjects.Sort((a, b) => a.StartTime.CompareTo(b.StartTime));
         }
 
         private int getSnapBetweenNotes(ControlPointInfo controlPointInfo, Hit currentNote, Hit nextNote)

--- a/osu.Game.Tests/NonVisual/ClosestBeatDivisorTest.cs
+++ b/osu.Game.Tests/NonVisual/ClosestBeatDivisorTest.cs
@@ -66,6 +66,18 @@ namespace osu.Game.Tests.NonVisual
             assertClosestDivisors(divisors, closestDivisors, cpi);
         }
 
+        [Test]
+        public void TestNegativeTimingPointOffset()
+        {
+            var cpi = new ControlPointInfo();
+            cpi.Add(-300000, new TimingControlPoint { BeatLength = 1000 });
+
+            double[] divisors = { 3.03d, 0.97d, 14, 13, 7.94d, 6.08d, 3.93d, 2.96d, 2.02d, 64 };
+            double[] closestDivisors = { 3, 1, 16, 12, 8, 6, 4, 3, 2, 1 };
+
+            assertClosestDivisors(divisors, closestDivisors, cpi);
+        }
+
         private static void assertClosestDivisors(IReadOnlyList<double> divisors, IReadOnlyList<double> closestDivisors, ControlPointInfo cpi, double step = 1)
         {
             List<HitObject> hitobjects = new List<HitObject>();

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         public double GetClosestSnappedTime(double time, int beatDivisor, double? referenceTime = null)
         {
             var timingPoint = TimingPointAt(referenceTime ?? time);
-            double snappedTime = getClosestSnappedTime(timingPoint, time, beatDivisor);
+            double snappedTime = getClosestPositiveSnappedTime(timingPoint, time, beatDivisor);
 
             if (referenceTime.HasValue)
                 return snappedTime;
@@ -209,7 +209,7 @@ namespace osu.Game.Beatmaps.ControlPoints
 
             foreach (int divisor in BindableBeatDivisor.PREDEFINED_DIVISORS)
             {
-                double distanceFromSnap = Math.Abs(time - getClosestSnappedTime(timingPoint, time, divisor));
+                double distanceFromSnap = Math.Abs(time - getClosestPositiveSnappedTime(timingPoint, time, divisor));
 
                 if (Precision.DefinitelyBigger(closestTime, distanceFromSnap))
                 {
@@ -221,7 +221,7 @@ namespace osu.Game.Beatmaps.ControlPoints
             return closestDivisor;
         }
 
-        private static double getClosestSnappedTime(TimingControlPoint timingPoint, double time, int beatDivisor)
+        private static double getClosestPositiveSnappedTime(TimingControlPoint timingPoint, double time, int beatDivisor)
         {
             double beatLength = timingPoint.BeatLength / beatDivisor;
             double beats = (Math.Max(time, 0) - timingPoint.Time) / beatLength;

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -197,6 +197,16 @@ namespace osu.Game.Beatmaps.ControlPoints
             int closestDivisor = 0;
             double closestTime = double.MaxValue;
 
+            // `getClosestSnappedTime()` only returns positive time values.
+            // due to that, if `time` is allowed to be negative, the loop lower below could return bogus results
+            // as the "snapped time" will not necessarily be "closest" at that point.
+            // compensate for this by moving `time` by enough beat lengths to go back to the positives.
+            if (time < 0)
+            {
+                int offsetBeats = (int)Math.Ceiling(-time / timingPoint.BeatLength);
+                time += offsetBeats * timingPoint.BeatLength;
+            }
+
             foreach (int divisor in BindableBeatDivisor.PREDEFINED_DIVISORS)
             {
                 double distanceFromSnap = Math.Abs(time - getClosestSnappedTime(timingPoint, time, divisor));


### PR DESCRIPTION
- closes https://github.com/ppy/osu/issues/36942
- fixes https://osu.ppy.sh/community/forums/topics/2187041?n=1

## [Ensure Simplified Rhythm mod does not produce beatmaps with objects out of order](https://github.com/ppy/osu/commit/f4807b3a42dbf46ea0e669b0ba658feaef9baca5)

This is a last ditch safety.

This mod has more apparent issues (see below) but this is a first step of restoring sanity.

Aside than the other fix described below I have not attempted to figure out further why this is happening because the conversion logic is in over my head. I just want hard breakage to not be possible. Why this extra sort is necessary can be investigated by @Hiviexd if he's so inclined.

## [Fix `GetClosestBeatDivisor()` not working correctly with negative time instants](https://github.com/ppy/osu/commit/88dc0d8a73c712a040635af262d7519fe6d772a0) 

This was causing the 1/3 -> 1/2 conversion in Simplified Rhythm to engage on some maps that weren't even mapped in waltz time. Those maps had the common trait of having a timing point with a negative start time.

Notably this could feasibly affect other places as well, like mania beat snap colouring, or the Synesthesia osu! mod.

<details>

<summary>testing</summary>

Tested with Simplified Rhythm engaged, with 1/6 -> 1/4 and 1/3 -> 1/2 conversion enabled

[BULANOVA - NE PLACH' [oni]](https://osu.ppy.sh/beatmapsets/1740291#taiko/3664995) (1/8 snap):
- No mods: 5.18*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 3.48*
- Simplified Rhythm @ 933de7ab: 5.18*

[BULANOVA - NE PLACH' [inner oni]](https://osu.ppy.sh/beatmapsets/1740291#taiko/3648625) (1/8 snap):
- No mods: 5.84*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 4.13*
- Simplified Rhythm @ 933de7ab: 5.84*

[BULANOVA - NE PLACH' [don't cry]](https://osu.ppy.sh/beatmapsets/1740291#taiko/3557681) (1/8 snap):
- No mods: 6.91*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 4.84*
- Simplified Rhythm @ 933de7ab: 6.91*

[Mili - Peach Pit and Cyanide [nik's Normal]](https://osu.ppy.sh/beatmapsets/2468654#osu/5405909) (1/6 snap):
- No mods: 1.63*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 1.10*
- Simplified Rhythm @ 933de7ab: 1.10*

[Mili - Peach Pit and Cyanide [Ix's Hard]](https://osu.ppy.sh/beatmapsets/2468654#osu/5405906) (1/3 snap):
- No mods: 2.50*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 1.71*
- Simplified Rhythm @ 933de7ab: 1.71*

[Mili - Peach Pit and Cyanide [nomi's Hidden Insane]](https://osu.ppy.sh/beatmapsets/2468654#osu/5405910) (1/3 snap):
- No mods: 3.93*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 2.59*
- Simplified Rhythm @ 933de7ab: 2.59*

[Within Temptation - The Unforgiving [Stairway To The Skies]](https://osu.ppy.sh/beatmapsets/29157#osu/172617) (1/3 snap in editor):
- No mods: 1.53*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 1.48*
- Simplified Rhythm @ 933de7ab: 1.48*

[Within Temptation - The Unforgiving [Iron]](https://osu.ppy.sh/beatmapsets/29157#osu/172612) (1/6 snap in editor):
- No mods: 2.76*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 1.75*
- Simplified Rhythm @ 933de7ab: 1.75*

[Within Temptation - The Unforgiving [Marathon]](https://osu.ppy.sh/beatmapsets/29157#osu/156352) (1/4 snap in editor, but has 1/3 / 1/6 sections for sure):
- No mods: 2.96*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 2.75*
- Simplified Rhythm @ 933de7ab: 2.75*
	
[Halozy - Genryuu Kaiko [Higan Torrent]](https://osu.ppy.sh/beatmapsets/180138#osu/433005) (1/4 snap):
- No mods: 5.37*
- Simplified Rhythm @ master: 0.00*
- Simplified Rhythm @ f4807b3a: 3.95*
- Simplified Rhythm @ 933de7ab: 5.37*

</details>