### PR TITLE
Implement background music for ranked play

### DIFF
--- a/osu.Game/Audio/PreviewTrackManager.cs
+++ b/osu.Game/Audio/PreviewTrackManager.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Audio
 
         protected TrackManagerPreviewTrack? CurrentTrack;
 
+        public readonly BindableBool IsPlayingPreview = new BindableBool();
+
         public PreviewTrackManager(IAdjustableAudioComponent mainTrackAdjustments)
         {
             this.mainTrackAdjustments = mainTrackAdjustments;
@@ -47,6 +49,7 @@ namespace osu.Game.Audio
                 CurrentTrack?.Stop();
                 CurrentTrack = track;
                 mainTrackAdjustments.AddAdjustment(AdjustableProperty.Volume, muteBindable);
+                IsPlayingPreview.Value = true;
             });
 
             track.Stopped += () => Schedule(() =>
@@ -56,6 +59,7 @@ namespace osu.Game.Audio
 
                 CurrentTrack = null;
                 mainTrackAdjustments.RemoveAdjustment(AdjustableProperty.Volume, muteBindable);
+                IsPlayingPreview.Value = false;
             });
 
             return track;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 previewStopDelegate = Scheduler.AddDelayed(() =>
                 {
                     previewTrack?.Stop();
-                }, 500);
+                }, BackgroundMusicManager.DELAY_BEFORE_UNDUCK);
             }
 
             private ScheduledDelegate? previewStopDelegate;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -14,7 +14,6 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input.Events;
-using osu.Framework.Threading;
 using osu.Framework.Timing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -22,7 +21,6 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osuTK;
 using osuTK.Graphics;
 
@@ -43,6 +41,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
             protected override Container<Drawable> Content { get; }
 
             private readonly Bindable<bool> trackRunning = new BindableBool();
+
             private readonly Container overlayLayer;
 
             private bool shouldBePlaying => Enabled.Value && IsHovered;
@@ -52,9 +51,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             [Resolved]
             private OsuColour osuColour { get; set; } = null!;
-
-            [Resolved]
-            private BackgroundMusicManager? backgroundMusic { get; set; }
 
             public SongPreviewContainer()
             {
@@ -119,7 +115,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
                     overlayLayer.Add(new RippleVisualization(cardColours.Border)
                     {
-                        TrackRunning = trackRunning.GetBoundCopy(),
+                        TrackRunning = { BindTarget = trackRunning }
                     });
 
                     if (IsHovered)
@@ -129,29 +125,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             protected override bool OnHover(HoverEvent e)
             {
-                previewStopDelegate?.Cancel();
-
                 if (shouldBePlaying)
                 {
                     startPreviewIfAvailable();
-                    backgroundMusic?.Duck();
                 }
 
                 return base.OnHover(e);
             }
-
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                previewStopDelegate?.Cancel();
-
-                backgroundMusic?.Unduck();
-                previewStopDelegate = Scheduler.AddDelayed(() =>
-                {
-                    previewTrack?.Stop();
-                }, BackgroundMusicManager.DELAY_BEFORE_UNDUCK);
-            }
-
-            private ScheduledDelegate? previewStopDelegate;
 
             private void onTrackStarted() => Schedule(() => trackRunning.Value = true);
 
@@ -216,7 +196,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 [Resolved]
                 private SongPreviewParticleContainer? particleContainer { get; set; }
 
-                public required IBindable<bool> TrackRunning { get; init; }
+                public readonly IBindable<bool> TrackRunning = new Bindable<bool>();
 
                 private readonly Color4 accentColour;
                 private readonly Container rippleContainer;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input.Events;
+using osu.Framework.Threading;
 using osu.Framework.Timing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -21,6 +22,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osuTK;
 using osuTK.Graphics;
 
@@ -50,6 +52,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             [Resolved]
             private OsuColour osuColour { get; set; } = null!;
