### PR TITLE
Improve song select audio transitions

### DIFF
--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -424,7 +424,7 @@ namespace osu.Game.Beatmaps
             Stream IWorkingBeatmap.GetStream(string storagePath) => working.GetStream(storagePath);
             void IWorkingBeatmap.BeginAsyncLoad() => working.BeginAsyncLoad();
             void IWorkingBeatmap.CancelAsyncLoad() => working.CancelAsyncLoad();
-            void IWorkingBeatmap.PrepareTrackForPreview(bool looping, double offsetFromPreviewPoint) => working.PrepareTrackForPreview(looping, offsetFromPreviewPoint);
+            void IWorkingBeatmap.PrepareTrackForPreview(bool looping, double? offsetFromPreviewPoint) => working.PrepareTrackForPreview(looping, offsetFromPreviewPoint);
         }
     }
 }

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -139,6 +139,6 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Reads the correct track restart point from beatmap metadata and sets looping to enabled.
         /// </summary>
-        void PrepareTrackForPreview(bool looping, double offsetFromPreviewPoint = 0);
+        void PrepareTrackForPreview(bool looping, double? offsetFromPreviewPoint = null);
     }
 }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -16,6 +16,7 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
+using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
@@ -119,7 +120,7 @@ namespace osu.Game.Beatmaps
             return track;
         }
 
-        public void PrepareTrackForPreview(bool looping, double offsetFromPreviewPoint = 0)
+        public void PrepareTrackForPreview(bool looping, double? offsetFromPreviewPoint = null)
         {
             Track.Looping = looping;
             Track.RestartPoint = Metadata.PreviewTime;
@@ -133,7 +134,9 @@ namespace osu.Game.Beatmaps
             if (Track.RestartPoint < 0 || Track.RestartPoint > Track.Length)
                 Track.RestartPoint = 0.4f * Track.Length;
 
-            Track.RestartPoint = Math.Clamp(Track.RestartPoint + offsetFromPreviewPoint, 0, Track.Length);
+            offsetFromPreviewPoint ??= -MusicController.TRACK_FADE_IN_TIME;
+
+            Track.RestartPoint = Math.Clamp(Track.RestartPoint + offsetFromPreviewPoint.Value, 0, Track.Length);
         }
 
         /// <summary>

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Overlays
         /// </summary>
         private const double restart_cutoff_point = 5000;
 
+        public const double TRACK_FADE_IN_TIME = 500;
+        public const double TRACK_FADE_OUT_TIME = 300;
+
         /// <summary>
         /// Whether the user has requested the track to be paused. Use <see cref="IsPlaying"/> to determine whether the track is still playing.
         /// </summary>
