### PR TITLE
Add invert selection keybinding to editor

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -155,6 +155,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Alt, InputKey.Left }, GlobalAction.EditorSeekToPreviousBookmark),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Right }, GlobalAction.EditorSeekToNextBookmark),
             new KeyBinding(new[] { InputKey.Control, InputKey.L }, GlobalAction.EditorDiscardUnsavedChanges),
+            new KeyBinding(new[] { InputKey.Control, InputKey.I }, GlobalAction.EditorInvertSelection),
         };
 
         private static IEnumerable<KeyBinding> editorTestPlayKeyBindings => new[]
@@ -528,6 +529,9 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.NextSkin))]
         NextSkin,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorInvertSelection))]
+        EditorInvertSelection,
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -160,6 +160,11 @@ namespace osu.Game.Localisation
         public static LocalisableString Clone => new TranslatableString(getKey(@"clone"), @"Clone");
 
         /// <summary>
+        /// "Invert selection"
+        /// </summary>
+        public static LocalisableString InvertSelection => new TranslatableString(getKey(@"invert_selection"), @"Invert selection");
+
+        /// <summary>
         /// "Exit"
         /// </summary>
         public static LocalisableString Exit => new TranslatableString(getKey(@"exit"), @"Exit");

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -489,6 +489,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString EditorDiscardUnsavedChanges => new TranslatableString(getKey(@"editor_discard_unsaved_changes"), @"Discard unsaved changes");
 
+        /// <summary>
+        /// "Invert selection"
+        /// </summary>
+        public static LocalisableString EditorInvertSelection => new TranslatableString(getKey(@"editor_invert_selection"), @"Invert selection");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -300,6 +300,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     }
 
                     break;
+
+                case GlobalAction.EditorInvertSelection:
+                    InvertSelection();
+                    return true;
             }
 
             return false;
@@ -516,6 +520,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Select all currently-present items.
         /// </summary>
         protected abstract void SelectAll();
+
+        /// <summary>
+        /// Invert the current selection, deselecting all selected items and selecting all unselected items.
+        /// </summary>
+        protected virtual void InvertSelection()
+        {
+        }
 
         /// <summary>
         /// Deselect all selected items.

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -129,6 +129,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
             SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).ToArray());
         }
 
+        protected override void InvertSelection()
+        {
+            Composer.Playfield.KeepAllAlive();
+
+            var toSelect = Beatmap.HitObjects.Except(SelectedItems).ToArray();
+
+            SelectedItems.Clear();
+            SelectedItems.AddRange(toSelect);
+        }
+
         /// <summary>
         /// Ensures that newly-selected hitobjects are kept alive
         /// and drops that keep-alive from newly-deselected objects.


### PR DESCRIPTION
Adds the ability to invert the current hit object selection in the editor.

## Why `Ctrl + I`
`Ctrl + I` matches the selection inversion shortcut used by programs like GIMP and Paint.NET, so it should feel familiar to users instead of introducing a new convention.

## Why not `Ctrl + Shift + I`
Photoshop and Krita use `Ctrl + Shift + I` for selection inversion, but in Photoshop `Ctrl + I` is already used for the image inversion filter. Since osu! has no equivalent "invert image" action that would use this shortcut, `Ctrl + I` is the more appropriate choice here.