### PR TITLE
Update lots of packages

### DIFF
--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Game.Rulesets.EmptyFreeform\osu.Game.Rulesets.EmptyFreeform.csproj" />

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Game.Rulesets.Pippidon\osu.Game.Rulesets.Pippidon.csproj" />

--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj
+++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Game.Rulesets.EmptyScrolling\osu.Game.Rulesets.EmptyScrolling.csproj" />

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Game.Rulesets.Pippidon\osu.Game.Rulesets.Pippidon.csproj" />

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -24,8 +24,8 @@
     <ProjectReference Include="..\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="System.IO.Packaging" Version="9.0.2" />
-    <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
+    <PackageReference Include="System.IO.Packaging" Version="10.0.5" />
+    <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
   <ItemGroup Label="Resources">

--- a/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj
+++ b/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="nunit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="nunit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/osu.Game.Rulesets.Catch.Tests/CatchSkinColourDecodingTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchSkinColourDecodingTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.IO.Stores;
 using osu.Game.Rulesets.Catch.Skinning;
 using osu.Game.Rulesets.Catch.Skinning.Legacy;
@@ -21,9 +22,9 @@ namespace osu.Game.Rulesets.Catch.Tests
             var skinSource = new SkinProvidingContainer(rawSkin);
             var skin = new CatchLegacySkinTransformer(skinSource);
 
-            Assert.AreEqual(new Color4(232, 185, 35, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value);
-            Assert.AreEqual(new Color4(232, 74, 35, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value);
-            Assert.AreEqual(new Color4(0, 255, 255, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashFruit)?.Value);
+            ClassicAssert.AreEqual(new Color4(232, 185, 35, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value);
+            ClassicAssert.AreEqual(new Color4(232, 74, 35, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value);
+            ClassicAssert.AreEqual(new Color4(0, 255, 255, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashFruit)?.Value);
         }
 
         private class TestLegacySkin : LegacySkin

--- a/osu.Game.Rulesets.Catch.Tests/osu.Game.Rulesets.Catch.Tests.csproj
+++ b/osu.Game.Rulesets.Catch.Tests/osu.Game.Rulesets.Catch.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.TestProject.props" />
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneObjectPlacement.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneObjectPlacement.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             AddStep("change seek setting to true", () => config.SetValue(OsuSetting.EditorAutoSeekOnPlacement, true));
             placeObject();
             AddUntilStep("wait for seek to complete", () => !EditorClock.IsSeeking);
-            AddAssert("seeked forward to object", () => EditorClock.CurrentTime, () => Is.GreaterThan(initialTime));
+            AddAssert("seeked forward to object", () => EditorClock.CurrentTime, () => Is.GreaterThan(initialTime!));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Screens.Select;
@@ -18,19 +19,19 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
             criteria.TryParseCustomKeywordCriteria("keys", Operator.Equal, "1");
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 1 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 2 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 3 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new RulesetInfo { OnlineID = 0 }, new BeatmapDifficulty { CircleSize = 4 }),
                 new FilterCriteria
                 {
@@ -44,19 +45,19 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
             criteria.TryParseCustomKeywordCriteria("keys", Operator.Equal, "1,3,5,7");
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 1 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 2 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 3 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new RulesetInfo { OnlineID = 0 }, new BeatmapDifficulty { CircleSize = 4 }),
                 new FilterCriteria
                 {
@@ -70,19 +71,19 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
             criteria.TryParseCustomKeywordCriteria("keys", Operator.NotEqual, "1");
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 1 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 2 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 3 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new RulesetInfo { OnlineID = 0 }, new BeatmapDifficulty { CircleSize = 4 }),
                 new FilterCriteria
                 {
@@ -96,19 +97,19 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
             criteria.TryParseCustomKeywordCriteria("keys", Operator.NotEqual, "1,3,5,7");
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 1 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 2 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 3 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new RulesetInfo { OnlineID = 0 }, new BeatmapDifficulty { CircleSize = 4 }),
                 new FilterCriteria
                 {
@@ -122,23 +123,23 @@ namespace osu.Game.Rulesets.Mania.Tests
             var criteria = new ManiaFilterCriteria();
             criteria.TryParseCustomKeywordCriteria("keys", Operator.GreaterOrEqual, "4");
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 1 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 2 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 4 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 5 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new RulesetInfo { OnlineID = 0 }, new BeatmapDifficulty { CircleSize = 3 }),
                 new FilterCriteria
                 {
@@ -153,23 +154,23 @@ namespace osu.Game.Rulesets.Mania.Tests
             criteria.TryParseCustomKeywordCriteria("keys", Operator.Greater, "4");
             criteria.TryParseCustomKeywordCriteria("keys", Operator.NotEqual, "7");
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 3 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 4 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 5 }),
                 new FilterCriteria()));
 
-            Assert.False(criteria.Matches(
+            ClassicAssert.False(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 7 }),
                 new FilterCriteria()));
 
-            Assert.True(criteria.Matches(
+            ClassicAssert.True(criteria.Matches(
                 new BeatmapInfo(new ManiaRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 9 }),
                 new FilterCriteria()));
         }
@@ -179,9 +180,9 @@ namespace osu.Game.Rulesets.Mania.Tests
         {
             var criteria = new ManiaFilterCriteria();
 
-            Assert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.Equal, "some text"));
-            Assert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.NotEqual, "4,some text"));
-            Assert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.GreaterOrEqual, "4,5,6"));
+            ClassicAssert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.Equal, "some text"));
+            ClassicAssert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.NotEqual, "4,some text"));
+            ClassicAssert.False(criteria.TryParseCustomKeywordCriteria("keys", Operator.GreaterOrEqual, "4,5,6"));
         }
 
         [TestCase]
@@ -199,7 +200,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 0,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -207,7 +208,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo2, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo2, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "100");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -215,7 +216,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 100
             };
-            Assert.True(criteria.Matches(beatmapInfo3, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo3, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "1");
             BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -223,7 +224,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo4, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "0.1");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -231,7 +232,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 1000,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo5, filterCriteria));
         }
 
         [TestCase]
@@ -249,7 +250,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 0,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo1, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo1, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0");
             BeatmapInfo beatmapInfo2 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -257,7 +258,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 0
             };
-            Assert.True(criteria.Matches(beatmapInfo2, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo2, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "100");
             BeatmapInfo beatmapInfo3 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -265,7 +266,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 100
             };
-            Assert.True(criteria.Matches(beatmapInfo3, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo3, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "1");
             BeatmapInfo beatmapInfo4 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -273,7 +274,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo4, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo4, filterCriteria));
 
             criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "0.1");
             BeatmapInfo beatmapInfo5 = new BeatmapInfo(new ManiaRuleset().RulesetInfo)
@@ -281,7 +282,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 1000,
                 EndTimeObjectCount = 1
             };
-            Assert.True(criteria.Matches(beatmapInfo5, filterCriteria));
+            ClassicAssert.True(criteria.Matches(beatmapInfo5, filterCriteria));
         }
 
         [TestCase]
@@ -299,7 +300,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 TotalObjectCount = 100,
                 EndTimeObjectCount = 50
             };
-            Assert.False(criteria.Matches(beatmapInfo, filterCriteria));
+            ClassicAssert.False(criteria.Matches(beatmapInfo, filterCriteria));
         }
 
         [TestCase]
@@ -307,8 +308,8 @@ namespace osu.Game.Rulesets.Mania.Tests
         {
             var criteria = new ManiaFilterCriteria();
 
-            Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "some text"));
-            Assert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "1some text"));
+            ClassicAssert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.Equal, "some text"));
+            ClassicAssert.False(criteria.TryParseCustomKeywordCriteria("lns", Operator.GreaterOrEqual, "1some text"));
         }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaSpecialColumnTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaSpecialColumnTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace osu.Game.Rulesets.Mania.Tests
 {
@@ -35,7 +36,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         {
             var definition = new StageDefinition(columns);
             var results = getResults(definition);
-            Assert.AreEqual(special, results);
+            ClassicAssert.AreEqual(special, results);
         }
 
         private IEnumerable<bool> getResults(StageDefinition definition)

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHoldOff.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHoldOff.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Tests.Visual;
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
         public void TestMapHasNoHoldNotes()
         {
             var testBeatmap = createModdedBeatmap();
-            Assert.False(testBeatmap.HitObjects.OfType<HoldNote>().Any());
+            ClassicAssert.False(testBeatmap.HitObjects.OfType<HoldNote>().Any());
         }
 
         [Test]

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
@@ -33,11 +34,11 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
-            Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
-            Assert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
+            ClassicAssert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
+            ClassicAssert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
+            ClassicAssert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
         }
 
         [Test]
@@ -54,11 +55,11 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
-            Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
-            Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
+            ClassicAssert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
+            ClassicAssert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
+            ClassicAssert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
         }
 
         [Test]
@@ -74,11 +75,11 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
-            Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
-            Assert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been released");
+            ClassicAssert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
+            ClassicAssert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
+            ClassicAssert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been released");
         }
 
         [Test]
@@ -96,13 +97,13 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
+            ClassicAssert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
 
-            Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
-            Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
+            ClassicAssert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
+            ClassicAssert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
 
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been released");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been released");
         }
 
         [Test]
@@ -119,15 +120,15 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.AreEqual(generated.Frames.Count, frame_offset + 4, "Incorrect number of frames");
-            Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
-            Assert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect first note release time");
-            Assert.AreEqual(2000, generated.Frames[frame_offset + 2].Time, "Incorrect second note hit time");
-            Assert.AreEqual(2000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 3].Time, "Incorrect second note release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key2), "Key2 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 3], ManiaAction.Key2), "Key2 has not been released");
+            ClassicAssert.AreEqual(generated.Frames.Count, frame_offset + 4, "Incorrect number of frames");
+            ClassicAssert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
+            ClassicAssert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect first note release time");
+            ClassicAssert.AreEqual(2000, generated.Frames[frame_offset + 2].Time, "Incorrect second note hit time");
+            ClassicAssert.AreEqual(2000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 3].Time, "Incorrect second note release time");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key2), "Key2 has not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 3], ManiaAction.Key2), "Key2 has not been released");
         }
 
         [Test]
@@ -146,16 +147,16 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.AreEqual(generated.Frames.Count, frame_offset + 4, "Incorrect number of frames");
-            Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
-            Assert.AreEqual(3000, generated.Frames[frame_offset + 2].Time, "Incorrect first note release time");
-            Assert.AreEqual(2000, generated.Frames[frame_offset + 1].Time, "Incorrect second note hit time");
-            Assert.AreEqual(4000, generated.Frames[frame_offset + 3].Time, "Incorrect second note release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key1), "Key1 has not been released");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key2), "Key2 has been released");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 3], ManiaAction.Key2), "Key2 has not been released");
+            ClassicAssert.AreEqual(generated.Frames.Count, frame_offset + 4, "Incorrect number of frames");
+            ClassicAssert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
+            ClassicAssert.AreEqual(3000, generated.Frames[frame_offset + 2].Time, "Incorrect first note release time");
+            ClassicAssert.AreEqual(2000, generated.Frames[frame_offset + 1].Time, "Incorrect second note hit time");
+            ClassicAssert.AreEqual(4000, generated.Frames[frame_offset + 3].Time, "Incorrect second note release time");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key1), "Key1 has not been released");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key2), "Key2 has been released");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 3], ManiaAction.Key2), "Key2 has not been released");
         }
 
         [Test]
@@ -173,14 +174,14 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.AreEqual(generated.Frames.Count, frame_offset + 3, "Incorrect number of frames");
-            Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
-            Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect second note press time + first note release time");
-            Assert.AreEqual(3000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 2].Time, "Incorrect second note release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key2), "Key2 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key2), "Key2 has not been released");
+            ClassicAssert.AreEqual(generated.Frames.Count, frame_offset + 3, "Incorrect number of frames");
+            ClassicAssert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
+            ClassicAssert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect second note press time + first note release time");
+            ClassicAssert.AreEqual(3000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 2].Time, "Incorrect second note release time");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
+            ClassicAssert.True(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key2), "Key2 has not been pressed");
+            ClassicAssert.False(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key2), "Key2 has not been released");
         }
 
         private bool checkContains(ReplayFrame frame, params ManiaAction[] actions) => actions.All(action => ((ManiaReplayFrame)frame).Actions.Contains(action));

--- a/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
+++ b/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.TestProject.props" />
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -102,7 +103,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             for (int i = 0; i < 100; i++)
             {
-                Assert.True(Precision.AlmostEquals(sliderPathPerfect.PositionAt(i / 100.0f), sliderPathBezier.PositionAt(i / 100.0f)));
+                ClassicAssert.True(Precision.AlmostEquals(sliderPathPerfect.PositionAt(i / 100.0f), sliderPathBezier.PositionAt(i / 100.0f)));
             }
         }
 
@@ -174,7 +175,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 double theta = circularArcProperties.ThetaStart + (circularArcProperties.Direction * progress * circularArcProperties.ThetaRange);
                 Vector2 vector = new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta)) * circularArcProperties.Radius;
 
-                Assert.True(Precision.AlmostEquals(circularArcProperties.Centre + vector, path.PositionAt(progress), 0.01f),
+                ClassicAssert.True(Precision.AlmostEquals(circularArcProperties.Centre + vector, path.PositionAt(progress), 0.01f),
                     "A perfect circle with points " + string.Join(", ", path.ControlPoints.Select(x => x.Position)) + " and radius" + circularArcProperties.Radius + "from SliderPath does not almost equal a theoretical perfect circle with " + subpoints + " subpoints"
                     + ": " + (circularArcProperties.Centre + vector) + " - " + path.PositionAt(progress)
                     + " = " + (circularArcProperties.Centre + vector - path.PositionAt(progress))

--- a/osu.Game.Rulesets.Osu.Tests/StackingTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/StackingTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.IO;
 using osu.Game.Rulesets.Mods;
@@ -57,7 +58,7 @@ SliderTickRate:0.5
 
                 // The last hitobject triggers the stacking
                 for (int i = 0; i < objects.Count - 1; i++)
-                    Assert.AreEqual(0, ((OsuHitObject)objects[i]).StackHeight);
+                    ClassicAssert.AreEqual(0, ((OsuHitObject)objects[i]).StackHeight);
             }
         }
 
@@ -104,7 +105,7 @@ SliderTickRate:1
 
                 // The last hitobject triggers the stacking
                 for (int i = 0; i < objects.Count - 1; i++)
-                    Assert.AreEqual(0, ((OsuHitObject)objects[i]).StackHeight);
+                    ClassicAssert.AreEqual(0, ((OsuHitObject)objects[i]).StackHeight);
             }
         }
     }

--- a/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj
+++ b/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.TestProject.props" />
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorSaving.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorSaving.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
                 string export = LocalStorage.GetFiles("exports").First();
 
                 using (var stream = LocalStorage.GetStream(export))
-                using (var zip = ZipArchive.Open(stream))
+                using (var zip = ZipArchive.OpenArchive(stream))
                 {
                     using (var osuStream = zip.Entries.First().OpenEntryStream())
                     using (var reader = new StreamReader(osuStream))

--- a/osu.Game.Rulesets.Taiko.Tests/osu.Game.Rulesets.Taiko.Tests.csproj
+++ b/osu.Game.Rulesets.Taiko.Tests/osu.Game.Rulesets.Taiko.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.TestProject.props" />
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
@@ -42,9 +43,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var decoder = Decoder.GetDecoder<Beatmap>(stream);
                 var working = new TestWorkingBeatmap(decoder.Decode(stream));
 
-                Assert.AreEqual(6, working.Beatmap.BeatmapVersion);
+                ClassicAssert.AreEqual(6, working.Beatmap.BeatmapVersion);
                 Assert.That(working.Beatmap.BeatmapInfo.Ruleset.Name, Is.Not.EqualTo("null placeholder ruleset"));
-                Assert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapVersion);
+                ClassicAssert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapVersion);
             }
         }
 
@@ -59,10 +60,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 ((LegacyBeatmapDecoder)decoder).ApplyOffsets = applyOffsets;
                 var working = new TestWorkingBeatmap(decoder.Decode(stream));
 
-                Assert.AreEqual(4, working.Beatmap.BeatmapVersion);
-                Assert.AreEqual(4, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapVersion);
+                ClassicAssert.AreEqual(4, working.Beatmap.BeatmapVersion);
+                ClassicAssert.AreEqual(4, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapVersion);
 
-                Assert.AreEqual(-1, working.BeatmapInfo.Metadata.PreviewTime);
+                ClassicAssert.AreEqual(-1, working.BeatmapInfo.Metadata.PreviewTime);
             }
         }
 
@@ -78,17 +79,17 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var beatmapInfo = beatmap.BeatmapInfo;
                 var metadata = beatmap.Metadata;
 
-                Assert.AreEqual("03. Renatus - Soleily 192kbps.mp3", metadata.AudioFile);
-                Assert.AreEqual(0, beatmap.AudioLeadIn);
-                Assert.AreEqual(164471, metadata.PreviewTime);
-                Assert.AreEqual(0.7f, beatmap.StackLeniency);
-                Assert.IsTrue(beatmapInfo.Ruleset.OnlineID == 0);
-                Assert.IsFalse(beatmap.LetterboxInBreaks);
-                Assert.IsFalse(beatmap.SpecialStyle);
-                Assert.IsFalse(beatmap.WidescreenStoryboard);
-                Assert.IsFalse(beatmap.SamplesMatchPlaybackRate);
-                Assert.AreEqual(CountdownType.None, beatmap.Countdown);
-                Assert.AreEqual(0, beatmap.CountdownOffset);
+                ClassicAssert.AreEqual("03. Renatus - Soleily 192kbps.mp3", metadata.AudioFile);
+                ClassicAssert.AreEqual(0, beatmap.AudioLeadIn);
+                ClassicAssert.AreEqual(164471, metadata.PreviewTime);
+                ClassicAssert.AreEqual(0.7f, beatmap.StackLeniency);
+                ClassicAssert.True(beatmapInfo.Ruleset.OnlineID == 0);
+                ClassicAssert.False(beatmap.LetterboxInBreaks);
+                ClassicAssert.False(beatmap.SpecialStyle);
+                ClassicAssert.False(beatmap.WidescreenStoryboard);
+                ClassicAssert.False(beatmap.SamplesMatchPlaybackRate);
+                ClassicAssert.AreEqual(CountdownType.None, beatmap.Countdown);
+                ClassicAssert.AreEqual(0, beatmap.CountdownOffset);
             }
         }
 
@@ -108,13 +109,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
                     95901, 106450, 116999, 119637, 130186, 140735, 151285,
                     161834, 164471, 175020, 185570, 196119, 206669, 209306
                 };
-                Assert.AreEqual(expectedBookmarks.Length, beatmap.Bookmarks.Length);
+                ClassicAssert.AreEqual(expectedBookmarks.Length, beatmap.Bookmarks.Length);
                 for (int i = 0; i < expectedBookmarks.Length; i++)
-                    Assert.AreEqual(expectedBookmarks[i], beatmap.Bookmarks[i]);
-                Assert.AreEqual(1.8, beatmap.DistanceSpacing);
-                Assert.AreEqual(4, beatmap.BeatmapInfo.BeatDivisor);
-                Assert.AreEqual(4, beatmap.GridSize);
-                Assert.AreEqual(2, beatmap.TimelineZoom);
+                    ClassicAssert.AreEqual(expectedBookmarks[i], beatmap.Bookmarks[i]);
+                ClassicAssert.AreEqual(1.8, beatmap.DistanceSpacing);
+                ClassicAssert.AreEqual(4, beatmap.BeatmapInfo.BeatDivisor);
+                ClassicAssert.AreEqual(4, beatmap.GridSize);
+                ClassicAssert.AreEqual(2, beatmap.TimelineZoom);
             }
         }
 
@@ -130,16 +131,16 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var beatmapInfo = beatmap.BeatmapInfo;
                 var metadata = beatmap.Metadata;
 
-                Assert.AreEqual("Renatus", metadata.Title);
-                Assert.AreEqual("Renatus", metadata.TitleUnicode);
-                Assert.AreEqual("Soleily", metadata.Artist);
-                Assert.AreEqual("Soleily", metadata.ArtistUnicode);
-                Assert.AreEqual("Gamu", metadata.Author.Username);
-                Assert.AreEqual("Insane", beatmapInfo.DifficultyName);
-                Assert.AreEqual(string.Empty, metadata.Source);
-                Assert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", metadata.Tags);
-                Assert.AreEqual(557821, beatmapInfo.OnlineID);
-                Assert.AreEqual(241526, beatmapInfo.BeatmapSet?.OnlineID);
+                ClassicAssert.AreEqual("Renatus", metadata.Title);
+                ClassicAssert.AreEqual("Renatus", metadata.TitleUnicode);
+                ClassicAssert.AreEqual("Soleily", metadata.Artist);
+                ClassicAssert.AreEqual("Soleily", metadata.ArtistUnicode);
+                ClassicAssert.AreEqual("Gamu", metadata.Author.Username);
+                ClassicAssert.AreEqual("Insane", beatmapInfo.DifficultyName);
+                ClassicAssert.AreEqual(string.Empty, metadata.Source);
+                ClassicAssert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", metadata.Tags);
+                ClassicAssert.AreEqual(557821, beatmapInfo.OnlineID);
+                ClassicAssert.AreEqual(241526, beatmapInfo.BeatmapSet?.OnlineID);
             }
         }
 
@@ -153,12 +154,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var difficulty = decoder.Decode(stream).Difficulty;
 
-                Assert.AreEqual(6.5f, difficulty.DrainRate);
-                Assert.AreEqual(4, difficulty.CircleSize);
-                Assert.AreEqual(8, difficulty.OverallDifficulty);
-                Assert.AreEqual(9, difficulty.ApproachRate);
-                Assert.AreEqual(1.8, difficulty.SliderMultiplier);
-                Assert.AreEqual(2, difficulty.SliderTickRate);
+                ClassicAssert.AreEqual(6.5f, difficulty.DrainRate);
+                ClassicAssert.AreEqual(4, difficulty.CircleSize);
+                ClassicAssert.AreEqual(8, difficulty.OverallDifficulty);
+                ClassicAssert.AreEqual(9, difficulty.ApproachRate);
+                ClassicAssert.AreEqual(1.8, difficulty.SliderMultiplier);
+                ClassicAssert.AreEqual(2, difficulty.SliderTickRate);
             }
         }
 
@@ -174,10 +175,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var metadata = beatmap.Metadata;
                 var breakPoint = beatmap.Breaks[0];
 
-                Assert.AreEqual("machinetop_background.jpg", metadata.BackgroundFile);
-                Assert.AreEqual(122474, breakPoint.StartTime);
-                Assert.AreEqual(140135, breakPoint.EndTime);
-                Assert.IsTrue(breakPoint.HasEffect);
+                ClassicAssert.AreEqual("machinetop_background.jpg", metadata.BackgroundFile);
+                ClassicAssert.AreEqual(122474, breakPoint.StartTime);
+                ClassicAssert.AreEqual(140135, breakPoint.EndTime);
+                ClassicAssert.True(breakPoint.HasEffect);
             }
         }
 
@@ -192,7 +193,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var beatmap = decoder.Decode(stream);
                 var metadata = beatmap.Metadata;
 
-                Assert.AreEqual("BG.jpg", metadata.BackgroundFile);
+                ClassicAssert.AreEqual("BG.jpg", metadata.BackgroundFile);
             }
         }
 
@@ -207,7 +208,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var beatmap = decoder.Decode(stream);
                 var metadata = beatmap.Metadata;
 
-                Assert.AreEqual("BG.jpg", metadata.BackgroundFile);
+                ClassicAssert.AreEqual("BG.jpg", metadata.BackgroundFile);
             }
         }
 
@@ -222,7 +223,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var beatmap = decoder.Decode(stream);
                 var metadata = beatmap.Metadata;
 
-                Assert.AreEqual("BG.jpg", metadata.BackgroundFile);
+                ClassicAssert.AreEqual("BG.jpg", metadata.BackgroundFile);
             }
         }
 
@@ -237,67 +238,67 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var beatmap = decoder.Decode(stream);
                 var controlPoints = (LegacyControlPointInfo)beatmap.ControlPointInfo;
 
-                Assert.AreEqual(4, controlPoints.TimingPoints.Count);
-                Assert.AreEqual(5, controlPoints.DifficultyPoints.Count);
-                Assert.AreEqual(34, controlPoints.SamplePoints.Count);
-                Assert.AreEqual(8, controlPoints.EffectPoints.Count);
+                ClassicAssert.AreEqual(4, controlPoints.TimingPoints.Count);
+                ClassicAssert.AreEqual(5, controlPoints.DifficultyPoints.Count);
+                ClassicAssert.AreEqual(34, controlPoints.SamplePoints.Count);
+                ClassicAssert.AreEqual(8, controlPoints.EffectPoints.Count);
 
                 var timingPoint = controlPoints.TimingPointAt(0);
-                Assert.AreEqual(956, timingPoint.Time);
-                Assert.AreEqual(329.67032967033, timingPoint.BeatLength);
-                Assert.AreEqual(TimeSignature.SimpleQuadruple, timingPoint.TimeSignature);
-                Assert.IsFalse(timingPoint.OmitFirstBarLine);
+                ClassicAssert.AreEqual(956, timingPoint.Time);
+                ClassicAssert.AreEqual(329.67032967033, timingPoint.BeatLength);
+                ClassicAssert.AreEqual(TimeSignature.SimpleQuadruple, timingPoint.TimeSignature);
+                ClassicAssert.False(timingPoint.OmitFirstBarLine);
 
                 timingPoint = controlPoints.TimingPointAt(48428);
-                Assert.AreEqual(956, timingPoint.Time);
-                Assert.AreEqual(329.67032967033d, timingPoint.BeatLength);
-                Assert.AreEqual(TimeSignature.SimpleQuadruple, timingPoint.TimeSignature);
-                Assert.IsFalse(timingPoint.OmitFirstBarLine);
+                ClassicAssert.AreEqual(956, timingPoint.Time);
+                ClassicAssert.AreEqual(329.67032967033d, timingPoint.BeatLength);
+                ClassicAssert.AreEqual(TimeSignature.SimpleQuadruple, timingPoint.TimeSignature);
+                ClassicAssert.False(timingPoint.OmitFirstBarLine);
 
                 timingPoint = controlPoints.TimingPointAt(119637);
-                Assert.AreEqual(119637, timingPoint.Time);
-                Assert.AreEqual(659.340659340659, timingPoint.BeatLength);
-                Assert.AreEqual(TimeSignature.SimpleQuadruple, timingPoint.TimeSignature);
-                Assert.IsFalse(timingPoint.OmitFirstBarLine);
+                ClassicAssert.AreEqual(119637, timingPoint.Time);
+                ClassicAssert.AreEqual(659.340659340659, timingPoint.BeatLength);
+                ClassicAssert.AreEqual(TimeSignature.SimpleQuadruple, timingPoint.TimeSignature);
+                ClassicAssert.False(timingPoint.OmitFirstBarLine);
 
                 var difficultyPoint = controlPoints.DifficultyPointAt(0);
-                Assert.AreEqual(0, difficultyPoint.Time);
-                Assert.AreEqual(1.0, difficultyPoint.SliderVelocity);
+                ClassicAssert.AreEqual(0, difficultyPoint.Time);
+                ClassicAssert.AreEqual(1.0, difficultyPoint.SliderVelocity);
 
                 difficultyPoint = controlPoints.DifficultyPointAt(48428);
-                Assert.AreEqual(0, difficultyPoint.Time);
-                Assert.AreEqual(1.0, difficultyPoint.SliderVelocity);
+                ClassicAssert.AreEqual(0, difficultyPoint.Time);
+                ClassicAssert.AreEqual(1.0, difficultyPoint.SliderVelocity);
 
                 difficultyPoint = controlPoints.DifficultyPointAt(116999);
-                Assert.AreEqual(116999, difficultyPoint.Time);
-                Assert.AreEqual(0.75, difficultyPoint.SliderVelocity, 0.1);
+                ClassicAssert.AreEqual(116999, difficultyPoint.Time);
+                ClassicAssert.AreEqual(0.75, difficultyPoint.SliderVelocity, 0.1);
 
                 var soundPoint = controlPoints.SamplePointAt(0);
-                Assert.AreEqual(956, soundPoint.Time);
-                Assert.AreEqual(HitSampleInfo.BANK_SOFT, soundPoint.SampleBank);
-                Assert.AreEqual(60, soundPoint.SampleVolume);
+                ClassicAssert.AreEqual(956, soundPoint.Time);
+                ClassicAssert.AreEqual(HitSampleInfo.BANK_SOFT, soundPoint.SampleBank);
+                ClassicAssert.AreEqual(60, soundPoint.SampleVolume);
 
                 soundPoint = controlPoints.SamplePointAt(53373);
-                Assert.AreEqual(53373, soundPoint.Time);
-                Assert.AreEqual(HitSampleInfo.BANK_SOFT, soundPoint.SampleBank);
-                Assert.AreEqual(60, soundPoint.SampleVolume);
+                ClassicAssert.AreEqual(53373, soundPoint.Time);
+                ClassicAssert.AreEqual(HitSampleInfo.BANK_SOFT, soundPoint.SampleBank);
+                ClassicAssert.AreEqual(60, soundPoint.SampleVolume);
 
                 soundPoint = controlPoints.SamplePointAt(119637);
-                Assert.AreEqual(119637, soundPoint.Time);
-                Assert.AreEqual(HitSampleInfo.BANK_SOFT, soundPoint.SampleBank);
-                Assert.AreEqual(80, soundPoint.SampleVolume);
+                ClassicAssert.AreEqual(119637, soundPoint.Time);
+                ClassicAssert.AreEqual(HitSampleInfo.BANK_SOFT, soundPoint.SampleBank);
+                ClassicAssert.AreEqual(80, soundPoint.SampleVolume);
 
                 var effectPoint = controlPoints.EffectPointAt(0);
-                Assert.AreEqual(0, effectPoint.Time);
-                Assert.IsFalse(effectPoint.KiaiMode);
+                ClassicAssert.AreEqual(0, effectPoint.Time);
+                ClassicAssert.False(effectPoint.KiaiMode);
 
                 effectPoint = controlPoints.EffectPointAt(53703);
-                Assert.AreEqual(53703, effectPoint.Time);
-                Assert.IsTrue(effectPoint.KiaiMode);
+                ClassicAssert.AreEqual(53703, effectPoint.Time);
+                ClassicAssert.True(effectPoint.KiaiMode);
 
                 effectPoint = controlPoints.EffectPointAt(116637);
-                Assert.AreEqual(95901, effectPoint.Time);
-                Assert.IsFalse(effectPoint.KiaiMode);
+                ClassicAssert.AreEqual(95901, effectPoint.Time);
+                ClassicAssert.False(effectPoint.KiaiMode);
             }
         }
 
@@ -397,9 +398,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                     new Color4(255, 177, 140, 255),
                     new Color4(100, 100, 100, 255), // alpha is specified as 100, but should be ignored.
                 };
-                Assert.AreEqual(expectedColors.Length, comboColors.Count);
+                ClassicAssert.AreEqual(expectedColors.Length, comboColors.Count);
                 for (int i = 0; i < expectedColors.Length; i++)
-                    Assert.AreEqual(expectedColors[i], comboColors[i]);
+                    ClassicAssert.AreEqual(expectedColors[i], comboColors[i]);
             }
         }
 
@@ -426,9 +427,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                     new Color4(100, 100, 100, 255),
                     new Color4(142, 199, 255, 255),
                 };
-                Assert.AreEqual(expectedColors.Length, comboColors.Count);
+                ClassicAssert.AreEqual(expectedColors.Length, comboColors.Count);
                 for (int i = 0; i < expectedColors.Length; i++)
-                    Assert.AreEqual(expectedColors[i], comboColors[i]);
+                    ClassicAssert.AreEqual(expectedColors[i], comboColors[i]);
             }
         }
 
@@ -464,12 +465,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 new OsuBeatmapProcessor(converted).PreProcess();
                 new OsuBeatmapProcessor(converted).PostProcess();
 
