### PR TITLE
Ranked Play: Make cards draggable and reorderable

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneHandReplay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneHandReplay.cs
@@ -75,14 +75,14 @@ namespace osu.Game.Tests.Visual.RankedPlay
         }
 
         private double flushInterval = 1000;
-        private double recordInterval = 25;
+        private double recordInterval = 50;
         private double fixedLatency;
         private double maxLatency;
 
         [Test]
         public void TestCardHandReplay()
         {
-            AddSliderStep("record interval", 0.0, 1000.0, 25.0, value =>
+            AddSliderStep("record interval", 0.0, 1000.0, 50.0, value =>
             {
                 recordInterval = value;
                 recreateRecorder();

--- a/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
@@ -6,6 +6,7 @@ using Humanizer;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
@@ -33,12 +34,23 @@ namespace osu.Game.Tests.Visual.RankedPlay
             };
         }
 
+        [SetUpSteps]
+        public void SetupSteps()
+        {
+            AddStep("reset card hand", () => Child = handOfCards = new PlayerHandOfCards
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.Both,
+                Height = 0.5f,
+            });
+        }
+
         [Test]
         public void TestSingleSelectionMode()
         {
             AddStep("add cards", () =>
             {
-                handOfCards.Clear();
                 for (int i = 0; i < 5; i++)
                     handOfCards.AddCard(new RankedPlayCardWithPlaylistItem(new RankedPlayCardItem()));
             });
@@ -59,7 +71,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("add cards", () =>
             {
-                handOfCards.Clear();
                 for (int i = 0; i < 5; i++)
                     handOfCards.AddCard(new RankedPlayCardWithPlaylistItem(new RankedPlayCardItem()));
             });
@@ -84,7 +95,13 @@ namespace osu.Game.Tests.Visual.RankedPlay
 
                 AddStep($"{i} {"cards".Pluralize(i == 1)}", () =>
                 {
-                    handOfCards.Clear();
+                    Child = handOfCards = new PlayerHandOfCards
+                    {
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                        RelativeSizeAxes = Axes.Both,
+                        Height = 0.5f,
+                    };
 
                     for (int j = 0; j < numCards; j++)
                         handOfCards.AddCard(new RankedPlayCardWithPlaylistItem(new RankedPlayCardItem()));
@@ -138,7 +155,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("add cards", () =>
             {
-                handOfCards.Clear();
                 for (int i = 0; i < 5; i++)
                     handOfCards.AddCard(new RankedPlayCardWithPlaylistItem(new RankedPlayCardItem()));
             });
@@ -156,6 +172,25 @@ namespace osu.Game.Tests.Visual.RankedPlay
                 AddStep("space", () => InputManager.Key(Key.Space));
                 AddAssert("card selected", () => handOfCards.Selection.Contains(handOfCards.Cards.ElementAt(i1).Card.Item));
             }
+        }
+
+        [Test]
+        public void TestContract()
+        {
+            AddStep("add cards", () =>
+            {
+                for (int i = 0; i < 5; i++)
+                    handOfCards.AddCard(new RankedPlayCardWithPlaylistItem(new RankedPlayCardItem()));
+            });
+            AddWaitStep("wait", 5);
+            AddStep("contract", () => handOfCards.Contract());
+            AddWaitStep("wait", 5);
+            AddAssert(
+                "all cards outside bounds", () =>
+                    handOfCards
+                        .ChildrenOfType<HandOfCards.HandCard>()
+                        .All(card => !card.ScreenSpaceDrawQuad.AABBFloat.IntersectsWith(handOfCards.ScreenSpaceDrawQuad.AABBFloat))
+            );
         }
     }
 }

--- a/osu.Game/Online/RankedPlay/RankedPlayCardState.cs
+++ b/osu.Game/Online/RankedPlay/RankedPlayCardState.cs
@@ -18,5 +18,8 @@ namespace osu.Game.Online.RankedPlay
 
         [Key(2)]
         public required bool Selected { get; init; }
+
+        [Key(3)]
+        public required bool Dragged { get; init; }
     }
 }

--- a/osu.Game/Online/RankedPlay/RankedPlayCardState.cs
+++ b/osu.Game/Online/RankedPlay/RankedPlayCardState.cs
@@ -24,9 +24,12 @@ namespace osu.Game.Online.RankedPlay
         public required bool Dragged { get; init; }
 
         [Key(4)]
-        public float DragX { get; init; }
+        public required int Order { get; init; }
 
         [Key(5)]
+        public float DragX { get; init; }
+
+        [Key(6)]
         public float DragY { get; init; }
 
         [IgnoreMember]

--- a/osu.Game/Online/RankedPlay/RankedPlayCardState.cs
+++ b/osu.Game/Online/RankedPlay/RankedPlayCardState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using MessagePack;
+using osuTK;
 
 namespace osu.Game.Online.RankedPlay
 {
@@ -21,5 +22,22 @@ namespace osu.Game.Online.RankedPlay
 
         [Key(3)]
         public required bool Dragged { get; init; }
+
+        [Key(4)]
+        public float DragX { get; init; }
+
+        [Key(5)]
+        public float DragY { get; init; }
+
+        [IgnoreMember]
+        public Vector2 DragPosition
+        {
+            get => new Vector2(DragX, DragY);
+            init
+            {
+                DragX = value.X;
+                DragY = value.Y;
+            }
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -254,6 +254,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                             this.FadeOut(200);
                         }
                     }, true);
+                    FinishTransforms();
                 }
 
                 protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -81,6 +81,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
