### PR TITLE
Fix difficulty flicker when using mods & importing new maps (#36964)

### DIFF
--- a/osu.Game/Screens/Select/PanelBeatmap.cs
+++ b/osu.Game/Screens/Select/PanelBeatmap.cs
@@ -243,6 +243,7 @@ namespace osu.Game.Screens.Select
             starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, starDifficultyCancellationSource.Token, SongSelect.DIFFICULTY_CALCULATION_DEBOUNCE);
             starDifficultyBindable.BindValueChanged(starDifficulty =>
             {
+                if (starDifficulty.OldValue == starDifficulty.NewValue) return;
                 starRatingDisplay.Current.Value = starDifficulty.NewValue;
                 starCounter.Current = (float)starDifficulty.NewValue.Stars;
             }, true);


### PR DESCRIPTION
I tested importing a lot of beatmaps with mods enabled. Both beatmap flicker and difficulty flicker seem to be fixed.