### PR TITLE
Add warning display when player loading is paused due to user interaction

### DIFF
--- a/osu.Game/Localisation/PlayerLoaderStrings.cs
+++ b/osu.Game/Localisation/PlayerLoaderStrings.cs
@@ -44,9 +44,9 @@ Leaderboards may be reset.");
 Leaderboards will be reset when the beatmap is ranked.");
 
         /// <summary>
-        /// "Loading paused.."
+        /// "Loading paused..."
         /// </summary>
-        public static LocalisableString LoadingPaused => new TranslatableString(getKey(@"loading_paused"), @"Loading paused..");
+        public static LocalisableString LoadingPaused => new TranslatableString(getKey(@"loading_paused"), @"Loading paused...");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/PlayerLoaderStrings.cs
+++ b/osu.Game/Localisation/PlayerLoaderStrings.cs
@@ -43,6 +43,11 @@ Leaderboards may be reset.");
         public static LocalisableString QualifiedBeatmapDisclaimerContent => new TranslatableString(getKey(@"qualified_beatmap_disclaimer_content"), @"No performance points will be awarded.
 Leaderboards will be reset when the beatmap is ranked.");
 
+        /// <summary>
+        /// "Loading paused.."
+        /// </summary>
+        public static LocalisableString LoadingPaused => new TranslatableString(getKey(@"loading_paused"), @"Loading paused..");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -15,6 +16,7 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play.HUD;
@@ -32,6 +34,7 @@ namespace osu.Game.Screens.Play
         private readonly Bindable<IReadOnlyList<Mod>> mods;
         private readonly Drawable logoFacade;
         private LoadingSpinner loading;
+        private Drawable blockingLoadLayer;
 
         public IBindable<IReadOnlyList<Mod>> Mods => mods;
 
@@ -43,6 +46,30 @@ namespace osu.Game.Screens.Play
                     loading.Show();
                 else
                     loading.Hide();
+            }
+        }
+
+        private bool userBlocked;
+
+        public bool UserBlocked
+        {
+            set
+            {
+                if (value == userBlocked)
+                    return;
+
+                userBlocked = value;
+
+                if (userBlocked)
+                {
+                    blockingLoadLayer
+                        .FadeIn(300, Easing.Out)
+                        .Then()
+                        .FadeTo(0.5f, 1000, Easing.In)
+                        .Loop();
+                }
+                else
+                    blockingLoadLayer.FadeOut(500, Easing.OutQuint);
             }
         }
 
@@ -61,7 +88,7 @@ namespace osu.Game.Screens.Play
         private StarRatingDisplay starRatingDisplay;
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapDifficultyCache difficultyCache)
+        private void load(BeatmapDifficultyCache difficultyCache, OsuColour colours)
         {
             var metadata = beatmap.BeatmapInfo.Metadata;
 
@@ -117,7 +144,28 @@ namespace osu.Game.Screens.Play
                                 loading = new LoadingLayer(dimBackground: true)
                                 {
                                     BlockPositionalInput = false,
-                                }
+                                },
+                                blockingLoadLayer = new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            Colour = colours.PinkDarker,
+                                            Alpha = 0.5f,
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Font = OsuFont.Style.Heading2,
+                                            Text = PlayerLoaderStrings.LoadingPaused
+                                        }
+                                    }
+                                },
                             }
                         },
                         versionFlow = new FillFlowContainer

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -62,11 +62,16 @@ namespace osu.Game.Screens.Play
 
                 if (userBlocked)
                 {
-                    blockingLoadLayer
-                        .FadeIn(300, Easing.Out)
-                        .Then()
-                        .FadeTo(0.5f, 1000, Easing.In)
-                        .Loop();
+                    using (BeginDelayedSequence(500))
+                    {
+                        blockingLoadLayer
+                            // Slight delay to avoid this flashing briefly during multiplayer load and other scenarios where
+                            // load may be blocked for a short period.
+                            .FadeIn(300, Easing.Out)
+                            .Then()
+                            .FadeTo(0.6f, 1000, Easing.In)
+                            .Loop();
+                    }
                 }
                 else
                     blockingLoadLayer.FadeOut(500, Easing.OutQuint);

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -120,22 +120,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private bool readyForPush =>
-            !playerConsumed
-            // don't push unless the player is completely loaded
-            && CurrentPlayer?.LoadState == LoadState.Ready
-            // don't push unless the player is ready to start gameplay
-            && ReadyForGameplay;
-
-        protected virtual bool ReadyForGameplay =>
-            // not ready if the user is hovering one of the panes (logo is excluded), unless they are idle.
-            (IsHovered || osuLogo?.IsHovered == true || idleTracker.IsIdle.Value)
-            // not ready if the user is dragging a slider or otherwise.
-            && (inputManager.DraggedDrawable == null || inputManager.DraggedDrawable is OsuLogo)
-            // not ready if a focused overlay is visible, like settings.
-            && inputManager.FocusedDrawable is not OsuFocusedOverlayContainer
-            // or if a child of a focused overlay is focused, like settings' search textbox.
-            && inputManager.FocusedDrawable?.FindClosestParent<OsuFocusedOverlayContainer>() == null;
+        protected virtual bool ReadyForGameplay { get; private set; }
 
         private bool holdForMenuExitButton => !AllowUserExit;
 
