### PR TITLE
Fix storyboard / beatmap backgrounds being rendered in background of multiplayer

### DIFF
--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBlack.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBlack.cs
@@ -10,18 +10,24 @@ namespace osu.Game.Screens.Backgrounds
 {
     public partial class BackgroundScreenBlack : BackgroundScreen
     {
-        public BackgroundScreenBlack()
+        private readonly double delayBeforeBlack;
+
+        public BackgroundScreenBlack(double delayBeforeBlack = 0)
         {
+            this.delayBeforeBlack = delayBeforeBlack;
+
             InternalChild = new Box
             {
                 Colour = Color4.Black,
                 RelativeSizeAxes = Axes.Both,
             };
+
+            Alpha = 0;
         }
 
         public override void OnEntering(ScreenTransitionEvent e)
         {
-            Show();
+            this.Delay(delayBeforeBlack).FadeIn(200);
         }
     }
 }

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBlack.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBlack.cs
@@ -11,12 +11,13 @@ namespace osu.Game.Screens.Backgrounds
     public partial class BackgroundScreenBlack : BackgroundScreen
     {
         private readonly double delayBeforeBlack;
+        private readonly Box box;
 
         public BackgroundScreenBlack(double delayBeforeBlack = 0)
         {
             this.delayBeforeBlack = delayBeforeBlack;
 
-            InternalChild = new Box
+            InternalChild = box = new Box
             {
                 Colour = Color4.Black,
                 RelativeSizeAxes = Axes.Both,
@@ -27,7 +28,10 @@ namespace osu.Game.Screens.Backgrounds
 
         public override void OnEntering(ScreenTransitionEvent e)
         {
-            this.Delay(delayBeforeBlack).FadeIn(200);
+            this
+                .Delay(delayBeforeBlack)
+                .FadeIn(200)
+                .OnComplete(_ => box.Hide());
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
+using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Users;
@@ -21,6 +22,10 @@ namespace osu.Game.Screens.OnlinePlay
     {
         [Cached]
         protected readonly OverlayColourProvider ColourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
+
+        // Without this, the beatmap / menu background will be displayed behind the online play overlays.
+        // This adds needless load, and in some cases is visible when everything in front is transparent momentarily (song select).
+        protected override BackgroundScreen CreateBackground() => new BackgroundScreenBlack(WaveContainer.APPEAR_DURATION);
 
         public IScreen CurrentSubScreen => screenStack.CurrentScreen;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/37006 visually.

Note that this adds a brief fade in on entering `PlayerLoader` from `OnlinePlayScreen`s due to actually loading the background at this point. I think this is fine.