### PR TITLE
"Fix" performance drop caused by changing scroll speed

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
+++ b/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         protected override void Update()
         {
-            TargetTimeRange = TimelineTimeRange == null || ShowSpeedChanges.Value ? ComputeScrollTime(Config.Get<double>(ManiaRulesetSetting.ScrollSpeed)) : TimelineTimeRange.Value;
+            TimeRange.Value = TimelineTimeRange == null || ShowSpeedChanges.Value ? ComputeScrollTime(Config.Get<double>(ManiaRulesetSetting.ScrollSpeed)) : TimelineTimeRange.Value;
             base.Update();
         }
     }

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -59,10 +59,7 @@ namespace osu.Game.Rulesets.Mania.UI
         private readonly BindableDouble configScrollSpeed = new BindableDouble();
         private readonly Bindable<ManiaMobileLayout> mobileLayout = new Bindable<ManiaMobileLayout>();
         private readonly Bindable<bool> touchOverlay = new Bindable<bool>();
-
-        public double TargetTimeRange { get; protected set; }
-
-        private double currentTimeRange;
+        public double CurrentTimeRange => TimeRange.Value;
 
         // Stores the current speed adjustment active in gameplay.
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
@@ -115,10 +112,10 @@ namespace osu.Game.Rulesets.Mania.UI
                 if (!AllowScrollSpeedAdjustment)
                     return;
 
-                TargetTimeRange = ComputeScrollTime(speed.NewValue);
+                TimeRange.Value = ComputeScrollTime(speed.NewValue);
             });
 
-            TimeRange.Value = TargetTimeRange = currentTimeRange = ComputeScrollTime(configScrollSpeed.Value);
+            TimeRange.Value = ComputeScrollTime(configScrollSpeed.Value);
 
             Config.BindWith(ManiaRulesetSetting.MobileLayout, mobileLayout);
             mobileLayout.BindValueChanged(_ => updateMobileLayout(), true);
@@ -147,7 +144,6 @@ namespace osu.Game.Rulesets.Mania.UI
         protected override void Update()
         {
             base.Update();
-            TimeRange.Value = TargetTimeRange;
         }
 
         private ScheduledDelegate? pendingSkinChange;

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -141,11 +141,6 @@ namespace osu.Game.Rulesets.Mania.UI
 
         protected override void AdjustScrollSpeed(int amount) => configScrollSpeed.Value += amount;
 
-        protected override void Update()
-        {
-            base.Update();
-        }
-
         private ScheduledDelegate? pendingSkinChange;
         private float hitPosition;
 

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Input;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Input.Handlers;
@@ -148,7 +147,7 @@ namespace osu.Game.Rulesets.Mania.UI
         protected override void Update()
         {
             base.Update();
-            updateTimeRange();
+            TimeRange.Value = TargetTimeRange;
         }
 
         private ScheduledDelegate? pendingSkinChange;
@@ -169,19 +168,6 @@ namespace osu.Game.Rulesets.Mania.UI
                           ?? Stage.HIT_TARGET_POSITION;
 
             pendingSkinChange = null;
-        }
-
-        private void updateTimeRange()
-        {
-            const float length_to_default_hit_position = 768 - LegacyManiaSkinConfiguration.DEFAULT_HIT_POSITION;
-            float lengthToHitPosition = 768 - hitPosition;
-
-            // This scaling factor preserves the scroll speed as the scroll length varies from changes to the hit position.
-            float scale = lengthToHitPosition / length_to_default_hit_position;
-
-            // we're intentionally using the game host's update clock here to decouple the time range tween from the gameplay clock (which can be arbitrarily paused, or even rewinding)
-            currentTimeRange = Interpolation.DampContinuously(currentTimeRange, TargetTimeRange, 50, gameHost.UpdateThread.Clock.ElapsedFrameTime);
-            TimeRange.Value = currentTimeRange * speedAdjustmentTrack.AggregateTempo.Value * speedAdjustmentTrack.AggregateFrequency.Value * scale;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -9,7 +9,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Input;
-using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -19,7 +18,6 @@ using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Replays;
-using osu.Game.Rulesets.Mania.Skinning;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -59,15 +57,11 @@ namespace osu.Game.Rulesets.Mania.UI
         private readonly BindableDouble configScrollSpeed = new BindableDouble();
         private readonly Bindable<ManiaMobileLayout> mobileLayout = new Bindable<ManiaMobileLayout>();
         private readonly Bindable<bool> touchOverlay = new Bindable<bool>();
-        public double CurrentTimeRange => TimeRange.Value;
 
         // Stores the current speed adjustment active in gameplay.
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
 
         private ISkinSource currentSkin = null!;
-
-        [Resolved]
-        private GameHost gameHost { get; set; } = null!;
 
         public DrawableManiaRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod>? mods = null)
             : base(ruleset, beatmap, mods)
