### PR TITLE
Increase Aim strain decay base

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
@@ -38,6 +38,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             return strain * DifficultyCalculationUtils.Smootherstep(distance, 0, OsuDifficultyHitObject.NORMALISED_RADIUS);
         }
 
-        private static double highBpmBonus(double ms) => 1 / (1 - Math.Pow(0.15, ms / 1000));
+        private static double highBpmBonus(double ms) => 1 / (1 - Math.Pow(0.2, ms / 1000));
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 {
     public static class SnapAimEvaluator
     {
-        private const double wide_angle_multiplier = 1.0;
+        private const double wide_angle_multiplier = 1.05;
         private const double acute_angle_multiplier = 2.41;
         private const double slider_multiplier = 1.5;
         private const double velocity_change_multiplier = 0.9;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 {
     public static class SnapAimEvaluator
     {
-        private const double wide_angle_multiplier = 1.05;
+        private const double wide_angle_multiplier = 1.0;
         private const double acute_angle_multiplier = 2.41;
         private const double slider_multiplier = 1.5;
         private const double velocity_change_multiplier = 0.9;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -32,9 +32,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
 
         private double skillMultiplierSnap => 71.0;
-        private double skillMultiplierAgility => 2.25;
-        private double skillMultiplierFlow => 240.0;
-        private double skillMultiplierTotal => 1.1;
+        private double skillMultiplierAgility => 2.2;
+        private double skillMultiplierFlow => 245.0;
+        private double skillMultiplierTotal => 1.12;
         private double meanExponent => 1.2;
 
         /// <summary>
@@ -77,10 +77,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double totalDifficulty = calculateTotalValue(snapDifficulty, agilityDifficulty, flowDifficulty);
 
-            const double overcap_per_ms = 0.01;
-
             currentStrain *= decay;
-            currentStrain += overcap_per_ms * ((OsuDifficultyHitObject)current).AdjustedDeltaTime;
             currentStrain += totalDifficulty * (1 - decay);
 
             if (current.BaseObject is Slider)

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
 
         private double skillMultiplierSnap => 71.0;
-        private double skillMultiplierAgility => 2.4;
+        private double skillMultiplierAgility => 2.35;
         private double skillMultiplierFlow => 245.0;
         private double skillMultiplierTotal => 1.11;
         private double meanExponent => 1.2;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
 
         private double skillMultiplierSnap => 71.0;
-        private double skillMultiplierAgility => 2.5;
+        private double skillMultiplierAgility => 2.3;
         private double skillMultiplierFlow => 245.0;
         private double skillMultiplierTotal => 1.11;
         private double meanExponent => 1.2;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double skillMultiplierSnap => 71.0;
         private double skillMultiplierAgility => 2.25;
         private double skillMultiplierFlow => 240.0;
-        private double skillMultiplierTotal => 1.13;
+        private double skillMultiplierTotal => 1.1;
         private double meanExponent => 1.2;
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private readonly List<double> sliderStrains = new List<double>();
 
-        private double strainDecay(double ms) => Math.Pow(0.25, ms / 1000);
+        private double strainDecay(double ms) => Math.Pow(0.2, ms / 1000);
 
         protected override double CalculateInitialStrain(double time, DifficultyHitObject current) =>
             currentStrain * strainDecay(time - current.Previous(0).StartTime);
@@ -77,7 +77,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double totalDifficulty = calculateTotalValue(snapDifficulty, agilityDifficulty, flowDifficulty);
 
+            const double overcap_per_ms = 0.01;
+
             currentStrain *= decay;
+            currentStrain += overcap_per_ms * ((OsuDifficultyHitObject)current).AdjustedDeltaTime;
             currentStrain += totalDifficulty * (1 - decay);
 
             if (current.BaseObject is Slider)

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -33,8 +33,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double skillMultiplierSnap => 71.0;
         private double skillMultiplierAgility => 2.25;
-        private double skillMultiplierFlow => 245.0;
-        private double skillMultiplierTotal => 1.12;
+        private double skillMultiplierFlow => 240.0;
+        private double skillMultiplierTotal => 1.13;
         private double meanExponent => 1.2;
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double skillMultiplierSnap => 71.0;
         private double skillMultiplierAgility => 2.2;
         private double skillMultiplierFlow => 245.0;
-        private double skillMultiplierTotal => 1.12;
+        private double skillMultiplierTotal => 1.11;
         private double meanExponent => 1.2;
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -32,9 +32,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
 
         private double skillMultiplierSnap => 71.0;
-        private double skillMultiplierAgility => 2.0;
+        private double skillMultiplierAgility => 2.25;
         private double skillMultiplierFlow => 245.0;
-        private double skillMultiplierTotal => 1.1;
+        private double skillMultiplierTotal => 1.12;
         private double meanExponent => 1.2;
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private readonly List<double> sliderStrains = new List<double>();
 
-        private double strainDecay(double ms) => Math.Pow(0.15, ms / 1000);
+        private double strainDecay(double ms) => Math.Pow(0.25, ms / 1000);
 
         protected override double CalculateInitialStrain(double time, DifficultyHitObject current) =>
             currentStrain * strainDecay(time - current.Previous(0).StartTime);

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double currentStrain;
 
         private double skillMultiplierSnap => 71.0;
-        private double skillMultiplierAgility => 2.3;
+        private double skillMultiplierAgility => 2.4;
         private double skillMultiplierFlow => 245.0;
         private double skillMultiplierTotal => 1.11;
         private double meanExponent => 1.2;


### PR DESCRIPTION
This buffs longer jump sections and slightly nerfs short jump spikes. Mostly a way to slightly restore non-aimslop DT aim maps since they got hit with all the nerfs a bit too hard