### PR TITLE
Only show one dialog and automatically restart when changing folder to already installed location

### DIFF
--- a/osu.Game/Localisation/MaintenanceSettingsStrings.cs
+++ b/osu.Game/Localisation/MaintenanceSettingsStrings.cs
@@ -40,14 +40,9 @@ namespace osu.Game.Localisation
         public static LocalisableString SelectNewLocation => new TranslatableString(getKey(@"select_new_location"), @"Please select a new location");
 
         /// <summary>
-        /// "The target directory already seems to have an osu! install. Use that data instead?"
+        /// "The target directory already seems to have an osu! install. Use that data instead? osu! will restart."
         /// </summary>
-        public static LocalisableString TargetDirectoryAlreadyInstalledOsu => new TranslatableString(getKey(@"target_directory_already_installed_osu"), @"The target directory already seems to have an osu! install. Use that data instead?");
-
-        /// <summary>
-        /// "To complete this operation, osu! will close. Please open it again to use the new data location."
-        /// </summary>
-        public static LocalisableString RestartAndReOpenRequiredForCompletion => new TranslatableString(getKey(@"restart_and_re_open_required_for_completion"), @"To complete this operation, osu! will close. Please open it again to use the new data location.");
+        public static LocalisableString TargetDirectoryAlreadyInstalledOsu => new TranslatableString(getKey(@"target_directory_already_installed_osu"), @"The target directory already seems to have an osu! install. Use that data instead? osu! will restart.");
 
         /// <summary>
         /// "Delete ALL beatmaps"

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -54,11 +54,9 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                     {
                         dialogOverlay.Push(new ConfirmDialog(MaintenanceSettingsStrings.TargetDirectoryAlreadyInstalledOsu, () =>
                             {
-                                dialogOverlay.Push(new ConfirmDialog(MaintenanceSettingsStrings.RestartAndReOpenRequiredForCompletion, () =>
-                                {
-                                    (storage as OsuStorage)?.ChangeDataPath(target.FullName);
-                                    game.Exit();
-                                }, () => { }));
+                                (storage as OsuStorage)?.ChangeDataPath(target.FullName);
+                                game.RestartAppWhenExited();
+                                game.Exit();
                             },
                             () => { }));
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/37039

https://github.com/user-attachments/assets/eb788984-783c-42ac-a7db-e6daa64d609d

Can't gracefully exit because main menu has another exit confirmation dialog. May need to revisit https://github.com/ppy/osu/pull/26558. Unless force exiting is intentional?