### PR TITLE
Restore precision buff in Agility

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             double strain = distanceScaled * 1000 / osuCurrObj.AdjustedDeltaTime;
 
+            strain *= osuCurrObj.SmallCircleBonus;
+
             strain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
 
             return strain * DifficultyCalculationUtils.Smootherstep(distance, 0, OsuDifficultyHitObject.NORMALISED_RADIUS);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -42,7 +42,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             double flowDifficulty = currVelocity;
 
-            // Apply high circle size bonus to the base velocity
+            // Apply high circle size bonus to the base velocity.
+            // We use reduced CS bonus here because the bonus was made for an evaluator with a different d/t scaling
             flowDifficulty *= Math.Pow(osuCurrObj.SmallCircleBonus, 0.75);
 
             // Rhythm changes are harder to flow

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             double flowDifficulty = currVelocity;
 
             // Apply high circle size bonus to the base velocity
-            flowDifficulty *= osuCurrObj.SmallCircleBonus;
+            flowDifficulty *= Math.Pow(osuCurrObj.SmallCircleBonus, 0.75);
 
             // Rhythm changes are harder to flow
             flowDifficulty *= 1 + Math.Min(0.25,


### PR DESCRIPTION
Seems like it got lost somewhere in the #36902. Great upside is that flow cs bonus can be reduced as it's supposed to be now since the bonus is made with d/t^1.65 in mind and flow is d/t. Values-wise it's a small precision buff 