### PR TITLE
Fix editor background taking too long to load with certain storyboards

### DIFF
--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -21,9 +22,12 @@ namespace osu.Game.Graphics.Backgrounds
     {
         private readonly InterpolatingFramedClock storyboardClock;
 
-        private AudioContainer storyboardContainer = null!;
+        public readonly AudioContainer Storyboard;
+
         private DrawableStoryboard? drawableStoryboard;
         private CancellationTokenSource? loadCancellationSource = new CancellationTokenSource();
+
+        public Action? StoryboardLoaded { get; set; }
 
         [Resolved(CanBeNull = true)]
         private MusicController? musicController { get; set; }
@@ -35,17 +39,17 @@ namespace osu.Game.Graphics.Backgrounds
             : base(beatmap, fallbackTextureName)
         {
             storyboardClock = new InterpolatingFramedClock();
+
+            AddInternal(Storyboard = new AudioContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Volume = { Value = 0 },
+            });
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(storyboardContainer = new AudioContainer
-            {
-                RelativeSizeAxes = Axes.Both,
-                Volume = { Value = 0 },
-            });
-
             LoadStoryboard(false);
         }
 
@@ -74,8 +78,10 @@ namespace osu.Game.Graphics.Backgrounds
                 if (Beatmap.Storyboard.ReplacesBackground)
                     Sprite.FadeOut(BackgroundScreen.TRANSITION_LENGTH, Easing.InQuint);
 
-                storyboardContainer.FadeInFromZero(BackgroundScreen.TRANSITION_LENGTH, Easing.OutQuint);
-                storyboardContainer.Add(s);
+                Storyboard.FadeInFromZero(BackgroundScreen.TRANSITION_LENGTH, Easing.OutQuint);
+                Storyboard.Add(s);
+
+                StoryboardLoaded?.Invoke();
             }
         }
 
@@ -88,7 +94,7 @@ namespace osu.Game.Graphics.Backgrounds
             loadCancellationSource = null;
 
             // clear is intentionally used here for the storyboard to be disposed asynchronously.
-            storyboardContainer.Clear();
+            Storyboard.Clear();
 
             drawableStoryboard = null;
 

