### PR TITLE
Add current stage overlay to ranked play

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayCornerPiece.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayCornerPiece.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osu.Game.Tests.Visual.Multiplayer;
@@ -27,7 +28,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     new RankedPlayCornerPiece(RankedPlayColourScheme.Blue, Anchor.BottomLeft)
                     {
                         State = { BindTarget = visibility },
-                        Child = new RankedPlayUserDisplay(2, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+                        Child = new RankedPlayUserDisplay(new APIUser { Id = 2, Username = "peppy" }, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
                         {
                             RelativeSizeAxes = Axes.Both,
                         }
@@ -35,7 +36,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     new RankedPlayCornerPiece(RankedPlayColourScheme.Red, Anchor.TopRight)
                     {
                         State = { BindTarget = visibility },
-                        Child = new RankedPlayUserDisplay(2, Anchor.TopRight, RankedPlayColourScheme.Red)
+                        Child = new RankedPlayUserDisplay(new APIUser { Id = 2, Username = "peppy" }, Anchor.TopRight, RankedPlayColourScheme.Red)
                         {
                             RelativeSizeAxes = Axes.Both,
                         }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayStageOverlay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayStageOverlay.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    public partial class TestSceneRankedPlayStageOverlay : RankedPlayTestScene
+    {
+        private Container content = null!;
+        protected override Container<Drawable> Content => content;
+
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("create components", () => base.Content.Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new RankedPlayBackground
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    content = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                }
+            });
+        }
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("create", () => Child = new RankedPlayStageOverlay("Pick Phase", RankedPlayColourScheme.Blue)
+            {
+                PickingUser = new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                },
+                Multiplier = 2,
+            });
+        }
+
+        [Test]
+        public void TestLongUsername()
+        {
+            AddStep("create", () => Child = new RankedPlayStageOverlay("Pick Phase", RankedPlayColourScheme.Blue)
+            {
+                PickingUser = new APIUser
+                {
+                    Id = 226597,
+                    Username = "WWWWWWWWWWWWWWWWWWWW",
+                },
+                Multiplier = 2,
+            });
+        }
+
+        [Test]
+        public void TestColourScheme()
+        {
+            AddStep("create blue", () => Child = new RankedPlayStageOverlay("Pick Phase", RankedPlayColourScheme.Blue)
+            {
+                PickingUser = new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                },
+                Multiplier = 2,
+            });
+            AddStep("create red", () => Child = new RankedPlayStageOverlay("Pick Phase", RankedPlayColourScheme.Red)
+            {
+                PickingUser = new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                },
+                Multiplier = 2,
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Online.Rooms;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osu.Game.Tests.Visual.Multiplayer;
@@ -34,7 +35,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.RankedPlay)));
             WaitForJoined();
 
