### PR TITLE
Add models for improvements to matchmaking lobby

### DIFF
--- a/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Threading.Tasks;
+using osu.Game.Online.Matchmaking.Requests;
+using osu.Game.Online.Matchmaking.Responses;
 
 namespace osu.Game.Online.Matchmaking
 {
@@ -16,7 +18,7 @@ namespace osu.Game.Online.Matchmaking
         /// <summary>
         /// Joins the matchmaking lobby, allowing the local user to receive status updates.
         /// </summary>
-        Task MatchmakingJoinLobby();
+        Task<MatchmakingJoinLobbyResponse> MatchmakingJoinLobbyWithParams(MatchmakingJoinLobbyRequest request);
 
         /// <summary>
         /// Leaves the matchmaking lobby.

--- a/osu.Game/Online/Matchmaking/MatchmakingLobbyStatus.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingLobbyStatus.cs
@@ -3,6 +3,7 @@
 
 using System;
 using MessagePack;
+using osu.Game.Online.Multiplayer;
 
 namespace osu.Game.Online.Matchmaking
 {
@@ -10,7 +11,28 @@ namespace osu.Game.Online.Matchmaking
     [MessagePackObject]
     public class MatchmakingLobbyStatus
     {
+        /// <summary>
+        /// A sample of users in the lobby.
+        /// </summary>
         [Key(0)]
         public int[] UsersInQueue { get; set; } = [];
+
+        /// <summary>
+        /// The distribution of user ratings in the lobby.
+        /// </summary>
+        [Key(1)]
+        public (int Rating, int Count)[] RatingDistribution { get; set; } = [];
+
+        /// <summary>
+        /// The current user's rating.
+        /// </summary>
+        [Key(2)]
+        public int? UserRating { get; set; }
+
+        /// <summary>
+        /// A sample of the most recent completed matches.
+        /// </summary>
+        [Key(3)]
+        public MatchRoomState[] RecentMatches { get; set; } = [];
     }
 }

--- a/osu.Game/Online/Matchmaking/Requests/MatchmakingJoinLobbyRequest.cs
+++ b/osu.Game/Online/Matchmaking/Requests/MatchmakingJoinLobbyRequest.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Requests
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingJoinLobbyRequest
+    {
+        /// <summary>
+        /// The pool to receive status updates from.
+        /// </summary>
+        [Key(0)]
+        public int PoolId { get; set; }
+    }
+}

--- a/osu.Game/Online/Matchmaking/Responses/MatchmakingJoinLobbyResponse.cs
+++ b/osu.Game/Online/Matchmaking/Responses/MatchmakingJoinLobbyResponse.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Responses
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingJoinLobbyResponse
+    {
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
@@ -43,5 +43,11 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// </remarks>
         [Key(4)]
         public RankedPlayDamageInfo? DamageInfo;
+
+        /// <summary>
+        /// Number of rounds this player has won.
+        /// </summary>
+        [Key(5)]
+        public int RoundsWon { get; set; }
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -18,6 +18,8 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
+using osu.Game.Online.Matchmaking.Requests;
+using osu.Game.Online.Matchmaking.Responses;
 using osu.Game.Online.Multiplayer.Countdown;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
@@ -1211,7 +1213,7 @@ namespace osu.Game.Online.Multiplayer
 
         public abstract Task<MatchmakingPool[]> GetMatchmakingPoolsOfType(MatchmakingPoolType type);
 
-        public abstract Task MatchmakingJoinLobby();
+        public abstract Task<MatchmakingJoinLobbyResponse> MatchmakingJoinLobbyWithParams(MatchmakingJoinLobbyRequest request);
 
         public abstract Task MatchmakingLeaveLobby();
 

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -15,6 +15,8 @@ using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Localisation;
 using osu.Game.Online.Matchmaking;
+using osu.Game.Online.Matchmaking.Requests;
+using osu.Game.Online.Matchmaking.Responses;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
 
@@ -369,13 +371,13 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync<MatchmakingPool[]>(nameof(IMatchmakingServer.GetMatchmakingPoolsOfType), type);
         }
 
