### PR TITLE
Add additional information to the matchmaking queue screen

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingQueueScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingQueueScreen.cs
@@ -1,17 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Testing;
-using osu.Framework.Utils;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Intro;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
 using osu.Game.Tests.Visual.Multiplayer;
-using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
@@ -28,23 +29,33 @@ namespace osu.Game.Tests.Visual.Matchmaking
             base.SetUpSteps();
 
             AddStep("load screen", () => LoadScreen(new ScreenIntro(MatchmakingPoolType.QuickPlay)));
+            AddUntilStep("wait for queue screen", () => queueScreen?.IsLoaded == true);
+
+            AddStep("send status update", () =>
+            {
+                int userId1 = Random.Shared.Next(1, 11);
+                int userId2 = Random.Shared.GetItems(Enumerable.Range(1, 10).Except([userId1]).ToArray(), 1).Single();
+
+                MultiplayerClient.MatchmakingLobbyStatusChanged(new MatchmakingLobbyStatus
+                {
+                    UsersInQueue = Enumerable.Range(1, 10).ToArray(),
+                    RatingDistribution = Enumerable.Range(0, 24).Select(i => (400 + i * 100, (int)Math.Round(generateCount(400 + i * 100, 1600, 400, 7200)))).ToArray(),
+                    UserRating = Random.Shared.Next(400, 2800),
+                    RecentMatches = Enumerable.Range(1, 10).Select(_ => (MatchRoomState)new RankedPlayRoomState
+                    {
+                        Users =
+                        {
+                            { userId1, new RankedPlayUserInfo { Rating = 0, Life = Random.Shared.Next(0, 1_000_001), RoundsWon = Random.Shared.Next(0, 4) } },
+                            { userId2, new RankedPlayUserInfo { Rating = 0, Life = Random.Shared.Next(0, 1_000_001), RoundsWon = Random.Shared.Next(0, 4) } },
+                        }
+                    }).ToArray()
+                }).WaitSafely();
+            });
         }
 
         [Test]
         public void TestBasic()
         {
-            AddUntilStep("wait for queue screen", () => queueScreen?.IsLoaded == true);
-
-            AddStep("set users", () =>
-            {
-                queueScreen!.Users = Enumerable.Range(0, 10).Select(_ => new APIUser
-                {
-                    Username = "peppy",
-                    Statistics = new UserStatistics { GlobalRank = 1234 },
-                    Id = RNG.Next(2, 30000000),
-                }).ToArray();
-            });
-
             AddStep("change state to idle", () => queueScreen!.SetState(ScreenQueue.MatchmakingScreenState.Idle));
 
             AddStep("change state to queueing", () => queueScreen!.SetState(ScreenQueue.MatchmakingScreenState.Queueing));
@@ -54,6 +65,11 @@ namespace osu.Game.Tests.Visual.Matchmaking
             AddStep("change state to waiting for room", () => queueScreen!.SetState(ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom));
 
             AddStep("change state to in room", () => queueScreen!.SetState(ScreenQueue.MatchmakingScreenState.InRoom));
+        }
+
+        private static double generateCount(double x, double mean, double stdDev, double amplitude)
+        {
+            return amplitude * Math.Exp(-Math.Pow(x - mean, 2) / (2 * Math.Pow(stdDev, 2))) + Random.Shared.Next(300);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingQueueScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingQueueScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Testing;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Intro;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
 using osu.Game.Tests.Visual.Multiplayer;
@@ -27,6 +28,9 @@ namespace osu.Game.Tests.Visual.Matchmaking
         public override void SetUpSteps()
         {
             base.SetUpSteps();
+
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.Matchmaking)));
+            WaitForJoined();
 
             AddStep("load screen", () => LoadScreen(new ScreenIntro(MatchmakingPoolType.QuickPlay)));
             AddUntilStep("wait for queue screen", () => queueScreen?.IsLoaded == true);

--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneRatingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneRatingDistributionGraph.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Matchmaking
+{
+    public partial class TestSceneRatingDistributionGraph : OsuTestScene
+    {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
+
+        private RatingDistributionGraph graph = null!;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Child = graph = new RatingDistributionGraph
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Size = new Vector2(0.5f, 0.25f)
+            };
+        });
+
+        [Test]
+        public void TestRandomData()
+        {
+            AddStep("set random data", () =>
+            {
+                List<(int x, int y)> values = new List<(int x, int y)>();
+                for (int i = 400; i <= 2800; i += 100)
+                    values.Add((i, (int)Math.Round(generateCount(i, 1600, 400, 7200))));
+                graph.SetData(values.ToArray(), Random.Shared.Next(400, 2800));
+            });
+        }
+
+        [Test]
+        public void TestNoUserRating()
+        {
+            AddStep("set data", () =>
+            {
+                List<(int x, int y)> values = new List<(int x, int y)>();
+                for (int i = 400; i <= 2800; i += 100)
+                    values.Add((i, (int)Math.Round(generateCount(i, 1600, 400, 7200))));
+                graph.SetData(values.ToArray(), null);
+            });
+        }
+
+        [Test]
+        public void TestNoData()
+        {
+            AddStep("set empty data", () => graph.SetData([], null));
+        }
+
+        private static double generateCount(double x, double mean, double stdDev, double amplitude)
+        {
+            return amplitude * Math.Exp(-Math.Pow(x - mean, 2) / (2 * Math.Pow(stdDev, 2))) + Random.Shared.Next(300);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayMatchPanel.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayMatchPanel.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
+using osu.Game.Tests.Visual.Multiplayer;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    public partial class TestSceneRankedPlayMatchPanel : MultiplayerTestScene
+    {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
+
+        [Test]
+        public void TestLeftWin()
+        {
+            AddStep("add panel", () => Child = new RankedPlayMatchPanel(new RankedPlayRoomState
+            {
+                Users =
+                {
+                    { 1, new RankedPlayUserInfo { Rating = 0, Life = 800_000, RoundsWon = 3 } },
+                    { 2, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 1 } }
+                }
+            })
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            });
+        }
+
+        [Test]
+        public void TestRightWin()
+        {
+            AddStep("add panel", () => Child = new RankedPlayMatchPanel(new RankedPlayRoomState
+            {
+                Users =
+                {
+                    { 1, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 3 } },
+                    { 2, new RankedPlayUserInfo { Rating = 0, Life = 800_000, RoundsWon = 1 } }
+                }
+            })
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            });
+        }
+
+        [Test]
+        public void TestDraw()
+        {
+            AddStep("add panel", () => Child = new RankedPlayMatchPanel(new RankedPlayRoomState
+            {
+                Users =
+                {
+                    { 1, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 3 } },
+                    { 2, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 1 } }
+                }
+            })
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
@@ -19,7 +19,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Overlays;
-using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Users;
 using osu.Game.Users.Drawables;
 using osuTK;
@@ -49,16 +48,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         {
             this.state = state;
 
-            Width = 300;
+            Width = 280;
             AutoSizeAxes = Axes.Y;
-
-            Masking = true;
-            CornerRadius = 10;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
+            Masking = true;
+            CornerRadius = 10;
+            BorderThickness = 3;
+            BorderColour = colours.YellowDarker;
+
             (int UserId, RankedPlayUserInfo Info)[] users = state.Users.Select(kvp => (kvp.Key, kvp.Value)).ToArray();
             Task<APIUser?> leftUser = userLookupCache.GetUserAsync(users[0].UserId);
             Task<APIUser?> rightUser = userLookupCache.GetUserAsync(users[1].UserId);
@@ -77,40 +78,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        new Container
-                        {
-                            Name = "Top part",
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = colourProvider.Background4
-                                },
-                                new PillContainer
-                                {
-                                    Margin = new MarginPadding(5),
-                                    Background =
-                                    {
-                                        Colour = colours.YellowDarker,
-                                        Alpha = 1
-                                    },
-                                    Child = new OsuSpriteText
-                                    {
-                                        Text = "Completed",
-                                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
-                                        Colour = Color4.Black
-                                    }
-                                }
-                            }
-                        },
-                        new Container
+                        new BufferedContainer
                         {
                             Name = "Middle part",
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
+                            BackgroundColour = colourProvider.Background3.Opacity(0),
                             Children = new[]
                             {
                                 new Container
@@ -118,7 +91,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                     RelativeSizeAxes = Axes.Both,
                                     Height = 0.5f,
                                     Masking = true,
-                                    Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0.3f), colourProvider.Background3.Opacity(0)),
+                                    Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0.7f), colourProvider.Background3.Opacity(0)),
                                     Child = new UserCoverBackground
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -132,7 +105,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                     RelativeSizeAxes = Axes.Both,
                                     Height = 0.5f,
                                     Masking = true,
-                                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background3.Opacity(0), Color4.White.Opacity(0.3f)),
+                                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background3.Opacity(0), Color4.White.Opacity(0.7f)),
                                     Child = new UserCoverBackground
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -338,6 +311,35 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                                     }
                                                 },
                                             }
+                                        }
+                                    }
+                                },
+                                new BufferedContainer(cachedFrameBuffer: true)
+                                {
+                                    Name = "Status pill",
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    AutoSizeAxes = Axes.Both,
+                                    Masking = true,
+                                    CornerRadius = 10,
+                                    Padding = new MarginPadding { Left = 10, Bottom = 10 },
+                                    Margin = new MarginPadding { Left = -10, Bottom = -10 },
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = colours.YellowDarker
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Margin = new MarginPadding { Horizontal = 8, Vertical = 5 },
+                                            Colour = colourProvider.Background4,
+                                            Text = "Completed",
+                                            Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
+                                            UseFullGlyphHeight = false,
                                         }
                                     }
                                 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
