### PR TITLE
Rework user beatmap tag picker to match web

### DIFF
--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Overlays
         public Color4 Colour4 => getColour(0.4f, 0.3f);
 
         public Color4 Highlight1 => getColour(1, 0.7f);
+        public Color4 Highlight2 => getColour(0.5f, 0.45f);
         public Color4 Content1 => getColour(0.4f, 1);
         public Color4 Content2 => getColour(0.4f, 0.9f);
         public Color4 Light1 => getColour(0.4f, 0.8f);

--- a/osu.Game/Screens/Ranking/UserTagControl.AddTagsPopover.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.AddTagsPopover.cs
@@ -10,16 +10,16 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Input.Bindings;
-using osu.Game.Screens.Ranking.Statistics;
+using osu.Game.Overlays;
 using osuTK;
 
 namespace osu.Game.Screens.Ranking
@@ -37,6 +37,11 @@ namespace osu.Game.Screens.Ranking
 
             private CancellationTokenSource? loadCancellationTokenSource;
 
+            public AddTagsPopover()
+                : base(withPadding: false)
+            {
+            }
+
             [BackgroundDependencyLoader]
             private void load()
             {
@@ -45,6 +50,8 @@ namespace osu.Game.Screens.Ranking
                     Anchor.TopCentre,
                     Anchor.BottomCentre,
                 };
+
+                Content.Padding = new MarginPadding { Vertical = 20 };
 
                 Children = new Drawable[]
                 {
@@ -58,20 +65,20 @@ namespace osu.Game.Screens.Ranking
                                 HoldFocus = true,
                                 RelativeSizeAxes = Axes.X,
                                 Depth = float.MinValue,
+                                Padding = new MarginPadding { Horizontal = 20 },
                             },
                             new OsuScrollContainer
                             {
                                 RelativeSizeAxes = Axes.X,
                                 Y = 40,
                                 Height = 260,
-                                ScrollbarOverlapsContent = false,
                                 Child = searchContainer = new SearchContainer
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Padding = new MarginPadding { Right = 5, Bottom = 10 },
+                                    Padding = new MarginPadding { Horizontal = 20 },
                                     Direction = FillDirection.Vertical,
-                                    Spacing = new Vector2(10),
+                                    Spacing = new Vector2(2.5f),
                                 }
                             }
                         },
@@ -135,6 +142,8 @@ namespace osu.Game.Screens.Ranking
             {
                 public IEnumerable<LocalisableString> FilterTerms { get; }
 
+                private readonly Circle circle;
+
                 public bool MatchingFilter
                 {
                     set => Alpha = value ? 1 : 0;
@@ -150,11 +159,41 @@ namespace osu.Game.Screens.Ranking
                     RelativeSizeAxes = Axes.X;
                     AutoSizeAxes = Axes.Y;
                     Direction = FillDirection.Vertical;
-                    Spacing = new Vector2(5);
+                    Spacing = new Vector2(2.5f);
 
-                    Add(new StatisticItemHeader { Text = name ?? "uncategorised" });
+                    Add(new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(5, 0),
+                        Margin = new MarginPadding { Vertical = 2.5f },
+                        Children = new Drawable[]
+                        {
+                            circle = new Circle
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Height = 12,
+                                Width = 6,
+                            },
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Text = name ?? "uncategorized",
+                                Font = OsuFont.Style.Heading2,
+                            }
+                        },
+                    });
 
                     FilterTerms = name == null ? [] : [name];
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider colourProvider)
+                {
+                    circle.Colour = colourProvider.Highlight1;
                 }
             }
 
@@ -162,8 +201,7 @@ namespace osu.Game.Screens.Ranking
             {
                 public readonly UserTag Tag;
 
-                private Box votedBackground = null!;
-                private SpriteIcon votedIcon = null!;
+                private Box background = null!;
 
                 private readonly Bindable<bool> voted = new Bindable<bool>();
                 private readonly BindableBool updating = new BindableBool();
@@ -177,6 +215,8 @@ namespace osu.Game.Screens.Ranking
                     RelativeSizeAxes = Axes.X;
                     AutoSizeAxes = Axes.Y;
 
+                    Content.CornerRadius = 4;
+
                     ScaleOnMouseDown = 0.95f;
 
                     voted.BindTo(Tag.Voted);
@@ -184,62 +224,56 @@ namespace osu.Game.Screens.Ranking
                 }
 
                 [Resolved]
