### PR TITLE
Localize `SetupScreen` and `StablePathSelectScreen` for tournament client

### DIFF
--- a/osu.Game.Tournament/Components/IPCErrorDialog.cs
+++ b/osu.Game.Tournament/Components/IPCErrorDialog.cs
@@ -2,13 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Overlays.Dialog;
+using osu.Game.Tournament.Localisation.Screens;
 
 namespace osu.Game.Tournament.Components
 {
     public partial class IPCErrorDialog : PopupDialog
     {
-        public IPCErrorDialog(string headerText, string bodyText)
+        public IPCErrorDialog(LocalisableString headerText, LocalisableString bodyText)
         {
             Icon = FontAwesome.Regular.SadTear;
             HeaderText = headerText;
@@ -17,7 +19,7 @@ namespace osu.Game.Tournament.Components
             {
                 new PopupDialogOkButton
                 {
-                    Text = @"Alright.",
+                    Text = StablePathSelectStrings.IPCErrorOkButton,
                     Action = () => Expire()
                 }
             };

--- a/osu.Game.Tournament/Localisation/CommonStrings.cs
+++ b/osu.Game.Tournament/Localisation/CommonStrings.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Tournament.Localisation
+{
+    public class CommonStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.Tournament.Common";
+
+        /// <summary>
+        /// "Refresh"
+        /// </summary>
+        public static LocalisableString Refresh => new TranslatableString(getKey(@"refresh"), @"Refresh");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game.Tournament/Localisation/Screens/SetupStrings.cs
+++ b/osu.Game.Tournament/Localisation/Screens/SetupStrings.cs
@@ -1,0 +1,115 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Tournament.Localisation.Screens
+{
+    public class SetupStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.Tournament.Screens.Setup";
+
+        /// <summary>
+        /// "Not found"
+        /// </summary>
+        public static LocalisableString NotFound => new TranslatableString(getKey(@"not_found"), @"Not found");
+
+        /// <summary>
+        /// "Current IPC source"
+        /// </summary>
+        public static LocalisableString CurrentIPCSource => new TranslatableString(getKey(@"current_ipc_source"), @"Current IPC source");
+
+        /// <summary>
+        /// "Change source"
+        /// </summary>
+        public static LocalisableString ChangeIPCSource => new TranslatableString(getKey(@"change_ipc_source"), @"Change source");
+
+        /// <summary>
+        /// "The osu!stable installation which is currently being used as a data source. If a source is not found, make sure you have created an empty ipc.txt in your stable cutting-edge installation."
+        /// </summary>
+        public static LocalisableString IPCSourceDescription => new TranslatableString(getKey(@"ipc_source_description"),
+            @"The osu!stable installation which is currently being used as a data source. If a source is not found, make sure you have created an empty ipc.txt in your stable cutting-edge installation.");
+
+        /// <summary>
+        /// "Current user"
+        /// </summary>
+        public static LocalisableString CurrentUser => new TranslatableString(getKey(@"current_user"), @"Current user");
+
+        /// <summary>
+        /// "Change sign-in"
+        /// </summary>
+        public static LocalisableString ChangeSignin => new TranslatableString(getKey(@"change_sign_in"), @"Change sign-in");
+
+        /// <summary>
+        /// "In order to access the API and display metadata, signing in is required."
+        /// </summary>
+        public static LocalisableString CurrentUserDescription => new TranslatableString(getKey(@"current_user_description"),
+            @"In order to access the API and display metadata, signing in is required.");
+
+        /// <summary>
+        /// "Current tournament"
+        /// </summary>
+        public static LocalisableString CurrentTournament => new TranslatableString(getKey(@"current_tournament"), @"Current tournament");
+
+        /// <summary>
+        /// "Changes the background videos and bracket to match the selected tournament. This requires a restart to apply changes."
+        /// </summary>
+        public static LocalisableString CurrentTournamentDescription => new TranslatableString(getKey(@"current_tournament_description"),
+            @"Changes the background videos and bracket to match the selected tournament. This requires a restart to apply changes.");
+
+        /// <summary>
+        /// "Stream area resolution"
+        /// </summary>
+        public static LocalisableString StreamAreaResolution => new TranslatableString(getKey(@"stream_area_resolution"), @"Stream area resolution");
+
+        /// <summary>
+        /// "Set height"
+        /// </summary>
+        public static LocalisableString SetHeight => new TranslatableString(getKey(@"set_height"), @"Set height");
+
+        /// <summary>
+        /// "Ruleset"
+        /// </summary>
+        public static LocalisableString Ruleset => new TranslatableString(getKey(@"ruleset"), @"Ruleset");
+
+        /// <summary>
+        /// "Decides what stats are displayed and which ranks are retrieved for players. This requires a restart to reload data for an existing bracket."
+        /// </summary>
+        public static LocalisableString RulesetDescription => new TranslatableString(getKey(@"ruleset_description"),
+            @"Decides what stats are displayed and which ranks are retrieved for players. This requires a restart to reload data for an existing bracket.");
+
+        /// <summary>
+        /// "Display team seeds"
+        /// </summary>
+        public static LocalisableString DisplaySeeds => new TranslatableString(getKey(@"display_seeds"), @"Display team seeds");
+
+        /// <summary>
+        /// "Team seeds will display alongside each team at the top in gameplay/map pool screens."
+        /// </summary>
+        public static LocalisableString DisplaySeedsDescription => new TranslatableString(getKey(@"display_seeds_description"),
+            @"Team seeds will display alongside each team at the top in gameplay/map pool screens.");
+
+        /// <summary>
+        /// "Auto advance screens"
+        /// </summary>
+        public static LocalisableString AutoAdvanceScreens => new TranslatableString(getKey(@"auto_advance_screens"), @"Auto advance screens");
+
+        /// <summary>
+        /// "Screens will progress automatically from gameplay -> results -> map pool"
+        /// </summary>
+        public static LocalisableString AutoAdvanceScreensDescription => new TranslatableString(getKey(@"auto_advance_screens_description"),
+            @"Screens will progress automatically from gameplay -> results -> map pool");
+
+        /// <summary>
+        /// "Open folder"
+        /// </summary>
+        public static LocalisableString OpenFolder => new TranslatableString(getKey(@"open_folder"), @"Open folder");
+
+        /// <summary>
+        /// "Close osu!"
+        /// </summary>
+        public static LocalisableString CloseOsu => new TranslatableString(getKey(@"close_osu"), @"Close osu!");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game.Tournament/Localisation/Screens/StablePathSelectStrings.cs
+++ b/osu.Game.Tournament/Localisation/Screens/StablePathSelectStrings.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Tournament.Localisation.Screens
+{
+    public class StablePathSelectStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.Tournament.Screens.StablePathSelect";
+
+        /// <summary>
+        /// "Please select a new location"
+        /// </summary>
+        public static LocalisableString PathSelectTitle => new TranslatableString(getKey(@"path_select_title"), @"Please select a new location");
+
+        /// <summary>
+        /// "Select stable path"
+        /// </summary>
+        public static LocalisableString SelectStablePath => new TranslatableString(getKey(@"select_stable_path"), @"Select stable path");
+
+        /// <summary>
+        /// "Auto detect"
+        /// </summary>
+        public static LocalisableString AutoDetect => new TranslatableString(getKey(@"auto_detect"), @"Auto detect");
+
+        /// <summary>
+        /// "This is an invalid IPC Directory"
+        /// </summary>
+        public static LocalisableString InvalidDirectoryTitle => new TranslatableString(getKey(@"invalid_directory_title"), @"This is an invalid IPC Directory");
+
+        /// <summary>
+        /// "Select a directory that contains an osu! stable cutting edge installation and make sure it has an empty ipc.txt file in it."
+        /// </summary>
+        public static LocalisableString InvalidDirectoryText => new TranslatableString(getKey(@"invalid_directory_text"),
+            @"Select a directory that contains an osu! stable cutting edge installation and make sure it has an empty ipc.txt file in it.");
+
+        /// <summary>
+        /// "Failed to automatically detect"
+        /// </summary>
+        public static LocalisableString DetectFailureTitle => new TranslatableString(getKey(@"detect_failure_title"), @"Failed to automatically detect");
+
+        /// <summary>
+        /// "An osu! stable cutting-edge installation could not be detected. Please try and manually point to the directory."
+        /// </summary>
+        public static LocalisableString DetectFailureText => new TranslatableString(getKey(@"detect_failure_text"),
+            @"An osu! stable cutting-edge installation could not be detected. Please try and manually point to the directory.");
+
+        /// <summary>
+        /// "Alright."
+        /// </summary>
+        public static LocalisableString IPCErrorOkButton => new TranslatableString(getKey(@"ipc_error_ok_button"), @"Alright.");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}
+

--- a/osu.Game.Tournament/Screens/Setup/ActionableInfo.cs
+++ b/osu.Game.Tournament/Screens/Setup/ActionableInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;
@@ -28,12 +29,12 @@ namespace osu.Game.Tournament.Screens.Setup
         {
         }
 
-        public string ButtonText
+        public LocalisableString ButtonText
         {
             set => Button.Text = value;
         }
 
-        public string Value
+        public LocalisableString Value
         {
             set => valueText.Text = value;
         }

--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -10,11 +10,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Tournament.IPC;
+using osu.Game.Tournament.Localisation.Screens;
 using osu.Game.Tournament.Models;
 using osuTK;
 
@@ -84,18 +86,17 @@ namespace osu.Game.Tournament.Screens.Setup
             {
                 new ActionableInfo
                 {
-                    Label = "Current IPC source",
-                    ButtonText = "Change source",
+                    Label = SetupStrings.CurrentIPCSource,
+                    ButtonText = SetupStrings.ChangeIPCSource,
                     Action = () => sceneManager?.SetScreen(new StablePathSelectScreen()),
-                    Value = fileBasedIpc?.IPCStorage?.GetFullPath(string.Empty) ?? "Not found",
+                    Value = fileBasedIpc?.IPCStorage?.GetFullPath(string.Empty) ?? SetupStrings.NotFound,
                     Failing = fileBasedIpc?.IPCStorage == null,
-                    Description =
-                        "The osu!stable installation which is currently being used as a data source. If a source is not found, make sure you have created an empty ipc.txt in your stable cutting-edge installation."
+                    Description = SetupStrings.IPCSourceDescription,
                 },
                 new ActionableInfo
                 {
-                    Label = "Current user",
-                    ButtonText = "Change sign-in",
+                    Label = SetupStrings.CurrentUser,
+                    ButtonText = SetupStrings.ChangeSignin,
                     Action = () =>
                     {
                         api.Logout();
@@ -113,25 +114,25 @@ namespace osu.Game.Tournament.Screens.Setup
                     },
                     Value = api.LocalUser.Value.Username,
                     Failing = api.IsLoggedIn != true,
-                    Description = "In order to access the API and display metadata, signing in is required."
+                    Description = SetupStrings.CurrentUserDescription,
                 },
                 new LabelledDropdown<RulesetInfo?>(padded: true)
                 {
-                    Label = "Ruleset",
-                    Description = "Decides what stats are displayed and which ranks are retrieved for players. This requires a restart to reload data for an existing bracket.",
+                    Label = SetupStrings.Ruleset,
+                    Description = SetupStrings.RulesetDescription,
                     Items = rulesets.AvailableRulesets,
                     Current = LadderInfo.Ruleset,
                     DropdownWidth = 0.5f,
                 },
                 new TournamentSwitcher
                 {
-                    Label = "Current tournament",
-                    Description = "Changes the background videos and bracket to match the selected tournament. This requires a restart to apply changes.",
+                    Label = SetupStrings.CurrentTournament,
+                    Description = SetupStrings.CurrentTournamentDescription,
                 },
                 resolution = new ResolutionSelector
                 {
-                    Label = "Stream area resolution",
-                    ButtonText = "Set height",
+                    Label = SetupStrings.StreamAreaResolution,
+                    ButtonText = SetupStrings.SetHeight,
                     Action = height =>
                     {
                         windowSize.Value = new Size((int)(height * aspect_ratio / TournamentSceneManager.STREAM_AREA_WIDTH * TournamentSceneManager.REQUIRED_WIDTH), height);
@@ -139,14 +140,14 @@ namespace osu.Game.Tournament.Screens.Setup
                 },
                 new LabelledSwitchButton
                 {
-                    Label = "Auto advance screens",
-                    Description = "Screens will progress automatically from gameplay -> results -> map pool",
+                    Label = SetupStrings.AutoAdvanceScreens,
+                    Description = SetupStrings.AutoAdvanceScreensDescription,
                     Current = LadderInfo.AutoProgressScreens,
                 },
                 new LabelledSwitchButton
                 {
-                    Label = "Display team seeds",
-                    Description = "Team seeds will display alongside each team at the top in gameplay/map pool screens.",
+                    Label = SetupStrings.DisplaySeeds,
+                    Description = SetupStrings.DisplaySeedsDescription,
                     Current = LadderInfo.DisplayTeamSeeds,
                 },
             };

--- a/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.IPC;
+using osu.Game.Tournament.Localisation.Screens;
 using osuTK;
 
 namespace osu.Game.Tournament.Screens.Setup
@@ -73,7 +74,7 @@ namespace osu.Game.Tournament.Screens.Setup
                                     {
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.Centre,
-                                        Text = "Please select a new location",
+                                        Text = StablePathSelectStrings.PathSelectTitle,
                                         Font = OsuFont.Default.With(size: 40)
                                     },
                                 },
@@ -99,7 +100,7 @@ namespace osu.Game.Tournament.Screens.Setup
                                                 Anchor = Anchor.Centre,
                                                 Origin = Anchor.Centre,
                                                 Width = 300,
-                                                Text = "Select stable path",
+                                                Text = StablePathSelectStrings.SelectStablePath,
                                                 Action = ChangePath
                                             },
                                             new RoundedButton
@@ -107,7 +108,7 @@ namespace osu.Game.Tournament.Screens.Setup
                                                 Anchor = Anchor.Centre,
                                                 Origin = Anchor.Centre,
                                                 Width = 300,
-                                                Text = "Auto detect",
+                                                Text = StablePathSelectStrings.AutoDetect,
                                                 Action = AutoDetect
                                             },
                                         }
@@ -136,7 +137,7 @@ namespace osu.Game.Tournament.Screens.Setup
             if (!fileBasedIpc?.SetIPCLocation(target) ?? true)
             {
                 overlay = new DialogOverlay();
-                overlay.Push(new IPCErrorDialog("This is an invalid IPC Directory", "Select a directory that contains an osu! stable cutting edge installation and make sure it has an empty ipc.txt file in it."));
+                overlay.Push(new IPCErrorDialog(StablePathSelectStrings.InvalidDirectoryTitle, StablePathSelectStrings.InvalidDirectoryText));
                 AddInternal(overlay);
                 Logger.Log("Folder is not an osu! stable CE directory");
                 return;
@@ -152,7 +153,7 @@ namespace osu.Game.Tournament.Screens.Setup
             if (!fileBasedIpc?.AutoDetectIPCLocation() ?? true)
             {
                 overlay = new DialogOverlay();
-                overlay.Push(new IPCErrorDialog("Failed to auto detect", "An osu! stable cutting-edge installation could not be auto detected.\nPlease try and manually point to the directory."));
+                overlay.Push(new IPCErrorDialog(StablePathSelectStrings.DetectFailureTitle, StablePathSelectStrings.DetectFailureText));
                 AddInternal(overlay);
             }
             else

--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -6,6 +6,8 @@ using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Tournament.IO;
+using osu.Game.Tournament.Localisation;
+using osu.Game.Tournament.Localisation.Screens;
 
 namespace osu.Game.Tournament.Screens.Setup
 {
@@ -36,7 +38,7 @@ namespace osu.Game.Tournament.Screens.Setup
             };
             folderButton.Action = () => storage.PresentExternally();
 
-            ButtonText = "Close osu!";
+            ButtonText = SetupStrings.CloseOsu;
         }
 
         protected override Drawable CreateComponent()
@@ -45,13 +47,13 @@ namespace osu.Game.Tournament.Screens.Setup
 
             FlowContainer.Insert(-1, folderButton = new RoundedButton
             {
-                Text = "Open folder",
+                Text = SetupStrings.OpenFolder,
                 Width = BUTTON_SIZE
             });
 
             FlowContainer.Insert(-2, reloadTournamentsButton = new RoundedButton
             {
-                Text = "Refresh",
+                Text = CommonStrings.Refresh,
                 Width = BUTTON_SIZE
             });
 


### PR DESCRIPTION
## Changes

- Add l10n support for `IPCErrorDialog` and `ActionableInfo`
- Localize two screens

The `CommonStrings` class would store other strings that are used frequently in the tournament client.