-                Assert.AreEqual(1, ((IHasComboInformation)converted.HitObjects.ElementAt(0)).ComboIndexWithOffsets);
-                Assert.AreEqual(2, ((IHasComboInformation)converted.HitObjects.ElementAt(2)).ComboIndexWithOffsets);
-                Assert.AreEqual(3, ((IHasComboInformation)converted.HitObjects.ElementAt(4)).ComboIndexWithOffsets);
-                Assert.AreEqual(4, ((IHasComboInformation)converted.HitObjects.ElementAt(6)).ComboIndexWithOffsets);
-                Assert.AreEqual(8, ((IHasComboInformation)converted.HitObjects.ElementAt(8)).ComboIndexWithOffsets);
-                Assert.AreEqual(9, ((IHasComboInformation)converted.HitObjects.ElementAt(11)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(1, ((IHasComboInformation)converted.HitObjects.ElementAt(0)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(2, ((IHasComboInformation)converted.HitObjects.ElementAt(2)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(3, ((IHasComboInformation)converted.HitObjects.ElementAt(4)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(4, ((IHasComboInformation)converted.HitObjects.ElementAt(6)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(8, ((IHasComboInformation)converted.HitObjects.ElementAt(8)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(9, ((IHasComboInformation)converted.HitObjects.ElementAt(11)).ComboIndexWithOffsets);
             }
         }
 
@@ -487,12 +488,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 new CatchBeatmapProcessor(converted).PreProcess();
                 new CatchBeatmapProcessor(converted).PostProcess();
 
-                Assert.AreEqual(1, ((IHasComboInformation)converted.HitObjects.ElementAt(0)).ComboIndexWithOffsets);
-                Assert.AreEqual(2, ((IHasComboInformation)converted.HitObjects.ElementAt(2)).ComboIndexWithOffsets);
-                Assert.AreEqual(3, ((IHasComboInformation)converted.HitObjects.ElementAt(4)).ComboIndexWithOffsets);
-                Assert.AreEqual(4, ((IHasComboInformation)converted.HitObjects.ElementAt(6)).ComboIndexWithOffsets);
-                Assert.AreEqual(8, ((IHasComboInformation)converted.HitObjects.ElementAt(8)).ComboIndexWithOffsets);
-                Assert.AreEqual(9, ((IHasComboInformation)converted.HitObjects.ElementAt(11)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(1, ((IHasComboInformation)converted.HitObjects.ElementAt(0)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(2, ((IHasComboInformation)converted.HitObjects.ElementAt(2)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(3, ((IHasComboInformation)converted.HitObjects.ElementAt(4)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(4, ((IHasComboInformation)converted.HitObjects.ElementAt(6)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(8, ((IHasComboInformation)converted.HitObjects.ElementAt(8)).ComboIndexWithOffsets);
+                ClassicAssert.AreEqual(9, ((IHasComboInformation)converted.HitObjects.ElementAt(11)).ComboIndexWithOffsets);
             }
         }
 
@@ -508,8 +509,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 var positionData = hitObjects[0] as IHasPosition;
 
-                Assert.IsNotNull(positionData);
-                Assert.AreEqual(new Vector2(256, 256), positionData!.Position);
+                ClassicAssert.NotNull(positionData);
+                ClassicAssert.AreEqual(new Vector2(256, 256), positionData!.Position);
             }
         }
 
@@ -525,8 +526,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 var positionData = hitObjects[0] as IHasPosition;
 
-                Assert.IsNotNull(positionData);
-                Assert.AreEqual(new Vector2(256.99853f, 256.001f), positionData!.Position);
+                ClassicAssert.NotNull(positionData);
+                ClassicAssert.AreEqual(new Vector2(256.99853f, 256.001f), positionData!.Position);
             }
         }
 
@@ -543,18 +544,18 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var curveData = hitObjects[0] as IHasPathWithRepeats;
                 var positionData = hitObjects[0] as IHasPosition;
 
-                Assert.IsNotNull(positionData);
-                Assert.IsNotNull(curveData);
-                Assert.AreEqual(new Vector2(192, 168), positionData!.Position);
-                Assert.AreEqual(956, hitObjects[0].StartTime);
-                Assert.IsTrue(hitObjects[0].Samples.Any(s => s.Name == HitSampleInfo.HIT_NORMAL));
+                ClassicAssert.NotNull(positionData);
+                ClassicAssert.NotNull(curveData);
+                ClassicAssert.AreEqual(new Vector2(192, 168), positionData!.Position);
+                ClassicAssert.AreEqual(956, hitObjects[0].StartTime);
+                ClassicAssert.True(hitObjects[0].Samples.Any(s => s.Name == HitSampleInfo.HIT_NORMAL));
 
                 positionData = hitObjects[1] as IHasPosition;
 
-                Assert.IsNotNull(positionData);
-                Assert.AreEqual(new Vector2(304, 56), positionData!.Position);
-                Assert.AreEqual(1285, hitObjects[1].StartTime);
-                Assert.IsTrue(hitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
+                ClassicAssert.NotNull(positionData);
+                ClassicAssert.AreEqual(new Vector2(304, 56), positionData!.Position);
+                ClassicAssert.AreEqual(1285, hitObjects[1].StartTime);
+                ClassicAssert.True(hitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
             }
         }
 
@@ -585,22 +586,22 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var hitObjects = decoder.Decode(stream).HitObjects;
 
-                Assert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[0]).LookupNames.First());
-                Assert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[1]).LookupNames.First());
-                Assert.AreEqual("Gameplay/normal-hitnormal2", getTestableSampleInfo(hitObjects[2]).LookupNames.First());
-                Assert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[3]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[0]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[1]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal2", getTestableSampleInfo(hitObjects[2]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[3]).LookupNames.First());
 
                 // The fourth object is a slider.
                 // `Samples` of a slider are presumed to control the volume of sounds that last the entire duration of the slider
                 // (such as ticks, slider slide sounds, etc.)
                 // Thus, the point of query of control points used for `Samples` is just beyond the start time of the slider.
-                Assert.AreEqual("Gameplay/soft-hitnormal11", getTestableSampleInfo(hitObjects[4]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/soft-hitnormal11", getTestableSampleInfo(hitObjects[4]).LookupNames.First());
 
                 // That said, the `NodeSamples` of the slider are responsible for the sounds of the slider's head / tail / repeats / large ticks etc.
                 // Therefore, they should be read at the time instant correspondent to the given node.
                 // This means that the tail should use bank 8 rather than 11.
-                Assert.AreEqual("Gameplay/soft-hitnormal11", ((ConvertSlider)hitObjects[4]).NodeSamples[0][0].LookupNames.First());
-                Assert.AreEqual("Gameplay/soft-hitnormal8", ((ConvertSlider)hitObjects[4]).NodeSamples[1][0].LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/soft-hitnormal11", ((ConvertSlider)hitObjects[4]).NodeSamples[0][0].LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/soft-hitnormal8", ((ConvertSlider)hitObjects[4]).NodeSamples[1][0].LookupNames.First());
             }
 
             static HitSampleInfo getTestableSampleInfo(HitObject hitObject) => hitObject.Samples[0];
@@ -616,9 +617,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var hitObjects = decoder.Decode(stream).HitObjects;
 
-                Assert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[0]).LookupNames.First());
-                Assert.AreEqual("Gameplay/normal-hitnormal2", getTestableSampleInfo(hitObjects[1]).LookupNames.First());
-                Assert.AreEqual("Gameplay/normal-hitnormal3", getTestableSampleInfo(hitObjects[2]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal", getTestableSampleInfo(hitObjects[0]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal2", getTestableSampleInfo(hitObjects[1]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal3", getTestableSampleInfo(hitObjects[2]).LookupNames.First());
             }
 
             static HitSampleInfo getTestableSampleInfo(HitObject hitObject) => hitObject.Samples[0];
@@ -634,11 +635,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var hitObjects = decoder.Decode(stream).HitObjects;
 
-                Assert.AreEqual("hit_1.wav", getTestableSampleInfo(hitObjects[0]).LookupNames.First());
-                Assert.AreEqual("hit_2.wav", getTestableSampleInfo(hitObjects[1]).LookupNames.First());
-                Assert.AreEqual("Gameplay/normal-hitnormal2", getTestableSampleInfo(hitObjects[2]).LookupNames.First());
-                Assert.AreEqual("hit_1.wav", getTestableSampleInfo(hitObjects[3]).LookupNames.First());
-                Assert.AreEqual(70, getTestableSampleInfo(hitObjects[3]).Volume);
+                ClassicAssert.AreEqual("hit_1.wav", getTestableSampleInfo(hitObjects[0]).LookupNames.First());
+                ClassicAssert.AreEqual("hit_2.wav", getTestableSampleInfo(hitObjects[1]).LookupNames.First());
+                ClassicAssert.AreEqual("Gameplay/normal-hitnormal2", getTestableSampleInfo(hitObjects[2]).LookupNames.First());
+                ClassicAssert.AreEqual("hit_1.wav", getTestableSampleInfo(hitObjects[3]).LookupNames.First());
+                ClassicAssert.AreEqual(70, getTestableSampleInfo(hitObjects[3]).Volume);
             }
 
             static HitSampleInfo getTestableSampleInfo(HitObject hitObject) => hitObject.Samples[0];
@@ -656,35 +657,35 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 var slider1 = (ConvertSlider)hitObjects[0];
 
-                Assert.AreEqual(1, slider1.NodeSamples[0].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider1.NodeSamples[0][0].Name);
-                Assert.AreEqual(1, slider1.NodeSamples[1].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider1.NodeSamples[1][0].Name);
-                Assert.AreEqual(1, slider1.NodeSamples[2].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider1.NodeSamples[2][0].Name);
+                ClassicAssert.AreEqual(1, slider1.NodeSamples[0].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider1.NodeSamples[0][0].Name);
+                ClassicAssert.AreEqual(1, slider1.NodeSamples[1].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider1.NodeSamples[1][0].Name);
+                ClassicAssert.AreEqual(1, slider1.NodeSamples[2].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider1.NodeSamples[2][0].Name);
 
                 var slider2 = (ConvertSlider)hitObjects[1];
 
-                Assert.AreEqual(2, slider2.NodeSamples[0].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider2.NodeSamples[0][0].Name);
-                Assert.AreEqual(HitSampleInfo.HIT_CLAP, slider2.NodeSamples[0][1].Name);
-                Assert.AreEqual(2, slider2.NodeSamples[1].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider2.NodeSamples[1][0].Name);
-                Assert.AreEqual(HitSampleInfo.HIT_CLAP, slider2.NodeSamples[1][1].Name);
-                Assert.AreEqual(2, slider2.NodeSamples[2].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider2.NodeSamples[2][0].Name);
-                Assert.AreEqual(HitSampleInfo.HIT_CLAP, slider2.NodeSamples[2][1].Name);
+                ClassicAssert.AreEqual(2, slider2.NodeSamples[0].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider2.NodeSamples[0][0].Name);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_CLAP, slider2.NodeSamples[0][1].Name);
+                ClassicAssert.AreEqual(2, slider2.NodeSamples[1].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider2.NodeSamples[1][0].Name);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_CLAP, slider2.NodeSamples[1][1].Name);
+                ClassicAssert.AreEqual(2, slider2.NodeSamples[2].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider2.NodeSamples[2][0].Name);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_CLAP, slider2.NodeSamples[2][1].Name);
 
                 var slider3 = (ConvertSlider)hitObjects[2];
 
-                Assert.AreEqual(2, slider3.NodeSamples[0].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider3.NodeSamples[0][0].Name);
-                Assert.AreEqual(HitSampleInfo.HIT_WHISTLE, slider3.NodeSamples[0][1].Name);
-                Assert.AreEqual(1, slider3.NodeSamples[1].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider3.NodeSamples[1][0].Name);
-                Assert.AreEqual(2, slider3.NodeSamples[2].Count);
-                Assert.AreEqual(HitSampleInfo.HIT_NORMAL, slider3.NodeSamples[2][0].Name);
-                Assert.AreEqual(HitSampleInfo.HIT_CLAP, slider3.NodeSamples[2][1].Name);
+                ClassicAssert.AreEqual(2, slider3.NodeSamples[0].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider3.NodeSamples[0][0].Name);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_WHISTLE, slider3.NodeSamples[0][1].Name);
+                ClassicAssert.AreEqual(1, slider3.NodeSamples[1].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider3.NodeSamples[1][0].Name);
+                ClassicAssert.AreEqual(2, slider3.NodeSamples[2].Count);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_NORMAL, slider3.NodeSamples[2][0].Name);
+                ClassicAssert.AreEqual(HitSampleInfo.HIT_CLAP, slider3.NodeSamples[2][1].Name);
             }
         }
 
@@ -698,7 +699,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var hitObjects = decoder.Decode(stream).HitObjects;
 
-                Assert.AreEqual(hitObjects[0].Samples[0].Bank, hitObjects[0].Samples[1].Bank);
+                ClassicAssert.AreEqual(hitObjects[0].Samples[0].Bank, hitObjects[0].Samples[1].Bank);
             }
         }
 
@@ -739,10 +740,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
             static void assertObjectHasBanks(HitObject hitObject, string normalBank, string? additionsBank = null)
             {
-                Assert.AreEqual(normalBank, hitObject.Samples[0].Bank);
+                ClassicAssert.AreEqual(normalBank, hitObject.Samples[0].Bank);
 
                 if (additionsBank != null)
-                    Assert.AreEqual(additionsBank, hitObject.Samples[1].Bank);
+                    ClassicAssert.AreEqual(additionsBank, hitObject.Samples[1].Bank);
             }
         }
 
@@ -756,11 +757,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var stream = new LineBufferedReader(resStream))
             {
                 Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
-                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                ClassicAssert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
                 Assert.DoesNotThrow(() => beatmap = decoder.Decode(stream));
-                Assert.IsNotNull(beatmap);
-                Assert.AreEqual("Beatmap with corrupted header", beatmap.Metadata.Title);
-                Assert.AreEqual("Evil Hacker", beatmap.Metadata.Author.Username);
+                ClassicAssert.NotNull(beatmap);
+                ClassicAssert.AreEqual("Beatmap with corrupted header", beatmap.Metadata.Title);
+                ClassicAssert.AreEqual("Evil Hacker", beatmap.Metadata.Author.Username);
             }
         }
 
@@ -774,11 +775,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var stream = new LineBufferedReader(resStream))
             {
                 Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
-                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                ClassicAssert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
                 Assert.DoesNotThrow(() => beatmap = decoder.Decode(stream));
-                Assert.IsNotNull(beatmap);
-                Assert.AreEqual("Beatmap with no header", beatmap.Metadata.Title);
-                Assert.AreEqual("Incredibly Evil Hacker", beatmap.Metadata.Author.Username);
+                ClassicAssert.NotNull(beatmap);
+                ClassicAssert.AreEqual("Beatmap with no header", beatmap.Metadata.Title);
+                ClassicAssert.AreEqual("Incredibly Evil Hacker", beatmap.Metadata.Author.Username);
             }
         }
 
@@ -792,11 +793,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var stream = new LineBufferedReader(resStream))
             {
                 Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
-                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                ClassicAssert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
                 Assert.DoesNotThrow(() => beatmap = decoder.Decode(stream));
-                Assert.IsNotNull(beatmap);
-                Assert.AreEqual("Empty lines at start", beatmap.Metadata.Title);
-                Assert.AreEqual("Edge Case Hunter", beatmap.Metadata.Author.Username);
+                ClassicAssert.NotNull(beatmap);
+                ClassicAssert.AreEqual("Empty lines at start", beatmap.Metadata.Title);
+                ClassicAssert.AreEqual("Edge Case Hunter", beatmap.Metadata.Author.Username);
             }
         }
 
@@ -810,11 +811,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var stream = new LineBufferedReader(resStream))
             {
                 Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
-                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                ClassicAssert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
                 Assert.DoesNotThrow(() => beatmap = decoder.Decode(stream));
-                Assert.IsNotNull(beatmap);
-                Assert.AreEqual("The dog ate the file header", beatmap.Metadata.Title);
-                Assert.AreEqual("Why does this keep happening", beatmap.Metadata.Author.Username);
+                ClassicAssert.NotNull(beatmap);
+                ClassicAssert.AreEqual("The dog ate the file header", beatmap.Metadata.Title);
+                ClassicAssert.AreEqual("Why does this keep happening", beatmap.Metadata.Author.Username);
             }
         }
 
@@ -828,11 +829,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var stream = new LineBufferedReader(resStream))
             {
                 Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
-                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                ClassicAssert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
                 Assert.DoesNotThrow(() => beatmap = decoder.Decode(stream));
-                Assert.IsNotNull(beatmap);
-                Assert.AreEqual("No empty line delimiting header from contents", beatmap.Metadata.Title);
-                Assert.AreEqual("Edge Case Hunter", beatmap.Metadata.Author.Username);
+                ClassicAssert.NotNull(beatmap);
+                ClassicAssert.AreEqual("No empty line delimiting header from contents", beatmap.Metadata.Title);
+                ClassicAssert.AreEqual("Edge Case Hunter", beatmap.Metadata.Author.Username);
             }
         }
 
@@ -855,7 +856,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var stream = new LineBufferedReader(resStream))
             {
                 Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
-                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                ClassicAssert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
             }
 
             Assert.DoesNotThrow(LegacyDifficultyCalculatorBeatmapDecoder.Register);
@@ -864,7 +865,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var stream = new LineBufferedReader(resStream))
             {
                 Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
-                Assert.IsInstanceOf<LegacyDifficultyCalculatorBeatmapDecoder>(decoder);
+                ClassicAssert.IsInstanceOf<LegacyDifficultyCalculatorBeatmapDecoder>(decoder);
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
@@ -100,7 +101,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 // emulate non-legacy control points by cloning the non-legacy portion.
                 // the assertion is that the encoder can recreate this losslessly from hitobject data.
-                Assert.IsInstanceOf<LegacyControlPointInfo>(controlPointInfo);
+                ClassicAssert.IsInstanceOf<LegacyControlPointInfo>(controlPointInfo);
 
                 var newControlPoints = new ControlPointInfo();
 
@@ -129,7 +130,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             Assert.That(actual.beatmap.HitObjects.Serialize(), Is.EqualTo(expected.beatmap.HitObjects.Serialize()));
 
             // Check skin.
-            Assert.IsTrue(areComboColoursEqual(expected.skin.Configuration, actual.skin.Configuration));
+            ClassicAssert.True(areComboColoursEqual(expected.skin.Configuration, actual.skin.Configuration));
         }
 
         [Test]

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
@@ -58,18 +59,18 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var score = decoder.Parse(resourceStream);
 
-                Assert.AreEqual(3, score.ScoreInfo.Ruleset.OnlineID);
+                ClassicAssert.AreEqual(3, score.ScoreInfo.Ruleset.OnlineID);
 
-                Assert.AreEqual(2, score.ScoreInfo.Statistics[HitResult.Great]);
-                Assert.AreEqual(1, score.ScoreInfo.Statistics[HitResult.Good]);
+                ClassicAssert.AreEqual(2, score.ScoreInfo.Statistics[HitResult.Great]);
+                ClassicAssert.AreEqual(1, score.ScoreInfo.Statistics[HitResult.Good]);
 
-                Assert.AreEqual(829_931, score.ScoreInfo.LegacyTotalScore);
-                Assert.AreEqual(3, score.ScoreInfo.MaxCombo);
+                ClassicAssert.AreEqual(829_931, score.ScoreInfo.LegacyTotalScore);
+                ClassicAssert.AreEqual(3, score.ScoreInfo.MaxCombo);
 
                 Assert.That(score.ScoreInfo.APIMods.Select(m => m.Acronym), Is.EquivalentTo(new[] { "CL", "9K", "DS" }));
 
                 Assert.That((2 * 300d + 1 * 200) / (3 * 305d), Is.EqualTo(score.ScoreInfo.Accuracy).Within(0.0001));
-                Assert.AreEqual(ScoreRank.B, score.ScoreInfo.Rank);
+                ClassicAssert.AreEqual(ScoreRank.B, score.ScoreInfo.Rank);
 
                 Assert.That(score.Replay.Frames, Has.One.Matches<ManiaReplayFrame>(frame =>
                     frame.Time == 414 && frame.Actions.SequenceEqual(new[] { ManiaAction.Key1, ManiaAction.Key18 })));
@@ -85,10 +86,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var score = decoder.Parse(resourceStream);
 
-                Assert.AreEqual(1, score.ScoreInfo.Ruleset.OnlineID);
-                Assert.AreEqual(4, score.ScoreInfo.Statistics[HitResult.Great]);
-                Assert.AreEqual(2, score.ScoreInfo.Statistics[HitResult.LargeBonus]);
-                Assert.AreEqual(4, score.ScoreInfo.MaxCombo);
+                ClassicAssert.AreEqual(1, score.ScoreInfo.Ruleset.OnlineID);
+                ClassicAssert.AreEqual(4, score.ScoreInfo.Statistics[HitResult.Great]);
+                ClassicAssert.AreEqual(2, score.ScoreInfo.Statistics[HitResult.LargeBonus]);
+                ClassicAssert.AreEqual(4, score.ScoreInfo.MaxCombo);
 
                 Assert.That(score.Replay.Frames, Is.Not.Empty);
             }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osuTK;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.Formats;
@@ -25,73 +26,73 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var storyboard = decoder.Decode(stream);
 
-                Assert.IsTrue(storyboard.HasDrawable);
-                Assert.AreEqual(6, storyboard.Layers.Count());
+                ClassicAssert.True(storyboard.HasDrawable);
+                ClassicAssert.AreEqual(6, storyboard.Layers.Count());
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.IsNotNull(background);
-                Assert.AreEqual(16, background.Elements.Count);
-                Assert.IsTrue(background.VisibleWhenFailing);
-                Assert.IsTrue(background.VisibleWhenPassing);
-                Assert.AreEqual("Background", background.Name);
+                ClassicAssert.NotNull(background);
+                ClassicAssert.AreEqual(16, background.Elements.Count);
+                ClassicAssert.True(background.VisibleWhenFailing);
+                ClassicAssert.True(background.VisibleWhenPassing);
+                ClassicAssert.AreEqual("Background", background.Name);
 
                 StoryboardLayer fail = storyboard.Layers.Single(l => l.Depth == 2);
-                Assert.IsNotNull(fail);
-                Assert.AreEqual(0, fail.Elements.Count);
-                Assert.IsTrue(fail.VisibleWhenFailing);
-                Assert.IsFalse(fail.VisibleWhenPassing);
-                Assert.AreEqual("Fail", fail.Name);
+                ClassicAssert.NotNull(fail);
+                ClassicAssert.AreEqual(0, fail.Elements.Count);
+                ClassicAssert.True(fail.VisibleWhenFailing);
+                ClassicAssert.False(fail.VisibleWhenPassing);
+                ClassicAssert.AreEqual("Fail", fail.Name);
 
                 StoryboardLayer pass = storyboard.Layers.Single(l => l.Depth == 1);
-                Assert.IsNotNull(pass);
-                Assert.AreEqual(0, pass.Elements.Count);
-                Assert.IsFalse(pass.VisibleWhenFailing);
-                Assert.IsTrue(pass.VisibleWhenPassing);
-                Assert.AreEqual("Pass", pass.Name);
+                ClassicAssert.NotNull(pass);
+                ClassicAssert.AreEqual(0, pass.Elements.Count);
+                ClassicAssert.False(pass.VisibleWhenFailing);
+                ClassicAssert.True(pass.VisibleWhenPassing);
+                ClassicAssert.AreEqual("Pass", pass.Name);
 
                 StoryboardLayer foreground = storyboard.Layers.Single(l => l.Depth == 0);
-                Assert.IsNotNull(foreground);
-                Assert.AreEqual(151, foreground.Elements.Count);
-                Assert.IsTrue(foreground.VisibleWhenFailing);
-                Assert.IsTrue(foreground.VisibleWhenPassing);
-                Assert.AreEqual("Foreground", foreground.Name);
+                ClassicAssert.NotNull(foreground);
+                ClassicAssert.AreEqual(151, foreground.Elements.Count);
+                ClassicAssert.True(foreground.VisibleWhenFailing);
+                ClassicAssert.True(foreground.VisibleWhenPassing);
+                ClassicAssert.AreEqual("Foreground", foreground.Name);
 
                 StoryboardLayer overlay = storyboard.Layers.Single(l => l.Depth == int.MinValue);
-                Assert.IsNotNull(overlay);
-                Assert.IsEmpty(overlay.Elements);
-                Assert.IsTrue(overlay.VisibleWhenFailing);
-                Assert.IsTrue(overlay.VisibleWhenPassing);
-                Assert.AreEqual("Overlay", overlay.Name);
+                ClassicAssert.NotNull(overlay);
+                ClassicAssert.IsEmpty(overlay.Elements);
+                ClassicAssert.True(overlay.VisibleWhenFailing);
+                ClassicAssert.True(overlay.VisibleWhenPassing);
+                ClassicAssert.AreEqual("Overlay", overlay.Name);
 
                 int spriteCount = background.Elements.Count(x => x.GetType() == typeof(StoryboardSprite));
                 int animationCount = background.Elements.Count(x => x.GetType() == typeof(StoryboardAnimation));
                 int sampleCount = background.Elements.Count(x => x.GetType() == typeof(StoryboardSampleInfo));
 
-                Assert.AreEqual(15, spriteCount);
-                Assert.AreEqual(1, animationCount);
-                Assert.AreEqual(0, sampleCount);
-                Assert.AreEqual(background.Elements.Count, spriteCount + animationCount + sampleCount);
+                ClassicAssert.AreEqual(15, spriteCount);
+                ClassicAssert.AreEqual(1, animationCount);
+                ClassicAssert.AreEqual(0, sampleCount);
+                ClassicAssert.AreEqual(background.Elements.Count, spriteCount + animationCount + sampleCount);
 
                 var sprite = background.Elements.ElementAt(0) as StoryboardSprite;
-                Assert.NotNull(sprite);
-                Assert.IsTrue(sprite!.HasCommands);
-                Assert.AreEqual(new Vector2(320, 240), sprite.InitialPosition);
-                Assert.IsTrue(sprite.IsDrawable);
-                Assert.AreEqual(Anchor.Centre, sprite.Origin);
-                Assert.AreEqual("SB/lyric/ja-21.png", sprite.Path);
+                ClassicAssert.NotNull(sprite);
+                ClassicAssert.True(sprite!.HasCommands);
+                ClassicAssert.AreEqual(new Vector2(320, 240), sprite.InitialPosition);
+                ClassicAssert.True(sprite.IsDrawable);
+                ClassicAssert.AreEqual(Anchor.Centre, sprite.Origin);
+                ClassicAssert.AreEqual("SB/lyric/ja-21.png", sprite.Path);
 
                 var animation = background.Elements.OfType<StoryboardAnimation>().First();
-                Assert.NotNull(animation);
-                Assert.AreEqual(141175, animation.EndTime);
-                Assert.AreEqual(10, animation.FrameCount);
-                Assert.AreEqual(30, animation.FrameDelay);
-                Assert.IsTrue(animation.HasCommands);
-                Assert.AreEqual(new Vector2(320, 240), animation.InitialPosition);
-                Assert.IsTrue(animation.IsDrawable);
-                Assert.AreEqual(AnimationLoopType.LoopForever, animation.LoopType);
-                Assert.AreEqual(Anchor.Centre, animation.Origin);
-                Assert.AreEqual("SB/red jitter/red_0000.jpg", animation.Path);
-                Assert.AreEqual(78993, animation.StartTime);
+                ClassicAssert.NotNull(animation);
+                ClassicAssert.AreEqual(141175, animation.EndTime);
+                ClassicAssert.AreEqual(10, animation.FrameCount);
+                ClassicAssert.AreEqual(30, animation.FrameDelay);
+                ClassicAssert.True(animation.HasCommands);
+                ClassicAssert.AreEqual(new Vector2(320, 240), animation.InitialPosition);
+                ClassicAssert.True(animation.IsDrawable);
+                ClassicAssert.AreEqual(AnimationLoopType.LoopForever, animation.LoopType);
+                ClassicAssert.AreEqual(Anchor.Centre, animation.Origin);
+                ClassicAssert.AreEqual("SB/red jitter/red_0000.jpg", animation.Path);
+                ClassicAssert.AreEqual(78993, animation.StartTime);
             }
         }
 
@@ -106,13 +107,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.AreEqual(1, background.Elements.Count);
+                ClassicAssert.AreEqual(1, background.Elements.Count);
 
-                Assert.AreEqual(2000, background.Elements[0].StartTime);
-                Assert.AreEqual(2000, (background.Elements[0] as StoryboardAnimation)?.EarliestTransformTime);
+                ClassicAssert.AreEqual(2000, background.Elements[0].StartTime);
+                ClassicAssert.AreEqual(2000, (background.Elements[0] as StoryboardAnimation)?.EarliestTransformTime);
 
-                Assert.AreEqual(3000, (background.Elements[0] as StoryboardAnimation)?.GetEndTime());
-                Assert.AreEqual(12000, (background.Elements[0] as StoryboardAnimation)?.EndTimeForDisplay);
+                ClassicAssert.AreEqual(3000, (background.Elements[0] as StoryboardAnimation)?.GetEndTime());
+                ClassicAssert.AreEqual(12000, (background.Elements[0] as StoryboardAnimation)?.EndTimeForDisplay);
             }
         }
 
@@ -127,11 +128,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.AreEqual(1, background.Elements.Count);
+                ClassicAssert.AreEqual(1, background.Elements.Count);
 
-                Assert.AreEqual(2000, background.Elements[0].StartTime);
+                ClassicAssert.AreEqual(2000, background.Elements[0].StartTime);
                 // This property should be used in DrawableStoryboardAnimation as a starting point for animation playback.
-                Assert.AreEqual(1000, (background.Elements[0] as StoryboardAnimation)?.EarliestTransformTime);
+                ClassicAssert.AreEqual(1000, (background.Elements[0] as StoryboardAnimation)?.EarliestTransformTime);
             }
         }
 
@@ -146,10 +147,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.AreEqual(2, background.Elements.Count);
+                ClassicAssert.AreEqual(2, background.Elements.Count);
 
-                Assert.AreEqual(1500, background.Elements[0].StartTime);
-                Assert.AreEqual(1500, background.Elements[1].StartTime);
+                ClassicAssert.AreEqual(1500, background.Elements[0].StartTime);
+                ClassicAssert.AreEqual(1500, background.Elements[1].StartTime);
             }
         }
 
@@ -164,12 +165,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.AreEqual(2, background.Elements.Count);
+                ClassicAssert.AreEqual(2, background.Elements.Count);
 
-                Assert.AreEqual(1500, background.Elements[0].StartTime);
-                Assert.AreEqual(1000, background.Elements[1].StartTime);
+                ClassicAssert.AreEqual(1500, background.Elements[0].StartTime);
+                ClassicAssert.AreEqual(1000, background.Elements[1].StartTime);
 
-                Assert.AreEqual(1000, storyboard.EarliestEventTime);
+                ClassicAssert.AreEqual(1000, storyboard.EarliestEventTime);
             }
         }
 
@@ -184,12 +185,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.AreEqual(2, background.Elements.Count);
+                ClassicAssert.AreEqual(2, background.Elements.Count);
 
-                Assert.AreEqual(1000, background.Elements[0].StartTime);
-                Assert.AreEqual(1000, background.Elements[1].StartTime);
+                ClassicAssert.AreEqual(1000, background.Elements[0].StartTime);
+                ClassicAssert.AreEqual(1000, background.Elements[1].StartTime);
 
-                Assert.AreEqual(1000, storyboard.EarliestEventTime);
+                ClassicAssert.AreEqual(1000, storyboard.EarliestEventTime);
             }
         }
 
@@ -204,7 +205,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.AreEqual(3456, ((StoryboardSprite)background.Elements.Single()).InitialPosition.X);
+                ClassicAssert.AreEqual(3456, ((StoryboardSprite)background.Elements.Single()).InitialPosition.X);
             }
         }
 
@@ -221,7 +222,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 StoryboardLayer video = storyboard.Layers.Single(l => l.Name == "Video");
                 Assert.That(video.Elements.Count, Is.EqualTo(1));
 
-                Assert.AreEqual("Video.avi", ((StoryboardVideo)video.Elements[0]).Path);
+                ClassicAssert.AreEqual("Video.avi", ((StoryboardVideo)video.Elements[0]).Path);
             }
         }
 
@@ -238,7 +239,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 StoryboardLayer video = storyboard.Layers.Single(l => l.Name == "Video");
                 Assert.That(video.Elements.Count, Is.EqualTo(1));
 
-                Assert.AreEqual("Video.AVI", ((StoryboardVideo)video.Elements[0]).Path);
+                ClassicAssert.AreEqual("Video.AVI", ((StoryboardVideo)video.Elements[0]).Path);
             }
         }
 
@@ -268,12 +269,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer foreground = storyboard.Layers.Single(l => l.Depth == 0);
-                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[0]).LoopType);
-                Assert.AreEqual(AnimationLoopType.LoopOnce, ((StoryboardAnimation)foreground.Elements[1]).LoopType);
-                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[2]).LoopType);
-                Assert.AreEqual(AnimationLoopType.LoopOnce, ((StoryboardAnimation)foreground.Elements[3]).LoopType);
-                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[4]).LoopType);
-                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[5]).LoopType);
+                ClassicAssert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[0]).LoopType);
+                ClassicAssert.AreEqual(AnimationLoopType.LoopOnce, ((StoryboardAnimation)foreground.Elements[1]).LoopType);
+                ClassicAssert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[2]).LoopType);
+                ClassicAssert.AreEqual(AnimationLoopType.LoopOnce, ((StoryboardAnimation)foreground.Elements[3]).LoopType);
+                ClassicAssert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[4]).LoopType);
+                ClassicAssert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[5]).LoopType);
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using DeepEqual.Syntax;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
@@ -33,17 +34,17 @@ namespace osu.Game.Tests.Beatmaps.Formats
         {
             var beatmap = decodeAsJson(normal);
             var meta = beatmap.BeatmapInfo.Metadata;
-            Assert.AreEqual(241526, beatmap.BeatmapInfo.BeatmapSet?.OnlineID);
-            Assert.AreEqual("Soleily", meta.Artist);
-            Assert.AreEqual("Soleily", meta.ArtistUnicode);
-            Assert.AreEqual("03. Renatus - Soleily 192kbps.mp3", meta.AudioFile);
-            Assert.AreEqual("Gamu", meta.Author.Username);
-            Assert.AreEqual("machinetop_background.jpg", meta.BackgroundFile);
-            Assert.AreEqual(164471, meta.PreviewTime);
-            Assert.AreEqual(string.Empty, meta.Source);
-            Assert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", meta.Tags);
-            Assert.AreEqual("Renatus", meta.Title);
-            Assert.AreEqual("Renatus", meta.TitleUnicode);
+            ClassicAssert.AreEqual(241526, beatmap.BeatmapInfo.BeatmapSet?.OnlineID);
+            ClassicAssert.AreEqual("Soleily", meta.Artist);
+            ClassicAssert.AreEqual("Soleily", meta.ArtistUnicode);
+            ClassicAssert.AreEqual("03. Renatus - Soleily 192kbps.mp3", meta.AudioFile);
+            ClassicAssert.AreEqual("Gamu", meta.Author.Username);
+            ClassicAssert.AreEqual("machinetop_background.jpg", meta.BackgroundFile);
+            ClassicAssert.AreEqual(164471, meta.PreviewTime);
+            ClassicAssert.AreEqual(string.Empty, meta.Source);
+            ClassicAssert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", meta.Tags);
+            ClassicAssert.AreEqual("Renatus", meta.Title);
+            ClassicAssert.AreEqual("Renatus", meta.TitleUnicode);
         }
 
         [Test]
@@ -51,14 +52,14 @@ namespace osu.Game.Tests.Beatmaps.Formats
         {
             var beatmap = decodeAsJson(normal);
             var beatmapInfo = beatmap.BeatmapInfo;
-            Assert.AreEqual(0, beatmap.AudioLeadIn);
-            Assert.AreEqual(0.7f, beatmap.StackLeniency);
-            Assert.AreEqual(false, beatmap.SpecialStyle);
-            Assert.IsTrue(beatmapInfo.Ruleset.OnlineID == 0);
-            Assert.AreEqual(false, beatmap.LetterboxInBreaks);
-            Assert.AreEqual(false, beatmap.WidescreenStoryboard);
-            Assert.AreEqual(CountdownType.None, beatmap.Countdown);
-            Assert.AreEqual(0, beatmap.CountdownOffset);
+            ClassicAssert.AreEqual(0, beatmap.AudioLeadIn);
+            ClassicAssert.AreEqual(0.7f, beatmap.StackLeniency);
+            ClassicAssert.AreEqual(false, beatmap.SpecialStyle);
+            ClassicAssert.True(beatmapInfo.Ruleset.OnlineID == 0);
+            ClassicAssert.AreEqual(false, beatmap.LetterboxInBreaks);
+            ClassicAssert.AreEqual(false, beatmap.WidescreenStoryboard);
+            ClassicAssert.AreEqual(CountdownType.None, beatmap.Countdown);
+            ClassicAssert.AreEqual(0, beatmap.CountdownOffset);
         }
 
         [Test]
@@ -73,13 +74,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 95901, 106450, 116999, 119637, 130186, 140735, 151285,
                 161834, 164471, 175020, 185570, 196119, 206669, 209306
             };
-            Assert.AreEqual(expectedBookmarks.Length, beatmap.Bookmarks.Length);
+            ClassicAssert.AreEqual(expectedBookmarks.Length, beatmap.Bookmarks.Length);
             for (int i = 0; i < expectedBookmarks.Length; i++)
-                Assert.AreEqual(expectedBookmarks[i], beatmap.Bookmarks[i]);
-            Assert.AreEqual(1.8, beatmap.DistanceSpacing);
-            Assert.AreEqual(4, beatmapInfo.BeatDivisor);
-            Assert.AreEqual(4, beatmap.GridSize);
-            Assert.AreEqual(2, beatmap.TimelineZoom);
+                ClassicAssert.AreEqual(expectedBookmarks[i], beatmap.Bookmarks[i]);
+            ClassicAssert.AreEqual(1.8, beatmap.DistanceSpacing);
+            ClassicAssert.AreEqual(4, beatmapInfo.BeatDivisor);
+            ClassicAssert.AreEqual(4, beatmap.GridSize);
+            ClassicAssert.AreEqual(2, beatmap.TimelineZoom);
         }
 
         [Test]
@@ -87,12 +88,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
         {
             var beatmap = decodeAsJson(normal);
             var difficulty = beatmap.Difficulty;
-            Assert.AreEqual(6.5f, difficulty.DrainRate);
-            Assert.AreEqual(4, difficulty.CircleSize);
-            Assert.AreEqual(8, difficulty.OverallDifficulty);
-            Assert.AreEqual(9, difficulty.ApproachRate);
-            Assert.AreEqual(1.8, difficulty.SliderMultiplier);
-            Assert.AreEqual(2, difficulty.SliderTickRate);
+            ClassicAssert.AreEqual(6.5f, difficulty.DrainRate);
+            ClassicAssert.AreEqual(4, difficulty.CircleSize);
+            ClassicAssert.AreEqual(8, difficulty.OverallDifficulty);
+            ClassicAssert.AreEqual(9, difficulty.ApproachRate);
+            ClassicAssert.AreEqual(1.8, difficulty.SliderMultiplier);
+            ClassicAssert.AreEqual(2, difficulty.SliderTickRate);
         }
 
         [Test]
@@ -112,19 +113,19 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var curveData = beatmap.HitObjects[0] as IHasPathWithRepeats;
             var positionData = beatmap.HitObjects[0] as IHasPosition;
 
-            Assert.IsNotNull(positionData);
-            Assert.IsNotNull(curveData);
-            Assert.AreEqual(90, curveData.Path.Distance);
-            Assert.AreEqual(new Vector2(192, 168), positionData.Position);
-            Assert.AreEqual(956, beatmap.HitObjects[0].StartTime);
-            Assert.IsTrue(beatmap.HitObjects[0].Samples.Any(s => s.Name == HitSampleInfo.HIT_NORMAL));
+            ClassicAssert.NotNull(positionData);
+            ClassicAssert.NotNull(curveData);
+            ClassicAssert.AreEqual(90, curveData.Path.Distance);
+            ClassicAssert.AreEqual(new Vector2(192, 168), positionData.Position);
+            ClassicAssert.AreEqual(956, beatmap.HitObjects[0].StartTime);
+            ClassicAssert.True(beatmap.HitObjects[0].Samples.Any(s => s.Name == HitSampleInfo.HIT_NORMAL));
 
             positionData = beatmap.HitObjects[1] as IHasPosition;
 
-            Assert.IsNotNull(positionData);
-            Assert.AreEqual(new Vector2(304, 56), positionData.Position);
-            Assert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
-            Assert.IsTrue(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
+            ClassicAssert.NotNull(positionData);
+            ClassicAssert.AreEqual(new Vector2(304, 56), positionData.Position);
+            ClassicAssert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
+            ClassicAssert.True(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
         }
 
         [Test]
@@ -135,19 +136,19 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var curveData = beatmap.HitObjects[0] as IHasPathWithRepeats;
             var positionData = beatmap.HitObjects[0] as IHasPosition;
 
-            Assert.IsNotNull(positionData);
-            Assert.IsNotNull(curveData);
-            Assert.AreEqual(90, curveData.Path.Distance);
-            Assert.AreEqual(new Vector2(192, 168), positionData.Position);
-            Assert.AreEqual(956, beatmap.HitObjects[0].StartTime);
-            Assert.IsTrue(beatmap.HitObjects[0].Samples.Any(s => s.Name == HitSampleInfo.HIT_NORMAL));
+            ClassicAssert.NotNull(positionData);
+            ClassicAssert.NotNull(curveData);
+            ClassicAssert.AreEqual(90, curveData.Path.Distance);
+            ClassicAssert.AreEqual(new Vector2(192, 168), positionData.Position);
+            ClassicAssert.AreEqual(956, beatmap.HitObjects[0].StartTime);
+            ClassicAssert.True(beatmap.HitObjects[0].Samples.Any(s => s.Name == HitSampleInfo.HIT_NORMAL));
 
             positionData = beatmap.HitObjects[1] as IHasPosition;
 
-            Assert.IsNotNull(positionData);
-            Assert.AreEqual(new Vector2(304, 56), positionData.Position);
-            Assert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
-            Assert.IsTrue(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
+            ClassicAssert.NotNull(positionData);
+            ClassicAssert.AreEqual(new Vector2(304, 56), positionData.Position);
+            ClassicAssert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
+            ClassicAssert.True(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
         }
 
         [TestCase(normal)]
@@ -187,7 +188,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 }
             }
 