-        public override Task MatchmakingJoinLobby()
+        public override Task<MatchmakingJoinLobbyResponse> MatchmakingJoinLobbyWithParams(MatchmakingJoinLobbyRequest request)
         {
             if (!IsConnected.Value)
-                return Task.CompletedTask;
+                return Task.FromResult(new MatchmakingJoinLobbyResponse());
 
             Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingJoinLobby));
+            return connection.InvokeAsync<MatchmakingJoinLobbyResponse>(nameof(IMatchmakingServer.MatchmakingJoinLobbyWithParams), request);
         }
 
         public override Task MatchmakingLeaveLobby()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -27,6 +27,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
+using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Volume;
@@ -95,6 +96,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             this.poolType = poolType;
         }
 
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            enqueueSample = audio.Samples.Get(@"Multiplayer/Matchmaking/enqueue");
+            waitingLoopSample = audio.Samples.Get(@"Multiplayer/Matchmaking/waiting-loop");
+            matchFoundSample = audio.Samples.Get(@"Multiplayer/Matchmaking/match-found");
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -156,6 +165,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             client.MatchmakingLobbyStatusChanged += onMatchmakingLobbyStatusChanged;
 
+            selectedPool.BindValueChanged(onSelectedPoolChanged, true);
+
             populateAvailablePools().FireAndForget();
         }
 
@@ -172,14 +183,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             });
         }
 
-        [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
-        {
-            enqueueSample = audio.Samples.Get(@"Multiplayer/Matchmaking/enqueue");
-            waitingLoopSample = audio.Samples.Get(@"Multiplayer/Matchmaking/waiting-loop");
-            matchFoundSample = audio.Samples.Get(@"Multiplayer/Matchmaking/match-found");
-        }
-
         private void onMatchmakingLobbyStatusChanged(MatchmakingLobbyStatus status) => Scheduler.Add(() =>
         {
             userLookupCancellation.Cancel();
@@ -194,13 +197,25 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                            }), cancellation.Token);
         });
 
+        private void onSelectedPoolChanged(ValueChangedEvent<MatchmakingPool?> e)
+        {
+            if (e.NewValue == null)
+            {
+                client.MatchmakingLeaveLobby();
+                return;
+            }
+
+            client.MatchmakingJoinLobbyWithParams(new MatchmakingJoinLobbyRequest
+            {
+                PoolId = e.NewValue.Id
+            });
+        }
+
         public override void OnEntering(ScreenTransitionEvent e)
         {
             base.OnEntering(e);
 
             controller.SearchInForeground();
-
-            client.MatchmakingJoinLobby().FireAndForget();
 
             using (BeginDelayedSequence(800))
                 Schedule(() => SetState(currentState.Value));
@@ -210,7 +225,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         {
             base.OnResuming(e);
 
-            client.MatchmakingJoinLobby().FireAndForget();
+            // Rejoin the lobby.
+            selectedPool.TriggerChange();
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -17,6 +17,8 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Matchmaking.Events;
+using osu.Game.Online.Matchmaking.Requests;
+using osu.Game.Online.Matchmaking.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.Countdown;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
@@ -888,9 +890,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
             ]);
         }
 
-        public override Task MatchmakingJoinLobby()
+        public override Task<MatchmakingJoinLobbyResponse> MatchmakingJoinLobbyWithParams(MatchmakingJoinLobbyRequest request)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(new MatchmakingJoinLobbyResponse());
         }
 
         public override Task MatchmakingLeaveLobby()


### PR DESCRIPTION
1. Gives `MatchmakingJoinLobby` parameters.
2. Adds additional data to lobby status update models.

A further PR will build upon (2) to add more data to the queue screen.