### PR TITLE
Increase precision for the Accuracy Challenge mod

### DIFF
--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -57,8 +57,8 @@ namespace osu.Game.Rulesets.Mods
         public BindableNumber<double> MinimumAccuracy { get; } = new BindableDouble
         {
             MinValue = 0.60,
-            MaxValue = 0.99,
-            Precision = 0.01,
+            MaxValue = 0.999,
+            Precision = 0.001,
             Default = 0.9,
             Value = 0.9,
         };


### PR DESCRIPTION
1% is not precise enough to push accuracy to high enough levels. Increasing the precision of the mod will make it more useful for a larger amount of players who want to push their accuracy to their absolute limits. This does come with the caveat that it's impossible to achieve over 99.9% accuracy on many short maps, but I don't think it really matters if high enough settings act like the Perfect mod on short enough maps.