### PR TITLE
Fix song select search not matching results when punctuation marks surround the searched double-quoted phrase

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -240,6 +240,26 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
+        [TestCase("~quoted words~", false)]
+        [TestCase("the artist", false)]
+        [TestCase("the artist ~quoted words~", false)]
+        [TestCase("~unknown~", true)]
+        public void TestCriteriaMatchingTermsAdjacentToMathSymbols(string terms, bool filtered)
+        {
+            var exampleBeatmapInfo = getExampleBeatmap();
+            exampleBeatmapInfo.Metadata.Title = "the artist ~quoted words~";
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { OnlineID = 6 },
+                AllowConvertedBeatmaps = true,
+                SearchText = terms
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
         [TestCase("", false)]
         [TestCase("Goes", false)]
         [TestCase("GOES", false)]

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -220,14 +220,14 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
-        [TestCase(""quoted words"", false)]
-        [TestCase(""the artist"", false)]
-        [TestCase("the artist "quoted words"", false)]
-        [TestCase(""unknown"", true)]
+        [TestCase("\"quoted words\"", false)]
+        [TestCase("\"the artist\"", false)]
+        [TestCase("the artist \"quoted words\"", false)]
+        [TestCase("\"unknown\"", true)]
         public void TestCriteriaMatchingTermsAdjacentToPunctuation(string terms, bool filtered)
         {
             var exampleBeatmapInfo = getExampleBeatmap();
-            exampleBeatmapInfo.Metadata.Title = "the artist "quoted words"";
+            exampleBeatmapInfo.Metadata.Title = "the artist \"quoted words\"";
             var criteria = new FilterCriteria
             {
                 Ruleset = new RulesetInfo { OnlineID = 6 },

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -220,6 +220,26 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
+        [TestCase(""quoted words"", false)]
+        [TestCase(""the artist"", false)]
+        [TestCase("the artist "quoted words"", false)]
+        [TestCase(""unknown"", true)]
+        public void TestCriteriaMatchingTermsAdjacentToPunctuation(string terms, bool filtered)
+        {
+            var exampleBeatmapInfo = getExampleBeatmap();
+            exampleBeatmapInfo.Metadata.Title = "the artist "quoted words"";
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { OnlineID = 6 },
+                AllowConvertedBeatmaps = true,
+                SearchText = terms
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            ClassicAssert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
         [TestCase("", false)]
         [TestCase("Goes", false)]
         [TestCase("GOES", false)]

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Screens.Select
                         break;
 
                     case MatchMode.IsolatedPhrase:
-                        result = Regex.IsMatch(value, $@"(^|\s){Regex.Escape(searchTerm)}($|\s)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                        result = Regex.IsMatch(value, $@"(^|[\s\p{{P}}]){Regex.Escape(searchTerm)}($|[\s\p{{P}}])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                         break;
 
                     case MatchMode.FullPhrase:

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Screens.Select
                         break;
 
                     case MatchMode.IsolatedPhrase:
-                        result = Regex.IsMatch(value, $@"(^|[\s\p{{P}}]){Regex.Escape(searchTerm)}($|[\s\p{{P}}])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                        result = Regex.IsMatch(value, $@"(^|\b){Regex.Escape(searchTerm)}($|\b)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                         break;
 
                     case MatchMode.FullPhrase:


### PR DESCRIPTION
Fixes #36645

The IsolatedPhrase match mode in FilterCriteria used \s (whitespace) as word boundaries, meaning a search term had to be surrounded by spaces (or start/end of string) to match.

This caused songs with titles like
'Music Theme "Some Artist"' to not appear when searching for "Some Artist", since the phrase was bounded by quote characters rather than spaces.

This change extends the boundary pattern to also accept Unicode punctuation (\p{P}) alongside whitespace, so terms surrounded by quotes, commas are correctly matched as isolated phrases.

Tests have been added to cover searching for terms adjacent to punctuation boundaries
(TestCriteriaMatchingTermsAdjacentToPunctuation).

Tests cover the example mentioned above.
Code inspector with no errors and tests passing.