### PR TITLE
Fix song select dropdowns not being navigable with keyboard

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelect.cs
@@ -11,6 +11,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Mods;
@@ -23,6 +24,7 @@ using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.Leaderboards;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
 using osu.Game.Tests.Resources;
 using osuTK.Input;
 using BeatmapCarousel = osu.Game.Screens.Select.BeatmapCarousel;
@@ -428,6 +430,31 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
             AddAssert("osu! cookie visible", () => this.ChildrenOfType<OsuLogo>().Single().Alpha, () => Is.Not.Zero);
+        }
+
+        [Test]
+        public void TestDropdownKeyboardNavigation()
+        {
+            ImportBeatmapForRuleset(0);
+
+            LoadSongSelect();
+
+            BeatmapInfo? firstBeatmap = null;
+            AddStep("store first difficulty", () => firstBeatmap = Beatmap.Value.BeatmapInfo);
+
+            AddStep("click sort dropdown", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedDropdown<SortMode>>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("press up arrow", () => InputManager.Key(Key.Up));
+            AddStep("press up arrow", () => InputManager.Key(Key.Up));
+
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+
+            AddAssert("sort mode is length", () => this.ChildrenOfType<ShearedDropdown<SortMode>>().Single().Current.Value, () => Is.EqualTo(SortMode.Length));
+            AddAssert("beatmap not changed", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(firstBeatmap));
         }
 
         #endregion

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -21,7 +21,6 @@ using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
-using osuTK.Input;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -163,15 +162,6 @@ namespace osu.Game.Graphics.UserInterface
             };
 
             protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new OsuScrollContainer(direction);
-
-            protected override bool OnKeyDown(KeyDownEvent e)
-            {
-                // disable the framework-level handling of up and down key for conformity (we use GlobalAction.SelectPrevious and SelectNext).
-                if (e.Key == Key.Up || e.Key == Key.Down)
-                    return false;
-
-                return base.OnKeyDown(e);
-            }
 
             public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
             {

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -21,6 +21,7 @@ using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -54,7 +55,7 @@ namespace osu.Game.Graphics.UserInterface
 
         #region OsuDropdownMenu
 
-        public partial class OsuDropdownMenu : DropdownMenu
+        public partial class OsuDropdownMenu : DropdownMenu, IKeyBindingHandler<GlobalAction>
         {
             public override bool HandleNonPositionalInput => State == MenuState.Open;
 
@@ -162,6 +163,44 @@ namespace osu.Game.Graphics.UserInterface
             };
 
             protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new OsuScrollContainer(direction);
+
+            protected override bool OnKeyDown(KeyDownEvent e)
+            {
+                // disable the framework-level handling of up and down key for conformity (we use GlobalAction.SelectPrevious and SelectNext).
+                if (e.Key == Key.Up || e.Key == Key.Down)
+                    return false;
+
+                return base.OnKeyDown(e);
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+            {
+                // logic copied from https://github.com/ppy/osu-framework/blob/baf865f1fd9e677310e7e432a7c6af99db7db914/osu.Framework/Graphics/UserInterface/Dropdown.cs#L702-L717
+                var visibleMenuItemsList = VisibleMenuItems.ToList();
+
+                if (visibleMenuItemsList.Count > 0)
+                {
+                    var currentPreselected = PreselectedItem;
+                    int targetPreselectionIndex = visibleMenuItemsList.IndexOf(currentPreselected);
+
+                    switch (e.Action)
+                    {
+                        case GlobalAction.SelectPrevious:
+                            PreselectItem(targetPreselectionIndex - 1);
+                            return true;
+
+                        case GlobalAction.SelectNext:
+                            PreselectItem(targetPreselectionIndex + 1);
+                            return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+            {
+            }
 
             #region DrawableOsuDropdownMenuItem
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/31684

Uses the global action variant of up and down for dropdown menus. It is already used in multiplayer/playlist room/beatmap navigation and gameplay menu overlays.

Comment wording is derived from:
https://github.com/ppy/osu/blob/fc817627e56b7db1c46e2f00fc9a3bd14af51211/osu.Game/Graphics/UserInterface/FocusedTextBox.cs#L73-L74