### PR TITLE
Ranked Play: fix cards not going all the way off-screen

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneOpponentPickScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneOpponentPickScreen.cs
@@ -32,8 +32,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
 
             AddStep("set pick state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActiveUserId = 2).WaitSafely());
 
-            AddWaitStep("wait some", 5);
-
             AddStep("reveal cards", () =>
             {
                 for (int i = 0; i < 5; i++)
@@ -46,6 +44,15 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     }).WaitSafely();
                 }
             });
+
+            AddWaitStep("wait", 15);
+
+            AddStep("play beatmap", () => MultiplayerClient.PlayUserCard(2, hand => hand[0]).WaitSafely());
+            AddStep("reveal card", () => MultiplayerClient.RankedPlayRevealUserCard(2, hand => hand[0], new MultiplayerPlaylistItem
+            {
+                ID = 0,
+                BeatmapID = requestHandler.Beatmaps[0].OnlineID
+            }).WaitSafely());
         }
     }
 }

--- a/osu.Game.Tests/Visual/RankedPlay/TestScenePickScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestScenePickScreen.cs
@@ -1,12 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Extensions;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.RankedPlay
 {
@@ -45,6 +50,30 @@ namespace osu.Game.Tests.Visual.RankedPlay
                         BeatmapID = requestHandler.Beatmaps[i2].OnlineID
                     }).WaitSafely();
                 }
+            });
+
+            for (int i = 0; i < 3; i++)
+            {
+                int i2 = i;
+                AddStep($"click card {i2}", () =>
+                {
+                    InputManager.MoveMouseTo(this.ChildrenOfType<PlayerHandOfCards.PlayerHandCard>().ElementAt(i2));
+                    InputManager.Click(MouseButton.Left);
+                });
+            }
+
+            AddWaitStep("wait", 3);
+
+            AddStep("click play button", () =>
+            {
+                var button = screen
+                             .ChildrenOfType<PlayerHandOfCards.PlayerHandCard>()
+                             .First(it => it.Selected)
+                             .ChildrenOfType<ShearedButton>()
+                             .First();
+
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
             });
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
@@ -51,7 +51,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         protected MultiplayerClient Client => client;
 
         protected override Container<Drawable> Content { get; }
+
+        /// <summary>
+        /// Column in the centre of the screen whose width is calculated so its content don't overlap with the <see cref="RankedPlayCornerPiece"/>s
+        /// </summary>
         protected readonly Container CenterColumn;
+
         protected readonly FillFlowContainer ButtonsContainer;
         protected readonly RankedPlayStageDisplay StageDisplay;
 
@@ -67,7 +72,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     RelativeSizeAxes = Axes.Y,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Padding = new MarginPadding(20),
                 },
                 Content = new Container
                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
-using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
@@ -57,7 +56,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         /// </summary>
         protected readonly Container CenterColumn;
 
-        protected readonly FillFlowContainer ButtonsContainer;
         protected readonly RankedPlayStageDisplay StageDisplay;
 
         protected RankedPlaySubScreen()
@@ -77,17 +75,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 {
                     Name = "Content",
                     RelativeSizeAxes = Axes.Both,
-                },
-                ButtonsContainer = new FillFlowContainer
-                {
-                    Name = "Buttons",
-                    AutoSizeAxes = Axes.Both,
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    X = 30,
-                    Y = -110,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(8)
                 },
                 StageDisplay = new RankedPlayStageDisplay(ColourScheme)
                 {


### PR DESCRIPTION
`RankedPlaySubScreen.CenterColumn` had a padding which moved the card hand up slightly, causing it to not fully dissapear when contracting.

The padding doesn't serve any purpose anymore (remnant of the very early versions of the screens), so I just removed it.
I checked against `DiscardScreen`, `PickScreen`, `OpponentPickScreen` & `EndedScreen` to make sure this doesn't cause any layout breakage.

Also removed the `ButtonsContainer` since it isn't being used anywhere anymore.

https://github.com/user-attachments/assets/2fd32407-fbf7-45a3-b92a-0730a0f8a3fd

