### PR TITLE
implement an option for cursor sensitivity being relative to playfield

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -115,6 +115,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.MenuCursorSize, 1.0f, 0.5f, 2f, 0.01f);
             SetDefault(OsuSetting.GameplayCursorSize, 1.0f, 0.1f, 2f, 0.01f);
             SetDefault(OsuSetting.GameplayCursorDuringTouch, false);
+            SetDefault(OsuSetting.SensitivityScaleWithPlayfieldSize, false);
             SetDefault(OsuSetting.AutoCursorSize, false);
 
             SetDefault(OsuSetting.MouseDisableButtons, false);
@@ -378,6 +379,11 @@ namespace osu.Game.Configuration
         MouseDisableButtons,
         MouseDisableWheel,
         ConfineMouseMode,
+
+        /// <summary>
+        /// Adjusts cursor sensitivity to playfield size.
+        /// </summary>
+        SensitivityScaleWithPlayfieldSize,
 
         /// <summary>
         /// Globally applied audio offset.

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -381,11 +381,6 @@ namespace osu.Game.Configuration
         ConfineMouseMode,
 
         /// <summary>
-        /// Adjusts cursor sensitivity to playfield size.
-        /// </summary>
-        SensitivityScaleWithPlayfieldSize,
-
-        /// <summary>
         /// Globally applied audio offset.
         /// This is added to the audio track's current time. Higher values will cause gameplay to occur earlier, relative to the audio track.
         /// </summary>
@@ -499,5 +494,11 @@ namespace osu.Game.Configuration
 
         DashboardSortMode,
         DashboardDisplayStyle,
+
+        /// <summary>
+        /// Adjusts cursor sensitivity to playfield size.
+        /// </summary>
+        SensitivityScaleWithPlayfieldSize,
+
     }
 }

--- a/osu.Game/Localisation/MouseSettingsStrings.cs
+++ b/osu.Game/Localisation/MouseSettingsStrings.cs
@@ -60,6 +60,16 @@ namespace osu.Game.Localisation
         public static LocalisableString CursorSensitivity => new TranslatableString(getKey(@"cursor_sensitivity"), @"Cursor sensitivity");
 
         /// <summary>
+        /// "Cursor sensitivity relative to Playfield"
+        /// </summary>
+        public static LocalisableString EnableCursorSensitivityRelativeToPlayfield => new TranslatableString(getKey(@"enable_cursor_sensitivity_relative_to_playfield"), @"Cursor sensitivity relative to Playfield");
+
+        /// <summary>
+        /// "Automatically adjusts cursor speed to stay proportional to the play area."
+        /// </summary>
+        public static LocalisableString EnableCursorSensitivityRelativeToPlayfieldToolTip => new TranslatableString(getKey(@"enable_cursor_sensitivity_relative_to_playfield_tooltip"), @"Automatically adjusts cursor speed to stay proportional to the play area.");
+
+        /// <summary>
         /// "This setting has known issues on your platform. If you encounter problems, it is recommended to adjust sensitivity externally and keep this disabled for now."
         /// </summary>
         public static LocalisableString HighPrecisionPlatformWarning => new TranslatableString(getKey(@"high_precision_platform_warning"), @"This setting has known issues on your platform. If you encounter problems, it is recommended to adjust sensitivity externally and keep this disabled for now.");

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Math;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Math;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -27,12 +29,22 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private Bindable<bool> minimiseOnFocusLoss = null!;
         private FormEnumDropdown<OsuConfineMouseMode> confineMouseModeSetting = null!;
         private Bindable<bool> relativeMode = null!;
+        private Bindable<bool> enabledPlayfieldRelative = null!;
 
         private FormCheckBox highPrecisionMouse = null!;
+
+        private FormCheckBox enableSensitivityRelativeToPlayfield = null!;
 
         private readonly Bindable<SettingsNote.Data?> highPrecisionMouseNote = new Bindable<SettingsNote.Data?>();
 
         protected override bool IsToggleable => false;
+        private Bindable<float> scalingSizeX = null!;
+        private Bindable<float> scalingSizeY = null!;
+        private float playfieldScale = 0.8f;
+        private float defaultScale = 0.8f;
+
+        // A entry guard that prevents the two callbacks from ping-ponging off each other.
+        private bool isSyncing;
 
         public MouseSettings(MouseHandler mouseHandler)
             : base(mouseHandler)
@@ -50,6 +62,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             relativeMode = mouseHandler.UseRelativeMode.GetBoundCopy();
             windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
             minimiseOnFocusLoss = config.GetBindable<bool>(FrameworkSetting.MinimiseOnFocusLossInFullscreen);
