### PR TITLE
Fix ranked play test failures from adding null playlist items

### DIFF
--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -860,15 +860,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public async Task PlayUserCard(int userId, Func<RankedPlayCardItem[], RankedPlayCardItem> selector)
         {
             RankedPlayCardItem card = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray());
-            MultiplayerPlaylistItem item = GetCardWithPlaylistItem(card).PlaylistItem.Value!;
+            MultiplayerPlaylistItem? item = GetCardWithPlaylistItem(card).PlaylistItem.Value;
 
-            ServerRoom!.Playlist.Add(item);
-            await ((IMultiplayerClient)this).PlaylistItemAdded(clone(item)).ConfigureAwait(false);
-            await ((IMultiplayerClient)this).PlaylistItemChanged(clone(item)).ConfigureAwait(false);
+            if (item != null)
+            {
+                ServerRoom!.Playlist.Add(item);
+                await ((IMultiplayerClient)this).PlaylistItemAdded(clone(item)).ConfigureAwait(false);
+                await ((IMultiplayerClient)this).PlaylistItemChanged(clone(item)).ConfigureAwait(false);
 
-            var settings = clone(ServerRoom!.Settings);
-            settings.PlaylistItemId = item.ID;
-            await ((IMultiplayerClient)this).SettingsChanged(settings).ConfigureAwait(false);
+                var settings = clone(ServerRoom!.Settings);
+                settings.PlaylistItemId = item.ID;
+                await ((IMultiplayerClient)this).SettingsChanged(settings).ConfigureAwait(false);
+            }
 
             await ((IRankedPlayClient)this).RankedPlayCardPlayed(clone(card)).ConfigureAwait(false);
         }


### PR DESCRIPTION
Example: https://github.com/ppy/osu/actions/runs/23900675414/job/69696255970?pr=37178#step:5:38

Regressed in https://github.com/ppy/osu/pull/37172, cc @LiquidPL

Would fail in multiple tests. I'm not going to spend time figuring out exactly why, I'm just going to guess that not all tests bother to set up the relevant playlist items for the cards or whatever.

Some of the failing tests are flaky but not because the `item` here isn't sometimes null in those cases. It's always null, but the callbacks are probably scheduled or whatever and therefore have a chance to never run. Also some of the failures appear to cascade / spill from other tests as well.