-            Assert.IsInstanceOf(typeof(JsonBeatmapDecoder), decoder);
+            ClassicAssert.IsInstanceOf(typeof(JsonBeatmapDecoder), decoder);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -5,7 +5,6 @@
 
 using System.IO;
 using System.Linq;
-using DeepEqual.Syntax;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using osu.Game.Audio;
@@ -16,7 +15,6 @@ using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Resources;
 using osuTK;
 
@@ -151,20 +149,20 @@ namespace osu.Game.Tests.Beatmaps.Formats
             ClassicAssert.True(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
         }
 
-        [TestCase(normal)]
-        [TestCase(marathon)]
-        [Ignore("temporarily disabled pending DeepEqual fix (https://github.com/jamesfoster/DeepEqual/pull/35)")]
-        // Currently fails:
-        // [TestCase(with_sb)]
-        public void TestParity(string beatmap)
-        {
-            var legacy = decode(beatmap, out Beatmap json);
-            json.WithDeepEqual(legacy)
-                .IgnoreProperty(r => r.DeclaringType == typeof(HitWindows)
-                                     // Todo: CustomSampleBank shouldn't exist going forward, we need a conversion mechanism
-                                     || r.Name == nameof(LegacyDecoder<Beatmap>.LegacySampleControlPoint.CustomSampleBank))
-                .Assert();
-        }
+        // [TestCase(normal)]
+        // [TestCase(marathon)]
+        // [Ignore("temporarily disabled pending DeepEqual fix (https://github.com/jamesfoster/DeepEqual/pull/35)")]
+        // // Currently fails:
+        // // [TestCase(with_sb)]
+        // public void TestParity(string beatmap)
+        // {
+        //     var legacy = decode(beatmap, out Beatmap json);
+        //     json.WithDeepEqual(legacy)
+        //         .IgnoreProperty(r => r.DeclaringType == typeof(HitWindows)
+        //                              // Todo: CustomSampleBank shouldn't exist going forward, we need a conversion mechanism
+        //                              || r.Name == nameof(LegacyDecoder<Beatmap>.LegacySampleControlPoint.CustomSampleBank))
+        //         .Assert();
+        // }
 
         [Test]
         public void TestGetJsonDecoder()

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -111,8 +111,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var curveData = beatmap.HitObjects[0] as IHasPathWithRepeats;
             var positionData = beatmap.HitObjects[0] as IHasPosition;
 
-            ClassicAssert.NotNull(positionData);
-            ClassicAssert.NotNull(curveData);
+            Assert.That(positionData, Is.Not.Null);
+            Assert.That(curveData, Is.Not.Null);
             ClassicAssert.AreEqual(90, curveData.Path.Distance);
             ClassicAssert.AreEqual(new Vector2(192, 168), positionData.Position);
             ClassicAssert.AreEqual(956, beatmap.HitObjects[0].StartTime);
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
             positionData = beatmap.HitObjects[1] as IHasPosition;
 
-            ClassicAssert.NotNull(positionData);
+            Assert.That(positionData, Is.Not.Null);
             ClassicAssert.AreEqual(new Vector2(304, 56), positionData.Position);
             ClassicAssert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
             ClassicAssert.True(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));
@@ -134,8 +134,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var curveData = beatmap.HitObjects[0] as IHasPathWithRepeats;
             var positionData = beatmap.HitObjects[0] as IHasPosition;
 
-            ClassicAssert.NotNull(positionData);
-            ClassicAssert.NotNull(curveData);
+            Assert.That(positionData, Is.Not.Null);
+            Assert.That(curveData, Is.Not.Null);
             ClassicAssert.AreEqual(90, curveData.Path.Distance);
             ClassicAssert.AreEqual(new Vector2(192, 168), positionData.Position);
             ClassicAssert.AreEqual(956, beatmap.HitObjects[0].StartTime);
@@ -143,7 +143,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
             positionData = beatmap.HitObjects[1] as IHasPosition;
 
-            ClassicAssert.NotNull(positionData);
+            Assert.That(positionData, Is.Not.Null);
             ClassicAssert.AreEqual(new Vector2(304, 56), positionData.Position);
             ClassicAssert.AreEqual(1285, beatmap.HitObjects[1].StartTime);
             ClassicAssert.True(beatmap.HitObjects[1].Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP));

--- a/osu.Game.Tests/Beatmaps/Formats/ParsingTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/ParsingTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Globalization;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps.Formats;
 
 namespace osu.Game.Tests.Beatmaps.Formats
@@ -33,9 +34,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
         [TestCase(-10, 10)]
         public void TestValidRanges(double input, double limit = Parsing.MAX_PARSE_VALUE)
         {
-            Assert.AreEqual(Parsing.ParseInt((input).ToString(CultureInfo.InvariantCulture), (int)limit), (int)input);
-            Assert.AreEqual(Parsing.ParseFloat((input).ToString(CultureInfo.InvariantCulture), (float)limit), (float)input);
-            Assert.AreEqual(Parsing.ParseDouble((input).ToString(CultureInfo.InvariantCulture), limit), input);
+            ClassicAssert.AreEqual(Parsing.ParseInt((input).ToString(CultureInfo.InvariantCulture), (int)limit), (int)input);
+            ClassicAssert.AreEqual(Parsing.ParseFloat((input).ToString(CultureInfo.InvariantCulture), (float)limit), (float)input);
+            ClassicAssert.AreEqual(Parsing.ParseDouble((input).ToString(CultureInfo.InvariantCulture), limit), input);
         }
 
         [TestCase(double.PositiveInfinity)]

--- a/osu.Game.Tests/Beatmaps/IO/BeatmapImportHelper.cs
+++ b/osu.Game.Tests/Beatmaps/IO/BeatmapImportHelper.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -62,16 +62,16 @@ namespace osu.Game.Tests.Beatmaps.IO
             // TODO: add back some extra checks outside of the realm ones?
             // var set = queryBeatmapSets().First();
             // foreach (BeatmapInfo b in set.Beatmaps)
-            //     Assert.IsTrue(set.Beatmaps.Any(c => c.OnlineID == b.OnlineID));
-            // Assert.IsTrue(set.Beatmaps.Count > 0);
+            //     ClassicAssert.True(set.Beatmaps.Any(c => c.OnlineID == b.OnlineID));
+            // ClassicAssert.True(set.Beatmaps.Count > 0);
             // var beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 0))?.Beatmap;
-            // Assert.IsTrue(beatmap?.HitObjects.Any() == true);
+            // ClassicAssert.True(beatmap?.HitObjects.Any() == true);
             // beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 1))?.Beatmap;
-            // Assert.IsTrue(beatmap?.HitObjects.Any() == true);
+            // ClassicAssert.True(beatmap?.HitObjects.Any() == true);
             // beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 2))?.Beatmap;
-            // Assert.IsTrue(beatmap?.HitObjects.Any() == true);
+            // ClassicAssert.True(beatmap?.HitObjects.Any() == true);
             // beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 3))?.Beatmap;
-            // Assert.IsTrue(beatmap?.HitObjects.Any() == true);
+            // ClassicAssert.True(beatmap?.HitObjects.Any() == true);
         }
 
         private static void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 60000)
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 while (!result()) Thread.Sleep(200);
             });
 
-            Assert.IsTrue(task.Wait(timeout), failureMessage);
+            ClassicAssert.True(task.Wait(timeout), failureMessage);
         }
     }
 }

--- a/osu.Game.Tests/Beatmaps/IO/LineBufferedReaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/LineBufferedReaderTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Text;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.IO;
 
 namespace osu.Game.Tests.Beatmaps.IO
@@ -20,10 +21,10 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.AreEqual("line 1", bufferedReader.ReadLine());
-                Assert.AreEqual("line 2", bufferedReader.ReadLine());
-                Assert.AreEqual("line 3", bufferedReader.ReadLine());
-                Assert.IsNull(bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("line 1", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("line 2", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("line 3", bufferedReader.ReadLine());
+                ClassicAssert.Null(bufferedReader.ReadLine());
             }
         }
 
@@ -35,11 +36,11 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.AreEqual("line 1", bufferedReader.ReadLine());
-                Assert.AreEqual("peek this", bufferedReader.PeekLine());
-                Assert.AreEqual("peek this", bufferedReader.ReadLine());
-                Assert.AreEqual("line 3", bufferedReader.ReadLine());
-                Assert.IsNull(bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("line 1", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("peek this", bufferedReader.PeekLine());
+                ClassicAssert.AreEqual("peek this", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("line 3", bufferedReader.ReadLine());
+                ClassicAssert.Null(bufferedReader.ReadLine());
             }
         }
 
@@ -51,14 +52,14 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.AreEqual("peek this once", bufferedReader.PeekLine());
-                Assert.AreEqual("peek this once", bufferedReader.ReadLine());
-                Assert.AreEqual("line 2", bufferedReader.ReadLine());
-                Assert.AreEqual("peek this a lot", bufferedReader.PeekLine());
-                Assert.AreEqual("peek this a lot", bufferedReader.PeekLine());
-                Assert.AreEqual("peek this a lot", bufferedReader.PeekLine());
-                Assert.AreEqual("peek this a lot", bufferedReader.ReadLine());
-                Assert.IsNull(bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("peek this once", bufferedReader.PeekLine());
+                ClassicAssert.AreEqual("peek this once", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("line 2", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("peek this a lot", bufferedReader.PeekLine());
+                ClassicAssert.AreEqual("peek this a lot", bufferedReader.PeekLine());
+                ClassicAssert.AreEqual("peek this a lot", bufferedReader.PeekLine());
+                ClassicAssert.AreEqual("peek this a lot", bufferedReader.ReadLine());
+                ClassicAssert.Null(bufferedReader.ReadLine());
             }
         }
 
@@ -70,11 +71,11 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.AreEqual("first line", bufferedReader.ReadLine());
-                Assert.AreEqual("second line", bufferedReader.ReadLine());
-                Assert.IsNull(bufferedReader.PeekLine());
-                Assert.IsNull(bufferedReader.ReadLine());
-                Assert.IsNull(bufferedReader.PeekLine());
+                ClassicAssert.AreEqual("first line", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("second line", bufferedReader.ReadLine());
+                ClassicAssert.Null(bufferedReader.PeekLine());
+                ClassicAssert.Null(bufferedReader.ReadLine());
+                ClassicAssert.Null(bufferedReader.PeekLine());
             }
         }
 
@@ -84,10 +85,10 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (var stream = new MemoryStream())
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.IsNull(bufferedReader.PeekLine());
-                Assert.IsNull(bufferedReader.ReadLine());
-                Assert.IsNull(bufferedReader.ReadLine());
-                Assert.IsNull(bufferedReader.PeekLine());
+                ClassicAssert.Null(bufferedReader.PeekLine());
+                ClassicAssert.Null(bufferedReader.ReadLine());
+                ClassicAssert.Null(bufferedReader.ReadLine());
+                ClassicAssert.Null(bufferedReader.PeekLine());
             }
         }
 
@@ -99,7 +100,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.AreEqual(contents, bufferedReader.ReadToEnd());
+                ClassicAssert.AreEqual(contents, bufferedReader.ReadToEnd());
             }
         }
 
@@ -111,14 +112,14 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.AreEqual("this line is gone", bufferedReader.ReadLine());
-                Assert.AreEqual("this one shouldn't be", bufferedReader.PeekLine());
+                ClassicAssert.AreEqual("this line is gone", bufferedReader.ReadLine());
+                ClassicAssert.AreEqual("this one shouldn't be", bufferedReader.PeekLine());
 
                 string[] endingLines = bufferedReader.ReadToEnd().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                Assert.AreEqual(3, endingLines.Length);
-                Assert.AreEqual("this one shouldn't be", endingLines[0]);
-                Assert.AreEqual("these ones", endingLines[1]);
-                Assert.AreEqual("definitely not", endingLines[2]);
+                ClassicAssert.AreEqual(3, endingLines.Length);
+                ClassicAssert.AreEqual("this one shouldn't be", endingLines[0]);
+                ClassicAssert.AreEqual("these ones", endingLines[1]);
+                ClassicAssert.AreEqual("definitely not", endingLines[2]);
             }
         }
     }

--- a/osu.Game.Tests/Beatmaps/IO/OszArchiveReaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/OszArchiveReaderTest.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Tests.Resources;
 using osu.Game.Beatmaps.Formats;
@@ -38,7 +39,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 };
                 string[] maps = reader.Filenames.ToArray();
                 foreach (string map in expected)
-                    Assert.Contains(map, maps);
+                    ClassicAssert.Contains(map, maps);
             }
         }
 
@@ -56,17 +57,17 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                 var meta = beatmap.Metadata;
 
-                Assert.AreEqual(241526, beatmap.BeatmapInfo.BeatmapSet?.OnlineID);
-                Assert.AreEqual("Soleily", meta.Artist);
-                Assert.AreEqual("Soleily", meta.ArtistUnicode);
-                Assert.AreEqual("03. Renatus - Soleily 192kbps.mp3", meta.AudioFile);
-                Assert.AreEqual("Deif", meta.Author.Username);
-                Assert.AreEqual("machinetop_background.jpg", meta.BackgroundFile);
-                Assert.AreEqual(164471, meta.PreviewTime);
-                Assert.AreEqual(string.Empty, meta.Source);
-                Assert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", meta.Tags);
-                Assert.AreEqual("Renatus", meta.Title);
-                Assert.AreEqual("Renatus", meta.TitleUnicode);
+                ClassicAssert.AreEqual(241526, beatmap.BeatmapInfo.BeatmapSet?.OnlineID);
+                ClassicAssert.AreEqual("Soleily", meta.Artist);
+                ClassicAssert.AreEqual("Soleily", meta.ArtistUnicode);
+                ClassicAssert.AreEqual("03. Renatus - Soleily 192kbps.mp3", meta.AudioFile);
+                ClassicAssert.AreEqual("Deif", meta.Author.Username);
+                ClassicAssert.AreEqual("machinetop_background.jpg", meta.BackgroundFile);
+                ClassicAssert.AreEqual(164471, meta.PreviewTime);
+                ClassicAssert.AreEqual(string.Empty, meta.Source);
+                ClassicAssert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", meta.Tags);
+                ClassicAssert.AreEqual("Renatus", meta.Title);
+                ClassicAssert.AreEqual("Renatus", meta.TitleUnicode);
             }
         }
 
@@ -79,7 +80,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                 using (var stream = new StreamReader(reader.GetStream("Soleily - Renatus (Deif) [Platter].osu")))
                 {
-                    Assert.AreEqual("osu file format v13", stream.ReadLine()?.Trim());
+                    ClassicAssert.AreEqual("osu file format v13", stream.ReadLine()?.Trim());
                 }
             }
         }

--- a/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
+++ b/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -225,7 +226,7 @@ namespace osu.Game.Tests.Beatmaps
         {
             var actualBracket = StarDifficulty.GetDifficultyRating(starRating);
 
-            Assert.AreEqual(expectedBracket, actualBracket);
+            ClassicAssert.AreEqual(expectedBracket, actualBracket);
         }
 
         private partial class TestBeatmapDifficultyCache : BeatmapDifficultyCache

--- a/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -29,7 +30,7 @@ namespace osu.Game.Tests.Beatmaps
 
             working.ResetEvent.Set();
 
-            Assert.NotNull(working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo));
+            ClassicAssert.NotNull(working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo));
         }
 
         [Test]
@@ -48,11 +49,11 @@ namespace osu.Game.Tests.Beatmaps
                 loadCompleted.Set();
             }, TaskCreationOptions.LongRunning);
 
-            Assert.IsTrue(loadStarted.Wait(10000));
+            ClassicAssert.True(loadStarted.Wait(10000));
 
             cts.Cancel();
 
-            Assert.IsTrue(loadCompleted.Wait(10000));
+            ClassicAssert.True(loadCompleted.Wait(10000));
 
             working.ResetEvent.Set();
         }

--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Online.Chat;
 
 namespace osu.Game.Tests.Chat
@@ -31,8 +32,8 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a gopher://really-old-protocol we don't support." });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(0, result.Links.Count);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(0, result.Links.Count);
         }
 
         [Test]
@@ -40,8 +41,8 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a osunotarealprotocol://completely-made-up-protocol we don't support." });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(0, result.Links.Count);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(0, result.Links.Count);
         }
 
         [Test]
@@ -49,9 +50,9 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "forgotspacehttps://dev.ppy.sh joinmyosump://12345 jointheosu://chan/#english" });
 
-            Assert.AreEqual("https://dev.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual("osump://12345", result.Links[1].Url);
-            Assert.AreEqual("osu://chan/#english", result.Links[2].Url);
+            ClassicAssert.AreEqual("https://dev.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual("osump://12345", result.Links[1].Url);
+            ClassicAssert.AreEqual("osu://chan/#english", result.Links[2].Url);
         }
 
         [Test]
@@ -59,11 +60,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a http://www.basic-link.com/?test=test." });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("http://www.basic-link.com/?test=test", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(36, result.Links[0].Length);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("http://www.basic-link.com/?test=test", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(36, result.Links[0].Length);
         }
 
         [TestCase(LinkAction.OpenBeatmap, "456", "https://dev.ppy.sh/beatmapsets/123#osu/456")]
@@ -79,12 +80,12 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = link });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual(expectedAction, result.Links[0].Action);
-            Assert.AreEqual(expectedArg, result.Links[0].Argument);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual(expectedAction, result.Links[0].Action);
+            ClassicAssert.AreEqual(expectedArg, result.Links[0].Argument);
             if (expectedAction == LinkAction.External)
-                Assert.AreEqual(link, result.Links[0].Url);
+                ClassicAssert.AreEqual(link, result.Links[0].Url);
         }
 
         [Test]
@@ -95,20 +96,20 @@ namespace osu.Game.Tests.Chat
                 Content = "This is a http://test.io/link#fragment. (see https://twitter.com). Also, This string should not be altered. http://example.com/"
             });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(3, result.Links.Count);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(3, result.Links.Count);
 
-            Assert.AreEqual("http://test.io/link#fragment", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(28, result.Links[0].Length);
+            ClassicAssert.AreEqual("http://test.io/link#fragment", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(28, result.Links[0].Length);
 
-            Assert.AreEqual("https://twitter.com", result.Links[1].Url);
-            Assert.AreEqual(45, result.Links[1].Index);
-            Assert.AreEqual(19, result.Links[1].Length);
+            ClassicAssert.AreEqual("https://twitter.com", result.Links[1].Url);
+            ClassicAssert.AreEqual(45, result.Links[1].Index);
+            ClassicAssert.AreEqual(19, result.Links[1].Length);
 
-            Assert.AreEqual("http://example.com/", result.Links[2].Url);
-            Assert.AreEqual(108, result.Links[2].Index);
-            Assert.AreEqual(19, result.Links[2].Length);
+            ClassicAssert.AreEqual("http://example.com/", result.Links[2].Url);
+            ClassicAssert.AreEqual(108, result.Links[2].Index);
+            ClassicAssert.AreEqual(19, result.Links[2].Length);
         }
 
         [Test]
@@ -116,10 +117,10 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "https://twitter.com/#!/hashbanglinks" });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(result.Content, result.Links[0].Url);
-            Assert.AreEqual(0, result.Links[0].Index);
-            Assert.AreEqual(36, result.Links[0].Length);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(result.Content, result.Links[0].Url);
+            ClassicAssert.AreEqual(0, result.Links[0].Index);
+            ClassicAssert.AreEqual(36, result.Links[0].Length);
         }
 
         [Test]
@@ -127,10 +128,10 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "http://www.chiark.greenend.org.uk/~sgtatham/putty/" });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(result.Content, result.Links[0].Url);
-            Assert.AreEqual(0, result.Links[0].Index);
-            Assert.AreEqual(50, result.Links[0].Length);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(result.Content, result.Links[0].Url);
+            ClassicAssert.AreEqual(0, result.Links[0].Index);
+            ClassicAssert.AreEqual(50, result.Links[0].Length);
         }
 
         [Test]
@@ -138,9 +139,9 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "look: http://puu.sh/7Ggh8xcC6/asf0asd9876.NEF" });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(6, result.Links[0].Index);
-            Assert.AreEqual(39, result.Links[0].Length);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(6, result.Links[0].Index);
+            ClassicAssert.AreEqual(39, result.Links[0].Length);
         }
 
         [Test]
@@ -148,11 +149,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [[Wiki Link]]." });
 
-            Assert.AreEqual("This is a Wiki Link.", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://dev.ppy.sh/wiki/Wiki Link", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(9, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a Wiki Link.", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://dev.ppy.sh/wiki/Wiki Link", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(9, result.Links[0].Length);
         }
 
         [Test]
@@ -160,20 +161,20 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [[Wiki Link]] [[Wiki:Link]][[Wiki.Link]]." });
 
-            Assert.AreEqual("This is a Wiki Link Wiki:LinkWiki.Link.", result.DisplayContent);
-            Assert.AreEqual(3, result.Links.Count);
+            ClassicAssert.AreEqual("This is a Wiki Link Wiki:LinkWiki.Link.", result.DisplayContent);
+            ClassicAssert.AreEqual(3, result.Links.Count);
 
