### PR TITLE
Extract common components from `BeatmapLeaderboardScore`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboardScore.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboardScore.cs
@@ -14,6 +14,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mods;
@@ -67,16 +68,16 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 foreach (var scoreInfo in getTestScores())
                 {
-                    BeatmapLeaderboardScore.HighlightType? highlightType = null;
+                    LeaderboardRankDisplay.HighlightType? highlightType = null;
 
                     switch (scoreInfo.User.Id)
                     {
                         case 2:
-                            highlightType = BeatmapLeaderboardScore.HighlightType.Own;
+                            highlightType = LeaderboardRankDisplay.HighlightType.Own;
                             break;
 
                         case 1541390:
-                            highlightType = BeatmapLeaderboardScore.HighlightType.Friend;
+                            highlightType = LeaderboardRankDisplay.HighlightType.Friend;
                             break;
                     }
 
@@ -118,16 +119,16 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 foreach (var scoreInfo in getTestScores())
                 {
-                    BeatmapLeaderboardScore.HighlightType? highlightType = null;
+                    LeaderboardRankDisplay.HighlightType? highlightType = null;
 
                     switch (scoreInfo.User.Id)
                     {
                         case 2:
-                            highlightType = BeatmapLeaderboardScore.HighlightType.Own;
+                            highlightType = LeaderboardRankDisplay.HighlightType.Own;
                             break;
 
                         case 1541390:
-                            highlightType = BeatmapLeaderboardScore.HighlightType.Friend;
+                            highlightType = LeaderboardRankDisplay.HighlightType.Friend;
                             break;
                     }
 

--- a/osu.Game/Online/Leaderboards/LeaderboardCommonDisplay.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardCommonDisplay.cs
@@ -1,0 +1,180 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Extensions;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Screens.Select;
+using osu.Game.Users.Drawables;
+using osuTK;
+
+namespace osu.Game.Online.Leaderboards
+{
+    public partial class LeaderboardCommonDisplay : Container
+    {
+        public readonly APIUser User;
+        public readonly DateTimeOffset? Date;
+        public readonly int? Rank;
+
+        private const int corner_radius = BeatmapLeaderboardScore.CORNER_RADIUS;
+
+        private FillFlowContainer fillFlowContainer = null!;
+        private ClickableAvatar innerAvatar = null!;
+        private Container rankOverlay = null!;
+
+        private readonly bool sheared;
+
+        public LeaderboardCommonDisplay(APIUser user, DateTimeOffset? date, int? rank = null, bool sheared = false)
+        {
+            User = user;
+            Date = date;
+            Rank = rank;
+
+            this.sheared = sheared;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            Child = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                ColumnDimensions = new[]
+                {
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(),
+                },
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        new Container
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            CornerRadius = corner_radius,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new DelayedLoadWrapper(innerAvatar = new ClickableAvatar(User)
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Scale = new Vector2(1.1f),
+                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                    RelativeSizeAxes = Axes.Both,
+                                })
+                                {
+                                    RelativeSizeAxes = Axes.None,
+                                    Size = new Vector2(BeatmapLeaderboardScore.HEIGHT)
+                                },
+                                rankOverlay = new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = Colour4.Black.Opacity(0.5f),
+                                        },
+                                        new LeaderboardRankLabel(Rank, sheared, false)
+                                        {
+                                            AutoSizeAxes = Axes.Both,
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                        },
+                                    }
+                                }
+                            },
+                        },
+                        new FillFlowContainer
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Padding = new MarginPadding { Horizontal = corner_radius },
+                            Children = new Drawable[]
+                            {
+                                fillFlowContainer = new FillFlowContainer
+                                {
+                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(5),
+                                    AutoSizeAxes = Axes.Both,
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new UpdateableFlag(User.CountryCode)
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Size = new Vector2(20, 14),
+                                        },
+                                        new UpdateableTeamFlag(User.Team)
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Size = new Vector2(30, 15),
+                                        },
+                                    },
+                                },
+                                new TruncatingSpriteText
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                                    Text = User.Username,
+                                    Font = OsuFont.Style.Heading2,
+                                }
+                            }
+                        },
+                    },
+                }
+            };
+
+            innerAvatar.OnLoadComplete += d => d.FadeInFromZero(200);
+
+            if (Date != null)
+            {
+                fillFlowContainer.Add(new DateLabel(Date.Value)
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Colour = colourProvider.Content2,
+                    UseFullGlyphHeight = false,
+                });
+            }
+        }
+
+        public void UpdateRankOverlayState(bool shouldBeVisible, double duration)
+        {
+            if (shouldBeVisible)
+                rankOverlay.FadeIn(duration, Easing.OutQuint);
+            else
+                rankOverlay.FadeOut(duration, Easing.OutQuint);
+        }
+
+        private partial class DateLabel : DrawableDate
+        {
+            public DateLabel(DateTimeOffset date)
+                : base(date)
+            {
+                Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold);
+            }
+
+            protected override LocalisableString Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));
+        }
+    }
+}

