### PR TITLE
Fix compatibility export using platform-dependent line endings

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -128,6 +130,42 @@ namespace osu.Game.Tests.Beatmaps.IO
                 using var archiveReader = new ZipArchiveReader(memoryStream);
                 byte[] fileContent = archiveReader.GetStream(filename).ReadAllBytesToArray();
                 return Encoding.UTF8.GetString(fileContent);
+            }
+        }
+
+        [Test]
+        public void TestExportUsesCarriageReturnLineFeed()
+        {
+            IWorkingBeatmap beatmap = null!;
+            MemoryStream outStream = null!;
+
+            AddStep("import beatmap", () => beatmap = importBeatmapFromArchives(@"legacy-export-stability-test.olz"));
+            AddStep("export", () =>
+            {
+                outStream = new MemoryStream();
+
+                new LegacyBeatmapExporter(LocalStorage)
+                    .ExportToStream((BeatmapSetInfo)beatmap.BeatmapInfo.BeatmapSet!, outStream, null);
+            });
+
+            AddAssert(".osu file uses CRLF line endings",
+                () => hasBareLineFeed(outStream.GetBuffer()),
+                () => Is.False);
+
+            bool hasBareLineFeed(byte[] archiveBytes)
+            {
+                using var memoryStream = new MemoryStream(archiveBytes);
+                using var archiveReader = new ZipArchiveReader(memoryStream);
+
+                foreach (string filename in archiveReader.Filenames.Where(f => f.EndsWith(".osu", StringComparison.Ordinal)))
+                {
+                    byte[] content = archiveReader.GetStream(filename).ReadAllBytesToArray();
+
+                    if (content.Prepend((byte)0).Zip(content).Any(pair => pair.Second == '\n' && pair.First != '\r'))
+                        return true;
+                }
+
+                return false;
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
@@ -161,8 +161,14 @@ namespace osu.Game.Tests.Beatmaps.IO
                 {
                     byte[] content = archiveReader.GetStream(filename).ReadAllBytesToArray();
 
-                    if (content.Prepend((byte)0).Zip(content).Any(pair => pair.Second == '\n' && pair.First != '\r'))
-                        return true;
+                    for (int i = 0; i < content.Length; i++)
+                    {
+                        if (content[i] != '\n')
+                            continue;
+
+                        if (i == 0 || content[i - 1] != '\r')
+                            return true;
+                    }
                 }
 
                 return false;

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -74,7 +74,10 @@ namespace osu.Game.Database
 
             using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
             {
+                // Maintain line endings in windows style.
+                // If we don't do that, uploads to BSS may show changes where there are none.
                 sw.NewLine = "\r\n";
+
                 new LegacyBeatmapEncoder(playableBeatmap, beatmapSkin).Encode(sw);
             }
 

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -71,8 +71,12 @@ namespace osu.Game.Database
 
             // Encode to legacy format
             var stream = new MemoryStream();
+
             using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
+            {
+                sw.NewLine = "\r\n";
                 new LegacyBeatmapEncoder(playableBeatmap, beatmapSkin).Encode(sw);
+            }
 
             stream.Seek(0, SeekOrigin.Begin);
 


### PR DESCRIPTION
The compatibility export was creating .osu files with CRLF line endings on Windows and LF line endings on Linux/macOS, because StreamWriter defaults to Environment.NewLine.

This caused the server to detect spurious file changes when a mapper alternated between platforms, leading to unnecessary wipes of local scores and noise in the beatmap update history.

Fix by explicitly setting NewLine = "\r\n" on the StreamWriter, ensuring CRLF is always used regardless of platform.

Closes #36846