+
+            [Resolved]
+            private BackgroundMusicManager? backgroundMusic { get; set; }
 
             public SongPreviewContainer()
             {
@@ -124,11 +129,29 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             protected override bool OnHover(HoverEvent e)
             {
+                previewStopDelegate?.Cancel();
+
                 if (shouldBePlaying)
+                {
                     startPreviewIfAvailable();
+                    backgroundMusic?.Duck();
+                }
 
                 return base.OnHover(e);
             }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                previewStopDelegate?.Cancel();
+
+                backgroundMusic?.Unduck();
+                previewStopDelegate = Scheduler.AddDelayed(() =>
+                {
+                    previewTrack?.Stop();
+                }, 500);
+            }
+
+            private ScheduledDelegate? previewStopDelegate;
 
             private void onTrackStarted() => Schedule(() => trackRunning.Value = true);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -125,12 +125,23 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             protected override bool OnHover(HoverEvent e)
             {
+                if (previewTrack != null)
+                    previewTrack.Looping = true;
+
                 if (shouldBePlaying)
                 {
                     startPreviewIfAvailable();
                 }
 
                 return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                if (previewTrack != null)
+                    previewTrack.Looping = false;
+
+                base.OnHoverLost(e);
             }
 
             private void onTrackStarted() => Schedule(() => trackRunning.Value = true);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -17,12 +17,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 {
     public partial class BackgroundMusicManager : CompositeComponent
     {
-        public const int DELAY_BEFORE_UNDUCK = 500;
-
         private const int hover_fade_duration = 250;
-        private const int track_fade_duration = 3000;
 
-        private ScheduledDelegate? unduckDebounceDelegate;
         private ScheduledDelegate? globalTrackFadeDelegate;
 
         private ITrackStore store = null!;
@@ -53,32 +49,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             isPlayingPreview = previewTrackManager.IsPlayingPreview.GetBoundCopy();
             isPlayingPreview.BindValueChanged(playing =>
             {
-                if (playing.NewValue)
-                    Duck();
-                else
-                    Unduck();
+                bgm.VolumeTo(playing.NewValue ? 0 : 1, hover_fade_duration);
             });
-        }
-
-        public void Duck()
-        {
-            unduckDebounceDelegate?.Cancel();
-            bgm.VolumeTo(0, hover_fade_duration);
-        }
-
-        public void Unduck()
-        {
-            unduckDebounceDelegate?.Cancel();
-            unduckDebounceDelegate = Scheduler.AddDelayed(() =>
-            {
-                bgm.VolumeTo(1, hover_fade_duration);
-            }, DELAY_BEFORE_UNDUCK);
         }
 
         public void Play()
         {
             if (bgm.IsRunning)
                 return;
+
+            const int track_fade_duration = 3000;
 
             // remove music control from player, to prevent overlapping music
             musicController.AllowTrackControl.Value = false;
@@ -106,7 +86,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         public void Stop()
         {
-            unduckDebounceDelegate?.Cancel();
             globalTrackFadeDelegate?.Cancel();
 
             bgm.Stop();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -14,7 +14,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 {
     public partial class BackgroundMusicManager : Component
     {
-        private const int unhover_debounce_duration = 500;
+        public const int DELAY_BEFORE_UNDUCK = 500;
+
         private const int hover_fade_duration = 250;
         private const int track_fade_duration = 3000;
 
@@ -49,7 +50,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             unduckDebounceDelegate = Scheduler.AddDelayed(() =>
             {
                 this.TransformBindableTo(bgmVolumeBindable, 1, hover_fade_duration);
-            }, unhover_debounce_duration);
+            }, DELAY_BEFORE_UNDUCK);
         }
 
         public void Play()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.IO.Stores;
+using osu.Framework.Threading;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
+{
+    public partial class BackgroundMusicManager : Component
+    {
+        private const int unhover_debounce_duration = 500;
+        private const int hover_fade_duration = 250;
+        private const int track_fade_duration = 3000;
+
+        private ScheduledDelegate? unduckDebounceDelegate;
+        private ScheduledDelegate? globalTrackFadeDelegate;
+
+        private readonly BindableDouble bgmVolumeBindable = new BindableDouble(1);
+
+        private Track bgmTrack = null!;
+
+        [Resolved]
+        private MusicController musicController { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio, OsuGameBase game)
+        {
+            // workaround to play BGM through `TrackMixer` instead of `SampleMixer`, so it inherits players' music volume settings, etc.
+            var store = audio.GetTrackStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Samples"));
+            bgmTrack = store.Get(@"Multiplayer/Matchmaking/Ranked/rankedplay_bgm");
+            bgmTrack.AddAdjustment(AdjustableProperty.Volume, bgmVolumeBindable);
+        }
+
+        public void Duck()
+        {
+            unduckDebounceDelegate?.Cancel();
+            this.TransformBindableTo(bgmVolumeBindable, 0, hover_fade_duration);
+        }
+
+        public void Unduck()
+        {
+            unduckDebounceDelegate?.Cancel();
+            unduckDebounceDelegate = Scheduler.AddDelayed(() =>
+            {
+                this.TransformBindableTo(bgmVolumeBindable, 1, hover_fade_duration);
+            }, unhover_debounce_duration);
+        }
+
+        public void Play()
+        {
+            if (bgmTrack.IsRunning)
+                return;
+
+            // remove music control from player, to prevent overlapping music
+            musicController.AllowTrackControl.Value = false;
+            globalTrackFadeDelegate?.Cancel();
+
+            // cross-fade if global track is playing something
+            if (musicController.IsPlaying)
+            {
+                var track = musicController.CurrentTrack;
+                track.VolumeTo(0, track_fade_duration, Easing.OutCubic);
+                globalTrackFadeDelegate = Scheduler.AddDelayed(() =>
+                {
+                    musicController.Stop();
+                    track.VolumeTo(1);
+                }, track_fade_duration);
+            }
+
+            bgmVolumeBindable.Value = 0;
+            this.TransformBindableTo(bgmVolumeBindable, 1, track_fade_duration, Easing.InCubic);
+
+            bgmTrack.Looping = true;
+            bgmTrack.Start();
+        }
+
+        public void Stop()
+        {
+            unduckDebounceDelegate?.Cancel();
+            globalTrackFadeDelegate?.Cancel();
+
+            bgmTrack.Stop();
+            bgmTrack.Reset();
+
+            // return control of music to player and reset volume
+            musicController.AllowTrackControl.Value = true;
+            musicController.CurrentTrack.Volume.Value = 1;
+            musicController.EnsurePlayingSomething();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            Stop();
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private ScheduledDelegate? unduckDebounceDelegate;
         private ScheduledDelegate? globalTrackFadeDelegate;
 
-        private readonly BindableDouble bgmVolumeBindable = new BindableDouble(1);
+        private readonly BindableDouble volume = new BindableDouble(1);
 
         private Track bgmTrack = null!;
 
@@ -35,13 +35,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             // workaround to play BGM through `TrackMixer` instead of `SampleMixer`, so it inherits players' music volume settings, etc.
             var store = audio.GetTrackStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Samples"));
             bgmTrack = store.Get(@"Multiplayer/Matchmaking/Ranked/rankedplay_bgm.ogg");
-            bgmTrack.AddAdjustment(AdjustableProperty.Volume, bgmVolumeBindable);
+            bgmTrack.AddAdjustment(AdjustableProperty.Volume, volume);
         }
 
         public void Duck()
         {
             unduckDebounceDelegate?.Cancel();
-            this.TransformBindableTo(bgmVolumeBindable, 0, hover_fade_duration);
+            this.TransformBindableTo(volume, 0, hover_fade_duration);
         }
 
         public void Unduck()
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             unduckDebounceDelegate?.Cancel();
             unduckDebounceDelegate = Scheduler.AddDelayed(() =>
             {
-                this.TransformBindableTo(bgmVolumeBindable, 1, hover_fade_duration);
+                this.TransformBindableTo(volume, 1, hover_fade_duration);
             }, DELAY_BEFORE_UNDUCK);
         }
 
@@ -74,8 +74,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 }, track_fade_duration);
             }
 