+            ];
+
+            CenterColumn.Children =
+            [
                 discardButton = new ShearedButton
                 {
                     Name = "Discard Button",
@@ -89,11 +93,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Width = 150,
                     Action = onDiscardButtonClicked,
                     Enabled = { Value = true },
-                }
-            ];
-
-            CenterColumn.Children =
-            [
+                },
                 playerHand = new PlayerHandOfCards
                 {
                     Anchor = Anchor.BottomCentre,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -12,6 +12,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Localisation;
+using osu.Framework.Logging;
 using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -180,22 +181,24 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             base.OnEntering(previous);
 
             var screenBottomCenter = new Vector2(DrawWidth / 2, DrawHeight);
-            int cardCount = 0;
+
+            double delay = 0;
+            const double stagger = 50;
 
             foreach (var card in matchInfo.PlayerCards)
             {
+                double currentDelay = delay;
+
                 playerHand.AddCard(card, c =>
                 {
-                    c.Position = ToSpaceOfOtherDrawable(screenBottomCenter, playerHand);
+                    c.Position = ToSpaceOfOtherDrawable(screenBottomCenter, playerHand) + new Vector2(0, playerHand.Height / 2);
+                    c.DelayMovementOnEntering(currentDelay);
                 });
-                Scheduler.AddDelayed(() =>
-                {
-                    SamplePlaybackHelper.PlayWithRandomPitch(cardAddSample);
-                }, 50 * cardCount);
-                cardCount++;
-            }
 
-            playerHand.UpdateLayout(stagger: 50);
+                Scheduler.AddDelayed(() => SamplePlaybackHelper.PlayWithRandomPitch(cardAddSample), delay);
+
+                delay += stagger;
+            }
         }
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
@@ -282,6 +285,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private void cardAdded(RankedPlayCardWithPlaylistItem card)
         {
+            Logger.Log("Card added");
+
             if (discardedCards.Count > 0)
             {
                 playDiscardAnimation();
@@ -297,8 +302,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             {
                 playerHand.AddCard(card, d =>
                 {
-                    d.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth, DrawHeight * 0.5f), playerHand);
-                    d.Rotation = -30;
+                    d.EnterFromSide(ToSpaceOfOtherDrawable(new Vector2(DrawWidth, DrawHeight * 0.5f), playerHand));
                 });
 
                 SamplePlaybackHelper.PlayWithRandomPitch(cardAddSample);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -179,8 +179,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             base.OnEntering(previous);
 
-            var screenBottomCenter = new Vector2(DrawWidth / 2, DrawHeight);
-
             double delay = 0;
             const double stagger = 50;
 
@@ -190,7 +188,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                 playerHand.AddCard(card, c =>
                 {
-                    c.Position = ToSpaceOfOtherDrawable(screenBottomCenter, playerHand) + new Vector2(0, playerHand.Height / 2);
+                    c.Position = playerHand.BottomCardInsertPosition;
                     c.DelayMovementOnEntering(currentDelay);
                 });
 
@@ -299,7 +297,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             {
                 playerHand.AddCard(card, d =>
                 {
-                    d.EnterFromSide(ToSpaceOfOtherDrawable(new Vector2(DrawWidth, DrawHeight * 0.5f), playerHand));
+                    // card should enter from centre-right of screen
+                    var cardEnterPosition = ToSpaceOfOtherDrawable(new Vector2(DrawWidth, DrawHeight * 0.5f), playerHand);
+                    d.SetupMovementForDrawnCard(cardEnterPosition);
                 });
 
                 SamplePlaybackHelper.PlayWithRandomPitch(cardAddSample);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -12,7 +12,6 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Localisation;
-using osu.Framework.Logging;
 using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -285,8 +284,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private void cardAdded(RankedPlayCardWithPlaylistItem card)
         {
-            Logger.Log("Card added");
-
             if (discardedCards.Count > 0)
             {
                 playDiscardAnimation();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -16,10 +16,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
     {
         public partial class HandCard : CompositeDrawable
         {
-            public float LayoutScale => CardHoveredOrDragged ? HOVER_SCALE : 1;
-
-            public float LayoutWidth => RankedPlayCard.SIZE.X * LayoutScale;
-
             private readonly Bindable<RankedPlayCardState> state = new Bindable<RankedPlayCardState>();
 
             public RankedPlayCardState State
@@ -53,6 +49,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             }
 
             public bool CardHoveredOrDragged => CardHovered || CardDragged;
+
+            public Vector2 DragPosition
+            {
+                get => State.DragPosition;
+                set => State = State with { DragPosition = value };
+            }
 
             [Resolved]
             private HandOfCards handOfCards { get; set; } = null!;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -16,7 +16,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
     {
         public partial class HandCard : CompositeDrawable
         {
-            public float LayoutWidth => DrawWidth * (State.Hovered ? HOVER_SCALE : 1);
+            public float LayoutScale => CardHoveredOrDragged ? HOVER_SCALE : 1;
+
+            public float LayoutWidth => RankedPlayCard.SIZE.X * LayoutScale;
 
             private readonly Bindable<RankedPlayCardState> state = new Bindable<RankedPlayCardState>();
 
@@ -49,6 +51,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 get => State.Dragged;
                 set => State = State with { Dragged = value };
             }
+
+            public bool CardHoveredOrDragged => CardHovered || CardDragged;
 
             [Resolved]
             private HandOfCards handOfCards { get; set; } = null!;
@@ -112,7 +116,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             {
                 base.Update();
 
-                Card.Elevation = float.Lerp(CardHovered ? 1 : 0, Card.Elevation, (float)Math.Exp(-0.03f * Time.Elapsed));
+                Card.Elevation = float.Lerp(CardHoveredOrDragged ? 1 : 0, Card.Elevation, (float)Math.Exp(-0.03f * Time.Elapsed));
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -44,6 +44,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 set => State = State with { Pressed = value };
             }
 
+            public bool CardDragged
+            {
+                get => State.Dragged;
+                set => State = State with { Dragged = value };
+            }
+
             [Resolved]
             private HandOfCards handOfCards { get; set; } = null!;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -56,6 +56,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 set => State = State with { DragPosition = value };
             }
 
+            public int Order
+            {
+                get => State.Order;
+                set => State = State with { Order = value };
+            }
+
             [Resolved]
             private HandOfCards handOfCards { get; set; } = null!;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -192,6 +192,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 }
             }
 
+            /// <summary>
+            /// Delays the time until a card starts to move to its layout position, intended to use for staggered movement when adding multiple cards to the hand at once.
+            /// Movement is slowed down a bit while it's moving towards the target position to make the transition appear less abrupt.
+            /// </summary>
             public void DelayMovementOnEntering(double delay)
             {
                 const double approximate_time_until_position_reached = 200;
@@ -211,7 +215,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                     });
             }
 
-            public void EnterFromSide(Vector2 position)
+            /// <summary>
+            /// Makes the card move towards its layout position from a given <paramref name="position"/> and updates
+            /// movement parameters so the card moves towards it's target position more slowly and less springy.
+            /// </summary>
+            public void SetupMovementForDrawnCard(Vector2 position)
             {
                 const double approximate_time_until_position_reached = 200;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             protected virtual void OnStateChanged(ValueChangedEvent<RankedPlayCardState> state)
             {
-                handOfCards.OnCardStateChanged(this, state.NewValue);
+                handOfCards.OnCardStateChanged(this, state);
 
                 Card.ShowSelectionOutline = state.NewValue.Selected;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -116,9 +116,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                         break;
                 }
 
-                rotationSpring.Parameters = state.NewValue.Dragged
-                    ? new SpringParameters(2f, 0.4f, 1.2f)
-                    : new SpringParameters(3f, 0.75f, 0.8f);
+                if (state.NewValue.Dragged)
+                {
+                    // while card is being dragged card should slowly swing from side to side,
+                    // so frequency is lowered and elasticity is increased
+                    rotationSpring.NaturalFrequency = 2f;
+                    rotationSpring.Damping = 0.4f;
+                    rotationSpring.Response = 1.2f;
+                }
+                else
+                {
+                    // otherwise rotation should be more snappy and not feel elastic
+                    rotationSpring.NaturalFrequency = 3f;
+                    rotationSpring.Damping = 0.75f;
+                    rotationSpring.Response = 0.8f;
+                }
             }
 
             public RankedPlayCard Detach()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Transforms;
 using osu.Game.Online.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
 using osuTK;
@@ -65,6 +66,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             [Resolved]
             private HandOfCards handOfCards { get; set; } = null!;
 
+            private float previousX;
+
+            private readonly FloatSpring rotationSpring = new FloatSpring
+            {
+                NaturalFrequency = 2f,
+                Damping = 0.4f,
+                Response = 1.2f,
+            };
+
             public readonly RankedPlayCard Card;
 
             public RankedPlayCardWithPlaylistItem Item => Card.Item;
@@ -108,6 +118,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                         Card.ScaleTo(1f, 400, Easing.OutElasticHalf);
                         break;
                 }
+
+                rotationSpring.Parameters = state.NewValue.Dragged
+                    ? new SpringParameters(2f, 0.4f, 1.2f)
+                    : new SpringParameters(3f, 0.9f, 0.8f);
             }
 
             public RankedPlayCard Detach()
@@ -125,6 +139,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 base.Update();
 
                 Card.Elevation = float.Lerp(CardHoveredOrDragged ? 1 : 0, Card.Elevation, (float)Math.Exp(-0.03f * Time.Elapsed));
+
+                if (CardDragged && Time.Elapsed > 0)
+                {
+                    float velocityX = (X - previousX) / (float)Time.Elapsed;
+
+                    float targetRotation = velocityX * 5;
+
+                    Card.Rotation = rotationSpring.Update(Time.Elapsed, targetRotation);
+                }
+                else
+                {
+                    Card.Rotation = rotationSpring.Update(Time.Elapsed, 0);
+                }
+
+                previousX = X;
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
     {
         public partial class HandCard : CompositeDrawable
         {
-            public float LayoutWidth => DrawWidth * (State.Hovered ? hover_scale : 1);
+            public float LayoutWidth => DrawWidth * (State.Hovered ? HOVER_SCALE : 1);
 
             private readonly Bindable<RankedPlayCardState> state = new Bindable<RankedPlayCardState>();
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -143,12 +143,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 return Card;
             }
 
-            private readonly Vector2Spring positionSpring = new Vector2Spring
+            private bool updateMovement = true;
+
+            private static readonly SpringParameters default_position_spring_parameters = new SpringParameters
             {
                 NaturalFrequency = 4f,
                 Response = 1.1f,
                 Damping = 0.8f
             };
+
+            private readonly Vector2Spring positionSpring = new Vector2Spring { Parameters = default_position_spring_parameters };
 
             private readonly FloatSpring rotationSpring = new FloatSpring
             {
@@ -166,37 +170,45 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 PreviousTarget = 1,
             };
 
-            public float MovementSpeed = 1;
-
             protected override void Update()
             {
                 base.Update();
 
-                if (MovementSpeed > 0)
-                    Position = positionSpring.Update(Time.Elapsed * MovementSpeed, LayoutTarget.Position);
-                Scale = new Vector2(scaleSpring.Update(Time.Elapsed, LayoutTarget.Scale));
-
-                float targetRotation = LayoutTarget.Rotation;
-
-                if (CardDragged)
+                if (updateMovement)
                 {
-                    targetRotation += positionSpring.Velocity.X * 0.006f;
+                    Position = positionSpring.Update(Time.Elapsed, LayoutTarget.Position);
+                    Scale = new Vector2(scaleSpring.Update(Time.Elapsed, LayoutTarget.Scale));
+
+                    float targetRotation = LayoutTarget.Rotation;
+
+                    if (CardDragged)
+                    {
+                        targetRotation += positionSpring.Velocity.X * 0.006f;
+                    }
+
+                    Rotation = rotationSpring.Update(Time.Elapsed, targetRotation);
+
+                    Card.Elevation = float.Lerp(CardHoveredOrDragged ? 1 : 0, Card.Elevation, (float)Math.Exp(-0.03f * Time.Elapsed));
                 }
-
-                Rotation = rotationSpring.Update(Time.Elapsed, targetRotation);
-
-                Card.Elevation = float.Lerp(CardHoveredOrDragged ? 1 : 0, Card.Elevation, (float)Math.Exp(-0.03f * Time.Elapsed));
             }
 
             public void DelayMovementOnEntering(double delay)
             {
                 const double approximate_time_until_position_reached = 200;
 
-                MovementSpeed = 0;
+                updateMovement = false;
+
                 this.Delay(delay)
-                    .Schedule(() => MovementSpeed = 0.7f)
+                    .Schedule(() =>
+                    {
+                        updateMovement = true;
+                        positionSpring.NaturalFrequency = 2.5f;
+                    })
                     .Delay(approximate_time_until_position_reached)
-                    .Schedule(() => MovementSpeed = 1f);
+                    .Schedule(() =>
+                    {
+                        positionSpring.Parameters = default_position_spring_parameters;
+                    });
             }
 
             public void EnterFromSide(Vector2 position)
@@ -205,15 +217,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 Position = position;
 
-                MovementSpeed = 0.5f;
+                positionSpring.NaturalFrequency = 2f;
                 positionSpring.Damping = 1f;
 
-                this.Delay(approximate_time_until_position_reached)
-                    .Schedule(() =>
-                    {
-                        MovementSpeed = 0.5f;
-                        positionSpring.Damping = 0.8f;
-                    });
+                Scheduler.AddDelayed(() => positionSpring.Parameters = default_position_spring_parameters, approximate_time_until_position_reached);
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -63,17 +63,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 set => State = State with { Order = value };
             }
 