--- a/osu.Game/Online/Leaderboards/LeaderboardRankDisplay.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardRankDisplay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
-using osu.Game.Screens.Select;
 using osuTK.Graphics;
 
 namespace osu.Game.Online.Leaderboards
@@ -26,12 +25,9 @@ namespace osu.Game.Online.Leaderboards
         private static readonly Color4 personal_best_gradient_left = Color4Extensions.FromHex("#66FFCC");
         private static readonly Color4 personal_best_gradient_right = Color4Extensions.FromHex("#51A388");
 
-        private const int transition_duration = BeatmapLeaderboardScore.TRANSITION_DURATION;
-
         private Container highlightGradient = null!;
 
         private readonly bool sheared;
-        private bool firstTransition = true;
 
         public LeaderboardRankDisplay(int? rank, bool sheared = false, HighlightType? highlight = null)
         {
@@ -78,27 +74,19 @@ namespace osu.Game.Online.Leaderboards
             }
         }
 
-        public void UpdateHighlightState(bool isHovered)
+        public void UpdateHighlightState(bool isHovered, double duration)
         {
-            highlightGradient.FadeColour(getHighlightColour(Highlight, isHovered ? 0.2f : 0), transition_duration, Easing.OutQuint);
+            highlightGradient.FadeColour(getHighlightColour(Highlight, isHovered ? 0.2f : 0), duration, Easing.OutQuint);
         }
 
-        private int transitionDuration() => firstTransition ? 0 : transition_duration;
-
-        public override void Show()
+        public void Appear(double duration)
         {
-            this.FadeIn(transitionDuration(), Easing.OutQuint)
-                .ResizeWidthTo(WIDTH, transitionDuration(), Easing.OutQuint);
-
-            firstTransition = false;
+            this.FadeIn(duration, Easing.OutQuint).ResizeWidthTo(WIDTH, duration, Easing.OutQuint);
         }
 
-        public override void Hide()
+        public void Disappear(double duration)
         {
-            this.FadeOut(transitionDuration(), Easing.OutQuint)
-                .ResizeWidthTo(0, transitionDuration(), Easing.OutQuint);
-
-            firstTransition = false;
+            this.FadeOut(duration, Easing.OutQuint).ResizeWidthTo(0, duration, Easing.OutQuint);
         }
 
         public enum HighlightType

--- a/osu.Game/Online/Leaderboards/LeaderboardRankDisplay.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardRankDisplay.cs
@@ -1,0 +1,110 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Screens.Select;
+using osuTK.Graphics;
+
+namespace osu.Game.Online.Leaderboards
+{
+    public partial class LeaderboardRankDisplay : Container
+    {
+        public const int WIDTH = 40;
+
+        public readonly int? Rank;
+        public readonly HighlightType? Highlight;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        private static readonly Color4 personal_best_gradient_left = Color4Extensions.FromHex("#66FFCC");
+        private static readonly Color4 personal_best_gradient_right = Color4Extensions.FromHex("#51A388");
+
+        private const int transition_duration = BeatmapLeaderboardScore.TRANSITION_DURATION;
+
+        private Container highlightGradient = null!;
+
+        private readonly bool sheared;
+        private bool firstTransition = true;
+
+        public LeaderboardRankDisplay(int? rank, bool sheared = false, HighlightType? highlight = null)
+        {
+            Rank = rank;
+            Highlight = highlight;
+
+            this.sheared = sheared;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Width = WIDTH;
+            RelativeSizeAxes = Axes.Y;
+            Children = new Drawable[]
+            {
+                highlightGradient = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Right = -10f },
+                    Alpha = Highlight != null ? 1 : 0,
+                    Colour = getHighlightColour(Highlight),
+                    Child = new Box { RelativeSizeAxes = Axes.Both },
+                },
+                new LeaderboardRankLabel(Rank, sheared, darkText: Highlight == HighlightType.Own)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+            };
+        }
+
+        private ColourInfo getHighlightColour(HighlightType? highlightType, float lightenAmount = 0)
+        {
+            switch (highlightType)
+            {
+                case HighlightType.Own:
+                    return ColourInfo.GradientHorizontal(personal_best_gradient_left.Lighten(lightenAmount), personal_best_gradient_right.Lighten(lightenAmount));
+
+                case HighlightType.Friend:
+                    return ColourInfo.GradientHorizontal(colours.Pink1.Lighten(lightenAmount), colours.Pink3.Lighten(lightenAmount));
+
+                default:
+                    return Colour4.White;
+            }
+        }
+
+        public void UpdateHighlightState(bool isHovered)
+        {
+            highlightGradient.FadeColour(getHighlightColour(Highlight, isHovered ? 0.2f : 0), transition_duration, Easing.OutQuint);
+        }
+
+        private int transitionDuration() => firstTransition ? 0 : transition_duration;
+
+        public override void Show()
+        {
+            this.FadeIn(transitionDuration(), Easing.OutQuint)
+                .ResizeWidthTo(WIDTH, transitionDuration(), Easing.OutQuint);
+
+            firstTransition = false;
+        }
+
+        public override void Hide()
+        {
+            this.FadeOut(transitionDuration(), Easing.OutQuint)
+                .ResizeWidthTo(0, transitionDuration(), Easing.OutQuint);
+
+            firstTransition = false;
+        }
+
+        public enum HighlightType
+        {
+            Own,
+            Friend,
+        }
+    }
+}