-            bgmVolumeBindable.Value = 0;
-            this.TransformBindableTo(bgmVolumeBindable, 1, track_fade_duration, Easing.InCubic);
+            volume.Value = 0;
+            this.TransformBindableTo(volume, 1, track_fade_duration, Easing.InCubic);
 
             bgmTrack.Looping = true;
             bgmTrack.Start();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -4,11 +4,13 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.IO.Stores;
 using osu.Framework.Threading;
+using osu.Game.Audio;
 using osu.Game.Overlays;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
@@ -26,8 +28,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private ITrackStore store = null!;
         private DrawableTrack bgm = null!;
 
+        private Bindable<bool> isPlayingPreview = null!;
+
         [Resolved]
         private MusicController musicController { get; set; } = null!;
+
+        [Resolved]
+        private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, OsuGameBase game)
@@ -39,10 +46,23 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             AddInternal(bgm = new DrawableTrack(track));
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            isPlayingPreview = previewTrackManager.IsPlayingPreview.GetBoundCopy();
+            isPlayingPreview.BindValueChanged(playing =>
+            {
+                if (playing.NewValue)
+                    Duck();
+                else
+                    Unduck();
+            });
+        }
+
         public void Duck()
         {
             unduckDebounceDelegate?.Cancel();
-
             bgm.VolumeTo(0, hover_fade_duration);
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -3,12 +3,10 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.IO.Stores;
 using osu.Framework.Threading;
 using osu.Game.Audio;
 using osu.Game.Overlays;
@@ -21,7 +19,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         private ScheduledDelegate? globalTrackFadeDelegate;
 
-        private ITrackStore store = null!;
         private DrawableTrack bgm = null!;
 
         private Bindable<bool> isPlayingPreview = null!;
@@ -35,11 +32,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, OsuGameBase game)
         {
-            // workaround to play BGM through `TrackMixer` instead of `SampleMixer`, so it inherits players' music volume settings, etc.
-            store = audio.GetTrackStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Samples"));
-            var track = store.Get(@"Multiplayer/Matchmaking/Ranked/rankedplay_bgm.ogg");
-
-            AddInternal(bgm = new DrawableTrack(track));
+            AddInternal(bgm = new DrawableTrack(audio.Tracks.Get("rankedplay_bgm.ogg")));
         }
 
         protected override void LoadComplete()
