### PR TITLE
Fix footer buttons still being able to fire their action when temporarily hidden by overlay content

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneScreenFooter.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneScreenFooter.cs
@@ -13,11 +13,13 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Screens;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Select;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -140,6 +142,44 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("hide overlay", () => screen.Overlay.Hide());
             contentHidden();
             AddAssert("other buttons returned", () => ScreenFooter.ChildrenOfType<ScreenFooterButton>().Skip(1).All(b => b.ChildrenOfType<Container>().First().Y == 0));
+        }
+
+        [Test]
+        public void TestButtonsHiddenByExternalOverlayContentCannotBeTriggered()
+        {
+            TestScreen screen = null!;
+            bool buttonTriggered = false;
+
+            AddStep("push screen", () =>
+            {
+                ShearedOverlayContainer overlay = new TestShearedOverlayContainer();
+
+                LoadScreen(screen = new TestScreen
+                {
+                    Overlay = overlay,
+                    CreateButtons = () => new[]
+                    {
+                        new ScreenFooterButton(overlay)
+                        {
+                            AccentColour = Dependencies.Get<OsuColour>().Orange1,
+                            Icon = FontAwesome.Solid.Toolbox,
+                            Text = "One",
+                        },
+                        new ScreenFooterButton { Text = "Two", Hotkey = GlobalAction.Select, Action = () => buttonTriggered = true },
+                        new ScreenFooterButton { Text = "Three", Action = () => { } },
+                    },
+                });
+            });
+            AddUntilStep("wait until screen is loaded", () => screen.IsCurrentScreen(), () => Is.True);
+
+            AddStep("show overlay", () => screen.Overlay.Show());
+            contentDisplayed();
+
+            AddStep("try direct click", () => ScreenFooter.ChildrenOfType<ScreenFooterButton>().ElementAt(1).TriggerClick());
+            AddAssert("action not triggered", () => buttonTriggered, () => Is.False);
+
+            AddStep("try hotkey", () => InputManager.Key(Key.Enter));
+            AddAssert("action not triggered", () => buttonTriggered, () => Is.False);
         }
 
         [Test]

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Screens.Footer
             for (int i = 0; i < oldButtons.Length; i++)
             {
                 var oldButton = oldButtons[i];
-                oldButton.Enabled.Value = false;
+                oldButton.State.Value = Visibility.Hidden;
 
                 buttonsFlow.Remove(oldButton, false);
                 hiddenButtonsContainer.Add(oldButton);
@@ -262,6 +262,7 @@ namespace osu.Game.Screens.Footer
             for (int i = temporarilyHiddenButtons.Count - 1; i >= 0; i--)
             {
                 var button = temporarilyHiddenButtons[i];
+                button.State.Value = Visibility.Hidden;
                 buttonsFlow.Remove(button, false);
                 hiddenButtonsContainer.Add(button);
 
@@ -300,6 +301,7 @@ namespace osu.Game.Screens.Footer
             for (int i = 0; i < temporarilyHiddenButtons.Count; i++)
             {
                 var button = temporarilyHiddenButtons[i];
+                button.State.Value = Visibility.Visible;
                 hiddenButtonsContainer.Remove(button, false);
 
                 // temporarily bypass autosize on the X axis to prevent the buttons taking space

--- a/osu.Game/Screens/Footer/ScreenFooterButton.cs
+++ b/osu.Game/Screens/Footer/ScreenFooterButton.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -30,7 +31,16 @@ namespace osu.Game.Screens.Footer
         public const int HEIGHT = 75;
         protected const int BUTTON_WIDTH = 116;
 
-        public Bindable<Visibility> OverlayState = new Bindable<Visibility>();
+        /// <summary>
+        /// If this footer button controls the visibility of an overlay, it will be bound to this bindable.
+        /// </summary>
+        public readonly Bindable<Visibility> OverlayState = new Bindable<Visibility>();
+
+        /// <summary>
+        /// Used to tell whether this button is currently on screen.
+        /// <see cref="ScreenFooter"/> controls this to convey when buttons are hidden temporarily via <see cref="ScreenFooter.RegisterActiveOverlayContainer"/>.
+        /// </summary>
+        public readonly Bindable<Visibility> State = new Bindable<Visibility>(Visibility.Visible);
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -56,6 +66,23 @@ namespace osu.Game.Screens.Footer
         {
             get => text.Text;
             set => text.Text = value;
+        }
+
+        public new Action? Action
+        {
+            set
+            {
+                if (value == null)
+                    base.Action = null;
+                else
+                {
+                    base.Action = () =>
+                    {
+                        if (State.Value != Visibility.Hidden)
+                            value.Invoke();
+                    };
+                }
+            }
         }
 
         private readonly Container shearedContent;


### PR DESCRIPTION
In human words: I read [this forum thread](https://osu.ppy.sh/community/forums/topics/2195138?n=1) today and was horrified to see the user there opening the F3 options menu in song select *when the F1 mod overlay was pulled up*, which is (a) not intended UX, (b) looks terrible, and (c) just wrecks the game behaviourally wholesale from start to end.

So with this change you don't get to open options via F3 while inside mod overlay at all.

The `Action` shadowing is pretty ugly but I don't have better ideas. Initially I tried to mess with `Enabled` (as I did once previously, see https://github.com/ppy/osu/commit/36628e24f92c286b87c118c7c1bb9bc582895571), but it's much more complicated in this case because the enabled state needs to be restored when the buttons reappear, or it could change independently while the buttons are temporarily hidden, etc. So I'd rather just not deal with all that and invent a parallel scheme.