### PR TITLE
Ranked Play: Simplify track handling + fix song preview

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
@@ -167,8 +167,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             globalRuleset.Value = ruleset;
             globalMods.Value = item.RequiredMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
 
+            // Play the new track from its preview point.
             globalBeatmap.Value.PrepareTrackForPreview(false);
-            musicController.EnsurePlayingSomething();
+            musicController.Play(true);
 
             Client.ChangeState(MultiplayerUserState.Ready).FireAndForget();
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
@@ -54,6 +54,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private RulesetStore rulesets { get; set; } = null!;
 
         [Resolved]
+        private MusicController musicController { get; set; } = null!;
+
+        [Resolved]
         private Bindable<WorkingBeatmap> globalBeatmap { get; set; } = null!;
 
         [Resolved]
@@ -163,6 +166,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             globalBeatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
             globalRuleset.Value = ruleset;
             globalMods.Value = item.RequiredMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
+
+            globalBeatmap.Value.PrepareTrackForPreview(false);
+            musicController.EnsurePlayingSomething();
 
             Client.ChangeState(MultiplayerUserState.Ready).FireAndForget();
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -67,9 +67,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
         [Resolved]
-        private MusicController music { get; set; } = null!;
-
-        [Resolved]
         private QueueController? controller { get; set; }
 
         private readonly MultiplayerRoom room;
@@ -285,16 +282,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             }
         }
 
-        public override void OnEntering(ScreenTransitionEvent e)
-        {
-            base.OnEntering(e);
-
-            beginHandlingTrack();
-        }
-
         public override void OnSuspending(ScreenTransitionEvent e)
         {
-            endHandlingTrack();
+            previewTrackManager.StopAnyPlaying(this);
 
             base.OnSuspending(e);
         }
@@ -312,7 +302,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     return true;
                 }
 
-                endHandlingTrack();
+                previewTrackManager.StopAnyPlaying(this);
 
                 client.LeaveRoom().FireAndForget();
 
@@ -341,8 +331,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             base.OnResuming(e);
 
-            beginHandlingTrack();
-
             if (e.Last is not MultiplayerPlayerLoader playerLoader)
                 return;
 
@@ -353,38 +341,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             }
 
             client.ChangeState(MultiplayerUserState.Idle).FireAndForget();
-        }
-
-        /// <summary>
-        /// Handles changes in the track to keep it looping while active.
-        /// </summary>
-        private void beginHandlingTrack()
-        {
-            Beatmap.BindValueChanged(applyLoopingToTrack, true);
-        }
-
-        /// <summary>
-        /// Stops looping the current track and stops handling further changes to the track.
-        /// </summary>
-        private void endHandlingTrack()
-        {
-            Beatmap.ValueChanged -= applyLoopingToTrack;
-            Beatmap.Value.Track.Looping = false;
-
-            previewTrackManager.StopAnyPlaying(this);
-        }
-
-        /// <summary>
-        /// Invoked on changes to the beatmap to loop the track. See: <see cref="beginHandlingTrack"/>.
-        /// </summary>
-        /// <param name="beatmap">The beatmap change event.</param>
-        private void applyLoopingToTrack(ValueChangedEvent<WorkingBeatmap> beatmap)
-        {
-            if (!this.IsCurrentScreen())
-                return;
-
-            beatmap.NewValue.PrepareTrackForPreview(true);
-            music.EnsurePlayingSomething();
         }
 
         public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)


### PR DESCRIPTION
- Simplifies track handling by not attaching to the global beatmap, not looping, and moving into `GameplayWarmupScreen` where the beatmap is set.
  - The main idea here is that the transition period until gameplay is so short (~10 seconds) that we don't need to account for the track ever looping in the first place.
- Fixes the track not playing from its preview point (feedback item mentioned in some meeting a while back).

This is definitely going to conflict with @nekodex 's work, sorry about that. It's a bit of a much-of-a-muchness change (imo) if the conclusion is to wait for ongoing work first.