+            public CardLayout LayoutTarget { get; set; }
+
             [Resolved]
             private HandOfCards handOfCards { get; set; } = null!;
-
-            private float previousX;
-
-            private readonly FloatSpring rotationSpring = new FloatSpring
-            {
-                NaturalFrequency = 2f,
-                Damping = 0.4f,
-                Response = 1.2f,
-            };
 
             public readonly RankedPlayCard Card;
 
@@ -91,13 +84,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 AddInternal(Card = card);
 
-                Anchor = Anchor.BottomCentre;
-                Origin = Anchor.BottomCentre;
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
             }
 
             protected override void LoadComplete()
             {
                 base.LoadComplete();
+
+                positionSpring.Current = positionSpring.PreviousTarget = Position;
+                scaleSpring.Current = scaleSpring.PreviousTarget = 1;
+                rotationSpring.Current = rotationSpring.PreviousTarget = Rotation;
 
                 state.BindValueChanged(OnStateChanged, true);
             }
@@ -121,7 +118,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 rotationSpring.Parameters = state.NewValue.Dragged
                     ? new SpringParameters(2f, 0.4f, 1.2f)
-                    : new SpringParameters(3f, 0.9f, 0.8f);
+                    : new SpringParameters(3f, 0.75f, 0.8f);
             }
 
             public RankedPlayCard Detach()
@@ -134,26 +131,78 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 return Card;
             }
 
+            private readonly Vector2Spring positionSpring = new Vector2Spring
+            {
+                NaturalFrequency = 4f,
+                Response = 1.1f,
+                Damping = 0.8f
+            };
+
+            private readonly FloatSpring rotationSpring = new FloatSpring
+            {
+                NaturalFrequency = 2f,
+                Damping = 0.4f,
+                Response = 1.2f,
+            };
+
+            private readonly FloatSpring scaleSpring = new FloatSpring
+            {
+                NaturalFrequency = 4f,
+                Response = 1.3f,
+                Damping = 0.75f,
+                Current = 1,
+                PreviousTarget = 1,
+            };
+
+            public float MovementSpeed = 1;
+
             protected override void Update()
             {
                 base.Update();
 
+                if (MovementSpeed > 0)
+                    Position = positionSpring.Update(Time.Elapsed * MovementSpeed, LayoutTarget.Position);
+                Scale = new Vector2(scaleSpring.Update(Time.Elapsed, LayoutTarget.Scale));
+
+                float targetRotation = LayoutTarget.Rotation;
+
+                if (CardDragged)
+                {
+                    targetRotation += positionSpring.Velocity.X * 0.006f;
+                }
+
+                Rotation = rotationSpring.Update(Time.Elapsed, targetRotation);
+
                 Card.Elevation = float.Lerp(CardHoveredOrDragged ? 1 : 0, Card.Elevation, (float)Math.Exp(-0.03f * Time.Elapsed));
+            }
 
-                if (CardDragged && Time.Elapsed > 0)
-                {
-                    float velocityX = (X - previousX) / (float)Time.Elapsed;
+            public void DelayMovementOnEntering(double delay)
+            {
+                const double approximate_time_until_position_reached = 200;
 
-                    float targetRotation = velocityX * 5;
+                MovementSpeed = 0;
+                this.Delay(delay)
+                    .Schedule(() => MovementSpeed = 0.7f)
+                    .Delay(approximate_time_until_position_reached)
+                    .Schedule(() => MovementSpeed = 1f);
+            }
 
-                    Card.Rotation = rotationSpring.Update(Time.Elapsed, targetRotation);
-                }
-                else
-                {
-                    Card.Rotation = rotationSpring.Update(Time.Elapsed, 0);
-                }
+            public void EnterFromSide(Vector2 position)
+            {
+                const double approximate_time_until_position_reached = 200;
 
-                previousX = X;
+                Position = position;
+
+                MovementSpeed = 0.5f;
+                positionSpring.Damping = 1f;
+
+                this.Delay(approximate_time_until_position_reached)
+                    .Schedule(() =>
+                    {
+                        MovementSpeed = 0.5f;
+                        positionSpring.Damping = 0.8f;
+                    });
+                ;
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -1,12 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
+using osu.Framework.Utils;
 using osu.Game.Online.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
 using osuTK;
@@ -188,7 +188,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                     Rotation = rotationSpring.Update(Time.Elapsed, targetRotation);
 
-                    Card.Elevation = float.Lerp(CardHoveredOrDragged ? 1 : 0, Card.Elevation, (float)Math.Exp(-0.03f * Time.Elapsed));
+                    Card.Elevation = (float)Interpolation.DampContinuously(Card.Elevation, CardHoveredOrDragged ? 1 : 0, 25, Time.Elapsed);
                 }
             }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -202,7 +202,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                         MovementSpeed = 0.5f;
                         positionSpring.Damping = 0.8f;
                     });
-                ;
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             cardContainer.Remove(drawable, true);
             InvalidateLayout(order: true);
-            return false;
+            return true;
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -187,10 +187,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             for (int i = 0; i < cardContainer.Count; i++)
             {
-                if (cardContainer[i].CardHovered)
+                // the mouse can temporarily leave the currently dragged card and hover a different card.
+                // in that case the hovered card should take precedence here
+                if (cardContainer[i].CardDragged)
                 {
                     hoverIndex = i;
                     break;
+                }
+
+                if (cardContainer[i].CardHovered)
+                {
+                    hoverIndex = i;
                 }
             }
 
@@ -238,7 +245,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 position *= Flipped ? -1 : 1;
 
