### PR TITLE
Adjust bad padding in `FilterControl`

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.ScopedBeatmapSetDisplay.cs
+++ b/osu.Game/Screens/Select/FilterControl.ScopedBeatmapSetDisplay.cs
@@ -107,7 +107,9 @@ namespace osu.Game.Screens.Select
             {
                 if (ScopedBeatmapSet.Value != null)
                 {
+                    this.TransformTo(nameof(Margin), new MarginPadding { Top = 5 }, transition_duration, Easing.OutQuint);
                     content.BypassAutoSizeAxes = Axes.None;
+
                     text.Clear();
                     text.AddText(SongSelectStrings.TemporarilyShowingAllBeatmapsIn);
                     text.AddText(@" ");
@@ -115,6 +117,7 @@ namespace osu.Game.Screens.Select
                 }
                 else
                 {
+                    this.TransformTo(nameof(Margin), new MarginPadding(0), transition_duration, Easing.OutQuint);
                     flashLayer.FadeOutFromOne(transition_duration, Easing.OutQuint);
                     content.BypassAutoSizeAxes = Axes.Y;
                 }

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -104,104 +104,113 @@ namespace osu.Game.Screens.Select
                         Scale = new Vector2(-1, 1),
                     }
                 },
-                new ReverseChildIDFillFlowContainer<Drawable>
+                new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0f, 5f),
                     Padding = new MarginPadding { Top = corner_radius + 5, Bottom = 2, Right = 40f, Left = 2f },
                     Children = new Drawable[]
                     {
-                        new Container
+                        new ReverseChildIDFillFlowContainer<Drawable>
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Shear = -OsuGame.SHEAR,
-                            Child = searchTextBox = new SongSelectSearchTextBox
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0f, 5f),
+                            Children = new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.X,
-                                HoldFocus = true,
-                                ScopedBeatmapSet = { BindTarget = ScopedBeatmapSet },
-                            },
-                        },
-                        new GridContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Shear = -OsuGame.SHEAR,
-                            RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
-                            ColumnDimensions = new[]
-                            {
-                                new Dimension(),
-                                new Dimension(GridSizeMode.Absolute), // can probably be removed?
-                                new Dimension(GridSizeMode.AutoSize),
-                            },
-                            Content = new[]
-                            {
-                                new[]
+                                new Container
                                 {
-                                    difficultyRangeSlider = new DifficultyRangeSlider
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Shear = -OsuGame.SHEAR,
+                                    Child = searchTextBox = new SongSelectSearchTextBox
                                     {
                                         RelativeSizeAxes = Axes.X,
-                                        MinRange = 0.1f,
-                                    },
-                                    Empty(),
-                                    showConvertedBeatmapsButton = new ShearedToggleButton
-                                    {
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        AutoSizeAxes = Axes.X,
-                                        Text = UserInterfaceStrings.ShowConverts,
-                                        Height = 30f,
+                                        HoldFocus = true,
+                                        ScopedBeatmapSet = { BindTarget = ScopedBeatmapSet },
                                     },
                                 },
-                            }
-                        },
-                        new GridContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Height = 30,
-                            Shear = -OsuGame.SHEAR,
-                            RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
-                            ColumnDimensions = new[]
-                            {
-                                new Dimension(maxSize: 180),
-                                new Dimension(GridSizeMode.Absolute, 5),
-                                new Dimension(maxSize: 180),
-                                new Dimension(GridSizeMode.Absolute, 5),
-                                new Dimension(),
-                                new Dimension(GridSizeMode.AutoSize),
-                            },
-                            Content = new[]
-                            {
-                                new[]
+                                new GridContainer
                                 {
-                                    sortDropdown = new ShearedDropdown<SortMode>(SongSelectStrings.Sort)
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Shear = -OsuGame.SHEAR,
+                                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                                    ColumnDimensions = new[]
                                     {
-                                        RelativeSizeAxes = Axes.X,
-                                        Items = Enum.GetValues<SortMode>(),
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.Absolute), // can probably be removed?
+                                        new Dimension(GridSizeMode.AutoSize),
                                     },
-                                    Empty(),
-                                    groupDropdown = new ShearedDropdown<GroupMode>(SongSelectStrings.Group)
+                                    Content = new[]
                                     {
-                                        RelativeSizeAxes = Axes.X,
-                                        Items = Enum.GetValues<GroupMode>(),
-                                    },
-                                    Empty(),
-                                    collectionDropdown = new CollectionDropdown
+                                        new[]
+                                        {
+                                            difficultyRangeSlider = new DifficultyRangeSlider
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                MinRange = 0.1f,
+                                            },
+                                            Empty(),
+                                            showConvertedBeatmapsButton = new ShearedToggleButton
+                                            {
+                                                Anchor = Anchor.Centre,
+                                                Origin = Anchor.Centre,
+                                                AutoSizeAxes = Axes.X,
+                                                Text = UserInterfaceStrings.ShowConverts,
+                                                Height = 30f,
+                                            },
+                                        },
+                                    }
+                                },
+                                new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = 30,
+                                    Shear = -OsuGame.SHEAR,
+                                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                                    ColumnDimensions = new[]
                                     {
-                                        RelativeSizeAxes = Axes.X,
+                                        new Dimension(maxSize: 180),
+                                        new Dimension(GridSizeMode.Absolute, 5),
+                                        new Dimension(maxSize: 180),
+                                        new Dimension(GridSizeMode.Absolute, 5),
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize),
                                     },
-                                }
-                            }
+                                    Content = new[]
+                                    {
+                                        new[]
+                                        {
+                                            sortDropdown = new ShearedDropdown<SortMode>(SongSelectStrings.Sort)
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                Items = Enum.GetValues<SortMode>(),
+                                            },
+                                            Empty(),
+                                            groupDropdown = new ShearedDropdown<GroupMode>(SongSelectStrings.Group)
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                Items = Enum.GetValues<GroupMode>(),
+                                            },
+                                            Empty(),
+                                            collectionDropdown = new CollectionDropdown
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                            },
+                                        }
+                                    }
+                                },
+                            },
                         },
                         new ScopedBeatmapSetDisplay
                         {
                             ScopedBeatmapSet = { BindTarget = ScopedBeatmapSet },
                         }
                     },
-                }
+                },
             };
 
             localUser = api.LocalUser.GetBoundCopy();

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Select
                         Scale = new Vector2(-1, 1),
                     }
                 },
-                new FillFlowContainer
+                new ReverseChildIDFillFlowContainer<Drawable>
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,


### PR DESCRIPTION
Reported [on discord](https://discord.com/channels/188630481301012481/1097318920991559880/1462402881658294355). Not sure if this has been turned into an issue anywhere.

Fixes awkward looking padding at the bottom of `FilterControl` by having `ScopedBeatmapSetDisplay` apply the top padding on its own instead of relying on the spacing of its parent fill flow. This way, the padding is animated away when the scoped display disappears, instead of remaining because the component is still technically there.

| Before | After |
|--------|--------|
| <img width="1123" height="247" alt="image" src="https://github.com/user-attachments/assets/edadd97e-cada-4378-98b7-cc85bfa01fb5" /> | <img width="1120" height="246" alt="image" src="https://github.com/user-attachments/assets/d8daecd0-1dfc-4594-95a4-94327677da89" /> | 

[Screencast_20260325_114439.webm](https://github.com/user-attachments/assets/99bb7083-b2da-40a3-b5a0-d94476e7c1ac)

I don't really like how `ScopedBeatmapSetDisplay` is now managing its own spacing in the parent container, but it's tightly tied to the filter control anyway so it's probably fine.