### PR TITLE
Fix floating point precision in LegacyPatternGenerator::GetColumn

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/LegacyPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/LegacyPatternGenerator.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
             }
 
             float localXDivisor = 512f / TotalColumns;
-            return Math.Clamp((int)MathF.Floor(position / localXDivisor), 0, TotalColumns - 1);
+            return Math.Clamp((int)MathF.Round(position / localXDivisor), 0, TotalColumns - 1);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #37232
Currently, there is a floating point division precision error in ```osu.Game.Rulesets.Mania\Beatmaps\Patterns\Legacy\LegacyPatternGenerator.cs::GetColumn()```

In mania 14K, this causes notes added on the 8th column to be moved to the 7th column after saving in the beatmap editor.

14 columns
512f / 14 = 36.57143f
8th column position = 256
0-indexed column = 256 / 36.57143f = 6.9999
MathF.Floor(256 / 36.57143f) should give the 0-indexed column, but is returning 6 instead of 7 here because of floating point precision.

<img width="869" height="536" alt="Image" src="https://github.com/user-attachments/assets/3718b3d4-c166-4d89-9888-0b2cae802379" />

To recreate:
download 14k beatmap ([ex](https://osu.ppy.sh/beatmapsets/1974347#mania/4097376))
ctrl + a, delete, save
Add note to the 8th column, save, close editor, edit beatmap

Before:
https://github.com/user-attachments/assets/c4f7f143-2b86-4e64-a6c0-7302a4d23b50

After:
https://github.com/user-attachments/assets/ed0104fc-5cb7-4a49-904a-5aa2e1f845cd