-                float scale = child.CardHovered ? HOVER_SCALE : 1f;
+                float scale = child.LayoutScale;
 
                 ApplyLayoutToCard(child, position, rotation, scale, delay);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -240,13 +240,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         protected int GetActiveCardIndex(IReadOnlyList<HandCard> cards)
         {
             // the mouse can temporarily leave the dragged card, so dragged card should take precedence
-            for (int i = 0; i < cardContainer.Count; i++)
+            for (int i = 0; i < cards.Count; i++)
             {
                 if (cards[i].CardDragged)
                     return i;
             }
 
-            for (int i = 0; i < cardContainer.Count; i++)
+            for (int i = 0; i < cards.Count; i++)
             {
                 if (cards[i].CardHovered)
                     return i;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -293,13 +293,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             switch (direction)
             {
-                // special case for the left card when there's only 2 cards
-                // too much offset looks kinda odd here so it's reduced
-                case -1 when cardContainer.Count == 2:
-                    x -= baseOffset + 3;
-                    break;
-
                 case -1:
+                    if (cardContainer.Count == 2)
+                    {
+                        // special case for the left card when there's only 2 cards
+                        // too much offset looks kinda odd here so it's reduced
+                        x -= baseOffset + 3;
+                        break;
+                    }
+
                     x -= baseOffset + 10 / MathF.Pow(distance, 2);
                     break;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
@@ -24,6 +23,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
     public abstract partial class HandOfCards : CompositeDrawable
     {
         protected const float HOVER_SCALE = 1.2f;
+
+        private const float card_spacing = -20;
 
         public IEnumerable<HandCard> Cards => cardContainer.Children;
 
@@ -176,91 +177,132 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             if (Contracted)
                 return;
 
-            const float spacing = -20;
-
-            float totalWidth = cardContainer.Sum(it => it.LayoutWidth + spacing) - spacing;
-
-            float x = -totalWidth / 2;
-
-            const int no_card_hovered = -1;
-            int hoverIndex = no_card_hovered;
-
-            for (int i = 0; i < cardContainer.Count; i++)
-            {
-                // the mouse can temporarily leave the currently dragged card and hover a different card.
-                // in that case the hovered card should take precedence here
-                if (cardContainer[i].CardDragged)
-                {
-                    hoverIndex = i;
-                    break;
-                }
-
-                if (cardContainer[i].CardHovered)
-                {
-                    hoverIndex = i;
-                }
-            }
-
             double delay = 0;
+
+            int activeCardIndex = getActiveCardIndex();
 
             for (int i = 0; i < cardContainer.Count; i++)
             {
                 var child = cardContainer[i];
 
-                x += child.LayoutWidth / 2;
+                Vector2 position;
+                float rotation;
+                float scale;
 
-                float yOffset = 0;
+                if (child.CardDragged)
+                    CalculateDraggedCardLayout(child.DragPosition, out position, out rotation, out scale);
+                else
+                    CalculateCardLayout(i, activeCardIndex, out position, out rotation, out scale);
 
-                var position = new Vector2(x, MathF.Pow(MathF.Abs(x / 250), 2) * 20 - 10);
+                if (Flipped)
+                    position *= -1;
 
-                if (hoverIndex != no_card_hovered && cardContainer.Children.Count > 1)
-                {
-                    int distance = Math.Abs(i - hoverIndex);
-                    int direction = Math.Sign(i - hoverIndex);
-
-                    position.X += direction switch
-                    {
-                        0 => 0,
-
-                        // special case for the left card when there's only 2 cards
-                        // too much offset looks kinda odd here so it's reduced
-                        < 0 when cardContainer.Count == 2 => -3,
-
-                        < 0 => -10 / MathF.Pow(distance, 3),
-
-                        // cards right to the hovered card have a higher offset because they are partially
-                        // covering the cards to their left
-                        > 0 => 20 / MathF.Pow(distance, 2),
-                    };
-                }
-
-                if (child.CardHovered)
-                    yOffset = -HoverYOffset;
-
-                float rotation = x * 0.03f;
-
-                float angle = MathHelper.DegreesToRadians(rotation + 90);
-
-                position += new Vector2(MathF.Cos(angle), MathF.Sin(angle)) * yOffset;
-
-                position *= Flipped ? -1 : 1;
-
-                float scale = child.LayoutScale;
-
-                ApplyLayoutToCard(child, position, rotation, scale, delay);
-
-                x += child.LayoutWidth / 2 + spacing;
+                child.Delay(delay)
+                     .MoveTo(position, 300, Easing.OutExpo)
+                     .RotateTo(rotation, 300, Easing.OutExpo)
+                     .ScaleTo(scale, 400, Easing.OutElasticQuarter);
 
                 delay += stagger;
             }
         }
 
-        protected virtual void ApplyLayoutToCard(HandCard card, Vector2 position, float rotation, float scale, double delay)
+        private int getActiveCardIndex()
         {
-            card.Delay(delay)
-                .MoveTo(position, 300, Easing.OutExpo)
-                .RotateTo(rotation, 300, Easing.OutExpo)
-                .ScaleTo(scale, 400, Easing.OutElasticQuarter);
+            // the mouse can temporarily leave the dragged card, so dragged card should take precedence
+            for (int i = 0; i < cardContainer.Count; i++)
+            {
+                if (cardContainer[i].CardDragged)
+                    return i;
+            }
+
+            for (int i = 0; i < cardContainer.Count; i++)
+            {
+                if (cardContainer[i].CardHovered)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        protected void CalculateCardLayout(
+            int index,
+            int activeIndex,
+            out Vector2 position,
+            out float rotation,
+            out float scale)
+        {
+            float x = GetCardX(index, activeIndex);
+
+            position = GetArcPosition(x);
+            rotation = GetArcRotation(x);
+            scale = index == activeIndex ? HOVER_SCALE : 1;
+
+            if (index == activeIndex)
+                position += GetCardUpwardsDirection(rotation) * HoverYOffset;
+        }
+
+        protected virtual void CalculateDraggedCardLayout(Vector2 dragPosition, out Vector2 position, out float rotation, out float scale)
+        {
+            position = dragPosition;
+            rotation = 0;
+            scale = HOVER_SCALE;
+        }
+
+        /// <summary>
+        /// Represents the total width of the layout for all cards in the hand.
+        /// </summary>
+        /// <remarks>
+        /// Does not account for extra space needed for spreading the cards adjacent to the active card apart.
+        /// </remarks>
+        protected float TotalLayoutWidth => cardContainer.Count * (RankedPlayCard.SIZE.X + card_spacing) - card_spacing;
+
+        protected float GetCardX(int index, int activeIndex)
+        {
+            float x = -TotalLayoutWidth / 2
+                      + index * (RankedPlayCard.SIZE.X + card_spacing)
+                      + RankedPlayCard.SIZE.X / 2;
+
+            if (activeIndex < 0 || cardContainer.Count <= 1)
+                return x;
+
+            // if a card is hovered or dragged, the adjacent cards should get spread apart
+            int distance = Math.Abs(index - activeIndex);
+            int direction = Math.Sign(index - activeIndex);
+
+            float baseOffset = RankedPlayCard.SIZE.X * 0.1f;
+
+            switch (direction)
+            {
+                // special case for the left card when there's only 2 cards
+                // too much offset looks kinda odd here so it's reduced
+                case -1 when cardContainer.Count == 2:
+                    x -= baseOffset + 3;
+                    break;
+
+                case -1:
+                    x -= baseOffset + 10 / MathF.Pow(distance, 2);
+                    break;
+
+                case 1:
+                    // cards right to the active card have a higher offset because they are partially
+                    // covering the cards to their left
+                    x += baseOffset + 20 / MathF.Pow(distance, 2);
+                    break;
+            }
+
+            return x;
+        }
+
+        protected static Vector2 GetArcPosition(float x) =>
+            new Vector2(x, MathF.Pow(MathF.Abs(x / 250), 2) * 20 - 10);
+
+        protected static float GetArcRotation(float x) => x * 0.03f;
+
+        protected static Vector2 GetCardUpwardsDirection(float rotation)
+        {
+            float angle = MathHelper.DegreesToRadians(rotation - 90);
+
+            return new Vector2(MathF.Cos(angle), MathF.Sin(angle));
         }
 
         #endregion

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -106,6 +106,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             var drawable = CreateHandCard(card);
             drawable.Anchor = drawable.Origin = cardAnchor;
 
+            if (card.Item.DisplayOrder != null)
+                drawable.Order = card.Item.DisplayOrder.Value;
+            else if (cardContainer.Count > 0)
+                drawable.Order = cardContainer.Max(c => c.Order) + 1;
+
             cardLookup[card.Item.Card] = drawable;
 
             cardContainer.Add(drawable);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -202,6 +202,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             if (Contracted)
                 return;
 
+            // card container draws dragged card on top so we need to sort those separately
             var cards = cardContainer.Children.OrderBy(static c => c.State.Order).ToArray();
 
             int activeCardIndex = GetActiveCardIndex(cards);
@@ -312,6 +313,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             return x;
         }
 
+        /// <summary>
+        /// Calculates the position of a card at a given <paramref name="x" /> coordinate so all cards are laid out in an arc
+        /// </summary>
         protected Vector2 GetArcPosition(float x)
         {
             float offset = (DrawHeight - RankedPlayCard.SIZE.Y) / 2;
@@ -319,6 +323,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             return new Vector2(x, MathF.Pow(MathF.Abs(x / 250), 2) * 20 + offset);
         }
 
+        /// <summary>
+        /// Calculates the rotation of a card at a given <paramref name="x"/> coordinate
+        /// </summary>
         protected static float GetArcRotation(float x) => x * 0.03f;
 
         protected static Vector2 GetCardUpwardsDirection(float rotation)
@@ -334,6 +341,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             {
                 if (x is HandCard c1 && y is HandCard c2)
                 {
+                    // dragged cards should always be drawn on top
                     if (c1.CardDragged)
                         return 1;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -42,6 +42,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// </summary>
         protected virtual bool Flipped => false;
 
+        /// <summary>
+        /// Position to insert cards at so they are start moving from the bottom relative to the card layout
+        /// </summary>
+        public Vector2 BottomCardInsertPosition => new Vector2(0, (DrawHeight + RankedPlayCard.SIZE.Y) / 2 * (Flipped ? -1 : 1));
+
         private readonly CardContainer cardContainer;
 
         private readonly Dictionary<RankedPlayCardItem, HandCard> cardLookup = new Dictionary<RankedPlayCardItem, HandCard>();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
     {
         protected const float HOVER_SCALE = 1.2f;
 
-        private const float card_spacing = -20;
+        private const float card_spacing = -15;
 
         public IReadOnlyList<HandCard> Cards => cardContainer.Children;
 
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// How far a card slides upwards when hovered.
         /// Used for making sure a card moves entirely into frame when the hand is partially off-screen.
         /// </summary>
-        public float HoverYOffset = 15;
+        public float HoverYOffset = 35;
 
         /// <summary>
         /// If true, card layout will be flipped on both axes for a card hand placed at the top edge of the screen, while keeping the cards upright.
@@ -85,16 +85,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             foreach (var card in cardContainer)
             {
-                card.Delay(delay)
-                    .MoveTo(new Vector2(0, Flipped ? -220 : 220), 400, Easing.OutExpo)
-                    .RotateTo(0, 400, Easing.OutExpo)
-                    .ScaleTo(1, 400, Easing.OutExpo);
+                Scheduler.AddDelayed(() =>
+                {
+                    card.LayoutTarget = new CardLayout
+                    {
+                        Position = new Vector2(0, (DrawHeight + RankedPlayCard.SIZE.Y + 10) / 2 * (Flipped ? -1 : 1)),
+                        Rotation = 0,
+                        Scale = 1,
+                    };
+                }, delay);
 
                 delay += 50;
             }
         }
-
-        private Anchor cardAnchor => Flipped ? Anchor.TopCentre : Anchor.BottomCentre;
 
         public void AddCard(RankedPlayCardWithPlaylistItem item, Action<HandCard>? setupAction = null) => AddCard(new RankedPlayCard(item), setupAction);
 
@@ -104,14 +107,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 return;
 
             var drawable = CreateHandCard(card);
-            drawable.Anchor = drawable.Origin = cardAnchor;
+
+            cardLookup[card.Item.Card] = drawable;
+
+            drawable.Position = GetArcPosition(0);
 
             if (card.Item.DisplayOrder != null)
                 drawable.Order = card.Item.DisplayOrder.Value;
             else if (cardContainer.Count > 0)
                 drawable.Order = cardContainer.Max(c => c.Order) + 1;
-
-            cardLookup[card.Item.Card] = drawable;
 
             cardContainer.Add(drawable);
             InvalidateLayout(drawOrder: true);
@@ -193,18 +197,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 drawOrderBacking.Invalidate();
         }
 
-        public void UpdateLayout(double stagger = 0)
-        {
-            updateLayout(stagger);
-            layoutBacking.Validate();
-        }
-
-        private void updateLayout(double stagger = 0)
+        private void updateLayout()
         {
             if (Contracted)
                 return;
-
-            double delay = 0;
 
             var cards = cardContainer.Children.OrderBy(static c => c.State.Order).ToArray();
 
@@ -214,24 +210,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             {
                 var card = cards[i];
 
-                Vector2 position;
-                float rotation;
-                float scale;
-
-                if (card.CardDragged)
-                    CalculateDraggedCardLayout(card.DragPosition, out position, out rotation, out scale);
-                else
-                    CalculateCardLayout(i, activeCardIndex, out position, out rotation, out scale);
+                var layout = card.CardDragged
+                    ? CalculateDraggedCardLayout(card.DragPosition)
+                    : CalculateCardLayout(i, activeCardIndex);
 
                 if (Flipped)
-                    position *= -1;
+                    layout.Position *= -1;
 
-                card.Delay(delay)
-                    .MoveTo(position, 300, Easing.OutExpo)
-                    .RotateTo(rotation, 300, Easing.OutExpo)
-                    .ScaleTo(scale, 400, Easing.OutElasticQuarter);
-
-                delay += stagger;
+                card.LayoutTarget = layout;
             }
         }
 
@@ -253,28 +239,32 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             return -1;
         }
 
-        protected void CalculateCardLayout(
-            int index,
-            int activeIndex,
-            out Vector2 position,
-            out float rotation,
-            out float scale)
+        protected CardLayout CalculateCardLayout(int index, int activeIndex)
         {
             float x = GetCardX(index, activeIndex);
 
-            position = GetArcPosition(x);
-            rotation = GetArcRotation(x);
-            scale = index == activeIndex ? HOVER_SCALE : 1;
+            var position = GetArcPosition(x);
+            float rotation = GetArcRotation(x);
 
             if (index == activeIndex)
                 position += GetCardUpwardsDirection(rotation) * HoverYOffset;
+
+            return new CardLayout
+            {
+                Position = position,
+                Rotation = rotation,
+                Scale = index == activeIndex ? HOVER_SCALE : 1,
+            };
         }
 
-        protected virtual void CalculateDraggedCardLayout(Vector2 dragPosition, out Vector2 position, out float rotation, out float scale)
+        protected virtual CardLayout CalculateDraggedCardLayout(Vector2 dragPosition)
         {
-            position = dragPosition;
-            rotation = 0;
-            scale = HOVER_SCALE;
+            return new CardLayout
+            {
+                Position = dragPosition,
+                Rotation = 0,
+                Scale = HOVER_SCALE,
+            };
         }
 
         /// <summary>
@@ -322,8 +312,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             return x;
         }
 
-        protected static Vector2 GetArcPosition(float x) =>
-            new Vector2(x, MathF.Pow(MathF.Abs(x / 250), 2) * 20 - 10);
+        protected Vector2 GetArcPosition(float x)
+        {
+            float offset = (DrawHeight - RankedPlayCard.SIZE.Y) / 2;
+
+            return new Vector2(x, MathF.Pow(MathF.Abs(x / 250), 2) * 20 + offset);
+        }
 
         protected static float GetArcRotation(float x) => x * 0.03f;
 
@@ -355,6 +349,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             }
 
             public void Sort() => SortInternal();
+        }
+
+        public struct CardLayout
+        {
+            public required Vector2 Position { get; set; }
+            public required float Rotation { get; set; }
+            public required float Scale { get; set; }
         }
 
         #endregion

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -41,13 +42,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// </summary>
         protected virtual bool Flipped => false;
 
-        private readonly Container<HandCard> cardContainer;
+        private readonly CardContainer cardContainer;
 
         private readonly Dictionary<RankedPlayCardItem, HandCard> cardLookup = new Dictionary<RankedPlayCardItem, HandCard>();
 
         protected HandOfCards()
         {
-            AddInternal(cardContainer = new Container<HandCard>
+            AddInternal(cardContainer = new CardContainer
             {
                 RelativeSizeAxes = Axes.Both,
             });
@@ -56,6 +57,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         protected override void Update()
         {
             base.Update();
+
+            if (!cardOrderBacking.IsValid)
+            {
+                cardContainer.Sort();
+                cardOrderBacking.Validate();
+            }
 
             if (!layoutBacking.IsValid)
             {
@@ -102,7 +109,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             cardLookup[card.Item.Card] = drawable;
 
             cardContainer.Add(drawable);
-            layoutBacking.Invalidate();
+            InvalidateLayout(order: true);
 
             setupAction?.Invoke(drawable);
         }
@@ -115,7 +122,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 return false;
 
             cardContainer.Remove(drawable, true);
-            layoutBacking.Invalidate();
+            InvalidateLayout(order: true);
             return false;
         }
 
@@ -139,19 +146,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             card = drawable.Detach();
 
             cardContainer.Remove(drawable, true);
-            layoutBacking.Invalidate();
+            InvalidateLayout(order: true);
 
             return true;
         }
 
         protected virtual HandCard CreateHandCard(RankedPlayCard card) => new HandCard(card);
 
-        protected virtual void OnCardStateChanged(HandCard card, RankedPlayCardState state)
+        protected virtual void OnCardStateChanged(HandCard card, ValueChangedEvent<RankedPlayCardState> evt)
         {
-            InvalidateLayout();
+            InvalidateLayout(order: affectsDrawOrder(evt));
 
             // hovered state can be caused by keyboard focus, in which case we have to clean up after the other cards manually
-            if (state.Hovered)
+            if (evt.NewValue.Hovered)
             {
                 foreach (var c in cardContainer)
                 {
@@ -161,11 +168,27 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             }
         }
 
+        private static bool affectsDrawOrder(ValueChangedEvent<RankedPlayCardState> evt)
+        {
+            return evt.OldValue.Order != evt.NewValue.Order ||
+                   evt.OldValue.Dragged != evt.NewValue.Dragged;
+        }
+
         #region Layout
 
         private readonly Cached layoutBacking = new Cached();
+        private readonly Cached cardOrderBacking = new Cached();
 
-        protected void InvalidateLayout() => layoutBacking.Invalidate();
+        /// <summary>
+        /// Invalidates the layout of the hand of cards, causing a relayout to occur.
+        /// </summary>
+        /// <param name="order">If set to true, also invalidates the order of the cards.</param>
+        protected void InvalidateLayout(bool order = false)
+        {
+            layoutBacking.Invalidate();
+            if (order)
+                cardOrderBacking.Invalidate();
+        }
 
         public void UpdateLayout(double stagger = 0)
         {
@@ -306,6 +329,27 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             float angle = MathHelper.DegreesToRadians(rotation - 90);
 
             return new Vector2(MathF.Cos(angle), MathF.Sin(angle));
+        }
+
+        private partial class CardContainer : Container<HandCard>
+        {
+            protected override int Compare(Drawable x, Drawable y)
+            {
+                if (x is HandCard c1 && y is HandCard c2)
+                {
+                    if (c1.CardDragged)
+                        return 1;
+
+                    if (c2.CardDragged)
+                        return -1;
+
+                    return c1.Order.CompareTo(c2.Order);
+                }
+
+                return base.Compare(x, y);
+            }
+
+            public void Sort() => SortInternal();
         }
 
         #endregion

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -58,10 +58,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         {
             base.Update();
 
-            if (!cardOrderBacking.IsValid)
+            if (!drawOrderBacking.IsValid)
             {
                 cardContainer.Sort();
-                cardOrderBacking.Validate();
+                drawOrderBacking.Validate();
             }
 
             if (!layoutBacking.IsValid)
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             cardLookup[card.Item.Card] = drawable;
 
             cardContainer.Add(drawable);
-            InvalidateLayout(order: true);
+            InvalidateLayout(drawOrder: true);
 
             setupAction?.Invoke(drawable);
         }
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 return false;
 
             cardContainer.Remove(drawable, true);
-            InvalidateLayout(order: true);
+            InvalidateLayout(drawOrder: true);
             return true;
         }
 
@@ -151,7 +151,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             card = drawable.Detach();
 
             cardContainer.Remove(drawable, true);
-            InvalidateLayout(order: true);
+            InvalidateLayout(drawOrder: true);
 
             return true;
         }
@@ -160,7 +160,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
         protected virtual void OnCardStateChanged(HandCard card, ValueChangedEvent<RankedPlayCardState> evt)
         {
-            InvalidateLayout(order: affectsDrawOrder(evt));
+            InvalidateLayout(drawOrder: affectsDrawOrder(evt));
 
             // hovered state can be caused by keyboard focus, in which case we have to clean up after the other cards manually
             if (evt.NewValue.Hovered)
@@ -173,26 +173,24 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             }
         }
 
