### PR TITLE
Update editor icons

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/GridFromPointsTool.cs
+++ b/osu.Game.Rulesets.Osu/Edit/GridFromPointsTool.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Osu.Edit.Blueprints;
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                           """;
         }
 
-        public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.Solid.DraftingCompass };
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorGrid };
 
         public override PlacementBlueprint CreatePlacementBlueprint() => new GridPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Osu/Edit/HitCircleCompositionTool.cs
+++ b/osu.Game.Rulesets.Osu/Edit/HitCircleCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorHitCircle };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new HitCirclePlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Osu/Edit/SliderCompositionTool.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SliderCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
@@ -24,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 """;
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorSlider };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new SliderPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Osu/Edit/SpinnerCompositionTool.cs
+++ b/osu.Game.Rulesets.Osu/Edit/SpinnerCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorSpinner };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new SpinnerPlacementBlueprint();
     }

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -90,13 +90,16 @@ namespace osu.Game.Graphics
         public static IconUsage Twitter => get(OsuIconMapping.Twitter);
         public static IconUsage UserInterface => get(OsuIconMapping.UserInterface);
         public static IconUsage Wiki => get(OsuIconMapping.Wiki);
+        public static IconUsage EditorHitCircle => get(OsuIconMapping.EditorHitCircle);
+        public static IconUsage EditorSlider => get(OsuIconMapping.EditorSlider);
+        public static IconUsage EditorSpinner => get(OsuIconMapping.EditorSpinner);
+        public static IconUsage EditorGrid => get(OsuIconMapping.EditorGrid);
         public static IconUsage EditorAddControlPoint => get(OsuIconMapping.EditorAddControlPoint);
         public static IconUsage EditorConvertToStream => get(OsuIconMapping.EditorConvertToStream);
         public static IconUsage EditorDistanceSnap => get(OsuIconMapping.EditorDistanceSnap);
         public static IconUsage EditorFinish => get(OsuIconMapping.EditorFinish);
         public static IconUsage EditorGridSnap => get(OsuIconMapping.EditorGridSnap);
-        public static IconUsage EditorNewComboA => get(OsuIconMapping.EditorNewComboA);
-        public static IconUsage EditorNewComboB => get(OsuIconMapping.EditorNewComboB);
+        public static IconUsage EditorNewCombo => get(OsuIconMapping.EditorNewCombo);
         public static IconUsage EditorSelect => get(OsuIconMapping.EditorSelect);
         public static IconUsage EditorSound => get(OsuIconMapping.EditorSound);
         public static IconUsage EditorWhistle => get(OsuIconMapping.EditorWhistle);
@@ -397,6 +400,18 @@ namespace osu.Game.Graphics
             [Description(@"wiki")]
             Wiki,
 
+            [Description(@"Editor/hitcircle")]
+            EditorHitCircle,
+
+            [Description(@"Editor/slider")]
+            EditorSlider,
+
+            [Description(@"Editor/spinner")]
+            EditorSpinner,
+
+            [Description(@"Editor/grid")]
+            EditorGrid,
+
             [Description(@"Editor/add-control-point")]
             EditorAddControlPoint = 1000,
 
@@ -412,11 +427,8 @@ namespace osu.Game.Graphics
             [Description(@"Editor/grid-snap")]
             EditorGridSnap,
 
-            [Description(@"Editor/new-combo-a")]
-            EditorNewComboA,
-
-            [Description(@"Editor/new-combo-b")]
-            EditorNewComboB,
+            [Description(@"Editor/new-combo")]
+            EditorNewCombo,
 
             [Description(@"Editor/select")]
             EditorSelect,

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                     {
                         Current = Current,
                         Description = "New combo",
-                        CreateIcon = () => new SpriteIcon { Icon = OsuIcon.EditorNewComboA },
+                        CreateIcon = () => new SpriteIcon { Icon = OsuIcon.EditorNewCombo },
                     },
                 },
                 pickerButton = new ColourPickerButton


### PR DESCRIPTION
Brings in new fresh icons for the toolbox (select, hitcircle, slider, spinner, grid) and toggles (new combo, whistle, finish, clap, grid/distance snap).

Depends on https://github.com/ppy/osu-resources/pull/416.

| Before | After |
|--------|--------|
| <img width="300" height="897" alt="image" src="https://github.com/user-attachments/assets/279ea162-c3e2-4312-a0a2-39ad08df16f9" /> | <img width="304" height="889" alt="image" src="https://github.com/user-attachments/assets/aab2a143-0e6b-45c1-bf84-8998c12bd960" /> | 


