### PR TITLE
All settings within same filterable containers are visible when search is matched

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -52,6 +52,7 @@ namespace osu.Game.Overlays.Settings
                     showIFilterableChildren(child);
             }
         }
+
         public bool MatchingFilter
         {
             get => matchingFilter;

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Overlays.Settings
                 if (child is FillFlowContainer { Direction: FillDirection.Horizontal } row)
                 {
                     bool hasVisibleButtons = false;
+
                     foreach (var item in row.Children)
                     {
                         if (item is IFilterable && item.IsPresent)
@@ -74,6 +75,7 @@ namespace osu.Game.Overlays.Settings
                             break;
                         }
                     }
+
                     if (hasVisibleButtons)
                     {
                         foreach (var item in row.Children)

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -42,17 +42,6 @@ namespace osu.Game.Overlays.Settings
 
         private bool matchingFilter = true;
 
-        private static void showIFilterableChildren(Drawable drawable)
-        {
-            if (drawable is IFilterable filterable)
-                filterable.MatchingFilter = true;
-            if (drawable is IContainerEnumerable<Drawable> container)
-            {
-                foreach (var child in container.Children)
-                    showIFilterableChildren(child);
-            }
-        }
-
         public bool MatchingFilter
         {
             get => matchingFilter;
@@ -63,13 +52,37 @@ namespace osu.Game.Overlays.Settings
                 matchingFilter = value;
 
                 if (matchingFilter && FilteringActive)
-                {
-                    foreach (var child in Children)
-                        showIFilterableChildren(child);
-                }
+                    showHorizontalSiblings();
 
                 if (IsPresent != wasPresent)
                     Invalidate(Invalidation.Presence);
+            }
+        }
+
+        private void showHorizontalSiblings()
+        {
+            foreach (var child in FlowContent)
+            {
+                if (child is FillFlowContainer { Direction: FillDirection.Horizontal } row)
+                {
+                    bool hasVisibleButtons = false;
+                    foreach (var item in row.Children)
+                    {
+                        if (item is IFilterable && item.IsPresent)
+                        {
+                            hasVisibleButtons = true;
+                            break;
+                        }
+                    }
+                    if (hasVisibleButtons)
+                    {
+                        foreach (var item in row.Children)
+                        {
+                            if (item is IFilterable filterable)
+                                filterable.MatchingFilter = true;
+                        }
+                    }
+                }
             }
         }
 

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -42,6 +42,16 @@ namespace osu.Game.Overlays.Settings
 
         private bool matchingFilter = true;
 
+        private static void showIFilterableChildren(Drawable drawable)
+        {
+            if (drawable is IFilterable filterable)
+                filterable.MatchingFilter = true;
+            if (drawable is IContainerEnumerable<Drawable> container)
+            {
+                foreach (var child in container.Children)
+                    showIFilterableChildren(child);
+            }
+        }
         public bool MatchingFilter
         {
             get => matchingFilter;
@@ -50,6 +60,12 @@ namespace osu.Game.Overlays.Settings
                 bool wasPresent = IsPresent;
 
                 matchingFilter = value;
+
+                if (matchingFilter && FilteringActive)
+                {
+                    foreach (var child in Children)
+                        showIFilterableChildren(child);
+                }
 
                 if (IsPresent != wasPresent)
                     Invalidate(Invalidation.Presence);


### PR DESCRIPTION
Fixes #35917 

Modified the `MatchingFilter` setter in `SettingsSection.cs` to additionally mark `MatchingFilter` attribute of child elements to true when a setting is being searched. Added a private helper function `showIFilterableChildren` that recurses on `IContainerEnumerable<Drawable>`.   

Before:

https://github.com/user-attachments/assets/1f684039-2121-45e2-80ee-c8cfe9c601fc
 
After:

https://github.com/user-attachments/assets/5225a4d5-5b6f-4a87-bfe0-c00f15cefc94


A big downside of this approach is that it makes the screens a bit cluttered when searching for more popular options like "cursor"