-            Assert.AreEqual("https://dev.ppy.sh/wiki/Wiki Link", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(9, result.Links[0].Length);
+            ClassicAssert.AreEqual("https://dev.ppy.sh/wiki/Wiki Link", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(9, result.Links[0].Length);
 
-            Assert.AreEqual("https://dev.ppy.sh/wiki/Wiki:Link", result.Links[1].Url);
-            Assert.AreEqual(20, result.Links[1].Index);
-            Assert.AreEqual(9, result.Links[1].Length);
+            ClassicAssert.AreEqual("https://dev.ppy.sh/wiki/Wiki:Link", result.Links[1].Url);
+            ClassicAssert.AreEqual(20, result.Links[1].Index);
+            ClassicAssert.AreEqual(9, result.Links[1].Length);
 
-            Assert.AreEqual("https://dev.ppy.sh/wiki/Wiki.Link", result.Links[2].Url);
-            Assert.AreEqual(29, result.Links[2].Index);
-            Assert.AreEqual(9, result.Links[2].Length);
+            ClassicAssert.AreEqual("https://dev.ppy.sh/wiki/Wiki.Link", result.Links[2].Url);
+            ClassicAssert.AreEqual(29, result.Links[2].Index);
+            ClassicAssert.AreEqual(9, result.Links[2].Length);
         }
 
         [Test]
@@ -181,11 +182,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a (simple test)[https://osu.ppy.sh] of links." });
 
-            Assert.AreEqual("This is a simple test of links.", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(11, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a simple test of links.", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(11, result.Links[0].Length);
         }
 
         [Test]
@@ -193,11 +194,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a (tricky (one))[https://osu.ppy.sh]!" });
 
-            Assert.AreEqual("This is a tricky (one)!", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(12, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a tricky (one)!", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(12, result.Links[0].Length);
         }
 
         [Test]
@@ -205,22 +206,22 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is (another loose bracket \\))[https://osu.ppy.sh]." });
 
-            Assert.AreEqual("This is another loose bracket ).", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(8, result.Links[0].Index);
-            Assert.AreEqual(23, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is another loose bracket ).", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(8, result.Links[0].Index);
+            ClassicAssert.AreEqual(23, result.Links[0].Length);
         }
 
         [Test]
         public void TestOldFormatWithBackslashes()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This link (should end with a backslash \\)[https://osu.ppy.sh]." });
-            Assert.AreEqual("This link should end with a backslash \\.", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(29, result.Links[0].Length);
+            ClassicAssert.AreEqual("This link should end with a backslash \\.", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(29, result.Links[0].Length);
         }
 
         [Test]
@@ -228,11 +229,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a (\\)super\\(\\( tricky (one))[https://osu.ppy.sh]!" });
 
-            Assert.AreEqual("This is a )super(( tricky (one)!", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(21, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a )super(( tricky (one)!", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(21, result.Links[0].Length);
         }
 
         [Test]
@@ -240,11 +241,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh simple test]." });
 
-            Assert.AreEqual("This is a simple test.", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(11, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a simple test.", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(11, result.Links[0].Length);
         }
 
         [Test]
@@ -252,11 +253,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh nasty link with escaped brackets: \\] and \\[]" });
 
-            Assert.AreEqual("This is a nasty link with escaped brackets: ] and [", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(41, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a nasty link with escaped brackets: ] and [", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(41, result.Links[0].Length);
         }
 
         [Test]
@@ -264,11 +265,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh link \\ with \\ backslashes \\]" });
 
-            Assert.AreEqual("This is a link \\ with \\ backslashes \\", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(27, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a link \\ with \\ backslashes \\", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(27, result.Links[0].Length);
         }
 
         [Test]
@@ -276,11 +277,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh [link [with \\] too many brackets \\[ ]]]" });
 
-            Assert.AreEqual("This is a [link [with ] too many brackets [ ]]", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(36, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a [link [with ] too many brackets [ ]]", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(36, result.Links[0].Length);
         }
 
         [Test]
@@ -288,11 +289,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [simple test](https://osu.ppy.sh)." });
 
-            Assert.AreEqual("This is a simple test.", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(11, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a simple test.", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(11, result.Links[0].Length);
         }
 
         [Test]
@@ -300,11 +301,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [tricky [one]](https://osu.ppy.sh)!" });
 
-            Assert.AreEqual("This is a tricky [one]!", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(12, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a tricky [one]!", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(12, result.Links[0].Length);
         }
 
         [Test]
@@ -312,22 +313,22 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is [another loose bracket \\]](https://osu.ppy.sh)." });
 
-            Assert.AreEqual("This is another loose bracket ].", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(8, result.Links[0].Index);
-            Assert.AreEqual(23, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is another loose bracket ].", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(8, result.Links[0].Index);
+            ClassicAssert.AreEqual(23, result.Links[0].Length);
         }
 
         [Test]
         public void TestMarkdownFormatWithBackslashes()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This link [should end with a backslash \\](https://osu.ppy.sh)." });
-            Assert.AreEqual("This link should end with a backslash \\.", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(29, result.Links[0].Length);
+            ClassicAssert.AreEqual("This link should end with a backslash \\.", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(29, result.Links[0].Length);
         }
 
         [Test]
@@ -335,11 +336,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [\\]super\\[\\[ tricky [one]](https://osu.ppy.sh)!" });
 
-            Assert.AreEqual("This is a ]super[[ tricky [one]!", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(21, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a ]super[[ tricky [one]!", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(21, result.Links[0].Length);
         }
 
         [Test]
@@ -347,11 +348,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [this link format](https://osu.ppy.sh \"osu!\") before..." });
 
-            Assert.AreEqual("I haven't seen this link format before...", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(15, result.Links[0].Index);
-            Assert.AreEqual(16, result.Links[0].Length);
+            ClassicAssert.AreEqual("I haven't seen this link format before...", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(15, result.Links[0].Index);
+            ClassicAssert.AreEqual(16, result.Links[0].Length);
         }
 
         [Test]
@@ -359,11 +360,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [this link format](https://osu.ppy.sh \"inner quote \\\" just to confuse \") before..." });
 
-            Assert.AreEqual("I haven't seen this link format before...", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(15, result.Links[0].Index);
-            Assert.AreEqual(16, result.Links[0].Length);
+            ClassicAssert.AreEqual("I haven't seen this link format before...", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(15, result.Links[0].Index);
+            ClassicAssert.AreEqual(16, result.Links[0].Length);
         }
 
         [Test]
@@ -371,11 +372,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [https://osu.ppy.sh](https://osu.ppy.sh \"https://osu.ppy.sh\") before..." });
 
-            Assert.AreEqual("I haven't seen https://osu.ppy.sh before...", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(15, result.Links[0].Index);
-            Assert.AreEqual(18, result.Links[0].Length);
+            ClassicAssert.AreEqual("I haven't seen https://osu.ppy.sh before...", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(15, result.Links[0].Index);
+            ClassicAssert.AreEqual(18, result.Links[0].Length);
         }
 
         [Test]
@@ -383,11 +384,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [oh no, text here! https://osu.ppy.sh](https://osu.ppy.sh) before..." });
 
-            Assert.AreEqual("I haven't seen oh no, text here! https://osu.ppy.sh before...", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(15, result.Links[0].Index);
-            Assert.AreEqual(36, result.Links[0].Length);
+            ClassicAssert.AreEqual("I haven't seen oh no, text here! https://osu.ppy.sh before...", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(15, result.Links[0].Index);
+            ClassicAssert.AreEqual(36, result.Links[0].Length);
         }
 
         [Test]
@@ -395,11 +396,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [https://google.com](https://osu.ppy.sh) before..." });
 
-            Assert.AreEqual("I haven't seen https://google.com before...", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(15, result.Links[0].Index);
-            Assert.AreEqual(18, result.Links[0].Length);
+            ClassicAssert.AreEqual("I haven't seen https://google.com before...", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(15, result.Links[0].Index);
+            ClassicAssert.AreEqual(18, result.Links[0].Length);
         }
 
         [Test]
@@ -407,11 +408,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "super broken https://[osu.ppy](https://reddit.com).sh/" });
 
-            Assert.AreEqual("super broken https://osu.ppy.sh/", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://reddit.com", result.Links[0].Url);
-            Assert.AreEqual(21, result.Links[0].Index);
-            Assert.AreEqual(7, result.Links[0].Length);
+            ClassicAssert.AreEqual("super broken https://osu.ppy.sh/", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://reddit.com", result.Links[0].Url);
+            ClassicAssert.AreEqual(21, result.Links[0].Index);
+            ClassicAssert.AreEqual(7, result.Links[0].Length);
         }
 
         [Test]
@@ -420,16 +421,16 @@ namespace osu.Game.Tests.Chat
             // the raw link has a port at the end of it, so that the raw link regex terminates at the port and doesn't consume display text from the formatted one
             Message result = MessageFormatter.FormatMessage(new Message { Content = "https://localhost:8080[https://osu.ppy.sh](https://osu.ppy.sh) should be two links" });
 
-            Assert.AreEqual("https://localhost:8080https://osu.ppy.sh should be two links", result.DisplayContent);
-            Assert.AreEqual(2, result.Links.Count);
+            ClassicAssert.AreEqual("https://localhost:8080https://osu.ppy.sh should be two links", result.DisplayContent);
+            ClassicAssert.AreEqual(2, result.Links.Count);
 
-            Assert.AreEqual("https://localhost:8080", result.Links[0].Url);
-            Assert.AreEqual(0, result.Links[0].Index);
-            Assert.AreEqual(22, result.Links[0].Length);
+            ClassicAssert.AreEqual("https://localhost:8080", result.Links[0].Url);
+            ClassicAssert.AreEqual(0, result.Links[0].Index);
+            ClassicAssert.AreEqual(22, result.Links[0].Length);
 
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[1].Url);
-            Assert.AreEqual(22, result.Links[1].Index);
-            Assert.AreEqual(18, result.Links[1].Length);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[1].Url);
+            ClassicAssert.AreEqual(22, result.Links[1].Index);
+            ClassicAssert.AreEqual(18, result.Links[1].Length);
         }
 
         [Test]
@@ -437,10 +438,10 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is an #english and #japanese." });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(2, result.Links.Count);
-            Assert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#english", result.Links[0].Url);
-            Assert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#japanese", result.Links[1].Url);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(2, result.Links.Count);
+            ClassicAssert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#english", result.Links[0].Url);
+            ClassicAssert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#japanese", result.Links[1].Url);
         }
 
         [Test]
@@ -448,20 +449,20 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = $"This is a custom protocol {OsuGameBase.OSU_PROTOCOL}chan/#english." });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#english", result.Links[0].Url);
-            Assert.AreEqual(26, result.Links[0].Index);
-            Assert.AreEqual(19, result.Links[0].Length);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#english", result.Links[0].Url);
+            ClassicAssert.AreEqual(26, result.Links[0].Index);
+            ClassicAssert.AreEqual(19, result.Links[0].Length);
 
             result = MessageFormatter.FormatMessage(new Message { Content = $"This is a [custom protocol]({OsuGameBase.OSU_PROTOCOL}chan/#english)." });
 
-            Assert.AreEqual("This is a custom protocol.", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#english", result.Links[0].Url);
-            Assert.AreEqual("#english", result.Links[0].Argument);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(15, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a custom protocol.", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual($"{OsuGameBase.OSU_PROTOCOL}chan/#english", result.Links[0].Url);
+            ClassicAssert.AreEqual("#english", result.Links[0].Argument);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(15, result.Links[0].Length);
         }
 
         [Test]
@@ -469,11 +470,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "Join my multiplayer game osump://12346." });
 
-            Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("osump://12346", result.Links[0].Url);
-            Assert.AreEqual(25, result.Links[0].Index);
-            Assert.AreEqual(13, result.Links[0].Length);
+            ClassicAssert.AreEqual(result.Content, result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("osump://12346", result.Links[0].Url);
+            ClassicAssert.AreEqual(25, result.Links[0].Index);
+            ClassicAssert.AreEqual(13, result.Links[0].Length);
         }
 
         [Test]
@@ -481,11 +482,11 @@ namespace osu.Game.Tests.Chat
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh [[simple test]]]." });
 
-            Assert.AreEqual("This is a [[simple test]].", result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
-            Assert.AreEqual(10, result.Links[0].Index);
-            Assert.AreEqual(15, result.Links[0].Length);
+            ClassicAssert.AreEqual("This is a [[simple test]].", result.DisplayContent);
+            ClassicAssert.AreEqual(1, result.Links.Count);
+            ClassicAssert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            ClassicAssert.AreEqual(10, result.Links[0].Index);
+            ClassicAssert.AreEqual(15, result.Links[0].Length);
         }
 
         [Test]
@@ -496,44 +497,44 @@ namespace osu.Game.Tests.Chat
                 Content = "This is a [http://www.simple-test.com simple test] with some [traps] and [[wiki links]]. Don't forget to visit https://osu.ppy.sh (now!)[http://google.com]\uD83D\uDE12"
             });
 
-            Assert.AreEqual("This is a simple test with some [traps] and wiki links. Don't forget to visit https://osu.ppy.sh now![emoji]", result.DisplayContent);
-            Assert.AreEqual(4, result.Links.Count);
+            ClassicAssert.AreEqual("This is a simple test with some [traps] and wiki links. Don't forget to visit https://osu.ppy.sh now![emoji]", result.DisplayContent);
+            ClassicAssert.AreEqual(4, result.Links.Count);
 
             Link f = result.Links.Find(l => l.Url == "https://dev.ppy.sh/wiki/wiki links");
             Assert.That(f, Is.Not.Null);
-            Assert.AreEqual(44, f.Index);
-            Assert.AreEqual(10, f.Length);
+            ClassicAssert.AreEqual(44, f.Index);
+            ClassicAssert.AreEqual(10, f.Length);
 
             f = result.Links.Find(l => l.Url == "http://www.simple-test.com");
             Assert.That(f, Is.Not.Null);
-            Assert.AreEqual(10, f.Index);
-            Assert.AreEqual(11, f.Length);
+            ClassicAssert.AreEqual(10, f.Index);
+            ClassicAssert.AreEqual(11, f.Length);
 
             f = result.Links.Find(l => l.Url == "http://google.com");
             Assert.That(f, Is.Not.Null);
-            Assert.AreEqual(97, f.Index);
-            Assert.AreEqual(4, f.Length);
+            ClassicAssert.AreEqual(97, f.Index);
+            ClassicAssert.AreEqual(4, f.Length);
 
             f = result.Links.Find(l => l.Url == "https://osu.ppy.sh");
             Assert.That(f, Is.Not.Null);
-            Assert.AreEqual(78, f.Index);
-            Assert.AreEqual(18, f.Length);
+            ClassicAssert.AreEqual(78, f.Index);
+            ClassicAssert.AreEqual(18, f.Length);
         }
 
         [Test]
         public void TestEmoji()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "Hello world\uD83D\uDE12<--This is an emoji,There are more emojis among us:\uD83D\uDE10\uD83D\uDE00,\uD83D\uDE20" });
-            Assert.AreEqual("Hello world[emoji]<--This is an emoji,There are more emojis among us:[emoji][emoji],[emoji]", result.DisplayContent);
-            Assert.AreEqual(result.Links.Count, 0);
+            ClassicAssert.AreEqual("Hello world[emoji]<--This is an emoji,There are more emojis among us:[emoji][emoji],[emoji]", result.DisplayContent);
+            ClassicAssert.AreEqual(result.Links.Count, 0);
         }
 
         [Test]
         public void TestEmojiWithSuccessiveParens()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "\uD83D\uDE10(let's hope this doesn't accidentally turn into a link)" });
-            Assert.AreEqual("[emoji](let's hope this doesn't accidentally turn into a link)", result.DisplayContent);
-            Assert.AreEqual(result.Links.Count, 0);
+            ClassicAssert.AreEqual("[emoji](let's hope this doesn't accidentally turn into a link)", result.DisplayContent);
+            ClassicAssert.AreEqual(result.Links.Count, 0);
         }
 
         [Test]
@@ -541,8 +542,8 @@ namespace osu.Game.Tests.Chat
         {
             LinkDetails result = MessageFormatter.GetLinkDetails("https://google.com");
 
-            Assert.AreEqual(LinkAction.External, result.Action);
-            Assert.AreEqual("https://google.com", result.Argument);
+            ClassicAssert.AreEqual(LinkAction.External, result.Action);
+            ClassicAssert.AreEqual("https://google.com", result.Argument);
         }
 
         [Test]
@@ -550,8 +551,8 @@ namespace osu.Game.Tests.Chat
         {
             LinkDetails result = MessageFormatter.GetLinkDetails("/relative");
 
-            Assert.AreEqual(LinkAction.External, result.Action);
-            Assert.AreEqual("/relative", result.Argument);
+            ClassicAssert.AreEqual(LinkAction.External, result.Action);
+            ClassicAssert.AreEqual("/relative", result.Argument);
         }
 
         [TestCase("https://dev.ppy.sh/home/changelog", "")]
@@ -560,8 +561,8 @@ namespace osu.Game.Tests.Chat
         {
             LinkDetails result = MessageFormatter.GetLinkDetails(link);
 
-            Assert.AreEqual(LinkAction.OpenChangelog, result.Action);
-            Assert.AreEqual(expectedArg, result.Argument);
+            ClassicAssert.AreEqual(LinkAction.OpenChangelog, result.Action);
+            ClassicAssert.AreEqual(expectedArg, result.Argument);
         }
     }
 }

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -292,7 +292,7 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(extractedFolder);
 
                     foreach (var file in new DirectoryInfo(extractedFolder).GetFiles("*.osu"))
@@ -333,10 +333,10 @@ namespace osu.Game.Tests.Database
 
                     string hashBefore = hashFile(temp);
 
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(extractedFolder);
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(temp, new ZipWriterOptions(CompressionType.Deflate));
@@ -382,7 +382,7 @@ namespace osu.Game.Tests.Database
 
                     await createScoreForBeatmap(realm.Realm, imported.Beatmaps.First());
 
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(extractedFolder);
 
                     // arbitrary write to hashed file
@@ -390,7 +390,7 @@ namespace osu.Game.Tests.Database
                     using (var sw = new FileInfo(Directory.GetFiles(extractedFolder, "*.osu").First()).AppendText())
                         await sw.WriteLineAsync("// changed");
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(temp, new ZipWriterOptions(CompressionType.Deflate));
@@ -533,14 +533,14 @@ namespace osu.Game.Tests.Database
                 {
                     var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(extractedFolder);
 
                     // arbitrary write to non-hashed file
                     using (var sw = new FileInfo(Directory.GetFiles(extractedFolder, "*.mp3").First()).AppendText())
                         await sw.WriteLineAsync("text");
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(temp, new ZipWriterOptions(CompressionType.Deflate));
@@ -581,14 +581,14 @@ namespace osu.Game.Tests.Database
                 {
                     var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(extractedFolder);
 
                     // change filename
                     var firstFile = new FileInfo(Directory.GetFiles(extractedFolder).First());
                     firstFile.MoveTo(Path.Combine(firstFile.DirectoryName.AsNonNull(), $"{firstFile.Name}-changed{firstFile.Extension}"));
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(temp, new ZipWriterOptions(CompressionType.Deflate));
@@ -659,7 +659,7 @@ namespace osu.Game.Tests.Database
 
                 var zipStream = new MemoryStream();
 
-                using (var zip = ZipArchive.Create())
+                using (var zip = ZipArchive.CreateArchive())
                     zip.SaveTo(zipStream, new ZipWriterOptions(CompressionType.Deflate));
 
                 var imported = await importer.Import(
@@ -709,7 +709,7 @@ namespace osu.Game.Tests.Database
                 File.Delete(brokenTempFilename);
 
                 using (var outStream = File.Open(brokenTempFilename, FileMode.CreateNew))
-                using (var zip = ZipArchive.Open(brokenOsz))
+                using (var zip = ZipArchive.OpenArchive(brokenOsz))
                 {
                     foreach (var entry in zip.Entries.ToArray())
                     {
@@ -787,13 +787,13 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    using (var zip = ZipArchive.Open(pathOriginal))
+                    using (var zip = ZipArchive.OpenArchive(pathOriginal))
                         zip.WriteToDirectory(extractedFolder);
 
                     // remove one difficulty before first import
                     new FileInfo(Directory.GetFiles(extractedFolder, "*.osu").First()).Delete();
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(pathMissingOneBeatmap, new ZipWriterOptions(CompressionType.Deflate));
@@ -994,10 +994,10 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(extractedFolder);
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.AddEntry("duplicate.osu", Directory.GetFiles(extractedFolder, "*.osu").First());
@@ -1030,7 +1030,7 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(extractedFolder);
 
                     var subdirectory = Directory.CreateDirectory(Path.Combine(extractedFolder, "subdir"));
@@ -1041,7 +1041,7 @@ namespace osu.Game.Tests.Database
                     using (var textWriter = new StreamWriter(stream))
                         await textWriter.WriteLineAsync("# adding a comment so that the hashes are different");
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(temp, new ZipWriterOptions(CompressionType.Deflate));
@@ -1075,10 +1075,10 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(subfolder);
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(temp, new ZipWriterOptions(CompressionType.Deflate));
@@ -1125,10 +1125,10 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    using (var zip = ZipArchive.Open(temp))
+                    using (var zip = ZipArchive.OpenArchive(temp))
                         zip.WriteToDirectory(dataFolder);
 
-                    using (var zip = ZipArchive.Create())
+                    using (var zip = ZipArchive.CreateArchive())
                     {
                         zip.AddAllFromDirectory(extractedFolder);
                         zip.SaveTo(temp, new ZipWriterOptions(CompressionType.Deflate));

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Logging;
@@ -42,7 +43,7 @@ namespace osu.Game.Tests.Database
                 {
                     var beatmapSet = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
 
-                    Assert.NotNull(beatmapSet);
+                    ClassicAssert.NotNull(beatmapSet);
                     Debug.Assert(beatmapSet != null);
 
                     BeatmapSetInfo? detachedBeatmapSet = null;
@@ -52,23 +53,23 @@ namespace osu.Game.Tests.Database
                         detachedBeatmapSet = live.Detach();
 
                         // files are omitted
-                        Assert.AreEqual(0, detachedBeatmapSet.Files.Count);
+                        ClassicAssert.AreEqual(0, detachedBeatmapSet.Files.Count);
 
-                        Assert.AreEqual(live.Beatmaps.Count, detachedBeatmapSet.Beatmaps.Count);
-                        Assert.AreEqual(live.Beatmaps.Select(f => f.Difficulty).Count(), detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
-                        Assert.AreEqual(live.Metadata, detachedBeatmapSet.Metadata);
+                        ClassicAssert.AreEqual(live.Beatmaps.Count, detachedBeatmapSet.Beatmaps.Count);
+                        ClassicAssert.AreEqual(live.Beatmaps.Select(f => f.Difficulty).Count(), detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
+                        ClassicAssert.AreEqual(live.Metadata, detachedBeatmapSet.Metadata);
                     });
 
                     Debug.Assert(detachedBeatmapSet != null);
 
                     // Check detached instances can all be accessed without throwing.
-                    Assert.AreEqual(0, detachedBeatmapSet.Files.Count);
-                    Assert.NotNull(detachedBeatmapSet.Beatmaps.Count);
-                    Assert.NotZero(detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
-                    Assert.NotNull(detachedBeatmapSet.Metadata);
+                    ClassicAssert.AreEqual(0, detachedBeatmapSet.Files.Count);
+                    ClassicAssert.NotNull(detachedBeatmapSet.Beatmaps.Count);
+                    ClassicAssert.NotZero(detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
+                    ClassicAssert.NotNull(detachedBeatmapSet.Metadata);
 
                     // Check cyclic reference to beatmap set
-                    Assert.AreEqual(detachedBeatmapSet, detachedBeatmapSet.Beatmaps.First().BeatmapSet);
+                    ClassicAssert.AreEqual(detachedBeatmapSet, detachedBeatmapSet.Beatmaps.First().BeatmapSet);
                 }
             });
         }
@@ -84,7 +85,7 @@ namespace osu.Game.Tests.Database
                 {
                     var beatmapSet = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
 
-                    Assert.NotNull(beatmapSet);
+                    ClassicAssert.NotNull(beatmapSet);
                     Debug.Assert(beatmapSet != null);
 
                     // Detach at the BeatmapInfo point, similar to what GetWorkingBeatmap does.
@@ -101,7 +102,7 @@ namespace osu.Game.Tests.Database
                     detachedBeatmapSet.Beatmaps.First().Metadata.Artist = "New Artist";
                     detachedBeatmapSet.Beatmaps.First().Metadata.Author = newUser;
 
-                    Assert.AreNotEqual(detachedBeatmapSet.Status, BeatmapOnlineStatus.Ranked);
+                    ClassicAssert.AreNotEqual(detachedBeatmapSet.Status, BeatmapOnlineStatus.Ranked);
                     detachedBeatmapSet.Status = BeatmapOnlineStatus.Ranked;
 
                     beatmapSet.PerformWrite(detachedBeatmapSet.CopyChangesToRealm);
@@ -109,17 +110,17 @@ namespace osu.Game.Tests.Database
                     beatmapSet.PerformRead(s =>
                     {
                         // Check above changes explicitly.
-                        Assert.AreEqual(BeatmapOnlineStatus.Ranked, s.Status);
-                        Assert.AreEqual("New Artist", s.Beatmaps.First().Metadata.Artist);
-                        Assert.AreEqual(newUser, s.Beatmaps.First().Metadata.Author);
-                        Assert.NotZero(s.Files.Count);
+                        ClassicAssert.AreEqual(BeatmapOnlineStatus.Ranked, s.Status);
+                        ClassicAssert.AreEqual("New Artist", s.Beatmaps.First().Metadata.Artist);
+                        ClassicAssert.AreEqual(newUser, s.Beatmaps.First().Metadata.Author);
+                        ClassicAssert.NotZero(s.Files.Count);
 
                         // Check nothing was lost in the copy operation.
-                        Assert.AreEqual(s.Files.Count, detachedBeatmapSet.Files.Count);
-                        Assert.AreEqual(s.Files.Select(f => f.File).Count(), detachedBeatmapSet.Files.Select(f => f.File).Count());
-                        Assert.AreEqual(s.Beatmaps.Count, detachedBeatmapSet.Beatmaps.Count);
-                        Assert.AreEqual(s.Beatmaps.Select(f => f.Difficulty).Count(), detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
-                        Assert.AreEqual(s.Metadata, detachedBeatmapSet.Metadata);
+                        ClassicAssert.AreEqual(s.Files.Count, detachedBeatmapSet.Files.Count);
+                        ClassicAssert.AreEqual(s.Files.Select(f => f.File).Count(), detachedBeatmapSet.Files.Select(f => f.File).Count());
+                        ClassicAssert.AreEqual(s.Beatmaps.Count, detachedBeatmapSet.Beatmaps.Count);
+                        ClassicAssert.AreEqual(s.Beatmaps.Select(f => f.Difficulty).Count(), detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
+                        ClassicAssert.AreEqual(s.Metadata, detachedBeatmapSet.Metadata);
                     });
                 }
             });
@@ -142,7 +143,7 @@ namespace osu.Game.Tests.Database
                     {
                         var beatmapSet = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
 
-                        Assert.NotNull(beatmapSet);
+                        ClassicAssert.NotNull(beatmapSet);
                         Debug.Assert(beatmapSet != null);
 
                         // Intentionally detach on async thread as to not trigger a refresh on the main thread.
@@ -167,20 +168,20 @@ namespace osu.Game.Tests.Database
                     var imported = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
                     EnsureLoaded(realm.Realm);
 
-                    Assert.AreEqual(1, realm.Realm.All<BeatmapSetInfo>().Count());
+                    ClassicAssert.AreEqual(1, realm.Realm.All<BeatmapSetInfo>().Count());
 
-                    Assert.NotNull(imported);
+                    ClassicAssert.NotNull(imported);
                     Debug.Assert(imported != null);
 
                     imported.PerformWrite(s => s.DeletePending = true);
 
-                    Assert.AreEqual(1, realm.Realm.All<BeatmapSetInfo>().Count(s => s.DeletePending));
+                    ClassicAssert.AreEqual(1, realm.Realm.All<BeatmapSetInfo>().Count(s => s.DeletePending));
                 }
             });
 
             Logger.Log("Running with no work to purge pending deletions");
 
-            RunTestWithRealm((realm, _) => { Assert.AreEqual(0, realm.Realm.All<BeatmapSetInfo>().Count()); });
+            RunTestWithRealm((realm, _) => { ClassicAssert.AreEqual(0, realm.Realm.All<BeatmapSetInfo>().Count()); });
         }
 
         [Test]
@@ -208,8 +209,8 @@ namespace osu.Game.Tests.Database
                 var beatmap = imported.Beatmaps.First();
                 var file = beatmap.File;
 
-                Assert.NotNull(file);
-                Assert.AreEqual(beatmap.Hash, file!.File.Hash);
+                ClassicAssert.NotNull(file);
+                ClassicAssert.AreEqual(beatmap.Hash, file!.File.Hash);
             });
         }
 
@@ -245,10 +246,10 @@ namespace osu.Game.Tests.Database
                     EnsureLoaded(realm.Realm);
                 }
 
-                Assert.NotNull(importedSet);
+                ClassicAssert.NotNull(importedSet);
                 Debug.Assert(importedSet != null);
 
-                Assert.IsTrue(File.Exists(tempPath), "Stream source file somehow went missing");
+                ClassicAssert.True(File.Exists(tempPath), "Stream source file somehow went missing");
                 File.Delete(tempPath);
 
                 var imported = realm.Realm.All<BeatmapSetInfo>().First(beatmapSet => beatmapSet.ID == importedSet.ID);
@@ -269,8 +270,8 @@ namespace osu.Game.Tests.Database
                 var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
-                Assert.IsTrue(imported.ID == importedSecondTime.ID);
-                Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
+                ClassicAssert.True(imported.ID == importedSecondTime.ID);
+                ClassicAssert.True(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
 
                 checkBeatmapSetCount(realm.Realm, 1);
                 checkSingleReferencedFileCount(realm.Realm, 18);
@@ -304,7 +305,7 @@ namespace osu.Game.Tests.Database
                     }
 
                     var imported = await importer.Import(new ImportTask(extractedFolder));
-                    Assert.IsNull(imported);
+                    ClassicAssert.Null(imported);
                 }
                 finally
                 {
@@ -343,18 +344,18 @@ namespace osu.Game.Tests.Database
                     }
 
                     // zip files differ because different compression or encoder.
-                    Assert.AreNotEqual(hashBefore, hashFile(temp));
+                    ClassicAssert.AreNotEqual(hashBefore, hashFile(temp));
 
                     var importedSecondTime = await importer.Import(new ImportTask(temp));
 
                     EnsureLoaded(realm.Realm);
 
-                    Assert.NotNull(importedSecondTime);
+                    ClassicAssert.NotNull(importedSecondTime);
                     Debug.Assert(importedSecondTime != null);
 
                     // but contents doesn't, so existing should still be used.
-                    Assert.IsTrue(imported.ID == importedSecondTime.ID);
-                    Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
+                    ClassicAssert.True(imported.ID == importedSecondTime.ID);
+                    ClassicAssert.True(imported.Beatmaps.First().ID == importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
                 }
                 finally
                 {
@@ -401,11 +402,11 @@ namespace osu.Game.Tests.Database
                     EnsureLoaded(realm.Realm);
 
                     // check the newly "imported" beatmap is not the original.
-                    Assert.NotNull(importedSecondTime);
+                    ClassicAssert.NotNull(importedSecondTime);
                     Debug.Assert(importedSecondTime != null);
 
-                    Assert.IsTrue(imported.ID != importedSecondTime.ID);
-                    Assert.IsTrue(imported.Beatmaps.First().ID != importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
+                    ClassicAssert.True(imported.ID != importedSecondTime.ID);
+                    ClassicAssert.True(imported.Beatmaps.First().ID != importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
                 }
                 finally
                 {
@@ -501,7 +502,7 @@ namespace osu.Game.Tests.Database
                 EnsureLoaded(realm.Realm);
 
                 // check the newly "imported" beatmap is not the original.
-                Assert.NotNull(importedSecondTime);
+                ClassicAssert.NotNull(importedSecondTime);
                 Debug.Assert(importedSecondTime != null);
                 Assert.That(imported.ID != importedSecondTime.ID);
 
@@ -550,12 +551,12 @@ namespace osu.Game.Tests.Database
 
                     EnsureLoaded(realm.Realm);
 
-                    Assert.NotNull(importedSecondTime);
+                    ClassicAssert.NotNull(importedSecondTime);
                     Debug.Assert(importedSecondTime != null);
 
                     // check the newly "imported" beatmap is not the original.
-                    Assert.IsTrue(imported.ID != importedSecondTime.ID);
-                    Assert.IsTrue(imported.Beatmaps.First().ID != importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
+                    ClassicAssert.True(imported.ID != importedSecondTime.ID);
+                    ClassicAssert.True(imported.Beatmaps.First().ID != importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
                 }
                 finally
                 {
@@ -598,12 +599,12 @@ namespace osu.Game.Tests.Database
 
                     EnsureLoaded(realm.Realm);
 
-                    Assert.NotNull(importedSecondTime);
+                    ClassicAssert.NotNull(importedSecondTime);
                     Debug.Assert(importedSecondTime != null);
 
                     // check the newly "imported" beatmap is not the original.
-                    Assert.IsTrue(imported.ID != importedSecondTime.ID);
-                    Assert.IsTrue(imported.Beatmaps.First().ID != importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
+                    ClassicAssert.True(imported.ID != importedSecondTime.ID);
+                    ClassicAssert.True(imported.Beatmaps.First().ID != importedSecondTime.PerformRead(s => s.Beatmaps.First().ID));
                 }
                 finally
                 {
@@ -636,11 +637,11 @@ namespace osu.Game.Tests.Database
                 var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 using (var stream = fileStorage.GetStream(firstFile.File.GetStoragePath()))
-                    Assert.AreEqual(stream.Length, originalLength, "Corruption was not fixed on second import");
+                    ClassicAssert.AreEqual(stream.Length, originalLength, "Corruption was not fixed on second import");
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
-                Assert.IsTrue(imported.ID == importedSecondTime.ID);
-                Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
+                ClassicAssert.True(imported.ID == importedSecondTime.ID);
+                ClassicAssert.True(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
 
                 checkBeatmapSetCount(realm.Realm, 1);
                 checkSingleReferencedFileCount(realm.Realm, 18);
@@ -672,8 +673,8 @@ namespace osu.Game.Tests.Database
                 checkBeatmapSetCount(realm.Realm, 0);
                 checkBeatmapCount(realm.Realm, 0);
 
-                Assert.IsEmpty(imported);
-                Assert.AreEqual(ProgressNotificationState.Cancelled, progressNotification.State);
+                ClassicAssert.IsEmpty(imported);
+                ClassicAssert.AreEqual(ProgressNotificationState.Cancelled, progressNotification.State);
             });
         }
 
@@ -737,7 +738,7 @@ namespace osu.Game.Tests.Database
 
                 checkSingleReferencedFileCount(realm.Realm, 18);
 
-                Assert.AreEqual(0, loggedExceptionCount);
+                ClassicAssert.AreEqual(0, loggedExceptionCount);
 
                 File.Delete(brokenTempFilename);
             });
@@ -755,17 +756,17 @@ namespace osu.Game.Tests.Database
 
                 deleteBeatmapSet(imported, realm.Realm);
 
-                Assert.IsTrue(imported.DeletePending);
+                ClassicAssert.True(imported.DeletePending);
 
                 var originalAddedDate = imported.DateAdded;
 
                 var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
-                Assert.IsTrue(imported.ID == importedSecondTime.ID);
-                Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
-                Assert.IsFalse(imported.DeletePending);
-                Assert.IsFalse(importedSecondTime.DeletePending);
+                ClassicAssert.True(imported.ID == importedSecondTime.ID);
+                ClassicAssert.True(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
+                ClassicAssert.False(imported.DeletePending);
+                ClassicAssert.False(importedSecondTime.DeletePending);
                 Assert.That(importedSecondTime.DateAdded, Is.GreaterThan(originalAddedDate));
             });
         }
@@ -841,7 +842,7 @@ namespace osu.Game.Tests.Database
 
                 deleteBeatmapSet(imported, realmFactory.Realm);
 
-                Assert.IsTrue(imported.DeletePending);
+                ClassicAssert.True(imported.DeletePending);
 
                 // intentionally nuke all files
                 storage.DeleteDirectory("files");
@@ -851,10 +852,10 @@ namespace osu.Game.Tests.Database
                 var importedSecondTime = await LoadOszIntoStore(importer, realmFactory.Realm);
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
-                Assert.IsTrue(imported.ID == importedSecondTime.ID);
-                Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
-                Assert.IsFalse(imported.DeletePending);
-                Assert.IsFalse(importedSecondTime.DeletePending);
+                ClassicAssert.True(imported.ID == importedSecondTime.ID);
+                ClassicAssert.True(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
+                ClassicAssert.False(imported.DeletePending);
+                ClassicAssert.False(importedSecondTime.DeletePending);
 
                 // check that the files now exist, even though they were deleted above.
                 Assert.That(importedSecondTime.Files.All(f => storage.GetStorageForDirectory("files").Exists(f.File.GetStoragePath())));
@@ -873,17 +874,17 @@ namespace osu.Game.Tests.Database
 
                 deleteBeatmapSet(imported, realm.Realm);
 
-                Assert.IsTrue(imported.DeletePending);
+                ClassicAssert.True(imported.DeletePending);
 
                 var originalAddedDate = imported.DateAdded;
 
                 var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
-                Assert.IsTrue(imported.ID == importedSecondTime.ID);
-                Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
-                Assert.IsFalse(imported.DeletePending);
-                Assert.IsFalse(importedSecondTime.DeletePending);
+                ClassicAssert.True(imported.ID == importedSecondTime.ID);
+                ClassicAssert.True(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
+                ClassicAssert.False(imported.DeletePending);
+                ClassicAssert.False(importedSecondTime.DeletePending);
                 Assert.That(importedSecondTime.DateAdded, Is.GreaterThan(originalAddedDate));
             });
         }
@@ -909,8 +910,8 @@ namespace osu.Game.Tests.Database
                 var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap has been reimported due to mismatch (even though hashes matched)
-                Assert.IsTrue(imported.ID != importedSecondTime.ID);
-                Assert.IsTrue(imported.Beatmaps.First().ID != importedSecondTime.Beatmaps.First().ID);
+                ClassicAssert.True(imported.ID != importedSecondTime.ID);
+                ClassicAssert.True(imported.Beatmaps.First().ID != importedSecondTime.Beatmaps.First().ID);
             });
         }
 
@@ -954,11 +955,11 @@ namespace osu.Game.Tests.Database
 
                 realm.Run(r => r.Refresh());
 
-                Assert.NotNull(imported);
+                ClassicAssert.NotNull(imported);
                 Debug.Assert(imported != null);
 
-                Assert.AreEqual(-1, imported.PerformRead(s => s.Beatmaps[0].OnlineID));
-                Assert.AreEqual(-1, imported.PerformRead(s => s.Beatmaps[1].OnlineID));
+                ClassicAssert.AreEqual(-1, imported.PerformRead(s => s.Beatmaps[0].OnlineID));
+                ClassicAssert.AreEqual(-1, imported.PerformRead(s => s.Beatmaps[1].OnlineID));
             });
         }
 
@@ -975,7 +976,7 @@ namespace osu.Game.Tests.Database
                     await importer.Import(temp);
                 EnsureLoaded(realm.Realm);
                 File.Delete(temp);
-                Assert.IsFalse(File.Exists(temp), "We likely held a read lock on the file when we shouldn't");
+                ClassicAssert.False(File.Exists(temp), "We likely held a read lock on the file when we shouldn't");
             });
         }
 
@@ -1086,12 +1087,12 @@ namespace osu.Game.Tests.Database
 
                     var imported = await importer.Import(new ImportTask(temp));
 
-                    Assert.NotNull(imported);
+                    ClassicAssert.NotNull(imported);
                     Debug.Assert(imported != null);
 
                     EnsureLoaded(realm.Realm);
 
-                    Assert.IsFalse(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("subfolder"))), "Files contain common subfolder");
+                    ClassicAssert.False(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("subfolder"))), "Files contain common subfolder");
                 }
                 finally
                 {
@@ -1136,13 +1137,13 @@ namespace osu.Game.Tests.Database
 
                     var imported = await importer.Import(new ImportTask(temp));
 
-                    Assert.NotNull(imported);
+                    ClassicAssert.NotNull(imported);
                     Debug.Assert(imported != null);
 
                     EnsureLoaded(realm.Realm);
 
-                    Assert.IsFalse(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("__MACOSX"))), "Files contain resource fork folder, which should be ignored");
-                    Assert.IsFalse(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("actual_data"))), "Files contain common subfolder");
+                    ClassicAssert.False(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("__MACOSX"))), "Files contain resource fork folder, which should be ignored");
+                    ClassicAssert.False(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("actual_data"))), "Files contain common subfolder");
                 }
                 finally
                 {
@@ -1182,7 +1183,7 @@ namespace osu.Game.Tests.Database
 
             var importedSet = await importer.Import(new ImportTask(temp));
 
-            Assert.NotNull(importedSet);
+            ClassicAssert.NotNull(importedSet);
 
             EnsureLoaded(realm);
 
@@ -1197,7 +1198,7 @@ namespace osu.Game.Tests.Database
 
             var importedSet = await importer.Import(new ImportTask(temp), new ImportParameters { Batch = batchImport });
 
-            Assert.NotNull(importedSet);
+            ClassicAssert.NotNull(importedSet);
             Debug.Assert(importedSet != null);
 
             EnsureLoaded(realm);
@@ -1214,7 +1215,7 @@ namespace osu.Game.Tests.Database
             checkBeatmapSetCount(realm, 0);
             checkBeatmapSetCount(realm, 1, true);
 
-            Assert.IsTrue(realm.All<BeatmapSetInfo>().First(_ => true).DeletePending);
+            ClassicAssert.True(realm.All<BeatmapSetInfo>().First(_ => true).DeletePending);
         }
 
         private static Task createScoreForBeatmap(Realm realm, BeatmapInfo beatmap) =>
@@ -1230,7 +1231,7 @@ namespace osu.Game.Tests.Database
 
         private static void checkBeatmapSetCount(Realm realm, int expected, bool includeDeletePending = false)
         {
-            Assert.AreEqual(expected, includeDeletePending
+            ClassicAssert.AreEqual(expected, includeDeletePending
                 ? realm.All<BeatmapSetInfo>().Count()
                 : realm.All<BeatmapSetInfo>().Count(s => !s.DeletePending));
         }
@@ -1243,7 +1244,7 @@ namespace osu.Game.Tests.Database
 
         private static void checkBeatmapCount(Realm realm, int expected)
         {
-            Assert.AreEqual(expected, realm.All<BeatmapInfo>().Where(_ => true).ToList().Count);
+            ClassicAssert.AreEqual(expected, realm.All<BeatmapInfo>().Where(_ => true).ToList().Count);
         }
 
         private static void checkSingleReferencedFileCount(Realm realm, int expected)
@@ -1256,7 +1257,7 @@ namespace osu.Game.Tests.Database
                     singleReferencedCount++;
             }
 
-            Assert.AreEqual(expected, singleReferencedCount);
+            ClassicAssert.AreEqual(expected, singleReferencedCount);
         }
 
         internal static void EnsureLoaded(Realm realm, int timeout = 60000)
@@ -1270,7 +1271,7 @@ namespace osu.Game.Tests.Database
             }, @"BeatmapSet did not import to the database in allocated time.", timeout);
 
             // ensure we were stored to beatmap database backing...
-            Assert.IsTrue(resultSets?.Count() == 1, $@"Incorrect result count found ({resultSets?.Count()} but should be 1).");
+            ClassicAssert.True(resultSets?.Count() == 1, $@"Incorrect result count found ({resultSets?.Count()} but should be 1).");
 
             IEnumerable<BeatmapSetInfo> queryBeatmapSets() => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && s.OnlineID == 241526);
 
@@ -1279,20 +1280,20 @@ namespace osu.Game.Tests.Database
             // ReSharper disable once PossibleUnintendedReferenceComparison
             IEnumerable<BeatmapInfo> queryBeatmaps() => realm.All<BeatmapInfo>().Where(s => s.BeatmapSet != null && s.BeatmapSet == set);
 
-            Assert.AreEqual(12, queryBeatmaps().Count(), @"Beatmap count was not correct");
-            Assert.AreEqual(1, queryBeatmapSets().Count(), @"Beatmapset count was not correct");
+            ClassicAssert.AreEqual(12, queryBeatmaps().Count(), @"Beatmap count was not correct");
+            ClassicAssert.AreEqual(1, queryBeatmapSets().Count(), @"Beatmapset count was not correct");
 
             int countBeatmapSetBeatmaps;
             int countBeatmaps;
 
-            Assert.AreEqual(
+            ClassicAssert.AreEqual(
                 countBeatmapSetBeatmaps = queryBeatmapSets().First().Beatmaps.Count,
                 countBeatmaps = queryBeatmaps().Count(),
                 $@"Incorrect database beatmap count post-import ({countBeatmaps} but should be {countBeatmapSetBeatmaps}).");
 
             foreach (BeatmapInfo b in set.Beatmaps)
-                Assert.IsTrue(set.Beatmaps.Any(c => c.OnlineID == b.OnlineID));
-            Assert.IsTrue(set.Beatmaps.Count > 0);
+                ClassicAssert.True(set.Beatmaps.Any(c => c.OnlineID == b.OnlineID));
+            ClassicAssert.True(set.Beatmaps.Count > 0);
         }
 
         private static void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 60000)

--- a/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
@@ -680,14 +680,14 @@ namespace osu.Game.Tests.Database
             string extractedFolder = $"{path}_extracted";
             Directory.CreateDirectory(extractedFolder);
 
-            using (var zip = ZipArchive.Open(path))
+            using (var zip = ZipArchive.OpenArchive(path))
                 zip.WriteToDirectory(extractedFolder);
 
             applyModifications(new DirectoryInfo(extractedFolder));
 
             File.Delete(path);
 
-            using (var zip = ZipArchive.Create())
+            using (var zip = ZipArchive.CreateArchive())
             {
                 zip.AddAllFromDirectory(extractedFolder);
                 zip.SaveTo(path, new ZipWriterOptions(CompressionType.Deflate));

--- a/osu.Game.Tests/Database/FileStoreTests.cs
+++ b/osu.Game.Tests/Database/FileStoreTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Logging;
 using osu.Game.Database;
 using osu.Game.Extensions;
@@ -26,8 +27,8 @@ namespace osu.Game.Tests.Database
 
                 realm.Write(() => files.Add(testData, realm));
 
-                Assert.True(files.Storage.Exists("0/05/054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8"));
-                Assert.True(files.Storage.Exists(realm.All<RealmFile>().First().GetStoragePath()));
+                ClassicAssert.True(files.Storage.Exists("0/05/054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8"));
+                ClassicAssert.True(files.Storage.Exists(realm.All<RealmFile>().First().GetStoragePath()));
             });
         }
 
@@ -44,7 +45,7 @@ namespace osu.Game.Tests.Database
                 realm.Write(() => files.Add(testData, realm));
                 realm.Write(() => files.Add(testData, realm));
 
-                Assert.AreEqual(1, realm.All<RealmFile>().Count());
+                ClassicAssert.AreEqual(1, realm.All<RealmFile>().Count());
             });
         }
 
@@ -75,15 +76,15 @@ namespace osu.Game.Tests.Database
 
                 string path = file.GetStoragePath();
 
-                Assert.True(realm.All<RealmFile>().Any());
-                Assert.True(files.Storage.Exists(path));
+                ClassicAssert.True(realm.All<RealmFile>().Any());
+                ClassicAssert.True(files.Storage.Exists(path));
 
                 files.Cleanup();
                 Logger.Log($"Cleanup complete at {timer.ElapsedMilliseconds}");
 
-                Assert.True(realm.All<RealmFile>().Any());
-                Assert.True(file.IsValid);
-                Assert.True(files.Storage.Exists(path));
+                ClassicAssert.True(realm.All<RealmFile>().Any());
+                ClassicAssert.True(file.IsValid);
+                ClassicAssert.True(files.Storage.Exists(path));
             });
         }
 
@@ -99,14 +100,14 @@ namespace osu.Game.Tests.Database
 
                 string path = file.GetStoragePath();
 
-                Assert.True(realm.All<RealmFile>().Any());
-                Assert.True(files.Storage.Exists(path));
+                ClassicAssert.True(realm.All<RealmFile>().Any());
+                ClassicAssert.True(files.Storage.Exists(path));
 
                 files.Cleanup();
 
-                Assert.False(realm.All<RealmFile>().Any());
-                Assert.False(file.IsValid);
-                Assert.False(files.Storage.Exists(path));
+                ClassicAssert.False(realm.All<RealmFile>().Any());
+                ClassicAssert.False(file.IsValid);
+                ClassicAssert.False(files.Storage.Exists(path));
             });
         }
     }

--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -143,7 +144,7 @@ namespace osu.Game.Tests.Database
                     return null;
                 });
 
-                Assert.IsTrue(callbackRan);
+                ClassicAssert.True(callbackRan);
             });
         }
 

--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -93,8 +94,8 @@ namespace osu.Game.Tests.Database
 
                     var importedSet = realm.Realm.All<BeatmapSetInfo>().Single();
 
-                    Assert.NotNull(importedSet);
-                    Assert.AreEqual(new DateTimeOffset(new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc)), importedSet.DateAdded);
+                    ClassicAssert.NotNull(importedSet);
+                    ClassicAssert.AreEqual(new DateTimeOffset(new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc)), importedSet.DateAdded);
                 }
             });
         }

--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Extensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -25,7 +26,7 @@ namespace osu.Game.Tests.Database
 
                 Live<BeatmapInfo> beatmap2 = realm.Run(r => r.All<BeatmapInfo>().First().ToLive(realm));
 
-                Assert.AreEqual(beatmap, beatmap2);
+                ClassicAssert.AreEqual(beatmap, beatmap2);
             });
         }
 
@@ -52,7 +53,7 @@ namespace osu.Game.Tests.Database
                     using (realm.BlockAllOperations("testing"))
                         storage.Migrate(migratedStorage);
 
-                    Assert.IsFalse(liveBeatmap?.PerformRead(l => l.Hidden));
+                    ClassicAssert.False(liveBeatmap?.PerformRead(l => l.Hidden));
                 });
             }
         }
@@ -111,7 +112,7 @@ namespace osu.Game.Tests.Database
                             r.Add(beatmap)))
                 );
 
-                Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+                ClassicAssert.False(liveBeatmap.PerformRead(l => l.Hidden));
             });
         }
 
@@ -126,7 +127,7 @@ namespace osu.Game.Tests.Database
 
                 realm.Run(r => r.Write(_ => r.Add(beatmap)));
 
-                Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+                ClassicAssert.False(liveBeatmap.PerformRead(l => l.Hidden));
             });
         }
 
@@ -136,15 +137,15 @@ namespace osu.Game.Tests.Database
             var beatmap = new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata());
             var liveBeatmap = beatmap.ToLiveUnmanaged();
 
-            Assert.IsFalse(beatmap.Hidden);
-            Assert.IsFalse(liveBeatmap.Value.Hidden);
-            Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+            ClassicAssert.False(beatmap.Hidden);
+            ClassicAssert.False(liveBeatmap.Value.Hidden);
+            ClassicAssert.False(liveBeatmap.PerformRead(l => l.Hidden));
 
             Assert.Throws<InvalidOperationException>(() => liveBeatmap.PerformWrite(l => l.Hidden = true));
 
-            Assert.IsFalse(beatmap.Hidden);
-            Assert.IsFalse(liveBeatmap.Value.Hidden);
-            Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+            ClassicAssert.False(beatmap.Hidden);
+            ClassicAssert.False(liveBeatmap.Value.Hidden);
+            ClassicAssert.False(liveBeatmap.PerformRead(l => l.Hidden));
         }
 
         [Test]
@@ -159,10 +160,10 @@ namespace osu.Game.Tests.Database
                 var liveBeatmap = beatmap.ToLive(realm);
 
                 Assert.Throws<InvalidOperationException>(() => liveBeatmap.PerformWrite(l => throw new InvalidOperationException()));