@@ -1,0 +1,382 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.Lounge.Components;
+using osu.Game.Users;
+using osu.Game.Users.Drawables;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
+{
+    public partial class RankedPlayMatchPanel : CompositeDrawable
+    {
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved]
+        private UserLookupCache userLookupCache { get; set; } = null!;
+
+        private readonly RankedPlayRoomState state;
+
+        private Drawable leftResultLight = null!;
+        private Drawable rightResultLight = null!;
+        private OsuSpriteText leftLifeText = null!;
+        private OsuSpriteText rightLifeText = null!;
+
+        public RankedPlayMatchPanel(RankedPlayRoomState state)
+        {
+            this.state = state;
+
+            Width = 300;
+            AutoSizeAxes = Axes.Y;
+
+            Masking = true;
+            CornerRadius = 10;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            (int UserId, RankedPlayUserInfo Info)[] users = state.Users.Select(kvp => (kvp.Key, kvp.Value)).ToArray();
+            Task<APIUser?> leftUser = userLookupCache.GetUserAsync(users[0].UserId);
+            Task<APIUser?> rightUser = userLookupCache.GetUserAsync(users[1].UserId);
+            Task.WhenAll(leftUser, rightUser).WaitSafely();
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background3
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            Name = "Top part",
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = colourProvider.Background4
+                                },
+                                new PillContainer
+                                {
+                                    Margin = new MarginPadding(5),
+                                    Background =
+                                    {
+                                        Colour = colours.YellowDarker,
+                                        Alpha = 1
+                                    },
+                                    Child = new OsuSpriteText
+                                    {
+                                        Text = "Completed",
+                                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
+                                        Colour = Color4.Black
+                                    }
+                                }
+                            }
+                        },
+                        new Container
+                        {
+                            Name = "Middle part",
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Children = new[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Height = 0.5f,
+                                    Masking = true,
+                                    Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0.3f), colourProvider.Background3.Opacity(0)),
+                                    Child = new UserCoverBackground
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        User = leftUser.GetResultSafely()
+                                    }
+                                },
+                                new Container
+                                {
+                                    Anchor = Anchor.BottomCentre,
+                                    Origin = Anchor.BottomCentre,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Height = 0.5f,
+                                    Masking = true,
+                                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background3.Opacity(0), Color4.White.Opacity(0.3f)),
+                                    Child = new UserCoverBackground
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        User = rightUser.GetResultSafely()
+                                    }
+                                },
+                                leftResultLight = new Container
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    RelativeSizeAxes = Axes.X,
+                                    Size = new Vector2(0.4f, 3),
+                                    Child = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = ColourInfo.GradientHorizontal(Color4.White, Color4.White.Opacity(0))
+                                    }
+                                },
+                                rightResultLight = new Container
+                                {
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    RelativeSizeAxes = Axes.X,
+                                    Size = new Vector2(0.4f, 3),
+                                    Child = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0), Color4.White)
+                                    },
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Text = "vs",
+                                    Font = OsuFont.GetFont(size: 50, weight: FontWeight.Bold),
+                                    UseFullGlyphHeight = false,
+                                    Colour = colourProvider.Foreground1,
+                                },
+                                new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Vertical,
+                                    Children = new Drawable[]
+                                    {
+                                        new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Horizontal,
+                                            Padding = new MarginPadding(5),
+                                            Spacing = new Vector2(5),
+                                            Children = new Drawable[]
+                                            {
+                                                new CircularContainer
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Size = new Vector2(25),
+                                                    Masking = true,
+                                                    Child = new UpdateableAvatar(leftUser.GetResultSafely())
+                                                    {
+                                                        RelativeSizeAxes = Axes.Both
+                                                    }
+                                                },
+                                                new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Text = leftUser.GetResultSafely()?.Username ?? "Unknown",
+                                                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
+                                                    UseFullGlyphHeight = false,
+                                                },
+                                            }
+                                        },
+                                        new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Horizontal,
+                                            Padding = new MarginPadding(5),
+                                            Spacing = new Vector2(5),
+                                            Children = new Drawable[]
+                                            {
+                                                new CircularContainer
+                                                {
+                                                    Anchor = Anchor.CentreRight,
+                                                    Origin = Anchor.CentreRight,
+                                                    Size = new Vector2(25),
+                                                    Masking = true,
+                                                    Child = new UpdateableAvatar(rightUser.GetResultSafely())
+                                                    {
+                                                        RelativeSizeAxes = Axes.Both
+                                                    }
+                                                },
+                                                new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.CentreRight,
+                                                    Origin = Anchor.CentreRight,
+                                                    Text = rightUser.GetResultSafely()?.Username ?? "Unknown",
+                                                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
+                                                    UseFullGlyphHeight = false,
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Container
+                        {
+                            Name = "Bottom part",
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = colourProvider.Background4
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Padding = new MarginPadding(5),
+                                    Child = new FillFlowContainer
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Direction = FillDirection.Vertical,
+                                        Spacing = new Vector2(5),
+                                        Children = new Drawable[]
+                                        {
+                                            new Container
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Children = new Drawable[]
+                                                {
+                                                    new IconWithTooltip
+                                                    {
+                                                        Anchor = Anchor.Centre,
+                                                        Origin = Anchor.Centre,
+                                                        Size = new Vector2(12),
+                                                        Icon = FontAwesome.Solid.Heart,
+                                                        Colour = Color4.Red,
+                                                        TooltipText = "Remaining Life"
+                                                    },
+                                                    leftLifeText = new OsuSpriteText
+                                                    {
+                                                        Anchor = Anchor.Centre,
+                                                        Origin = Anchor.CentreRight,
+                                                        X = -20,
+                                                        Colour = colourProvider.Foreground1,
+                                                        Text = users[0].Info.Life.ToString("N0"),
+                                                        UseFullGlyphHeight = false,
+                                                    },
+                                                    rightLifeText = new OsuSpriteText
+                                                    {
+                                                        Anchor = Anchor.Centre,
+                                                        Origin = Anchor.CentreLeft,
+                                                        X = 20,
+                                                        Colour = colourProvider.Foreground1,
+                                                        Text = users[1].Info.Life.ToString("N0"),
+                                                        UseFullGlyphHeight = false,
+                                                    }
+                                                },
+                                            },
+                                            new Container
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Children = new Drawable[]
+                                                {
+                                                    new IconWithTooltip
+                                                    {
+                                                        Anchor = Anchor.Centre,
+                                                        Origin = Anchor.Centre,
+                                                        Size = new Vector2(10),
+                                                        Colour = colourProvider.Foreground1,
+                                                        Icon = FontAwesome.Solid.Skull,
+                                                        TooltipText = "Rounds Won",
+                                                    },
+                                                    new OsuSpriteText
+                                                    {
+                                                        Anchor = Anchor.Centre,
+                                                        Origin = Anchor.CentreRight,
+                                                        X = -20,
+                                                        Colour = colourProvider.Foreground1,
+                                                        Text = users[0].Info.RoundsWon.ToString(),
+                                                        UseFullGlyphHeight = false,
+                                                    },
+                                                    new OsuSpriteText
+                                                    {
+                                                        Anchor = Anchor.Centre,
+                                                        Origin = Anchor.CentreLeft,
+                                                        X = 20,
+                                                        Colour = colourProvider.Foreground1,
+                                                        Text = users[1].Info.RoundsWon.ToString(),
+                                                        UseFullGlyphHeight = false,
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            bool leftWin = users[0].Info.Life > users[1].Info.Life;
+            bool rightWin = users[1].Info.Life > users[0].Info.Life;
+            bool isDraw = users[0].Info.Life == users[1].Info.Life;
+
+            if (isDraw)
+            {
+                leftResultLight.Colour = colours.Yellow;
+                rightResultLight.Colour = colours.Yellow;
+            }
+            else if (leftWin)
+            {
+                leftResultLight.Colour = colours.Green;
+                rightResultLight.Colour = colours.Red;
+
+                leftLifeText.Colour = Color4.White;
+                leftLifeText.Font = OsuFont.GetFont(weight: FontWeight.SemiBold);
+            }
+            else if (rightWin)
+            {
+                leftResultLight.Colour = colours.Red;
+                rightResultLight.Colour = colours.Green;
+
+                rightLifeText.Colour = Color4.White;
+                rightLifeText.Font = OsuFont.GetFont(weight: FontWeight.SemiBold);
+            }
+        }
+
+        private partial class IconWithTooltip : SpriteIcon, IHasTooltip
+        {
+            public LocalisableString TooltipText { get; set; }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background3
+                    Colour = colourProvider.Background4
                 },
                 new FillFlowContainer
                 {
@@ -83,7 +83,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                             Name = "Middle part",
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            BackgroundColour = colourProvider.Background3.Opacity(0),
+                            BackgroundColour = colourProvider.Background4.Opacity(0),
                             Children = new[]
                             {
                                 new Container
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                     RelativeSizeAxes = Axes.Both,
                                     Height = 0.5f,
                                     Masking = true,
-                                    Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0.7f), colourProvider.Background3.Opacity(0)),
+                                    Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0.7f), colourProvider.Background4.Opacity(0)),
                                     Child = new UserCoverBackground
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                     RelativeSizeAxes = Axes.Both,
                                     Height = 0.5f,
                                     Masking = true,
-                                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background3.Opacity(0), Color4.White.Opacity(0.7f)),
+                                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background4.Opacity(0), Color4.White.Opacity(0.7f)),
                                     Child = new UserCoverBackground
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -226,7 +226,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                 new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = colourProvider.Background4
+                                    Colour = colourProvider.Background5
                                 },
                                 new Container
                                 {
@@ -336,7 +336,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                             Anchor = Anchor.Centre,
                                             Origin = Anchor.Centre,
                                             Margin = new MarginPadding { Horizontal = 8, Vertical = 5 },
-                                            Colour = colourProvider.Background4,
+                                            Colour = colourProvider.Background5,
                                             Text = "Completed",
                                             Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
                                             UseFullGlyphHeight = false,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
@@ -315,7 +315,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                                         Origin = Anchor.Centre,
                                                         Size = new Vector2(10),
                                                         Colour = colourProvider.Foreground1,
-                                                        Icon = FontAwesome.Solid.Skull,
+                                                        Icon = FontAwesome.Solid.Trophy,
                                                         TooltipText = "Rounds Won",
                                                     },
                                                     new OsuSpriteText

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
@@ -150,7 +150,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                                     },
                                                 }
                                             },