+
+            enabledPlayfieldRelative = osuConfig.GetBindable<bool>(OsuSetting.SensitivityScaleWithPlayfieldSize);
+            scalingSizeX = osuConfig.GetBindable<float>(OsuSetting.ScalingSizeX);
+            scalingSizeY = osuConfig.GetBindable<float>(OsuSetting.ScalingSizeY);
+            playfieldScale = Math.Min(scalingSizeX.Value, scalingSizeY.Value);
+            float defaultScale = Math.Min(scalingSizeX.Default, scalingSizeY.Default);
 
             AddRange(new Drawable[]
             {
@@ -75,6 +93,15 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Keywords = new[] { "speed", "velocity" },
                 },
+                new SettingsItemV2(enableSensitivityRelativeToPlayfield = new FormCheckBox
+                {
+                    Caption = MouseSettingsStrings.EnableCursorSensitivityRelativeToPlayfield,
+                    HintText = MouseSettingsStrings.EnableCursorSensitivityRelativeToPlayfieldToolTip,
+                    Current = enabledPlayfieldRelative
+                })
+                {
+                    Keywords = new[] { "speed", "velocity", "cursor" },
+                },
                 new SettingsItemV2(confineMouseModeSetting = new FormEnumDropdown<OsuConfineMouseMode>
                 {
                     Caption = MouseSettingsStrings.ConfineMouseMode,
@@ -98,21 +125,53 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.LoadComplete();
 
-            relativeMode.BindValueChanged(relative => localSensitivity.Disabled = !relative.NewValue, true);
+            relativeMode.BindValueChanged(relative =>
+            {
+                localSensitivity.Disabled = !relative.NewValue;
+                enabledPlayfieldRelative.Disabled = !relative.NewValue;
+            }, true);
 
             handlerSensitivity.BindValueChanged(val =>
             {
+                if (isSyncing) return;
+
+                isSyncing = true;
+
                 bool disabled = localSensitivity.Disabled;
 
                 localSensitivity.Disabled = false;
-                localSensitivity.Value = val.NewValue;
+
+                if (enabledPlayfieldRelative.Value)
+                    localSensitivity.Value = val.NewValue / (playfieldScale / defaultScale);
+                else
+                    localSensitivity.Value = val.NewValue;
+
                 localSensitivity.Disabled = disabled;
+
+                isSyncing = false;
             }, true);
 
-            localSensitivity.BindValueChanged(val => handlerSensitivity.Value = val.NewValue);
+            localSensitivity.BindValueChanged(val =>
+            {
+                if (isSyncing) return;
+
+                isSyncing = true;
+
+                if (enabledPlayfieldRelative.Value)
+                    handlerSensitivity.Value = val.NewValue * (playfieldScale / defaultScale);
+                else
+                    handlerSensitivity.Value = val.NewValue;
+
+                isSyncing = false;
+            });
+
+            enabledPlayfieldRelative.BindValueChanged(_ => syncToHandler());
 
             windowMode.BindValueChanged(_ => updateConfineMouseModeSettingVisibility());
             minimiseOnFocusLoss.BindValueChanged(_ => updateConfineMouseModeSettingVisibility(), true);
+
+            scalingSizeX.BindValueChanged(_ => updatePlayfieldScale());
+            scalingSizeY.BindValueChanged(_ => updatePlayfieldScale(), true);
 
             highPrecisionMouse.Current.BindValueChanged(highPrecision =>
             {
@@ -129,6 +188,33 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         break;
                 }
             }, true);
+        }
+
+        /// <summary>
+        /// Pushes the current slider value (<see cref="localSensitivity"/>) to the actual cursor sensitivity
+        /// (<see cref="handlerSensitivity"/>) used by the framework.
+        /// When playfield-relative scaling is enabled, the handler value is adjusted by the ratio of current
+        /// playfield scale to the default, so cursor speed stays proportional to the play area.
+        /// Called when the playfield-relative toggle changes or when playfield scale sliders are adjusted.
+        /// </summary>
+        private void syncToHandler()
+        {
+            if (isSyncing) return;
+
+            isSyncing = true;
+
+            if (enabledPlayfieldRelative.Value)
+                handlerSensitivity.Value = localSensitivity.Value * (playfieldScale / defaultScale);
+            else
+                handlerSensitivity.Value = localSensitivity.Value;
+
+            isSyncing = false;
+        }
+
+        private void updatePlayfieldScale()
+        {
+            playfieldScale = Math.Min(scalingSizeX.Value, scalingSizeY.Value);
+            syncToHandler();
         }
 
         /// <summary>

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -32,15 +32,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private FormCheckBox highPrecisionMouse = null!;
 
-        private FormCheckBox enableSensitivityRelativeToPlayfield = null!;
-
         private readonly Bindable<SettingsNote.Data?> highPrecisionMouseNote = new Bindable<SettingsNote.Data?>();
 
         protected override bool IsToggleable => false;
         private Bindable<float> scalingSizeX = null!;
         private Bindable<float> scalingSizeY = null!;
-        private float playfieldScale = 0.8f;
-        private float defaultScale = 0.8f;
+        private float playfieldScale;
+        private float defaultScale;
 
         // A entry guard that prevents the two callbacks from ping-ponging off each other.
         private bool isSyncing;
@@ -66,7 +64,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             scalingSizeX = osuConfig.GetBindable<float>(OsuSetting.ScalingSizeX);
             scalingSizeY = osuConfig.GetBindable<float>(OsuSetting.ScalingSizeY);
             playfieldScale = Math.Min(scalingSizeX.Value, scalingSizeY.Value);
-            float defaultScale = Math.Min(scalingSizeX.Default, scalingSizeY.Default);
+            defaultScale = Math.Min(scalingSizeX.Default, scalingSizeY.Default);
 
             AddRange(new Drawable[]
             {
@@ -92,7 +90,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Keywords = new[] { "speed", "velocity" },
                 },
-                new SettingsItemV2(enableSensitivityRelativeToPlayfield = new FormCheckBox
+                new SettingsItemV2(new FormCheckBox
                 {
                     Caption = MouseSettingsStrings.EnableCursorSensitivityRelativeToPlayfield,
                     HintText = MouseSettingsStrings.EnableCursorSensitivityRelativeToPlayfieldToolTip,


### PR DESCRIPTION
Throwing an idea as a pull request.

Not many (or close to none) has complained about this issue, but I felt like bugged when adjusting playfield size and my cursor sensitivity wouldn't match. So I decided to code this specific equation.

new_cursor_sens = current_cursor_sens * (current_playfield_size / default_playfield_size).

This option will be next to the slider bar called cursor sensitivity and will be disabled on default.

only issues I currently see:

- isSyncing could break in half of a blue moon.
- The UI for cursor sens constantly triggers when adjusting vertical or horizontal scale.
- Cursor sensitivity caps to 0.1 and 10 (as intended by the devs however)