-                Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+                ClassicAssert.False(liveBeatmap.PerformRead(l => l.Hidden));
 
                 liveBeatmap.PerformWrite(l => l.Hidden = true);
-                Assert.IsTrue(liveBeatmap.PerformRead(l => l.Hidden));
+                ClassicAssert.True(liveBeatmap.PerformRead(l => l.Hidden));
             });
         }
 
@@ -188,8 +189,8 @@ namespace osu.Game.Tests.Database
                 {
                     liveBeatmap.PerformRead(beatmap =>
                     {
-                        Assert.IsTrue(beatmap.IsValid);
-                        Assert.IsFalse(beatmap.Hidden);
+                        ClassicAssert.True(beatmap.IsValid);
+                        ClassicAssert.False(beatmap.Hidden);
                     });
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
             });
@@ -216,7 +217,7 @@ namespace osu.Game.Tests.Database
                 Task.Factory.StartNew(() =>
                 {
                     liveBeatmap.PerformWrite(beatmap => { beatmap.Hidden = true; });
-                    liveBeatmap.PerformRead(beatmap => { Assert.IsTrue(beatmap.Hidden); });
+                    liveBeatmap.PerformRead(beatmap => { ClassicAssert.True(beatmap.Hidden); });
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
             });
         }
@@ -333,17 +334,17 @@ namespace osu.Game.Tests.Database
                     Debug.Assert(liveBeatmap != null);
 
                     // not yet seen by main context
-                    Assert.AreEqual(0, outerRealm.All<BeatmapInfo>().Count());
-                    Assert.AreEqual(0, changesTriggered);
+                    ClassicAssert.AreEqual(0, outerRealm.All<BeatmapInfo>().Count());
+                    ClassicAssert.AreEqual(0, changesTriggered);
 
                     liveBeatmap.PerformRead(resolved =>
                     {
                         // retrieval causes an implicit refresh. even changes that aren't related to the retrieval are fired at this point.
-                        Assert.AreEqual(2, outerRealm.All<BeatmapInfo>().Count());
-                        Assert.AreEqual(1, changesTriggered);
+                        ClassicAssert.AreEqual(2, outerRealm.All<BeatmapInfo>().Count());
+                        ClassicAssert.AreEqual(1, changesTriggered);
 
                         // can access properties without a crash.
-                        Assert.IsFalse(resolved.Hidden);
+                        ClassicAssert.False(resolved.Hidden);
 
                         outerRealm.Write(r =>
                         {

--- a/osu.Game.Tests/Database/RulesetStoreTests.cs
+++ b/osu.Game.Tests/Database/RulesetStoreTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
@@ -27,8 +28,8 @@ namespace osu.Game.Tests.Database
             {
                 using var rulesets = new RealmRulesetStore(realm, storage);
 
-                Assert.AreEqual(4, rulesets.AvailableRulesets.Count());
-                Assert.AreEqual(4, realm.Realm.All<RulesetInfo>().Count());
+                ClassicAssert.AreEqual(4, rulesets.AvailableRulesets.Count());
+                ClassicAssert.AreEqual(4, realm.Realm.All<RulesetInfo>().Count());
             });
         }
 
@@ -40,11 +41,11 @@ namespace osu.Game.Tests.Database
                 using var rulesets = new RealmRulesetStore(realm, storage);
                 using var rulesets2 = new RealmRulesetStore(realm, storage);
 
-                Assert.AreEqual(4, rulesets.AvailableRulesets.Count());
-                Assert.AreEqual(4, rulesets2.AvailableRulesets.Count());
+                ClassicAssert.AreEqual(4, rulesets.AvailableRulesets.Count());
+                ClassicAssert.AreEqual(4, rulesets2.AvailableRulesets.Count());
 
-                Assert.AreEqual(rulesets.AvailableRulesets.First(), rulesets2.AvailableRulesets.First());
-                Assert.AreEqual(4, realm.Realm.All<RulesetInfo>().Count());
+                ClassicAssert.AreEqual(rulesets.AvailableRulesets.First(), rulesets2.AvailableRulesets.First());
+                ClassicAssert.AreEqual(4, realm.Realm.All<RulesetInfo>().Count());
             });
         }
 
@@ -55,9 +56,9 @@ namespace osu.Game.Tests.Database
             {
                 using var rulesets = new RealmRulesetStore(realm, storage);
 
-                Assert.IsFalse(rulesets.AvailableRulesets.First().IsManaged);
-                Assert.IsFalse(rulesets.GetRuleset(0)?.IsManaged);
-                Assert.IsFalse(rulesets.GetRuleset("mania")?.IsManaged);
+                ClassicAssert.False(rulesets.AvailableRulesets.First().IsManaged);
+                ClassicAssert.False(rulesets.GetRuleset(0)?.IsManaged);
+                ClassicAssert.False(rulesets.GetRuleset("mania")?.IsManaged);
             });
         }
 

--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -3,14 +3,11 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
@@ -20,63 +17,87 @@ using Realms;
 namespace osu.Game.Tests.Database
 {
     [TestFixture]
-    public partial class TestRealmKeyBindingStore
+    public partial class TestRealmKeyBindingStore : RealmTest
     {
-        private NativeStorage storage;
-
-        private RealmKeyBindingStore keyBindingStore;
-
-        private RealmAccess realm;
-
-        [SetUp]
-        public void SetUp()
-        {
-            var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
-
-            storage = new NativeStorage(directory.FullName);
-
-            realm = new RealmAccess(storage, "test");
-            keyBindingStore = new RealmKeyBindingStore(realm, new ReadableKeyCombinationProvider());
-        }
-
         [Test]
         public void TestDefaultsPopulationAndQuery()
         {
-            Assert.That(queryCount(), Is.EqualTo(0));
+            RunTestWithRealm((realm, _) =>
+            {
+                Assert.That(queryCount(realm), Is.EqualTo(0));
 
-            KeyBindingContainer testContainer = new TestKeyBindingContainer();
+                KeyBindingContainer testContainer = new TestKeyBindingContainer();
 
-            keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
+                var keyBindingStore = new RealmKeyBindingStore(realm, new ReadableKeyCombinationProvider());
+                keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
 
-            Assert.That(queryCount(), Is.EqualTo(3));
+                Assert.That(queryCount(realm), Is.EqualTo(3));
 
-            Assert.That(queryCount(GlobalAction.Back), Is.EqualTo(1));
-            Assert.That(queryCount(GlobalAction.Select), Is.EqualTo(2));
+                Assert.That(queryCount(realm, GlobalAction.Back), Is.EqualTo(1));
+                Assert.That(queryCount(realm, GlobalAction.Select), Is.EqualTo(2));
+            });
         }
 
         [Test]
         public void TestDefaultsPopulationRemovesExcess()
         {
-            Assert.That(queryCount(), Is.EqualTo(0));
-
-            KeyBindingContainer testContainer = new TestKeyBindingContainer();
-
-            // Add some excess bindings for an action which only supports 1.
-            realm.Write(r =>
+            RunTestWithRealm((realm, _) =>
             {
-                r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.A)));
-                r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.S)));
-                r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.D)));
+                Assert.That(queryCount(realm), Is.EqualTo(0));
+
+                KeyBindingContainer testContainer = new TestKeyBindingContainer();
+
+                // Add some excess bindings for an action which only supports 1.
+                realm.Write(r =>
+                {
+                    r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.A)));
+                    r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.S)));
+                    r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.D)));
+                });
+
+                Assert.That(queryCount(realm, GlobalAction.Back), Is.EqualTo(3));
+
+                var keyBindingStore = new RealmKeyBindingStore(realm, new ReadableKeyCombinationProvider());
+                keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
+
+                Assert.That(queryCount(realm, GlobalAction.Back), Is.EqualTo(1));
             });
-
-            Assert.That(queryCount(GlobalAction.Back), Is.EqualTo(3));
-
-            keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
-
-            Assert.That(queryCount(GlobalAction.Back), Is.EqualTo(1));
         }
 
-        private int queryCount(GlobalAction? match = null)
+        [Test]
+        public void TestUpdateViaQueriedReference()
+        {
+            RunTestWithRealm((realm, _) =>
+            {
+                KeyBindingContainer testContainer = new TestKeyBindingContainer();
+
+                var keyBindingStore = new RealmKeyBindingStore(realm, new ReadableKeyCombinationProvider());
+                keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
+
+                realm.Run(outerRealm =>
+                {
+                    var backBinding = outerRealm.All<RealmKeyBinding>().Single(k => k.ActionInt == (int)GlobalAction.Back);
+
+                    Assert.That(backBinding.KeyCombination.Keys, Is.EquivalentTo(new[] { InputKey.Escape }));
+
+                    var tsr = ThreadSafeReference.Create(backBinding);
+
+                    realm.Run(innerRealm =>
+                    {
+                        var binding = innerRealm.ResolveReference(tsr)!;
+                        innerRealm.Write(() => binding.KeyCombination = new KeyCombination(InputKey.BackSpace));
+                    });
+
+                    Assert.That(backBinding.KeyCombination.Keys, Is.EquivalentTo(new[] { InputKey.BackSpace }));
+
+                    // check still correct after re-query.
+                    backBinding = outerRealm.All<RealmKeyBinding>().Single(k => k.ActionInt == (int)GlobalAction.Back);
+                    Assert.That(backBinding.KeyCombination.Keys, Is.EquivalentTo(new[] { InputKey.BackSpace }));
+                });
+            });
+        }
+
+        private static int queryCount(RealmAccess realm, GlobalAction? match = null)
         {
             return realm.Run(r =>
             {
@@ -85,42 +106,6 @@ namespace osu.Game.Tests.Database
                     results = results.Where(k => k.ActionInt == (int)match.Value);
                 return results.Count();
             });
-        }
-
-        [Test]
-        public void TestUpdateViaQueriedReference()
-        {
-            KeyBindingContainer testContainer = new TestKeyBindingContainer();
-
-            keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
-
-            realm.Run(outerRealm =>
-            {
-                var backBinding = outerRealm.All<RealmKeyBinding>().Single(k => k.ActionInt == (int)GlobalAction.Back);
-
-                Assert.That(backBinding.KeyCombination.Keys, Is.EquivalentTo(new[] { InputKey.Escape }));
-
-                var tsr = ThreadSafeReference.Create(backBinding);
-
-                realm.Run(innerRealm =>
-                {
-                    var binding = innerRealm.ResolveReference(tsr)!;
-                    innerRealm.Write(() => binding.KeyCombination = new KeyCombination(InputKey.BackSpace));
-                });
-
-                Assert.That(backBinding.KeyCombination.Keys, Is.EquivalentTo(new[] { InputKey.BackSpace }));
-
-                // check still correct after re-query.
-                backBinding = outerRealm.All<RealmKeyBinding>().Single(k => k.ActionInt == (int)GlobalAction.Back);
-                Assert.That(backBinding.KeyCombination.Keys, Is.EquivalentTo(new[] { InputKey.BackSpace }));
-            });
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            realm.Dispose();
-            storage.DeleteDirectory(string.Empty);
         }
 
         public partial class TestKeyBindingContainer : KeyBindingContainer

--- a/osu.Game.Tests/Editing/Checks/CheckAudioInVideoTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioInVideoTest.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
@@ -44,7 +45,7 @@ namespace osu.Game.Tests.Editing.Checks
         public void TestRegularVideoFile()
         {
             using (var resourceStream = TestResources.OpenResource("Videos/test-video.mp4"))
-                Assert.IsEmpty(check.Run(getContext(resourceStream)));
+                ClassicAssert.IsEmpty(check.Run(getContext(resourceStream)));
         }
 
         [Test]

--- a/osu.Game.Tests/Editing/Checks/CheckAudioInVideoTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioInVideoTest.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Editing.Checks
             var layer = storyboard.GetLayer("Video");
             layer.Add(new StoryboardVideo("abc123.mp4", 0));
 
-            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null, null);
+            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
             mockWorkingBeatmap.As<IWorkingBeatmap>().SetupGet(w => w.Storyboard).Returns(storyboard);
 

--- a/osu.Game.Tests/Editing/Checks/CheckDelayedHitsoundsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckDelayedHitsoundsTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using ManagedBass;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Models;
 using osu.Game.Rulesets.Edit;
@@ -49,7 +50,7 @@ namespace osu.Game.Tests.Editing.Checks
         public void TestNoDelayedHitsounds()
         {
             using var resourceStream = TestResources.OpenResource("Samples/hitsound-no-delay.wav");
-            Assert.IsEmpty(check.Run(getContext(resourceStream)));
+            ClassicAssert.IsEmpty(check.Run(getContext(resourceStream)));
         }
 
         [Test]

--- a/osu.Game.Tests/Editing/Checks/CheckDelayedHitsoundsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckDelayedHitsoundsTest.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(Stream? resourceStream)
         {
-            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null, null);
+            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
 
             return new BeatmapVerifierContext(beatmap, mockWorkingBeatmap.Object);

--- a/osu.Game.Tests/Editing/Checks/CheckHitsoundsFormatTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckHitsoundsFormatTest.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Tests.Editing.Checks
                         Metadata = new BeatmapMetadata { AudioFile = beatmapSet.Files[0].Filename }
                     }
                 };
-                var firstWorking = new Mock<TestWorkingBeatmap>(firstPlayable, null, null);
+                var firstWorking = new Mock<TestWorkingBeatmap>(firstPlayable, null!, null!);
                 firstWorking.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
 
                 var secondPlayable = new Beatmap<HitObject>
@@ -150,7 +150,7 @@ namespace osu.Game.Tests.Editing.Checks
                         Metadata = new BeatmapMetadata { AudioFile = beatmapSet.Files[1].Filename }
                     }
                 };
-                var secondWorking = new Mock<TestWorkingBeatmap>(secondPlayable, null, null);
+                var secondWorking = new Mock<TestWorkingBeatmap>(secondPlayable, null!, null!);
                 secondWorking.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
 
                 var context = new BeatmapVerifierContext(
@@ -165,7 +165,7 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(Stream? resourceStream)
         {
-            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null, null);
+            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
 
             return new BeatmapVerifierContext(beatmap, mockWorkingBeatmap.Object);

--- a/osu.Game.Tests/Editing/Checks/CheckSongFormatTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckSongFormatTest.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(Stream? resourceStream)
         {
-            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null, null);
+            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
 
             return new BeatmapVerifierContext(beatmap, mockWorkingBeatmap.Object);

--- a/osu.Game.Tests/Editing/Checks/CheckTooShortAudioFilesTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckTooShortAudioFilesTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using ManagedBass;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
@@ -52,7 +53,7 @@ namespace osu.Game.Tests.Editing.Checks
             beatmap.BeatmapInfo.BeatmapSet.Files.Add(CheckTestHelpers.CreateMockFile("jpg"));
 
             // Should fail to load, but not produce an error due to the extension not being expected to load.
-            Assert.IsEmpty(check.Run(getContext(null)));
+            ClassicAssert.IsEmpty(check.Run(getContext(null)));
         }
 
         [Test]
@@ -60,7 +61,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             using (var resourceStream = TestResources.OpenResource("Samples/test-sample.mp3"))
             {
-                Assert.IsEmpty(check.Run(getContext(resourceStream)));
+                ClassicAssert.IsEmpty(check.Run(getContext(resourceStream)));
             }
         }
 
@@ -70,7 +71,7 @@ namespace osu.Game.Tests.Editing.Checks
             using (var resourceStream = TestResources.OpenResource("Samples/blank.wav"))
             {
                 // This is a 0 ms duration audio file, commonly used to silence sliderslides/ticks, and so should be fine.
-                Assert.IsEmpty(check.Run(getContext(resourceStream)));
+                ClassicAssert.IsEmpty(check.Run(getContext(resourceStream)));
             }
         }
 
@@ -91,7 +92,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             using (var resourceStream = TestResources.OpenResource("Samples/missing.mp3"))
             {
-                Assert.IsEmpty(check.Run(getContext(resourceStream)));
+                ClassicAssert.IsEmpty(check.Run(getContext(resourceStream)));
             }
         }
 

--- a/osu.Game.Tests/Editing/Checks/CheckTooShortAudioFilesTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckTooShortAudioFilesTest.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(Stream? resourceStream)
         {
-            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null, null);
+            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
 
             return new BeatmapVerifierContext(beatmap, mockWorkingBeatmap.Object);

--- a/osu.Game.Tests/Editing/Checks/CheckVideoResolutionTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckVideoResolutionTest.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Editing.Checks
             var layer = storyboard.GetLayer("Video");
             layer.Add(new StoryboardVideo("abc123.mp4", 0));
 
-            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null, null);
+            var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);
             mockWorkingBeatmap.As<IWorkingBeatmap>().SetupGet(w => w.Storyboard).Returns(storyboard);
 

--- a/osu.Game.Tests/Editing/Checks/CheckZeroByteFilesTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckZeroByteFilesTest.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
@@ -40,7 +41,7 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestNonZeroBytes()
         {
-            Assert.IsEmpty(check.Run(getContext(byteLength: 44)));
+            ClassicAssert.IsEmpty(check.Run(getContext(byteLength: 44)));
         }
 
         [Test]
@@ -55,7 +56,7 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestMissing()
         {
-            Assert.IsEmpty(check.Run(getContextMissing()));
+            ClassicAssert.IsEmpty(check.Run(getContextMissing()));
         }
 
         private BeatmapVerifierContext getContext(long byteLength)

--- a/osu.Game.Tests/ImportTest.cs
+++ b/osu.Game.Tests/ImportTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Platform;
@@ -42,7 +43,7 @@ namespace osu.Game.Tests
                 while (!result()) Thread.Sleep(200);
             });
 
-            Assert.IsTrue(task.Wait(timeout), failureMessage);
+            ClassicAssert.True(task.Wait(timeout), failureMessage);
         }
 
         public partial class TestOsuGameBase : OsuGameBase

--- a/osu.Game.Tests/Localisation/BeatmapMetadataRomanisationTest.cs
+++ b/osu.Game.Tests/Localisation/BeatmapMetadataRomanisationTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 
 namespace osu.Game.Tests.Localisation
@@ -21,8 +22,8 @@ namespace osu.Game.Tests.Localisation
             };
             var romanisableString = metadata.GetDisplayTitleRomanisable();
 
-            Assert.AreEqual(metadata.ToString(), romanisableString.Romanised);
-            Assert.AreEqual($"{metadata.ArtistUnicode} - {metadata.TitleUnicode}", romanisableString.Original);
+            ClassicAssert.AreEqual(metadata.ToString(), romanisableString.Romanised);
+            ClassicAssert.AreEqual($"{metadata.ArtistUnicode} - {metadata.TitleUnicode}", romanisableString.Original);
         }
 
         [Test]
@@ -35,7 +36,7 @@ namespace osu.Game.Tests.Localisation
             };
             var romanisableString = metadata.GetDisplayTitleRomanisable();
 
-            Assert.AreEqual(romanisableString.Romanised, romanisableString.Original);
+            ClassicAssert.AreEqual(romanisableString.Romanised, romanisableString.Original);
         }
     }
 }

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Online.Rooms;
@@ -196,7 +197,7 @@ namespace osu.Game.Tests.Mods
             Assert.That(isValid, Is.EqualTo(expectedInvalid.Length == 0));
 
             if (isValid)
-                Assert.IsNull(invalid);
+                ClassicAssert.Null(invalid);
             else
                 Assert.That(invalid?.Select(t => t.GetType()), Is.EquivalentTo(expectedInvalid));
         }
@@ -214,21 +215,21 @@ namespace osu.Game.Tests.Mods
         [Test]
         public void TestFormatScoreMultiplier()
         {
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.9999).ToString(), "0.99x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.0).ToString(), "1.00x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.0001).ToString(), "1.01x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(0.9999).ToString(), "0.99x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.0).ToString(), "1.00x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.0001).ToString(), "1.01x");
 
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.899999999999999).ToString(), "0.90x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.9).ToString(), "0.90x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.900000000000001).ToString(), "0.90x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(0.899999999999999).ToString(), "0.90x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(0.9).ToString(), "0.90x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(0.900000000000001).ToString(), "0.90x");
 
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.099999999999999).ToString(), "1.10x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.1).ToString(), "1.10x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.100000000000001).ToString(), "1.10x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.099999999999999).ToString(), "1.10x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.1).ToString(), "1.10x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.100000000000001).ToString(), "1.10x");
 
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.045).ToString(), "1.05x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.05).ToString(), "1.05x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.055).ToString(), "1.06x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.045).ToString(), "1.05x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.05).ToString(), "1.05x");
+            ClassicAssert.AreEqual(ModUtils.FormatScoreMultiplier(1.055).ToString(), "1.06x");
         }
 
         private static readonly object[] multiplayer_mod_test_scenarios =
@@ -309,7 +310,7 @@ namespace osu.Game.Tests.Mods
             Assert.That(isValid, Is.EqualTo(scenario.InvalidTypes.Length == 0));
 
             if (isValid)
-                Assert.IsNull(invalidMods);
+                ClassicAssert.Null(invalidMods);
             else
                 Assert.That(invalidMods?.Select(t => t.GetType()), Is.EquivalentTo(scenario.InvalidTypes));
         }
@@ -318,12 +319,12 @@ namespace osu.Game.Tests.Mods
         public void TestPlaylistsModScenarios()
         {
             // The rest are tested by TestMultiplayerModScenarios.
-            Assert.IsTrue(ModUtils.IsValidModForMatch(new OsuModHardRock(), false, MatchType.Playlists, false));
-            Assert.IsTrue(ModUtils.IsValidModForMatch(new OsuModHardRock(), true, MatchType.Playlists, false));
-            Assert.IsTrue(ModUtils.IsValidModForMatch(new OsuModDoubleTime(), false, MatchType.Playlists, false));
-            Assert.IsTrue(ModUtils.IsValidModForMatch(new OsuModDoubleTime(), true, MatchType.Playlists, false));
-            Assert.IsTrue(ModUtils.IsValidModForMatch(new ModAdaptiveSpeed(), false, MatchType.Playlists, false));
-            Assert.IsTrue(ModUtils.IsValidModForMatch(new ModAdaptiveSpeed(), true, MatchType.Playlists, false));
+            ClassicAssert.True(ModUtils.IsValidModForMatch(new OsuModHardRock(), false, MatchType.Playlists, false));
+            ClassicAssert.True(ModUtils.IsValidModForMatch(new OsuModHardRock(), true, MatchType.Playlists, false));
+            ClassicAssert.True(ModUtils.IsValidModForMatch(new OsuModDoubleTime(), false, MatchType.Playlists, false));
+            ClassicAssert.True(ModUtils.IsValidModForMatch(new OsuModDoubleTime(), true, MatchType.Playlists, false));
+            ClassicAssert.True(ModUtils.IsValidModForMatch(new ModAdaptiveSpeed(), false, MatchType.Playlists, false));
+            ClassicAssert.True(ModUtils.IsValidModForMatch(new ModAdaptiveSpeed(), true, MatchType.Playlists, false));
         }
 
         [Test]

--- a/osu.Game.Tests/NonVisual/BarLineGeneratorTest.cs
+++ b/osu.Game.Tests/NonVisual/BarLineGeneratorTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -54,13 +55,13 @@ namespace osu.Game.Tests.NonVisual
                 // every seventh bar's start time should be at least greater than the whole number we expect.
                 // It cannot be less, as that can affect overlapping scroll algorithms
                 // (the previous timing point might be chosen incorrectly if this is not the case)
-                Assert.GreaterOrEqual(barLine.StartTime, expectedTime);
+                ClassicAssert.GreaterOrEqual(barLine.StartTime, expectedTime);
 
                 // on the other side, make sure we don't stray too far from the expected time either.
-                Assert.IsTrue(Precision.AlmostEquals(barLine.StartTime, expectedTime));
+                ClassicAssert.True(Precision.AlmostEquals(barLine.StartTime, expectedTime));
 
                 // check major/minor lines for good measure too
-                Assert.AreEqual(i % signature.Numerator == 0, barLine.Major);
+                ClassicAssert.AreEqual(i % signature.Numerator == 0, barLine.Major);
             }
         }
 

--- a/osu.Game.Tests/NonVisual/BeatmapSetInfoEqualityTest.cs
+++ b/osu.Game.Tests/NonVisual/BeatmapSetInfoEqualityTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
 using osu.Game.Models;
@@ -22,8 +23,8 @@ namespace osu.Game.Tests.NonVisual
             var ourInfo = new BeatmapSetInfo { OnlineID = 123 };
             var otherInfo = new BeatmapSetInfo { OnlineID = 123 };
 
-            Assert.AreNotEqual(ourInfo, otherInfo);
-            Assert.IsTrue(ourInfo.MatchesOnlineID(otherInfo));
+            ClassicAssert.AreNotEqual(ourInfo, otherInfo);
+            ClassicAssert.True(ourInfo.MatchesOnlineID(otherInfo));
         }
 
         [Test]
@@ -32,8 +33,8 @@ namespace osu.Game.Tests.NonVisual
             var beatmapSetA = TestResources.CreateTestBeatmapSetInfo(1);
             var beatmapSetB = TestResources.CreateTestBeatmapSetInfo(1);
 
-            Assert.AreNotEqual(beatmapSetA, beatmapSetB);
-            Assert.IsTrue(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
+            ClassicAssert.AreNotEqual(beatmapSetA, beatmapSetB);
+            ClassicAssert.True(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
         }
 
         [Test]
@@ -49,8 +50,8 @@ namespace osu.Game.Tests.NonVisual
             addAudioFile(beatmapSetA, "abc", "AuDiO.mP3");
             addAudioFile(beatmapSetB, "abc", "audio.mp3");
 
-            Assert.AreNotEqual(beatmapSetA, beatmapSetB);
-            Assert.IsTrue(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
+            ClassicAssert.AreNotEqual(beatmapSetA, beatmapSetB);
+            ClassicAssert.True(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
         }
 
         [Test]
@@ -62,8 +63,8 @@ namespace osu.Game.Tests.NonVisual
             addAudioFile(beatmapSetA, "abc");
             addAudioFile(beatmapSetB, "abc");
 
-            Assert.AreNotEqual(beatmapSetA, beatmapSetB);
-            Assert.IsTrue(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
+            ClassicAssert.AreNotEqual(beatmapSetA, beatmapSetB);
+            ClassicAssert.True(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
         }
 
         [Test]
@@ -75,8 +76,8 @@ namespace osu.Game.Tests.NonVisual
             addAudioFile(beatmapSetA);
             addAudioFile(beatmapSetB);
 
-            Assert.AreNotEqual(beatmapSetA, beatmapSetB);
-            Assert.IsTrue(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
+            ClassicAssert.AreNotEqual(beatmapSetA, beatmapSetB);
+            ClassicAssert.True(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
         }
 
         [Test]
@@ -89,8 +90,8 @@ namespace osu.Game.Tests.NonVisual
             var beatmap1 = beatmapSet.Beatmaps.First();
             var beatmap2 = beatmapSet.Beatmaps.Last();
 
-            Assert.AreNotEqual(beatmap1, beatmap2);
-            Assert.IsTrue(beatmap1.AudioEquals(beatmap2));
+            ClassicAssert.AreNotEqual(beatmap1, beatmap2);
+            ClassicAssert.True(beatmap1.AudioEquals(beatmap2));
         }
 
         [Test]
@@ -107,12 +108,12 @@ namespace osu.Game.Tests.NonVisual
             var beatmap1 = beatmapSet.Beatmaps.First();
             var beatmap2 = beatmapSet.Beatmaps.Last();
 
-            Assert.AreNotEqual(beatmap1, beatmap2);
+            ClassicAssert.AreNotEqual(beatmap1, beatmap2);
 
             beatmap1.Metadata.AudioFile = filename1;
             beatmap2.Metadata.AudioFile = filename2;
 
-            Assert.IsFalse(beatmap1.AudioEquals(beatmap2));
+            ClassicAssert.False(beatmap1.AudioEquals(beatmap2));
         }
 
         private static void addAudioFile(BeatmapSetInfo beatmapSetInfo, string hash = null, string filename = null)
@@ -128,7 +129,7 @@ namespace osu.Game.Tests.NonVisual
             var ourInfo = new BeatmapSetInfo { ID = guid };
             var otherInfo = new BeatmapSetInfo { ID = guid };
 
-            Assert.AreEqual(ourInfo, otherInfo);
+            ClassicAssert.AreEqual(ourInfo, otherInfo);
         }
 
         [Test]
@@ -137,8 +138,8 @@ namespace osu.Game.Tests.NonVisual
             var ourInfo = new BeatmapSetInfo { ID = Guid.NewGuid(), OnlineID = 12 };
             var otherInfo = new BeatmapSetInfo { OnlineID = 12 };
 
-            Assert.AreNotEqual(ourInfo, otherInfo);
-            Assert.IsTrue(ourInfo.MatchesOnlineID(otherInfo));
+            ClassicAssert.AreNotEqual(ourInfo, otherInfo);
+            ClassicAssert.True(ourInfo.MatchesOnlineID(otherInfo));
         }
 
         [Test]
@@ -147,7 +148,7 @@ namespace osu.Game.Tests.NonVisual
             var ourInfo = new BeatmapSetInfo { Hash = "1" };
             var otherInfo = new BeatmapSetInfo { Hash = "2" };
 
-            Assert.AreNotEqual(ourInfo, otherInfo);
+            ClassicAssert.AreNotEqual(ourInfo, otherInfo);
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/ClosestBeatDivisorTest.cs
+++ b/osu.Game.Tests/NonVisual/ClosestBeatDivisorTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
@@ -97,7 +98,7 @@ namespace osu.Game.Tests.NonVisual
             };
 
             for (int i = 0; i < divisors.Count; ++i)