-
                                             hoverMarker = new CircularContainer
                                             {
                                                 Origin = Anchor.Centre,
@@ -189,10 +188,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     {
                         xAxisContainer = new Container
                         {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
                             AutoSizeAxes = Axes.Y,
-                            Margin = new MarginPadding { Top = 5 }
+                            Margin = new MarginPadding { Top = 8 }
                         }
                     },
                     new Drawable[]
@@ -201,6 +198,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                         {
                             Anchor = Anchor.BottomCentre,
                             Origin = Anchor.BottomCentre,
+                            Margin = new MarginPadding { Top = 2 },
                             Text = "Rating",
                             Font = OsuFont.Default.With(size: 12),
                             Colour = colourProvider.Foreground1
@@ -249,6 +247,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         protected override void Update()
         {
             base.Update();
+
+            xAxisContainer.X = xAxisContainer.Parent!.ToLocalSpace(chartContainer.ScreenSpaceDrawQuad.TopLeft).X;
             xAxisContainer.Width = chartContainer.DrawWidth;
         }
 
@@ -277,6 +277,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     Origin = Anchor.CentreRight,
                     RelativePositionAxes = Axes.X,
                     X = (float)step / x_divisions,
+                    Margin = new MarginPadding { Right = -2 },
                     Rotation = -40,
                     Text = (xRange.min + (xRange.max - xRange.min) / x_divisions * step).ToString(),
                     UseFullGlyphHeight = false,
@@ -297,10 +298,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
                 yAxisLeftContainer.Add(new OsuSpriteText
                 {
-                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.CentreRight,
                     RelativePositionAxes = Axes.Y,
-                    Y = (float)step / y_divisions,
-                    Text = (yRange.max - (yRange.max - yRange.min) / y_divisions * step).ToString(),
+                    Y = 1f - (float)step / y_divisions,
+                    Text = (yRange.min + (yRange.max - yRange.min) / y_divisions * step).ToString(),
                     UseFullGlyphHeight = false,
                     Font = OsuFont.Default.With(size: 12),
                     Colour = colourProvider.Foreground1
@@ -310,8 +312,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 {
                     Origin = Anchor.CentreLeft,
                     RelativePositionAxes = Axes.Y,
-                    Y = (float)step / y_divisions,
-                    Text = $"{1.0 - (float)step / y_divisions:P1}",
+                    Y = 1f - (float)step / y_divisions,
+                    Text = $"{(float)step / y_divisions:P1}",
                     UseFullGlyphHeight = false,
                     Font = OsuFont.Default.With(size: 12),
                     Colour = colourProvider.Foreground1

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private (int x, int y)[] data = [];
         private int? userRating;
-        private (int min, int max) xRange;
+        private (int min, int max, int step) xRange;
         private (int min, int max) yRange;
 
         [BackgroundDependencyLoader]
@@ -232,8 +232,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             this.data = data;
             this.userRating = userRating;
 
-            xRange = (data.Select(d => d.x).DefaultIfEmpty().Min(), data.Select(d => d.x).DefaultIfEmpty().Max());
-            yRange = (0, (int)roundToSignificant(data.Select(d => d.y).DefaultIfEmpty().Max()));
+            xRange = (
+                data.Select(d => d.x).DefaultIfEmpty().Min(),
+                data.Select(d => d.x).DefaultIfEmpty().Max(),
+                data.Zip(data.Skip(1), (a, b) => Math.Abs(b.x - a.x)).DefaultIfEmpty().Min()
+            );
+
+            yRange = (
+                0,
+                (int)roundToSignificant(data.Select(d => d.y).DefaultIfEmpty().Max())
+            );
 
             updateGraph();
         }
@@ -320,7 +328,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     RelativeSizeAxes = Axes.Both,
                     X = pointOnGraph(point.x, point.y).X,
                     Height = 1 - pointOnGraph(point.x, point.y).Y,
-                    Width = 0.5f / x_divisions,
+                    Width = pointOnGraph(xRange.min + xRange.step, 0).X,
                     Colour = colourProvider.Colour0,
                     Masking = true,
                     CornerRadius = 2,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 {
     public partial class RatingDistributionGraph : CompositeDrawable, IHasCustomTooltip<RatingDistributionGraph.RatingDistributionGraphTooltipData>
     {
-        private const int y_divisions = 8;
+        private const int y_divisions = 4;
         private const int x_divisions = 16;
 
         [Resolved]
@@ -212,7 +212,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                             Origin = Anchor.Centre,
                             AutoSizeAxes = Axes.X,
                             Height = 16,
-                            Padding = new MarginPadding { Top = 5 }
+                            Margin = new MarginPadding { Top = 4 }
                         },
                     }
                 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
@@ -36,9 +36,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private Container xAxisContainer = null!;
         private Container chartContainer = null!;
 
-        private Container grid = null!;
+        private Container gridContainer = null!;
+        private Container barsContainer = null!;
+        private Container userRatingContainer = null!;
         private PointPath cumulativePath = null!;
-        private PointPath distributionPath = null!;
+
         private Drawable hoverMarker = null!;
         private Drawable hoverMarkerFill = null!;
         private OsuTextFlowContainer descriptionText = null!;
@@ -110,7 +112,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                         RelativeSizeAxes = Axes.Both,
                                         Children = new[]
                                         {
-                                            grid = new Container
+                                            gridContainer = new Container
+                                            {
+                                                RelativeSizeAxes = Axes.Both
+                                            },
+                                            barsContainer = new Container
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Masking = true
+                                            },
+                                            userRatingContainer = new Container
                                             {
                                                 RelativeSizeAxes = Axes.Both
                                             },
@@ -122,7 +133,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                                 Padding = new MarginPadding { Right = -2 },
                                                 Children = new Drawable[]
                                                 {
-                                                    distributionPath = new PointPath
+                                                    new PointPath
                                                     {
                                                         AutoSizeAxes = Axes.None,
                                                         RelativeSizeAxes = Axes.Both,
@@ -238,11 +249,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             xAxisContainer.Clear();
             yAxisLeftContainer.Clear();
             yAxisRightContainer.Clear();
-            grid.Clear();
+            gridContainer.Clear();
+            barsContainer.Clear();
+            userRatingContainer.Clear();
 
             for (int step = 0; step <= x_divisions; step++)
             {
-                grid.Add(new VerticalLine
+                gridContainer.Add(new VerticalLine
                 {
                     RelativeSizeAxes = Axes.Y,
                     RelativePositionAxes = Axes.X,
@@ -266,7 +279,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             for (int step = 0; step <= y_divisions; step++)
             {
-                grid.Add(new HorizontalLine
+                gridContainer.Add(new HorizontalLine
                 {
                     RelativeSizeAxes = Axes.X,
                     RelativePositionAxes = Axes.Y,
@@ -297,26 +310,35 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 });
             }
 
+            foreach (var point in data)
+            {
+                barsContainer.Add(new Container
+                {
+                    Origin = Anchor.BottomCentre,
+                    Anchor = Anchor.BottomLeft,
+                    RelativePositionAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Both,
+                    X = pointOnGraph(point.x, point.y).X,
+                    Height = 1 - pointOnGraph(point.x, point.y).Y,
+                    Width = 0.5f / x_divisions,
+                    Colour = colourProvider.Colour0,
+                    Masking = true,
+                    CornerRadius = 2,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    }
+                });
+            }
+
             if (userRating != null)
             {
-                grid.Add(new UserRatingLine(userRating.Value)
+                userRatingContainer.Add(new UserRatingLine(userRating.Value)
                 {
                     RelativeSizeAxes = Axes.Y,
                     RelativePositionAxes = Axes.X,
                     X = pointOnGraph(userRating.Value, 0).X,
                     Colour = colours.Green
-                });
-            }
-
-            foreach (var point in data)
-            {
-                grid.Add(new Circle
-                {
-                    Origin = Anchor.Centre,
-                    RelativePositionAxes = Axes.Both,
-                    Position = pointOnGraph(point.x, point.y),
-                    Size = new Vector2(8),
-                    Colour = colourProvider.Colour0
                 });
             }
 
@@ -339,8 +361,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 });
                 descriptionText.AddText(" of players.");
             }
-
-            distributionPath.Points = data.Select(d => pointOnGraph(d.x, d.y)).ToArray();
 
             int currentCount = 0;
             int totalCount = data.Sum(d => d.y);
@@ -389,7 +409,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         {
             var content = TooltipContent;
 
-            hoverMarker.Position = grid.ToLocalSpace(content.Position);
+            hoverMarker.Position = gridContainer.ToLocalSpace(content.Position);
             hoverMarkerFill.Colour = content.Colour;
 
             return true;
@@ -411,8 +431,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
                 if (userRating != null)
                 {
-                    Vector2 userRatingPos1 = grid.ToScreenSpace(pointOnGraph(userRating.Value, 0) * grid.DrawSize);
-                    Vector2 userRatingPos2 = grid.ToScreenSpace(pointOnGraph(userRating.Value, yRange.max) * grid.DrawSize);
+                    Vector2 userRatingPos1 = userRatingContainer.ToScreenSpace(pointOnGraph(userRating.Value, 0) * userRatingContainer.DrawSize);
+                    Vector2 userRatingPos2 = userRatingContainer.ToScreenSpace(pointOnGraph(userRating.Value, yRange.max) * userRatingContainer.DrawSize);
 
                     minDistToCursor = Vector2.Distance(mousePos, userRatingPos1);
                     closestPointToCursor = userRatingPos1;
@@ -429,9 +449,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     }
                 }
 
-                for (int i = 0; i < distributionPath.Vertices.Count; i++)
+                for (int i = 0; i < data.Length; i++)
                 {
-                    Vector2 pos = distributionPath.ToScreenSpace(distributionPath.Vertices[i] + new Vector2(2, 0));
+                    Vector2 pos = barsContainer.ToScreenSpace(pointOnGraph(data[i].x, data[i].y) * barsContainer.DrawSize);
                     float d = Vector2.Distance(mousePos, pos);
 
                     if (d < minDistToCursor)
@@ -451,7 +471,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 {
                     currentCount += data[i].y;
 
-                    Vector2 pos = distributionPath.ToScreenSpace(cumulativePath.Vertices[i] + new Vector2(2));
+                    Vector2 pos = cumulativePath.ToScreenSpace(cumulativePath.Vertices[i] + new Vector2(2));
                     float d = Vector2.Distance(mousePos, pos);
 
                     if (d < minDistToCursor)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
@@ -1,0 +1,698 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Lines;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Layout;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
+{
+    public partial class RatingDistributionGraph : CompositeDrawable, IHasCustomTooltip<RatingDistributionGraph.RatingDistributionGraphTooltipData>
+    {
+        private const int y_divisions = 8;
+        private const int x_divisions = 16;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        private Container yAxisLeftContainer = null!;
+        private Container yAxisRightContainer = null!;
+        private Container xAxisContainer = null!;
+        private Container chartContainer = null!;
+
+        private Container grid = null!;
+        private PointPath cumulativePath = null!;
+        private PointPath distributionPath = null!;
+        private Drawable hoverMarker = null!;
+        private Drawable hoverMarkerFill = null!;
+        private OsuTextFlowContainer descriptionText = null!;
+
+        private (int x, int y)[] data = [];
+        private int? userRating;
+        private (int min, int max) xRange;
+        private (int min, int max) yRange;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Padding = new MarginPadding { Top = 20 },
+                RowDimensions =
+                [
+                    // Chart
+                    new Dimension(),
+                    // x-axis
+                    new Dimension(GridSizeMode.AutoSize),
+                    // "Rating"
+                    new Dimension(GridSizeMode.AutoSize),
+                    // Description text
+                    new Dimension(GridSizeMode.AutoSize)
+                ],
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            ColumnDimensions = new[]
+                            {
+                                // "Players"
+                                new Dimension(GridSizeMode.AutoSize),
+                                // Left y-axis
+                                new Dimension(GridSizeMode.AutoSize),
+                                // Chart
+                                new Dimension(),
+                                // Right y-axis
+                                new Dimension(GridSizeMode.AutoSize),
+                                // "Cumulative"
+                                new Dimension(GridSizeMode.AutoSize),
+                            },
+                            Content = new[]
+                            {
+                                new Drawable[]
+                                {
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.TopCentre,
+                                        Text = "Players",
+                                        Font = OsuFont.Default.With(size: 12),
+                                        Rotation = -90,
+                                        Colour = colourProvider.Foreground1
+                                    },
+                                    yAxisLeftContainer = new Container
+                                    {
+                                        RelativeSizeAxes = Axes.Y,
+                                        AutoSizeAxes = Axes.X,
+                                        Margin = new MarginPadding { Left = 5, Right = 5 },
+                                    },
+                                    chartContainer = new Container
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Children = new[]
+                                        {
+                                            grid = new Container
+                                            {
+                                                RelativeSizeAxes = Axes.Both
+                                            },
+                                            new Container
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                // Margin and padding to better align the paths.
+                                                Margin = new MarginPadding { Left = -2 },
+                                                Padding = new MarginPadding { Right = -2 },
+                                                Children = new Drawable[]
+                                                {
+                                                    distributionPath = new PointPath
+                                                    {
+                                                        AutoSizeAxes = Axes.None,
+                                                        RelativeSizeAxes = Axes.Both,
+                                                        PathRadius = 2,
+                                                        Colour = colourProvider.Colour0,
+                                                    },
+                                                    cumulativePath = new PointPath
+                                                    {
+                                                        AutoSizeAxes = Axes.None,
+                                                        RelativeSizeAxes = Axes.Both,
+                                                        PathRadius = 2,
+                                                        Colour = colours.Yellow,
+                                                        Offset = new Vector2(0, -3)
+                                                    },
+                                                }
+                                            },
+
+                                            hoverMarker = new CircularContainer
+                                            {
+                                                Origin = Anchor.Centre,
+                                                Size = new Vector2(12),
+                                                Masking = true,
+                                                BorderThickness = 2,
+                                                BorderColour = Color4.White,
+                                                Alpha = 0,
+                                                Child = hoverMarkerFill = new Box
+                                                {
+                                                    RelativeSizeAxes = Axes.Both
+                                                }
+                                            }
+                                        }
+                                    },
+                                    yAxisRightContainer = new Container
+                                    {
+                                        RelativeSizeAxes = Axes.Y,
+                                        AutoSizeAxes = Axes.X,
+                                        Margin = new MarginPadding { Left = 5 },
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.CentreRight,
+                                        Origin = Anchor.TopCentre,
+                                        Text = "Cumulative",
+                                        Font = OsuFont.Default.With(size: 12),
+                                        Rotation = 90,
+                                        Colour = colourProvider.Foreground1
+                                    },
+                                }
+                            }
+                        }
+                    },
+                    new Drawable[]
+                    {
+                        xAxisContainer = new Container
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            AutoSizeAxes = Axes.Y,
+                            Margin = new MarginPadding { Top = 5 }
+                        }
+                    },
+                    new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            Text = "Rating",
+                            Font = OsuFont.Default.With(size: 12),
+                            Colour = colourProvider.Foreground1
+                        },
+                    },
+                    new Drawable[]
+                    {
+                        descriptionText = new OsuTextFlowContainer
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            AutoSizeAxes = Axes.X,
+                            Height = 16,
+                            Padding = new MarginPadding { Top = 5 }
+                        },
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateGraph();
+        }
+
+        public void SetData((int x, int y)[] data, int? userRating)
+        {
+            this.data = data;
+            this.userRating = userRating;
+
+            xRange = (data.Select(d => d.x).DefaultIfEmpty().Min(), data.Select(d => d.x).DefaultIfEmpty().Max());
+            yRange = (0, (int)roundToSignificant(data.Select(d => d.y).DefaultIfEmpty().Max()));
+
+            updateGraph();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            xAxisContainer.Width = chartContainer.DrawWidth;
+        }
+
+        private void updateGraph() => Scheduler.AddOnce(() =>
+        {
+            xAxisContainer.Clear();
+            yAxisLeftContainer.Clear();
+            yAxisRightContainer.Clear();
+            grid.Clear();
+
+            for (int step = 0; step <= x_divisions; step++)
+            {
+                grid.Add(new VerticalLine
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    RelativePositionAxes = Axes.X,
+                    X = (float)step / x_divisions,
+                    Colour = colourProvider.Background1
+                });
+
+                xAxisContainer.Add(new OsuSpriteText
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.CentreRight,
+                    RelativePositionAxes = Axes.X,
+                    X = (float)step / x_divisions,
+                    Rotation = -40,
+                    Text = (xRange.min + (xRange.max - xRange.min) / x_divisions * step).ToString(),
+                    UseFullGlyphHeight = false,
+                    Font = OsuFont.Default.With(size: 12),
+                    Colour = colourProvider.Foreground1
+                });
+            }
+
+            for (int step = 0; step <= y_divisions; step++)
+            {
+                grid.Add(new HorizontalLine
+                {
+                    RelativeSizeAxes = Axes.X,
+                    RelativePositionAxes = Axes.Y,
+                    Y = (float)step / y_divisions,
+                    Colour = colourProvider.Background1
+                });
+
+                yAxisLeftContainer.Add(new OsuSpriteText
+                {
+                    Origin = Anchor.CentreLeft,
+                    RelativePositionAxes = Axes.Y,
+                    Y = (float)step / y_divisions,
+                    Text = (yRange.max - (yRange.max - yRange.min) / y_divisions * step).ToString(),
+                    UseFullGlyphHeight = false,
+                    Font = OsuFont.Default.With(size: 12),
+                    Colour = colourProvider.Foreground1
+                });
+
+                yAxisRightContainer.Add(new OsuSpriteText
+                {
+                    Origin = Anchor.CentreLeft,
+                    RelativePositionAxes = Axes.Y,
+                    Y = (float)step / y_divisions,
+                    Text = $"{1.0 - (float)step / y_divisions:P1}",
+                    UseFullGlyphHeight = false,
+                    Font = OsuFont.Default.With(size: 12),
+                    Colour = colourProvider.Foreground1
+                });
+            }
+
+            if (userRating != null)
+            {
+                grid.Add(new UserRatingLine(userRating.Value)
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    RelativePositionAxes = Axes.X,
+                    X = pointOnGraph(userRating.Value, 0).X,
+                    Colour = colours.Green
+                });
+            }
+
+            foreach (var point in data)
+            {
+                grid.Add(new Circle
+                {
+                    Origin = Anchor.Centre,
+                    RelativePositionAxes = Axes.Both,
+                    Position = pointOnGraph(point.x, point.y),
+                    Size = new Vector2(8),
+                    Colour = colourProvider.Colour0
+                });
+            }
+
+            if (data.Length == 0)
+                descriptionText.Text = "No games have been played yet.";
+            else if (userRating == null)
+                descriptionText.Text = "Play more games to get rated!";
+            else
+            {
+                int countPlayersBelow = data.Where(d => d.x < userRating).Sum(d => d.y);
+                int countPlayersAbove = data.Where(d => d.x >= userRating).Sum(d => d.y);
+                float p = (float)countPlayersBelow / (countPlayersBelow + countPlayersAbove);
+
+                descriptionText.Clear();
+                descriptionText.AddText("You are better than ");
+                descriptionText.AddText($"{p:P1}", s =>
+                {
+                    s.Font = OsuFont.GetFont(weight: FontWeight.SemiBold);
+                    s.Colour = colours.Green;
+                });
+                descriptionText.AddText(" of players.");
+            }
+
+            distributionPath.Points = data.Select(d => pointOnGraph(d.x, d.y)).ToArray();
+
+            int currentCount = 0;
+            int totalCount = data.Sum(d => d.y);
+
+            cumulativePath.Points = data.Select(d =>
+            {
+                currentCount += d.y;
+                float p = (float)currentCount / totalCount;
+                return new Vector2(pointOnGraph(d.x, 0).X, 1 - p);
+            }).ToArray();
+        });
+
+        private Vector2 pointOnGraph(int x, int y)
+        {
+            float xPos = ((float)x - xRange.min) / (xRange.max - xRange.min);
+            float yPos = 1 - ((float)y - yRange.min) / (yRange.max - yRange.min);
+            return new Vector2(xPos, yPos);
+        }
+
+        private static double roundToSignificant(double value)
+        {
+            if (value == 0)
+                return 0;
+
+            double scale = Math.Pow(10, Math.Floor(Math.Log10(value)));
+            return Math.Ceiling(value / scale) * scale;
+        }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            return chartContainer.DrawRectangle.Inflate(20).Contains(chartContainer.ToLocalSpace(screenSpacePos));
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            hoverMarker.FadeTo(1f, 200);
+            return true;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            hoverMarker.FadeTo(0f, 200);
+        }
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            var content = TooltipContent;
+
+            hoverMarker.Position = grid.ToLocalSpace(content.Position);
+            hoverMarkerFill.Colour = content.Colour;
+
+            return true;
+        }
+
+        public ITooltip<RatingDistributionGraphTooltipData> GetCustomTooltip() => new RatingDistributionGraphTooltip();
+
+        public RatingDistributionGraphTooltipData TooltipContent
+        {
+            get
+            {
+                Vector2 mousePos = GetContainingInputManager()!.CurrentState.Mouse.Position;
+
+                float minDistToCursor = float.MaxValue;
+                Vector2 closestPointToCursor = Vector2.Zero;
+                Color4 closestColourToCursor = Color4.White;
+                int closestRatingToCursor = 0;
+                string closestValueToCursor = string.Empty;
+
+                if (userRating != null)
+                {
+                    Vector2 userRatingPos1 = grid.ToScreenSpace(pointOnGraph(userRating.Value, 0) * grid.DrawSize);
+                    Vector2 userRatingPos2 = grid.ToScreenSpace(pointOnGraph(userRating.Value, yRange.max) * grid.DrawSize);
+
+                    minDistToCursor = Vector2.Distance(mousePos, userRatingPos1);
+                    closestPointToCursor = userRatingPos1;
+                    closestColourToCursor = colours.Green;
+                    closestRatingToCursor = userRating.Value;
+                    closestValueToCursor = $"Your rating ({userRating})";
+
+                    float d = Vector2.Distance(mousePos, userRatingPos2);
+
+                    if (d < minDistToCursor)
+                    {
+                        minDistToCursor = d;
+                        closestPointToCursor = userRatingPos2;
+                    }
+                }
+
+                for (int i = 0; i < distributionPath.Vertices.Count; i++)
+                {
+                    Vector2 pos = distributionPath.ToScreenSpace(distributionPath.Vertices[i] + new Vector2(2, 0));
+                    float d = Vector2.Distance(mousePos, pos);
+
+                    if (d < minDistToCursor)
+                    {
+                        minDistToCursor = d;
+                        closestPointToCursor = pos;
+                        closestColourToCursor = colourProvider.Colour0;
+                        closestRatingToCursor = data[i].x;
+                        closestValueToCursor = $"Players: {data[i].y}";
+                    }
+                }
+
+                int currentCount = 0;
+                int totalCount = data.Sum(p => p.y);
+
+                for (int i = 0; i < cumulativePath.Vertices.Count; i++)
+                {
+                    currentCount += data[i].y;
+
+                    Vector2 pos = distributionPath.ToScreenSpace(cumulativePath.Vertices[i] + new Vector2(2));
+                    float d = Vector2.Distance(mousePos, pos);
+
+                    if (d < minDistToCursor)
+                    {
+                        minDistToCursor = d;
+                        closestPointToCursor = pos;
+                        closestColourToCursor = colours.Yellow;
+                        closestRatingToCursor = data[i].x;
+                        closestValueToCursor = $"Cumulative: {(float)currentCount / totalCount:P1}";
+                    }
+                }
+
+                if (float.IsNaN(minDistToCursor) || minDistToCursor == float.MaxValue)
+                    return new RatingDistributionGraphTooltipData();
+
+                return new RatingDistributionGraphTooltipData
+                {
+                    Colour = closestColourToCursor,
+                    Position = closestPointToCursor,
+                    Rating = closestRatingToCursor,
+                    Value = closestValueToCursor,
+                };
+            }
+        }
+
+        /// <summary>
+        /// A simple vertical line that always remains 1px in size.
+        /// </summary>
+        private partial class VerticalLine : Box
+        {
+            protected override void Update()
+            {
+                base.Update();
+                Width = Parent!.DrawWidth / Parent.ScreenSpaceDrawQuad.Width;
+            }
+        }
+
+        /// <summary>
+        /// A simple horizontal line that always remains 1px in size.
+        /// </summary>
+        private partial class HorizontalLine : Box
+        {
+            protected override void Update()
+            {
+                base.Update();
+                Height = Parent!.DrawHeight / Parent.ScreenSpaceDrawQuad.Height;
+            }
+        }
+
+        private partial class UserRatingLine : CompositeDrawable
+        {
+            public UserRatingLine(int rating)
+            {
+                InternalChildren = new Drawable[]
+                {
+                    new Box
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        RelativeSizeAxes = Axes.Y,
+                        Width = 2,
+                    },
+                    new Circle
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(8),
+                    },
+                    new Circle
+                    {
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(8),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.BottomCentre,
+                        Y = -4,
+                        Text = $"Your rating ({rating})",
+                        Font = OsuFont.Torus.With(size: 12),
+                    }
+                };
+            }
+        }
+
+        private partial class PointPath : SmoothPath
+        {
+            private Vector2[] points = [];
+
+            public Vector2[] Points
+            {
+                get => points;
+                set
+                {
+                    points = value;
+                    verticesCache.Invalidate();
+                }
+            }
+
+            private Vector2 offset;
+
+            public Vector2 Offset
+            {
+                get => offset;
+                set
+                {
+                    offset = value;
+                    verticesCache.Invalidate();
+                }
+            }
+
+            private readonly LayoutValue verticesCache = new LayoutValue(Invalidation.RequiredParentSizeToFit);
+
+            public PointPath()
+            {
+                AddLayout(verticesCache);
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                if (!verticesCache.IsValid)
+                {
+                    updateVertices();
+                    verticesCache.Validate();
+                }
+            }
+
+            private void updateVertices()
+            {
+                ClearVertices();
+
+                for (int i = 0; i < Points.Length; i++)
+                    AddVertex(Points[i] * (Parent!.DrawSize + offset));
+            }
+        }
+
+        private partial class RatingDistributionGraphTooltip : VisibilityContainer, ITooltip<RatingDistributionGraphTooltipData>
+        {
+            private readonly OsuSpriteText ratingText;
+            private readonly Drawable valueColour;
+            private readonly OsuSpriteText valueText;
+
+            private RatingDistributionGraphTooltipData content = new RatingDistributionGraphTooltipData();
+            private bool instantMove = true;
+
+            public RatingDistributionGraphTooltip()
+            {
+                AutoSizeAxes = Axes.Both;
+
+                InternalChild = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 3,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Black,
+                            Alpha = 0.7f
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Padding = new MarginPadding(8),
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(3),
+                            Children = new Drawable[]
+                            {
+                                ratingText = new OsuSpriteText
+                                {
+                                    Font = OsuFont.Torus.With(weight: FontWeight.SemiBold)
+                                },
+                                new FillFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(3),
+                                    Children = new[]
+                                    {
+                                        valueColour = new Box
+                                        {
+                                            Size = new Vector2(12)
+                                        },
+                                        valueText = new OsuSpriteText
+                                        {
+                                            Font = OsuFont.Torus.With(size: 12)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+
+            public void SetContent(RatingDistributionGraphTooltipData content)
+            {
+                this.content = content;
+
+                ratingText.Text = content.Rating.ToString();
+                valueColour.Colour = content.Colour;
+                valueText.Text = content.Value;
+            }
+
+            public void Move(Vector2 pos)
+            {
+                pos = Parent!.ToLocalSpace(content.Position) - new Vector2(DrawWidth + 10, 0);
+
+                if (instantMove)
+                {
+                    Position = pos;
+                    instantMove = false;
+                }
+                else
+                    this.MoveTo(pos, 200, Easing.OutQuint);
+            }
+
+            protected override void PopIn()
+            {
+                instantMove |= !IsPresent;
+                this.FadeIn(200, Easing.OutQuint);
+            }
+
+            protected override void PopOut()
+            {
+                this.FadeOut(200, Easing.OutQuint);
+            }
+        }
+
+        public class RatingDistributionGraphTooltipData
+        {
+            public Color4 Colour;
+            public Vector2 Position;
+
+            public int Rating;
+            public string Value = string.Empty;
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -21,6 +21,7 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Database;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
@@ -29,9 +30,11 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Volume;
 using osu.Game.Rulesets;
+using osu.Game.Screens.Footer;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osuTK;
@@ -48,8 +51,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         public override bool? ApplyModTrackAdjustments => false;
 
         private Container mainContent = null!;
-
         private CloudVisualisation cloud = null!;
+        private RatingDistributionGraph ratingGraph = null!;
+        private FillFlowContainer<RankedPlayMatchPanel> resultPanelContainer = null!;
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -91,6 +95,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private SampleChannel? waitingLoopChannel;
         private ScheduledDelegate? startLoopPlaybackDelegate;
 
+        private int? userRating;
+
         public ScreenQueue(MatchmakingPoolType poolType)
         {
             this.poolType = poolType;
@@ -114,47 +120,118 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 Children = new Drawable[]
                 {
                     new GlobalScrollAdjustsVolume(),
-                    cloud = new CloudVisualisation
+                    new GridContainer
                     {
-                        Y = -100,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.Both,
-                        Size = new Vector2(0.6f)
-                    },
-                    new MatchmakingAvatar(api.LocalUser.Value, true)
-                    {
-                        Y = -100,
-                        Scale = new Vector2(3),
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                    },
-                    new Container
-                    {
-                        RelativePositionAxes = Axes.Y,
-                        Y = 0.25f,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        AutoSizeAxes = Axes.Both,
-                        CornerRadius = 10f,
-                        Masking = true,
-                        Children = new Drawable[]
+                        Padding = new MarginPadding
                         {
-                            new Box
+                            Horizontal = 50,
+                            Top = 50,
+                            Bottom = ScreenFooter.HEIGHT + 50
+                        },
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.Absolute, 20),
+                            new Dimension()
+                        },
+                        RowDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.Absolute, 20),
+                            new Dimension(GridSizeMode.Absolute, 200)
+                        },
+                        Content = new[]
+                        {
+                            new Drawable?[]
                             {
-                                Colour = colourProvider.Background3,
-                                RelativeSizeAxes = Axes.Both,
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Children = new Drawable[]
+                                    {
+                                        cloud = new CloudVisualisation
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            RelativeSizeAxes = Axes.Both,
+                                            Size = new Vector2(0.6f)
+                                        },
+                                        new MatchmakingAvatar(api.LocalUser.Value, true)
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Scale = new Vector2(3),
+                                        }
+                                    }
+                                },
+                                null,
+                                new OsuScrollContainer(Direction.Vertical)
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    ScrollbarOverlapsContent = false,
+                                    Child = resultPanelContainer = new FillFlowContainer<RankedPlayMatchPanel>
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Spacing = new Vector2(10),
+                                    }
+                                }
                             },
