### PR TITLE
feat(search): add search popover with shift for local/online search for similar beatmaps

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -21,7 +21,6 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
-using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
 
@@ -151,9 +150,6 @@ namespace osu.Game.Overlays.BeatmapListing
 
         public void FilterLanguage(SearchLanguage language)
             => Schedule(() => searchControl.Language.Value = language);
-
-        public void SetRuleset(RulesetInfo ruleset)
-            => Schedule(() => searchControl.Ruleset.Value = ruleset);
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -21,6 +21,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
 
@@ -150,6 +151,9 @@ namespace osu.Game.Overlays.BeatmapListing
 
         public void FilterLanguage(SearchLanguage language)
             => Schedule(() => searchControl.Language.Value = language);
+
+        public void SetRuleset(RulesetInfo ruleset)
+            => Schedule(() => searchControl.Ruleset.Value = ruleset);
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -26,6 +26,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
 
@@ -87,6 +88,11 @@ namespace osu.Game.Overlays
             filterControl.TypingStarted = onTypingStarted;
             filterControl.SearchStarted = onSearchStarted;
             filterControl.SearchFinished = onSearchFinished;
+        }
+
+        public void FilterRuleset(RulesetInfo ruleset)
+        {
+            filterControl.SetRuleset(ruleset);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -26,7 +26,6 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Resources.Localisation.Web;
-using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
 
@@ -88,11 +87,6 @@ namespace osu.Game.Overlays
             filterControl.TypingStarted = onTypingStarted;
             filterControl.SearchStarted = onSearchStarted;
             filterControl.SearchFinished = onSearchFinished;
-        }
-
-        public void FilterRuleset(RulesetInfo ruleset)
-        {
-            filterControl.SetRuleset(ruleset);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Select/FooterButtonOptions.Popover.cs
+++ b/osu.Game/Screens/Select/FooterButtonOptions.Popover.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -38,11 +39,16 @@ namespace osu.Game.Screens.Select
             // PopoverContainer.
             public ISongSelect? SongSelect { get; init; }
             public required OverlayColourProvider ColourProvider { get; init; }
+            public required BeatmapListingOverlay BeatmapListing { get; init; }
 
-            public Popover(FooterButtonOptions footerButton, BeatmapInfo beatmap)
+            [SetsRequiredMembers]
+            public Popover(FooterButtonOptions footerButton, BeatmapInfo beatmap, OverlayColourProvider colourProvider, BeatmapListingOverlay beatmapListing, ISongSelect? songSelect = null)
             {
                 this.footerButton = footerButton;
                 this.beatmap = beatmap;
+                ColourProvider = colourProvider;
+                BeatmapListing = beatmapListing;
+                SongSelect = songSelect;
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Select/FooterButtonSearch.cs
+++ b/osu.Game/Screens/Select/FooterButtonSearch.cs
@@ -9,14 +9,14 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics;
-using osu.Game.Input.Bindings;
-using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Screens.Footer;
+using osu.Game.Rulesets;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Select
 {
-    public partial class FooterButtonOptions : ScreenFooterButton, IHasPopover
+    public partial class FooterButtonSearch : ScreenFooterButton, IHasPopover
     {
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -34,14 +34,21 @@ namespace osu.Game.Screens.Select
         private BeatmapListingOverlay beatmapListing { get; set; } = null!;
 
         private Live<BeatmapInfo> beatmap = null!;
+        private bool f4WasPressedLastFrame;
+
+        public IBindable<WorkingBeatmap> WorkingBeatmap => workingBeatmap;
+
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        public IBindable<RulesetInfo> RulesetBindable => ruleset;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colour)
         {
-            Text = SongSelectStrings.Options;
-            Icon = FontAwesome.Solid.Cog;
+            Text = "Search";
+            Icon = FontAwesome.Solid.Search;
             AccentColour = colour.Purple1;
-            Hotkey = GlobalAction.ToggleBeatmapOptions;
 
             Action = this.ShowPopover;
         }
@@ -52,6 +59,20 @@ namespace osu.Game.Screens.Select
             workingBeatmap.BindValueChanged(_ => beatmapChanged(), true);
         }
 
+        protected override void Update()
+        {
+            base.Update();
+            var inputManager = GetContainingInputManager();
+            if (inputManager == null) return;
+
+            var keyboard = inputManager.CurrentState.Keyboard;
+            bool f4Pressed = keyboard.Keys.IsPressed(Key.F4);
+            if (f4Pressed && !f4WasPressedLastFrame)
+                Action?.Invoke();
+
+            f4WasPressedLastFrame = f4Pressed;
+        }
+
         private void beatmapChanged()
         {
             this.HidePopover();
@@ -60,6 +81,9 @@ namespace osu.Game.Screens.Select
                 beatmap = realm.Run(r => r.Find<BeatmapInfo>(workingBeatmap.Value.BeatmapInfo.ID)!.ToLive(realm));
         }
 
-        public Framework.Graphics.UserInterface.Popover GetPopover() => new Popover(this, beatmap.Value.Detach(), colourProvider, beatmapListing, songSelect);
+        public Framework.Graphics.UserInterface.Popover GetPopover()
+        {
+            return new SearchPopover(this, beatmap.Value.Detach(), colourProvider, beatmapListing, songSelect);
+        }
     }
 }

