### PR TITLE
Fix multiple issues with ranked play card audio previews

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
-using osu.Framework.Input.Events;
 using osu.Framework.Timing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             public readonly Bindable<bool> Enabled = new BindableBool(true);
 
+            public readonly Bindable<bool> CardHovered = new BindableBool(true);
+
             public bool TrackLoaded => previewTrack?.TrackLoaded ?? false;
 
             public bool IsRunning => previewTrack?.IsRunning ?? false;
@@ -44,13 +46,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             private readonly Container overlayLayer;
 
-            private bool shouldBePlaying => Enabled.Value && IsHovered;
+            private bool shouldBePlaying => Enabled.Value && CardHovered.Value;
 
             [Resolved]
             private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
             [Resolved]
-            private OsuColour osuColour { get; set; } = null!;
+            private OsuColour colours { get; set; } = null!;
 
             public SongPreviewContainer()
             {
@@ -93,6 +95,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                         startPreviewIfAvailable();
                     }
                 });
+
+                CardHovered.BindValueChanged(selected =>
+                {
+                    if (selected.NewValue && shouldBePlaying)
+                    {
+                        startPreviewIfAvailable();
+                    }
+                });
             }
 
             private PreviewTrack? previewTrack;
@@ -106,47 +116,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                     AddInternal(track);
 
                     track.Looping = true;
-                    track.Started += onTrackStarted;
-                    track.Stopped += onTrackStopped;
+                    track.Started += () => Schedule(() => trackRunning.Value = true);
+                    track.Stopped += () => Schedule(() => trackRunning.Value = false);
 
                     setupBeatSyncProvider(track, beatmap);
 
-                    var cardColours = new RankedPlayCardContent.CardColours(beatmap, osuColour);
+                    var cardColours = new RankedPlayCardContent.CardColours(beatmap, colours);
 
                     overlayLayer.Add(new RippleVisualization(cardColours.Border)
                     {
                         TrackRunning = { BindTarget = trackRunning }
                     });
 
-                    if (IsHovered)
+                    if (shouldBePlaying)
                         startPreviewIfAvailable();
                 });
             }
-
-            protected override bool OnHover(HoverEvent e)
-            {
-                if (previewTrack != null)
-                    previewTrack.Looping = true;
-
-                if (shouldBePlaying)
-                {
-                    startPreviewIfAvailable();
-                }
-
-                return base.OnHover(e);
-            }
-
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                if (previewTrack != null)
-                    previewTrack.Looping = false;
-
-                base.OnHoverLost(e);
-            }
-
-            private void onTrackStarted() => Schedule(() => trackRunning.Value = true);
-
-            private void onTrackStopped() => Schedule(() => trackRunning.Value = false);
 
             private void startPreviewIfAvailable() => previewTrack?.Start();
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs
@@ -44,6 +44,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
             set => selectionOutline.FadeTo(value ? 1 : 0, 50);
         }
 
+        public bool PlayAudioPreview
+        {
+            set => songPreviewContainer.CardHovered.Value = value;
+        }
+
         public float Elevation;
 
         public bool PreviewTrackLoaded => songPreviewContainer.TrackLoaded;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -259,6 +259,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 card.Anchor = Anchor.Centre;
                 card.Origin = Anchor.Centre;
 
+                card.SongPreviewEnabled.Value = false;
+
                 card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
 
                 CenterRow.Add(card);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -104,6 +104,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 handOfCards.OnCardStateChanged(this, state);
 
                 Card.ShowSelectionOutline = state.NewValue.Selected;
+                Card.PlayAudioPreview = state.NewValue.Hovered;
 
                 switch (state.NewValue.Pressed, state.OldValue.Pressed)
                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                     if (Cards.FirstOrDefault(it => it.HasFocus) is not PlayerHandCard card)
                         return false;
 
-                    if (card.Selected)
+                    if (card.Selected && card.PlayAction != null)
                         card.PlayButton.TriggerClick();
                     else
                         card.TriggerClick();


### PR DESCRIPTION
The main goal here is to:
- Make keyboard selection play previews just like hovering does with mouse.
- Make sure cards don't play previews when they are in animation.
- Drive by fix to fix toggling discard not working via keyboard.

(I really want to rewrite all these classes, the structure is not great)