-                            mainContent = new Container
+                            null,
+                            new Drawable?[]
                             {
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                Alpha = 0,
-                                AutoSizeAxes = Axes.Both,
-                                AutoSizeDuration = 300,
-                                AutoSizeEasing = Easing.OutQuint,
-                                Padding = new MarginPadding(20),
-                            },
+                                new Container
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    AutoSizeAxes = Axes.Both,
+                                    CornerRadius = 10f,
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            Colour = colourProvider.Background3,
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        mainContent = new Container
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Alpha = 0,
+                                            AutoSizeAxes = Axes.Both,
+                                            AutoSizeDuration = 300,
+                                            AutoSizeEasing = Easing.OutQuint,
+                                            Padding = new MarginPadding(20),
+                                        },
+                                    }
+                                },
+                                null,
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    CornerRadius = 10f,
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            Colour = colourProvider.Background3,
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        new Container
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Padding = new MarginPadding(10),
+                                            Child = ratingGraph = new RatingDistributionGraph
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                 }
@@ -195,10 +272,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                if (!cancellation.IsCancellationRequested)
                                    Users = users.OfType<APIUser>().ToArray();
                            }), cancellation.Token);
+
+            if (status.UserRating != null)
+                userRating = status.UserRating;
+
+            ratingGraph.SetData(status.RatingDistribution, userRating);
+
+            foreach (var state in status.RecentMatches.OfType<RankedPlayRoomState>())
+                resultPanelContainer.Insert(-resultPanelContainer.Count, new RankedPlayMatchPanel(state));
         });
 
         private void onSelectedPoolChanged(ValueChangedEvent<MatchmakingPool?> e)
         {
+            userRating = null;
+            resultPanelContainer.Clear();
+
             if (e.NewValue == null)
             {
                 client.MatchmakingLeaveLobby();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -286,6 +286,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private void onSelectedPoolChanged(ValueChangedEvent<MatchmakingPool?> e)
         {
             userRating = null;
+            ratingGraph.SetData([], null);
             resultPanelContainer.Clear();
 
             if (e.NewValue == null)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -125,9 +125,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                         RelativeSizeAxes = Axes.Both,
                         Padding = new MarginPadding
                         {
-                            Horizontal = 50,
-                            Top = 50,
-                            Bottom = ScreenFooter.HEIGHT + 50
+                            Horizontal = 20,
+                            Top = 20,
+                            Bottom = ScreenFooter.HEIGHT + 20
                         },
                         RowDimensions =
                         [
@@ -149,12 +149,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                         Masking = true,
                                         Children = new Drawable[]
                                         {
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Colour = colourProvider.Background3,
-                                                Alpha = 0.5f,
-                                            },
+                                            new PanelBackground(),
                                             new GridContainer
                                             {
                                                 RelativeSizeAxes = Axes.Both,
@@ -165,7 +160,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                                 ],
                                                 Content = new[]
                                                 {
-                                                    new Drawable[] { new SectionHeader("Players") },
+                                                    new Drawable[] { new QueueSectionHeader("Queued players") },
                                                     new Drawable[]
                                                     {
                                                         new Container
@@ -205,23 +200,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                         Masking = true,
                                         Children = new Drawable[]
                                         {
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Colour = colourProvider.Background3,
-                                                Alpha = 0.5f,
-                                            },
+                                            new PanelBackground(),
                                             new GridContainer
                                             {
                                                 RelativeSizeAxes = Axes.Both,
-                                                Padding = new MarginPadding(10),
+                                                Padding = new MarginPadding(10) { Bottom = 0 },
                                                 RowDimensions =
                                                 [
                                                     new Dimension(GridSizeMode.AutoSize)
                                                 ],
                                                 Content = new[]
                                                 {
-                                                    new Drawable[] { new SectionHeader("Completed Matches") },
+                                                    new Drawable[] { new QueueSectionHeader("Recent Matches") },
                                                     new Drawable[]
                                                     {
                                                         new OsuScrollContainer(Direction.Vertical)
@@ -255,18 +245,29 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                         Masking = true,
                                         Children = new Drawable[]
                                         {
-                                            new Box
+                                            new PanelBackground(),
+                                            new GridContainer
                                             {
                                                 RelativeSizeAxes = Axes.Both,
-                                                Colour = colourProvider.Background3,
-                                                Alpha = 0.5f,
-                                            },
-                                            mainContent = new Container
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Padding = new MarginPadding(20),
-                                                Alpha = 0,
-                                            },
+                                                Padding = new MarginPadding(10),
+                                                RowDimensions =
+                                                [
+                                                    new Dimension(GridSizeMode.AutoSize)
+                                                ],
+                                                Content = new[]
+                                                {
+                                                    new Drawable[] { new QueueSectionHeader("Queues") },
+                                                    new Drawable[]
+                                                    {
+                                                        mainContent = new Container
+                                                        {
+                                                            RelativeSizeAxes = Axes.Both,
+                                                            Padding = new MarginPadding(20),
+                                                            Alpha = 0,
+                                                        },
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 },
@@ -281,12 +282,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                         Masking = true,
                                         Children = new Drawable[]
                                         {
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Colour = colourProvider.Background3,
-                                                Alpha = 0.5f,
-                                            },
+                                            new PanelBackground(),
                                             new GridContainer
                                             {
                                                 RelativeSizeAxes = Axes.Both,
@@ -297,7 +293,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                                 ],
                                                 Content = new[]
                                                 {
-                                                    new Drawable[] { new SectionHeader("Ratings") },
+                                                    new Drawable[] { new QueueSectionHeader("Ratings") },
                                                     new Drawable[]
                                                     {
                                                         new Container
@@ -320,15 +316,41 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     }
                 }
             };
-
             currentState.BindTo(controller.CurrentState);
             currentState.BindValueChanged(s => SetState(s.NewValue));
-
             client.MatchmakingLobbyStatusChanged += onMatchmakingLobbyStatusChanged;
-
             selectedPool.BindValueChanged(onSelectedPoolChanged, true);
-
             populateAvailablePools().FireAndForget();
+        }
+
+        public class PanelBackground : CompositeDrawable
+        {
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                RelativeSizeAxes = Axes.Both;
+
+                InternalChild = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background3,
+                    Blending = BlendingParameters.Additive,
+                    Alpha = 0.3f,
+                };
+            }
+        }
+
+        public class QueueSectionHeader : SectionHeader
+        {
+            public QueueSectionHeader(string header)
+                : base(header)
+            {
+                // Reduce base class padding.
+                Margin = new MarginPadding { Top = 5, Bottom = 10, Horizontal = 5 };
+            }
         }
 
         private async Task populateAvailablePools()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -183,9 +183,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                             {
                                 new Container
                                 {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    AutoSizeAxes = Axes.Both,
+                                    RelativeSizeAxes = Axes.Both,
                                     CornerRadius = 10f,
                                     Masking = true,
                                     Children = new Drawable[]
@@ -197,13 +195,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                         },
                                         mainContent = new Container
                                         {
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Alpha = 0,
-                                            AutoSizeAxes = Axes.Both,
-                                            AutoSizeDuration = 300,
-                                            AutoSizeEasing = Easing.OutQuint,
+                                            RelativeSizeAxes = Axes.Both,
                                             Padding = new MarginPadding(20),
+                                            Alpha = 0,
                                         },
                                     }
                                 },
@@ -411,7 +405,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                         Origin = Anchor.Centre,
                         AutoSizeAxes = Axes.Both,
                         Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(20),
+                        Spacing = new Vector2(15),
                         Children = new Drawable[]
                         {
                             new OsuSpriteText

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -129,105 +129,195 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                             Top = 50,
                             Bottom = ScreenFooter.HEIGHT + 50
                         },
-                        ColumnDimensions = new[]
-                        {
+                        RowDimensions =
+                        [
                             new Dimension(),
-                            new Dimension(GridSizeMode.Absolute, 20),
-                            new Dimension()
-                        },
-                        RowDimensions = new[]
-                        {
-                            new Dimension(),
-                            new Dimension(GridSizeMode.Absolute, 20),
-                            new Dimension(GridSizeMode.Absolute, 200)
-                        },
+                            new Dimension(GridSizeMode.Relative, 0.35f)
+                        ],
                         Content = new[]
                         {
-                            new Drawable?[]
+                            new Drawable[]
                             {
                                 new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Children = new Drawable[]
+                                    Padding = new MarginPadding(5),
+                                    Child = new Container
                                     {
-                                        cloud = new CloudVisualisation
+                                        RelativeSizeAxes = Axes.Both,
+                                        CornerRadius = 10f,
+                                        Masking = true,
+                                        Children = new Drawable[]
                                         {
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            RelativeSizeAxes = Axes.Both,
-                                            Size = new Vector2(0.6f)
-                                        },
-                                        new MatchmakingAvatar(api.LocalUser.Value, true)
-                                        {
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Scale = new Vector2(3),
+                                            new Box
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Colour = colourProvider.Background3,
+                                                Alpha = 0.5f,
+                                            },
+                                            new GridContainer
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Padding = new MarginPadding(10),
+                                                RowDimensions =
+                                                [
+                                                    new Dimension(GridSizeMode.AutoSize)
+                                                ],
+                                                Content = new[]
+                                                {
+                                                    new Drawable[] { new SectionHeader("Players") },
+                                                    new Drawable[]
+                                                    {
+                                                        new Container
+                                                        {
+                                                            RelativeSizeAxes = Axes.Both,
+                                                            Children = new Drawable[]
+                                                            {
+                                                                cloud = new CloudVisualisation
+                                                                {
+                                                                    Anchor = Anchor.Centre,
+                                                                    Origin = Anchor.Centre,
+                                                                    RelativeSizeAxes = Axes.Both,
+                                                                    Size = new Vector2(0.6f)
+                                                                },
+                                                                new MatchmakingAvatar(api.LocalUser.Value, true)
+                                                                {
+                                                                    Anchor = Anchor.Centre,
+                                                                    Origin = Anchor.Centre,
+                                                                    Scale = new Vector2(3),
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 },
-                                null,
-                                new OsuScrollContainer(Direction.Vertical)
+                                new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    ScrollbarOverlapsContent = false,
-                                    Child = resultPanelContainer = new FillFlowContainer<RankedPlayMatchPanel>
+                                    Padding = new MarginPadding(5),
+                                    Child = new Container
                                     {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        Spacing = new Vector2(10),
+                                        RelativeSizeAxes = Axes.Both,
+                                        CornerRadius = 10f,
+                                        Masking = true,
+                                        Children = new Drawable[]
+                                        {
+                                            new Box
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Colour = colourProvider.Background3,
+                                                Alpha = 0.5f,
+                                            },
+                                            new GridContainer
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Padding = new MarginPadding(10),
+                                                RowDimensions =
+                                                [
+                                                    new Dimension(GridSizeMode.AutoSize)
+                                                ],
+                                                Content = new[]
+                                                {
+                                                    new Drawable[] { new SectionHeader("Completed Matches") },
+                                                    new Drawable[]
+                                                    {
+                                                        new OsuScrollContainer(Direction.Vertical)
+                                                        {
+                                                            RelativeSizeAxes = Axes.Both,
+                                                            ScrollbarOverlapsContent = false,
+                                                            Child = resultPanelContainer = new FillFlowContainer<RankedPlayMatchPanel>
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                AutoSizeAxes = Axes.Y,
+                                                                Spacing = new Vector2(10),
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },
-                            null,
-                            new Drawable?[]
+                            new Drawable[]
                             {
                                 new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    CornerRadius = 10f,
-                                    Masking = true,
-                                    Children = new Drawable[]
+                                    Padding = new MarginPadding(5),
+                                    Child = new Container
                                     {
-                                        new Box
+                                        RelativeSizeAxes = Axes.Both,
+                                        CornerRadius = 10f,
+                                        Masking = true,
+                                        Children = new Drawable[]
                                         {
-                                            Colour = colourProvider.Background3,
-                                            RelativeSizeAxes = Axes.Both,
-                                        },
-                                        mainContent = new Container
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Padding = new MarginPadding(20),
-                                            Alpha = 0,
-                                        },
+                                            new Box
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Colour = colourProvider.Background3,
+                                                Alpha = 0.5f,
+                                            },
+                                            mainContent = new Container
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Padding = new MarginPadding(20),
+                                                Alpha = 0,
+                                            },
+                                        }
                                     }
                                 },
-                                null,
                                 new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    CornerRadius = 10f,
-                                    Masking = true,
-                                    Children = new Drawable[]
+                                    Padding = new MarginPadding(5),
+                                    Child = new Container
                                     {
-                                        new Box
+                                        RelativeSizeAxes = Axes.Both,
+                                        CornerRadius = 10f,
+                                        Masking = true,
+                                        Children = new Drawable[]
                                         {
-                                            Colour = colourProvider.Background3,
-                                            RelativeSizeAxes = Axes.Both,
-                                        },
-                                        new Container
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Padding = new MarginPadding(10),
-                                            Child = ratingGraph = new RatingDistributionGraph
+                                            new Box
                                             {
                                                 RelativeSizeAxes = Axes.Both,
+                                                Colour = colourProvider.Background3,
+                                                Alpha = 0.5f,
+                                            },
+                                            new GridContainer
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Padding = new MarginPadding(10),
+                                                RowDimensions =
+                                                [
+                                                    new Dimension(GridSizeMode.AutoSize)
+                                                ],
+                                                Content = new[]
+                                                {
+                                                    new Drawable[] { new SectionHeader("Ratings") },
+                                                    new Drawable[]
+                                                    {
+                                                        new Container
+                                                        {
+                                                            RelativeSizeAxes = Axes.Both,
+                                                            Padding = new MarginPadding { Top = -10 },
+                                                            Child = ratingGraph = new RatingDistributionGraph
+                                                            {
+                                                                RelativeSizeAxes = Axes.Both,
+                                                            }
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     }
                                 }
                             }
                         }
-                    },
+                    }
                 }
             };
 
@@ -274,7 +364,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             ratingGraph.SetData(status.RatingDistribution, userRating);
 
             foreach (var state in status.RecentMatches.OfType<RankedPlayRoomState>())
-                resultPanelContainer.Insert(-resultPanelContainer.Count, new RankedPlayMatchPanel(state));
+            {
+                resultPanelContainer.Insert(-resultPanelContainer.Count, new RankedPlayMatchPanel(state)
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Width = 0.48f
+                });
+            }
         });
 
         private void onSelectedPoolChanged(ValueChangedEvent<MatchmakingPool?> e)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -334,36 +334,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             populateAvailablePools().FireAndForget();
         }
 
-        public class PanelBackground : CompositeDrawable
-        {
-            [Resolved]
-            private OverlayColourProvider colourProvider { get; set; } = null!;
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                RelativeSizeAxes = Axes.Both;
-
-                InternalChild = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background3,
-                    Blending = BlendingParameters.Additive,
-                    Alpha = 0.3f,
-                };
-            }
-        }
-
-        public class QueueSectionHeader : SectionHeader
-        {
-            public QueueSectionHeader(string header)
-                : base(header)
-            {
-                // Reduce base class padding.
-                Margin = new MarginPadding { Top = 5, Bottom = 10, Horizontal = 5 };
-            }
-        }
-
         private async Task populateAvailablePools()
         {
             MatchmakingPool[] pools = await client.GetMatchmakingPoolsOfType(poolType).ConfigureAwait(false);
@@ -680,6 +650,36 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         {
             waitingLoopChannel?.Stop();
             waitingLoopChannel?.Dispose();
+        }
+
+        public partial class PanelBackground : CompositeDrawable
+        {
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                RelativeSizeAxes = Axes.Both;
+
+                InternalChild = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background3,
+                    Blending = BlendingParameters.Additive,
+                    Alpha = 0.3f,
+                };
+            }
+        }
+
+        public partial class QueueSectionHeader : SectionHeader
+        {
+            public QueueSectionHeader(string header)
+                : base(header)
+            {
+                // Reduce base class padding.
+                Margin = new MarginPadding { Top = 5, Bottom = 10, Horizontal = 5 };
+            }
         }
 
         private partial class BeginQueueingButton : SelectionButton

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Lists;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Database;
@@ -97,6 +98,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private int? userRating;
 
