### PR TITLE
Warn macOS users if game is not in location which can be automatically updated

### DIFF
--- a/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
+++ b/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
@@ -29,10 +29,10 @@ namespace osu.Desktop.MacOS
             string asmPath = RuntimeInfo.EntryAssembly.Location;
             string userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string userApp = Path.Combine(userHome, "Applications/");
-            if (!(
-                asmPath.StartsWith("/Applications/", StringComparison.Ordinal)
-                || asmPath.StartsWith(userApp, StringComparison.Ordinal)
-            ))
+
+            bool inRootApp = asmPath.StartsWith("/Applications", StringComparison.Ordinal);
+            bool inUserApp = asmPath.StartsWith(userApp, StringComparison.Ordinal);
+            if (!(inRootApp || inUserApp))
                 notification.Post(new MacOSAppLocationNotification());
         }
 

--- a/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
+++ b/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
@@ -12,7 +12,7 @@ using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 
-namespace osu.Desktop.Updater
+namespace osu.Desktop.MacOS
 {
     /// <summary>
     /// Checks if the game is located at `Applications` folder and displays a warning notification if not so.

--- a/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
+++ b/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
@@ -26,13 +26,12 @@ namespace osu.Desktop.MacOS
         {
             base.LoadComplete();
 
-            string asmPath = RuntimeInfo.EntryAssembly.Location;
-            string userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            string userApp = Path.Combine(userHome, "Applications/");
+            string assemblyPath = RuntimeInfo.EntryAssembly.Location;
 
-            bool inRootApp = asmPath.StartsWith("/Applications", StringComparison.Ordinal);
-            bool inUserApp = asmPath.StartsWith(userApp, StringComparison.Ordinal);
-            if (!(inRootApp || inUserApp))
+            bool inRootApp = assemblyPath.StartsWith("/Applications/", StringComparison.Ordinal);
+            bool inUserApp = assemblyPath.StartsWith(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Applications/"), StringComparison.Ordinal);
+
+            if (!inRootApp && !inUserApp)
                 notification.Post(new MacOSAppLocationNotification());
 
             Expire();

--- a/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
+++ b/osu.Desktop/MacOS/MacOsAppLocationChecker.cs
@@ -34,6 +34,8 @@ namespace osu.Desktop.MacOS
             bool inUserApp = asmPath.StartsWith(userApp, StringComparison.Ordinal);
             if (!(inRootApp || inUserApp))
                 notification.Post(new MacOSAppLocationNotification());
+
+            Expire();
         }
 
         private partial class MacOSAppLocationNotification : SimpleNotification

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -132,10 +132,17 @@ namespace osu.Desktop
 
             LoadComponentAsync(new DiscordRichPresence(), Add);
 
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
-                LoadComponentAsync(new GameplayWinKeyBlocker(), Add);
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS && !IsPackageManaged)
-                LoadComponentAsync(new MacOSAppLocationChecker(), Add);
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.Windows:
+                    LoadComponentAsync(new GameplayWinKeyBlocker(), Add);
+                    break;
+
+                case RuntimeInfo.Platform.macOS when !IsPackageManaged && IsDeployedBuild:
+                    if (!IsPackageManaged && IsDeployedBuild)
+                        LoadComponentAsync(new MacOSAppLocationChecker(), Add);
+                    break;
+            }
 
             LoadComponentAsync(new ElevatedPrivilegesChecker(), Add);
 

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -133,6 +133,8 @@ namespace osu.Desktop
 
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
                 LoadComponentAsync(new GameplayWinKeyBlocker(), Add);
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS && !IsPackageManaged)
+                LoadComponentAsync(new MacOSAppLocationChecker(), Add);
 
             LoadComponentAsync(new ElevatedPrivilegesChecker(), Add);
 

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -14,6 +14,7 @@ using osu.Desktop.Updater;
 using osu.Framework;
 using osu.Framework.Logging;
 using osu.Game.Updater;
+using osu.Desktop.MacOS;
 using osu.Desktop.Windows;
 using osu.Framework.Allocation;
 using osu.Game.Configuration;

--- a/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
+++ b/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
@@ -27,6 +27,8 @@ namespace osu.Desktop.Security
 
             if (Environment.IsPrivilegedProcess)
                 notifications.Post(new ElevatedPrivilegesNotification());
+
+            Expire();
         }
 
         private partial class ElevatedPrivilegesNotification : SimpleNotification

