### PR TITLE
Undo Agility strain influence rescaling

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
@@ -38,6 +38,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             return strain * DifficultyCalculationUtils.Smootherstep(distance, 0, OsuDifficultyHitObject.NORMALISED_RADIUS);
         }
 
-        private static double highBpmBonus(double ms) => 1 / (1 - Math.Pow(0.3, Math.Pow(ms / 1000, 0.9)));
+        private static double highBpmBonus(double ms) => 1 / (1 - Math.Pow(0.15, ms / 1000));
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
 
         private double skillMultiplierSnap => 71.0;
-        private double skillMultiplierAgility => 2.45;
+        private double skillMultiplierAgility => 2.5;
         private double skillMultiplierFlow => 245.0;
         private double skillMultiplierTotal => 1.1;
         private double meanExponent => 1.2;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
 
         private double skillMultiplierSnap => 71.0;
-        private double skillMultiplierAgility => 2.0;
+        private double skillMultiplierAgility => 2.45;
         private double skillMultiplierFlow => 245.0;
         private double skillMultiplierTotal => 1.1;
         private double meanExponent => 1.2;


### PR DESCRIPTION
Now that agility isn't "speedaim" that covers both snap and flow we can restore it back into it's original scaling. Arguably it should be _more_ than d/t^2 but that's a thing to explore separately