+        private GridContainer mainGrid = null!;
+
         public ScreenQueue(MatchmakingPoolType poolType)
         {
             this.poolType = poolType;
@@ -108,11 +111,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             enqueueSample = audio.Samples.Get(@"Multiplayer/Matchmaking/enqueue");
             waitingLoopSample = audio.Samples.Get(@"Multiplayer/Matchmaking/waiting-loop");
             matchFoundSample = audio.Samples.Get(@"Multiplayer/Matchmaking/match-found");
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
 
             InternalChild = new InverseScalingDrawSizePreservingFillContainer
             {
@@ -120,7 +118,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 Children = new Drawable[]
                 {
                     new GlobalScrollAdjustsVolume(),
-                    new GridContainer
+                    mainGrid = new GridContainer
                     {
                         RelativeSizeAxes = Axes.Both,
                         Padding = new MarginPadding
@@ -316,6 +314,26 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     }
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            int delay = 0;
+
+            foreach (var a in mainGrid.Content)
+            {
+                foreach (var d in a)
+                {
+                    d.FadeOut()
+                     .Delay(delay)
+                     .FadeInFromZero(500, Easing.OutQuint);
+
+                    delay += 100;
+                }
+            }
+
             currentState.BindTo(controller.CurrentState);
             currentState.BindValueChanged(s => SetState(s.NewValue));
             client.MatchmakingLobbyStatusChanged += onMatchmakingLobbyStatusChanged;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -17,7 +17,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.Lists;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Database;
@@ -57,19 +56,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private FillFlowContainer<RankedPlayMatchPanel> resultPanelContainer = null!;
 
         [Resolved]
-        private IAPIProvider api { get; set; } = null!;
-
-        [Resolved]
-        private OverlayColourProvider colourProvider { get; set; } = null!;
-
-        [Resolved]
         private OsuColour colours { get; set; } = null!;
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
 
         [Resolved]
-        private QueueController controller { get; set; } = null!;
+        private QueueController queue { get; set; } = null!;
 
         [Resolved]
         private UserLookupCache userLookupCache { get; set; } = null!;
@@ -78,7 +71,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
 
         [Resolved]
-        private MusicController musicController { get; set; } = null!;
+        private MusicController music { get; set; } = null!;
 
         private readonly IBindable<MatchmakingScreenState> currentState = new Bindable<MatchmakingScreenState>();
 
@@ -106,7 +99,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         }
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        private void load(AudioManager audio, IAPIProvider api)
         {
             enqueueSample = audio.Samples.Get(@"Multiplayer/Matchmaking/enqueue");
             waitingLoopSample = audio.Samples.Get(@"Multiplayer/Matchmaking/waiting-loop");
@@ -334,7 +327,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 }
             }
 
-            currentState.BindTo(controller.CurrentState);
+            currentState.BindTo(queue.CurrentState);
             currentState.BindValueChanged(s => SetState(s.NewValue));
             client.MatchmakingLobbyStatusChanged += onMatchmakingLobbyStatusChanged;
             selectedPool.BindValueChanged(onSelectedPoolChanged, true);
@@ -435,7 +428,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         {
             base.OnEntering(e);
 
-            controller.SearchInForeground();
+            queue.SearchInForeground();
 
             using (BeginDelayedSequence(800))
                 Schedule(() => SetState(currentState.Value));
@@ -469,12 +462,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     return false;
 
                 case MatchmakingScreenState.Queueing:
-                    controller.SearchInBackground();
+                    queue.SearchInBackground();
                     return false;
 
                 case MatchmakingScreenState.PendingAccept:
                 case MatchmakingScreenState.AcceptedWaitingForRoom:
-                    controller.LeaveQueue();
+                    queue.LeaveQueue();
                     return true;
 
                 case MatchmakingScreenState.InRoom:
@@ -526,7 +519,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                 Action = () =>
                                 {
                                     Debug.Assert(selectedPool.Value != null);
-                                    controller.JoinQueue(selectedPool.Value);
+                                    queue.JoinQueue(selectedPool.Value);
                                 },
                                 Text = "Begin queueing",
                             }
@@ -563,7 +556,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                 Origin = Anchor.Centre,
                                 Width = 200,
                                 Text = "Stop queueing",
-                                Action = () => controller.LeaveQueue()
+                                Action = () => queue.LeaveQueue()
                             }
                         }
                     };