-        private static bool affectsDrawOrder(ValueChangedEvent<RankedPlayCardState> evt)
-        {
-            return evt.OldValue.Order != evt.NewValue.Order ||
-                   evt.OldValue.Dragged != evt.NewValue.Dragged;
-        }
+        private static bool affectsDrawOrder(ValueChangedEvent<RankedPlayCardState> evt) =>
+            evt.OldValue.Order != evt.NewValue.Order ||
+            evt.OldValue.Dragged != evt.NewValue.Dragged;
 
         #region Layout
 
         private readonly Cached layoutBacking = new Cached();
-        private readonly Cached cardOrderBacking = new Cached();
+        private readonly Cached drawOrderBacking = new Cached();
 
         /// <summary>
         /// Invalidates the layout of the hand of cards, causing a relayout to occur.
         /// </summary>
-        /// <param name="order">If set to true, also invalidates the order of the cards.</param>
-        protected void InvalidateLayout(bool order = false)
+        /// <param name="drawOrder">If set to true, also invalidates the draw order of the cards.</param>
+        protected void InvalidateLayout(bool drawOrder = false)
         {
             layoutBacking.Invalidate();
-            if (order)
-                cardOrderBacking.Invalidate();
+            if (drawOrder)
+                drawOrderBacking.Invalidate();
         }
 
         public void UpdateLayout(double stagger = 0)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
