### PR TITLE
Add mania key count grouping to song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselFilterGroupingTest.cs
@@ -11,6 +11,9 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.Carousel;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
@@ -326,6 +329,62 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         #endregion
 
+        #region Key count grouping
+
+        [Test]
+        public void TestManiaKeyCountGroupingKeepsBeatmapSetsTogether()
+        {
+            var criteria = new FilterCriteria
+            {
+                Group = GroupMode.ManiaKeyCount,
+                Ruleset = new ManiaRuleset().RulesetInfo
+            };
+
+            Assert.That(BeatmapCarouselFilterGrouping.ShouldGroupBeatmapsTogether(criteria), Is.True);
+        }
+
+        [Test]
+        public async Task TestGroupingByKeyCountInMania()
+        {
+            int total = 0;
+
+            RulesetInfo maniaRuleset = new ManiaRuleset().RulesetInfo;
+            var beatmapSets = new List<BeatmapSetInfo>();
+
+            addBeatmapSet(applyKeyCount(4), beatmapSets, out var first4k, [maniaRuleset]);
+            addBeatmapSet(applyKeyCount(4), beatmapSets, out var second4k, [maniaRuleset]);
+            addBeatmapSet(applyKeyCount(7), beatmapSets, out var map7k, [maniaRuleset]);
+            addBeatmapSet(applyKeyCount(18), beatmapSets, out var map18k, [maniaRuleset]);
+
+            var results = await runGrouping(GroupMode.ManiaKeyCount, beatmapSets, maniaRuleset);
+            assertGroup(results, 0, "4K", first4k.Beatmaps.Concat(second4k.Beatmaps), ref total);
+            assertGroup(results, 1, "7K", map7k.Beatmaps, ref total);
+            assertGroup(results, 2, "18K", map18k.Beatmaps, ref total);
+            assertTotal(results, total);
+        }
+
+        [Test]
+        public async Task TestGroupingByKeyCountOutsideManiaFallsBackToNoGrouping()
+        {
+            RulesetInfo osuRuleset = new OsuRuleset().RulesetInfo;
+
+            var beatmapSets = new List<BeatmapSetInfo>();
+            addBeatmapSet(applyKeyCount(4), beatmapSets, out _, [osuRuleset]);
+            addBeatmapSet(applyKeyCount(7), beatmapSets, out _, [osuRuleset]);
+
+            var results = await runGrouping(GroupMode.ManiaKeyCount, beatmapSets, osuRuleset);
+
+            Assert.That(results.All(i => i.Model is not GroupDefinition), Is.True);
+            Assert.That(results.Select(r => r.Model).OfType<GroupedBeatmapSet>().Select(groupedSet => groupedSet.BeatmapSet), Is.EquivalentTo(beatmapSets));
+        }
+
+        private Action<BeatmapSetInfo> applyKeyCount(float keyCount)
+        {
+            return s => s.Beatmaps.ForEach(b => b.Difficulty.CircleSize = keyCount);
+        }
+
+        #endregion
+
         #region Ranked date grouping
 
         [Test]
@@ -397,11 +456,11 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private HashSet<int> favouriteBeatmapSets = [];
 