@@ -577,7 +570,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     SetState(MatchmakingScreenState.AcceptedWaitingForRoom);
 
                     matchFoundSample?.Play();
-                    musicController.DuckMomentarily(1250);
+                    music.DuckMomentarily(1250);
                     break;
 
                 case MatchmakingScreenState.AcceptedWaitingForRoom:

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -273,6 +273,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                    Users = users.OfType<APIUser>().ToArray();
                            }), cancellation.Token);
 
+            // Global (incremental) updates will not contain the user rating, so keep the one we already received from initial status data.
             if (status.UserRating != null)
                 userRating = status.UserRating;
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -921,6 +921,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return Task.CompletedTask;
         }
 
+        public new async Task MatchmakingLobbyStatusChanged(MatchmakingLobbyStatus status)
+        {
+            await ((IMatchmakingClient)this).MatchmakingLobbyStatusChanged(clone(status)).ConfigureAwait(false);
+        }
+
         public override Task MatchmakingToggleSelection(long playlistItemId)
             => MatchmakingToggleUserSelection(api.LocalUser.Value.OnlineID, playlistItemId);
 

--- a/osu.Game/Tests/Visual/TestUserLookupCache.cs
+++ b/osu.Game/Tests/Visual/TestUserLookupCache.cs
@@ -24,7 +24,8 @@ namespace osu.Game.Tests.Visual
             return Task.FromResult<APIUser?>(new APIUser
             {
                 Id = lookup,
-                Username = $"User {lookup}"
+                Username = $"User {lookup}",
+                CoverUrl = "https://assets.ppy.sh/user-cover-presets/1/df28696b58541a9e67f6755918951d542d93bdf1da41720fcca2fd2c1ea8cf51.jpeg"
             });
         }
     }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/37226
- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/464

This adds two new components to the queue screen:
- A listing of the most recently completed matches (global).
- A rank distribution graph.

It looks something like this (fake data / test scene):

<img width="1669" height="1005" alt="image" src="https://github.com/user-attachments/assets/caa57119-4267-4c6e-9898-2f414de865bf" />

It's completely dev-design(TM), but I used Lichess as inspiration for the graph, and the original design document as inspiration for the panels.

As for the history, because these are _completed_ matches one of the player life points will always be 0, but I've designed it so as to possibly support showing ongoing matches too in the future. It's only supported for ranked play right now, though there is no reason we couldn't track quick play rooms too (it's just... I'm not sure how to design the panels for quick play).