@@ -26,7 +27,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
         private const float card_spacing = -20;
 
-        public IEnumerable<HandCard> Cards => cardContainer.Children;
+        public IReadOnlyList<HandCard> Cards => cardContainer.Children;
 
         /// <summary>
         /// How far a card slides upwards when hovered.
@@ -179,45 +180,47 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             double delay = 0;
 
-            int activeCardIndex = getActiveCardIndex();
+            var cards = cardContainer.Children.OrderBy(static c => c.State.Order).ToArray();
 
-            for (int i = 0; i < cardContainer.Count; i++)
+            int activeCardIndex = GetActiveCardIndex(cards);
+
+            for (int i = 0; i < cards.Length; i++)
             {
-                var child = cardContainer[i];
+                var card = cards[i];
 
                 Vector2 position;
                 float rotation;
                 float scale;
 
-                if (child.CardDragged)
-                    CalculateDraggedCardLayout(child.DragPosition, out position, out rotation, out scale);
+                if (card.CardDragged)
+                    CalculateDraggedCardLayout(card.DragPosition, out position, out rotation, out scale);
                 else
                     CalculateCardLayout(i, activeCardIndex, out position, out rotation, out scale);
 
                 if (Flipped)
                     position *= -1;
 
-                child.Delay(delay)
-                     .MoveTo(position, 300, Easing.OutExpo)
-                     .RotateTo(rotation, 300, Easing.OutExpo)
-                     .ScaleTo(scale, 400, Easing.OutElasticQuarter);
+                card.Delay(delay)
+                    .MoveTo(position, 300, Easing.OutExpo)
+                    .RotateTo(rotation, 300, Easing.OutExpo)
+                    .ScaleTo(scale, 400, Easing.OutElasticQuarter);
 
                 delay += stagger;
             }
         }
 
-        private int getActiveCardIndex()
+        protected int GetActiveCardIndex(IReadOnlyList<HandCard> cards)
         {
             // the mouse can temporarily leave the dragged card, so dragged card should take precedence
             for (int i = 0; i < cardContainer.Count; i++)
             {
-                if (cardContainer[i].CardDragged)
+                if (cards[i].CardDragged)
                     return i;
             }
 
             for (int i = 0; i < cardContainer.Count; i++)
             {
-                if (cardContainer[i].CardHovered)
+                if (cards[i].CardHovered)
                     return i;
             }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -343,7 +343,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                     if (c2.CardDragged)
                         return -1;
 
-                    return c1.Order.CompareTo(c2.Order);
+                    int result = c1.Order.CompareTo(c2.Order);
+                    if (result != 0)
+                        return result;
                 }
 
                 return base.Compare(x, y);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
     [Cached]
     public abstract partial class HandOfCards : CompositeDrawable
     {
-        private const float hover_scale = 1.2f;
+        protected const float HOVER_SCALE = 1.2f;
 
         public IEnumerable<HandCard> Cards => cardContainer.Children;
 
@@ -238,16 +238,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 position *= Flipped ? -1 : 1;
 
-                child
-                    .Delay(delay)
-                    .MoveTo(position, 300, Easing.OutExpo)
-                    .RotateTo(rotation, 300, Easing.OutExpo)
-                    .ScaleTo(child.CardHovered ? hover_scale : 1f, 400, Easing.OutElasticQuarter);
+                float scale = child.CardHovered ? HOVER_SCALE : 1f;
+
+                ApplyLayoutToCard(child, position, rotation, scale, delay);
 
                 x += child.LayoutWidth / 2 + spacing;
 
                 delay += stagger;
             }
+        }
+
+        protected virtual void ApplyLayoutToCard(HandCard card, Vector2 position, float rotation, float scale, double delay)
+        {
+            card.Delay(delay)
+                .MoveTo(position, 300, Easing.OutExpo)
+                .RotateTo(rotation, 300, Easing.OutExpo)
+                .ScaleTo(scale, 400, Easing.OutElasticQuarter);
         }
 
         #endregion

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandReplayPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandReplayPlayer.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// <summary>
         /// Maximum amount of frames that can get queued up at the same time
         /// </summary>
-        public int MaxQueuedFrames { get; set; } = 20;
+        public int MaxQueuedFrames { get; set; } = 30;
 
         private readonly int userId;
         private readonly OpponentHandOfCards handOfCards;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandReplayRecorder.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandReplayRecorder.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// <summary>
         /// Minimum interval between individual replay frames
         /// </summary>
-        public double RecordInterval { get; init; } = 25;
+        public double RecordInterval { get; init; } = 50;
 
         /// <summary>
         /// Max amount of frames to collect per <see cref="FlushInterval"/>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
@@ -28,14 +28,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
         protected override CardLayout CalculateDraggedCardLayout(Vector2 dragPosition)
         {
+            // the opponent shouldn't be able to drag his card across the entire screen.
+            // card movement is limited to roughly the width of the hand horizontally
+            // and has a fixed vertical offset (extended slightly further than when hovered)
             float maxExtent = TotalLayoutWidth / 2;
 
             float x = float.Clamp(dragPosition.X, -maxExtent, maxExtent);
-            float arcRotation = GetArcRotation(x);
 
             return new CardLayout
             {
-                Position = GetArcPosition(x) + GetCardUpwardsDirection(arcRotation) * 60,
+                Position = GetArcPosition(x) + new Vector2(0, -60),
                 Rotation = 0,
                 Scale = HOVER_SCALE,
             };

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Game.Online.RankedPlay;
+using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 {
@@ -23,6 +24,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 card.State = cardState;
             }
+        }
+
+        protected override void CalculateDraggedCardLayout(Vector2 dragPosition, out Vector2 position, out float rotation, out float scale)
+        {
+            float maxExtent = TotalLayoutWidth / 2;
+
+            float x = float.Clamp(dragPosition.X, -maxExtent, maxExtent);
+
+            scale = HOVER_SCALE;
+            rotation = GetArcRotation(x);
+            position = GetArcPosition(x) + GetCardUpwardsDirection(rotation) * 60;
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
@@ -26,16 +26,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             }
         }
 