-            AddStep("add display", () => Child = new RankedPlayUserDisplay(1001, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+            AddStep("add display", () => Child = new RankedPlayUserDisplay(new APIUser { Id = 1001, Username = "User 1001" }, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -46,7 +47,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         [Test]
         public void TesUserDisplay()
         {
-            AddStep("blue color scheme", () => Child = new RankedPlayUserDisplay(1001, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+            AddStep("blue color scheme", () => Child = new RankedPlayUserDisplay(new APIUser { Id = 1001, Username = "User 1001" }, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -54,7 +55,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                 Health = { BindTarget = health }
             });
 
-            AddStep("red color scheme", () => Child = new RankedPlayUserDisplay(1001, Anchor.BottomLeft, RankedPlayColourScheme.Red)
+            AddStep("red color scheme", () => Child = new RankedPlayUserDisplay(new APIUser { Id = 1001, Username = "User 1001" }, Anchor.BottomLeft, RankedPlayColourScheme.Red)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -40,7 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         [Resolved]
         private UserLookupCache users { get; set; } = null!;
 
-        private readonly int userId;
+        private readonly APIUser user;
         private readonly Anchor contentAnchor;
         private readonly RankedPlayColourScheme colourScheme;
 
@@ -56,9 +55,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         [Resolved]
         private RankedPlayCornerPiece? cornerPiece { get; set; }
 
-        public RankedPlayUserDisplay(int userId, Anchor contentAnchor, RankedPlayColourScheme colourScheme)
+        public RankedPlayUserDisplay(APIUser user, Anchor contentAnchor, RankedPlayColourScheme colourScheme)
         {
-            this.userId = userId;
+            this.user = user;
             this.contentAnchor = contentAnchor;
             this.colourScheme = colourScheme;
         }
@@ -66,8 +65,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            APIUser user = users.GetUserAsync(userId).GetResultSafely()!;
-
             var shear = contentAnchor == Anchor.TopLeft || contentAnchor == Anchor.BottomRight
                 ? -OsuGame.SHEAR
                 : OsuGame.SHEAR;
@@ -168,12 +165,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         private void onRoomUpdated()
         {
-            var user = client.Room?.Users.SingleOrDefault(u => u.UserID == userId);
+            var multiplayerUser = client.Room?.Users.SingleOrDefault(u => u.UserID == user.Id);
 
-            if (user == null || availability == user.BeatmapAvailability)
+            if (multiplayerUser == null || availability == multiplayerUser.BeatmapAvailability)
                 return;
 
-            availability = user.BeatmapAvailability;
+            availability = multiplayerUser.BeatmapAvailability;
 
             if (availability.State is DownloadState.NotDownloaded or DownloadState.Downloading or DownloadState.Importing)
                 beatmapState.FadeIn(50);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -34,7 +34,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         public CardFlow CenterRow { get; private set; } = null!;
 
-        protected override LocalisableString StageHeading => "Discard Phase";
+        public override bool ShowStageOverlay => true;
+        public override LocalisableString StageHeading => "Discard Phase";
         protected override LocalisableString StageCaption => "Replace cards from your hand";
 
         private PlayerHandOfCards playerHand = null!;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/EndedScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/EndedScreen.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         /// </summary>
         public Action<bool>? ExitRequested { get; init; }
 
-        protected override LocalisableString StageHeading => "Results";
+        public override LocalisableString StageHeading => "Results";
         protected override LocalisableString StageCaption => string.Empty;
 
         [Resolved]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayScreen.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class GameplayScreen : RankedPlaySubScreen
     {
-        protected override LocalisableString StageHeading => "Gameplay";
+        public override LocalisableString StageHeading => "Gameplay";
         protected override LocalisableString StageCaption => string.Empty;
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
     {
         public override bool ShowBeatmapBackground => true;
 
-        protected override LocalisableString StageHeading => "Gameplay";
+        public override LocalisableString StageHeading => "Gameplay";
         protected override LocalisableString StageCaption => string.Empty;
 
         [Cached(typeof(IBindable<SongSelect.BeatmapSetLookupResult?>))]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 {
     public partial class IntroScreen : RankedPlaySubScreen
     {
-        protected override LocalisableString StageHeading => string.Empty;
+        public override LocalisableString StageHeading => string.Empty;
         protected override LocalisableString StageCaption => string.Empty;
 
         public IntroScreen()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
@@ -23,7 +23,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
     {
         public CardFlow CenterRow { get; private set; } = null!;
 
-        protected override LocalisableString StageHeading => "Pick Phase";
+        public override bool ShowStageOverlay => true;
+        public override LocalisableString StageHeading => "Pick Phase";
         protected override LocalisableString StageCaption => "Waiting for your opponent...";
 
         protected override RankedPlayColourScheme ColourScheme => RankedPlayColourScheme.Red;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -28,7 +28,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         public CardFlow CenterRow { get; private set; } = null!;
 
-        protected override LocalisableString StageHeading => "Pick Phase";
+        public override bool ShowStageOverlay => true;
+
+        public override LocalisableString StageHeading => "Pick Phase";
         protected override LocalisableString StageCaption => "It's your turn to play a card!";
 
         private PlayerHandOfCards playerHand = null!;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayMatchInfo.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayMatchInfo.cs
@@ -74,6 +74,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         public bool IsOwnTurn => RoomState.ActiveUserId == client.LocalUser?.UserID;
 
+        public bool IsOpponentTurn => RoomState.ActiveUserId == OpponentId;
+
         public int CurrentRound => RoomState.CurrentRound;
 
         public int OpponentId => RoomState.Users.Keys.Single(u => u != client.LocalUser?.UserID);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -14,8 +15,10 @@ using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
@@ -57,6 +60,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
+        private UserLookupCache users { get; set; } = null!;
+
+        [Resolved]
         private IDialogOverlay dialogOverlay { get; set; } = null!;
 
         [Resolved]
@@ -69,6 +75,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private QueueController? controller { get; set; }
 
         private readonly MultiplayerRoom room;
+
+        private APIUser localUser = null!;
+        private APIUser opponentUser = null!;
+
         private readonly Container<RankedPlaySubScreen> screenContainer;
         private readonly RankedPlayChatDisplay chat;
 
@@ -154,11 +164,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             int localUserId = api.LocalUser.Value.OnlineID;
             int opponentUserId = ((RankedPlayRoomState)client.Room!.MatchState!).Users.Keys.Single(it => it != localUserId);
 
+            localUser = users.GetUserAsync(localUserId).GetResultSafely()!;
+            opponentUser = users.GetUserAsync(opponentUserId).GetResultSafely()!;
+
             AddRangeInternal([
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Blue, Anchor.BottomLeft)
                 {
                     State = { BindTarget = cornerPieceVisibility },
-                    Child = new RankedPlayUserDisplay(localUserId, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+                    Child = new RankedPlayUserDisplay(localUser, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
                     {
                         RelativeSizeAxes = Axes.Both,
                         Health = { BindTarget = matchInfo.PlayerHealth }
@@ -167,7 +180,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Red, Anchor.TopRight)
                 {
                     State = { BindTarget = cornerPieceVisibility },
-                    Child = new RankedPlayUserDisplay(opponentUserId, Anchor.TopRight, RankedPlayColourScheme.Red)
+                    Child = new RankedPlayUserDisplay(opponentUser, Anchor.TopRight, RankedPlayColourScheme.Red)
                     {
                         RelativeSizeAxes = Axes.Both,
                         Health = { BindTarget = matchInfo.OpponentHealth }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -79,6 +79,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private APIUser localUser = null!;
         private APIUser opponentUser = null!;
 
+        private readonly Container<RankedPlayStageOverlay> stageOverlayContainer;
         private readonly Container<RankedPlaySubScreen> screenContainer;
         private readonly RankedPlayChatDisplay chat;
 
@@ -139,6 +140,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             }
                         }
                     }
+                },
+                stageOverlayContainer = new Container<RankedPlayStageOverlay>
+                {
+                    RelativeSizeAxes = Axes.Both,
                 },
                 overlayContainer = new CardDetailsOverlayContainer(),
                 particleContainer = new SongPreviewParticleContainer(),
@@ -212,6 +217,25 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                 cornerPieceVisibility.BindTo(screen.CornerPieceVisibility);
                 showBeatmapBackground.Value = screen.ShowBeatmapBackground;
+
+                if (screen.ShowStageOverlay)
+                {
+                    APIUser? pickingUser = null;
+                    double? multiplier = matchInfo.Stage.Value < RankedPlayStage.CardPlay ? null : matchInfo.RoomState.DamageMultiplier;
+                    RankedPlayColourScheme colourScheme = RankedPlayColourScheme.Blue;
+
+                    if (matchInfo.Stage.Value == RankedPlayStage.CardPlay && matchInfo.RoomState.ActiveUser != null)
+                    {
+                        pickingUser = matchInfo.IsOwnTurn ? localUser : opponentUser;
+                        colourScheme = matchInfo.IsOwnTurn ? RankedPlayColourScheme.Blue : RankedPlayColourScheme.Red;
+                    }
+
+                    stageOverlayContainer.Add(new RankedPlayStageOverlay(screen.StageHeading, colourScheme)
+                    {
+                        PickingUser = pickingUser,
+                        Multiplier = multiplier,
+                    });
+                }
             };
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private APIUser localUser = null!;
         private APIUser opponentUser = null!;
 
-        private readonly Container<RankedPlayStageOverlay> stageOverlayContainer;
+        private readonly Container stageOverlayContainer;
         private readonly Container<RankedPlaySubScreen> screenContainer;
         private readonly RankedPlayChatDisplay chat;
 
@@ -141,7 +141,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                         }
                     }
                 },
-                stageOverlayContainer = new Container<RankedPlayStageOverlay>
+                stageOverlayContainer = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
                 },

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         public APIUser? PickingUser { get; init; }
         public double? Multiplier { get; init; }
 
-        private Box background = null!;
         private FillFlowContainer displayContainer = null!;
         private FillFlowContainer detailsContainer = null!;
         private CircularContainer avatarContainer = null!;
@@ -46,13 +45,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 Origin = Anchor.Centre,
                 Children = new Drawable[]
                 {
-                    background = new Box
+                    new Box
                     {
+                        Alpha = 0.4f,
                         RelativeSizeAxes = Axes.Both,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Colour = Color4Extensions.FromHex("#000"),
-                        Alpha = 0.4f,
                     },
                     displayContainer = new FillFlowContainer
                     {
@@ -159,20 +158,20 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             const int time_visible = 1500;
             const Easing easing = Easing.OutQuint;
 
-            background.FadeTo(0f)
-                      .FadeTo(0.4f, 300, easing)
-                      .Delay(time_visible)
-                      .FadeOut(duration, easing);
+            this.FadeInFromZero(300, easing);
 
-            displayContainer.FadeTo(0)
-                            .ScaleTo(0.9f)
-                            .FadeIn(duration, easing)
-                            .ScaleTo(1f, duration, easing)
-                            .Delay(time_visible)
-                            .FadeOut(duration, easing)
-                            .ScaleTo(0.9f, duration, easing)
-                            .Then()
-                            .Schedule(() => Expire());
+            displayContainer
+                .ScaleTo(0.9f)
+                .ScaleTo(1f, duration, easing);
+
+            using (BeginDelayedSequence(time_visible))
+            {
+                this.FadeOut(duration, easing)
+                    .Expire();
+
+                displayContainer
+                    .ScaleTo(0.9f, duration, easing);
+            }
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
@@ -115,6 +115,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     {
                         avatarContainer = new CircularContainer
                         {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
                             Size = new Vector2(32),
                             Masking = true,
                             Children = new Drawable[]
@@ -129,6 +131,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                         },
                         new OsuSpriteText
                         {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            UseFullGlyphHeight = false,
                             Font = OsuFont.Torus.With(size: 32),
                             Text = $"{PickingUser.Username}'s pick",
                             Colour = colourScheme.Primary,
@@ -141,8 +146,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             {
                 detailsContainer.Add(new OsuSpriteText
                 {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    UseFullGlyphHeight = false,
                     Font = OsuFont.Torus.With(size: 32),
-                    Text = $"{Multiplier:N0}x Damage",
+                    Text = $"{Multiplier:N0}x damage",
                 });
             }
         }
@@ -156,6 +164,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             const int duration = 500;
             const int time_visible = 1500;
+
             const Easing easing = Easing.OutQuint;
 
             this.FadeInFromZero(300, easing);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
@@ -1,0 +1,185 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Users.Drawables;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class RankedPlayStageOverlay : CompositeDrawable
+    {
+        private readonly LocalisableString stageName;
+        private readonly RankedPlayColourScheme colourScheme;
+
+        public APIUser? PickingUser { get; init; }
+        public double? Multiplier { get; init; }
+
+        private Box background = null!;
+        private FillFlowContainer displayContainer = null!;
+        private FillFlowContainer detailsContainer = null!;
+        private CircularContainer avatarContainer = null!;
+
+        public RankedPlayStageOverlay(LocalisableString stageName, RankedPlayColourScheme colourScheme)
+        {
+            this.stageName = stageName;
+            this.colourScheme = colourScheme;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Colour = Color4Extensions.FromHex("#000"),
+                        Alpha = 0.4f,
+                    },
+                    displayContainer = new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(0, 10),
+                        Children = new Drawable[]
+                        {
+                            new Container
+                            {
+                                Width = 500,
+                                AutoSizeAxes = Axes.Y,
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Shear = OsuGame.SHEAR,
+                                Masking = true,
+                                CornerRadius = 10,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = colourScheme.Surface.Darken(0.1f),
+                                        Alpha = 0.8f,
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Shear = -OsuGame.SHEAR,
+                                        Padding = new MarginPadding { Vertical = 20 },
+                                        Font = OsuFont.TorusAlternate.With(size: 72),
+                                        Shadow = false,
+                                        Text = stageName,
+                                    },
+                                },
+                            },
+                            detailsContainer = new FillFlowContainer
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Direction = FillDirection.Horizontal,
+                                Spacing = new Vector2(40, 0),
+                            },
+                        },
+                    }
+                },
+            };
+
+            if (PickingUser != null)
+            {
+                detailsContainer.Add(new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(5, 0),
+                    Children = new Drawable[]
+                    {
+                        avatarContainer = new CircularContainer
+                        {
+                            Size = new Vector2(32),
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = colourScheme.Surface,
+                                    Alpha = 0.5f,
+                                },
+                            },
+                        },
+                        new OsuSpriteText
+                        {
+                            Font = OsuFont.Torus.With(size: 32),
+                            Text = $"{PickingUser.Username}'s pick",
+                            Colour = colourScheme.Primary,
+                        },
+                    },
+                });
+            }
+
+            if (Multiplier != null)
+            {
+                detailsContainer.Add(new OsuSpriteText
+                {
+                    Font = OsuFont.Torus.With(size: 32),
+                    Text = $"{Multiplier:N0}x Damage",
+                });
+            }
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (PickingUser != null)
+                LoadComponentAsync(new DrawableAvatar(PickingUser), a => avatarContainer.Add(a));
+
+            const int duration = 500;
+            const int time_visible = 1500;
+            const Easing easing = Easing.OutQuint;
+
+            background.FadeTo(0f)
+                      .FadeTo(0.4f, 300, easing)
+                      .Delay(time_visible)
+                      .FadeOut(duration, easing);
+
+            displayContainer.FadeTo(0)
+                            .ScaleTo(0.9f)
+                            .FadeIn(duration, easing)
+                            .ScaleTo(1f, duration, easing)
+                            .Delay(time_visible)
+                            .FadeOut(duration, easing)
+                            .ScaleTo(0.9f, duration, easing)
+                            .Then()
+                            .Schedule(() => Expire());
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            displayContainer.Y = DrawHeight * -0.2f;
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
@@ -174,12 +174,5 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             .Then()
                             .Schedule(() => Expire());
         }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            displayContainer.Y = DrawHeight * -0.2f;
-        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
@@ -24,9 +24,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         public virtual bool ShowBeatmapBackground => false;
 
         /// <summary>
+        /// Whether a fullscreen overlay displaying the current stage (and any additional
+        /// information like the currently picking player and/or the damage multiplier)
+        /// should be displayed upon entering this screen.
+        /// </summary>
+        public virtual bool ShowStageOverlay => false;
+
+        /// <summary>
         /// Heading text to be displayed indicating the purpose of the current stage.
         /// </summary>
-        protected abstract LocalisableString StageHeading { get; }
+        public abstract LocalisableString StageHeading { get; }
 
         /// <summary>
         /// Subtitle text to be displayed indicating the action a user should take in the current stage.

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class ResultsScreen : RankedPlaySubScreen
     {
-        protected override LocalisableString StageHeading => "Results";
+        public override LocalisableString StageHeading => "Results";
         protected override LocalisableString StageCaption => string.Empty;
 
         public override bool ShowBeatmapBackground => true;
@@ -243,7 +243,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
                             State = { BindTarget = cornerPieceVisibility },
-                            Child = playerUserDisplay = new RankedPlayUserDisplay(PlayerScore.UserID, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+                            Child = playerUserDisplay = new RankedPlayUserDisplay(PlayerScore.User, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Health = { Value = PlayerDamageInfo.OldLife }
@@ -254,7 +254,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.BottomRight,
                             State = { BindTarget = cornerPieceVisibility },
-                            Child = opponentUserDisplay = new RankedPlayUserDisplay(OpponentScore.UserID, Anchor.BottomRight, RankedPlayColourScheme.Red)
+                            Child = opponentUserDisplay = new RankedPlayUserDisplay(OpponentScore.User, Anchor.BottomRight, RankedPlayColourScheme.Red)
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Health = { Value = OpponentDamageInfo.OldLife }


### PR DESCRIPTION
Displays the stage name and details like currently picking player
and damage multiplayer where applicable.

Currently only shown on the discard and pick stages.

# Move user retrieval to `RankedPlayScreen`

This is done because I need the relevant `APIUser` instances in order to pass them to the overlay component. `RankedPlayScreen` seems like the appropriate place to manage the overlays since it manages the stage subscreens, hence the need to access the `APIUser`s in here.

# Add current stage overlay to ranked play

The actual change of this PR. Very much a dev design.

https://github.com/user-attachments/assets/2388e934-2fc7-4e15-9947-9f98412765d2

