### PR TITLE
Fix dashboard overlay eagerly requesting global user presence

### DIFF
--- a/osu.Game/Overlays/Dashboard/CurrentlyOnline/CurrentlyOnlineDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyOnline/CurrentlyOnlineDisplay.cs
@@ -1,13 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.Metadata;
 using osu.Game.Overlays.Dashboard.Friends;
 using osu.Game.Resources.Localisation.Web;
 
@@ -15,6 +18,17 @@ namespace osu.Game.Overlays.Dashboard.CurrentlyOnline
 {
     public partial class CurrentlyOnlineDisplay : CompositeDrawable
     {
+        /// <summary>
+        /// The current state of the <see cref="DashboardOverlay"/>.
+        /// Presence is only updated when this value is <see cref="Visibility.Visible"/>.
+        /// </summary>
+        public readonly Bindable<Visibility> OverlayState = new Bindable<Visibility>(Visibility.Visible);
+
+        [Resolved]
+        private MetadataClient metadataClient { get; set; } = null!;
+
+        private readonly IBindable<bool> isConnected = new Bindable<bool>();
+
         private Box background = null!;
         private UserListToolbar userListToolbar = null!;
         private Container<RealtimeUserList> listContainer = null!;
@@ -22,6 +36,7 @@ namespace osu.Game.Overlays.Dashboard.CurrentlyOnline
         private BasicSearchTextBox searchTextBox = null!;
 
         private CancellationTokenSource? listLoadCancellation;
+        private IDisposable? userPresenceWatchToken;
 
         public CurrentlyOnlineDisplay()
         {
@@ -114,6 +129,11 @@ namespace osu.Game.Overlays.Dashboard.CurrentlyOnline
         {
             base.LoadComplete();
 
+            isConnected.BindTo(metadataClient.IsConnected);
+            isConnected.BindValueChanged(_ => updateUserPresenceState());
+
+            OverlayState.BindValueChanged(_ => updateUserPresenceState(), true);
+
             userListToolbar.DisplayStyle.BindValueChanged(_ => reloadList(), true);
         }
 
@@ -147,12 +167,28 @@ namespace osu.Game.Overlays.Dashboard.CurrentlyOnline
             }
         }
 
+        private void updateUserPresenceState()
+        {
+            if (!isConnected.Value)
+                return;
+
+            if (OverlayState.Value == Visibility.Visible)
+                userPresenceWatchToken ??= metadataClient.BeginWatchingUserPresence();
+            else
+            {
+                userPresenceWatchToken?.Dispose();
+                userPresenceWatchToken = null;
+            }
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
 
             listLoadCancellation?.Cancel();
             listLoadCancellation?.Dispose();
+
+            userPresenceWatchToken?.Dispose();
         }
     }
 }

--- a/osu.Game/Overlays/DashboardOverlay.cs
+++ b/osu.Game/Overlays/DashboardOverlay.cs
@@ -2,10 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Online.Metadata;
 using osu.Game.Overlays.Dashboard;
 using osu.Game.Overlays.Dashboard.CurrentlyOnline;
 using osu.Game.Overlays.Dashboard.Friends;
@@ -14,12 +10,6 @@ namespace osu.Game.Overlays
 {
     public partial class DashboardOverlay : TabbableOnlineOverlay<DashboardOverlayHeader, DashboardOverlayTabs>
     {
-        [Resolved]
-        private MetadataClient metadataClient { get; set; } = null!;
-
-        private IBindable<bool> metadataConnected = null!;
-        private IDisposable? userPresenceWatchToken;
-
         public DashboardOverlay()
             : base(OverlayColourScheme.Purple)
         {
@@ -38,35 +28,14 @@ namespace osu.Game.Overlays
                     break;
 
                 case DashboardOverlayTabs.CurrentlyPlaying:
-                    LoadDisplay(new CurrentlyOnlineDisplay());
+                    LoadDisplay(new CurrentlyOnlineDisplay
+                    {
+                        OverlayState = { BindTarget = State }
+                    });
                     break;
 
                 default:
                     throw new NotImplementedException($"Display for {tab} tab is not implemented");
-            }
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            metadataConnected = metadataClient.IsConnected.GetBoundCopy();
-            metadataConnected.BindValueChanged(_ => updateUserPresenceState());
-            State.BindValueChanged(_ => updateUserPresenceState());
-            updateUserPresenceState();
-        }
-
-        private void updateUserPresenceState()
-        {
-            if (!metadataConnected.Value)
-                return;
-
-            if (State.Value == Visibility.Visible)
-                userPresenceWatchToken ??= metadataClient.BeginWatchingUserPresence();
-            else
-            {
-                userPresenceWatchToken?.Dispose();
-                userPresenceWatchToken = null;
             }
         }
     }


### PR DESCRIPTION
I noticed that going into the dashboard overlay currently requests global user presence, which is not required for the friends display. This could create additional load (client and server) where unnecessary.