### PR TITLE
Make Ok adjustment formula more stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -403,7 +403,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double estimatedSliderBreaks = Math.Min(countOk, effectiveMissCount * topWeightedSliderFactor);
 
             // Scores with more Oks are more likely to have slider breaks.
-            double okAdjustment = (countOk - estimatedSliderBreaks + 4) / (countOk + 4);
+            double okAdjustment = (countOk - estimatedSliderBreaks + 4.5) / (countOk + 4);
 
             // There is a low probability of extra slider breaks on effective miss counts close to 1, as score based calculations are good at indicating if only a single break occurred.
             estimatedSliderBreaks *= DifficultyCalculationUtils.Smoothstep(effectiveMissCount, 1, 2);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -399,7 +399,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double missedComboPercent = 1.0 - (double)scoreMaxCombo / attributes.MaxCombo;
             double estimatedSliderBreaks = Math.Min(nonMissMistakes, effectiveMissCount * topWeightedSliderFactor);
 
-            // Scores with more Oks are more likely to have slider breaks.
+            // Scores with more Oks and Mehs are more likely to have slider breaks.
+            // We add an arbitrary value to both sides of the division to make it more stable on extreme ends.
             double nonMissMistakeAdjustment = (nonMissMistakes - estimatedSliderBreaks + 4.5) / (nonMissMistakes + 4);
 
             // There is a low probability of extra slider breaks on effective miss counts close to 1, as score based calculations are good at indicating if only a single break occurred.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -403,7 +403,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double estimatedSliderBreaks = Math.Min(countOk, effectiveMissCount * topWeightedSliderFactor);
 
             // Scores with more Oks are more likely to have slider breaks.
-            double okAdjustment = ((countOk - estimatedSliderBreaks) + 0.5) / countOk;
+            double okAdjustment = (countOk - estimatedSliderBreaks + 4) / (countOk + 4);
 
             // There is a low probability of extra slider breaks on effective miss counts close to 1, as score based calculations are good at indicating if only a single break occurred.
             estimatedSliderBreaks *= DifficultyCalculationUtils.Smoothstep(effectiveMissCount, 1, 2);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -400,7 +400,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double estimatedSliderBreaks = Math.Min(nonMissMistakes, effectiveMissCount * topWeightedSliderFactor);
 
             // Scores with more Oks are more likely to have slider breaks.
-            double okAdjustment = (nonMissMistakes - estimatedSliderBreaks + 4.5) / (nonMissMistakes + 4);
+            double nonMissMistakeAdjustment = (nonMissMistakes - estimatedSliderBreaks + 4.5) / (nonMissMistakes + 4);
 
             // There is a low probability of extra slider breaks on effective miss counts close to 1, as score based calculations are good at indicating if only a single break occurred.
             estimatedSliderBreaks *= DifficultyCalculationUtils.Smoothstep(effectiveMissCount, 1, 2);


### PR DESCRIPTION
Current formula can output drastically different values on simlar countOk / estimatedSliderBreaks amounts.
For example if countOk is 10, then changing estimatedSliderBreaks from 9 to 10 is gonna change okAdjustment from 0.15 to 0.05, what is a 3 times lower resulting "estimated sliderbreaks" value.

This PR is fixing that in the most simple way - by increasing the buffer constants, so very small variables won't skew the result as much.