### PR TITLE
Debounce user offline notifications

### DIFF
--- a/osu.Game.Tests/Visual/Components/TestSceneFriendPresenceNotifier.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneFriendPresenceNotifier.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Tests.Visual.Components
         private NotificationOverlay notificationOverlay = null!;
         private ChatOverlay chatOverlay = null!;
         private TestMetadataClient metadataClient = null!;
+        private FriendPresenceNotifier notifier = null!;
 
         [SetUp]
         public void Setup() => Schedule(() =>
@@ -45,7 +46,11 @@ namespace osu.Game.Tests.Visual.Components
                     notificationOverlay,
                     chatOverlay,
                     metadataClient,
-                    new FriendPresenceNotifier()
+                    notifier = new FriendPresenceNotifier
+                    {
+                        // Speeds up tests that don't rely on this debounce a little bit.
+                        OfflineDebounceTime = 0
+                    }
                 }
             };
 
@@ -126,6 +131,28 @@ namespace osu.Game.Tests.Visual.Components
             });
 
             AddUntilStep("wait for notification", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestOfflineDebounce()
+        {
+            AddStep("set debounce time", () =>
+            {
+                notifier.NotificationDebounceTime = 0;
+                notifier.OfflineDebounceTime = 5000;
+            });
+
+            AddStep("bring friend online", () => metadataClient.FriendPresenceUpdated(1, new UserPresence { Status = UserStatus.Online }));
+            AddUntilStep("online notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(1));
+
+            for (int i = 0; i < 3; i++)
+            {
+                AddStep("bring friend online", () => metadataClient.FriendPresenceUpdated(1, new UserPresence { Status = UserStatus.Online }));
+                AddStep("bring friend offline", () => metadataClient.FriendPresenceUpdated(1, null));
+            }
+
+            AddUntilStep("online notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(1));
+            AddUntilStep("offline notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(2));
         }
     }
 }

--- a/osu.Game/Online/FriendPresenceNotifier.cs
+++ b/osu.Game/Online/FriendPresenceNotifier.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Online
         }
 
         /// <summary>
-        /// Waits <see cref="debounce_time_before_offline"/> before adding a user to the next offline notification alert.
+        /// Waits <see cref="OfflineDebounceTime"/> before adding a user to the next offline notification alert.
         /// </summary>
         /// <param name="user"></param>
         private void markUserOfflineDebounced(APIUser user)

--- a/osu.Game/Online/FriendPresenceNotifier.cs
+++ b/osu.Game/Online/FriendPresenceNotifier.cs
@@ -42,10 +42,24 @@ namespace osu.Game.Online
         private readonly IBindableList<APIRelation> friends = new BindableList<APIRelation>();
         private readonly IBindableDictionary<int, UserPresence> friendPresences = new BindableDictionary<int, UserPresence>();
 
+        /// <summary>
+        /// List of users that will be notified as having come online with the next notification.
+        /// </summary>
         private readonly HashSet<APIUser> onlineAlertQueue = new HashSet<APIUser>();
+
+        /// <summary>
+        /// List of users that will be notified as having gone offline with the next notification.
+        /// </summary>
         private readonly HashSet<APIUser> offlineAlertQueue = new HashSet<APIUser>();
 
+        /// <summary>
+        /// The post time for the next online notification.
+        /// </summary>
         private double? nextOnlineAlertTime;
+
+        /// <summary>
+        /// The post time for the next offline notification.
+        /// </summary>
         private double? nextOfflineAlertTime;
 
         private const double debounce_time_before_notification = 1000;

--- a/osu.Game/Online/FriendPresenceNotifier.cs
+++ b/osu.Game/Online/FriendPresenceNotifier.cs
@@ -25,6 +25,16 @@ namespace osu.Game.Online
 {
     public partial class FriendPresenceNotifier : Component
     {
+        /// <summary>
+        /// Minimum time between subsequent online/offline notifications.
+        /// </summary>
+        public double NotificationDebounceTime { get; set; } = 1000;
+
+        /// <summary>
+        /// Minimum time after a user has gone offline, before they're added to the offline alert queue.
+        /// </summary>
+        public double OfflineDebounceTime { get; set; } = 15000;
+
         [Resolved]
         private INotificationOverlay notifications { get; set; } = null!;
 
@@ -53,6 +63,12 @@ namespace osu.Game.Online
         private readonly HashSet<APIUser> offlineAlertQueue = new HashSet<APIUser>();
 
         /// <summary>
+        /// List of users that have gone offline, but we're waiting for them to potentially come online again before queueing them for notification.
+        /// For example, if a user is quickly toggling between the "Online" and "Appear Offline" states.
+        /// </summary>
+        private readonly HashSet<APIUser> pendingOfflineUsers = new HashSet<APIUser>();
+
+        /// <summary>
         /// The post time for the next online notification.
         /// </summary>
         private double? nextOnlineAlertTime;
@@ -61,8 +77,6 @@ namespace osu.Game.Online
         /// The post time for the next offline notification.
         /// </summary>
         private double? nextOfflineAlertTime;
-
-        private const double debounce_time_before_notification = 1000;
 
         protected override void LoadComplete()
         {
@@ -147,28 +161,55 @@ namespace osu.Game.Online
                         APIRelation? friend = friends.FirstOrDefault(f => f.TargetID == friendId);
 
                         if (friend?.TargetUser is APIUser user)
-                            markUserOffline(user);
+                            markUserOfflineDebounced(user);
                     }
 
                     break;
             }
         }
 
+        /// <summary>
+        /// Immediately registers a user for the next online notification alert.
+        /// </summary>
         private void markUserOnline(APIUser user)
         {
+            if (pendingOfflineUsers.Remove(user))
+                return;
+
             if (!offlineAlertQueue.Remove(user))
             {
                 onlineAlertQueue.Add(user);
-                nextOnlineAlertTime ??= Time.Current + debounce_time_before_notification;
+                nextOnlineAlertTime ??= Time.Current + NotificationDebounceTime;
             }
         }
 
+        /// <summary>
+        /// Waits <see cref="debounce_time_before_offline"/> before adding a user to the next offline notification alert.
+        /// </summary>
+        /// <param name="user"></param>
+        private void markUserOfflineDebounced(APIUser user)
+        {
+            pendingOfflineUsers.Add(user);
+
+            Scheduler.AddDelayed(() =>
+            {
+                // Check if the friend has come back online.
+                if (!pendingOfflineUsers.Remove(user))
+                    return;
+
+                markUserOffline(user);
+            }, OfflineDebounceTime);
+        }
+
+        /// <summary>
+        /// Immediately registers a user for the next offline notification alert.
+        /// </summary>
         private void markUserOffline(APIUser user)
         {
             if (!onlineAlertQueue.Remove(user))
             {
                 offlineAlertQueue.Add(user);
-                nextOfflineAlertTime ??= Time.Current + debounce_time_before_notification;
+                nextOfflineAlertTime ??= Time.Current + NotificationDebounceTime;
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35586

This implements [my proposal](https://github.com/ppy/osu/issues/35586#issuecomment-3709041680) in the issue thread, debouncing offline state transitions to occur once every 15s for any user. It means that intermittent connections (of at least 1 second) or users toggling online/appear offline spam a little bit less.

Without debounce (normally period of intermittency would be 1s, so this is illustrative):

https://github.com/user-attachments/assets/71a02ade-7690-4357-bf06-311966debabc

With debounce (added in this PR):

https://github.com/user-attachments/assets/2ee4bca8-ca01-4a7e-a8b4-238529e9885b