### PR TITLE
Fix Discord playtime counter resetting on every activity change

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -58,6 +58,7 @@ namespace osu.Desktop
         private readonly RichPresence presence = new RichPresence
         {
             Assets = new Assets { LargeImageKey = "osu_logo_lazer" },
+            Timestamps = Timestamps.Now,
             Secrets = new Secrets
             {
                 JoinSecret = null,


### PR DESCRIPTION
Discord resets the playtime counter on the rich presence whenever the status changes since there's no timestamp set as the start time for the activity. This PR adds the timestamp as `Timestamps.Now` as per the [library docs](https://lachee.github.io/discord-rpc-csharp/articles/features/timestamps.html)

<table>
<tr>
 <td> Before
 <td> After
<tr>
 <td>

https://github.com/user-attachments/assets/a745967a-3dfa-4f70-938c-a9abd45866c6


 <td>

https://github.com/user-attachments/assets/09c24fde-f150-4a3b-bb6a-afb325561508


</table>