### PR TITLE
Fix timing points sometimes not showing up in the editor timeline when paired with a kiai start/end

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/GroupVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/GroupVisualisation.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 
                         case EffectControlPoint:
                             if (!showScrollSpeed)
-                                return;
+                                continue;
 
                             AddInternal(new ControlPointVisualisation(point)
                             {


### PR DESCRIPTION
Initially reported on [discord](https://discord.com/channels/188630481301012481/1097318920991559880/1481649645167054878).

`return` instead of `continue` led to the loop exiting too early if there was an `EffectControlPoint` in the list before a `TimingControlPoint`.

Behaviour can be reproduced with topdiff on this [mapset](https://osu.ppy.sh/beatmapsets/1884175#osu/4027941). When opened, all timing points on kiai start don't show up in the timeline. If you disable/enable the effects section on one of those timing points the order changes and it becomes visible again.