-                Assert.AreEqual(closestDivisors[i], beatmap.ControlPointInfo.GetClosestBeatDivisor(beatmap.HitObjects[i].StartTime), $"at index {i}");
+                ClassicAssert.AreEqual(closestDivisors[i], beatmap.ControlPointInfo.GetClosestBeatDivisor(beatmap.HitObjects[i].StartTime), $"at index {i}");
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
@@ -141,7 +142,7 @@ namespace osu.Game.Tests.NonVisual
 
         private void assertCombinations(Type[][] expectedCombinations, Mod[] actualCombinations)
         {
-            Assert.AreEqual(expectedCombinations.Length, actualCombinations.Length);
+            ClassicAssert.AreEqual(expectedCombinations.Length, actualCombinations.Length);
 
             Assert.Multiple(() =>
             {

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
@@ -61,7 +62,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var criteria = new FilterCriteria();
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.IsFalse(carouselItem.Filtered.Value);
+            ClassicAssert.False(carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -74,7 +75,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.IsTrue(carouselItem.Filtered.Value);
+            ClassicAssert.True(carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -88,7 +89,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.IsFalse(carouselItem.Filtered.Value);
+            ClassicAssert.False(carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -102,7 +103,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.IsFalse(carouselItem.Filtered.Value);
+            ClassicAssert.False(carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -123,7 +124,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(!inclusive, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(!inclusive, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -144,7 +145,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(!inclusive, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(!inclusive, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -166,7 +167,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -195,7 +196,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -215,7 +216,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -236,7 +237,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -260,7 +261,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -278,7 +279,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [TestCase("202010", true)]
@@ -295,7 +296,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -312,7 +313,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.True(carouselItem.Filtered.Value);
+            ClassicAssert.True(carouselItem.Filtered.Value);
         }
 
         [TestCase("simple", false)]
@@ -327,7 +328,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -345,7 +346,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.AreEqual(false, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(false, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -363,7 +364,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.AreEqual(true, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(true, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -380,7 +381,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.AreEqual(true, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(true, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -398,7 +399,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.AreEqual(true, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(true, carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -410,7 +411,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             carouselItem.BeatmapInfo.Metadata.UserTags.Clear();
             carouselItem.Filter(criteria);
 
-            Assert.True(carouselItem.Filtered.Value);
+            ClassicAssert.True(carouselItem.Filtered.Value);
         }
 
         [Test]
@@ -423,7 +424,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var carouselItem = new CarouselBeatmap(beatmap);
             carouselItem.Filter(criteria);
 
-            Assert.AreEqual(matchCustomCriteria == false, carouselItem.Filtered.Value);
+            ClassicAssert.AreEqual(matchCustomCriteria == false, carouselItem.Filtered.Value);
         }
 
         [TestCase("title!=Title", new[] { 2, 4, 6 })]

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
@@ -23,8 +24,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "looking for a beatmap";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("looking for a beatmap", filterCriteria.SearchText);
-            Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("looking for a beatmap", filterCriteria.SearchText);
+            ClassicAssert.AreEqual(4, filterCriteria.SearchTerms.Length);
         }
 
         [Test]
@@ -33,8 +34,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "looking for \"a beatmap\"! like \"this\"";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("looking for \"a beatmap\"! like \"this\"", filterCriteria.SearchText);
-            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("looking for \"a beatmap\"! like \"this\"", filterCriteria.SearchText);
+            ClassicAssert.AreEqual(5, filterCriteria.SearchTerms.Length);
 
             Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("a beatmap"));
             Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
@@ -58,8 +59,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "looking for \"circles!\"!";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("looking for \"circles!\"!", filterCriteria.SearchText);
-            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("looking for \"circles!\"!", filterCriteria.SearchText);
+            ClassicAssert.AreEqual(3, filterCriteria.SearchTerms.Length);
 
             Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("circles!"));
             Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
@@ -77,8 +78,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "\"!";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("\"!", filterCriteria.SearchText);
-            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("\"!", filterCriteria.SearchText);
+            ClassicAssert.AreEqual(1, filterCriteria.SearchTerms.Length);
 
             Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("!"));
             Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
@@ -91,11 +92,11 @@ namespace osu.Game.Tests.NonVisual.Filtering
             string query = $"{variant}<4 easy";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("easy", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
-            Assert.IsNotNull(filterCriteria.StarDifficulty.Max);
-            Assert.AreEqual(filterCriteria.StarDifficulty.Max, 4.00d);
-            Assert.IsNull(filterCriteria.StarDifficulty.Min);
+            ClassicAssert.AreEqual("easy", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            ClassicAssert.NotNull(filterCriteria.StarDifficulty.Max);
+            ClassicAssert.AreEqual(filterCriteria.StarDifficulty.Max!, 4.00d);
+            ClassicAssert.Null(filterCriteria.StarDifficulty.Min);
         }
 
         [Test]
@@ -104,9 +105,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "stars>=6";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(filterCriteria.StarDifficulty.Min, 6.00d);
-            Assert.True(filterCriteria.StarDifficulty.IsLowerInclusive);
-            Assert.IsNull(filterCriteria.StarDifficulty.Max);
+            ClassicAssert.AreEqual(filterCriteria.StarDifficulty.Min!, 6.00d);
+            ClassicAssert.True(filterCriteria.StarDifficulty.IsLowerInclusive);
+            ClassicAssert.Null(filterCriteria.StarDifficulty.Max);
         }
 
         /*
@@ -125,12 +126,12 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "ar>=9 difficult";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("difficult", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
-            Assert.IsNotNull(filterCriteria.ApproachRate.Min);
-            Assert.Greater(filterCriteria.ApproachRate.Min, 8.9f);
-            Assert.Less(filterCriteria.ApproachRate.Min, 9.0f);
-            Assert.IsNull(filterCriteria.ApproachRate.Max);
+            ClassicAssert.AreEqual("difficult", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            ClassicAssert.NotNull(filterCriteria.ApproachRate.Min);
+            ClassicAssert.Greater(filterCriteria.ApproachRate.Min!, 8.9f);
+            ClassicAssert.Less(filterCriteria.ApproachRate.Min!, 9.0f);
+            ClassicAssert.Null(filterCriteria.ApproachRate.Max);
         }
 
         [Test]
@@ -139,12 +140,12 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "dr>2 quite specific dr<:6";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(2, filterCriteria.SearchTerms.Length);
-            Assert.Greater(filterCriteria.DrainRate.Min, 2.0f);
-            Assert.Less(filterCriteria.DrainRate.Min, 2.1f);
-            Assert.Greater(filterCriteria.DrainRate.Max, 6.0f);
-            Assert.Less(filterCriteria.DrainRate.Min, 6.1f);
+            ClassicAssert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(2, filterCriteria.SearchTerms.Length);
+            ClassicAssert.Greater(filterCriteria.DrainRate.Min!, 2.0f);
+            ClassicAssert.Less(filterCriteria.DrainRate.Min!, 2.1f);
+            ClassicAssert.Greater(filterCriteria.DrainRate.Max!, 6.0f);
+            ClassicAssert.Less(filterCriteria.DrainRate.Min!, 6.1f);
         }
 
         [Test]
@@ -153,12 +154,12 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "hp>2 quite specific hp<=6";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(2, filterCriteria.SearchTerms.Length);
-            Assert.Greater(filterCriteria.DrainRate.Min, 2.0f);
-            Assert.Less(filterCriteria.DrainRate.Min, 2.1f);
-            Assert.Greater(filterCriteria.DrainRate.Max, 6.0f);
-            Assert.Less(filterCriteria.DrainRate.Min, 6.1f);
+            ClassicAssert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(2, filterCriteria.SearchTerms.Length);
+            ClassicAssert.Greater(filterCriteria.DrainRate.Min!, 2.0f);
+            ClassicAssert.Less(filterCriteria.DrainRate.Min!, 2.1f);
+            ClassicAssert.Greater(filterCriteria.DrainRate.Max!, 6.0f);
+            ClassicAssert.Less(filterCriteria.DrainRate.Min!, 6.1f);
         }
 
         [Test]
@@ -167,12 +168,12 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "od>4 easy od<8";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("easy", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
-            Assert.Greater(filterCriteria.OverallDifficulty.Min, 4.0);
-            Assert.Less(filterCriteria.OverallDifficulty.Min, 4.1);
-            Assert.Greater(filterCriteria.OverallDifficulty.Max, 7.9);
-            Assert.Less(filterCriteria.OverallDifficulty.Max, 8.0);
+            ClassicAssert.AreEqual("easy", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            ClassicAssert.Greater(filterCriteria.OverallDifficulty.Min!, 4.0);
+            ClassicAssert.Less(filterCriteria.OverallDifficulty.Min!, 4.1);
+            ClassicAssert.Greater(filterCriteria.OverallDifficulty.Max!, 7.9);
+            ClassicAssert.Less(filterCriteria.OverallDifficulty.Max!, 8.0);
         }
 
         [Test]
@@ -181,8 +182,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "bpm=200";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(filterCriteria.BPM.Min, 199.5d);
-            Assert.AreEqual(filterCriteria.BPM.Max, 200.5d);
+            ClassicAssert.AreEqual(filterCriteria.BPM.Min!, 199.5d);
+            ClassicAssert.AreEqual(filterCriteria.BPM.Max!, 200.5d);
         }
 
         [Test]
@@ -191,11 +192,11 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "bpm>:200 gotta go fast";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("gotta go fast", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
-            Assert.IsNotNull(filterCriteria.BPM.Min);
-            Assert.AreEqual(filterCriteria.BPM.Min, 199.5d);
-            Assert.IsNull(filterCriteria.BPM.Max);
+            ClassicAssert.AreEqual("gotta go fast", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(3, filterCriteria.SearchTerms.Length);
+            ClassicAssert.NotNull(filterCriteria.BPM.Min);
+            ClassicAssert.AreEqual(filterCriteria.BPM.Min!, 199.5d);
+            ClassicAssert.Null(filterCriteria.BPM.Max);
         }
 
         private static readonly object[] correct_length_query_examples =
@@ -228,10 +229,10 @@ namespace osu.Game.Tests.NonVisual.Filtering
             string query = $"length={lengthQuery} time";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("time", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual(expectedLength.TotalMilliseconds - scale.TotalMilliseconds / 2.0, filterCriteria.Length.Min);
-            Assert.AreEqual(expectedLength.TotalMilliseconds + scale.TotalMilliseconds / 2.0, filterCriteria.Length.Max);
+            ClassicAssert.AreEqual("time", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual(expectedLength.TotalMilliseconds - scale.TotalMilliseconds / 2.0, filterCriteria.Length.Min);
+            ClassicAssert.AreEqual(expectedLength.TotalMilliseconds + scale.TotalMilliseconds / 2.0, filterCriteria.Length.Max);
         }
 
         private static readonly object[] incorrect_length_query_examples =
@@ -254,7 +255,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             string query = $"length={lengthQuery} time";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(false, filterCriteria.Length.HasFilter);
+            ClassicAssert.AreEqual(false, filterCriteria.Length.HasFilter);
         }
 
         [Test]
@@ -263,12 +264,12 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "that's a time signature alright! divisor:12";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("that's a time signature alright!", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual(12, filterCriteria.BeatDivisor.Min);
-            Assert.IsTrue(filterCriteria.BeatDivisor.IsLowerInclusive);
-            Assert.AreEqual(12, filterCriteria.BeatDivisor.Max);
-            Assert.IsTrue(filterCriteria.BeatDivisor.IsUpperInclusive);
+            ClassicAssert.AreEqual("that's a time signature alright!", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(5, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual(12, filterCriteria.BeatDivisor.Min);
+            ClassicAssert.True(filterCriteria.BeatDivisor.IsLowerInclusive);
+            ClassicAssert.AreEqual(12, filterCriteria.BeatDivisor.Max);
+            ClassicAssert.True(filterCriteria.BeatDivisor.IsUpperInclusive);
         }
 
         [Test]
@@ -277,7 +278,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "status=r";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.IsNotEmpty(filterCriteria.OnlineStatus.Values);
+            ClassicAssert.IsNotEmpty(filterCriteria.OnlineStatus.Values);
             Assert.That(filterCriteria.OnlineStatus.Values, Contains.Item(BeatmapOnlineStatus.Ranked));
         }
 
@@ -287,9 +288,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "I want the pp status=ranked";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("I want the pp", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
-            Assert.IsNotEmpty(filterCriteria.OnlineStatus.Values);
+            ClassicAssert.AreEqual("I want the pp", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(4, filterCriteria.SearchTerms.Length);
+            ClassicAssert.IsNotEmpty(filterCriteria.OnlineStatus.Values);
             Assert.That(filterCriteria.OnlineStatus.Values, Contains.Item(BeatmapOnlineStatus.Ranked));
         }
 
@@ -308,7 +309,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "status!=r";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.IsNotEmpty(filterCriteria.OnlineStatus.Values);
+            ClassicAssert.IsNotEmpty(filterCriteria.OnlineStatus.Values);
             Assert.That(filterCriteria.OnlineStatus.Values, Does.Not.Contain(BeatmapOnlineStatus.Ranked));
         }
 
@@ -374,9 +375,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             string query = $"beatmap specifically by {keyword}=my_fav";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("beatmap specifically by", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual("my_fav", filterCriteria.Creator.SearchTerm);
+            ClassicAssert.AreEqual("beatmap specifically by", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(3, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("my_fav", filterCriteria.Creator.SearchTerm);
         }
 
         [Test]
@@ -385,9 +386,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "find me songs with title=\"a certain title\" please";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("find me songs with  please", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual("a certain title", filterCriteria.Title.SearchTerm);
+            ClassicAssert.AreEqual("find me songs with  please", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(5, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("a certain title", filterCriteria.Title.SearchTerm);
             Assert.That(filterCriteria.Title.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
         }
 
@@ -397,9 +398,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "find me songs by artist=singer please";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("find me songs by  please", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual("singer", filterCriteria.Artist.SearchTerm);
+            ClassicAssert.AreEqual("find me songs by  please", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(5, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("singer", filterCriteria.Artist.SearchTerm);
             Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
         }
 
@@ -409,9 +410,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "really like artist=\"name with space\" yes";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("really like  yes", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual("name with space", filterCriteria.Artist.SearchTerm);
+            ClassicAssert.AreEqual("really like  yes", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(3, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("name with space", filterCriteria.Artist.SearchTerm);
             Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
         }
 
@@ -422,8 +423,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.That(filterCriteria.SearchText.Trim(), Is.Empty);
-            Assert.AreEqual(0, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual("The Only One", filterCriteria.Artist.SearchTerm);
+            ClassicAssert.AreEqual(0, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("The Only One", filterCriteria.Artist.SearchTerm);
             Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
         }
 
@@ -433,9 +434,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "weird artist=double\"quote";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("weird", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual("double\"quote", filterCriteria.Artist.SearchTerm);
+            ClassicAssert.AreEqual("weird", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("double\"quote", filterCriteria.Artist.SearchTerm);
         }
 
         [Test]
@@ -444,7 +445,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "artist=><something";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("><something", filterCriteria.Artist.SearchTerm);
+            ClassicAssert.AreEqual("><something", filterCriteria.Artist.SearchTerm);
         }
 
         [Test]
@@ -453,7 +454,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "unrecognised=keyword";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("unrecognised=keyword", filterCriteria.SearchText);
+            ClassicAssert.AreEqual("unrecognised=keyword", filterCriteria.SearchText);
         }
 
         [TestCase("cs=nope")]
@@ -464,7 +465,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         {
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(query, filterCriteria.SearchText);
+            ClassicAssert.AreEqual(query, filterCriteria.SearchText);
         }
 
         [Test]
@@ -474,8 +475,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "custom=readme unrecognised=keyword";
             var filterCriteria = new FilterCriteria { RulesetCriteria = customCriteria };
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("readme", customCriteria.CustomValue);
-            Assert.AreEqual("unrecognised=keyword", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual("readme", customCriteria.CustomValue);
+            ClassicAssert.AreEqual("unrecognised=keyword", filterCriteria.SearchText.Trim());
         }
 
         [TestCase("[1]", new[] { 0 })]
@@ -535,9 +536,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "find me songs with source=\"unit tests\" please";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("find me songs with  please", filterCriteria.SearchText.Trim());
-            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual("unit tests", filterCriteria.Source.SearchTerm);
+            ClassicAssert.AreEqual("find me songs with  please", filterCriteria.SearchText.Trim());
+            ClassicAssert.AreEqual(5, filterCriteria.SearchTerms.Length);
+            ClassicAssert.AreEqual("unit tests", filterCriteria.Source.SearchTerm);
             Assert.That(filterCriteria.Source.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
         }
 
@@ -580,7 +581,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             string query = $"lastplayed<{dateQuery} time";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
+            ClassicAssert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
         }
 
         private static readonly object[] incorrect_date_query_examples =
@@ -605,7 +606,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             string query = $"played<{dateQuery} time";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(false, filterCriteria.LastPlayed.HasFilter);
+            ClassicAssert.AreEqual(false, filterCriteria.LastPlayed.HasFilter);
         }
 
         [Test]
@@ -614,11 +615,11 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "lastplayed>50";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.That(filterCriteria.LastPlayed.Max, Is.Not.Null);
-            Assert.That(filterCriteria.LastPlayed.Min, Is.Null);
+            Assert.That(filterCriteria.LastPlayed.Max!, Is.Not.Null);
+            Assert.That(filterCriteria.LastPlayed.Min!, Is.Null);
             // the parser internally references `DateTimeOffset.Now`, so to not make things too annoying for tests, just assume some tolerance
             // (irrelevant in proportion to the actual filter proscribed).
-            Assert.That(filterCriteria.LastPlayed.Max, Is.EqualTo(DateTimeOffset.Now.AddDays(-50)).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(filterCriteria.LastPlayed.Max!, Is.EqualTo(DateTimeOffset.Now.AddDays(-50)).Within(TimeSpan.FromSeconds(5)));
         }
 
         [Test]
@@ -627,11 +628,11 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "lastplayed<50";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.That(filterCriteria.LastPlayed.Max, Is.Null);
-            Assert.That(filterCriteria.LastPlayed.Min, Is.Not.Null);
+            Assert.That(filterCriteria.LastPlayed.Max!, Is.Null);
+            Assert.That(filterCriteria.LastPlayed.Min!, Is.Not.Null);
             // the parser internally references `DateTimeOffset.Now`, so to not make things too annoying for tests, just assume some tolerance
             // (irrelevant in proportion to the actual filter proscribed).
-            Assert.That(filterCriteria.LastPlayed.Min, Is.EqualTo(DateTimeOffset.Now.AddDays(-50)).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(filterCriteria.LastPlayed.Min!, Is.EqualTo(DateTimeOffset.Now.AddDays(-50)).Within(TimeSpan.FromSeconds(5)));
         }
 
         [Test]
@@ -640,12 +641,12 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "lastplayed>3M lastplayed<1y6M";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.That(filterCriteria.LastPlayed.Min, Is.Not.Null);
-            Assert.That(filterCriteria.LastPlayed.Max, Is.Not.Null);
+            Assert.That(filterCriteria.LastPlayed.Min!, Is.Not.Null);
+            Assert.That(filterCriteria.LastPlayed.Max!, Is.Not.Null);
             // the parser internally references `DateTimeOffset.Now`, so to not make things too annoying for tests, just assume some tolerance
             // (irrelevant in proportion to the actual filter proscribed).
-            Assert.That(filterCriteria.LastPlayed.Min, Is.EqualTo(DateTimeOffset.Now.AddMonths(-6).AddYears(-1)).Within(TimeSpan.FromSeconds(5)));
-            Assert.That(filterCriteria.LastPlayed.Max, Is.EqualTo(DateTimeOffset.Now.AddMonths(-3)).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(filterCriteria.LastPlayed.Min!, Is.EqualTo(DateTimeOffset.Now.AddMonths(-6).AddYears(-1)).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(filterCriteria.LastPlayed.Max!, Is.EqualTo(DateTimeOffset.Now.AddMonths(-3)).Within(TimeSpan.FromSeconds(5)));
         }
 
         [Test]
@@ -654,7 +655,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "lastplayed=50";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(false, filterCriteria.LastPlayed.HasFilter);
+            ClassicAssert.AreEqual(false, filterCriteria.LastPlayed.HasFilter);
         }
 
         [Test]
@@ -663,8 +664,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             const string query = "lastplayed<10000y";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
-            Assert.AreEqual(DateTimeOffset.MinValue.AddMilliseconds(1), filterCriteria.LastPlayed.Min);
+            ClassicAssert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
+            ClassicAssert.AreEqual(DateTimeOffset.MinValue.AddMilliseconds(1), filterCriteria.LastPlayed.Min);
         }
 
         private static DateTimeOffset dateTimeOffsetFromDateOnly(int year, int month, int day) =>
@@ -706,8 +707,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
         {
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(true, filterCriteria.DateRanked.HasFilter);
-            Assert.AreEqual(expected, f(filterCriteria));
+            ClassicAssert.AreEqual(true, filterCriteria.DateRanked.HasFilter);
+            ClassicAssert.AreEqual(expected, f(filterCriteria));
         }
 
         private static readonly object[] ranked_date_invalid_test_cases =
@@ -723,7 +724,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         {
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(false, filterCriteria.DateRanked.HasFilter);
+            ClassicAssert.AreEqual(false, filterCriteria.DateRanked.HasFilter);
         }
 
         private static readonly object[] submitted_date_test_cases =
@@ -755,7 +756,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         {
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual(expected, filterCriteria.DateSubmitted.HasFilter);
+            ClassicAssert.AreEqual(expected, filterCriteria.DateSubmitted.HasFilter);
         }
 
         private static readonly object[] played_query_tests =
@@ -781,8 +782,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
         {
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, $"played={query}");
-            Assert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
-            Assert.AreEqual(matched, filterCriteria.LastPlayed.IsInRange(reference));
+            ClassicAssert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
+            ClassicAssert.AreEqual(matched, filterCriteria.LastPlayed.IsInRange(reference));
         }
 
         [Test]

--- a/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
+++ b/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Audio;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
@@ -37,7 +38,7 @@ namespace osu.Game.Tests.NonVisual
             testObject.AddNested(nested);
             testDrawableRuleset.HitObjects = new List<HitObject> { testObject };
 
-            Assert.AreSame(testDrawableRuleset.FirstAvailableHitWindows, nested.HitWindows);
+            ClassicAssert.AreSame(testDrawableRuleset.FirstAvailableHitWindows, nested.HitWindows);
         }
 
         [Test]
@@ -48,7 +49,7 @@ namespace osu.Game.Tests.NonVisual
             testObject.AddNested(nested);
             testDrawableRuleset.HitObjects = new List<HitObject> { testObject };
 
-            Assert.AreSame(testDrawableRuleset.FirstAvailableHitWindows, testObject.HitWindows);
+            ClassicAssert.AreSame(testDrawableRuleset.FirstAvailableHitWindows, testObject.HitWindows);
         }
 
         [Test]
@@ -61,7 +62,7 @@ namespace osu.Game.Tests.NonVisual
             var secondObject = new TestHitObject(new DefaultHitWindows());
             testDrawableRuleset.HitObjects = new List<HitObject> { firstObject, secondObject };
 
-            Assert.AreSame(testDrawableRuleset.FirstAvailableHitWindows, secondObject.HitWindows);
+            ClassicAssert.AreSame(testDrawableRuleset.FirstAvailableHitWindows, secondObject.HitWindows);
         }
 
         [Test]
@@ -73,7 +74,7 @@ namespace osu.Game.Tests.NonVisual
 
             testDrawableRuleset.HitObjects = new List<HitObject> { firstObject };
 
-            Assert.IsNull(testDrawableRuleset.FirstAvailableHitWindows);
+            ClassicAssert.Null(testDrawableRuleset.FirstAvailableHitWindows);
         }
 
         [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]

--- a/osu.Game.Tests/NonVisual/FormatUtilsTest.cs
+++ b/osu.Game.Tests/NonVisual/FormatUtilsTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Utils;
 
 namespace osu.Game.Tests.NonVisual
@@ -19,7 +20,7 @@ namespace osu.Game.Tests.NonVisual
         [TestCase(1, "100.00%")]
         public void TestAccuracyFormatting(double input, string expectedOutput)
         {
-            Assert.AreEqual(expectedOutput, input.FormatAccuracy().ToString());
+            ClassicAssert.AreEqual(expectedOutput, input.FormatAccuracy().ToString());
         }
 
         [TestCase(3, "3.00")]
@@ -32,7 +33,7 @@ namespace osu.Game.Tests.NonVisual
         [TestCase(4, "4.00")]
         public void TestStarRatingFormatting(double input, string expectedOutput)
         {
-            Assert.AreEqual(expectedOutput, input.FormatStarRating().ToString());
+            ClassicAssert.AreEqual(expectedOutput, input.FormatStarRating().ToString());
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
+++ b/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
 
@@ -223,7 +224,7 @@ namespace osu.Game.Tests.NonVisual
             // no frames are arrived yet
             setTime(0, null);
             setTime(1000, null);
-            Assert.IsTrue(handler.WaitingForFrame, "Should be waiting for the first frame");
+            ClassicAssert.True(handler.WaitingForFrame, "Should be waiting for the first frame");
 
             replay.Frames.Add(new TestReplayFrame(0));
             replay.Frames.Add(new TestReplayFrame(1000));
@@ -231,11 +232,11 @@ namespace osu.Game.Tests.NonVisual
             // should always play from beginning
             setTime(1000, 0);
             confirmCurrentFrame(0);
-            Assert.IsFalse(handler.WaitingForFrame, "Should not be waiting yet");
+            ClassicAssert.False(handler.WaitingForFrame, "Should not be waiting yet");
             setTime(1000, 1000);
             confirmCurrentFrame(1);
             confirmNextFrame(null);
-            Assert.IsTrue(handler.WaitingForFrame, "Should be waiting");
+            ClassicAssert.True(handler.WaitingForFrame, "Should be waiting");
 
             // cannot seek beyond the last frame
             setTime(1500, null);
@@ -359,17 +360,17 @@ namespace osu.Game.Tests.NonVisual
 
         private void setTime(double set, double? expect)
         {
-            Assert.AreEqual(expect, handler.SetFrameFromTime(set), "Unexpected return value");
+            ClassicAssert.AreEqual(expect, handler.SetFrameFromTime(set), "Unexpected return value");
         }
 
         private void confirmCurrentFrame(int? frame)
         {
-            Assert.AreEqual(frame is int x ? replay.Frames[x].Time : null, handler.CurrentFrame?.Time, "Unexpected current frame");
+            ClassicAssert.AreEqual(frame is int x ? replay.Frames[x].Time : null, handler.CurrentFrame?.Time, "Unexpected current frame");
         }
 
         private void confirmNextFrame(int? frame)
         {
-            Assert.AreEqual(frame is int x ? replay.Frames[x].Time : null, handler.NextFrame?.Time, "Unexpected next frame");
+            ClassicAssert.AreEqual(frame is int x ? replay.Frames[x].Time : null, handler.NextFrame?.Time, "Unexpected next frame");
         }
 
         private class TestReplayFrame : ReplayFrame

--- a/osu.Game.Tests/NonVisual/LimitedCapacityQueueTest.cs
+++ b/osu.Game.Tests/NonVisual/LimitedCapacityQueueTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Utils;
 
 namespace osu.Game.Tests.NonVisual
@@ -25,7 +26,7 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void TestEmptyQueue()
         {
-            Assert.AreEqual(0, queue.Count);
+            ClassicAssert.AreEqual(0, queue.Count);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => _ = queue[0]);
 
@@ -35,7 +36,7 @@ namespace osu.Game.Tests.NonVisual
             foreach (int _ in queue)
                 count++;
 
-            Assert.AreEqual(0, count);
+            ClassicAssert.AreEqual(0, count);
         }
 
         [TestCase(1)]
@@ -46,14 +47,14 @@ namespace osu.Game.Tests.NonVisual
             for (int i = 0; i < count; ++i)
                 queue.Enqueue(i);
 
-            Assert.AreEqual(count, queue.Count);
+            ClassicAssert.AreEqual(count, queue.Count);
 
             for (int i = 0; i < count; ++i)
-                Assert.AreEqual(i, queue[i]);
+                ClassicAssert.AreEqual(i, queue[i]);
 
             int j = 0;
             foreach (int item in queue)
-                Assert.AreEqual(j++, item);
+                ClassicAssert.AreEqual(j++, item);
 
             for (int i = queue.Count; i < queue.Count + capacity; i++)
                 Assert.Throws<ArgumentOutOfRangeException>(() => _ = queue[i]);
@@ -67,14 +68,14 @@ namespace osu.Game.Tests.NonVisual
             for (int i = 0; i < count; ++i)
                 queue.Enqueue(i);
 
-            Assert.AreEqual(capacity, queue.Count);
+            ClassicAssert.AreEqual(capacity, queue.Count);
 
             for (int i = 0; i < queue.Count; ++i)
-                Assert.AreEqual(count - capacity + i, queue[i]);
+                ClassicAssert.AreEqual(count - capacity + i, queue[i]);
 
             int j = count - capacity;
             foreach (int item in queue)
-                Assert.AreEqual(j++, item);
+                ClassicAssert.AreEqual(j++, item);
 
             for (int i = queue.Count; i < queue.Count + capacity; i++)
                 Assert.Throws<ArgumentOutOfRangeException>(() => _ = queue[i]);
@@ -90,8 +91,8 @@ namespace osu.Game.Tests.NonVisual
 
             for (int i = 0; i < capacity; ++i)
             {
-                Assert.AreEqual(count - capacity + i, queue.Dequeue());
-                Assert.AreEqual(2 - i, queue.Count);
+                ClassicAssert.AreEqual(count - capacity + i, queue.Dequeue());
+                ClassicAssert.AreEqual(2 - i, queue.Count);
             }
 
             Assert.Throws<InvalidOperationException>(() => queue.Dequeue());
@@ -102,20 +103,20 @@ namespace osu.Game.Tests.NonVisual
         {
             queue.Enqueue(3);
             queue.Enqueue(5);
-            Assert.AreEqual(2, queue.Count);
+            ClassicAssert.AreEqual(2, queue.Count);
 
             queue.Clear();
-            Assert.AreEqual(0, queue.Count);
+            ClassicAssert.AreEqual(0, queue.Count);
             Assert.Throws<ArgumentOutOfRangeException>(() => _ = queue[0]);
 
             queue.Enqueue(7);
-            Assert.AreEqual(1, queue.Count);
-            Assert.AreEqual(7, queue[0]);
+            ClassicAssert.AreEqual(1, queue.Count);
+            ClassicAssert.AreEqual(7, queue[0]);
             Assert.Throws<ArgumentOutOfRangeException>(() => _ = queue[1]);
 
             queue.Enqueue(9);
-            Assert.AreEqual(2, queue.Count);
-            Assert.AreEqual(9, queue[1]);
+            ClassicAssert.AreEqual(2, queue.Count);
+            ClassicAssert.AreEqual(9, queue[1]);
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/PeriodTrackerTest.cs
+++ b/osu.Game.Tests/NonVisual/PeriodTrackerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Utils;
 using osu.Game.Utils;
 
@@ -28,9 +29,9 @@ namespace osu.Game.Tests.NonVisual
             var tracker = new PeriodTracker(single_period);
 
             var period = single_period.Single();
-            Assert.IsTrue(tracker.IsInAny(period.Start));
-            Assert.IsTrue(tracker.IsInAny(getMidpoint(period)));
-            Assert.IsTrue(tracker.IsInAny(period.End));
+            ClassicAssert.True(tracker.IsInAny(period.Start));
+            ClassicAssert.True(tracker.IsInAny(getMidpoint(period)));
+            ClassicAssert.True(tracker.IsInAny(period.End));
         }
 
         [Test]
@@ -39,7 +40,7 @@ namespace osu.Game.Tests.NonVisual
             var tracker = new PeriodTracker(unordered_periods);
 
             foreach (var period in unordered_periods)
-                Assert.IsTrue(tracker.IsInAny(getMidpoint(period)));
+                ClassicAssert.True(tracker.IsInAny(getMidpoint(period)));
         }
 
         [Test]
@@ -48,7 +49,7 @@ namespace osu.Game.Tests.NonVisual
             var tracker = new PeriodTracker(unordered_periods);
 
             foreach (var period in unordered_periods.OrderBy(_ => RNG.Next()))
-                Assert.IsTrue(tracker.IsInAny(getMidpoint(period)));
+                ClassicAssert.True(tracker.IsInAny(getMidpoint(period)));
         }
 
         [Test]
@@ -60,12 +61,12 @@ namespace osu.Game.Tests.NonVisual
                 new Period(3.0, 4.0)
             });
 
-            Assert.IsFalse(tracker.IsInAny(0.9), "Time before first period is being considered inside");
+            ClassicAssert.False(tracker.IsInAny(0.9), "Time before first period is being considered inside");
 
-            Assert.IsFalse(tracker.IsInAny(2.1), "Time right after first period is being considered inside");
-            Assert.IsFalse(tracker.IsInAny(2.9), "Time right before second period is being considered inside");
+            ClassicAssert.False(tracker.IsInAny(2.1), "Time right after first period is being considered inside");
+            ClassicAssert.False(tracker.IsInAny(2.9), "Time right before second period is being considered inside");
 
-            Assert.IsFalse(tracker.IsInAny(4.1), "Time after last period is being considered inside");
+            ClassicAssert.False(tracker.IsInAny(4.1), "Time after last period is being considered inside");
         }
 
         [Test]

--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             var unstableRate = new UnstableRate(events);
 
-            ClassicAssert.NotNull(unstableRate.Value);
+            Assert.That(unstableRate.Value, Is.Not.Null);
             ClassicAssert.AreEqual(unstableRate.Value.Value, 10 * Math.Sqrt(10), Precision.DOUBLE_EPSILON);
         }
 

--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
@@ -25,8 +26,8 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             var unstableRate = new UnstableRate(events);
 
-            Assert.IsNotNull(unstableRate.Value);
-            Assert.AreEqual(unstableRate.Value.Value, 10 * Math.Sqrt(10), Precision.DOUBLE_EPSILON);
+            ClassicAssert.NotNull(unstableRate.Value);
+            ClassicAssert.AreEqual(unstableRate.Value.Value, 10 * Math.Sqrt(10), Precision.DOUBLE_EPSILON);
         }
 
         [Test]
@@ -50,8 +51,8 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             result = events.GetRange(0, 2).CalculateUnstableRate(result);
 
-            Assert.IsNotNull(result!.Result);
-            Assert.AreEqual(5, result.Result, Precision.DOUBLE_EPSILON);
+            ClassicAssert.NotNull(result!.Result);
+            ClassicAssert.AreEqual(5, result.Result, Precision.DOUBLE_EPSILON);
         }
 
         [Test]
@@ -73,8 +74,8 @@ namespace osu.Game.Tests.NonVisual.Ranking
                                .CalculateUnstableRate(result);
             }
 
-            Assert.IsNotNull(result!.Result);
-            Assert.AreEqual(10 * Math.Sqrt(10), result.Result, Precision.DOUBLE_EPSILON);
+            ClassicAssert.NotNull(result!.Result);
+            ClassicAssert.AreEqual(10 * Math.Sqrt(10), result.Result, Precision.DOUBLE_EPSILON);
         }
 
         [Test]
@@ -89,7 +90,7 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             var unstableRate = new UnstableRate(events);
 
-            Assert.AreEqual(0, unstableRate.Value);
+            ClassicAssert.AreEqual(0, unstableRate.Value);
         }
 
         [Test]
@@ -105,7 +106,7 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             var unstableRate = new UnstableRate(events);
 
-            Assert.AreEqual(10 * 100, unstableRate.Value);
+            ClassicAssert.AreEqual(10 * 100, unstableRate.Value);
         }
 
         [Test]
@@ -121,7 +122,7 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             var unstableRate = new UnstableRate(events);
 
-            Assert.AreEqual(10 * 100, unstableRate.Value);
+            ClassicAssert.AreEqual(10 * 100, unstableRate.Value);
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/ReverseQueueTest.cs
+++ b/osu.Game.Tests/NonVisual/ReverseQueueTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Rulesets.Difficulty.Utils;
 
 namespace osu.Game.Tests.NonVisual
@@ -23,7 +24,7 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void TestEmptyQueue()
         {
-            Assert.AreEqual(0, queue.Count);
+            ClassicAssert.AreEqual(0, queue.Count);
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
@@ -34,7 +35,7 @@ namespace osu.Game.Tests.NonVisual
             foreach (char unused in queue)
                 count++;
 
-            Assert.AreEqual(0, count);
+            ClassicAssert.AreEqual(0, count);
         }
 
         [Test]
@@ -45,21 +46,21 @@ namespace osu.Game.Tests.NonVisual
             queue.Enqueue('b');
             queue.Enqueue('c');
 
-            Assert.AreEqual('c', queue[0]);
-            Assert.AreEqual('b', queue[1]);
-            Assert.AreEqual('a', queue[2]);
+            ClassicAssert.AreEqual('c', queue[0]);
+            ClassicAssert.AreEqual('b', queue[1]);
+            ClassicAssert.AreEqual('a', queue[2]);
 
             // Assert correct values and reverse index after enqueueing beyond initial capacity of 4
             queue.Enqueue('d');
             queue.Enqueue('e');
             queue.Enqueue('f');
 
-            Assert.AreEqual('f', queue[0]);
-            Assert.AreEqual('e', queue[1]);
-            Assert.AreEqual('d', queue[2]);
-            Assert.AreEqual('c', queue[3]);
-            Assert.AreEqual('b', queue[4]);
-            Assert.AreEqual('a', queue[5]);
+            ClassicAssert.AreEqual('f', queue[0]);
+            ClassicAssert.AreEqual('e', queue[1]);
+            ClassicAssert.AreEqual('d', queue[2]);
+            ClassicAssert.AreEqual('c', queue[3]);
+            ClassicAssert.AreEqual('b', queue[4]);
+            ClassicAssert.AreEqual('a', queue[5]);
         }
 
         [Test]
@@ -73,13 +74,13 @@ namespace osu.Game.Tests.NonVisual
             queue.Enqueue('f');
 
             // Assert correct item return and no longer in queue after dequeueing
-            Assert.AreEqual('a', queue[5]);
+            ClassicAssert.AreEqual('a', queue[5]);
             char dequeuedItem = queue.Dequeue();
 
-            Assert.AreEqual('a', dequeuedItem);
-            Assert.AreEqual(5, queue.Count);
-            Assert.AreEqual('f', queue[0]);
-            Assert.AreEqual('b', queue[4]);
+            ClassicAssert.AreEqual('a', dequeuedItem);
+            ClassicAssert.AreEqual(5, queue.Count);
+            ClassicAssert.AreEqual('f', queue[0]);
+            ClassicAssert.AreEqual('b', queue[4]);
             Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 char unused = queue[5];
@@ -97,8 +98,8 @@ namespace osu.Game.Tests.NonVisual
             queue.Dequeue();
             queue.Dequeue();
 
-            Assert.AreEqual(1, queue.Count);
-            Assert.AreEqual('i', queue[0]);
+            ClassicAssert.AreEqual(1, queue.Count);
+            ClassicAssert.AreEqual('i', queue[0]);
         }
 
         [Test]
@@ -114,7 +115,7 @@ namespace osu.Game.Tests.NonVisual
             // Assert queue is empty after clearing
             queue.Clear();
 
-            Assert.AreEqual(0, queue.Count);
+            ClassicAssert.AreEqual(0, queue.Count);
             Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 char unused = queue[0];
@@ -137,7 +138,7 @@ namespace osu.Game.Tests.NonVisual
             // Assert items are enumerated in correct order
             foreach (char item in queue)
             {
-                Assert.AreEqual(expectedValues[expectedValueIndex], item);
+                ClassicAssert.AreEqual(expectedValues[expectedValueIndex], item);
                 expectedValueIndex++;
             }
         }

--- a/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
+++ b/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Configuration;
 using osu.Game.Online.API.Requests.Responses;
 
@@ -26,20 +27,20 @@ namespace osu.Game.Tests.NonVisual
             sessionStatics.SetValue(Static.LastHoverSoundPlaybackTime, (double?)1d);
             sessionStatics.SetValue(Static.SeasonalBackgrounds, new APISeasonalBackgrounds { EndDate = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) });
 
-            Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
-            Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
-            Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
-            Assert.IsFalse(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
-            Assert.IsFalse(sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).IsDefault);
+            ClassicAssert.False(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
+            ClassicAssert.False(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
+            ClassicAssert.False(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
+            ClassicAssert.False(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
+            ClassicAssert.False(sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).IsDefault);
 
             sessionStatics.ResetAfterInactivity();
 
-            Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
-            Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
-            Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
+            ClassicAssert.True(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
+            ClassicAssert.True(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
+            ClassicAssert.True(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
             // some statics should not reset despite inactivity.
-            Assert.IsFalse(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
-            Assert.IsFalse(sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).IsDefault);
+            ClassicAssert.False(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
+            ClassicAssert.False(sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).IsDefault);
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.NonVisual.Skinning
 
             var texture = legacySkin.GetTexture(requestedComponent);
 
-            ClassicAssert.NotNull(texture);
+            Assert.That(texture, Is.Not.Null);
             ClassicAssert.AreEqual(textureStore.Textures[expectedTexture].Width, texture.Width);
             ClassicAssert.AreEqual(expectedScale, texture.ScaleAdjust);
         }
@@ -118,12 +118,12 @@ namespace osu.Game.Tests.NonVisual.Skinning
 
             var texture = legacySkin.GetTexture("hitcircle");
 
-            ClassicAssert.NotNull(texture);
+            Assert.That(texture, Is.Not.Null);
             Assert.That(texture.ScaleAdjust, Is.EqualTo(1));
 
             var twoTimesTexture = legacySkin.GetTexture("hitcircle@2x");
 
-            ClassicAssert.NotNull(twoTimesTexture);
+            Assert.That(twoTimesTexture, Is.Not.Null);
             Assert.That(twoTimesTexture.ScaleAdjust, Is.EqualTo(1));
 
             ClassicAssert.AreNotEqual(texture, twoTimesTexture);
@@ -137,12 +137,12 @@ namespace osu.Game.Tests.NonVisual.Skinning
 
             var texture = legacySkin.GetTexture("hitcircle");
 
-            ClassicAssert.NotNull(texture);
+            Assert.That(texture, Is.Not.Null);
             Assert.That(texture.ScaleAdjust, Is.EqualTo(2));
 
             var twoTimesTexture = legacySkin.GetTexture("hitcircle@2x");
 
-            ClassicAssert.NotNull(twoTimesTexture);
+            Assert.That(twoTimesTexture, Is.Not.Null);
             Assert.That(twoTimesTexture.ScaleAdjust, Is.EqualTo(2));
 
             ClassicAssert.AreEqual(texture, twoTimesTexture);

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Audio;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Dummy;
@@ -93,9 +94,9 @@ namespace osu.Game.Tests.NonVisual.Skinning
 
             var texture = legacySkin.GetTexture(requestedComponent);
 
-            Assert.IsNotNull(texture);
-            Assert.AreEqual(textureStore.Textures[expectedTexture].Width, texture.Width);
-            Assert.AreEqual(expectedScale, texture.ScaleAdjust);
+            ClassicAssert.NotNull(texture);
+            ClassicAssert.AreEqual(textureStore.Textures[expectedTexture].Width, texture.Width);
+            ClassicAssert.AreEqual(expectedScale, texture.ScaleAdjust);
         }
 
         [Test]
@@ -106,7 +107,7 @@ namespace osu.Game.Tests.NonVisual.Skinning
 
             var texture = legacySkin.GetTexture("Gameplay/osu/followpoint");
 
-            Assert.IsNull(texture);
+            ClassicAssert.Null(texture);
         }
 
         [Test]
@@ -117,15 +118,15 @@ namespace osu.Game.Tests.NonVisual.Skinning
 
             var texture = legacySkin.GetTexture("hitcircle");
 
-            Assert.IsNotNull(texture);
+            ClassicAssert.NotNull(texture);
             Assert.That(texture.ScaleAdjust, Is.EqualTo(1));
 
             var twoTimesTexture = legacySkin.GetTexture("hitcircle@2x");
 
-            Assert.IsNotNull(twoTimesTexture);
+            ClassicAssert.NotNull(twoTimesTexture);
             Assert.That(twoTimesTexture.ScaleAdjust, Is.EqualTo(1));
 
-            Assert.AreNotEqual(texture, twoTimesTexture);
+            ClassicAssert.AreNotEqual(texture, twoTimesTexture);
         }
 
         [Test]
@@ -136,15 +137,15 @@ namespace osu.Game.Tests.NonVisual.Skinning
 
             var texture = legacySkin.GetTexture("hitcircle");
 
-            Assert.IsNotNull(texture);
+            ClassicAssert.NotNull(texture);
             Assert.That(texture.ScaleAdjust, Is.EqualTo(2));
 
             var twoTimesTexture = legacySkin.GetTexture("hitcircle@2x");
 
-            Assert.IsNotNull(twoTimesTexture);
+            ClassicAssert.NotNull(twoTimesTexture);
             Assert.That(twoTimesTexture.ScaleAdjust, Is.EqualTo(2));
 
-            Assert.AreEqual(texture, twoTimesTexture);
+            ClassicAssert.AreEqual(texture, twoTimesTexture);
         }
 
         private class TestLegacySkin : LegacySkin

--- a/osu.Game.Tests/NonVisual/TimeDisplayExtensionTest.cs
+++ b/osu.Game.Tests/NonVisual/TimeDisplayExtensionTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Extensions;
 
 namespace osu.Game.Tests.NonVisual
@@ -21,7 +22,7 @@ namespace osu.Game.Tests.NonVisual
         [TestCaseSource(nameof(editor_formatted_duration_tests))]
         public void TestEditorFormat(TimeSpan input, string expectedOutput)
         {
-            Assert.AreEqual(expectedOutput, input.ToEditorFormattedString());
+            ClassicAssert.AreEqual(expectedOutput, input.ToEditorFormattedString());
         }
 
         private static readonly object[][] formatted_duration_tests =
@@ -35,7 +36,7 @@ namespace osu.Game.Tests.NonVisual
         [TestCaseSource(nameof(formatted_duration_tests))]
         public void TestFormattedDuration(TimeSpan input, string expectedOutput)
         {
-            Assert.AreEqual(expectedOutput, input.ToFormattedDuration().ToString());
+            ClassicAssert.AreEqual(expectedOutput, input.ToFormattedDuration().ToString());
         }
     }
 }

--- a/osu.Game.Tests/Online/Chat/MessageNotifierTest.cs
+++ b/osu.Game.Tests/Online/Chat/MessageNotifierTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Online.Chat;
 
 namespace osu.Game.Tests.Online.Chat
@@ -12,79 +13,79 @@ namespace osu.Game.Tests.Online.Chat
         [Test]
         public void TestContainsUsernameMidlinePositive()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("This is a test message", "Test").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("This is a test message", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameStartOfLinePositive()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("Test message", "Test").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("Test message", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameEndOfLinePositive()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("This is a test", "Test").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("This is a test", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameMidlineNegative()
         {
-            Assert.IsFalse(MessageNotifier.MatchUsername("This is a testmessage for notifications", "Test").Success);
+            ClassicAssert.False(MessageNotifier.MatchUsername("This is a testmessage for notifications", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameStartOfLineNegative()
         {
-            Assert.IsFalse(MessageNotifier.MatchUsername("Testmessage", "Test").Success);
+            ClassicAssert.False(MessageNotifier.MatchUsername("Testmessage", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameEndOfLineNegative()
         {
-            Assert.IsFalse(MessageNotifier.MatchUsername("This is a notificationtest", "Test").Success);
+            ClassicAssert.False(MessageNotifier.MatchUsername("This is a notificationtest", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameBetweenPunctuation()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("Hello 'test'-message", "Test").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("Hello 'test'-message", "Test").Success);
         }
 
         [Test]
         public void TestContainsUsernameUnicode()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("Test \u0460\u0460 message", "\u0460\u0460").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("Test \u0460\u0460 message", "\u0460\u0460").Success);
         }
 
         [Test]
         public void TestContainsUsernameUnicodeNegative()
         {
-            Assert.IsFalse(MessageNotifier.MatchUsername("Test ha\u0460\u0460o message", "\u0460\u0460").Success);
+            ClassicAssert.False(MessageNotifier.MatchUsername("Test ha\u0460\u0460o message", "\u0460\u0460").Success);
         }
 
         [Test]
         public void TestContainsUsernameSpecialCharactersPositive()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("Test [#^-^#] message", "[#^-^#]").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("Test [#^-^#] message", "[#^-^#]").Success);
         }
 
         [Test]
         public void TestContainsUsernameSpecialCharactersNegative()
         {
-            Assert.IsFalse(MessageNotifier.MatchUsername("Test pad[#^-^#]oru message", "[#^-^#]").Success);
+            ClassicAssert.False(MessageNotifier.MatchUsername("Test pad[#^-^#]oru message", "[#^-^#]").Success);
         }
 
         [Test]
         public void TestContainsUsernameAtSign()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("@username hi", "username").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("@username hi", "username").Success);
         }
 
         [Test]
         public void TestContainsUsernameColon()
         {
-            Assert.IsTrue(MessageNotifier.MatchUsername("username: hi", "username").Success);
+            ClassicAssert.True(MessageNotifier.MatchUsername("username: hi", "username").Success);
         }
     }
 }

--- a/osu.Game.Tests/Online/Matchmaking/MatchmakingRoomStateTest.cs
+++ b/osu.Game.Tests/Online/Matchmaking/MatchmakingRoomStateTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 
@@ -30,17 +31,17 @@ namespace osu.Game.Tests.Online.Matchmaking
                 new SoloScoreInfo { UserID = 3, TotalScore = 750 },
             ], placement_points);
 
-            Assert.AreEqual(8, state.Users.GetOrAdd(1).Points);
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Rounds.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(8, state.Users.GetOrAdd(1).Points);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Rounds.GetOrAdd(1).Placement);
 
-            Assert.AreEqual(6, state.Users.GetOrAdd(2).Points);
-            Assert.AreEqual(3, state.Users.GetOrAdd(2).Placement);
-            Assert.AreEqual(3, state.Users.GetOrAdd(2).Rounds.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(6, state.Users.GetOrAdd(2).Points);
+            ClassicAssert.AreEqual(3, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(3, state.Users.GetOrAdd(2).Rounds.GetOrAdd(1).Placement);
 
-            Assert.AreEqual(7, state.Users.GetOrAdd(3).Points);
-            Assert.AreEqual(2, state.Users.GetOrAdd(3).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(3).Rounds.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(7, state.Users.GetOrAdd(3).Points);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(3).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(3).Rounds.GetOrAdd(1).Placement);
 
             // 2 -> 1 -> 3
 
@@ -52,17 +53,17 @@ namespace osu.Game.Tests.Online.Matchmaking
                 new SoloScoreInfo { UserID = 3, TotalScore = 500 },
             ], placement_points);
 
-            Assert.AreEqual(15, state.Users.GetOrAdd(1).Points);
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(1).Rounds.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(15, state.Users.GetOrAdd(1).Points);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(1).Rounds.GetOrAdd(2).Placement);
 
-            Assert.AreEqual(14, state.Users.GetOrAdd(2).Points);
-            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
-            Assert.AreEqual(1, state.Users.GetOrAdd(2).Rounds.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(14, state.Users.GetOrAdd(2).Points);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(2).Rounds.GetOrAdd(2).Placement);
 
-            Assert.AreEqual(13, state.Users.GetOrAdd(3).Points);
-            Assert.AreEqual(3, state.Users.GetOrAdd(3).Placement);
-            Assert.AreEqual(3, state.Users.GetOrAdd(3).Rounds.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(13, state.Users.GetOrAdd(3).Points);
+            ClassicAssert.AreEqual(3, state.Users.GetOrAdd(3).Placement);
+            ClassicAssert.AreEqual(3, state.Users.GetOrAdd(3).Rounds.GetOrAdd(2).Placement);
         }
 
         [Test]
@@ -81,21 +82,21 @@ namespace osu.Game.Tests.Online.Matchmaking
                 new SoloScoreInfo { UserID = 4, TotalScore = 500 },
             ], placement_points);
 
-            Assert.AreEqual(7, state.Users.GetOrAdd(1).Points);
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(1).Rounds.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(7, state.Users.GetOrAdd(1).Points);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(1).Rounds.GetOrAdd(1).Placement);
 
-            Assert.AreEqual(7, state.Users.GetOrAdd(2).Points);
-            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(2).Rounds.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(7, state.Users.GetOrAdd(2).Points);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(2).Rounds.GetOrAdd(1).Placement);
 
-            Assert.AreEqual(5, state.Users.GetOrAdd(3).Points);
-            Assert.AreEqual(3, state.Users.GetOrAdd(3).Placement);
-            Assert.AreEqual(4, state.Users.GetOrAdd(3).Rounds.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(5, state.Users.GetOrAdd(3).Points);
+            ClassicAssert.AreEqual(3, state.Users.GetOrAdd(3).Placement);
+            ClassicAssert.AreEqual(4, state.Users.GetOrAdd(3).Rounds.GetOrAdd(1).Placement);
 
-            Assert.AreEqual(5, state.Users.GetOrAdd(4).Points);
-            Assert.AreEqual(4, state.Users.GetOrAdd(4).Placement);
-            Assert.AreEqual(4, state.Users.GetOrAdd(4).Rounds.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(5, state.Users.GetOrAdd(4).Points);
+            ClassicAssert.AreEqual(4, state.Users.GetOrAdd(4).Placement);
+            ClassicAssert.AreEqual(4, state.Users.GetOrAdd(4).Rounds.GetOrAdd(1).Placement);
         }
 
         [Test]
@@ -121,8 +122,8 @@ namespace osu.Game.Tests.Online.Matchmaking
                 new SoloScoreInfo { UserID = 2, TotalScore = 1000 },
             ], placement_points);
 
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
         }
 
         [Test]
@@ -143,12 +144,12 @@ namespace osu.Game.Tests.Online.Matchmaking
                 new SoloScoreInfo { UserID = 5, TotalScore = 1000 },
             ], placement_points);
 
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
-            Assert.AreEqual(3, state.Users.GetOrAdd(3).Placement);
-            Assert.AreEqual(4, state.Users.GetOrAdd(4).Placement);
-            Assert.AreEqual(5, state.Users.GetOrAdd(5).Placement);
-            Assert.AreEqual(6, state.Users.GetOrAdd(6).Placement);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(3, state.Users.GetOrAdd(3).Placement);
+            ClassicAssert.AreEqual(4, state.Users.GetOrAdd(4).Placement);
+            ClassicAssert.AreEqual(5, state.Users.GetOrAdd(5).Placement);
+            ClassicAssert.AreEqual(6, state.Users.GetOrAdd(6).Placement);
         }
 
         [Test]
@@ -163,20 +164,20 @@ namespace osu.Game.Tests.Online.Matchmaking
                 new SoloScoreInfo { UserID = 2, TotalScore = 500 },
             ], placement_points);
 
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
 
             state.Users.GetOrAdd(1).AbandonedAt = DateTimeOffset.Now;
             state.RecordScores([], placement_points);
 
-            Assert.AreEqual(2, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(1, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(2).Placement);
 
             state.Users.GetOrAdd(2).AbandonedAt = DateTimeOffset.Now - TimeSpan.FromMinutes(1);
             state.RecordScores([], placement_points);
 
-            Assert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
-            Assert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
+            ClassicAssert.AreEqual(1, state.Users.GetOrAdd(1).Placement);
+            ClassicAssert.AreEqual(2, state.Users.GetOrAdd(2).Placement);
         }
     }
 }

--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Online
 
             var converted = deserialized?.ToMod(new TestRuleset());
 
-            ClassicAssert.NotNull(converted);
+            Assert.That(converted, Is.Not.Null);
             Assert.That(converted, Is.TypeOf(typeof(UnknownMod)));
             Assert.That(converted.Type, Is.EqualTo(ModType.System));
             Assert.That(converted.Acronym, Is.EqualTo("WNG??"));

--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -36,7 +37,7 @@ namespace osu.Game.Tests.Online
 
             var converted = deserialized?.ToMod(new TestRuleset());
 
-            Assert.NotNull(converted);
+            ClassicAssert.NotNull(converted);
             Assert.That(converted, Is.TypeOf(typeof(UnknownMod)));
             Assert.That(converted.Type, Is.EqualTo(ModType.System));
             Assert.That(converted.Acronym, Is.EqualTo("WNG??"));
@@ -157,7 +158,7 @@ namespace osu.Game.Tests.Online
 
             mod.TestSetting.Value = mod.TestSetting.Default;
             JObject serialised = JObject.Parse(JsonConvert.SerializeObject(new APIMod(mod)));
-            Assert.False(serialised.ContainsKey("settings"));
+            ClassicAssert.False(serialised.ContainsKey("settings"));
         }
 
         private class TestRuleset : Ruleset

--- a/osu.Game.Tests/Online/TestMultiplayerMessagePackSerialization.cs
+++ b/osu.Game.Tests/Online/TestMultiplayerMessagePackSerialization.cs
@@ -3,6 +3,7 @@
 
 using MessagePack;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
@@ -24,7 +25,7 @@ namespace osu.Game.Tests.Online
 
             var deserialized = MessagePackSerializer.Deserialize<MultiplayerRoom>(serialized);
 
-            Assert.IsTrue(deserialized.MatchState is TeamVersusRoomState);
+            ClassicAssert.True(deserialized.MatchState is TeamVersusRoomState);
         }
 
         [Test]
@@ -35,7 +36,7 @@ namespace osu.Game.Tests.Online
             byte[] serialized = MessagePackSerializer.Serialize(typeof(MatchUserState), state);
             var deserialized = MessagePackSerializer.Deserialize<MatchUserState>(serialized);
 
-            Assert.IsTrue(deserialized is TeamVersusUserState);
+            ClassicAssert.True(deserialized is TeamVersusUserState);
         }
 
         [Test]
@@ -66,7 +67,7 @@ namespace osu.Game.Tests.Online
 
             // works with custom resolver.
             var deserialized = MessagePackSerializer.Deserialize<MatchUserState>(serialized, SignalRUnionWorkaroundResolver.OPTIONS);
-            Assert.IsTrue(deserialized is TeamVersusUserState);
+            ClassicAssert.True(deserialized is TeamVersusUserState);
         }
     }
 }

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Resources
             using (var newFile = File.Create(tempPath))
                 stream.CopyTo(newFile);
 
-            Assert.IsTrue(File.Exists(tempPath));
+            ClassicAssert.True(File.Exists(tempPath));
             return tempPath;
         }
 
@@ -72,7 +72,7 @@ namespace osu.Game.Tests.Resources
             using (var newFile = File.Create(tempPath))
                 stream.CopyTo(newFile);
 
-            Assert.IsTrue(File.Exists(tempPath));
+            ClassicAssert.True(File.Exists(tempPath));
             return tempPath;
         }
 

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
@@ -174,7 +175,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeBonus, HitResult.IgnoreMiss)]
         public void TestMinResults(HitResult hitResult, HitResult expectedMinResult)
         {
-            Assert.AreEqual(expectedMinResult, new TestJudgement(hitResult).MinResult);
+            ClassicAssert.AreEqual(expectedMinResult, new TestJudgement(hitResult).MinResult);
         }
 
         [TestCase(HitResult.None, false)]
@@ -195,7 +196,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeBonus, false)]
         public void TestAffectsCombo(HitResult hitResult, bool expectedReturnValue)
         {
-            Assert.AreEqual(expectedReturnValue, hitResult.AffectsCombo());
+            ClassicAssert.AreEqual(expectedReturnValue, hitResult.AffectsCombo());
         }
 
         [TestCase(HitResult.None, false)]
@@ -216,7 +217,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeBonus, false)]
         public void TestAffectsAccuracy(HitResult hitResult, bool expectedReturnValue)
         {
-            Assert.AreEqual(expectedReturnValue, hitResult.AffectsAccuracy());
+            ClassicAssert.AreEqual(expectedReturnValue, hitResult.AffectsAccuracy());
         }
 
         [TestCase(HitResult.None, false)]
@@ -237,7 +238,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeBonus, true)]
         public void TestIsBonus(HitResult hitResult, bool expectedReturnValue)
         {
-            Assert.AreEqual(expectedReturnValue, hitResult.IsBonus());
+            ClassicAssert.AreEqual(expectedReturnValue, hitResult.IsBonus());
         }
 
         [TestCase(HitResult.None, false)]
@@ -258,7 +259,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeBonus, true)]
         public void TestIsHit(HitResult hitResult, bool expectedReturnValue)
         {
-            Assert.AreEqual(expectedReturnValue, hitResult.IsHit());
+            ClassicAssert.AreEqual(expectedReturnValue, hitResult.IsHit());
         }
 
         [TestCase(HitResult.None, false)]
@@ -279,7 +280,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeBonus, true)]
         public void TestIsScorable(HitResult hitResult, bool expectedReturnValue)
         {
-            Assert.AreEqual(expectedReturnValue, hitResult.IsScorable());
+            ClassicAssert.AreEqual(expectedReturnValue, hitResult.IsScorable());
         }
 
 #pragma warning disable CS0618

--- a/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
+++ b/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Platform;
@@ -57,13 +58,13 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Rank, imported.Rank);
-                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
-                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
-                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
-                    Assert.AreEqual(toImport.Date, imported.Date);
-                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    ClassicAssert.AreEqual(toImport.Rank, imported.Rank);
+                    ClassicAssert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    ClassicAssert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    ClassicAssert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.User.Username);
+                    ClassicAssert.AreEqual(toImport.Date, imported.Date);
+                    ClassicAssert.AreEqual(toImport.OnlineID, imported.OnlineID);
                 }
                 finally
                 {
@@ -110,13 +111,13 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Rank, imported.Rank);
-                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
-                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
-                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
-                    Assert.AreEqual(toImport.Date, imported.Date);
-                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    ClassicAssert.AreEqual(toImport.Rank, imported.Rank);
+                    ClassicAssert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    ClassicAssert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    ClassicAssert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.User.Username);
+                    ClassicAssert.AreEqual(toImport.Date, imported.Date);
+                    ClassicAssert.AreEqual(toImport.OnlineID, imported.OnlineID);
 
                     if (isLocalUser)
                         Assert.That(imported.BeatmapInfo!.LastPlayed, Is.EqualTo(replayDate));
@@ -165,13 +166,13 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Rank, imported.Rank);
-                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
-                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
-                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
-                    Assert.AreEqual(toImport.Date, imported.Date);
-                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    ClassicAssert.AreEqual(toImport.Rank, imported.Rank);
+                    ClassicAssert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    ClassicAssert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    ClassicAssert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.User.Username);
+                    ClassicAssert.AreEqual(toImport.Date, imported.Date);
+                    ClassicAssert.AreEqual(toImport.OnlineID, imported.OnlineID);
 
                     Assert.That(imported.BeatmapInfo!.LastPlayed, Is.EqualTo(new DateTimeOffset(2023, 10, 30, 0, 0, 0, TimeSpan.Zero)));
                 }
@@ -204,8 +205,8 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.IsTrue(imported.Mods.Any(m => m is OsuModHardRock));
-                    Assert.IsTrue(imported.Mods.Any(m => m is OsuModDoubleTime));
+                    ClassicAssert.True(imported.Mods.Any(m => m is OsuModHardRock));
+                    ClassicAssert.True(imported.Mods.Any(m => m is OsuModDoubleTime));
                     Assert.That(imported.ClientVersion, Is.EqualTo(toImport.ClientVersion));
                 }
                 finally
@@ -269,8 +270,8 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Statistics[HitResult.Perfect], imported.Statistics[HitResult.Perfect]);
-                    Assert.AreEqual(toImport.Statistics[HitResult.Miss], imported.Statistics[HitResult.Miss]);
+                    ClassicAssert.AreEqual(toImport.Statistics[HitResult.Perfect], imported.Statistics[HitResult.Perfect]);
+                    ClassicAssert.AreEqual(toImport.Statistics[HitResult.Miss], imported.Statistics[HitResult.Miss]);
                 }
                 finally
                 {
@@ -364,15 +365,15 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Rank, imported.Rank);
-                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
-                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
-                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
-                    Assert.AreEqual(toImport.Date, imported.Date);
-                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
-                    Assert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
-                    Assert.AreEqual(1234, imported.RealmUser.OnlineID);
+                    ClassicAssert.AreEqual(toImport.Rank, imported.Rank);
+                    ClassicAssert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    ClassicAssert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    ClassicAssert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.User.Username);
+                    ClassicAssert.AreEqual(toImport.Date, imported.Date);
+                    ClassicAssert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
+                    ClassicAssert.AreEqual(1234, imported.RealmUser.OnlineID);
                 }
                 finally
                 {
@@ -430,15 +431,15 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Rank, imported.Rank);
-                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
-                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
-                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
-                    Assert.AreEqual(toImport.Date, imported.Date);
-                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
-                    Assert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
-                    Assert.AreEqual(1234, imported.RealmUser.OnlineID);
+                    ClassicAssert.AreEqual(toImport.Rank, imported.Rank);
+                    ClassicAssert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    ClassicAssert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    ClassicAssert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.User.Username);
+                    ClassicAssert.AreEqual(toImport.Date, imported.Date);
+                    ClassicAssert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
+                    ClassicAssert.AreEqual(1234, imported.RealmUser.OnlineID);
                 }
                 finally
                 {
@@ -497,14 +498,14 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Rank, imported.Rank);
-                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
-                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
-                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
-                    Assert.AreEqual(toImport.Date, imported.Date);
-                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
-                    Assert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
+                    ClassicAssert.AreEqual(toImport.Rank, imported.Rank);
+                    ClassicAssert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    ClassicAssert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    ClassicAssert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.User.Username);
+                    ClassicAssert.AreEqual(toImport.Date, imported.Date);
+                    ClassicAssert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    ClassicAssert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
                     Assert.That(imported.RealmUser.OnlineID, Is.LessThanOrEqualTo(1));
                 }
                 finally
@@ -564,15 +565,15 @@ namespace osu.Game.Tests.Scores.IO
 
                     var imported = LoadScoreIntoOsu(osu, toImport);
 
-                    Assert.AreEqual(toImport.Rank, imported.Rank);
-                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
-                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
-                    Assert.AreEqual(toImport.Date, imported.Date);
-                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
-                    Assert.AreEqual("Some other guy", imported.RealmUser.Username);
-                    Assert.AreEqual(5555, imported.RealmUser.OnlineID);
-                    Assert.AreEqual(CountryCode.DE, imported.RealmUser.CountryCode);
+                    ClassicAssert.AreEqual(toImport.Rank, imported.Rank);
+                    ClassicAssert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    ClassicAssert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    ClassicAssert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    ClassicAssert.AreEqual(toImport.Date, imported.Date);
+                    ClassicAssert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    ClassicAssert.AreEqual("Some other guy", imported.RealmUser.Username);
+                    ClassicAssert.AreEqual(5555, imported.RealmUser.OnlineID);
+                    ClassicAssert.AreEqual(CountryCode.DE, imported.RealmUser.CountryCode);
                 }
                 finally
                 {

--- a/osu.Game.Tests/ScrollAlgorithms/ConstantScrollTest.cs
+++ b/osu.Game.Tests/ScrollAlgorithms/ConstantScrollTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Rulesets.UI.Scrolling.Algorithms;
 
 namespace osu.Game.Tests.ScrollAlgorithms
@@ -22,33 +23,33 @@ namespace osu.Game.Tests.ScrollAlgorithms
         [Test]
         public void TestPointDisplayStartTime()
         {
-            Assert.AreEqual(-8000, algorithm.GetDisplayStartTime(2000, 0, 10000, 1));
-            Assert.AreEqual(-3000, algorithm.GetDisplayStartTime(2000, 0, 5000, 1));
-            Assert.AreEqual(2000, algorithm.GetDisplayStartTime(7000, 0, 5000, 1));
-            Assert.AreEqual(7000, algorithm.GetDisplayStartTime(17000, 0, 10000, 1));
+            ClassicAssert.AreEqual(-8000, algorithm.GetDisplayStartTime(2000, 0, 10000, 1));
+            ClassicAssert.AreEqual(-3000, algorithm.GetDisplayStartTime(2000, 0, 5000, 1));
+            ClassicAssert.AreEqual(2000, algorithm.GetDisplayStartTime(7000, 0, 5000, 1));
+            ClassicAssert.AreEqual(7000, algorithm.GetDisplayStartTime(17000, 0, 10000, 1));
         }
 
         [Test]
         public void TestObjectDisplayStartTime()
         {
-            Assert.AreEqual(900, algorithm.GetDisplayStartTime(2000, 50, 1000, 500)); // 2000 - (1 + 50 / 500) * 1000
-            Assert.AreEqual(8900, algorithm.GetDisplayStartTime(10000, 50, 1000, 500)); // 10000 - (1 + 50 / 500) * 1000
-            Assert.AreEqual(13500, algorithm.GetDisplayStartTime(15000, 250, 1000, 500)); // 15000 - (1 + 250 / 500) * 1000
-            Assert.AreEqual(19000, algorithm.GetDisplayStartTime(25000, 100, 5000, 500)); // 25000 - (1 + 100 / 500) * 5000
+            ClassicAssert.AreEqual(900, algorithm.GetDisplayStartTime(2000, 50, 1000, 500)); // 2000 - (1 + 50 / 500) * 1000
+            ClassicAssert.AreEqual(8900, algorithm.GetDisplayStartTime(10000, 50, 1000, 500)); // 10000 - (1 + 50 / 500) * 1000
+            ClassicAssert.AreEqual(13500, algorithm.GetDisplayStartTime(15000, 250, 1000, 500)); // 15000 - (1 + 250 / 500) * 1000
+            ClassicAssert.AreEqual(19000, algorithm.GetDisplayStartTime(25000, 100, 5000, 500)); // 25000 - (1 + 100 / 500) * 5000
         }
 
         [Test]
         public void TestLength()
         {
-            Assert.AreEqual(1f / 5, algorithm.GetLength(0, 1000, 5000, 1));
-            Assert.AreEqual(1f / 5, algorithm.GetLength(6000, 7000, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(0, 1000, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(6000, 7000, 5000, 1));
         }
 
         [Test]
         public void TestPosition()
         {
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(1000, 0, 5000, 1));
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(6000, 5000, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(1000, 0, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(6000, 5000, 5000, 1));
         }
 
         [TestCase(1000)]
@@ -58,8 +59,8 @@ namespace osu.Game.Tests.ScrollAlgorithms
         [TestCase(25000)]
         public void TestTime(double time)
         {
-            Assert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 0, 5000, 1), 0, 5000, 1), 0.001);
-            Assert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 5000, 5000, 1), 5000, 5000, 1), 0.001);
+            ClassicAssert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 0, 5000, 1), 0, 5000, 1), 0.001);
+            ClassicAssert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 5000, 5000, 1), 5000, 5000, 1), 0.001);
         }
     }
 }

--- a/osu.Game.Tests/ScrollAlgorithms/OverlappingScrollTest.cs
+++ b/osu.Game.Tests/ScrollAlgorithms/OverlappingScrollTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Lists;
 using osu.Game.Rulesets.Timing;
 using osu.Game.Rulesets.UI.Scrolling.Algorithms;
@@ -31,37 +32,37 @@ namespace osu.Game.Tests.ScrollAlgorithms
         [Test]
         public void TestPointDisplayStartTime()
         {
-            Assert.AreEqual(1000, algorithm.GetDisplayStartTime(2000, 0, 1000, 1)); // Like constant
-            Assert.AreEqual(10000, algorithm.GetDisplayStartTime(10500, 0, 1000, 1)); // 10500 - (1000 * 0.5)
-            Assert.AreEqual(20000, algorithm.GetDisplayStartTime(22000, 0, 1000, 1)); // 23000 - (1000 / 0.5)
+            ClassicAssert.AreEqual(1000, algorithm.GetDisplayStartTime(2000, 0, 1000, 1)); // Like constant
+            ClassicAssert.AreEqual(10000, algorithm.GetDisplayStartTime(10500, 0, 1000, 1)); // 10500 - (1000 * 0.5)
+            ClassicAssert.AreEqual(20000, algorithm.GetDisplayStartTime(22000, 0, 1000, 1)); // 23000 - (1000 / 0.5)
         }
 
         [Test]
         public void TestObjectDisplayStartTime()
         {
-            Assert.AreEqual(900, algorithm.GetDisplayStartTime(2000, 50, 1000, 500)); // 2000 - (1 + 50 / 500) * 1000 / 1
-            Assert.AreEqual(9450, algorithm.GetDisplayStartTime(10000, 50, 1000, 500)); // 10000 - (1 + 50 / 500) * 1000 / 2
-            Assert.AreEqual(14250, algorithm.GetDisplayStartTime(15000, 250, 1000, 500)); // 15000 - (1 + 250 / 500) * 1000 / 2
-            Assert.AreEqual(16500, algorithm.GetDisplayStartTime(18000, 250, 2000, 500)); // 18000 - (1 + 250 / 500) * 2000 / 2
-            Assert.AreEqual(17800, algorithm.GetDisplayStartTime(20000, 50, 1000, 500)); // 20000 - (1 + 50 / 500) * 1000 / 0.5
-            Assert.AreEqual(19800, algorithm.GetDisplayStartTime(22000, 50, 1000, 500)); // 22000 - (1 + 50 / 500) * 1000 / 0.5
+            ClassicAssert.AreEqual(900, algorithm.GetDisplayStartTime(2000, 50, 1000, 500)); // 2000 - (1 + 50 / 500) * 1000 / 1
+            ClassicAssert.AreEqual(9450, algorithm.GetDisplayStartTime(10000, 50, 1000, 500)); // 10000 - (1 + 50 / 500) * 1000 / 2
+            ClassicAssert.AreEqual(14250, algorithm.GetDisplayStartTime(15000, 250, 1000, 500)); // 15000 - (1 + 250 / 500) * 1000 / 2
+            ClassicAssert.AreEqual(16500, algorithm.GetDisplayStartTime(18000, 250, 2000, 500)); // 18000 - (1 + 250 / 500) * 2000 / 2
+            ClassicAssert.AreEqual(17800, algorithm.GetDisplayStartTime(20000, 50, 1000, 500)); // 20000 - (1 + 50 / 500) * 1000 / 0.5
+            ClassicAssert.AreEqual(19800, algorithm.GetDisplayStartTime(22000, 50, 1000, 500)); // 22000 - (1 + 50 / 500) * 1000 / 0.5
         }
 
         [Test]
         public void TestLength()
         {
-            Assert.AreEqual(1f / 5, algorithm.GetLength(0, 1000, 5000, 1)); // Like constant
-            Assert.AreEqual(1f / 5, algorithm.GetLength(10000, 10500, 5000, 1)); // (10500 - 10000) / 0.5 / 5000
-            Assert.AreEqual(1f / 5, algorithm.GetLength(20000, 22000, 5000, 1)); // (22000 - 20000) * 0.5 / 5000
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(0, 1000, 5000, 1)); // Like constant
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(10000, 10500, 5000, 1)); // (10500 - 10000) / 0.5 / 5000
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(20000, 22000, 5000, 1)); // (22000 - 20000) * 0.5 / 5000
         }
 
         [Test]
         public void TestPosition()
         {
             // Basically same calculations as TestLength()
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(1000, 0, 5000, 1));
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(10500, 10000, 5000, 1));
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(22000, 20000, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(1000, 0, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(10500, 10000, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(22000, 20000, 5000, 1));
         }
 
         [TestCase(1000)]
@@ -73,8 +74,8 @@ namespace osu.Game.Tests.ScrollAlgorithms
                 + "Ideally, scrolling should be changed to constant or sequential during editing of hitobjects.")]
         public void TestTime(double time)
         {
-            Assert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 0, 5000, 1), 0, 5000, 1), 0.001);
-            Assert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 5000, 5000, 1), 5000, 5000, 1), 0.001);
+            ClassicAssert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 0, 5000, 1), 0, 5000, 1), 0.001);
+            ClassicAssert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 5000, 5000, 1), 5000, 5000, 1), 0.001);
         }
     }
 }

--- a/osu.Game.Tests/ScrollAlgorithms/SequentialScrollTest.cs
+++ b/osu.Game.Tests/ScrollAlgorithms/SequentialScrollTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Lists;
 using osu.Game.Rulesets.Timing;
 using osu.Game.Rulesets.UI.Scrolling.Algorithms;
@@ -32,9 +33,9 @@ namespace osu.Game.Tests.ScrollAlgorithms
         public void TestDisplayStartTime()
         {
             // easy cases - time range adjusted for velocity fits within control point duration
-            Assert.AreEqual(2500, algorithm.GetDisplayStartTime(5000, 0, 2500, 1)); // 5000 - (2500 / 1)
-            Assert.AreEqual(13750, algorithm.GetDisplayStartTime(15000, 0, 2500, 1)); // 15000 - (2500 / 2)
-            Assert.AreEqual(20000, algorithm.GetDisplayStartTime(25000, 0, 2500, 1)); // 25000 - (2500 / 0.5)
+            ClassicAssert.AreEqual(2500, algorithm.GetDisplayStartTime(5000, 0, 2500, 1)); // 5000 - (2500 / 1)
+            ClassicAssert.AreEqual(13750, algorithm.GetDisplayStartTime(15000, 0, 2500, 1)); // 15000 - (2500 / 2)
+            ClassicAssert.AreEqual(20000, algorithm.GetDisplayStartTime(25000, 0, 2500, 1)); // 25000 - (2500 / 0.5)
 
             // hard case - time range adjusted for velocity exceeds control point duration
 
@@ -46,24 +47,24 @@ namespace osu.Game.Tests.ScrollAlgorithms
             // minus one scroll length allowance = 12500 - 1000 = 11500 = 11.5 [scroll lengths]
             // therefore the start time lies within the second multiplier point (because 11.5 < 4 + 8)
             // its exact time position is = 10000 + 7.5 * (2500 / 2) = 19375
-            Assert.AreEqual(19375, algorithm.GetDisplayStartTime(22500, 0, 2500, 1000));
+            ClassicAssert.AreEqual(19375, algorithm.GetDisplayStartTime(22500, 0, 2500, 1000));
         }
 
         [Test]
         public void TestLength()
         {
-            Assert.AreEqual(1f / 5, algorithm.GetLength(0, 1000, 5000, 1)); // Like constant
-            Assert.AreEqual(1f / 5, algorithm.GetLength(10000, 10500, 5000, 1)); // (10500 - 10000) / 0.5 / 5000
-            Assert.AreEqual(1f / 5, algorithm.GetLength(20000, 22000, 5000, 1)); // (22000 - 20000) * 0.5 / 5000
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(0, 1000, 5000, 1)); // Like constant
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(10000, 10500, 5000, 1)); // (10500 - 10000) / 0.5 / 5000
+            ClassicAssert.AreEqual(1f / 5, algorithm.GetLength(20000, 22000, 5000, 1)); // (22000 - 20000) * 0.5 / 5000
         }
 
         [Test]
         public void TestPosition()
         {
             // Basically same calculations as TestLength()
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(1000, 0, 5000, 1));
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(10500, 10000, 5000, 1));
-            Assert.AreEqual(1f / 5, algorithm.PositionAt(22000, 20000, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(1000, 0, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(10500, 10000, 5000, 1));
+            ClassicAssert.AreEqual(1f / 5, algorithm.PositionAt(22000, 20000, 5000, 1));
         }
 
         [TestCase(1000)]
@@ -73,8 +74,8 @@ namespace osu.Game.Tests.ScrollAlgorithms
         [TestCase(25000)]
         public void TestTime(double time)
         {
-            Assert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 0, 5000, 1), 0, 5000, 1), 0.001);
-            Assert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 5000, 5000, 1), 5000, 5000, 1), 0.001);
+            ClassicAssert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 0, 5000, 1), 0, 5000, 1), 0.001);
+            ClassicAssert.AreEqual(time, algorithm.TimeAt(algorithm.PositionAt(time, 5000, 5000, 1), 5000, 5000, 1), 0.001);
         }
     }
 }

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Game.Database;
@@ -243,21 +244,21 @@ namespace osu.Game.Tests.Skins.IO
 
             await skinManager.CurrentSkinInfo.Value.PerformRead(async s =>
             {
-                Assert.IsFalse(s.Protected);
-                Assert.AreEqual(typeof(ArgonSkin), s.CreateInstance(skinManager).GetType());
+                ClassicAssert.False(s.Protected);
+                ClassicAssert.AreEqual(typeof(ArgonSkin), s.CreateInstance(skinManager).GetType());
 
                 await new LegacySkinExporter(osu.Dependencies.Get<Storage>()).ExportToStreamAsync(skinManager.CurrentSkinInfo.Value, exportStream);
 
-                Assert.Greater(exportStream.Length, 0);
+                ClassicAssert.Greater(exportStream.Length, 0);
             });
 
             var imported = await skinManager.Import(new ImportTask(exportStream, "exported.osk"));
 
             imported.PerformRead(s =>
             {
-                Assert.IsFalse(s.Protected);
-                Assert.AreNotEqual(originalSkinId, s.ID);
-                Assert.AreEqual(typeof(ArgonSkin), s.CreateInstance(skinManager).GetType());
+                ClassicAssert.False(s.Protected);
+                ClassicAssert.AreNotEqual(originalSkinId, s.ID);
+                ClassicAssert.AreEqual(typeof(ArgonSkin), s.CreateInstance(skinManager).GetType());
             });
         });
 
@@ -276,21 +277,21 @@ namespace osu.Game.Tests.Skins.IO
 
             await skinManager.CurrentSkinInfo.Value.PerformRead(async s =>
             {
-                Assert.IsFalse(s.Protected);
-                Assert.AreEqual(typeof(DefaultLegacySkin), s.CreateInstance(skinManager).GetType());
+                ClassicAssert.False(s.Protected);
+                ClassicAssert.AreEqual(typeof(DefaultLegacySkin), s.CreateInstance(skinManager).GetType());
 
                 await new LegacySkinExporter(osu.Dependencies.Get<Storage>()).ExportToStreamAsync(skinManager.CurrentSkinInfo.Value, exportStream);
 
-                Assert.Greater(exportStream.Length, 0);
+                ClassicAssert.Greater(exportStream.Length, 0);
             });
 
             var imported = await skinManager.Import(new ImportTask(exportStream, "exported.osk"));
 
             imported.PerformRead(s =>
             {
-                Assert.IsFalse(s.Protected);
-                Assert.AreNotEqual(originalSkinId, s.ID);
-                Assert.AreEqual(typeof(DefaultLegacySkin), s.CreateInstance(skinManager).GetType());
+                ClassicAssert.False(s.Protected);
+                ClassicAssert.AreNotEqual(originalSkinId, s.ID);
+                ClassicAssert.AreEqual(typeof(DefaultLegacySkin), s.CreateInstance(skinManager).GetType());
             });
         });
 

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -15,6 +15,8 @@ using osu.Game.IO;
 using osu.Game.Skinning;
 using osu.Game.Tests.Resources;
 using SharpCompress.Archives.Zip;
+using SharpCompress.Common;
+using SharpCompress.Writers.Zip;
 
 namespace osu.Game.Tests.Skins.IO
 {
@@ -304,9 +306,9 @@ namespace osu.Game.Tests.Skins.IO
                     var osu = LoadOsuIntoHost(host);
 
                     var zipStream = new MemoryStream();
-                    using var zip = ZipArchive.Create();
-                    zip.AddEntry("folder/test.png", new MemoryStream(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }));
-                    zip.SaveTo(zipStream);
+                    using var zip = ZipArchive.CreateArchive();
+                    zip.AddEntry("folder/test.png", new MemoryStream(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }), true);
+                    zip.SaveTo(zipStream, new ZipWriterOptions(CompressionType.Deflate));
 
                     var import = await loadSkinIntoOsu(osu, new ImportTask(zipStream, "test skin.osk"));
 
@@ -353,9 +355,9 @@ namespace osu.Game.Tests.Skins.IO
                     var osu = LoadOsuIntoHost(host);
 
                     var zipStream = new MemoryStream();
-                    using var zip = ZipArchive.Create();
-                    zip.AddEntry("test?.png", new MemoryStream(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }));
-                    zip.SaveTo(zipStream);
+                    using var zip = ZipArchive.CreateArchive();
+                    zip.AddEntry("test?.png", new MemoryStream(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }), true);
+                    zip.SaveTo(zipStream, new ZipWriterOptions(CompressionType.Deflate));
 
                     var import = await loadSkinIntoOsu(osu, new ImportTask(zipStream, "test skin.osk"));
 
@@ -419,26 +421,26 @@ namespace osu.Game.Tests.Skins.IO
         private MemoryStream createEmptyOsk()
         {
             var zipStream = new MemoryStream();
-            using var zip = ZipArchive.Create();
-            zip.SaveTo(zipStream);
+            using var zip = ZipArchive.CreateArchive();
+            zip.SaveTo(zipStream, new ZipWriterOptions(CompressionType.Deflate));
             return zipStream;
         }
 
         private MemoryStream createOskWithNonIniFile()
         {
             var zipStream = new MemoryStream();
-            using var zip = ZipArchive.Create();
-            zip.AddEntry("hitcircle.png", new MemoryStream(new byte[] { 0, 1, 2, 3 }));
-            zip.SaveTo(zipStream);
+            using var zip = ZipArchive.CreateArchive();
+            zip.AddEntry("hitcircle.png", new MemoryStream(new byte[] { 0, 1, 2, 3 }), true);
+            zip.SaveTo(zipStream, new ZipWriterOptions(CompressionType.Deflate));
             return zipStream;
         }
 
         private MemoryStream createOskWithIni(string name, string author, bool makeUnique = false, string iniFilename = @"skin.ini", bool includeSectionHeader = true)
         {
             var zipStream = new MemoryStream();
-            using var zip = ZipArchive.Create();
-            zip.AddEntry(iniFilename, generateSkinIni(name, author, makeUnique, includeSectionHeader));
-            zip.SaveTo(zipStream);
+            using var zip = ZipArchive.CreateArchive();
+            zip.AddEntry(iniFilename, generateSkinIni(name, author, makeUnique, includeSectionHeader), true);
+            zip.SaveTo(zipStream, new ZipWriterOptions(CompressionType.Deflate));
             return zipStream;
         }
 

--- a/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Skins
 
                 ClassicAssert.AreEqual(expectedColors.Count, comboColors?.Count);
                 for (int i = 0; i < expectedColors.Count; i++)
-                    ClassicAssert.AreEqual(expectedColors[i], comboColors[i]);
+                    ClassicAssert.AreEqual(expectedColors[i], comboColors![i]);
             }
         }
 
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Skins
 
                 ClassicAssert.AreEqual(expectedColors.Count, comboColors?.Count);
                 for (int i = 0; i < expectedColors.Count; i++)
-                    ClassicAssert.AreEqual(expectedColors[i], comboColors[i]);
+                    ClassicAssert.AreEqual(expectedColors[i], comboColors![i]);
             }
         }
 

--- a/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.IO;
 using osu.Game.Skinning;
 using osu.Game.Tests.Resources;
@@ -32,9 +33,9 @@ namespace osu.Game.Tests.Skins
                     new Color4(100, 100, 100, 255), // alpha is specified as 100, but should be ignored.
                 };
 
-                Assert.AreEqual(expectedColors.Count, comboColors?.Count);
+                ClassicAssert.AreEqual(expectedColors.Count, comboColors?.Count);
                 for (int i = 0; i < expectedColors.Count; i++)
-                    Assert.AreEqual(expectedColors[i], comboColors[i]);
+                    ClassicAssert.AreEqual(expectedColors[i], comboColors[i]);
             }
         }
 
@@ -49,9 +50,9 @@ namespace osu.Game.Tests.Skins
                 var comboColors = decoder.Decode(stream).ComboColours;
                 var expectedColors = SkinConfiguration.DefaultComboColours;
 
-                Assert.AreEqual(expectedColors.Count, comboColors?.Count);
+                ClassicAssert.AreEqual(expectedColors.Count, comboColors?.Count);
                 for (int i = 0; i < expectedColors.Count; i++)
-                    Assert.AreEqual(expectedColors[i], comboColors[i]);
+                    ClassicAssert.AreEqual(expectedColors[i], comboColors[i]);
             }
         }
 
@@ -65,7 +66,7 @@ namespace osu.Game.Tests.Skins
             {
                 var skinConfiguration = decoder.Decode(stream);
                 skinConfiguration.AllowDefaultComboColoursFallback = false;
-                Assert.IsNull(skinConfiguration.ComboColours);
+                ClassicAssert.Null(skinConfiguration.ComboColours);
             }
         }
 
@@ -79,8 +80,8 @@ namespace osu.Game.Tests.Skins
             {
                 var config = decoder.Decode(stream);
 
-                Assert.AreEqual("test skin", config.SkinInfo.Name);
-                Assert.AreEqual("TestValue", config.ConfigDictionary["TestLookup"]);
+                ClassicAssert.AreEqual("test skin", config.SkinInfo.Name);
+                ClassicAssert.AreEqual("TestValue", config.ConfigDictionary["TestLookup"]);
             }
         }
 
@@ -90,7 +91,7 @@ namespace osu.Game.Tests.Skins
             var decoder = new LegacySkinDecoder();
             using (var resStream = TestResources.OpenResource("skin-20.ini"))
             using (var stream = new LineBufferedReader(resStream))
-                Assert.AreEqual(2.0m, decoder.Decode(stream).LegacyVersion);
+                ClassicAssert.AreEqual(2.0m, decoder.Decode(stream).LegacyVersion);
         }
 
         [Test]
@@ -99,7 +100,7 @@ namespace osu.Game.Tests.Skins
             var decoder = new LegacySkinDecoder();
             using (var resStream = TestResources.OpenResource("skin-with-space.ini"))
             using (var stream = new LineBufferedReader(resStream))
-                Assert.AreEqual(2.0m, decoder.Decode(stream).LegacyVersion);
+                ClassicAssert.AreEqual(2.0m, decoder.Decode(stream).LegacyVersion);
         }
 
         [Test]
@@ -108,7 +109,7 @@ namespace osu.Game.Tests.Skins
             var decoder = new LegacySkinDecoder();
             using (var resStream = TestResources.OpenResource("skin-latest.ini"))
             using (var stream = new LineBufferedReader(resStream))
-                Assert.AreEqual(SkinConfiguration.LATEST_VERSION, decoder.Decode(stream).LegacyVersion);
+                ClassicAssert.AreEqual(SkinConfiguration.LATEST_VERSION, decoder.Decode(stream).LegacyVersion);
         }
 
         [Test]

--- a/osu.Game.Tests/Skins/TestSceneSkinResources.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinResources.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Tests.Skins
                 mockResourceStore = new Mock<IResourceStore<byte[]>>();
                 mockResourceStore.Setup(r => r.Get(It.IsAny<string>()))
                                  .Callback<string>(n => lookedUpFileNames.Add(n))
-                                 .Returns<byte>(null);
+                                 .Returns<byte>(null!);
             });
 
             AddStep("query sample", () =>

--- a/osu.Game.Tests/Utils/NamingUtilsTest.cs
+++ b/osu.Game.Tests/Utils/NamingUtilsTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Utils;
 
 namespace osu.Game.Tests.Utils
@@ -15,7 +16,7 @@ namespace osu.Game.Tests.Utils
         {
             string nextBestName = NamingUtils.GetNextBestName(Enumerable.Empty<string>(), "New Difficulty");
 
-            Assert.AreEqual("New Difficulty", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty", nextBestName);
         }
 
         [Test]
@@ -30,7 +31,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
 
-            Assert.AreEqual("New Difficulty", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty", nextBestName);
         }
 
         [Test]
@@ -45,7 +46,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
 
-            Assert.AreEqual("New Difficulty", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty", nextBestName);
         }
 
         [Test]
@@ -58,7 +59,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
 
-            Assert.AreEqual("New Difficulty (1)", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty (1)", nextBestName);
         }
 
         [Test]
@@ -71,7 +72,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
 
-            Assert.AreEqual("New Difficulty (1)", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty (1)", nextBestName);
         }
 
         [Test]
@@ -84,7 +85,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty (copy)");
 
-            Assert.AreEqual("New Difficulty (copy) (1)", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty (copy) (1)", nextBestName);
         }
 
         [Test]
@@ -100,7 +101,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
 
-            Assert.AreEqual("New Difficulty (4)", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty (4)", nextBestName);
         }
 
         [Test]
@@ -110,7 +111,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
 
-            Assert.AreEqual("New Difficulty (31)", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty (31)", nextBestName);
         }
 
         [Test]
@@ -126,7 +127,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
 
-            Assert.AreEqual("New Difficulty (2)", nextBestName);
+            ClassicAssert.AreEqual("New Difficulty (2)", nextBestName);
         }
 
         [Test]
@@ -134,7 +135,7 @@ namespace osu.Game.Tests.Utils
         {
             string nextBestFilename = NamingUtils.GetNextBestFilename(Enumerable.Empty<string>(), "test_file.osr");
 
-            Assert.AreEqual("test_file.osr", nextBestFilename);
+            ClassicAssert.AreEqual("test_file.osr", nextBestFilename);
         }
 
         [Test]
@@ -149,7 +150,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "test_file.osr");
 
-            Assert.AreEqual("test_file.osr", nextBestFilename);
+            ClassicAssert.AreEqual("test_file.osr", nextBestFilename);
         }
 
         [Test]
@@ -164,7 +165,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.osr");
 
-            Assert.AreEqual("replay_file.osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file.osr", nextBestFilename);
         }
 
         [Test]
@@ -177,7 +178,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.osr");
 
-            Assert.AreEqual("replay_file (1).osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (1).osr", nextBestFilename);
         }
 
         [Test]
@@ -191,7 +192,7 @@ namespace osu.Game.Tests.Utils
             };
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.osr");
-            Assert.AreEqual("replay_file (3).osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (3).osr", nextBestFilename);
         }
 
         [Test]
@@ -204,10 +205,10 @@ namespace osu.Game.Tests.Utils
             };
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.osr");
-            Assert.AreEqual("replay_file (1).osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (1).osr", nextBestFilename);
 
             nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file (copy).osr");
-            Assert.AreEqual("replay_file (copy) (1).osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (copy) (1).osr", nextBestFilename);
         }
 
         [Test]
@@ -223,7 +224,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.osr");
 
-            Assert.AreEqual("replay_file (4).osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (4).osr", nextBestFilename);
         }
 
         [Test]
@@ -240,7 +241,7 @@ namespace osu.Game.Tests.Utils
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.osr");
 
-            Assert.AreEqual("replay_file (3).osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (3).osr", nextBestFilename);
         }
 
         [Test]
@@ -254,10 +255,10 @@ namespace osu.Game.Tests.Utils
             };
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "surely");
-            Assert.AreEqual("surely", nextBestFilename);
+            ClassicAssert.AreEqual("surely", nextBestFilename);
 
             nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "those");
-            Assert.AreEqual("those (1)", nextBestFilename);
+            ClassicAssert.AreEqual("those (1)", nextBestFilename);
         }
 
         [Test]
@@ -271,10 +272,10 @@ namespace osu.Game.Tests.Utils
             };
 
             string nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.osr");
-            Assert.AreEqual("replay_file (2).osr", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (2).osr", nextBestFilename);
 
             nextBestFilename = NamingUtils.GetNextBestFilename(existingFiles, "replay_file.txt");
-            Assert.AreEqual("replay_file (1).txt", nextBestFilename);
+            ClassicAssert.AreEqual("replay_file (1).txt", nextBestFilename);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
@@ -662,11 +663,11 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
 
-            AddStep("aspect ratio does not equal", () => Assert.AreNotEqual(aspectRatioBeforeDrag, getAspectRatio()));
+            AddStep("aspect ratio does not equal", () => ClassicAssert.AreNotEqual(aspectRatioBeforeDrag, getAspectRatio()));
 
             AddStep("press shift", () => InputManager.PressKey(Key.ShiftLeft));
 
-            AddStep("aspect ratio does equal", () => Assert.AreEqual(aspectRatioBeforeDrag, getAspectRatio()));
+            AddStep("aspect ratio does equal", () => ClassicAssert.AreEqual(aspectRatioBeforeDrag, getAspectRatio()));
 
             AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
 
@@ -701,11 +702,11 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
 
-            AddStep("center does not equal", () => Assert.AreNotEqual(centerBeforeDrag, getCenter()));
+            AddStep("center does not equal", () => ClassicAssert.AreNotEqual(centerBeforeDrag, getCenter()));
 
             AddStep("press alt", () => InputManager.PressKey(Key.AltLeft));
 
-            AddStep("center does equal", () => Assert.AreEqual(centerBeforeDrag, getCenter()));
+            AddStep("center does equal", () => ClassicAssert.AreEqual(centerBeforeDrag, getCenter()));
 
             AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
 
@@ -745,19 +746,19 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
 
-            AddStep("aspect ratio does not equal", () => Assert.AreNotEqual(aspectRatioBeforeDrag, getAspectRatio()));
+            AddStep("aspect ratio does not equal", () => ClassicAssert.AreNotEqual(aspectRatioBeforeDrag, getAspectRatio()));
 
-            AddStep("center does not equal", () => Assert.AreNotEqual(centerBeforeDrag, getCenter()));
+            AddStep("center does not equal", () => ClassicAssert.AreNotEqual(centerBeforeDrag, getCenter()));
 
             AddStep("press shift", () => InputManager.PressKey(Key.ShiftLeft));
 
-            AddStep("aspect ratio does equal", () => Assert.AreEqual(aspectRatioBeforeDrag, getAspectRatio()));
+            AddStep("aspect ratio does equal", () => ClassicAssert.AreEqual(aspectRatioBeforeDrag, getAspectRatio()));
 
-            AddStep("center does not equal", () => Assert.AreNotEqual(centerBeforeDrag, getCenter()));
+            AddStep("center does not equal", () => ClassicAssert.AreNotEqual(centerBeforeDrag, getCenter()));
 
             AddStep("press alt", () => InputManager.PressKey(Key.AltLeft));
 
-            AddStep("center does equal", () => Assert.AreEqual(centerBeforeDrag, getCenter()));
+            AddStep("center does equal", () => ClassicAssert.AreEqual(centerBeforeDrag, getCenter()));
 
             AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -881,7 +881,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             try
             {
-                using (var zip = ZipArchive.Open(temp))
+                using (var zip = ZipArchive.OpenArchive(temp))
                     zip.WriteToDirectory(extractedFolder);
 
                 return func(extractedFolder);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for frame starvation", () => replayHandler.WaitingForFrame);
             checkPaused(true);
 
-            AddAssert("time advanced", () => currentFrameStableTime, () => Is.GreaterThan(pausedTime));
+            AddAssert("time advanced", () => currentFrameStableTime, () => Is.GreaterThan(pausedTime!));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -142,7 +143,7 @@ namespace osu.Game.Tests.Visual.Online
             AddRepeatStep("check background", () =>
             {
                 // +1 because the day separator take one index
-                Assert.AreEqual((checkCount + 1) % 2 == 0, drawableChannel.ChildrenOfType<ChatLine>().ToList()[checkCount].AlternatingBackground);
+                ClassicAssert.AreEqual((checkCount + 1) % 2 == 0, drawableChannel.ChildrenOfType<ChatLine>().ToList()[checkCount].AlternatingBackground);
                 checkCount++;
             }, 10);
         }

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.TestProject.props" />
   <ItemGroup Label="Package References">
-    <PackageReference Include="Bogus" Version="35.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="DeepEqual" Version="4.2.1" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="DeepEqual" Version="5.1.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -3,7 +3,6 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="DeepEqual" Version="5.1.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -38,8 +39,8 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
                     WaitForOrAssert(() => (ipc = osu.Dependencies.Get<MatchIPCInfo>() as FileBasedIPC)?.IsLoaded == true, @"ipc could not be populated in a reasonable amount of time");
 
-                    Assert.True(ipc!.SetIPCLocation(testStableInstallDirectory));
-                    Assert.True(storage.AllTournaments.Exists("stable.json"));
+                    ClassicAssert.True(ipc!.SetIPCLocation(testStableInstallDirectory));
+                    ClassicAssert.True(storage.AllTournaments.Exists("stable.json"));
                 }
                 finally
                 {

--- a/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Platform;
 
 namespace osu.Game.Tournament.Tests.NonVisual
@@ -27,7 +28,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 while (!result()) Thread.Sleep(200);
             });
 
-            Assert.IsTrue(task.Wait(timeout), failureMessage);
+            ClassicAssert.True(task.Wait(timeout), failureMessage);
         }
     }
 }

--- a/osu.Game.Tournament.Tests/osu.Game.Tournament.Tests.csproj
+++ b/osu.Game.Tournament.Tests/osu.Game.Tournament.Tests.csproj
@@ -4,9 +4,9 @@
     <StartupObject>osu.Game.Tournament.Tests.TournamentTestRunner</StartupObject>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -205,7 +205,7 @@ namespace osu.Game.Beatmaps
                         // ensure to clobber any and all existing data to avoid accidental corruption.
                         outStream.SetLength(0);
 
-                        using (var bz2 = new BZip2Stream(stream, CompressionMode.Decompress, false))
+                        using (var bz2 = BZip2Stream.Create(stream, CompressionMode.Decompress, false))
                             bz2.CopyTo(outStream);
                     }
 

--- a/osu.Game/Database/LegacyArchiveExporter.cs
+++ b/osu.Game/Database/LegacyArchiveExporter.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Database
         {
             var zipWriterOptions = new ZipWriterOptions(CompressionType.Deflate)
             {
-                ArchiveEncoding = UseFixedEncoding ? ZipArchiveReader.DEFAULT_ENCODING : new ArchiveEncoding(Encoding.UTF8, Encoding.UTF8)
+                ArchiveEncoding = UseFixedEncoding ? ZipArchiveReader.DEFAULT_ENCODING : new ArchiveEncoding { Default = Encoding.UTF8, Password = Encoding.UTF8 }
             };
 
             using (var writer = new ZipWriter(outputStream, zipWriterOptions))

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using AutoMapper;
 using AutoMapper.Internal;
-using Microsoft.Extensions.Logging.Abstractions;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
@@ -98,7 +97,7 @@ namespace osu.Game.Database
                         m.Ignore();
                 });
             });
-        }, new NullLoggerFactory()).CreateMapper();
+        }).CreateMapper();
 
         private static readonly IMapper mapper = new MapperConfiguration(c =>
         {
@@ -128,7 +127,7 @@ namespace osu.Game.Database
                      }
                  }
              });
-        }, new NullLoggerFactory()).CreateMapper();
+        }).CreateMapper();
 
         /// <summary>
         /// A slightly optimised mapper that avoids double-fetches in cyclic reference.
@@ -151,7 +150,7 @@ namespace osu.Game.Database
              .MaxDepth(1)
              // This is not required as it will be populated in the `AfterMap` call from the `BeatmapInfo`'s parent.
              .ForMember(b => b.BeatmapSet, cc => cc.Ignore());
-        }, new NullLoggerFactory()).CreateMapper();
+        }).CreateMapper();
 
         private static void applyCommonConfiguration(IMapperConfigurationExpression c)
         {

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using AutoMapper;
 using AutoMapper.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
@@ -97,7 +98,7 @@ namespace osu.Game.Database
                         m.Ignore();
                 });
             });
-        }).CreateMapper();
+        }, new NullLoggerFactory()).CreateMapper();
 
         private static readonly IMapper mapper = new MapperConfiguration(c =>
         {
@@ -127,7 +128,7 @@ namespace osu.Game.Database
                      }
                  }
              });
-        }).CreateMapper();
+        }, new NullLoggerFactory()).CreateMapper();
 
         /// <summary>
         /// A slightly optimised mapper that avoids double-fetches in cyclic reference.
@@ -150,7 +151,7 @@ namespace osu.Game.Database
              .MaxDepth(1)
              // This is not required as it will be populated in the `AfterMap` call from the `BeatmapInfo`'s parent.
              .ForMember(b => b.BeatmapSet, cc => cc.Ignore());
-        }).CreateMapper();
+        }, new NullLoggerFactory()).CreateMapper();
 
         private static void applyCommonConfiguration(IMapperConfigurationExpression c)
         {
@@ -299,7 +300,7 @@ namespace osu.Game.Database
                 throw new InvalidOperationException($"Make sure to call {nameof(RealmAccess)}.{nameof(RealmAccess.RegisterForNotifications)}");
 
             bool initial = true;
-            return collection.SubscribeForNotifications(((sender, changes) =>
+            return collection.SubscribeForNotifications((sender, changes) =>
             {
                 if (initial)
                 {
@@ -315,7 +316,7 @@ namespace osu.Game.Database
                 }
 
                 callback(sender, changes);
-            }));
+            });
         }
 
         /// <summary>

--- a/osu.Game/IO/Archives/ZipArchiveReader.cs
+++ b/osu.Game/IO/Archives/ZipArchiveReader.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Microsoft.Toolkit.HighPerformance;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
+using SharpCompress.Archives;
 using SharpCompress.Archives.Zip;
 using SharpCompress.Common;
 using SharpCompress.Readers;
@@ -28,14 +29,18 @@ namespace osu.Game.IO.Archives
         public static readonly ArchiveEncoding DEFAULT_ENCODING;
 
         private readonly Stream archiveStream;
-        private readonly ZipArchive archive;
+        private readonly IWritableArchive archive;
 
         static ZipArchiveReader()
         {
             // Required to support rare code pages.
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
-            DEFAULT_ENCODING = new ArchiveEncoding(Encoding.GetEncoding(932), Encoding.GetEncoding(932));
+            DEFAULT_ENCODING = new ArchiveEncoding
+            {
+                Default = Encoding.GetEncoding(932),
+                Password = Encoding.GetEncoding(932),
+            };
         }
 
         public ZipArchiveReader(Stream archiveStream, string name = null)
@@ -43,7 +48,7 @@ namespace osu.Game.IO.Archives
         {
             this.archiveStream = archiveStream;
 
-            archive = ZipArchive.Open(archiveStream, new ReaderOptions
+            archive = ZipArchive.OpenArchive(archiveStream, new ReaderOptions
             {
                 ArchiveEncoding = DEFAULT_ENCODING
             });
@@ -51,7 +56,7 @@ namespace osu.Game.IO.Archives
 
         public override Stream GetStream(string name)
         {
-            ZipArchiveEntry entry = archive.Entries.SingleOrDefault(e => e.Key == name);
+            IArchiveEntry entry = archive.Entries.SingleOrDefault(e => e.Key == name);
             if (entry == null)
                 return null;
 

--- a/osu.Game/Online/Multiplayer/ServerShutdownNotification.cs
+++ b/osu.Game/Online/Multiplayer/ServerShutdownNotification.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using Humanizer.Localisation;
+using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Threading;
 using osu.Game.Localisation;

--- a/osu.Game/Online/Multiplayer/ServerShutdownNotification.cs
+++ b/osu.Game/Online/Multiplayer/ServerShutdownNotification.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using Humanizer;
+using Humanizer.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Threading;
 using osu.Game.Localisation;

--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
-using Humanizer.Localisation;
 using osu.Game.Rulesets;
 using osu.Game.Utils;
 

--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
+using Humanizer.Localisation;
 using osu.Game.Rulesets;
 using osu.Game.Utils;
 

--- a/osu.Game/Overlays/Settings/Sections/General/QuickActionSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/QuickActionSettings.cs
@@ -16,6 +16,8 @@ using osu.Game.Online.Chat;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Utils;
 using SharpCompress.Archives.Zip;
+using SharpCompress.Common;
+using SharpCompress.Writers.Zip;
 
 namespace osu.Game.Overlays.Settings.Sections.General
 {
@@ -93,12 +95,12 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 var logStorage = Logger.Storage;
 
                 using (var outStream = exportStorage.CreateFileSafely(archive_filename))
-                using (var zip = ZipArchive.Create())
+                using (var zip = ZipArchive.CreateArchive())
                 {
                     foreach (string? f in logStorage.GetFiles(string.Empty, "*.log"))
                         FileUtils.AttemptOperation(z => z.AddEntry(f, logStorage.GetStream(f), closeStream: true), zip, throwOnFailure: false);
 
-                    zip.SaveTo(outStream);
+                    zip.SaveTo(outStream, new ZipWriterOptions(CompressionType.Deflate));
                 }
             }
             catch

--- a/osu.Game/Rulesets/Edit/Checks/Components/IssueTemplate.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/IssueTemplate.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Humanizer;
 using osu.Framework.Graphics;
 using osuTK.Graphics;
 

--- a/osu.Game/Rulesets/Edit/Checks/Components/IssueTemplate.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/IssueTemplate.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// Returns the formatted message given the arguments used to format it.
         /// </summary>
         /// <param name="args">The arguments used to format the message.</param>
-        public string GetMessage(params object[] args) => UnformattedMessage.FormatWith(args);
+        public string GetMessage(params object[] args) => string.Format(UnformattedMessage, args);
 
         /// <summary>
         /// Returns the colour corresponding to the type of this issue.

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -188,7 +188,7 @@ namespace osu.Game.Scoring.Legacy
 
                 long compressedSize = replayInStream.Length - replayInStream.Position;
 
-                using (var lzma = new LzmaStream(properties, replayInStream, compressedSize, outSize))
+                using (var lzma = LzmaStream.Create(properties, replayInStream, compressedSize, outSize))
                 using (var reader = new StreamReader(lzma))
                     readFunc(reader);
             }

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Scoring.Legacy
 
             using (var outStream = new MemoryStream())
             {
-                using (var lzma = new LzmaStream(new LzmaEncoderProperties(false, 1 << 21, 255), false, outStream))
+                using (var lzma = LzmaStream.Create(new LzmaEncoderProperties(false, 1 << 21, 255), false, outStream))
                 {
                     outStream.Write(lzma.Properties);
 

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -179,22 +179,25 @@ namespace osu.Game.Screens.Edit
             removedIndices = new List<int>();
             addedIndices = new List<int>();
 
+            string[] oldArr = result.PiecesOld.ToArray();
+            string[] newArr = result.PiecesNew.ToArray();
+
             // Find the start and end indices of the relevant section headers in both the old and the new beatmap file. Lines changed outside of the modified ranges are ignored.
-            int oldSectionStartIndex = Array.IndexOf(result.PiecesOld, $"[{section}]");
+            int oldSectionStartIndex = Array.IndexOf(oldArr, $"[{section}]");
             if (oldSectionStartIndex == -1)
                 return;
 
-            int oldSectionEndIndex = Array.FindIndex(result.PiecesOld, oldSectionStartIndex + 1, s => s.StartsWith('['));
+            int oldSectionEndIndex = Array.FindIndex(oldArr, oldSectionStartIndex + 1, s => s.StartsWith('['));
             if (oldSectionEndIndex == -1)
-                oldSectionEndIndex = result.PiecesOld.Length;
+                oldSectionEndIndex = oldArr.Length;
 
-            int newSectionStartIndex = Array.IndexOf(result.PiecesNew, $"[{section}]");
+            int newSectionStartIndex = Array.IndexOf(newArr, $"[{section}]");
             if (newSectionStartIndex == -1)
                 return;
 
-            int newSectionEndIndex = Array.FindIndex(result.PiecesNew, newSectionStartIndex + 1, s => s.StartsWith('['));
+            int newSectionEndIndex = Array.FindIndex(newArr, newSectionStartIndex + 1, s => s.StartsWith('['));
             if (newSectionEndIndex == -1)
-                newSectionEndIndex = result.PiecesNew.Length;
+                newSectionEndIndex = newArr.Length;
 
             foreach (var block in result.DiffBlocks)
             {

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
@@ -6,7 +6,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using Humanizer;
-using Humanizer.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using Humanizer;
+using Humanizer.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -133,7 +134,7 @@ namespace osu.Game.Tests.Beatmaps
 
                 string afterConversion = beatmap.Serialize();
 
-                Assert.AreEqual(beforeConversion, afterConversion, "Conversion altered original beatmap");
+                ClassicAssert.AreEqual(beforeConversion, afterConversion, "Conversion altered original beatmap");
 
                 return new ConvertResult
                 {

--- a/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets;
 
@@ -23,11 +23,11 @@ namespace osu.Game.Tests.Beatmaps
         {
             var ruleset = CreateRuleset();
             var mods = ruleset.ConvertFromLegacyMods(legacyMods).ToList();
-            Assert.AreEqual(expectedMods.Length, mods.Count);
+            ClassicAssert.AreEqual(expectedMods.Length, mods.Count);
 
             foreach (var modType in expectedMods)
             {
-                Assert.IsNotNull(mods.SingleOrDefault(mod => mod.GetType() == modType));
+                ClassicAssert.NotNull(mods.SingleOrDefault(mod => mod.GetType() == modType));
             }
         }
 
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Beatmaps
                                       .Where(mod => providedModTypes.Contains(mod.GetType()))
                                       .ToArray();
             var actualLegacyMods = ruleset.ConvertToLegacyMods(modInstances);
-            Assert.AreEqual(expectedLegacyMods, actualLegacyMods);
+            ClassicAssert.AreEqual(expectedLegacyMods, actualLegacyMods);
         }
     }
 }

--- a/osu.Game/Utils/HumanizerUtils.cs
+++ b/osu.Game/Utils/HumanizerUtils.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using Humanizer;
-using Humanizer.Localisation;
 
 namespace osu.Game.Utils
 {

--- a/osu.Game/Utils/HumanizerUtils.cs
+++ b/osu.Game/Utils/HumanizerUtils.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using Humanizer;
+using Humanizer.Localisation;
 
 namespace osu.Game.Utils
 {

--- a/osu.Game/Utils/ZipUtils.cs
+++ b/osu.Game/Utils/ZipUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using SharpCompress.Archives.Zip;
 
 namespace osu.Game.Utils
@@ -15,7 +16,7 @@ namespace osu.Game.Utils
             {
                 stream.Seek(0, SeekOrigin.Begin);
 
-                using (var arc = ZipArchive.Open(stream))
+                using (var arc = ZipArchive.OpenArchive(stream))
                 {
                     foreach (var entry in arc.Entries)
                     {
@@ -30,7 +31,7 @@ namespace osu.Game.Utils
                     // the worst case is that it's actually *not* a zip and instead a stream of binary
                     // which *accidentally* happened to contain the magic sequence of bytes for the zip header (50 4b 05 06),
                     // and if that's the case, then we are *misclassifying* it as a zip by returning `true` unconditionally.
-                    return arc.Entries.Count > 0;
+                    return arc.Entries.Any();
                 }
             }
             catch (Exception)
@@ -50,7 +51,7 @@ namespace osu.Game.Utils
 
             try
             {
-                using (var arc = ZipArchive.Open(path))
+                using (var arc = ZipArchive.OpenArchive(path))
                 {
                     foreach (var entry in arc.Entries)
                     {
@@ -65,7 +66,7 @@ namespace osu.Game.Utils
                     // the worst case is that it's actually *not* a zip and instead a stream of binary
                     // which *accidentally* happened to contain the magic sequence of bytes for the zip header (50 4b 05 06),
                     // and if that's the case, then we are *misclassifying* it as a zip by returning `true` unconditionally.
-                    return arc.Entries.Count > 0;
+                    return arc.Entries.Any();
                 }
             }
             catch (Exception)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,7 +18,11 @@
     </None>
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <!-- Held back due to licencing change stupidness. Silenced vulnerability does not affect us. -->
+    <PackageReference Include="AutoMapper" Version="13.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <NoWarn>NU1903</NoWarn>
+    </PackageReference>
     <PackageReference Include="DiffPlex" Version="1.9.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Humanizer" Version="3.0.10" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -20,7 +20,6 @@
   <ItemGroup Label="Package References">
     <!-- Held back due to licencing change stupidness. Silenced vulnerability does not affect us. -->
     <PackageReference Include="AutoMapper" Version="13.0.1">
-      <PrivateAssets>all</PrivateAssets>
       <NoWarn>NU1903</NoWarn>
     </PackageReference>
     <PackageReference Include="DiffPlex" Version="1.9.0" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,18 +18,18 @@
     </None>
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="DiffPlex" Version="1.7.2" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.72" />
-    <PackageReference Include="Humanizer" Version="2.14.1" />
-    <PackageReference Include="MessagePack" Version="3.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.2" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="DiffPlex" Version="1.9.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Humanizer" Version="3.0.10" />
+    <PackageReference Include="MessagePack" Version="3.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ppy.LocalisationAnalyser" Version="2025.1208.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -37,11 +37,11 @@
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2026.310.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.312.0" />
-    <PackageReference Include="Sentry" Version="5.1.1" />
+    <PackageReference Include="Sentry" Version="6.2.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
-    <PackageReference Include="SharpCompress" Version="0.39.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="SharpCompress" Version="0.47.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -25,7 +25,8 @@
     </PackageReference>
     <PackageReference Include="DiffPlex" Version="1.9.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Humanizer" Version="3.0.10" />
+    <!-- Held back due to .NET 9 requirement. See https://github.com/Humanizr/Humanizer?tab=readme-ov-file#supported-frameworks-->
+    <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="MessagePack" Version="3.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />


### PR DESCRIPTION
It's been a while.

Notes:

- `SharpCompress` usages changed a bit. Manually adjusted these, mostly just renames or adjusted parameters.
- nUnit 3 -> 4 migrated using https://gist.github.com/peppy/07994386d793a117350cb5f24b156585. there's a mode in this script to update to the newer `Assert.That` syntax but it requires fixes and couldn't really be bothered.
- DeepEqual nuked as the only usage was on a disabled test. The reason it's disabled has been merged upstream, but it's failing for other (realm) reasons which I don't think is worthwhile to investigate for now.
- This bumps Moq. I think the author is back in a sensible headspace and the new version has the stupid shit removed, so probably okay? Nice to be on a level playing field with packages for once in a long time.
- Automapper is silly, but we've discussed this elsewhere.
- `TestRealmKeyBindingStore` failures are a wildcard, but fixed by using a more standardised testing method. Dunno why, don't care.