@@ -523,12 +526,12 @@ namespace osu.Game.Overlays
             // but the mutation of the hierarchy is scheduled to avoid exceptions.
             Schedule(() =>
             {
-                lastTrack.VolumeTo(0, 500, Easing.Out).Expire();
+                lastTrack.VolumeTo(0, TRACK_FADE_OUT_TIME, Easing.Out).Expire();
 
                 if (queuedTrack == CurrentTrack)
                 {
                     AddInternal(queuedTrack);
-                    queuedTrack.VolumeTo(0).Then().VolumeTo(1, 300, Easing.Out);
+                    queuedTrack.VolumeTo(0).Then().VolumeTo(1, TRACK_FADE_IN_TIME, Easing.Out);
                 }
                 else
                 {

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -521,26 +521,20 @@ namespace osu.Game.Overlays
 
             CurrentTrack = queuedTrack;
 
-            // At this point we may potentially be in an async context from tests. This is extremely dangerous but we have to make do for now.
-            // CurrentTrack is immediately updated above for situations where a immediate knowledge about the new track is required,
-            // but the mutation of the hierarchy is scheduled to avoid exceptions.
-            Schedule(() =>
-            {
-                lastTrack.VolumeTo(0, TRACK_FADE_OUT_TIME, Easing.Out).Expire();
+            lastTrack.VolumeTo(0, TRACK_FADE_OUT_TIME, Easing.Out).Expire();
 
-                if (queuedTrack == CurrentTrack)
-                {
-                    queuedTrack.Volume.Value = 0;
-                    AddInternal(queuedTrack);
-                    queuedTrack.Delay(50).VolumeTo(1, TRACK_FADE_IN_TIME, Easing.Out);
-                }
-                else
-                {
-                    // If the track has changed since the call to changeTrack, it is safe to dispose the
-                    // queued track rather than consume it.
-                    queuedTrack.Dispose();
-                }
-            });
+            if (queuedTrack == CurrentTrack)
+            {
+                queuedTrack.Volume.Value = 0;
+                AddInternal(queuedTrack);
+                queuedTrack.Delay(50).VolumeTo(1, TRACK_FADE_IN_TIME, Easing.Out);
+            }
+            else
+            {
+                // If the track has changed since the call to changeTrack, it is safe to dispose the
+                // queued track rather than consume it.
+                queuedTrack.Dispose();
+            }
         }
 
         private DrawableTrack getQueuedTrack()

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Overlays
         /// </summary>
         private const double restart_cutoff_point = 5000;
 
-        public const double TRACK_FADE_IN_TIME = 500;
-        public const double TRACK_FADE_OUT_TIME = 300;
+        public const double TRACK_FADE_IN_TIME = 250;
+        public const double TRACK_FADE_OUT_TIME = 100;
 
         /// <summary>
         /// Whether the user has requested the track to be paused. Use <see cref="IsPlaying"/> to determine whether the track is still playing.
@@ -530,8 +530,9 @@ namespace osu.Game.Overlays
 
                 if (queuedTrack == CurrentTrack)
                 {
+                    queuedTrack.Volume.Value = 0;
                     AddInternal(queuedTrack);
-                    queuedTrack.VolumeTo(0).Then().VolumeTo(1, TRACK_FADE_IN_TIME, Easing.Out);
+                    queuedTrack.Delay(50).VolumeTo(1, TRACK_FADE_IN_TIME, Easing.Out);
                 }
                 else
                 {


### PR DESCRIPTION
Based on feedback I've heard more than once ([most recently](https://github.com/ppy/osu/discussions/36933)), there's too much overlap compared to stable. And it can sound a bit "jumbled" as a result, especially when transitioning between two songs with loud and "complex" audio.

This also fixes noticeable audio glitching that some users may have been experiencing when switching tracks.

---

Unless there's any very loud objections, I'd ask that review is on the code not the audible change. This is the kind of change that I tweak to my personal spec and then push out to hear the general reaction.

### b8d0dfe2edd9b06b46d2878f020084bf5cea9679 Better default preview time based on global fade

This is an oversight. The preview point wasn't being offset to account for the fade in. This is something we do when generating web-side previews, which allows for the actual preview point to be audible, rather than mid-fade.

### 8de323b68c9a1ef39faa44759b5fdda0648184f1 Adjust fade in and fade out during track transitions to reduce overlap

Yes, I'm aware that the delay is not accounted for in the constant. This is intentional because it sounds better. I want this to be an internal adjustment which is not to be considered by any external usages of those constants. Just sounds better.

### aab01b0fe54c543e015e7be4f218bf71d72290c7 Remove weird/dated schedule usage

This causes audible artifacts in playback. The track is not set to zero volume early enough. Original change was made in [this ancient PR](https://github.com/ppy/osu/pull/9792) (see [commit](https://github.com/ppy/osu/commit/688e4479506645bdacee7cdc7ae9ee9deaa5f1b4)). The original failure does not occur. Tests still pass. I'd argue that if we encounter this again, it's an issue at the call site, not this code.

This is a drive-by fix, as I noticed this glitching while working on the main issue here. Arguably should be it's own PR 🤷 .