### PR TITLE
Add `osu! (Debug, Second Client)` launch option for VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,19 @@
             "console": "internalConsole"
         },
         {
+            "name": "osu! (Debug, Second Client)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+                "${workspaceRoot}/osu.Desktop/bin/Debug/net8.0/osu!.dll",
+                "--debug-client-id=1"
+            ],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "Build osu! (Debug)",
+            "console": "internalConsole"
+        },
+        {
             "name": "osu! (Release)",
             "type": "coreclr",
             "request": "launch",


### PR DESCRIPTION
Kinda self explanatory, adds a second client configurations so its easier to test multiplayer-specific things when using VSCode

For people that don't know how to use this, basically just run the first debug like normal, then swap to the second client option and run that. You can also do it in reverse. Visual guide here: 
https://github.com/user-attachments/assets/1dab50eb-3bd2-422d-a776-852ac4454213