-        protected override void CalculateDraggedCardLayout(Vector2 dragPosition, out Vector2 position, out float rotation, out float scale)
+        protected override CardLayout CalculateDraggedCardLayout(Vector2 dragPosition)
         {
             float maxExtent = TotalLayoutWidth / 2;
 
             float x = float.Clamp(dragPosition.X, -maxExtent, maxExtent);
             float arcRotation = GetArcRotation(x);
 
-            position = GetArcPosition(x) + GetCardUpwardsDirection(arcRotation) * 60;
-            rotation = 0;
-            scale = HOVER_SCALE;
+            return new CardLayout
+            {
+                Position = GetArcPosition(x) + GetCardUpwardsDirection(arcRotation) * 60,
+                Rotation = 0,
+                Scale = HOVER_SCALE,
+            };
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
@@ -31,10 +31,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             float maxExtent = TotalLayoutWidth / 2;
 
             float x = float.Clamp(dragPosition.X, -maxExtent, maxExtent);
+            float arcRotation = GetArcRotation(x);
 
-            scale = HOVER_SCALE;
+            position = GetArcPosition(x) + GetCardUpwardsDirection(arcRotation) * 60;
             rotation = 0;
-            position = GetArcPosition(x) + GetCardUpwardsDirection(rotation) * 60;
+            scale = HOVER_SCALE;
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/OpponentHandOfCards.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             float x = float.Clamp(dragPosition.X, -maxExtent, maxExtent);
 
             scale = HOVER_SCALE;
-            rotation = GetArcRotation(x);
+            rotation = 0;
             position = GetArcPosition(x) + GetCardUpwardsDirection(rotation) * 60;
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
@@ -88,6 +88,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 AddInternal(new HoverSounds());
             }
 
+            protected override void Update()
+            {
+                base.Update();
+
+                if (IsDragged)
+                    updateDragMovement();
+            }
+
             protected override void OnStateChanged(ValueChangedEvent<RankedPlayCardState> state)
             {
                 base.OnStateChanged(state);
@@ -165,6 +173,34 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 CardHovered = false;
             }
+
+            #region Drag/Drop
+
+            private Vector2 dragOffset;
+            private Vector2 dragPosition;
+
+            protected override bool OnDragStart(DragStartEvent e)
+            {
+                ClearTransforms();
+                this.RotateTo(0, 400, Easing.Out)
+                    .ScaleTo(HOVER_SCALE, 400, Easing.Out);
+
+                dragOffset = DrawPosition + AnchorPosition - e.MouseDownPosition;
+
+                return true;
+            }
+
+            protected override void OnDrag(DragEvent e)
+            {
+                dragPosition = e.MousePosition - AnchorPosition + dragOffset;
+            }
+
+            private void updateDragMovement()
+            {
+                Position = Vector2.Lerp(dragPosition, Position, MathF.Exp(-0.03f * (float)Time.Elapsed));
+            }
+
+            #endregion
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
@@ -187,12 +187,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 dragOffset = DrawPosition + AnchorPosition - e.MouseDownPosition;
 
+                CardDragged = true;
+
                 return true;
             }
 
             protected override void OnDrag(DragEvent e)
             {
                 dragPosition = e.MousePosition - AnchorPosition + dragOffset;
+            }
+
+            protected override void OnDragEnd(DragEndEvent e)
+            {
+                base.OnDragEnd(e);
+
+                CardDragged = false;
             }
 
             private void updateDragMovement()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
@@ -174,10 +174,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             protected override bool OnDragStart(DragStartEvent e)
             {
-                ClearTransforms();
-                this.RotateTo(0, 400, Easing.Out)
-                    .ScaleTo(HOVER_SCALE, 400, Easing.Out);
-
                 dragOffset = DrawPosition + AnchorPosition - e.MouseDownPosition;
 
                 CardDragged = true;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             public required Action<PlayerHandCard> Clicked;
 
+            public required Action<PlayerHandCard, Vector2> Dragged;
+
             public required IBindable<bool> AllowSelection;
 
             private readonly Drawable cardInputArea;
@@ -186,6 +188,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             protected override void OnDrag(DragEvent e)
             {
                 DragPosition = e.MousePosition - AnchorPosition + dragOffset;
+
+                Dragged(this, e.ScreenSpaceMousePosition);
             }
 
             protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.PlayerHandCard.cs
@@ -88,14 +88,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 AddInternal(new HoverSounds());
             }
 
-            protected override void Update()
-            {
-                base.Update();
-
-                if (IsDragged)
-                    updateDragMovement();
-            }
-
             protected override void OnStateChanged(ValueChangedEvent<RankedPlayCardState> state)
             {
                 base.OnStateChanged(state);
@@ -177,7 +169,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             #region Drag/Drop
 
             private Vector2 dragOffset;
-            private Vector2 dragPosition;
 
             protected override bool OnDragStart(DragStartEvent e)
             {
@@ -194,7 +185,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             protected override void OnDrag(DragEvent e)
             {
-                dragPosition = e.MousePosition - AnchorPosition + dragOffset;
+                DragPosition = e.MousePosition - AnchorPosition + dragOffset;
             }
 
             protected override void OnDragEnd(DragEndEvent e)
@@ -202,11 +193,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 base.OnDragEnd(e);
 
                 CardDragged = false;
-            }
-
-            private void updateDragMovement()
-            {
-                Position = Vector2.Lerp(dragPosition, Position, MathF.Exp(-0.03f * (float)Time.Elapsed));
             }
 
             #endregion

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (e.Repeat || Contracted)
+            if (e.Repeat || Contracted || Cards.Any(static c => c.CardDragged))
                 return false;
 
             switch (e.Key)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -239,6 +239,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
                 c.Order = order++;
             }
+
+            foreach (var c in Cards)
+                c.Item.DisplayOrder = c.Order;
         }
 
         private int cardIndexInLayout(HandCard[] cards, Vector2 screenSpacePosition)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -12,7 +12,6 @@ using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Online.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
-using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
@@ -215,14 +214,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             if (SelectionMode == HandSelectionMode.Single && !card.Selected)
                 card.TriggerClick();
-        }
-
-        protected override void ApplyLayoutToCard(HandCard card, Vector2 position, float rotation, float scale, double delay)
-        {
-            if (card.IsDragged)
-                return;
-
-            base.ApplyLayoutToCard(card, position, rotation, scale, delay);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Online.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
@@ -214,6 +215,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             if (SelectionMode == HandSelectionMode.Single && !card.Selected)
                 card.TriggerClick();
+        }
+
+        protected override void ApplyLayoutToCard(HandCard card, Vector2 position, float rotation, float scale, double delay)
+        {
+            if (card.IsDragged)
+                return;
+
+            base.ApplyLayoutToCard(card, position, rotation, scale, delay);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -141,11 +141,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             }
         }
 
-        protected override void OnCardStateChanged(HandCard card, RankedPlayCardState state)
+        protected override void OnCardStateChanged(HandCard card, ValueChangedEvent<RankedPlayCardState> evt)
         {
             StateChanged?.Invoke();
 
-            base.OnCardStateChanged(card, state);
+            base.OnCardStateChanged(card, evt);
         }
 
         public Dictionary<Guid, RankedPlayCardState> State => Cards.Select(static card => new KeyValuePair<Guid, RankedPlayCardState>(card.Item.Card.ID, card.State)).ToDictionary();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -12,6 +13,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Online.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
@@ -103,6 +105,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         protected override HandCard CreateHandCard(RankedPlayCard card) => new PlayerHandCard(card)
         {
             Clicked = cardClicked,
+            Dragged = cardDragged,
             AllowSelection = allowSelection.GetBoundCopy(),
             PlayAction = PlayCardAction,
         };
@@ -214,6 +217,53 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
             if (SelectionMode == HandSelectionMode.Single && !card.Selected)
                 card.TriggerClick();
