### PR TITLE
Localize tournament screen strings

### DIFF
--- a/osu.Game.Tournament/Localisation/ScreenStrings.cs
+++ b/osu.Game.Tournament/Localisation/ScreenStrings.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Tournament.Localisation
+{
+    public class ScreenStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.Tournament.Screen";
+
+        /// <summary>
+        /// "Setup"
+        /// </summary>
+        public static LocalisableString Setup => new TranslatableString(getKey(@"setup"), @"Setup");
+
+        /// <summary>
+        /// "Team Editor"
+        /// </summary>
+        public static LocalisableString TeamEditor => new TranslatableString(getKey(@"team_editor"), @"Team Editor");
+
+        /// <summary>
+        /// "Rounds Editor"
+        /// </summary>
+        public static LocalisableString RoundsEditor => new TranslatableString(getKey(@"rounds_editor"), @"Rounds Editor");
+
+        /// <summary>
+        /// "Bracket Editor"
+        /// </summary>
+        public static LocalisableString BracketEditor => new TranslatableString(getKey(@"bracket_editor"), @"Bracket Editor");
+
+        /// <summary>
+        /// "Schedule"
+        /// </summary>
+        public static LocalisableString Schedule => new TranslatableString(getKey(@"schedule"), @"Schedule");
+
+        /// <summary>
+        /// "Bracket"
+        /// </summary>
+        public static LocalisableString Bracket => new TranslatableString(getKey(@"bracket"), @"Bracket");
+
+        /// <summary>
+        /// "Team Intro"
+        /// </summary>
+        public static LocalisableString TeamIntro => new TranslatableString(getKey(@"team_intro"), @"Team Intro");
+
+        /// <summary>
+        /// "Seeding"
+        /// </summary>
+        public static LocalisableString Seeding => new TranslatableString(getKey(@"seeding"), @"Seeding");
+
+        /// <summary>
+        /// "Map Pool"
+        /// </summary>
+        public static LocalisableString MapPool => new TranslatableString(getKey(@"map_pool"), @"Map Pool");
+
+        /// <summary>
+        /// "Gameplay"
+        /// </summary>
+        public static LocalisableString Gameplay => new TranslatableString(getKey(@"gameplay"), @"Gameplay");
+
+        /// <summary>
+        /// "Win"
+        /// </summary>
+        public static LocalisableString Win => new TranslatableString(getKey(@"win"), @"Win");
+
+        /// <summary>
+        /// "Drawings"
+        /// </summary>
+        public static LocalisableString Drawings => new TranslatableString(getKey(@"drawings"), @"Drawings");
+
+        /// <summary>
+        /// "Showcase"
+        /// </summary>
+        public static LocalisableString Showcase => new TranslatableString(getKey(@"showcase"), @"Showcase");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game.Tournament/TournamentSceneManager.cs
+++ b/osu.Game.Tournament/TournamentSceneManager.cs
@@ -27,6 +27,7 @@ using osu.Game.Tournament.Screens.TeamWin;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
+using osu.Game.Tournament.Localisation;
 
 namespace osu.Game.Tournament
 {
@@ -131,25 +132,25 @@ namespace osu.Game.Tournament
                             Padding = new MarginPadding(5),
                             Children = new Drawable[]
                             {
-                                new ScreenButton(typeof(SetupScreen)) { Text = "Setup", RequestSelection = SetScreen },
+                                new ScreenButton(typeof(SetupScreen)) { Text = ScreenStrings.Setup, RequestSelection = SetScreen },
                                 new Separator(),
-                                new ScreenButton(typeof(TeamEditorScreen)) { Text = "Team Editor", RequestSelection = SetScreen },
-                                new ScreenButton(typeof(RoundEditorScreen)) { Text = "Rounds Editor", RequestSelection = SetScreen },
-                                new ScreenButton(typeof(LadderEditorScreen)) { Text = "Bracket Editor", RequestSelection = SetScreen },
+                                new ScreenButton(typeof(TeamEditorScreen)) { Text = ScreenStrings.TeamEditor, RequestSelection = SetScreen },
+                                new ScreenButton(typeof(RoundEditorScreen)) { Text = ScreenStrings.RoundsEditor, RequestSelection = SetScreen },
+                                new ScreenButton(typeof(LadderEditorScreen)) { Text = ScreenStrings.BracketEditor, RequestSelection = SetScreen },
                                 new Separator(),
-                                new ScreenButton(typeof(ScheduleScreen), Key.S) { Text = "Schedule", RequestSelection = SetScreen },
-                                new ScreenButton(typeof(LadderScreen), Key.B) { Text = "Bracket", RequestSelection = SetScreen },
+                                new ScreenButton(typeof(ScheduleScreen), Key.S) { Text = ScreenStrings.Schedule, RequestSelection = SetScreen },
+                                new ScreenButton(typeof(LadderScreen), Key.R) { Text = ScreenStrings.Bracket, RequestSelection = SetScreen },
                                 new Separator(),
-                                new ScreenButton(typeof(TeamIntroScreen), Key.I) { Text = "Team Intro", RequestSelection = SetScreen },
-                                new ScreenButton(typeof(SeedingScreen), Key.D) { Text = "Seeding", RequestSelection = SetScreen },
+                                new ScreenButton(typeof(TeamIntroScreen), Key.I) { Text = ScreenStrings.TeamIntro, RequestSelection = SetScreen },
+                                new ScreenButton(typeof(SeedingScreen), Key.D) { Text = ScreenStrings.Seeding, RequestSelection = SetScreen },
                                 new Separator(),
-                                new ScreenButton(typeof(MapPoolScreen), Key.M) { Text = "Map Pool", RequestSelection = SetScreen },
-                                new ScreenButton(typeof(GameplayScreen), Key.G) { Text = "Gameplay", RequestSelection = SetScreen },
+                                new ScreenButton(typeof(MapPoolScreen), Key.M) { Text = ScreenStrings.MapPool, RequestSelection = SetScreen },
+                                new ScreenButton(typeof(GameplayScreen), Key.G) { Text = ScreenStrings.Gameplay, RequestSelection = SetScreen },
                                 new Separator(),
-                                new ScreenButton(typeof(TeamWinScreen), Key.W) { Text = "Win", RequestSelection = SetScreen },
+                                new ScreenButton(typeof(TeamWinScreen), Key.W) { Text = ScreenStrings.Win, RequestSelection = SetScreen },
                                 new Separator(),
-                                new ScreenButton(typeof(DrawingsScreen)) { Text = "Drawings", RequestSelection = SetScreen },
-                                new ScreenButton(typeof(ShowcaseScreen)) { Text = "Showcase", RequestSelection = SetScreen },
+                                new ScreenButton(typeof(DrawingsScreen)) { Text = ScreenStrings.Drawings, RequestSelection = SetScreen },
+                                new ScreenButton(typeof(ShowcaseScreen)) { Text = ScreenStrings.Showcase, RequestSelection = SetScreen },
                             }
                         },
                     },


### PR DESCRIPTION
This PR localizes names of screens of the tournament client, which are shown on the left sidebar.

<img width="269" height="835" alt="image" src="https://github.com/user-attachments/assets/8146be3a-be6e-47a7-b561-f811fdf0eb97" />