--- a/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
+++ b/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
@@ -1,36 +1,30 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Screens.Edit;
-using osu.Game.Storyboards.Drawables;
 
 namespace osu.Game.Screens.Backgrounds
 {
     public partial class EditorBackgroundScreen : BackgroundScreen
     {
-        private readonly EditorBeatmap editorBeatmap;
         private readonly Container dimContainer;
 
         private CancellationTokenSource? cancellationTokenSource;
         private Bindable<float> dimLevel = null!;
         private Bindable<bool> showStoryboard = null!;
 
-        private BeatmapBackground background = null!;
-        private Container storyboardContainer = null!;
+        private BeatmapBackgroundWithStoryboard? background;
 
-        private IFrameBasedClock? clockSource;
+        private readonly Container content;
 
         // We retrieve IBindable<WorkingBeatmap> from our dependency cache instead of passing WorkingBeatmap directly into EditorBackgroundScreen.
         // Otherwise, DummyWorkingBeatmap will be erroneously passed in whenever creating a new beatmap (since the Schedule() in the Editor that populates
@@ -40,40 +34,29 @@ namespace osu.Game.Screens.Backgrounds
 
         public EditorBackgroundScreen(EditorBeatmap editorBeatmap)
         {
-            this.editorBeatmap = editorBeatmap;
             InternalChild = dimContainer = new Container
             {
                 RelativeSizeAxes = Axes.Both,
+                // one reason for this kooky container nesting being here is that the storyboard needs a custom clock
+                // but also needs it on an isolated-enough level that doesn't break screen stack expiry logic (which happens if the clock was put on `this`),
+                // or doesn't make it literally impossible to fade the storyboard in/out in real time (which happens if the fade transforms were to be applied directly to the storyboard).
+                // another is that we need `EditorSkinProvidingContainer` so that storyboard sample lookups succeed.
+                Child = content = new EditorSkinProvidingContainer(editorBeatmap)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
             };
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            dimContainer.AddRange(createContent());
-            background = dimContainer.OfType<BeatmapBackground>().Single();
-            storyboardContainer = dimContainer.OfType<Container>().Single();
-
             dimLevel = config.GetBindable<float>(OsuSetting.EditorDim);
             showStoryboard = config.GetBindable<bool>(OsuSetting.EditorShowStoryboard);
-        }
 
-        private IEnumerable<Drawable> createContent() =>
-        [
-            new BeatmapBackground(beatmap.Value) { RelativeSizeAxes = Axes.Both, },
-            // one reason for this kooky container nesting being here is that the storyboard needs a custom clock
-            // but also needs it on an isolated-enough level that doesn't break screen stack expiry logic (which happens if the clock was put on `this`),
-            // or doesn't make it literally impossible to fade the storyboard in/out in real time (which happens if the fade transforms were to be applied directly to the storyboard).
-            // another is that we need `EditorSkinProvidingContainer` so that storyboard sample lookups succeed.
-            new EditorSkinProvidingContainer(editorBeatmap)
-            {
-                RelativeSizeAxes = Axes.Both,
-                Child = new DrawableStoryboard(beatmap.Value.Storyboard)
-                {
-                    Clock = clockSource ?? Clock,
-                }
-            }
-        ];
+            content.Child = createContent();
+            updateState(withAnimation: false);
+        }
 
         protected override void LoadComplete()
         {
@@ -81,36 +64,29 @@ namespace osu.Game.Screens.Backgrounds
 
             dimLevel.BindValueChanged(_ => dimContainer.FadeColour(OsuColour.Gray(1 - dimLevel.Value), 500, Easing.OutQuint), true);
             showStoryboard.BindValueChanged(_ => updateState());
-            updateState(0);
+
+            updateState(withAnimation: false);
         }
 
-        private void updateState(double duration = 500)
-        {
-            storyboardContainer.FadeTo(showStoryboard.Value ? 1 : 0, duration, Easing.OutQuint);
-            // yes, this causes overdraw, but is also a (crude) fix for bad-looking transitions on screen entry
-            // caused by the previous background on the background stack poking out from under this one and then instantly fading out
-            background.FadeColour(beatmap.Value.Storyboard.ReplacesBackground && showStoryboard.Value ? Colour4.Black : Colour4.White, duration, Easing.OutQuint);
-        }
-
-        public void ChangeClockSource(IFrameBasedClock frameBasedClock)
-        {
-            clockSource = frameBasedClock;
-            if (IsLoaded)
-                storyboardContainer.Child.Clock = frameBasedClock;
-        }
-
-        public void RefreshBackground()
+        public void RefreshBackgroundAsync()
         {
             cancellationTokenSource?.Cancel();
-            LoadComponentsAsync(createContent(), loaded =>
+            LoadComponentAsync(createContent(), loaded =>
             {
-                dimContainer.Clear();
-                dimContainer.AddRange(loaded);
-
-                background = dimContainer.OfType<BeatmapBackground>().Single();
-                storyboardContainer = dimContainer.OfType<Container>().Single();
-                updateState(0);
+                content.Child = loaded;
+                updateState(withAnimation: false);
             }, (cancellationTokenSource = new CancellationTokenSource()).Token);
+        }
+
+        private Drawable createContent() => background = new BeatmapBackgroundWithStoryboard(beatmap.Value)
+        {
+            RelativeSizeAxes = Axes.Both,
+            StoryboardLoaded = () => updateState(withAnimation: false)
+        };
+
+        private void updateState(bool withAnimation = true)
+        {
+            background?.Storyboard.FadeTo(showStoryboard.Value ? 1 : 0, withAnimation ? 500 : 0, Easing.OutQuint);
         }
 
         public override bool Equals(BackgroundScreen? other)

--- a/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
+++ b/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Backgrounds
         public override void OnEntering(ScreenTransitionEvent e)
         {
             base.OnEntering(e);
-            blackBox.Delay(TRANSITION_LENGTH).Expire();
+            blackBox.LifetimeEnd = LatestTransformEndTime;
         }
 
         public override bool OnExiting(ScreenExitEvent e)

--- a/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
+++ b/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
@@ -37,10 +37,6 @@ namespace osu.Game.Screens.Backgrounds
             InternalChild = dimContainer = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                // one reason for this kooky container nesting being here is that the storyboard needs a custom clock
-                // but also needs it on an isolated-enough level that doesn't break screen stack expiry logic (which happens if the clock was put on `this`),
-                // or doesn't make it literally impossible to fade the storyboard in/out in real time (which happens if the fade transforms were to be applied directly to the storyboard).
-                // another is that we need `EditorSkinProvidingContainer` so that storyboard sample lookups succeed.
                 Child = content = new EditorSkinProvidingContainer(editorBeatmap)
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
+++ b/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
@@ -6,11 +6,14 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Screens.Edit;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Backgrounds
 {
@@ -25,6 +28,7 @@ namespace osu.Game.Screens.Backgrounds
         private BeatmapBackgroundWithStoryboard? background;
 
         private readonly Container content;
+        private readonly Box blackBox;
 
         // We retrieve IBindable<WorkingBeatmap> from our dependency cache instead of passing WorkingBeatmap directly into EditorBackgroundScreen.
         // Otherwise, DummyWorkingBeatmap will be erroneously passed in whenever creating a new beatmap (since the Schedule() in the Editor that populates
@@ -37,9 +41,19 @@ namespace osu.Game.Screens.Backgrounds
             InternalChild = dimContainer = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = content = new EditorSkinProvidingContainer(editorBeatmap)
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    // This adds overdraw but makes transitions not suck.
+                    // There's probably a better way to do this, but it's high effort.
+                    blackBox = new Box
+                    {
+                        Colour = Color4.Black,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    content = new EditorSkinProvidingContainer(editorBeatmap)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
                 },
             };
         }
@@ -62,6 +76,20 @@ namespace osu.Game.Screens.Backgrounds
             showStoryboard.BindValueChanged(_ => updateState());
 
             updateState(withAnimation: false);
+        }
+
+        public override void OnEntering(ScreenTransitionEvent e)
+        {
+            base.OnEntering(e);
+            blackBox.Delay(TRANSITION_LENGTH).Expire();
+        }
+
+        public override bool OnExiting(ScreenExitEvent e)
+        {
+            // The storyboard will do weird things with clock time changing on exit, so let's just hide it instead.
+            background?.UnloadStoryboard();
+
+            return base.OnExiting(e);
         }
 
         public void RefreshBackgroundAsync()

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -472,8 +472,6 @@ namespace osu.Game.Screens.Edit
 
             changeHandler?.CanUndo.BindValueChanged(v => undoMenuItem.Action.Disabled = !v.NewValue, true);
             changeHandler?.CanRedo.BindValueChanged(v => redoMenuItem.Action.Disabled = !v.NewValue, true);
