### PR TITLE
Adjust high CS bonuses after all the distance-time rescaling

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             double strain = distanceScaled * 1000 / osuCurrObj.AdjustedDeltaTime;
 
-            strain *= osuCurrObj.SmallCircleBonus;
+            strain *= Math.Pow(osuCurrObj.SmallCircleBonus, 1.5);
 
             strain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             // Apply high circle size bonus to the base velocity.
             // We use reduced CS bonus here because the bonus was made for an evaluator with a different d/t scaling
-            flowDifficulty *= Math.Pow(osuCurrObj.SmallCircleBonus, 0.75);
+            flowDifficulty *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
 
             // Rhythm changes are harder to flow
             flowDifficulty *= 1 + Math.Min(0.25,


### PR DESCRIPTION
At this point maybe having a shared small circle bonus in ODHO isn't even worth it since we have different d/t scalings in all evaluators. Bonus was made for snap (~d/t^1.65), here it's adjusted to be higher on agility (~d/t^2) and lower on flow (~d/t). Practically affects like [1 map](https://osu.ppy.sh/beatmapsets/2191876#osu/5192354)