### PR TITLE
Move Aim mod-related difficulty adjustments to after the probability calculation

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuRatingCalculator.cs
@@ -31,9 +31,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double aimRating = Math.Pow(aimDifficultyValue, 0.63) * 0.02275;
 
-            if (mods.Any(m => m is OsuModRelax))
-                aimRating *= 0.9;
-
             if (mods.Any(m => m is OsuModMagnetised))
             {
                 float magnetisedStrength = mods.OfType<OsuModMagnetised>().First().AttractionStrength.Value;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         private double skillMultiplierAgility => 2.35;
         private double skillMultiplierFlow => 243.0;
         private double skillMultiplierTotal => 1.12;
-        private double meanExponent => 1.2;
+        private double combinedSnapNormExponent => 1.2;
 
         /// <summary>
         /// The number of sections with the highest strains, which the peak strain reductions will apply to.
@@ -63,18 +63,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(current) * skillMultiplierAgility;
             double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skillMultiplierFlow;
 
-            if (Mods.Any(m => m is OsuModTouchDevice))
-            {
-                snapDifficulty = Math.Pow(snapDifficulty, 0.89);
-                // we don't adjust agility here since agility represents TD difficulty in a decent enough way
-                flowDifficulty = Math.Pow(flowDifficulty, 1.1);
-            }
-
-            if (Mods.Any(m => m is OsuModRelax))
-            {
-                agilityDifficulty *= 0.3;
-            }
-
             double totalDifficulty = calculateTotalValue(snapDifficulty, agilityDifficulty, flowDifficulty);
 
             currentStrain *= decay;
@@ -91,10 +79,23 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             // We compare flow to combined snap and agility because snap by itself doesn't have enough difficulty to be above flow on streams
             // Agility on the other hand is supposed to measure the rate of cursor velocity changes while snapping
             // So snapping every circle on a stream requires an enormous amount of agility at which point it's easier to flow
-            double combinedSnapDifficulty = DifficultyCalculationUtils.Norm(meanExponent, snapDifficulty, agilityDifficulty);
+            double combinedSnapDifficulty = DifficultyCalculationUtils.Norm(combinedSnapNormExponent, snapDifficulty, agilityDifficulty);
 
             double pSnap = calculateSnapFlowProbability(flowDifficulty / combinedSnapDifficulty);
             double pFlow = 1 - pSnap;
+
+            if (Mods.Any(m => m is OsuModTouchDevice))
+            {
+                // we don't adjust agility here since agility represents TD difficulty in a decent enough way
+                snapDifficulty = Math.Pow(snapDifficulty, 0.89);
+                combinedSnapDifficulty = DifficultyCalculationUtils.Norm(combinedSnapNormExponent, snapDifficulty, agilityDifficulty);
+            }
+
+            if (Mods.Any(m => m is OsuModRelax))
+            {
+                combinedSnapDifficulty *= 0.75;
+                flowDifficulty *= 0.6;
+            }
 
             double totalDifficulty = combinedSnapDifficulty * pSnap + flowDifficulty * pFlow;
 


### PR DESCRIPTION
Adjusting difficulty before we calculate the flow probability is technically wrong. This makes flow adjustment on RX actually work as it should instead of trying to lower the snap to achieve similar results. TD flow buff was removed because here it actually made some maps _very_ buffed. Values are mostly the same otherwise

RX:
<img width="1322" height="1410" alt="image" src="https://github.com/user-attachments/assets/8146b227-24c5-42d2-a31c-03cb12003407" />

TD:
https://pp.huismetbenen.nl/player/30790527/master
<img width="1322" height="1410" alt="image" src="https://github.com/user-attachments/assets/e4eb681a-5719-4008-8453-86df31c5d64c" />

https://pp.huismetbenen.nl/player/11740168/master
<img width="1322" height="1410" alt="image" src="https://github.com/user-attachments/assets/c0440c3b-a3cc-46c9-bd6c-b5660dcefb40" />