-
-            editorBackgroundDim.BindValueChanged(_ => setUpBackground());
         }
 
         [Resolved]
@@ -845,24 +843,13 @@ namespace osu.Game.Screens.Edit
         public override void OnEntering(ScreenTransitionEvent e)
         {
             base.OnEntering(e);
-            setUpBackground();
             setUpTrack(seekToStart: true);
         }
 
         public override void OnResuming(ScreenTransitionEvent e)
         {
             base.OnResuming(e);
-            setUpBackground();
             setUpTrack();
-        }
-
-        private void setUpBackground()
-        {
-            ApplyToBackground(b =>
-            {
-                var editorBackground = (EditorBackgroundScreen)b;
-                editorBackground.ChangeClockSource(clock);
-            });
         }
 
         public override bool OnExiting(ScreenExitEvent e)

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Edit.Setup
                 (metadata, name) => metadata.BackgroundFile = name);
 
             headerBackground.UpdateBackground();
-            editor?.ApplyToBackground(bg => ((EditorBackgroundScreen)bg).RefreshBackground());
+            editor?.ApplyToBackground(bg => ((EditorBackgroundScreen)bg).RefreshBackgroundAsync());
             return true;
         }
 


### PR DESCRIPTION
TL;DR the clock was being set too late, causing more transforms to be created than necessary.

This solves the issue by way of a refactor (sorry). Overall this should simplify handling of things as more of the logic is shared with the known good-state `BeatmapBackgroundWithStoryboard`.

I did try without a refactor (just delaying the creation until the clock arrives) but this version made more sense because background generally expect to do their main load in BDL to aid in smooth transitions. And we can't get the clock by there. (although arguably we could just use a similar method to `BeatmapBackgroundWithStoryboard` and forego using the editor clock).

Of note, I removed the black background overdraw hack. There are edge cases where it will lead to weird transitions, but these are far and few between. Basically you need a storyboard which sets the flag to hide the beatmap background and has transparency in it. This is no longer as flagrantly bad as things used to be (which led to the inline fix) as far as I can tell, but feel free to prove me wrong. If this is a blocker I'll probably just add a permanent black box (which does fix this).

Closes #36875.