-                private OsuColour colours { get; set; } = null!;
+                private OverlayColourProvider colourProvider { get; set; } = null!;
 
                 [BackgroundDependencyLoader]
                 private void load()
                 {
                     Content.AddRange(new Drawable[]
                     {
-                        new Box
+                        background = new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Colour = colours.Gray7,
+                            Colour = colourProvider.Background3,
                             Depth = float.MaxValue,
                         },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Y,
-                            Width = 30,
-                            Anchor = Anchor.CentreRight,
-                            Origin = Anchor.CentreRight,
-                            Depth = float.MaxValue,
-                            Children = new Drawable[]
-                            {
-                                votedBackground = new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                },
-                                votedIcon = new SpriteIcon
-                                {
-                                    Size = new Vector2(16),
-                                    Icon = FontAwesome.Solid.ThumbsUp,
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                }
-                            }
-                        },
-                        new FillFlowContainer
+                        new GridContainer
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Direction = FillDirection.Vertical,
-                            Spacing = new Vector2(2),
-                            Padding = new MarginPadding(5) { Right = 35 },
-                            Children = new Drawable[]
+                            Padding = new MarginPadding { Horizontal = 10, Vertical = 5 },
+                            ColumnDimensions = new[]
                             {
-                                new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(weight: FontWeight.SemiBold))
+                                new Dimension(GridSizeMode.Absolute, 100),
+                                new Dimension(GridSizeMode.Absolute, 10),
+                                new Dimension(),
+                            },
+                            RowDimensions = new[]
+                            {
+                                new Dimension(GridSizeMode.AutoSize),
+                            },
+                            Content = new[]
+                            {
+                                new Drawable?[]
                                 {
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                    Text = Tag.DisplayName,
+                                    new OsuTextFlowContainer(t => t.Font = OsuFont.Style.Caption1.With(weight: FontWeight.Bold))
+                                    {
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Text = Tag.DisplayName,
+                                    },
+                                    null,
+                                    new OsuTextFlowContainer(t => t.Font = OsuFont.Style.Caption2)
+                                    {
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Text = Tag.Description,
+                                    }
                                 },
-                                new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(size: 14))
-                                {
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                    Text = Tag.Description,
-                                }
                             }
                         },
                         loadingLayer = new LoadingLayer(dimBackground: true),
@@ -264,8 +298,7 @@ namespace osu.Game.Screens.Ranking
 
                     voted.BindValueChanged(_ =>
                     {
-                        votedBackground.FadeColour(voted.Value ? colours.Lime2 : colours.Gray2, 250, Easing.OutQuint);
-                        votedIcon.FadeColour(voted.Value ? Colour4.Black : Colour4.White, 250, Easing.OutQuint);
+                        background.FadeColour(voted.Value ? colourProvider.Highlight2 : colourProvider.Background3, 250, Easing.OutQuint);
                     }, true);
                     FinishTransforms(true);
 

--- a/osu.Game/Screens/Ranking/UserTagControl.AddTagsPopover.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.AddTagsPopover.cs
@@ -60,12 +60,16 @@ namespace osu.Game.Screens.Ranking
                         Size = new Vector2(400, 300),
                         Children = new Drawable[]
                         {
-                            searchBox = new SearchTextBox
+                            new Container
                             {
-                                HoldFocus = true,
                                 RelativeSizeAxes = Axes.X,
-                                Depth = float.MinValue,
                                 Padding = new MarginPadding { Horizontal = 20 },
+                                Child = searchBox = new SearchTextBox
+                                {
+                                    HoldFocus = true,
+                                    RelativeSizeAxes = Axes.X,
+                                    Depth = float.MinValue,
+                                },
                             },
                             new OsuScrollContainer
                             {


### PR DESCRIPTION
This commit brings the tag picker on the results screen in line with the one on the website's beatmap listing page. The main changes are:

* moved scrollbar more to the right, 'outside' of the search container, so that the actual content is fully aligned with the search bar,
* contents of a single tag container are arranged horizontally instead of vertically,
* padding, spacing, and font sizes have been reduced in order to fit more tags on the screen (not particlarly sure on the font sizes),
* components follow the colour provider of the parent screen (not that anything else on the results screen does),
* removed the thumbs up icon in favor of changing colour of the entire tag drawable when selected.

I'm just not particularly confident about that tag group header component, but I can't come up with anything better, and I feel that this is an improvement already.

<img width="718" height="611" alt="image" src="https://github.com/user-attachments/assets/9aa9b94b-f55c-42df-8a39-fc655d53f448" />
