### PR TITLE
Fix osu!mania editor not zooming playfield to match timeline

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
+++ b/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         protected override void Update()
         {
-            TimeRange.Value = TimelineTimeRange == null || ShowSpeedChanges.Value ? ComputeScrollTime(Config.Get<double>(ManiaRulesetSetting.ScrollSpeed)) : TimelineTimeRange.Value;
+            TargetTimeRange = TimelineTimeRange == null || ShowSpeedChanges.Value ? ComputeScrollTime(Config.Get<double>(ManiaRulesetSetting.ScrollSpeed)) : TimelineTimeRange.Value;
             base.Update();
         }
     }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -472,7 +472,7 @@ namespace osu.Game.Tests.Visual.Navigation
             void checkScrollSpeed(double configValue, double gameplayValue)
             {
                 AddUntilStep($"config value is {configValue}", () => getConfigManager().Get<double>(ManiaRulesetSetting.ScrollSpeed), () => Is.EqualTo(configValue));
-                AddUntilStep($"gameplay value is {gameplayValue}", () => this.ChildrenOfType<DrawableManiaRuleset>().Single().ScrollingInfo.TimeRange.Value,
+                AddUntilStep($"gameplay value is {gameplayValue}", () => this.ChildrenOfType<DrawableManiaRuleset>().Single().TargetTimeRange,
                     () => Is.EqualTo(DrawableManiaRuleset.ComputeScrollTime(gameplayValue)));
             }
 


### PR DESCRIPTION
- Fixes CI failures due to completely wrong test (sorry)
- Fixes #37167 (oops)