+        }
+
+        private void cardDragged(PlayerHandCard card, Vector2 screenSpacePosition)
+        {
+            var cards = Cards.OrderBy(static c => c.Order).ToArray();
+
+            int newIndex = cardIndexInLayout(cards, card.ScreenSpaceDrawQuad.Centre);
+
+            card.Order = newIndex;
+
+            int order = 0;
+
+            foreach (var c in cards)
+            {
+                if (order == newIndex)
+                    order++;
+
+                if (c == card)
+                    continue;
+
+                c.Order = order++;
+            }
+        }
+
+        private int cardIndexInLayout(HandCard[] cards, Vector2 screenSpacePosition)
+        {
+            Debug.Assert(cards.Length > 0);
+
+            var position = ToLocalSpace(screenSpacePosition) - DrawSize / 2;
+
+            int activeIndex = GetActiveCardIndex(cards);
+
+            int minIndex = 0;
+            float minDistance = float.MaxValue;
+
+            for (int i = 0; i < cards.Length; i++)
+            {
+                float distance = MathF.Abs(GetCardX(i, activeIndex) - position.X);
+
+                if (distance < minDistance)
+                {
+                    minDistance = distance;
+                    minIndex = i;
+                }
+            }
+
+            return minIndex;
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -199,8 +199,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             int newIndex = currentIndex + direction;
 
             if (newIndex < 0)
-                newIndex = Cards.Count() - 1;
-            else if (newIndex >= Cards.Count())
+                newIndex = Cards.Count - 1;
+            else if (newIndex >= Cards.Count)
                 newIndex = 0;
 
             focusCard(newIndex);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 {
                     playerHand.AddCard(item, c =>
                     {
-                        c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, DrawHeight), playerHand);
+                        c.Position = playerHand.BottomCardInsertPosition;
                         c.DelayMovementOnEntering(currentDelay);
                     });
                     Scheduler.AddDelayed(() =>
@@ -126,9 +126,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                 opponentHand.AddCard(card, c =>
                 {
-                    c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, 0), playerHand);
+                    c.Position = opponentHand.BottomCardInsertPosition;
                     c.DelayMovementOnEntering(currentDelay);
                 });
+
+                delay += 50;
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         [Resolved]
         private RankedPlayMatchInfo matchInfo { get; set; } = null!;
 
+        private Sample? cardAddSample;
+
         private const int card_play_samples = 2;
         private Sample?[]? cardPlaySamples;
 
@@ -69,12 +71,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Origin = Anchor.BottomCentre,
                     RelativeSizeAxes = Axes.Both,
                     Height = 0.5f,
-                    Y = 100,
-                    HoverYOffset = 90
                 },
                 new HandReplayRecorder(playerHand),
                 new HandReplayPlayer(matchInfo.OpponentId, opponentHand),
             ];
+
+            cardAddSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/card-add-1");
 
             cardPlaySamples = new Sample?[card_play_samples];
             for (int i = 0; i < card_play_samples; i++)
@@ -85,24 +87,49 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             base.OnEntering(previous);
 
-            foreach (var card in matchInfo.PlayerCards)
+            const double stagger = 50;
+            double delay = 0;
+
+            foreach (var item in matchInfo.PlayerCards)
             {
-                playerHand.AddCard(card, c =>
+                double currentDelay = delay;
+
+                if ((previous as DiscardScreen)?.CenterRow.RemoveCard(item, out var card, out var drawQuad) == true)
                 {
-                    c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, DrawHeight), playerHand);
-                });
+                    playerHand.AddCard(card, c =>
+                    {
+                        c.MatchScreenSpaceDrawQuad(drawQuad, playerHand);
+                        c.DelayMovementOnEntering(currentDelay);
+                    });
+                }
+                else
+                {
+                    playerHand.AddCard(item, c =>
+                    {
+                        c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, DrawHeight), playerHand);
+                        c.DelayMovementOnEntering(currentDelay);
+                    });
+                    Scheduler.AddDelayed(() =>
+                    {
+                        SamplePlaybackHelper.PlayWithRandomPitch(cardAddSample);
+                    }, delay);
+                }
+
+                delay += stagger;
             }
+
+            delay = 0;
 
             foreach (var card in matchInfo.OpponentCards)
             {
+                double currentDelay = delay;
+
                 opponentHand.AddCard(card, c =>
                 {
                     c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, 0), playerHand);
+                    c.DelayMovementOnEntering(currentDelay);
                 });
             }
-
-            playerHand.UpdateLayout(stagger: 50);
-            opponentHand.UpdateLayout(stagger: 50);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
@@ -56,6 +56,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             CenterColumn.Children =
             [
+                opponentHand = new OpponentHandOfCards
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    RelativeSizeAxes = Axes.Both,
+                    Height = 0.5f,
+                },
                 playerHand = new PlayerHandOfCards
                 {
                     Anchor = Anchor.BottomCentre,
@@ -64,13 +71,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Height = 0.5f,
                     Y = 100,
                     HoverYOffset = 90
-                },
-                opponentHand = new OpponentHandOfCards
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    RelativeSizeAxes = Axes.Both,
-                    Height = 0.5f,
                 },
                 new HandReplayRecorder(playerHand),
                 new HandReplayPlayer(matchInfo.OpponentId, opponentHand),

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 {
                     playerHand.AddCard(item, c =>
                     {
-                        c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, DrawHeight), playerHand);
+                        c.Position = playerHand.BottomCardInsertPosition;
                         c.DelayMovementOnEntering(currentDelay);
                     });
                     Scheduler.AddDelayed(() =>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -149,15 +149,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             base.OnEntering(previous);
 
-            int delay = 0;
+            const double stagger = 50;
+            double delay = 0;
 
             foreach (var item in matchInfo.PlayerCards)
             {
+                double currentDelay = delay;
+
                 if ((previous as DiscardScreen)?.CenterRow.RemoveCard(item, out var card, out var drawQuad) == true)
                 {
                     playerHand.AddCard(card, c =>
                     {
                         c.MatchScreenSpaceDrawQuad(drawQuad, playerHand);
+                        c.DelayMovementOnEntering(currentDelay);
                     });
                 }
                 else
@@ -165,25 +169,31 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     playerHand.AddCard(item, c =>
                     {
                         c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, DrawHeight), playerHand);
+                        c.DelayMovementOnEntering(currentDelay);
                     });
                     Scheduler.AddDelayed(() =>
                     {
                         SamplePlaybackHelper.PlayWithRandomPitch(cardAddSample);
-                    }, 50 * delay);
-                    delay++;
+                    }, delay);
                 }
+
+                delay += stagger;
             }
+
+            delay = 0;
 
             foreach (var item in matchInfo.OpponentCards)
             {
+                double currentDelay = delay;
+
                 opponentHand.AddCard(item, c =>
                 {
                     c.Position = ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, 0), playerHand);
+                    c.DelayMovementOnEntering(currentDelay);
                 });
-            }
 
-            playerHand.UpdateLayout(stagger: 50);
-            opponentHand.UpdateLayout(stagger: 50);
+                delay += 50;
+            }
         }
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -73,6 +73,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             CenterColumn.Children =
             [
+                opponentHand = new OpponentHandOfCards
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    RelativeSizeAxes = Axes.Both,
+                    Height = 0.5f,
+                    Y = -100,
+                },
                 playerHand = new PlayerHandOfCards
                 {
                     Anchor = Anchor.BottomCentre,
@@ -81,14 +89,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Height = 0.5f,
                     SelectionMode = HandSelectionMode.Single,
                     PlayCardAction = onPlayButtonClicked
-                },
-                opponentHand = new OpponentHandOfCards
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    RelativeSizeAxes = Axes.Both,
-                    Height = 0.5f,
-                    Y = -100,
                 },
                 new HandReplayRecorder(playerHand),
                 new HandReplayPlayer(matchInfo.OpponentId, opponentHand),

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCardWithPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCardWithPlaylistItem.cs
@@ -13,6 +13,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         public readonly Bindable<MultiplayerPlaylistItem?> PlaylistItem = new Bindable<MultiplayerPlaylistItem?>();
         public readonly RankedPlayCardItem Card;
 
+        /// <summary>
+        /// The player's preferred display order for this card
+        /// </summary>
+        public int? DisplayOrder { get; set; }
+
         public RankedPlayCardWithPlaylistItem(RankedPlayCardItem card)
         {
             Card = card;


### PR DESCRIPTION
Adds the ability to drag and reorder cards. Card order is preserved between rounds and is synchronized between both players (each player can see the other player drag around and reorder their cards).

To make this possible I had to rewrite the card layout algorithm to be stateless (e0a46fefaf0f234370132d055e2edd7be069b242), there wasn't really a way around that since I needed a way to calculate a layout position based on a card's index. Should hopefully be a lot easier to read now though.

Some noteworthy stuff:
- I didn't really know what the best place to store the card order is, so I put it on `RankedPlayCardWithPlaylistItem` since that one will stay the same instance per round.
- To prevent the opponent's cards from dragged into the middle of the playfield, only the x axis of the drag gets synchronized for the `OpponentHandOfCards` with a fixed y value.
- I adjusted the replay recorder/player parameters a little. With the drag events happening every frame the replay recorder record new frames every 25ms and end up dropping half the replay frames per flush interval, so I increased the sample interval to 50ms so the buffer size matches the sample rate exactly (50ms -> 20 samples per flush every 1000ms).
I also increased the buffer size in the replay player a bit so slight fluctuations in latency won't make it start to drop frames.

https://github.com/user-attachments/assets/b810cb85-db02-4edf-a63e-bfc96cf59665

https://github.com/user-attachments/assets/4d2f884d-fcce-4948-9659-fbb314634cb8



