### PR TITLE
Fix mania hold notes dimming unexpectedly

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Objects;
@@ -503,6 +504,29 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddAssert("hold note hit", () => judgementResults.Where(j => beatmap.HitObjects[0].NestedHitObjects.Contains(j.HitObject))
                                                              .All(j => j.Type.IsHit()));
+        }
+
+        /// <summary>
+        /// This ensures that the value of <see cref="DrawableHoldNote.MissingStartTime"/>
+        /// will be set correctly when the body receives a judgment during the hold.
+        ///
+        ///     -----[           ]-----
+        ///          x     o
+        /// </summary>
+        [Test]
+        public void TestReleaseDuringHoldMissingStartTime()
+        {
+            performTest([
+                new ManiaReplayFrame(time_head, ManiaAction.Key1),
+                new ManiaReplayFrame(time_during_hold_1)
+            ]);
+
+            assertHeadJudgement(HitResult.Perfect);
+            assertTailJudgement(HitResult.Miss);
+            assertNoteJudgement(HitResult.IgnoreMiss);
+
+            AddAssert("body judgement is miss", () => !judgementResults.Single(j => j.HitObject is HoldNoteBody).IsHit);
+            AddAssert("body judgement time indicates during hold", () => judgementResults.Single(j => j.HitObject is HoldNoteBody).TimeAbsolute, () => Is.EqualTo(time_during_hold_1).Within(100));
         }
 
         private void assertHitObjectJudgement(HitObject hitObject, HitResult result)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -137,7 +137,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             base.OnApply();
 
             sizingContainer.Size = Vector2.One;
-            missingStartTime.Value = null;
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
@@ -209,11 +208,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         public override void OnKilled()
         {
             base.OnKilled();
+
             // flush the final state of holding on kill.
             // this matters because some skin implementations like legacy skin
             // insert drawables in the hierarchy that are not a child of this DHO
             // (see `LegacyBodyPiece` and related machinations with `lightContainer` being added at column level)
             isHolding.Value = Result.IsHolding(Time.Current);
+            missingStartTime.Value = null;
             (bodyPiece.Drawable as IHoldNoteBody)?.Recycle();
         }
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -32,8 +32,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         public override bool DisplayResult => false;
 
         public IBindable<bool> IsHolding => isHolding;
-
         private readonly Bindable<bool> isHolding = new Bindable<bool>();
+
+        public IBindable<double?> MissingStartTime => missingStartTime;
+        private readonly Bindable<double?> missingStartTime = new Bindable<double?>();
 
         public DrawableHoldNoteHead Head => headContainer.Child;
         public DrawableHoldNoteTail Tail => tailContainer.Child;
@@ -126,6 +128,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             base.OnApply();
 
             sizingContainer.Size = Vector2.One;
