### PR TITLE
Add method for silently dismissing progress notifications without completion

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -369,10 +369,10 @@ namespace osu.Game.Tests.Visual.UserInterface
                     CompletionText = "Uploaded to BSS!",
                 };
 
+                notification.CompleteSilently();
+
                 notificationOverlay.Post(notification);
                 progressingNotifications.Add(notification);
-
-                notification.CompleteSilently();
             });
 
             AddAssert("completed", () => notification.State == ProgressNotificationState.Completed);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -336,6 +336,50 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestProgressSilentDismissal()
+        {
+            ProgressNotification notification = null!;
+
+            AddStep("add progress notification", () =>
+            {
+                notification = new ProgressNotification
+                {
+                    Text = @"Uploading to BSS...",
+                    CompletionText = "Uploaded to BSS!",
+                };
+                notificationOverlay.Post(notification);
+                progressingNotifications.Add(notification);
+            });
+
+            AddStep("silently dismiss", () => notification.CompleteSilently());
+            AddAssert("completed", () => notification.State == ProgressNotificationState.Completed);
+            AddAssert("Completion toast not shown", () => notificationOverlay.ToastCount == 0);
+        }
+
+        [Test]
+        public void TestProgressSilentDismissalImmediate()
+        {
+            ProgressNotification notification = null!;
+
+            AddStep("add progress notification", () =>
+            {
+                notification = new ProgressNotification
+                {
+                    Text = @"Uploading to BSS...",
+                    CompletionText = "Uploaded to BSS!",
+                };
+
+                notificationOverlay.Post(notification);
+                progressingNotifications.Add(notification);
+
+                notification.CompleteSilently();
+            });
+
+            AddAssert("completed", () => notification.State == ProgressNotificationState.Completed);
+            AddAssert("Completion toast not shown", () => notificationOverlay.ToastCount == 0);
+        }
+
+        [Test]
         public void TestProgressClick()
         {
             ProgressNotification notification = null!;

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -172,39 +172,35 @@ namespace osu.Game.Overlays
 
         private double? lastSamplePlayback;
 
-        public void Post(Notification notification)
+        public void Post(Notification notification) => (notification.IsCritical ? criticalPostScheduler : postScheduler).Add(() =>
         {
-            // Completion target set early to ensure that if something else decides to redirect before the schedule below occurs, it's still respected.
+            ++runningDepth;
+
+            Logger.Log($"⚠️ {notification.Text}");
+
+            notification.Closed += () => notificationClosed(notification);
+
             if (notification is IHasCompletionTarget hasCompletionTarget)
                 hasCompletionTarget.CompletionTarget ??= Post;
 
-            (notification.IsCritical ? criticalPostScheduler : postScheduler).Add(() =>
+            playDebouncedSample(notification.PopInSampleName);
+
+            if (notification.IsImportant)
             {
-                ++runningDepth;
+                game?.Window?.Flash();
+                notification.Closed += () => game?.Window?.CancelFlash();
+            }
 
-                Logger.Log($"⚠️ {notification.Text}");
+            if (State.Value == Visibility.Hidden)
+            {
+                notification.IsInToastTray = true;
+                toastTray.Post(notification);
+            }
+            else
+                addPermanently(notification);
 
-                notification.Closed += () => notificationClosed(notification);
-
-                playDebouncedSample(notification.PopInSampleName);
-
-                if (notification.IsImportant)
-                {
-                    game?.Window?.Flash();
-                    notification.Closed += () => game?.Window?.CancelFlash();
-                }
-
-                if (State.Value == Visibility.Hidden)
-                {
-                    notification.IsInToastTray = true;
-                    toastTray.Post(notification);
-                }
-                else
-                    addPermanently(notification);
-
-                updateCounts();
-            });
-        }
+            updateCounts();
+        });
 
         private void addPermanently(Notification notification)
         {

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -172,35 +172,39 @@ namespace osu.Game.Overlays
 
         private double? lastSamplePlayback;
 
-        public void Post(Notification notification) => (notification.IsCritical ? criticalPostScheduler : postScheduler).Add(() =>
+        public void Post(Notification notification)
         {
-            ++runningDepth;
-
-            Logger.Log($"⚠️ {notification.Text}");
-
-            notification.Closed += () => notificationClosed(notification);
-
+            // Completion target set early to ensure that if something else decides to redirect before the schedule below occurs, it's still respected.
             if (notification is IHasCompletionTarget hasCompletionTarget)
                 hasCompletionTarget.CompletionTarget ??= Post;
 
-            playDebouncedSample(notification.PopInSampleName);
-
-            if (notification.IsImportant)
+            (notification.IsCritical ? criticalPostScheduler : postScheduler).Add(() =>
             {
-                game?.Window?.Flash();
-                notification.Closed += () => game?.Window?.CancelFlash();
-            }
+                ++runningDepth;
 
-            if (State.Value == Visibility.Hidden)
-            {
-                notification.IsInToastTray = true;
-                toastTray.Post(notification);
-            }
-            else
-                addPermanently(notification);
+                Logger.Log($"⚠️ {notification.Text}");
 
-            updateCounts();
-        });
+                notification.Closed += () => notificationClosed(notification);
+
+                playDebouncedSample(notification.PopInSampleName);
+
+                if (notification.IsImportant)
+                {
+                    game?.Window?.Flash();
+                    notification.Closed += () => game?.Window?.CancelFlash();
+                }
+
+                if (State.Value == Visibility.Hidden)
+                {
+                    notification.IsInToastTray = true;
+                    toastTray.Post(notification);
+                }
+                else
+                    addPermanently(notification);
+
+                updateCounts();
+            });
+        }
 
         private void addPermanently(Notification notification)
         {

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -38,6 +38,9 @@ namespace osu.Game.Overlays.Notifications
 
         /// <summary>
         /// The function to post completion notifications back to.
+        ///
+        /// If not set, it will be assumed by <see cref="NotificationOverlay"/> when posting.
+        /// If set, it will override <see cref="NotificationOverlay"/>'s handling.
         /// </summary>
         public Action<Notification>? CompletionTarget { get; set; }
 
@@ -255,7 +258,7 @@ namespace osu.Game.Overlays.Notifications
         public void CompleteSilently()
         {
             // This sequence allows the notification to be immediately dismissed without posting a continuation message.
-            CompletionTarget = null;
+            CompletionTarget = _ => { };
             State = ProgressNotificationState.Completed;
             Close(false);
         }

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -252,6 +252,14 @@ namespace osu.Game.Overlays.Notifications
             cancelSample = audioManager.Samples.Get(@"UI/notification-cancel");
         }
 
+        public void CompleteSilently()
+        {
+            // This sequence allows the notification to be immediately dismissed without posting a continuation message.
+            CompletionTarget = null;
+            State = ProgressNotificationState.Completed;
+            Close(false);
+        }
+
         public override void Close(bool runFlingAnimation)
         {
             switch (State)

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -127,10 +127,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
             }
             finally
             {
-                // This sequence allows the notification to be immediately dismissed without posting a continuation message.
-                checkingNotification.CompletionTarget = null;
-                checkingNotification.State = ProgressNotificationState.Completed;
-                checkingNotification.Close(false);
+                checkingNotification.CompleteSilently();
                 checkForUpdatesButton.Enabled.Value = true;
             }
         }


### PR DESCRIPTION
This was used in one place, but I foresee this being a more common scenario. This also fixes an edge case where the dismiss process would fail if completion happened on an async thread before the `NotificationOverlay`'s scheduler could handle the initial ingress.