--- a/osu.Game/Online/Leaderboards/LeaderboardRankLabel.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardRankLabel.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Utils;
+using osuTK;
+
+namespace osu.Game.Online.Leaderboards
+{
+    public partial class LeaderboardRankLabel : Container, IHasTooltip
+    {
+        private readonly bool darkText;
+        private readonly OsuSpriteText text;
+
+        public LeaderboardRankLabel(int? rank, bool sheared, bool darkText)
+        {
+            this.darkText = darkText;
+            if (rank >= 1000)
+                TooltipText = $"#{rank:N0}";
+
+            Child = text = new OsuSpriteText
+            {
+                Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Font = OsuFont.Style.Heading2,
+                Text = rank?.FormatRank().Insert(0, "#") ?? "-",
+                Shadow = !darkText,
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            text.Colour = darkText ? colourProvider.Background3 : colourProvider.Content1;
+        }
+
+        public LocalisableString TooltipText { get; }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeLeaderboard.cs
@@ -13,6 +13,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
+using osu.Game.Online.Leaderboards;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -160,12 +161,12 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                 {
                     LoadComponentsAsync(best.Select((s, index) =>
                     {
-                        BeatmapLeaderboardScore.HighlightType? highlightType = null;
+                        LeaderboardRankDisplay.HighlightType? highlightType = null;
 
                         if (s.UserID == api.LocalUser.Value.Id)
-                            highlightType = BeatmapLeaderboardScore.HighlightType.Own;
+                            highlightType = LeaderboardRankDisplay.HighlightType.Own;
                         else if (api.LocalUserState.Friends.Any(r => r.TargetID == s.UserID))
-                            highlightType = BeatmapLeaderboardScore.HighlightType.Friend;
+                            highlightType = LeaderboardRankDisplay.HighlightType.Friend;
 
                         return new BeatmapLeaderboardScore(s, sheared: false)
                         {
@@ -191,7 +192,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     userBestContainer.Add(new BeatmapLeaderboardScore(userBest, sheared: false)
                     {
                         Rank = userBest.Position,
-                        Highlight = BeatmapLeaderboardScore.HighlightType.Own,
+                        Highlight = LeaderboardRankDisplay.HighlightType.Own,
                         Action = () => PresentScore?.Invoke(userBest.OnlineID),
                         SelectedMods = { BindTarget = SelectedMods },
                         IsValidMod = IsValidMod,

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.Tooltip.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.Tooltip.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.X;
                     AutoSizeAxes = Axes.Y;
-                    CornerRadius = corner_radius;
+                    CornerRadius = CORNER_RADIUS;
                     Masking = true;
 
                     EdgeEffect = new EdgeEffectParameters
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.Select
                                     Origin = Anchor.TopCentre,
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    CornerRadius = corner_radius,
+                                    CornerRadius = CORNER_RADIUS,
                                     Masking = true,
                                     Margin = new MarginPadding { Top = 4f },
                                     Children = new Drawable[]
@@ -357,7 +357,7 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.X;
                     AutoSizeAxes = Axes.Y;
-                    CornerRadius = corner_radius;
+                    CornerRadius = CORNER_RADIUS;
                     Masking = true;
 
                     EdgeEffect = new EdgeEffectParameters
@@ -417,7 +417,7 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.X;
                     AutoSizeAxes = Axes.Y;
-                    CornerRadius = corner_radius;
+                    CornerRadius = CORNER_RADIUS;
                     Masking = true;
 
                     EdgeEffect = new EdgeEffectParameters

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -43,7 +43,6 @@ namespace osu.Game.Screens.Select
     public sealed partial class BeatmapLeaderboardScore : OsuClickableContainer, IHasContextMenu, IHasCustomTooltip<ScoreInfo>
     {
         public const int HEIGHT = 50;
-        public const int TRANSITION_DURATION = 200;
 
         public readonly ScoreInfo Score;
 
@@ -85,6 +84,7 @@ namespace osu.Game.Screens.Select
         private const float statistics_compact_min_width = 90;
 
         private const int corner_radius = 10;
+        private const int transition_duration = 200;
 
         private Colour4 foregroundColour;
         private Colour4 backgroundColour;
@@ -495,15 +495,15 @@ namespace osu.Game.Screens.Select
         {
             var lightenedGradient = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0).Lighten(0.2f), backgroundColour.Lighten(0.2f));
 
-            foreground.FadeColour(IsHovered ? foregroundColour.Lighten(0.2f) : foregroundColour, TRANSITION_DURATION, Easing.OutQuint);
-            background.FadeColour(IsHovered ? backgroundColour.Lighten(0.2f) : backgroundColour, TRANSITION_DURATION, Easing.OutQuint);
-            totalScoreBackground.FadeColour(IsHovered ? lightenedGradient : totalScoreBackgroundGradient, TRANSITION_DURATION, Easing.OutQuint);
-            rankLabelStandalone.UpdateHighlightState(IsHovered);
+            foreground.FadeColour(IsHovered ? foregroundColour.Lighten(0.2f) : foregroundColour, transition_duration, Easing.OutQuint);
+            background.FadeColour(IsHovered ? backgroundColour.Lighten(0.2f) : backgroundColour, transition_duration, Easing.OutQuint);
+            totalScoreBackground.FadeColour(IsHovered ? lightenedGradient : totalScoreBackgroundGradient, transition_duration, Easing.OutQuint);
+            rankLabelStandalone.UpdateHighlightState(IsHovered, transition_duration);
 
             if (IsHovered && currentMode != DisplayMode.Full)
-                rankLabelOverlay.FadeIn(TRANSITION_DURATION, Easing.OutQuint);
+                rankLabelOverlay.FadeIn(transition_duration, Easing.OutQuint);
             else
-                rankLabelOverlay.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
+                rankLabelOverlay.FadeOut(transition_duration, Easing.OutQuint);
         }
 
         private DisplayMode? currentMode;
@@ -526,12 +526,12 @@ namespace osu.Game.Screens.Select
 
         private void updateDisplayMode(DisplayMode mode)
         {
-            if (mode >= DisplayMode.Full)
-                rankLabelStandalone.Show();
-            else
-                rankLabelStandalone.Hide();
+            double duration = currentMode == null ? 0 : transition_duration;
 
-            double duration = currentMode == null ? 0 : TRANSITION_DURATION;
+            if (mode >= DisplayMode.Full)
+                rankLabelStandalone.Appear(duration);
+            else
+                rankLabelStandalone.Disappear(duration);
 
             if (mode >= DisplayMode.Regular)
             {

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Screens.Select
     public sealed partial class BeatmapLeaderboardScore : OsuClickableContainer, IHasContextMenu, IHasCustomTooltip<ScoreInfo>
     {
         public const int HEIGHT = 50;
+        public const int TRANSITION_DURATION = 200;
 
         public readonly ScoreInfo Score;
 
@@ -57,14 +58,11 @@ namespace osu.Game.Screens.Select
         public Func<Mod, bool> IsValidMod { get; set; } = _ => true;
 
         public int? Rank { get; init; }
-        public HighlightType? Highlight { get; init; }
+        public LeaderboardRankDisplay.HighlightType? Highlight { get; init; }
         public Action<ScoreInfo>? ShowReplay { get; init; }
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
-
-        [Resolved]
-        private OsuColour colours { get; set; } = null!;
 
         [Resolved]
         private IDialogOverlay? dialogOverlay { get; set; }
@@ -86,13 +84,8 @@ namespace osu.Game.Screens.Select
         private const float username_min_width = 120;
         private const float statistics_regular_min_width = 165;
         private const float statistics_compact_min_width = 90;
-        private const float rank_label_width = 40;
 
         private const int corner_radius = 10;
-        private const int transition_duration = 200;
-
-        private static readonly Color4 personal_best_gradient_left = Color4Extensions.FromHex("#66FFCC");
-        private static readonly Color4 personal_best_gradient_right = Color4Extensions.FromHex("#51A388");
 
         private Colour4 foregroundColour;
         private Colour4 backgroundColour;
@@ -113,8 +106,7 @@ namespace osu.Game.Screens.Select
         private Box totalScoreBackground = null!;
 
         private FillFlowContainer statisticsContainer = null!;
-        private Container highlightGradient = null!;
-        private Container rankLabelStandalone = null!;
+        private LeaderboardRankDisplay rankLabelStandalone = null!;
         private Container rankLabelOverlay = null!;
 
         private readonly bool sheared;
@@ -159,26 +151,7 @@ namespace osu.Game.Screens.Select
                         RelativeSizeAxes = Axes.Both,
                         Colour = backgroundColour
                     },
-                    rankLabelStandalone = new Container
-                    {
-                        Width = rank_label_width,
-                        RelativeSizeAxes = Axes.Y,
-                        Children = new Drawable[]
-                        {
-                            highlightGradient = new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding { Right = -10f },
-                                Alpha = Highlight != null ? 1 : 0,
-                                Colour = getHighlightColour(Highlight),
-                                Child = new Box { RelativeSizeAxes = Axes.Both },
-                            },
-                            new RankLabel(Rank, sheared, darkText: Highlight == HighlightType.Own)
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                            }
-                        },
-                    },
+                    rankLabelStandalone = new LeaderboardRankDisplay(Rank, sheared, Highlight),
                     centreContent = new Container
                     {
                         Name = @"Centre container",
@@ -465,21 +438,6 @@ namespace osu.Game.Screens.Select
             innerAvatar.OnLoadComplete += d => d.FadeInFromZero(200);
         }
 
-        private ColourInfo getHighlightColour(HighlightType? highlightType, float lightenAmount = 0)
-        {
-            switch (highlightType)
-            {
-                case HighlightType.Own:
-                    return ColourInfo.GradientHorizontal(personal_best_gradient_left.Lighten(lightenAmount), personal_best_gradient_right.Lighten(lightenAmount));
-
-                case HighlightType.Friend:
-                    return ColourInfo.GradientHorizontal(colours.Pink1.Lighten(lightenAmount), colours.Pink3.Lighten(lightenAmount));
-
-                default:
-                    return Colour4.White;
-            }
-        }
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -538,15 +496,15 @@ namespace osu.Game.Screens.Select
         {
             var lightenedGradient = ColourInfo.GradientHorizontal(backgroundColour.Opacity(0).Lighten(0.2f), backgroundColour.Lighten(0.2f));
 
-            foreground.FadeColour(IsHovered ? foregroundColour.Lighten(0.2f) : foregroundColour, transition_duration, Easing.OutQuint);
-            background.FadeColour(IsHovered ? backgroundColour.Lighten(0.2f) : backgroundColour, transition_duration, Easing.OutQuint);
-            totalScoreBackground.FadeColour(IsHovered ? lightenedGradient : totalScoreBackgroundGradient, transition_duration, Easing.OutQuint);
-            highlightGradient.FadeColour(getHighlightColour(Highlight, IsHovered ? 0.2f : 0), transition_duration, Easing.OutQuint);
+            foreground.FadeColour(IsHovered ? foregroundColour.Lighten(0.2f) : foregroundColour, TRANSITION_DURATION, Easing.OutQuint);
+            background.FadeColour(IsHovered ? backgroundColour.Lighten(0.2f) : backgroundColour, TRANSITION_DURATION, Easing.OutQuint);
+            totalScoreBackground.FadeColour(IsHovered ? lightenedGradient : totalScoreBackgroundGradient, TRANSITION_DURATION, Easing.OutQuint);
+            rankLabelStandalone.UpdateHighlightState(IsHovered);
 
             if (IsHovered && currentMode != DisplayMode.Full)
-                rankLabelOverlay.FadeIn(transition_duration, Easing.OutQuint);
+                rankLabelOverlay.FadeIn(TRANSITION_DURATION, Easing.OutQuint);
             else
-                rankLabelOverlay.FadeOut(transition_duration, Easing.OutQuint);
+                rankLabelOverlay.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
         }
 
         private DisplayMode? currentMode;
@@ -569,11 +527,12 @@ namespace osu.Game.Screens.Select
 
         private void updateDisplayMode(DisplayMode mode)
         {
-            double duration = currentMode == null ? 0 : transition_duration;
             if (mode >= DisplayMode.Full)
-                rankLabelStandalone.FadeIn(duration, Easing.OutQuint).ResizeWidthTo(rank_label_width, duration, Easing.OutQuint);
+                rankLabelStandalone.Show();
             else
-                rankLabelStandalone.FadeOut(duration, Easing.OutQuint).ResizeWidthTo(0, duration, Easing.OutQuint);
+                rankLabelStandalone.Hide();
+
+            double duration = currentMode == null ? 0 : TRANSITION_DURATION;
 
             if (mode >= DisplayMode.Regular)
             {
@@ -595,7 +554,7 @@ namespace osu.Game.Screens.Select
 
         private DisplayMode getCurrentDisplayMode()
         {
-            if (DrawWidth >= username_min_width + statistics_regular_min_width + expanded_right_content_width + rank_label_width)
+            if (DrawWidth >= username_min_width + statistics_regular_min_width + expanded_right_content_width + LeaderboardRankDisplay.WIDTH)
                 return DisplayMode.Full;
 
             if (DrawWidth >= username_min_width + statistics_regular_min_width + expanded_right_content_width)
@@ -737,12 +696,6 @@ namespace osu.Game.Screens.Select
             }
 
             public LocalisableString TooltipText { get; }
-        }
-
-        public enum HighlightType
-        {
-            Own,
-            Friend,
         }
     }
 }

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -105,8 +105,8 @@ namespace osu.Game.Screens.Select
         private Box totalScoreBackground = null!;
 
         private FillFlowContainer statisticsContainer = null!;
-        private LeaderboardRankDisplay rankLabelStandalone = null!;
-        private Container rankLabelOverlay = null!;
+        private LeaderboardRankDisplay rankDisplay = null!;
+        private Container rankOverlay = null!;
 
         private readonly bool sheared;
 
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Select
                         RelativeSizeAxes = Axes.Both,
                         Colour = backgroundColour
                     },
-                    rankLabelStandalone = new LeaderboardRankDisplay(Rank, sheared, Highlight),
+                    rankDisplay = new LeaderboardRankDisplay(Rank, sheared, Highlight),
                     centreContent = new Container
                     {
                         Name = @"Centre container",
@@ -209,7 +209,7 @@ namespace osu.Game.Screens.Select
                                                         RelativeSizeAxes = Axes.None,
                                                         Size = new Vector2(HEIGHT)
                                                     },
-                                                    rankLabelOverlay = new Container
+                                                    rankOverlay = new Container
                                                     {
                                                         RelativeSizeAxes = Axes.Both,
                                                         Alpha = 0,
@@ -498,12 +498,12 @@ namespace osu.Game.Screens.Select
             foreground.FadeColour(IsHovered ? foregroundColour.Lighten(0.2f) : foregroundColour, transition_duration, Easing.OutQuint);
             background.FadeColour(IsHovered ? backgroundColour.Lighten(0.2f) : backgroundColour, transition_duration, Easing.OutQuint);
             totalScoreBackground.FadeColour(IsHovered ? lightenedGradient : totalScoreBackgroundGradient, transition_duration, Easing.OutQuint);
-            rankLabelStandalone.UpdateHighlightState(IsHovered, transition_duration);
+            rankDisplay.UpdateHighlightState(IsHovered, transition_duration);
 
             if (IsHovered && currentMode != DisplayMode.Full)
-                rankLabelOverlay.FadeIn(transition_duration, Easing.OutQuint);
+                rankOverlay.FadeIn(transition_duration, Easing.OutQuint);
             else
-                rankLabelOverlay.FadeOut(transition_duration, Easing.OutQuint);
+                rankOverlay.FadeOut(transition_duration, Easing.OutQuint);
         }
 
         private DisplayMode? currentMode;
@@ -519,7 +519,7 @@ namespace osu.Game.Screens.Select
 
             centreContent.Padding = new MarginPadding
             {
-                Left = rankLabelStandalone.DrawWidth,
+                Left = rankDisplay.DrawWidth,
                 Right = rightContent.DrawWidth,
             };
         }
@@ -529,9 +529,9 @@ namespace osu.Game.Screens.Select
             double duration = currentMode == null ? 0 : transition_duration;
 
             if (mode >= DisplayMode.Full)
-                rankLabelStandalone.Appear(duration);
+                rankDisplay.Appear(duration);
             else
-                rankLabelStandalone.Disappear(duration);
+                rankDisplay.Disappear(duration);
 
             if (mode >= DisplayMode.Regular)
             {

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -17,7 +17,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
-using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
@@ -33,7 +32,6 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Users;
-using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
 using CommonStrings = osu.Game.Localisation.CommonStrings;
@@ -43,6 +41,7 @@ namespace osu.Game.Screens.Select
     public sealed partial class BeatmapLeaderboardScore : OsuClickableContainer, IHasContextMenu, IHasCustomTooltip<ScoreInfo>
     {
         public const int HEIGHT = 50;
+        public const int CORNER_RADIUS = 10;
 
         public readonly ScoreInfo Score;
 
@@ -83,7 +82,6 @@ namespace osu.Game.Screens.Select
         private const float statistics_regular_min_width = 165;
         private const float statistics_compact_min_width = 90;
 
-        private const int corner_radius = 10;
         private const int transition_duration = 200;
 
         private Colour4 foregroundColour;
@@ -95,8 +93,6 @@ namespace osu.Game.Screens.Select
         private Box background = null!;
         private Box foreground = null!;
 
-        private ClickableAvatar innerAvatar = null!;
-
         private Container centreContent = null!;
         private Container rightContent = null!;
 
@@ -104,9 +100,9 @@ namespace osu.Game.Screens.Select
 
         private Box totalScoreBackground = null!;
 
+        private LeaderboardCommonDisplay leaderboardCommonDisplay = null!;
         private FillFlowContainer statisticsContainer = null!;
         private LeaderboardRankDisplay rankDisplay = null!;
-        private Container rankOverlay = null!;
 
         private readonly bool sheared;
 
@@ -140,7 +136,7 @@ namespace osu.Game.Screens.Select
             Child = new Container
             {
                 Masking = true,
-                CornerRadius = corner_radius,
+                CornerRadius = CORNER_RADIUS,
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
@@ -158,7 +154,7 @@ namespace osu.Game.Screens.Select
                         Child = new Container
                         {
                             Masking = true,
-                            CornerRadius = corner_radius,
+                            CornerRadius = CORNER_RADIUS,
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
@@ -182,7 +178,6 @@ namespace osu.Game.Screens.Select
                                     RelativeSizeAxes = Axes.Both,
                                     ColumnDimensions = new[]
                                     {
-                                        new Dimension(GridSizeMode.AutoSize),
                                         new Dimension(),
                                         new Dimension(GridSizeMode.AutoSize),
                                     },
@@ -190,95 +185,7 @@ namespace osu.Game.Screens.Select
                                     {
                                         new Drawable[]
                                         {
-                                            new Container
-                                            {
-                                                AutoSizeAxes = Axes.Both,
-                                                CornerRadius = corner_radius,
-                                                Masking = true,
-                                                Children = new Drawable[]
-                                                {
-                                                    new DelayedLoadWrapper(innerAvatar = new ClickableAvatar(Score.User)
-                                                    {
-                                                        Anchor = Anchor.Centre,
-                                                        Origin = Anchor.Centre,
-                                                        Scale = new Vector2(1.1f),
-                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                        RelativeSizeAxes = Axes.Both,
-                                                    })
-                                                    {
-                                                        RelativeSizeAxes = Axes.None,
-                                                        Size = new Vector2(HEIGHT)
-                                                    },
-                                                    rankOverlay = new Container
-                                                    {
-                                                        RelativeSizeAxes = Axes.Both,
-                                                        Alpha = 0,
-                                                        Children = new Drawable[]
-                                                        {
-                                                            new Box
-                                                            {
-                                                                RelativeSizeAxes = Axes.Both,
-                                                                Colour = Colour4.Black.Opacity(0.5f),
-                                                            },
-                                                            new LeaderboardRankLabel(Rank, sheared, false)
-                                                            {
-                                                                AutoSizeAxes = Axes.Both,
-                                                                Anchor = Anchor.Centre,
-                                                                Origin = Anchor.Centre,
-                                                            },
-                                                        }
-                                                    }
-                                                },
-                                            },
-                                            new FillFlowContainer
-                                            {
-                                                Anchor = Anchor.CentreLeft,
-                                                Origin = Anchor.CentreLeft,
-                                                RelativeSizeAxes = Axes.X,
-                                                AutoSizeAxes = Axes.Y,
-                                                Direction = FillDirection.Vertical,
-                                                Padding = new MarginPadding { Horizontal = corner_radius },
-                                                Children = new Drawable[]
-                                                {
-                                                    new FillFlowContainer
-                                                    {
-                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                        Direction = FillDirection.Horizontal,
-                                                        Spacing = new Vector2(5),
-                                                        AutoSizeAxes = Axes.Both,
-                                                        Masking = true,
-                                                        Children = new Drawable[]
-                                                        {
-                                                            new UpdateableFlag(Score.User.CountryCode)
-                                                            {
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Origin = Anchor.CentreLeft,
-                                                                Size = new Vector2(20, 14),
-                                                            },
-                                                            new UpdateableTeamFlag(Score.User.Team)
-                                                            {
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Origin = Anchor.CentreLeft,
-                                                                Size = new Vector2(30, 15),
-                                                            },
-                                                            new DateLabel(Score.Date)
-                                                            {
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Origin = Anchor.CentreLeft,
-                                                                Colour = colourProvider.Content2,
-                                                                UseFullGlyphHeight = false,
-                                                            }
-                                                        }
-                                                    },
-                                                    new TruncatingSpriteText
-                                                    {
-                                                        RelativeSizeAxes = Axes.X,
-                                                        Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                                                        Text = Score.User.Username,
-                                                        Font = OsuFont.Style.Heading2,
-                                                    }
-                                                }
-                                            },
+                                            leaderboardCommonDisplay = new LeaderboardCommonDisplay(Score.User, Score.Date, Rank, sheared),
                                             new Container
                                             {
                                                 AutoSizeAxes = Axes.Both,
@@ -382,7 +289,7 @@ namespace osu.Game.Screens.Select
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                         Masking = true,
-                                        CornerRadius = corner_radius,
+                                        CornerRadius = CORNER_RADIUS,
                                         Children = new Drawable[]
                                         {
                                             totalScoreBackground = new Box
@@ -401,7 +308,7 @@ namespace osu.Game.Screens.Select
                                                 Anchor = Anchor.CentreRight,
                                                 Origin = Anchor.CentreRight,
                                                 Direction = FillDirection.Vertical,
-                                                Padding = new MarginPadding { Horizontal = corner_radius },
+                                                Padding = new MarginPadding { Horizontal = CORNER_RADIUS },
                                                 Spacing = new Vector2(0f, -2f),
                                                 Children = new Drawable[]
                                                 {
@@ -434,7 +341,6 @@ namespace osu.Game.Screens.Select
                     }
                 }
             };
-            innerAvatar.OnLoadComplete += d => d.FadeInFromZero(200);
         }
 
         protected override void LoadComplete()
@@ -499,11 +405,7 @@ namespace osu.Game.Screens.Select
             background.FadeColour(IsHovered ? backgroundColour.Lighten(0.2f) : backgroundColour, transition_duration, Easing.OutQuint);
             totalScoreBackground.FadeColour(IsHovered ? lightenedGradient : totalScoreBackgroundGradient, transition_duration, Easing.OutQuint);
             rankDisplay.UpdateHighlightState(IsHovered, transition_duration);
-
-            if (IsHovered && currentMode != DisplayMode.Full)
-                rankOverlay.FadeIn(transition_duration, Easing.OutQuint);
-            else
-                rankOverlay.FadeOut(transition_duration, Easing.OutQuint);
+            leaderboardCommonDisplay.UpdateRankOverlayState(IsHovered && currentMode != DisplayMode.Full, transition_duration);
         }
 
         private DisplayMode? currentMode;
@@ -604,17 +506,6 @@ namespace osu.Game.Screens.Select
             Compact,
             Regular,
             Full
-        }
-
-        private partial class DateLabel : DrawableDate
-        {
-            public DateLabel(DateTimeOffset date)
-                : base(date)
-            {
-                Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold);
-            }
-
-            protected override LocalisableString Format() => Date.ToShortRelativeTime(TimeSpan.FromSeconds(30));
         }
 
         private partial class ScoreComponentLabel : Container

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -34,7 +34,6 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Users;
 using osu.Game.Users.Drawables;
-using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
 using CommonStrings = osu.Game.Localisation.CommonStrings;
@@ -221,7 +220,7 @@ namespace osu.Game.Screens.Select
                                                                 RelativeSizeAxes = Axes.Both,
                                                                 Colour = Colour4.Black.Opacity(0.5f),
                                                             },
-                                                            new RankLabel(Rank, sheared, false)
+                                                            new LeaderboardRankLabel(Rank, sheared, false)
                                                             {
                                                                 AutoSizeAxes = Axes.Both,
                                                                 Anchor = Anchor.Centre,
@@ -665,37 +664,6 @@ namespace osu.Game.Screens.Select
                     }
                 };
             }
-        }
-
-        private partial class RankLabel : Container, IHasTooltip
-        {
-            private readonly bool darkText;
-            private readonly OsuSpriteText text;
-
-            public RankLabel(int? rank, bool sheared, bool darkText)
-            {
-                this.darkText = darkText;
-                if (rank >= 1000)
-                    TooltipText = $"#{rank:N0}";
-
-                Child = text = new OsuSpriteText
-                {
-                    Shear = sheared ? -OsuGame.SHEAR : Vector2.Zero,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Font = OsuFont.Style.Heading2,
-                    Text = rank?.FormatRank().Insert(0, "#") ?? "-",
-                    Shadow = !darkText,
-                };
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                text.Colour = darkText ? colourProvider.Background3 : colourProvider.Content1;
-            }
-
-            public LocalisableString TooltipText { get; }
         }
     }
 }

--- a/osu.Game/Screens/Select/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardWedge.cs
@@ -298,12 +298,12 @@ namespace osu.Game.Screens.Select
 
             LoadComponentsAsync(scores.Select((s, i) =>
             {
-                BeatmapLeaderboardScore.HighlightType? highlightType = null;
+                LeaderboardRankDisplay.HighlightType? highlightType = null;
 
                 if (s.OnlineID == userScore?.OnlineID)
-                    highlightType = BeatmapLeaderboardScore.HighlightType.Own;
+                    highlightType = LeaderboardRankDisplay.HighlightType.Own;
                 else if (api.LocalUserState.Friends.Any(r => r.TargetID == s.UserID) && Scope.Value != BeatmapLeaderboardScope.Friend)
-                    highlightType = BeatmapLeaderboardScore.HighlightType.Friend;
+                    highlightType = LeaderboardRankDisplay.HighlightType.Friend;
 
                 return new BeatmapLeaderboardScore(s)
                 {
@@ -366,7 +366,7 @@ namespace osu.Game.Screens.Select
                 personalBestDisplay.FadeIn(600, Easing.OutQuint);
                 personalBestScoreContainer.Child = new BeatmapLeaderboardScore(userScore)
                 {
-                    Highlight = BeatmapLeaderboardScore.HighlightType.Own,
+                    Highlight = LeaderboardRankDisplay.HighlightType.Own,
                     Rank = userScore.Position,
                     SelectedMods = { BindTarget = mods },
                     Action = () => onLeaderboardScoreClicked(userScore),


### PR DESCRIPTION
Specifically user (username, avatar, flag, team), rank (in the overlay
showing above the avatar when in compact mode) and date.

Depends on #37064.