--- a/osu.Game/Screens/Select/SearchPopover.cs
+++ b/osu.Game/Screens/Select/SearchPopover.cs
@@ -1,0 +1,248 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Screens.Select
+{
+    public partial class SearchPopover : OsuPopover
+    {
+        private FillFlowContainer buttonFlow = null!;
+        private readonly FooterButtonSearch footerButton;
+
+        private readonly BeatmapInfo beatmap;
+        private bool was1Pressed;
+        private bool was2Pressed;
+        private bool was3Pressed;
+        private Visibility currentVisibility;
+        private OsuSpriteText? searchModeText;
+
+        public OverlayColourProvider ColourProvider { get; init; }
+        public BeatmapListingOverlay BeatmapListing { get; init; }
+        public ISongSelect? SongSelect { get; init; }
+
+        public SearchPopover(FooterButtonSearch footerButton, BeatmapInfo beatmap, OverlayColourProvider colourProvider, BeatmapListingOverlay beatmapListing, ISongSelect? songSelect)
+        {
+            this.footerButton = footerButton;
+            this.beatmap = beatmap;
+            ColourProvider = colourProvider;
+            BeatmapListing = beatmapListing;
+            SongSelect = songSelect;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            Content.Padding = new MarginPadding(5);
+
+            searchModeText = new OsuSpriteText
+            {
+                Text = "Search online for beatmaps",
+                Font = OsuFont.Default.With(size: 12, weight: FontWeight.Bold),
+                Colour = Color4.White,
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                Margin = new MarginPadding { Bottom = 5 }
+            };
+
+            var hintText = new OsuSpriteText
+            {
+                Text = "Hold Shift for local search",
+                Font = OsuFont.Default.With(size: 9),
+                Colour = Color4.Gray,
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                Margin = new MarginPadding { Bottom = 10 }
+            };
+
+            Child = new FillFlowContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    searchModeText,
+                    hintText,
+                    buttonFlow = new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(10),
+                    }
+                }
+            };
+
+            addButton("By title", FontAwesome.Solid.Search, "title");
+            addButton("By artist", FontAwesome.Solid.User, "artist");
+            addButton("By source", FontAwesome.Solid.Tag, "source");
+        }
+
+
+        private void searchBy(string field)
+        {
+            if (beatmap?.Metadata == null) return;
+            var meta = beatmap.Metadata;
+
+            string query = field switch
+            {
+                "title" => !string.IsNullOrEmpty(meta.Title) ? $"title=={meta.Title}" : string.Empty,
+                "artist" => !string.IsNullOrEmpty(meta.Artist) ? $"artist=={meta.Artist}" : string.Empty,
+                "source" => !string.IsNullOrEmpty(meta.Source) ? $"source=={meta.Source}" : string.Empty,
+                _ => string.Empty
+            };
+
+
+            if (!string.IsNullOrEmpty(query))
+                BeatmapListing.ShowWithSearch(query);
+
+            Hide();
+        }
+
+        private void performLocalSearch(string field)
+        {
+            if (beatmap?.Metadata == null) return;
+            var meta = beatmap.Metadata;
+
+            string query = field switch
+            {
+                "title" => !string.IsNullOrEmpty(meta.Title) ? $"title={meta.Title}" : string.Empty,
+                "artist" => !string.IsNullOrEmpty(meta.Artist) ? $"artist={meta.Artist}" : string.Empty,
+                "source" => !string.IsNullOrEmpty(meta.Source) ? $"source={meta.Source}" : string.Empty,
+                _ => string.Empty
+            };
+
+            if (!string.IsNullOrEmpty(query))
+                SongSelect?.Search(query);
+
+            Hide();
+        }
+
+        private void addButton(LocalisableString text, IconUsage icon, string field)
+        {
+            var button = new OptionButton
+            {
+                Text = text,
+                Icon = icon,
+                BackgroundColour = ColourProvider.Background3,
+                Action = () =>
+                {
+                    Scheduler.AddDelayed(Hide, 50);
+
+                    var inputManager = GetContainingInputManager();
+                    bool shiftPressed = inputManager?.CurrentState.Keyboard.ShiftPressed == true;
+
+                    if (shiftPressed)
+                        performLocalSearch(field);
+                    else
+                        searchBy(field);
+                },
+            };
+
+            buttonFlow.Add(button);
+        }
+
+        private partial class OptionButton : OsuButton
+        {
+            public IconUsage Icon { get; init; }
+
+            public OptionButton()
+            {
+                Size = new Vector2(100, 35);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Add(new SpriteIcon
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Size = new Vector2(14),
+                    X = 10,
+                    Icon = Icon,
+                    Colour = Color4.White,
+                });
+            }
+
+            protected override SpriteText CreateText() => new OsuSpriteText
+            {
+                Origin = Anchor.CentreLeft,
+                Anchor = Anchor.CentreLeft,
+                X = 30,
+                Font = OsuFont.Default.With(size: 12)
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            ScheduleAfterChildren(() => GetContainingFocusManager()?.ChangeFocus(this));
+        }
+
+        protected override void UpdateState(ValueChangedEvent<Visibility> state)
+        {
+            base.UpdateState(state);
+            footerButton.OverlayState.Value = state.NewValue;
+            currentVisibility = state.NewValue;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (currentVisibility != Visibility.Visible) return;
+
+            var inputManager = GetContainingInputManager();
+            if (inputManager == null) return;
+
+            var keyboard = inputManager.CurrentState.Keyboard;
+
+            if (searchModeText != null)
+                searchModeText.Text = keyboard.ShiftPressed ? "Search in song select" : "Search online for beatmaps";
+
+            bool pressed1 = keyboard.Keys.IsPressed(Key.Number1);
+            if (pressed1 && !was1Pressed)
+            {
+                if (keyboard.ShiftPressed)
+                    performLocalSearch("title");
+                else
+                    searchBy("title");
+            }
+            was1Pressed = pressed1;
+
+            bool pressed2 = keyboard.Keys.IsPressed(Key.Number2);
+            if (pressed2 && !was2Pressed)
+            {
+                if (keyboard.ShiftPressed)
+                    performLocalSearch("artist");
+                else
+                    searchBy("artist");
+            }
+            was2Pressed = pressed2;
+
+            bool pressed3 = keyboard.Keys.IsPressed(Key.Number3);
+            if (pressed3 && !was3Pressed)
+            {
+                if (keyboard.ShiftPressed)
+                    performLocalSearch("source");
+                else
+                    searchBy("source");
+            }
+            was3Pressed = pressed3;
+        }
+    }
+}

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -370,7 +370,8 @@ namespace osu.Game.Screens.Select
             new FooterButtonOptions
             {
                 Hotkey = GlobalAction.ToggleBeatmapOptions,
-            }
+            },
+            new FooterButtonSearch {}
         };
 
         protected override void LoadComplete()


### PR DESCRIPTION
- Added a new button in song select (FooterButtonSearch)
  - Created a popover that shows search options
  - When you hold Shift, it searches locally (in your song list)
  - When you don't hold Shift, it searches online (on the beatmap website)
  - Added a hint telling users about the Shift keybind
  - Buttons and keyboard shortcuts (1/2/3) with Shift for local search

## Why I did it
  Makes it easiear and faster to search for for similar beatmaps online and in the song select