-        private async Task<List<CarouselItem>> runGrouping(GroupMode group, List<BeatmapSetInfo> beatmapSets)
+        private async Task<List<CarouselItem>> runGrouping(GroupMode group, List<BeatmapSetInfo> beatmapSets, RulesetInfo? ruleset = null)
         {
             var groupingFilter = new BeatmapCarouselFilterGrouping
             {
-                GetCriteria = () => new FilterCriteria { Group = group },
+                GetCriteria = () => new FilterCriteria { Group = group, Ruleset = ruleset },
                 GetCollections = () => new List<BeatmapCollection>(),
                 GetLocalUserTopRanks = _ => new Dictionary<Guid, ScoreRank>(),
                 GetFavouriteBeatmapSets = () => favouriteBeatmapSets,
@@ -435,9 +494,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             Assert.That(items.Count, Is.EqualTo(total));
         }
 
-        private static void addBeatmapSet(Action<BeatmapSetInfo> change, List<BeatmapSetInfo> list, out BeatmapSetInfo added)
+        private static void addBeatmapSet(Action<BeatmapSetInfo> change, List<BeatmapSetInfo> list, out BeatmapSetInfo added, RulesetInfo[]? rulesets = null)
         {
-            var set = TestResources.CreateTestBeatmapSetInfo();
+            var set = TestResources.CreateTestBeatmapSetInfo(rulesets: rulesets);
             change(set);
             list.Add(set);
             added = set;

--- a/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselFilterGroupingTest.cs
+++ b/osu.Game.Tests/Visual/SongSelect/BeatmapCarouselFilterGroupingTest.cs
@@ -351,15 +351,15 @@ namespace osu.Game.Tests.Visual.SongSelect
             RulesetInfo maniaRuleset = new ManiaRuleset().RulesetInfo;
             var beatmapSets = new List<BeatmapSetInfo>();
 
-            addBeatmapSet(applyKeyCount(4), beatmapSets, out var first4k, [maniaRuleset]);
-            addBeatmapSet(applyKeyCount(4), beatmapSets, out var second4k, [maniaRuleset]);
-            addBeatmapSet(applyKeyCount(7), beatmapSets, out var map7k, [maniaRuleset]);
-            addBeatmapSet(applyKeyCount(18), beatmapSets, out var map18k, [maniaRuleset]);
+            addBeatmapSet(applyKeyCount(4), beatmapSets, out var first4K, [maniaRuleset]);
+            addBeatmapSet(applyKeyCount(4), beatmapSets, out var second4K, [maniaRuleset]);
+            addBeatmapSet(applyKeyCount(7), beatmapSets, out var map7K, [maniaRuleset]);
+            addBeatmapSet(applyKeyCount(18), beatmapSets, out var map18K, [maniaRuleset]);
 
             var results = await runGrouping(GroupMode.ManiaKeyCount, beatmapSets, maniaRuleset);
-            assertGroup(results, 0, "4K", first4k.Beatmaps.Concat(second4k.Beatmaps), ref total);
-            assertGroup(results, 1, "7K", map7k.Beatmaps, ref total);
-            assertGroup(results, 2, "18K", map18k.Beatmaps, ref total);
+            assertGroup(results, 0, "4K", first4K.Beatmaps.Concat(second4K.Beatmaps), ref total);
+            assertGroup(results, 1, "7K", map7K.Beatmaps, ref total);
+            assertGroup(results, 2, "18K", map18K.Beatmaps, ref total);
             assertTotal(results, total);
         }
 

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -213,7 +213,10 @@ namespace osu.Game.Screens.Select
                     if (criteria.Ruleset?.ShortName != mania_ruleset_short_name)
                         return new List<GroupMapping> { new GroupMapping(null, items) };
 
-                    ILegacyRuleset legacyRuleset = (ILegacyRuleset)criteria.Ruleset.CreateInstance();
+                    ILegacyRuleset? legacyRuleset = criteria.Ruleset.CreateInstance() as ILegacyRuleset;
+                    if (legacyRuleset == null)
+                        return new List<GroupMapping> { new GroupMapping(null, items) };
+
                     return getGroupsBy(b => defineGroupByKeyCount(legacyRuleset.GetKeyCount(b, criteria.Mods)), items);
                 }
 

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Screens.Select
 {
     public class BeatmapCarouselFilterGrouping : ICarouselFilter
     {
+        private const int mania_key_count_cache_limit = 100_000;
+
         public bool BeatmapSetsGroupedTogether { get; private set; }
 
         /// <summary>
@@ -417,7 +419,12 @@ namespace osu.Game.Screens.Select
         }
 
         private int getManiaKeyCount(ILegacyRuleset legacyRuleset, BeatmapInfo beatmap, IReadOnlyList<Mod>? mods, int converterModsSignature)
-            => maniaKeyCountCache.GetOrAdd((beatmap.ID, converterModsSignature), _ => legacyRuleset.GetKeyCount(beatmap, mods));
+        {
+            if (maniaKeyCountCache.Count >= mania_key_count_cache_limit)
+                maniaKeyCountCache.Clear();
+
+            return maniaKeyCountCache.GetOrAdd((beatmap.ID, converterModsSignature), _ => legacyRuleset.GetKeyCount(beatmap, mods));
+        }
 
         private static int getConverterModsSignature(IReadOnlyList<Mod>? mods)
         {

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Screens.Select
 {
     public class BeatmapCarouselFilterGrouping : ICarouselFilter
     {
+        private const string mania_ruleset_short_name = "mania";
+
         public bool BeatmapSetsGroupedTogether { get; private set; }
 
         /// <summary>
@@ -208,7 +210,7 @@ namespace osu.Game.Screens.Select
                 case GroupMode.ManiaKeyCount:
                 {
                     // Key count is only meaningful in mania.
-                    if (criteria.Ruleset?.OnlineID != 3)
+                    if (criteria.Ruleset?.ShortName != mania_ruleset_short_name)
                         return new List<GroupMapping> { new GroupMapping(null, items) };
 
                     ILegacyRuleset legacyRuleset = (ILegacyRuleset)criteria.Ruleset.CreateInstance();

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -10,6 +11,8 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.Carousel;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Utils;
@@ -40,6 +43,8 @@ namespace osu.Game.Screens.Select
         private Dictionary<object, (CarouselItem, int)> itemMap = new Dictionary<object, (CarouselItem, int)>();
         private Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>> setMap = new Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>>();
         private Dictionary<GroupDefinition, HashSet<CarouselItem>> groupMap = new Dictionary<GroupDefinition, HashSet<CarouselItem>>();
+
+        private readonly ConcurrentDictionary<(Guid beatmapId, int converterModsSignature), int> maniaKeyCountCache = new ConcurrentDictionary<(Guid beatmapId, int converterModsSignature), int>();
 
         public required Func<FilterCriteria> GetCriteria { get; init; }
         public required Func<List<BeatmapCollection>> GetCollections { get; init; }
@@ -158,7 +163,6 @@ namespace osu.Game.Screens.Select
                 return false;
             if (criteria.Group == GroupMode.RankAchieved)
                 return false;
-
             // In the majority case we group sets together for display.
             return true;
         }
@@ -204,6 +208,17 @@ namespace osu.Game.Screens.Select
 
                 case GroupMode.Difficulty:
                     return getGroupsBy(b => defineGroupByStars(b.StarRating), items);
+
+                case GroupMode.ManiaKeyCount:
+                {
+                    // Key count is only meaningful in mania.
+                    if (criteria.Ruleset?.OnlineID != 3)
+                        return new List<GroupMapping> { new GroupMapping(null, items) };
+
+                    int converterModsSignature = getConverterModsSignature(criteria.Mods);
+                    ILegacyRuleset legacyRuleset = (ILegacyRuleset)criteria.Ruleset.CreateInstance();
+                    return getGroupsBy(b => defineGroupByKeyCount(getManiaKeyCount(legacyRuleset, b, criteria.Mods, converterModsSignature)), items);
+                }
 
                 case GroupMode.Length:
                     return getGroupsBy(b => defineGroupByLength(b.Length), items);
@@ -391,6 +406,34 @@ namespace osu.Game.Screens.Select
                 return new GroupDefinition(10, "10 minutes or less").Yield();
 
             return new GroupDefinition(11, "Over 10 minutes").Yield();
+        }
+
+        private IEnumerable<GroupDefinition> defineGroupByKeyCount(int keyCount)
+        {
+            if (keyCount <= 0)
+                return new GroupDefinition(int.MaxValue, "Unknown key count").Yield();
+
+            return new GroupDefinition(keyCount, $"{keyCount}K").Yield();
+        }
+
+        private int getManiaKeyCount(ILegacyRuleset legacyRuleset, BeatmapInfo beatmap, IReadOnlyList<Mod>? mods, int converterModsSignature)
+            => maniaKeyCountCache.GetOrAdd((beatmap.ID, converterModsSignature), _ => legacyRuleset.GetKeyCount(beatmap, mods));
+
+        private static int getConverterModsSignature(IReadOnlyList<Mod>? mods)
+        {
+            if (mods == null || mods.Count == 0)
+                return 0;
+
+            HashCode hash = default;
+
+            foreach (string typeName in mods.OfType<IApplicableToBeatmapConverter>()
+                                             .Select(m => m.GetType().FullName ?? m.GetType().Name)
+                                             .OrderBy(name => name, StringComparer.Ordinal))
+            {
+                hash.Add(typeName, StringComparer.Ordinal);
+            }
+
+            return hash.ToHashCode();
         }
 
         private IEnumerable<GroupDefinition> defineGroupBySource(string source)

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,7 +11,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Utils;
@@ -21,8 +19,6 @@ namespace osu.Game.Screens.Select
 {
     public class BeatmapCarouselFilterGrouping : ICarouselFilter
     {
-        private const int mania_key_count_cache_limit = 100_000;
-
         public bool BeatmapSetsGroupedTogether { get; private set; }
 
         /// <summary>
@@ -45,8 +41,6 @@ namespace osu.Game.Screens.Select
         private Dictionary<object, (CarouselItem, int)> itemMap = new Dictionary<object, (CarouselItem, int)>();
         private Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>> setMap = new Dictionary<GroupedBeatmapSet, HashSet<CarouselItem>>();
         private Dictionary<GroupDefinition, HashSet<CarouselItem>> groupMap = new Dictionary<GroupDefinition, HashSet<CarouselItem>>();
-
-        private readonly ConcurrentDictionary<(Guid beatmapId, int converterModsSignature), int> maniaKeyCountCache = new ConcurrentDictionary<(Guid beatmapId, int converterModsSignature), int>();
 
         public required Func<FilterCriteria> GetCriteria { get; init; }
         public required Func<List<BeatmapCollection>> GetCollections { get; init; }
@@ -217,9 +211,8 @@ namespace osu.Game.Screens.Select
                     if (criteria.Ruleset?.OnlineID != 3)
                         return new List<GroupMapping> { new GroupMapping(null, items) };
 
-                    int converterModsSignature = getConverterModsSignature(criteria.Mods);
                     ILegacyRuleset legacyRuleset = (ILegacyRuleset)criteria.Ruleset.CreateInstance();
-                    return getGroupsBy(b => defineGroupByKeyCount(getManiaKeyCount(legacyRuleset, b, criteria.Mods, converterModsSignature)), items);
+                    return getGroupsBy(b => defineGroupByKeyCount(legacyRuleset.GetKeyCount(b, criteria.Mods)), items);
                 }
 
                 case GroupMode.Length:
@@ -416,31 +409,6 @@ namespace osu.Game.Screens.Select
                 return new GroupDefinition(int.MaxValue, "Unknown key count").Yield();
 
             return new GroupDefinition(keyCount, $"{keyCount}K").Yield();
-        }
-
-        private int getManiaKeyCount(ILegacyRuleset legacyRuleset, BeatmapInfo beatmap, IReadOnlyList<Mod>? mods, int converterModsSignature)
-        {
-            if (maniaKeyCountCache.Count >= mania_key_count_cache_limit)
-                maniaKeyCountCache.Clear();
-
-            return maniaKeyCountCache.GetOrAdd((beatmap.ID, converterModsSignature), _ => legacyRuleset.GetKeyCount(beatmap, mods));
-        }
-
-        private static int getConverterModsSignature(IReadOnlyList<Mod>? mods)
-        {
-            if (mods == null || mods.Count == 0)
-                return 0;
-
-            HashCode hash = default;
-
-            IEnumerable<string> converterModTypeNames = mods.OfType<IApplicableToBeatmapConverter>().Select(m => m.GetType().FullName ?? m.GetType().Name).OrderBy(name => name, StringComparer.Ordinal);
-
-            foreach (string typeName in converterModTypeNames)
-            {
-                hash.Add(typeName, StringComparer.Ordinal);
-            }
-
-            return hash.ToHashCode();
         }
 
         private IEnumerable<GroupDefinition> defineGroupBySource(string source)

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -433,9 +433,9 @@ namespace osu.Game.Screens.Select
 
             HashCode hash = default;
 
-            foreach (string typeName in mods.OfType<IApplicableToBeatmapConverter>()
-                                             .Select(m => m.GetType().FullName ?? m.GetType().Name)
-                                             .OrderBy(name => name, StringComparer.Ordinal))
+            IEnumerable<string> converterModTypeNames = mods.OfType<IApplicableToBeatmapConverter>().Select(m => m.GetType().FullName ?? m.GetType().Name).OrderBy(name => name, StringComparer.Ordinal);
+
+            foreach (string typeName in converterModTypeNames)
             {
                 hash.Add(typeName, StringComparer.Ordinal);
             }

--- a/osu.Game/Screens/Select/Filter/GroupMode.cs
+++ b/osu.Game/Screens/Select/Filter/GroupMode.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Screens.Select.Filter
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Difficulty))]
         Difficulty,
 
