### PR TITLE
Replace MacOS hitsound composer "Alt" text tooltip with "Opt".

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -8,13 +8,13 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using JetBrains.Annotations;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Testing;
@@ -562,7 +562,7 @@ namespace osu.Game.Rulesets.Edit
         #endregion
     }
 
-        /// <summary>
+    /// <summary>
     /// A non-generic definition of a HitObject composer class.
     /// Generally used to access certain methods without requiring a generic type for <see cref="HitObjectComposer{T}" />.
     /// </summary>
@@ -573,6 +573,9 @@ namespace osu.Game.Rulesets.Edit
         public const float TOOLBOX_CONTRACTED_SIZE_RIGHT = 120;
 
         public readonly Ruleset Ruleset;
+
+        [Resolved]
+        private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; } = null!;
 
         protected HitObjectComposer(Ruleset ruleset)
         {
@@ -615,6 +618,6 @@ namespace osu.Game.Rulesets.Edit
         /// Returns the platform-specific Alt key name.
         /// For macOS, this returns "Option". Otherwise returns "Alt".
         /// </summary>
-        protected internal static string AltKeyName => RuntimeInfo.OS == RuntimeInfo.Platform.macOS ? "Opt" : "Alt";
+        protected internal string AltKeyName => readableKeyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Alt));
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -180,7 +181,7 @@ namespace osu.Game.Rulesets.Edit
                                         Spacing = new Vector2(0, 5),
                                     },
                                 },
-                                new EditorToolboxGroup("bank (Shift/Alt-Q~R)")
+                                new EditorToolboxGroup($"bank (Shift/{AltKeyName}-Q~R)")
                                 {
                                     Child = new FillFlowContainer
                                     {
@@ -561,7 +562,7 @@ namespace osu.Game.Rulesets.Edit
         #endregion
     }
 
-    /// <summary>
+        /// <summary>
     /// A non-generic definition of a HitObject composer class.
     /// Generally used to access certain methods without requiring a generic type for <see cref="HitObjectComposer{T}" />.
     /// </summary>
@@ -609,5 +610,11 @@ namespace osu.Game.Rulesets.Edit
         /// <param name="timestamp">The time instant to seek to, in milliseconds.</param>
         /// <param name="objectDescription">The ruleset-specific description of objects to select at the given timestamp.</param>
         public virtual void SelectFromTimestamp(double timestamp, string objectDescription) { }
+
+        /// <summary>
+        /// Returns the platform-specific Alt key name.
+        /// For macOS, this returns "Option". Otherwise returns "Alt".
+        /// </summary>
+        protected internal static string AltKeyName => !(RuntimeInfo.OS == RuntimeInfo.Platform.macOS) ? "Opt" : "Alt";
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Edit
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, [CanBeNull] Editor editor)
+        private void load(OsuConfigManager config, [CanBeNull] Editor editor, ReadableKeyCombinationProvider keyCombinationProvider)
         {
             autoSeekOnPlacement = config.GetBindable<bool>(OsuSetting.EditorAutoSeekOnPlacement);
 
@@ -135,6 +135,9 @@ namespace osu.Game.Rulesets.Edit
                 dependencies.CacheAs(scrollingRuleset.ScrollingInfo);
 
             dependencies.CacheAs(Playfield);
+
+            string shiftDisplay = keyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Shift));
+            string altDisplay = keyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Alt));
 
             InternalChildren = new[]
             {
@@ -181,7 +184,7 @@ namespace osu.Game.Rulesets.Edit
                                         Spacing = new Vector2(0, 5),
                                     },
                                 },
-                                new EditorToolboxGroup($"bank (Shift/{AltKeyName}-Q~R)")
+                                new EditorToolboxGroup($"bank ({shiftDisplay}/{altDisplay}-Q~R)")
                                 {
                                     Child = new FillFlowContainer
                                     {
@@ -574,9 +577,6 @@ namespace osu.Game.Rulesets.Edit
 
         public readonly Ruleset Ruleset;
 
-        [Resolved]
-        private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; } = null!;
-
         protected HitObjectComposer(Ruleset ruleset)
         {
             Ruleset = ruleset;
@@ -613,11 +613,5 @@ namespace osu.Game.Rulesets.Edit
         /// <param name="timestamp">The time instant to seek to, in milliseconds.</param>
         /// <param name="objectDescription">The ruleset-specific description of objects to select at the given timestamp.</param>
         public virtual void SelectFromTimestamp(double timestamp, string objectDescription) { }
-
-        /// <summary>
-        /// Returns the platform-specific Alt key name.
-        /// For macOS, this returns "Option". Otherwise returns "Alt".
-        /// </summary>
-        protected internal string AltKeyName => readableKeyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Alt));
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -180,7 +181,7 @@ namespace osu.Game.Rulesets.Edit
                                         Spacing = new Vector2(0, 5),
                                     },
                                 },
-                                new EditorToolboxGroup("bank (Shift/Alt-Q~R)")
+                                new EditorToolboxGroup($"bank (Shift/{AltKeyName}-Q~R)")
                                 {
                                     Child = new FillFlowContainer
                                     {
@@ -561,7 +562,7 @@ namespace osu.Game.Rulesets.Edit
         #endregion
     }
 
-    /// <summary>
+        /// <summary>
     /// A non-generic definition of a HitObject composer class.
     /// Generally used to access certain methods without requiring a generic type for <see cref="HitObjectComposer{T}" />.
     /// </summary>
@@ -609,5 +610,11 @@ namespace osu.Game.Rulesets.Edit
         /// <param name="timestamp">The time instant to seek to, in milliseconds.</param>
         /// <param name="objectDescription">The ruleset-specific description of objects to select at the given timestamp.</param>
         public virtual void SelectFromTimestamp(double timestamp, string objectDescription) { }
+
+        /// <summary>
+        /// Returns the platform-specific Alt key name.
+        /// For macOS, this returns "Option". Otherwise returns "Alt".
+        /// </summary>
+        protected internal static string AltKeyName => RuntimeInfo.OS == RuntimeInfo.Platform.macOS ? "Opt" : "Alt";
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/37055

In the editor, keybinds and the tooltip for the hitsounding section are hardcoded. Since the keybind contains "Alt", this is inconsistent on MacOS where "Opt" is used instead.

Before:
<img width="191" height="244" alt="image" src="https://github.com/user-attachments/assets/749f9dd1-f037-4061-848e-44161913190d" />


After (MacOS only):
<img width="193" height="244" alt="image" src="https://github.com/user-attachments/assets/c807a23d-225e-41ab-993a-df9230be58bc" />