@@ -95,16 +88,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             musicController.AllowTrackControl.Value = true;
             musicController.CurrentTrack.Volume.Value = 1;
             musicController.EnsurePlayingSomething();
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            Stop();
-
-            bgm.Dispose();
-            store.Dispose();
-
-            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
             // workaround to play BGM through `TrackMixer` instead of `SampleMixer`, so it inherits players' music volume settings, etc.
             var store = audio.GetTrackStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Samples"));
-            bgmTrack = store.Get(@"Multiplayer/Matchmaking/Ranked/rankedplay_bgm");
+            bgmTrack = store.Get(@"Multiplayer/Matchmaking/Ranked/rankedplay_bgm.ogg");
             bgmTrack.AddAdjustment(AdjustableProperty.Volume, bgmVolumeBindable);
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs
@@ -4,15 +4,16 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.IO.Stores;
 using osu.Framework.Threading;
 using osu.Game.Overlays;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 {
-    public partial class BackgroundMusicManager : Component
+    public partial class BackgroundMusicManager : CompositeComponent
     {
         public const int DELAY_BEFORE_UNDUCK = 500;
 
@@ -22,9 +23,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private ScheduledDelegate? unduckDebounceDelegate;
         private ScheduledDelegate? globalTrackFadeDelegate;
 
-        private readonly BindableDouble volume = new BindableDouble(1);
-
-        private Track bgmTrack = null!;
+        private ITrackStore store = null!;
+        private DrawableTrack bgm = null!;
 
         [Resolved]
         private MusicController musicController { get; set; } = null!;
@@ -33,15 +33,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private void load(AudioManager audio, OsuGameBase game)
         {
             // workaround to play BGM through `TrackMixer` instead of `SampleMixer`, so it inherits players' music volume settings, etc.
-            var store = audio.GetTrackStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Samples"));
-            bgmTrack = store.Get(@"Multiplayer/Matchmaking/Ranked/rankedplay_bgm.ogg");
-            bgmTrack.AddAdjustment(AdjustableProperty.Volume, volume);
+            store = audio.GetTrackStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Samples"));
+            var track = store.Get(@"Multiplayer/Matchmaking/Ranked/rankedplay_bgm.ogg");
+
+            AddInternal(bgm = new DrawableTrack(track));
         }
 
         public void Duck()
         {
             unduckDebounceDelegate?.Cancel();
-            this.TransformBindableTo(volume, 0, hover_fade_duration);
+
+            bgm.VolumeTo(0, hover_fade_duration);
         }
 
         public void Unduck()
@@ -49,13 +51,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             unduckDebounceDelegate?.Cancel();
             unduckDebounceDelegate = Scheduler.AddDelayed(() =>
             {
-                this.TransformBindableTo(volume, 1, hover_fade_duration);
+                bgm.VolumeTo(1, hover_fade_duration);
             }, DELAY_BEFORE_UNDUCK);
         }
 
         public void Play()
         {
-            if (bgmTrack.IsRunning)
+            if (bgm.IsRunning)
                 return;
 
             // remove music control from player, to prevent overlapping music
@@ -65,20 +67,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             // cross-fade if global track is playing something
             if (musicController.IsPlaying)
             {
-                var track = musicController.CurrentTrack;
-                track.VolumeTo(0, track_fade_duration, Easing.OutCubic);
+                var globalTrack = musicController.CurrentTrack;
+
+                globalTrack.VolumeTo(0, track_fade_duration, Easing.OutCubic);
                 globalTrackFadeDelegate = Scheduler.AddDelayed(() =>
                 {
                     musicController.Stop();
-                    track.VolumeTo(1);
+                    globalTrack.VolumeTo(1);
                 }, track_fade_duration);
             }
 
-            volume.Value = 0;
-            this.TransformBindableTo(volume, 1, track_fade_duration, Easing.InCubic);
+            bgm.VolumeTo(0)
+               .VolumeTo(1, track_fade_duration, Easing.InCubic);
 
-            bgmTrack.Looping = true;
-            bgmTrack.Start();
+            bgm.Looping = true;
+            bgm.Start();
         }
 
         public void Stop()
@@ -86,8 +89,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             unduckDebounceDelegate?.Cancel();
             globalTrackFadeDelegate?.Cancel();
 
-            bgmTrack.Stop();
-            bgmTrack.Reset();
+            bgm.Stop();
+            bgm.Reset();
 
             // return control of music to player and reset volume
             musicController.AllowTrackControl.Value = true;
@@ -98,6 +101,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         protected override void Dispose(bool isDisposing)
         {
             Stop();
+
+            bgm.Dispose();
+            store.Dispose();
 
             base.Dispose(isDisposing);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
@@ -81,8 +80,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
         private StarRatingSequence? starRatingAnimation;
 
-        private IDisposable? duckOperation;
-
         public void PlayIntroSequence(UserWithRating player, UserWithRating opponent, double starRating)
         {
             double delay = 0;
@@ -111,16 +108,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
         {
             starRatingAnimation?.PopOut();
 
-            duckOperation?.Dispose();
-
             this.Delay(500).FadeOut();
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            duckOperation?.Dispose();
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
@@ -95,8 +95,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
             vsScreen.Play(ref delay, out double impactDelay);
 
-            duckOperation = musicController?.Duck();
-
             if (windupSample != null)
             {
                 Scheduler.AddDelayed(() => windupSample?.Play(), impactDelay - windupSample.Length);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
@@ -14,7 +14,6 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
-using osu.Game.Overlays;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 {
@@ -34,9 +33,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
-
-        [Resolved]
-        private MusicController? musicController { get; set; }
 
         private Sample? windupSample;
         private Sample? impactSample;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -88,6 +88,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         [Cached]
         private readonly SongPreviewParticleContainer particleContainer;
 
+        [Cached]
+        private BackgroundMusicManager backgroundMusic;
+
         public RankedPlayScreen(MultiplayerRoom room)
         {
             this.room = room;
@@ -129,6 +132,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 },
                 overlayContainer = new CardDetailsOverlayContainer(),
                 particleContainer = new SongPreviewParticleContainer(),
+                backgroundMusic = new BackgroundMusicManager()
             };
         }
 
@@ -224,6 +228,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             chat.Appear();
 
+            if (stage is RankedPlayStage.GameplayWarmup or RankedPlayStage.Gameplay)
+                backgroundMusic.Stop();
+            else
+                backgroundMusic.Play();
+
             switch (stage)
             {
                 case RankedPlayStage.RoundWarmup when matchInfo.CurrentRound == 1:
@@ -278,6 +287,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         public override void OnSuspending(ScreenTransitionEvent e)
         {
             chat.Disappear();
+            backgroundMusic.Stop();
             previewTrackManager.StopAnyPlaying(this);
 
             base.OnSuspending(e);
@@ -296,6 +306,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     return true;
                 }
 
+                backgroundMusic.Stop();
                 previewTrackManager.StopAnyPlaying(this);
 
                 client.LeaveRoom().FireAndForget();

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2026.318.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.401.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.402.0" />
     <PackageReference Include="Sentry" Version="6.2.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.47.0" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2026.318.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.331.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.401.0" />
     <PackageReference Include="Sentry" Version="6.2.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.47.0" />


### PR DESCRIPTION
Using a bespoke music loop, fades in during the intro:

https://github.com/user-attachments/assets/8db7e30c-2a7c-4fd0-8385-fa77a6e0a506

Ducks when hovering cards for previews, with debouncing to smooth it:

https://github.com/user-attachments/assets/b3557c08-c675-4591-963c-95866d45107f

---
- [x] depends on ppy/osu-resources#414