--- a/osu.Desktop/Updater/MacOsAppLocationChecker.cs
+++ b/osu.Desktop/Updater/MacOsAppLocationChecker.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using osu.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Desktop.Updater
+{
+    /// <summary>
+    /// Checks if the game is located at `Applications` folder and displays a warning notification if not so.
+    /// </summary>
+    public partial class MacOSAppLocationChecker : Component
+    {
+        [Resolved]
+        private INotificationOverlay notification { get; set; } = null!;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            string asmPath = RuntimeInfo.EntryAssembly.Location;
+            string userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string userApp = Path.Combine(userHome, "Applications/");
+            if (!(
+                asmPath.StartsWith("/Applications/", StringComparison.Ordinal)
+                || asmPath.StartsWith(userApp, StringComparison.Ordinal)
+            ))
+                notification.Post(new MacOSAppLocationNotification());
+        }
+
+        private partial class MacOSAppLocationNotification : SimpleNotification
+        {
+            public MacOSAppLocationNotification()
+            {
+                Text = NotificationsStrings.MacOSAppLocation(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                Icon = FontAwesome.Solid.ShieldAlt;
+                IconContent.Colour = colours.YellowDark;
+            }
+        }
+    }
+}

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -236,9 +236,9 @@ Click to see what's new!", version);
         public static LocalisableString ElevatedPrivileges(LocalisableString user) => new TranslatableString(getKey(@"elevated_privileges"), @"Running osu! as {0} does not improve performance, may break integrations and poses a security risk. Please run the game as a normal user.", user);
 
         /// <summary>
-        /// "On macOS, installing osu! to a directory other than /Applications or {0}/Applications can cause issues with updating the game. Please move your game installation to one of them."
+        /// "On macOS, installing osu! to a directory other than /Applications or {0}/Applications can cause issues with updating the game. Please move your game installation to one of these locations."
         /// </summary>
-        public static LocalisableString MacOSAppLocation(LocalisableString userProfile) => new TranslatableString(getKey(@"macos_app_location"), @"On macOS, installing osu! to a directory other than /Applications or {0}/Applications can cause issues with updating the game. Please move your game installation to one of them.", userProfile);
+        public static LocalisableString MacOSAppLocation(LocalisableString userProfile) => new TranslatableString(getKey(@"macos_app_location"), @"On macOS, installing osu! to a directory other than /Applications or {0}/Applications can cause issues with updating the game. Please move your game installation to one of these locations.", userProfile);
 
         /// <summary>
         /// "Screenshot saved! Click to view.

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -236,6 +236,11 @@ Click to see what's new!", version);
         public static LocalisableString ElevatedPrivileges(LocalisableString user) => new TranslatableString(getKey(@"elevated_privileges"), @"Running osu! as {0} does not improve performance, may break integrations and poses a security risk. Please run the game as a normal user.", user);
 
         /// <summary>
+        /// "osu! should be located in /Applications or {0}/Applications on macOS. Please move the game into Applications folder."
+        /// </summary>
+        public static LocalisableString MacOSAppLocation(LocalisableString userProfile) => new TranslatableString(getKey(@"macos_app_location"), @"osu! should be located in /Applications or {0}/Applications on macOS. Please move the game into Applications folder.", userProfile);
+
+        /// <summary>
         /// "Screenshot saved! Click to view.
         /// {0}"
         /// </summary>

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -236,9 +236,9 @@ Click to see what's new!", version);
         public static LocalisableString ElevatedPrivileges(LocalisableString user) => new TranslatableString(getKey(@"elevated_privileges"), @"Running osu! as {0} does not improve performance, may break integrations and poses a security risk. Please run the game as a normal user.", user);
 
         /// <summary>
-        /// "osu! should be located in /Applications or {0}/Applications on macOS. Please move the game into Applications folder."
+        /// "On macOS, installing osu! to a directory other than /Applications or {0}/Applications can cause issues with updating the game. Please move your game installation to one of them."
         /// </summary>
-        public static LocalisableString MacOSAppLocation(LocalisableString userProfile) => new TranslatableString(getKey(@"macos_app_location"), @"osu! should be located in /Applications or {0}/Applications on macOS. Please move the game into Applications folder.", userProfile);
+        public static LocalisableString MacOSAppLocation(LocalisableString userProfile) => new TranslatableString(getKey(@"macos_app_location"), @"On macOS, installing osu! to a directory other than /Applications or {0}/Applications can cause issues with updating the game. Please move your game installation to one of them.", userProfile);
 
         /// <summary>
         /// "Screenshot saved! Click to view.


### PR DESCRIPTION
Updates can fail on macOS when osu! is run outside /Applications or ~/Applications, but users currently get no actionable guidance.

Add a startup notification that warns when the install location is outside those directories, and skip this check for package-managed installs where in-app updates are not used. 

Resolves #36662. 