@@ -490,6 +475,18 @@ namespace osu.Game.Screens.Play
             if (!this.IsCurrentScreen())
                 return;
 
+            ReadyForGameplay =
+                // not ready if the user is hovering one of the panes (logo is excluded), unless they are idle.
+                (IsHovered || osuLogo?.IsHovered == true || idleTracker.IsIdle.Value)
+                // not ready if the user is dragging a slider or otherwise.
+                && (inputManager.DraggedDrawable == null || inputManager.DraggedDrawable is OsuLogo)
+                // not ready if a focused overlay is visible, like settings.
+                && inputManager.FocusedDrawable is not OsuFocusedOverlayContainer
+                // or if a child of a focused overlay is focused, like settings' search textbox.
+                && inputManager.FocusedDrawable?.FindClosestParent<OsuFocusedOverlayContainer>() == null;
+
+            MetadataInfo.UserBlocked = !ReadyForGameplay && CurrentPlayer?.LoadState == LoadState.Ready;
+
             // We need to perform this check here rather than in OnHover as any number of children of VisualSettings
             // may also be handling the hover events.
             if (inputManager.HoveredDrawables.Contains(VisualSettings) || QuickRestart)
@@ -653,6 +650,13 @@ namespace osu.Game.Screens.Play
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
             if (!this.IsCurrentScreen()) return;
+
+            bool readyForPush =
+                !playerConsumed
+                // don't push unless the player is completely loaded
+                && CurrentPlayer?.LoadState == LoadState.Ready
+                // don't push unless the player is ready to start gameplay
+                && ReadyForGameplay;
 
             if (!readyForPush)
             {

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -120,7 +120,15 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        protected virtual bool ReadyForGameplay { get; private set; }
+        protected virtual bool ReadyForGameplay =>
+            // not ready if the user is hovering one of the panes (logo is excluded), unless they are idle.
+            (IsHovered || osuLogo?.IsHovered == true || idleTracker.IsIdle.Value)
+            // not ready if the user is dragging a slider or otherwise.
+            && (inputManager.DraggedDrawable == null || inputManager.DraggedDrawable is OsuLogo)
+            // not ready if a focused overlay is visible, like settings.
+            && inputManager.FocusedDrawable is not OsuFocusedOverlayContainer
+            // or if a child of a focused overlay is focused, like settings' search textbox.
+            && inputManager.FocusedDrawable?.FindClosestParent<OsuFocusedOverlayContainer>() == null;
 
         private bool holdForMenuExitButton => !AllowUserExit;
 
@@ -474,16 +482,6 @@ namespace osu.Game.Screens.Play
 
             if (!this.IsCurrentScreen())
                 return;
-
-            ReadyForGameplay =
-                // not ready if the user is hovering one of the panes (logo is excluded), unless they are idle.
-                (IsHovered || osuLogo?.IsHovered == true || idleTracker.IsIdle.Value)
-                // not ready if the user is dragging a slider or otherwise.
-                && (inputManager.DraggedDrawable == null || inputManager.DraggedDrawable is OsuLogo)
-                // not ready if a focused overlay is visible, like settings.
-                && inputManager.FocusedDrawable is not OsuFocusedOverlayContainer
-                // or if a child of a focused overlay is focused, like settings' search textbox.
-                && inputManager.FocusedDrawable?.FindClosestParent<OsuFocusedOverlayContainer>() == null;
 
             MetadataInfo.UserBlocked = !ReadyForGameplay && CurrentPlayer?.LoadState == LoadState.Ready;
 


### PR DESCRIPTION
As touched on in https://github.com/ppy/osu/discussions/37082.

15 minute task fixing a UX which was definitely not as visible as it should have been.

https://github.com/user-attachments/assets/c7e39f65-e8d4-4b05-b64c-d37fde379f77