+        [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.KeyCount))]
+        ManiaKeyCount,
+
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Favourites))]
         Favourites,
 

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Screens.Select
     {
         // taken from draw visualiser. used for carousel alignment purposes.
         public const float HEIGHT_FROM_SCREEN_TOP = 141 - corner_radius;
+        private const string mania_ruleset_short_name = "mania";
 
         private static readonly GroupMode[] all_group_modes = Enum.GetValues<GroupMode>();
         private static readonly GroupMode[] non_mania_group_modes = all_group_modes.Where(m => m != GroupMode.ManiaKeyCount).ToArray();
@@ -283,7 +284,7 @@ namespace osu.Game.Screens.Select
 
         private void updateAvailableGroupModes()
         {
-            bool isManiaRuleset = ruleset.Value.OnlineID == 3;
+            bool isManiaRuleset = ruleset.Value.ShortName == mania_ruleset_short_name;
 
             if (!isManiaRuleset && groupDropdown.Current.Value == GroupMode.ManiaKeyCount)
                 groupDropdown.Current.Value = GroupMode.None;

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -36,6 +36,9 @@ namespace osu.Game.Screens.Select
         // taken from draw visualiser. used for carousel alignment purposes.
         public const float HEIGHT_FROM_SCREEN_TOP = 141 - corner_radius;
 
+        private static readonly GroupMode[] all_group_modes = Enum.GetValues<GroupMode>();
+        private static readonly GroupMode[] non_mania_group_modes = all_group_modes.Where(m => m != GroupMode.ManiaKeyCount).ToArray();
+
         private const float corner_radius = 10;
 
         public IBindable<BeatmapSetInfo?> ScopedBeatmapSet { get; } = new Bindable<BeatmapSetInfo?>();
@@ -193,7 +196,7 @@ namespace osu.Game.Screens.Select
                                             groupDropdown = new ShearedDropdown<GroupMode>(SongSelectStrings.Group)
                                             {
                                                 RelativeSizeAxes = Axes.X,
-                                                Items = Enum.GetValues<GroupMode>(),
+                                                Items = non_mania_group_modes,
                                             },
                                             Empty(),
                                             collectionDropdown = new CollectionDropdown
@@ -227,7 +230,13 @@ namespace osu.Game.Screens.Select
             config.BindWith(OsuSetting.SongSelectSortingMode, sortDropdown.Current);
             config.BindWith(OsuSetting.SongSelectGroupMode, groupDropdown.Current);
 
-            ruleset.BindValueChanged(_ => updateCriteria());
+            updateAvailableGroupModes();
+
+            ruleset.BindValueChanged(_ =>
+            {
+                updateAvailableGroupModes();
+                updateCriteria();
+            });
             mods.BindValueChanged(m =>
             {
                 // The following is a note carried from old song select and may not be a valid reason anymore:
@@ -270,6 +279,16 @@ namespace osu.Game.Screens.Select
             ScopedBeatmapSet.BindValueChanged(_ => updateCriteria(clearScopedSet: false));
 
             updateCriteria();
+        }
+
+        private void updateAvailableGroupModes()
+        {
+            bool isManiaRuleset = ruleset.Value.OnlineID == 3;
+
+            if (!isManiaRuleset && groupDropdown.Current.Value == GroupMode.ManiaKeyCount)
+                groupDropdown.Current.Value = GroupMode.None;
+
+            groupDropdown.Items = isManiaRuleset ? all_group_modes : non_mania_group_modes;
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
### Summary

I found the key count grouping in osu!stable's mania song select very useful.
While playing osu!lazer, I noticed that this grouping option was missing, so I implemented it here.

### Changes

- Adds a ManiaKeyCount grouping mode in song select.
- Makes ManiaKeyCount available only when mania is the active ruleset.
- Keeps the UI label as Key Count.
- Keeps beatmap sets grouped together in this mode to avoid expanding all beatmap entries at once.

1. Removed previously added key-count caching/signature logic to keep the implementation simple.
2. Replaced mania number checks (OnlineID == 3)with short-name checks for better maintainability.
3. Switched ILegacyRuleset creation to a safe cast with null fallback in ManiaKeyCount grouping.

### Testing

- dotnet build osu.Game.Tests -p:GenerateFullPaths=true -m -verbosity:m 
  - Succeeded, 0 warnings, 0 errors.

- dotnet test osu.Game.Tests --filter "FullyQualifiedName~BeatmapCarouselFilterGroupingTest" -v minimal
  - Passed: 18, Failed: 0, Skipped: 0.

- InspectCode.ps1
  - Exits with code 1 in my local environment because dotnet-nvika is not available as a local tool.

- Equivalent static analysis steps were run manually:
  - dotnet jb inspectcode "osu.Desktop.slnf" --no-build --format=Xml --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN --jobs=1 --no-updates
  - nvika parsereport "inspectcodereport.xml" --treatwarningsaserrors
  - Result: 0 issues. 