@@ -142,7 +136,6 @@ namespace osu.Game.Rulesets.Mania.UI
         protected override void AdjustScrollSpeed(int amount) => configScrollSpeed.Value += amount;
 
         private ScheduledDelegate? pendingSkinChange;
-        private float hitPosition;
 
         private void onSkinChange()
         {
@@ -154,10 +147,6 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private void skinChanged()
         {
-            hitPosition = currentSkin.GetConfig<ManiaSkinConfigurationLookup, float>(
-                              new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.HitPosition))?.Value
-                          ?? Stage.HIT_TARGET_POSITION;
-
             pendingSkinChange = null;
         }
 

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -472,7 +472,7 @@ namespace osu.Game.Tests.Visual.Navigation
             void checkScrollSpeed(double configValue, double gameplayValue)
             {
                 AddUntilStep($"config value is {configValue}", () => getConfigManager().Get<double>(ManiaRulesetSetting.ScrollSpeed), () => Is.EqualTo(configValue));
-                AddUntilStep($"gameplay value is {gameplayValue}", () => this.ChildrenOfType<DrawableManiaRuleset>().Single().TargetTimeRange,
+                AddUntilStep($"gameplay value is {gameplayValue}", () => this.ChildrenOfType<DrawableManiaRuleset>().Single().CurrentTimeRange,
                     () => Is.EqualTo(DrawableManiaRuleset.ComputeScrollTime(gameplayValue)));
             }
 

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -472,7 +472,7 @@ namespace osu.Game.Tests.Visual.Navigation
             void checkScrollSpeed(double configValue, double gameplayValue)
             {
                 AddUntilStep($"config value is {configValue}", () => getConfigManager().Get<double>(ManiaRulesetSetting.ScrollSpeed), () => Is.EqualTo(configValue));
-                AddUntilStep($"gameplay value is {gameplayValue}", () => this.ChildrenOfType<DrawableManiaRuleset>().Single().CurrentTimeRange,
+                AddUntilStep($"gameplay value is {gameplayValue}", () => this.ChildrenOfType<DrawableManiaRuleset>().Single().ScrollingInfo.TimeRange.Value,
                     () => Is.EqualTo(DrawableManiaRuleset.ComputeScrollTime(gameplayValue)));
             }
 


### PR DESCRIPTION
The fix is just disabling the animation. It works I guess.

---

- Closes https://github.com/ppy/osu/issues/37042

Currently in Mania, you can change the scroll speed for a brief period during the beginning of a song. However this scroll speed change occurs over a short period of time, which causes a bunch of extra hit object updates, causing major fps and latency drops.

This fix simply replaces the dampening with an immediate scroll speed update. Since the scroll speed can only be updated for a short time at the beginning of the song, providing immediate visual feedback on the scroll speed makes sense to me. However another potential solution would be to filter the TimeRange Value updates to keep the gradual scroll speed visual change, while greatly reducing the number of updates to the hit objects currently on screen.

If there is any feedback I would greatly appreciate it as this is my first issue here. I had ran both inspectCode.ps1 and the code formatter before creating the merge request. Thank you.

Before fix:
https://github.com/user-attachments/assets/55e30894-7341-414a-af2e-2ec051c3a252

After fix:
https://github.com/user-attachments/assets/c085d33f-c0ae-45dd-8131-e79a5682b9ca

