### PR TITLE
Fix editor showing no background at all if storyboard that does not replace background is disabled

### DIFF
--- a/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
+++ b/osu.Game/Screens/Backgrounds/EditorBackgroundScreen.cs
@@ -111,6 +111,9 @@ namespace osu.Game.Screens.Backgrounds
         private void updateState(bool withAnimation = true)
         {
             background?.Storyboard.FadeTo(showStoryboard.Value ? 1 : 0, withAnimation ? 500 : 0, Easing.OutQuint);
+            // if the storyboard is disabled, in some cases (e.g. involving `StoryboardReplacesBackground`)
+            // we still need to show the background sprite, because if we don't, then there will be no background shown at all
+            background?.Sprite.FadeTo(showStoryboard.Value ? 0 : 1, withAnimation ? 500 : 0, Easing.OutQuint);
         }
 
         public override bool Equals(BackgroundScreen? other)


### PR DESCRIPTION
Man this "storyboard replaces background" baloney has taken hours of bugfixing alone. So many forehead indentations from stepping onto this stupid rake.

This still fails in one more case: when you download a no-video variant of a beatmap that has video, but then edit it, all of the flags on storyboard will claim that the beatmap has a storyboard that replaces a background, but the video asset is missing, so the background will still be black. There's currently no way to check for this and the simplest way to address this as far as I can see would be reverting https://github.com/ppy/osu/pull/37038 and going with the non-refactor route to fix https://github.com/ppy/osu/issues/36875 instead. The alternative is adding all sorts of weird jingles and checks in the storyboard machinery that can be used to be able to tell that a video was supposed to be present in the storyboard but is missing.

Also when entering editor on a map that has background video and storyboard enabled the background will be black until you hit play. Something to do with `Video` idiosyncrasies for sure.

Closes https://github.com/ppy/osu/issues/37104 maybe? Kind of? Partially? I don't know. This is all very low effort because I'm not confident about digging this ditch any deeper, but just PRing a direct revert would feel pretty offensive I guess?