+            missingStartTime.Value = null;
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
@@ -208,6 +211,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         protected override void Update()
         {
             base.Update();
+
+            if (Head.Judged && !Head.IsHit)
+                missingStartTime.Value ??= Head.Result.TimeAbsolute;
+            if (Body.HasHoldBreak)
+                missingStartTime.Value ??= Body.Result.TimeAbsolute;
+            if (Tail.Judged && !Tail.IsHit)
+                missingStartTime.Value ??= Tail.Result.TimeAbsolute;
 
             isHolding.Value = Result.IsHolding(Time.Current);
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -31,10 +31,19 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     {
         public override bool DisplayResult => false;
 
+        /// <summary>
+        /// Whether the user is currently pressing the hold note.
+        /// </summary>
         public IBindable<bool> IsHolding => isHolding;
+
         private readonly Bindable<bool> isHolding = new Bindable<bool>();
 
+        /// <summary>
+        /// The time at which the user starting missing the hold note.
+        /// This could be the time at which they missed the head, broke on the body, or missed the tail.
+        /// </summary>
         public IBindable<double?> MissingStartTime => missingStartTime;
+
         private readonly Bindable<double?> missingStartTime = new Bindable<double?>();
 
         public DrawableHoldNoteHead Head => headContainer.Child;

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -15,6 +15,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public partial class DrawableHoldNoteHead : DrawableNote
     {
+        /// <summary>
+        /// The time at which the user starting missing the hold note.
+        /// This could be the time at which they missed the head, broke on the body, or missed the tail.
+        /// </summary>
         public readonly IBindable<double?> MissingStartTime = new Bindable<double?>();
 
         protected override ManiaSkinComponents Component => ManiaSkinComponents.HoldNoteHead;

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -14,6 +15,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public partial class DrawableHoldNoteHead : DrawableNote
     {
+        public readonly IBindable<double?> MissingStartTime = new Bindable<double?>();
+
         protected override ManiaSkinComponents Component => ManiaSkinComponents.HoldNoteHead;
 
         public DrawableHoldNoteHead()
@@ -26,6 +29,22 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
+
+            if (ParentHitObject is DrawableHoldNote parentHold)
+                MissingStartTime.BindTo(parentHold.MissingStartTime);
+        }
+
+        protected override void OnFree()
+        {
+            base.OnFree();
+
+            if (ParentHitObject is DrawableHoldNote parentHold)
+                MissingStartTime.UnbindFrom(parentHold.MissingStartTime);
         }
 
         public bool UpdateResult() => base.UpdateResult(true);

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Scoring;
@@ -14,6 +15,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public partial class DrawableHoldNoteTail : DrawableNote
     {
+        public readonly IBindable<double?> MissingStartTime = new Bindable<double?>();
+
         protected override ManiaSkinComponents Component => ManiaSkinComponents.HoldNoteTail;
 
         protected internal DrawableHoldNote HoldNote => (DrawableHoldNote)ParentHitObject;
@@ -28,6 +31,22 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
+
+            if (ParentHitObject is DrawableHoldNote parentHold)
+                MissingStartTime.BindTo(parentHold.MissingStartTime);
+        }
+
+        protected override void OnFree()
+        {
+            base.OnFree();
+
+            if (ParentHitObject is DrawableHoldNote parentHold)
+                MissingStartTime.UnbindFrom(parentHold.MissingStartTime);
         }
 
         public void UpdateResult() => base.UpdateResult(true);

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
@@ -15,6 +15,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public partial class DrawableHoldNoteTail : DrawableNote
     {
+        /// <summary>
+        /// The time at which the user starting missing the hold note.
+        /// This could be the time at which they missed the head, broke on the body, or missed the tail.
+        /// </summary>
         public readonly IBindable<double?> MissingStartTime = new Bindable<double?>();
 
         protected override ManiaSkinComponents Component => ManiaSkinComponents.HoldNoteTail;

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -118,7 +118,8 @@ namespace osu.Game.Rulesets.Mania.Objects
             AddNested(Body = new HoldNoteBody
             {
                 StartTime = StartTime,
-                Column = Column
+                Column = Column,
+                Duration = Duration
             });
         }
 

--- a/osu.Game.Rulesets.Mania/Objects/HoldNoteBody.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNoteBody.cs
@@ -3,6 +3,7 @@
 
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Judgements;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Objects
@@ -13,9 +14,11 @@ namespace osu.Game.Rulesets.Mania.Objects
     /// On hit - the hold note was held correctly for the full duration.<br />
     /// On miss - the hold note was released at some point during its judgement period.
     /// </summary>
-    public class HoldNoteBody : ManiaHitObject
+    public class HoldNoteBody : ManiaHitObject, IHasDuration
     {
         public override Judgement CreateJudgement() => new HoldNoteBodyJudgement();
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+        public double Duration { get; set; }
+        public double EndTime => StartTime + Duration;
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Sprites;
@@ -16,6 +15,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
@@ -25,17 +25,10 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
         private readonly IBindable<bool> isHitting = new Bindable<bool>();
-
-        /// <summary>
-        /// Stores the start time of the fade animation that plays when any of the nested
-        /// hitobjects of the hold note are missed.
-        /// </summary>
-        private readonly Bindable<double?> missFadeTime = new Bindable<double?>();
+        private readonly IBindable<double?> missingStartTime = new Bindable<double?>();
 
         private Drawable? bodySprite;
-
         private Drawable? lightContainer;
-
         private Drawable? light;
         private LegacyNoteBodyStyle? bodyStyle;
 
@@ -87,6 +80,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
             direction.BindTo(scrollingInfo.Direction);
             isHitting.BindTo(holdNote.IsHolding);
+            missingStartTime.BindTo(holdNote.MissingStartTime);
 
             bodySprite = skin.GetAnimation(imageName, wrapMode, wrapMode, true, true, frameLength: 30)?.With(d =>
             {
@@ -109,25 +103,17 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
             direction.BindValueChanged(onDirectionChanged, true);
             isHitting.BindValueChanged(onIsHittingChanged, true);
-            missFadeTime.BindValueChanged(onMissFadeTimeChanged, true);
-
-            holdNote.ApplyCustomUpdateState += applyCustomUpdateState;
-            applyCustomUpdateState(holdNote, holdNote.State.Value);
+            missingStartTime.BindValueChanged(onMissingStartTimeChanged, true);
         }
 
-        private void applyCustomUpdateState(DrawableHitObject hitObject, ArmedState state)
+        private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
         {
-            switch (hitObject)
+            using (BeginAbsoluteSequence(startTime.NewValue ?? double.MinValue))
             {
-                // Ensure that the hold note is also faded out when the head/tail/body is missed.
-                // Importantly, we filter out unrelated objects like DrawableNotePerfectBonus.
-                case DrawableHoldNoteTail:
-                case DrawableHoldNoteHead:
-                case DrawableHoldNoteBody:
-                    if (state == ArmedState.Miss)
-                        missFadeTime.Value ??= hitObject.HitStateUpdateTime;
-
-                    break;
+                if (startTime.NewValue == null)
+                    bodySprite?.FadeColour(Color4.White);
+                else
+                    bodySprite?.FadeColour(Colour4.DarkGray, 60);
             }
         }
 
@@ -187,34 +173,12 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
             }
         }
 
-        private void onMissFadeTimeChanged(ValueChangedEvent<double?> missFadeTimeChange)
-        {
-            if (missFadeTimeChange.NewValue == null)
-                return;
-
-            // this update could come from any nested object of the hold note (or even from an input).
-            // make sure the transforms are consistent across all affected parts.
-            using (BeginAbsoluteSequence(missFadeTimeChange.NewValue.Value))
-            {
-                // colour and duration matches stable
-                // transforms not applied to entire hold note in order to not affect hit lighting
-                const double fade_duration = 60;
-
-                holdNote.Head.FadeColour(Colour4.DarkGray, fade_duration);
-                holdNote.Tail.FadeColour(Colour4.DarkGray, fade_duration);
-                bodySprite?.FadeColour(Colour4.DarkGray, fade_duration);
-            }
-        }
-
         protected override void Update()
         {
             base.Update();
 
             if (!isHitting.Value)
                 (bodySprite as TextureAnimation)?.GotoFrame(0);
-
-            if (holdNote.Body.HasHoldBreak)
-                missFadeTime.Value = holdNote.Body.Result.TimeAbsolute;
 
             int scaleDirection = (direction.Value == ScrollingDirection.Down ? 1 : -1);
 
@@ -249,9 +213,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-
-            if (holdNote.IsNotNull())
-                holdNote.ApplyCustomUpdateState -= applyCustomUpdateState;
 
             lightContainer?.Expire();
         }

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -15,7 +15,6 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
@@ -108,13 +107,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
         {
-            using (BeginAbsoluteSequence(startTime.NewValue ?? double.MinValue))
+            if (startTime.NewValue == null)
             {
-                if (startTime.NewValue == null)
-                    bodySprite?.FadeColour(Color4.White);
-                else
-                    bodySprite?.FadeColour(Colour4.DarkGray, 60);
+                // Colour revert handled by the DHO transform reset.
+                return;
             }
+
+            using (BeginAbsoluteSequence(startTime.NewValue.Value))
+                bodySprite?.FadeColour(Colour4.DarkGray, 60);
         }
 
         private void onIsHittingChanged(ValueChangedEvent<bool> isHitting)

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -103,18 +103,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
             direction.BindValueChanged(onDirectionChanged, true);
             isHitting.BindValueChanged(onIsHittingChanged, true);
             missingStartTime.BindValueChanged(onMissingStartTimeChanged, true);
-        }
 
-        private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
-        {
-            if (startTime.NewValue == null)
-            {
-                // Colour revert handled by the DHO transform reset.
-                return;
-            }
-
-            using (BeginAbsoluteSequence(startTime.NewValue.Value))
-                bodySprite?.FadeColour(Colour4.DarkGray, 60);
+            holdNote.ApplyCustomUpdateState += onApplyCustomUpdateState;
         }
 
         private void onIsHittingChanged(ValueChangedEvent<bool> isHitting)
@@ -171,6 +161,21 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                 if (light != null)
                     light.Anchor = Anchor.BottomCentre;
             }
+        }
+
+        private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
+            => applyMissingDim();
+
+        private void onApplyCustomUpdateState(DrawableHitObject obj, ArmedState state)
+            => applyMissingDim();
+
+        private void applyMissingDim()
+        {
+            if (missingStartTime.Value == null)
+                return;
+
+            using (BeginAbsoluteSequence(missingStartTime.Value.Value))
+                this.FadeColour(Colour4.DarkGray, 60);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Sprites;
@@ -218,6 +219,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
+            if (holdNote.IsNotNull())
+                holdNote.ApplyCustomUpdateState -= onApplyCustomUpdateState;
 
             lightContainer?.Expire();
         }

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteHeadPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteHeadPiece.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Skinning;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
@@ -30,13 +29,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
         {
-            using (BeginAbsoluteSequence(startTime.NewValue ?? double.MinValue))
+            if (startTime.NewValue == null)
             {
-                if (startTime.NewValue == null)
-                    this.FadeColour(Color4.White);
-                else
-                    this.FadeColour(Colour4.DarkGray, 60);
+                // Colour revert handled by the DHO transform reset.
+                return;
             }
+
+            using (BeginAbsoluteSequence(startTime.NewValue.Value))
+                this.FadeColour(Colour4.DarkGray, 60);
         }
 
         protected override Drawable? GetAnimation(ISkinSource skin)

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteHeadPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteHeadPiece.cs
@@ -1,13 +1,44 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Skinning;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
     public partial class LegacyHoldNoteHeadPiece : LegacyNotePiece
     {
+        private readonly IBindable<double?> missingStartTime = new Bindable<double?>();
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableObject)
+        {
+            missingStartTime.BindTo(((DrawableHoldNoteHead)drawableObject).MissingStartTime);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            missingStartTime.BindValueChanged(onMissingStartTimeChanged, true);
+        }
+
+        private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
+        {
+            using (BeginAbsoluteSequence(startTime.NewValue ?? double.MinValue))
+            {
+                if (startTime.NewValue == null)
+                    this.FadeColour(Color4.White);
+                else
+                    this.FadeColour(Colour4.DarkGray, 60);
+            }
+        }
+
         protected override Drawable? GetAnimation(ISkinSource skin)
         {
             // TODO: Should fallback to the head from default legacy skin instead of note.

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteHeadPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteHeadPiece.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -14,28 +15,31 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
     {
         private readonly IBindable<double?> missingStartTime = new Bindable<double?>();
 
-        [BackgroundDependencyLoader]
-        private void load(DrawableHitObject drawableObject)
-        {
-            missingStartTime.BindTo(((DrawableHoldNoteHead)drawableObject).MissingStartTime);
-        }
+        [Resolved]
+        private DrawableHitObject drawableObject { get; set; } = null!;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
+            missingStartTime.BindTo(((DrawableHoldNoteHead)drawableObject).MissingStartTime);
             missingStartTime.BindValueChanged(onMissingStartTimeChanged, true);
+
+            drawableObject.ApplyCustomUpdateState += onApplyCustomUpdateState;
         }
 
         private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
-        {
-            if (startTime.NewValue == null)
-            {
-                // Colour revert handled by the DHO transform reset.
-                return;
-            }
+            => applyMissingDim();
 
-            using (BeginAbsoluteSequence(startTime.NewValue.Value))
+        private void onApplyCustomUpdateState(DrawableHitObject obj, ArmedState state)
+            => applyMissingDim();
+
+        private void applyMissingDim()
+        {
+            if (missingStartTime.Value == null)
+                return;
+
+            using (BeginAbsoluteSequence(missingStartTime.Value.Value))
                 this.FadeColour(Colour4.DarkGray, 60);
         }
 
@@ -44,6 +48,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
             // TODO: Should fallback to the head from default legacy skin instead of note.
             return GetAnimationFromLookup(skin, LegacyManiaSkinConfigurationLookups.HoldNoteHeadImage)
                    ?? GetAnimationFromLookup(skin, LegacyManiaSkinConfigurationLookups.NoteImage);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableObject.IsNotNull())
+                drawableObject.ApplyCustomUpdateState -= onApplyCustomUpdateState;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteTailPiece.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -15,28 +16,31 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
     {
         private readonly IBindable<double?> missingStartTime = new Bindable<double?>();
 
-        [BackgroundDependencyLoader]
-        private void load(DrawableHitObject drawableObject)
-        {
-            missingStartTime.BindTo(((DrawableHoldNoteTail)drawableObject).MissingStartTime);
-        }
+        [Resolved]
+        private DrawableHitObject drawableObject { get; set; } = null!;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
+            missingStartTime.BindTo(((DrawableHoldNoteTail)drawableObject).MissingStartTime);
             missingStartTime.BindValueChanged(onMissingStartTimeChanged, true);
+
+            drawableObject.ApplyCustomUpdateState += onApplyCustomUpdateState;
         }
 
         private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
-        {
-            if (startTime.NewValue == null)
-            {
-                // Colour revert handled by the DHO transform reset.
-                return;
-            }
+            => applyMissingDim();
 
-            using (BeginAbsoluteSequence(startTime.NewValue.Value))
+        private void onApplyCustomUpdateState(DrawableHitObject obj, ArmedState state)
+            => applyMissingDim();
+
+        private void applyMissingDim()
+        {
+            if (missingStartTime.Value == null)
+                return;
+
+            using (BeginAbsoluteSequence(missingStartTime.Value.Value))
                 this.FadeColour(Colour4.DarkGray, 60);
         }
 
@@ -54,6 +58,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
             return GetAnimationFromLookup(skin, LegacyManiaSkinConfigurationLookups.HoldNoteTailImage)
                    ?? GetAnimationFromLookup(skin, LegacyManiaSkinConfigurationLookups.HoldNoteHeadImage)
                    ?? GetAnimationFromLookup(skin, LegacyManiaSkinConfigurationLookups.NoteImage);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableObject.IsNotNull())
+                drawableObject.ApplyCustomUpdateState -= onApplyCustomUpdateState;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteTailPiece.cs
@@ -1,15 +1,45 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
     public partial class LegacyHoldNoteTailPiece : LegacyNotePiece
     {
+        private readonly IBindable<double?> missingStartTime = new Bindable<double?>();
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableObject)
+        {
+            missingStartTime.BindTo(((DrawableHoldNoteTail)drawableObject).MissingStartTime);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            missingStartTime.BindValueChanged(onMissingStartTimeChanged, true);
+        }
+
+        private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
+        {
+            using (BeginAbsoluteSequence(startTime.NewValue ?? double.MinValue))
+            {
+                if (startTime.NewValue == null)
+                    this.FadeColour(Color4.White);
+                else
+                    this.FadeColour(Colour4.DarkGray, 60);
+            }
+        }
+
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
         {
             // Invert the direction

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyHoldNoteTailPiece.cs
@@ -8,7 +8,6 @@ using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
@@ -31,13 +30,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         private void onMissingStartTimeChanged(ValueChangedEvent<double?> startTime)
         {
-            using (BeginAbsoluteSequence(startTime.NewValue ?? double.MinValue))
+            if (startTime.NewValue == null)
             {
-                if (startTime.NewValue == null)
-                    this.FadeColour(Color4.White);
-                else
-                    this.FadeColour(Colour4.DarkGray, 60);
+                // Colour revert handled by the DHO transform reset.
+                return;
             }
+
+            using (BeginAbsoluteSequence(startTime.NewValue.Value))
+                this.FadeColour(Colour4.DarkGray, 60);
         }
 
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/29223

This fixes several issues around hold note dimming.

Notice in the following video:
- The tail piece of the first note not getting dimmed.
- The body of the second note not responding to dimming at all.

https://github.com/user-attachments/assets/8e51053d-8d88-4e48-909b-79218d65917b

Then, notice in the following video:
- The body piece of the second note is dimmed from the very beginning.

https://github.com/user-attachments/assets/a514c630-5c72-4ba5-96d5-472bae1058b3

This requires a specific setup whereby the hold note and its components must be reused from the pool. In particular:
  1. The hold note must be long. So long that by the time the tail becomes on screen, the body will already have dimmed.
  2. The hold note must be re-used from the pool. We can induce this by setting the pool sizes to 1 in [`Column.cs`](https://github.com/ppy/osu/blob/780ce2666099c22d1e0673cafab544418b5d14b0/osu.Game.Rulesets.Mania/UI/Column.cs#L121-L123).
  3. The second hold note should be placed far enough in the timeline that the first hold note dies by the time it becomes visible.
  4. Scroll speed should be adjusted to fit the above constraints.

I haven't done a full deep dive into exactly _why_ this is happening, so the fix here is hand-wavy. That said, just by looking at the old code in `LegacyBodyPiece` you'll get a feeling that something's bound to go wrong;
- It never resets the `missingFadeTime` state.
- It never resets the colours back to `Color4.White`.
- It applies transforms onto external components.
- It jumps through hoops to figure out how to set `missingFadeTime`.

My hope is that these changes first bring some sanity in the process, and if it breaks again I'll consider doing a more proper root cause (I've had this issue in the back of my mind for about 1 year).

With this PR, they now behave as expected:

https://github.com/user-attachments/assets/140b37c5-cf84-44ba-b797-86ac6d8130c8

https://github.com/user-attachments/assets/6f2342a4-6a9a-4941-a55a-24a357f27c25