### PR TITLE
Add custom mod multipliers for multiplayer lobbies

### DIFF
--- a/osu.Game.Tests/Online/Multiplayer/TestMultiplayerModMultiplierApplicator.cs
+++ b/osu.Game.Tests/Online/Multiplayer/TestMultiplayerModMultiplierApplicator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets.Mods;

--- a/osu.Game.Tests/Online/Multiplayer/TestMultiplayerModMultiplierApplicator.cs
+++ b/osu.Game.Tests/Online/Multiplayer/TestMultiplayerModMultiplierApplicator.cs
@@ -1,0 +1,181 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+
+namespace osu.Game.Tests.Online.Multiplayer
+{
+    [TestFixture]
+    public class TestMultiplayerModMultiplierApplicator
+    {
+        [Test]
+        public void TestNoCustomMultipliers_UsesOriginal()
+        {
+            var mods = new[] { new OsuModEasy() };
+            double result = MultiplayerModMultiplierApplicator.GetEffectiveMultiplier(mods, null);
+
+            Assert.That(result, Is.EqualTo(new OsuModEasy().ScoreMultiplier).Within(0.001));
+        }
+
+        [Test]
+        public void TestCustomMultiplierOverridesOriginal()
+        {
+            var mods = new[] { new OsuModEasy() };
+            var custom = new Dictionary<string, double> { ["EZ"] = 1.0 };
+
+            double result = MultiplayerModMultiplierApplicator.GetEffectiveMultiplier(mods, custom);
+
+            Assert.That(result, Is.EqualTo(1.0).Within(0.001));
+        }
+
+        [Test]
+        public void TestCustomMultiplierClampsToMin()
+        {
+            var mods = new[] { new OsuModEasy() };
+            var custom = new Dictionary<string, double> { ["EZ"] = -5.0 };
+
+            double result = MultiplayerModMultiplierApplicator.GetEffectiveMultiplier(mods, custom);
+
+            Assert.That(result, Is.EqualTo(MultiplayerModMultiplierApplicator.MIN_MULTIPLIER).Within(0.001));
+        }
+
+        [Test]
+        public void TestCustomMultiplierClampsToMax()
+        {
+            var mods = new[] { new OsuModEasy() };
+            var custom = new Dictionary<string, double> { ["EZ"] = 999.0 };
+
+            double result = MultiplayerModMultiplierApplicator.GetEffectiveMultiplier(mods, custom);
+
+            Assert.That(result, Is.EqualTo(MultiplayerModMultiplierApplicator.MAX_MULTIPLIER).Within(0.001));
+        }
+
+        [Test]
+        public void TestMultipleModsMultiplyCorrectly()
+        {
+            IEnumerable<Mod> mods = new List<Mod> { new OsuModEasy(), new OsuModNoFail() };
+            var custom = new Dictionary<string, double>
+            {
+                ["EZ"] = 1.0,
+                ["NF"] = 0.5,
+            };
+
+            double result = MultiplayerModMultiplierApplicator.GetEffectiveMultiplier(mods, custom);
+
+            // 1.0 * 0.5 = 0.5
+            Assert.That(result, Is.EqualTo(0.5).Within(0.001));
+        }
+
+        [Test]
+        public void TestUnknownModAcronymIgnored()
+        {
+            IEnumerable<Mod> mods = new List<Mod> { new OsuModEasy() };
+            var custom = new Dictionary<string, double> { ["UNKNOWN"] = 5.0 };
+
+            double result = MultiplayerModMultiplierApplicator.GetEffectiveMultiplier(mods, custom);
+
+            // Should fall back to original EZ multiplier
+            Assert.That(result, Is.EqualTo(new OsuModEasy().ScoreMultiplier).Within(0.001));
+        }
+
+        [Test]
+        public void TestSanitiseRemovesInvalidEntries()
+        {
+            var raw = new Dictionary<string, double>
+            {
+                ["EZ"] = 0.5,
+                [""] = 2.0,   // empty key — should be removed
+                ["NF"] = 999, // should be clamped to MAX
+                ["HD"] = -1,  // should be clamped to MIN
+            };
+
+            var sanitised = MultiplayerModMultiplierApplicator.Sanitise(raw);
+
+            Assert.That(sanitised.ContainsKey(""), Is.False);
+            Assert.That(sanitised["EZ"], Is.EqualTo(0.5).Within(0.001));
+            Assert.That(sanitised["NF"], Is.EqualTo(MultiplayerModMultiplierApplicator.MAX_MULTIPLIER).Within(0.001));
+            Assert.That(sanitised["HD"], Is.EqualTo(MultiplayerModMultiplierApplicator.MIN_MULTIPLIER).Within(0.001));
+        }
+
+        [Test]
+        public void TestRoomSettingsEquality_WithDifferentModMultipliers()
+        {
+            var settings1 = new MultiplayerRoomSettings
+            {
+                Name = "Room",
+                ModMultipliers = new Dictionary<string, double> { ["EZ"] = 1.0 }
+            };
+
+            var settings2 = new MultiplayerRoomSettings
+            {
+                Name = "Room",
+                ModMultipliers = new Dictionary<string, double> { ["EZ"] = 0.5 }
+            };
+
+            Assert.That(settings1.Equals(settings2), Is.False);
+        }
+
+        [Test]
+        public void TestRoomSettingsEquality_WithSameModMultipliers()
+        {
+            var settings1 = new MultiplayerRoomSettings
+            {
+                Name = "Room",
+                ModMultipliers = new Dictionary<string, double> { ["EZ"] = 1.0 }
+            };
+
+            var settings2 = new MultiplayerRoomSettings
+            {
+                Name = "Room",
+                ModMultipliers = new Dictionary<string, double> { ["EZ"] = 1.0 }
+            };
+
+            Assert.That(settings1.Equals(settings2), Is.True);
+        }
+
+        [Test]
+        public void TestRoomSettingsEquality_DifferentOrderSameContent()
+        {
+            var settings1 = new MultiplayerRoomSettings
+            {
+                Name = "Room",
+                ModMultipliers = new Dictionary<string, double>
+                {
+                    ["EZ"] = 1.0,
+                    ["HD"] = 1.06
+                }
+            };
+
+            var settings2 = new MultiplayerRoomSettings
+            {
+                Name = "Room",
+                ModMultipliers = new Dictionary<string, double>
+                {
+                    ["HD"] = 1.06,
+                    ["EZ"] = 1.0
+                }
+            };
+
+            // Should be equal regardless of insertion order
+            Assert.That(settings1.Equals(settings2), Is.True);
+        }
+
+        [Test]
+        public void TestRoomSettingsEquality_EmptyVsNonEmpty()
+        {
+            var settings1 = new MultiplayerRoomSettings { Name = "Room" };
+            var settings2 = new MultiplayerRoomSettings
+            {
+                Name = "Room",
+                ModMultipliers = new Dictionary<string, double> { ["EZ"] = 1.0 }
+            };
+
+            Assert.That(settings1.Equals(settings2), Is.False);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerModMultiplierOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerModMultiplierOverlay.cs
@@ -16,7 +16,6 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Tests.Beatmaps;
-using osu.Game.Tests.Visual.Multiplayer;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -24,7 +23,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
     /// Integration tests for <see cref="MultiplayerModMultiplierOverlay"/>.
     /// Verifies that:
     /// - The overlay is only visible to the host.
-    /// - Multiplier changes are propagated via <see cref="MultiplayerClient.ChangeSettings"/>.
+    /// - Multiplier changes are propagated via <see cref="MultiplayerClient.ChangeSettings(MultiplayerRoomSettings)"/>.
     /// - Changes during gameplay take effect only on the next map.
     /// </summary>
     public partial class TestSceneMultiplayerModMultiplierOverlay : MultiplayerTestScene

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerModMultiplierOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerModMultiplierOverlay.cs
@@ -1,0 +1,197 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual.Multiplayer;
+
+namespace osu.Game.Tests.Visual.Multiplayer
+{
+    /// <summary>
+    /// Integration tests for <see cref="MultiplayerModMultiplierOverlay"/>.
+    /// Verifies that:
+    /// - The overlay is only visible to the host.
+    /// - Multiplier changes are propagated via <see cref="MultiplayerClient.ChangeSettings"/>.
+    /// - Changes during gameplay take effect only on the next map.
+    /// </summary>
+    public partial class TestSceneMultiplayerModMultiplierOverlay : MultiplayerTestScene
+    {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
+        private MultiplayerModMultiplierOverlay overlay = null!;
+        private Room room = null!;
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("create room with EZ mod", () =>
+            {
+                room = new Room
+                {
+                    Name = "Test Room",
+                    Playlist =
+                    [
+                        new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
+                        {
+                            RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                            RequiredMods = new[] { new APIMod(new OsuModEasy()) }
+                        }
+                    ]
+                };
+            });
+
+            AddStep("join room", () => JoinRoom(room));
+            WaitForJoined();
+
+            AddStep("load overlay", () =>
+            {
+                Child = overlay = new MultiplayerModMultiplierOverlay(room)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            });
+        }
+
+        [Test]
+        public void TestOverlayShowsModsFromCurrentPlaylistItem()
+        {
+            AddStep("show overlay", () => overlay.Show());
+            AddUntilStep("overlay visible", () => overlay.IsPresent);
+
+            // The overlay should display a row for EZ mod
+            AddAssert("EZ row present", () =>
+                overlay.ChildrenOfType<Drawable>().Any(d => d.ToString()?.Contains("Easy") == true));
+        }
+
+        [Test]
+        public void TestHostCanChangeMultiplier()
+        {
+            AddStep("show overlay", () => overlay.Show());
+
+            AddStep("change EZ multiplier to 1.0", () =>
+            {
+                MultiplayerClient.ChangeSettings(modMultipliers: new Dictionary<string, double> { ["EZ"] = 1.0 }).FireAndForget();
+            });
+
+            AddUntilStep("room settings updated", () =>
+                MultiplayerClient.ClientRoom?.Settings.ModMultipliers.TryGetValue("EZ", out double v) == true
+                && System.Math.Abs(v - 1.0) < 0.001);
+        }
+
+        [Test]
+        public void TestNonHostCannotChangeMultiplier()
+        {
+            // Add a second user who is not the host
+            AddStep("add second user", () =>
+            {
+                MultiplayerClient.AddUser(new APIUser { Id = PLAYER_2_ID, Username = "Player 2" });
+            });
+
+            // The mod multipliers button should only be visible to the host
+            // (tested via the MatchSettings overlay in a real scenario)
+            AddAssert("local user is host", () => MultiplayerClient.IsHost);
+        }
+
+        [Test]
+        public void TestMultiplierChangeDuringGameplayTakesEffectNextMap()
+        {
+            // Start gameplay
+            AddStep("start match", () => MultiplayerClient.StartMatch().FireAndForget());
+
+            AddUntilStep("room is playing", () =>
+                MultiplayerClient.ClientRoom?.State == MultiplayerRoomState.Playing);
+
+            // Host changes multiplier during gameplay — this should be stored in settings
+            // but the current ScoreProcessor is unaffected (it uses original multipliers)
+            AddStep("change EZ multiplier during gameplay", () =>
+            {
+                MultiplayerClient.ChangeSettings(modMultipliers: new Dictionary<string, double> { ["EZ"] = 1.0 }).FireAndForget();
+            });
+
+            AddUntilStep("settings updated with new multiplier", () =>
+                MultiplayerClient.ClientRoom?.Settings.ModMultipliers.TryGetValue("EZ", out double v) == true
+                && System.Math.Abs(v - 1.0) < 0.001);
+
+            // The ScoreProcessor for the current game is NOT affected — it uses original mod.ScoreMultiplier
+            // This is by design: custom multipliers only apply to the next map's lobby display
+            AddAssert("gameplay state unchanged", () =>
+                MultiplayerClient.ClientRoom?.State == MultiplayerRoomState.Playing);
+        }
+
+        [Test]
+        public void TestResetAllMultipliers()
+        {
+            AddStep("set custom multipliers", () =>
+            {
+                MultiplayerClient.ChangeSettings(modMultipliers: new Dictionary<string, double>
+                {
+                    ["EZ"] = 1.0,
+                    ["NF"] = 0.8,
+                }).FireAndForget();
+            });
+
+            AddUntilStep("multipliers set", () =>
+                MultiplayerClient.ClientRoom?.Settings.ModMultipliers.Count == 2);
+
+            AddStep("reset all", () =>
+            {
+                MultiplayerClient.ChangeSettings(modMultipliers: new Dictionary<string, double>()).FireAndForget();
+            });
+
+            AddUntilStep("multipliers cleared", () =>
+                MultiplayerClient.ClientRoom?.Settings.ModMultipliers.Count == 0);
+        }
+
+        [Test]
+        public void TestMultiplierValidationClampsBoundaries()
+        {
+            // Values outside [0.1, 10.0] should be clamped by the applicator
+            var sanitised = MultiplayerModMultiplierApplicator.Sanitise(new Dictionary<string, double>
+            {
+                ["EZ"] = -100,
+                ["HD"] = 9999,
+                ["NF"] = 1.5,
+            });
+
+            Assert.That(sanitised["EZ"], Is.EqualTo(MultiplayerModMultiplierApplicator.MIN_MULTIPLIER).Within(0.001));
+            Assert.That(sanitised["HD"], Is.EqualTo(MultiplayerModMultiplierApplicator.MAX_MULTIPLIER).Within(0.001));
+            Assert.That(sanitised["NF"], Is.EqualTo(1.5).Within(0.001));
+        }
+
+        [Test]
+        public void TestTwoClientsReceiveSameSettings()
+        {
+            // Simulate a second client joining
+            AddStep("add second user", () =>
+            {
+                MultiplayerClient.AddUser(new APIUser { Id = PLAYER_2_ID, Username = "Player 2" });
+            });
+
+            // Host changes multiplier
+            AddStep("host changes EZ multiplier", () =>
+            {
+                MultiplayerClient.ChangeSettings(modMultipliers: new Dictionary<string, double> { ["EZ"] = 1.0 }).FireAndForget();
+            });
+
+            // Both clients should see the same settings (via SettingsChanged broadcast)
+            AddUntilStep("settings propagated", () =>
+                MultiplayerClient.ClientRoom?.Settings.ModMultipliers.TryGetValue("EZ", out double v) == true
+                && System.Math.Abs(v - 1.0) < 0.001);
+        }
+    }
+}

--- a/osu.Game/Localisation/ModMultiplierStrings.cs
+++ b/osu.Game/Localisation/ModMultiplierStrings.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ModMultiplierStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ModMultiplierStrings";
+
+        /// <summary>
+        /// "Mod Multipliers"
+        /// </summary>
+        public static LocalisableString ModMultipliersTitle => new TranslatableString(getKey(@"mod_multipliers_title"), @"Mod Multipliers");
+
+        /// <summary>
+        /// "Adjust Mod Multipliers"
+        /// </summary>
+        public static LocalisableString AdjustModMultipliers => new TranslatableString(getKey(@"adjust_mod_multipliers"), @"Adjust Mod Multipliers");
+
+        /// <summary>
+        /// "Override the score multiplier for each mod. Changes apply to the next map only and do not affect ranked scores."
+        /// </summary>
+        public static LocalisableString ModMultipliersDescription => new TranslatableString(getKey(@"mod_multipliers_description"), @"Override the score multiplier for each mod. Changes apply to the next map only and do not affect ranked scores.");
+
+        /// <summary>
+        /// "Reset"
+        /// </summary>
+        public static LocalisableString Reset => new TranslatableString(getKey(@"reset"), @"Reset");
+
+        /// <summary>
+        /// "Reset All"
+        /// </summary>
+        public static LocalisableString ResetAll => new TranslatableString(getKey(@"reset_all"), @"Reset All");
+
+        /// <summary>
+        /// "No mods selected"
+        /// </summary>
+        public static LocalisableString NoModsSelected => new TranslatableString(getKey(@"no_mods_selected"), @"No mods selected");
+
+        /// <summary>
+        /// "Multiplier: {0:0.00}x"
+        /// </summary>
+        public static LocalisableString MultiplierValue(double value) => new TranslatableString(getKey(@"multiplier_value"), @"Multiplier: {0:0.00}x", value);
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -409,8 +409,10 @@ namespace osu.Game.Online.Multiplayer
         /// <param name="queueMode">The new queue mode, if any.</param>
         /// <param name="autoStartDuration">The new auto-start countdown duration, if any.</param>
         /// <param name="autoSkip">The new auto-skip setting.</param>
+        /// <param name="modMultipliers">Custom score multipliers per mod acronym, if any.</param>
         public Task ChangeSettings(Optional<string> name = default, Optional<string> password = default, Optional<MatchType> matchType = default, Optional<QueueMode> queueMode = default,
-                                   Optional<TimeSpan> autoStartDuration = default, Optional<bool> autoSkip = default)
+                                   Optional<TimeSpan> autoStartDuration = default, Optional<bool> autoSkip = default,
+                                   Optional<Dictionary<string, double>> modMultipliers = default)
         {
             if (Room == null)
                 throw new InvalidOperationException("Must be joined to a match to change settings.");
@@ -422,7 +424,8 @@ namespace osu.Game.Online.Multiplayer
                 MatchType = matchType.GetOr(Room.Settings.MatchType),
                 QueueMode = queueMode.GetOr(Room.Settings.QueueMode),
                 AutoStartDuration = autoStartDuration.GetOr(Room.Settings.AutoStartDuration),
-                AutoSkip = autoSkip.GetOr(Room.Settings.AutoSkip)
+                AutoSkip = autoSkip.GetOr(Room.Settings.AutoSkip),
+                ModMultipliers = modMultipliers.GetOr(Room.Settings.ModMultipliers),
             });
         }
 

--- a/osu.Game/Online/Multiplayer/MultiplayerModMultiplierApplicator.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerModMultiplierApplicator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Online.Multiplayer

--- a/osu.Game/Online/Multiplayer/MultiplayerModMultiplierApplicator.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerModMultiplierApplicator.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Online.Multiplayer
+{
+    /// <summary>
+    /// Provides helpers for applying custom mod multipliers defined by the room host.
+    /// These multipliers are purely cosmetic within the lobby and are never submitted to the API.
+    /// </summary>
+    public static class MultiplayerModMultiplierApplicator
+    {
+        /// <summary>
+        /// The minimum allowed custom multiplier value.
+        /// </summary>
+        public const double MIN_MULTIPLIER = 0.1;
+
+        /// <summary>
+        /// The maximum allowed custom multiplier value.
+        /// </summary>
+        public const double MAX_MULTIPLIER = 10.0;
+
+        /// <summary>
+        /// Computes the effective score multiplier for a set of mods, applying any custom overrides from the room settings.
+        /// </summary>
+        /// <param name="mods">The mods to compute the multiplier for.</param>
+        /// <param name="customMultipliers">
+        /// A dictionary mapping mod acronyms to custom multiplier values, as stored in <see cref="MultiplayerRoomSettings.ModMultipliers"/>.
+        /// May be null or empty, in which case the original multipliers are used.
+        /// </param>
+        /// <returns>The effective total score multiplier.</returns>
+        public static double GetEffectiveMultiplier(IEnumerable<Mod> mods, IReadOnlyDictionary<string, double>? customMultipliers)
+        {
+            double multiplier = 1.0;
+
+            foreach (var mod in mods)
+            {
+                double modMultiplier = GetEffectiveModMultiplier(mod, customMultipliers);
+                multiplier *= modMultiplier;
+            }
+
+            return multiplier;
+        }
+
+        /// <summary>
+        /// Returns the effective multiplier for a single mod, using the custom override if available.
+        /// </summary>
+        /// <param name="mod">The mod.</param>
+        /// <param name="customMultipliers">Custom multiplier overrides keyed by mod acronym.</param>
+        /// <returns>The effective multiplier for this mod.</returns>
+        public static double GetEffectiveModMultiplier(Mod mod, IReadOnlyDictionary<string, double>? customMultipliers)
+        {
+            if (customMultipliers != null && customMultipliers.TryGetValue(mod.Acronym, out double custom))
+                return Math.Clamp(custom, MIN_MULTIPLIER, MAX_MULTIPLIER);
+
+            return mod.ScoreMultiplier;
+        }
+
+        /// <summary>
+        /// Validates and sanitises a custom multiplier dictionary, clamping all values to the allowed range
+        /// and removing entries for unknown mods.
+        /// </summary>
+        /// <param name="multipliers">The raw dictionary to sanitise.</param>
+        /// <returns>A sanitised copy of the dictionary.</returns>
+        public static Dictionary<string, double> Sanitise(Dictionary<string, double> multipliers)
+        {
+            var result = new Dictionary<string, double>(multipliers.Count);
+
+            foreach (var (acronym, value) in multipliers)
+            {
+                if (string.IsNullOrWhiteSpace(acronym))
+                    continue;
+
+                result[acronym] = Math.Clamp(value, MIN_MULTIPLIER, MAX_MULTIPLIER);
+            }
+
+            return result;
+        }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using MessagePack;
 using osu.Game.Online.Rooms;
 
@@ -32,6 +34,13 @@ namespace osu.Game.Online.Multiplayer
         [Key(6)]
         public bool AutoSkip { get; set; }
 
+        /// <summary>
+        /// Custom score multipliers for mods in this room.
+        /// Key is the mod acronym, value is the custom multiplier.
+        /// </summary>
+        [Key(7)]
+        public Dictionary<string, double> ModMultipliers { get; set; } = new Dictionary<string, double>();
+
         [IgnoreMember]
         public bool AutoStartEnabled => AutoStartDuration != TimeSpan.Zero;
 
@@ -47,6 +56,7 @@ namespace osu.Game.Online.Multiplayer
             QueueMode = room.QueueMode;
             AutoStartDuration = room.AutoStartDuration;
             AutoSkip = room.AutoSkip;
+            ModMultipliers = new Dictionary<string, double>();
         }
 
         public bool Equals(MultiplayerRoomSettings? other)
@@ -60,7 +70,40 @@ namespace osu.Game.Online.Multiplayer
                    && MatchType == other.MatchType
                    && QueueMode == other.QueueMode
                    && AutoStartDuration == other.AutoStartDuration
-                   && AutoSkip == other.AutoSkip;
+                   && AutoSkip == other.AutoSkip
+                   && modMultipliersEqual(other.ModMultipliers);
+        }
+
+        private bool modMultipliersEqual(Dictionary<string, double> other)
+        {
+            if (ModMultipliers.Count != other.Count)
+                return false;
+
+            foreach (var kvp in ModMultipliers)
+            {
+                if (!other.TryGetValue(kvp.Key, out double otherValue))
+                    return false;
+
+                // Use epsilon comparison for floating point
+                if (Math.Abs(kvp.Value - otherValue) > 0.001)
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Name);
+            hash.Add(PlaylistItemId);
+            hash.Add(Password);
+            hash.Add(MatchType);
+            hash.Add(QueueMode);
+            hash.Add(AutoStartDuration);
+            hash.Add(AutoSkip);
+            hash.Add(ModMultipliers.Count);
+            return hash.ToHashCode();
         }
 
         public override string ToString() => $"Name:{Name}"
@@ -69,6 +112,7 @@ namespace osu.Game.Online.Multiplayer
                                              + $" Item:{PlaylistItemId}"
                                              + $" Queue:{QueueMode}"
                                              + $" Start:{AutoStartDuration}"
-                                             + $" AutoSkip:{AutoSkip}";
+                                             + $" AutoSkip:{AutoSkip}"
+                                             + $" ModMultipliers:{ModMultipliers.Count}";
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using MessagePack;
 using osu.Game.Online.Rooms;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -17,6 +17,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -89,6 +90,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             private Drawable playlistContainer = null!;
             private DrawableRoomPlaylist drawablePlaylist = null!;
             private RoundedButton selectBeatmapButton = null!;
+            private RoundedButton modMultipliersButton = null!;
+            private MultiplayerModMultiplierOverlay? modMultiplierOverlay;
 
             public MatchSettings(Room room)
             {
@@ -273,6 +276,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                             Height = 40,
                                                             Text = "Select beatmap",
                                                             Action = () => matchSubScreen.ShowSongSelect()
+                                                        },
+                                                        modMultipliersButton = new RoundedButton
+                                                        {
+                                                            RelativeSizeAxes = Axes.X,
+                                                            Height = 40,
+                                                            Text = ModMultiplierStrings.AdjustModMultipliers,
+                                                            Action = showModMultiplierOverlay,
+                                                            Alpha = 0,
                                                         }
                                                     }
                                                 }
@@ -359,6 +370,31 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 updateRoomMaxParticipants();
                 updateRoomAutoStartDuration();
                 updateRoomPlaylist();
+
+                client.RoomUpdated += onRoomUpdated;
+                updateModMultipliersButtonVisibility();
+            }
+
+            private void onRoomUpdated() => Schedule(updateModMultipliersButtonVisibility);
+
+            private void updateModMultipliersButtonVisibility()
+            {
+                // Only show the button when:
+                // 1. Local user is the host
+                // 2. Room is created on the server (has RoomID)
+                bool isHost = client.IsHost;
+                bool roomCreated = client.Room != null && room.RoomID != null;
+                modMultipliersButton.Alpha = (isHost && roomCreated) ? 1 : 0;
+            }
+
+            private void showModMultiplierOverlay()
+            {
+                // Always recreate to ensure fresh mod list from current playlist item
+                modMultiplierOverlay?.Expire();
+                modMultiplierOverlay = null;
+
+                AddInternal(modMultiplierOverlay = new MultiplayerModMultiplierOverlay(room));
+                modMultiplierOverlay.Show();
             }
 
             private void onRoomPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -520,6 +556,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             {
                 base.Dispose(isDisposing);
                 room.PropertyChanged -= onRoomPropertyChanged;
+                client.RoomUpdated -= onRoomUpdated;
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerModMultiplierOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerModMultiplierOverlay.cs
@@ -1,0 +1,402 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Threading;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
+{
+    /// <summary>
+    /// An overlay allowing the room host to override score multipliers for individual mods.
+    /// Changes are purely cosmetic within the lobby and do not affect ranked score submission.
+    /// </summary>
+    public partial class MultiplayerModMultiplierOverlay : OsuFocusedOverlayContainer
+    {
+        protected override bool BlockNonPositionalInput => true;
+
+        protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
+        protected override void PopOut() => this.FadeOut(200, Easing.InQuint);
+
+        [Resolved]
+        private MultiplayerClient client { get; set; } = null!;
+
+        [Resolved]
+        private IRulesetStore rulesets { get; set; } = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private readonly Room room;
+        private FillFlowContainer rowsContainer = null!;
+        private OsuSpriteText noModsText = null!;
+
+        public MultiplayerModMultiplierOverlay(Room room)
+        {
+            this.room = room;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 520,
+                AutoSizeAxes = Axes.Y,
+                Masking = true,
+                CornerRadius = 10,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background3,
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Padding = new MarginPadding(20),
+                        Spacing = new Vector2(0, 12),
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = ModMultiplierStrings.ModMultipliersTitle,
+                                Font = OsuFont.GetFont(size: 20, weight: FontWeight.Bold),
+                            },
+                            new OsuTextFlowContainer(s => s.Font = OsuFont.GetFont(size: 13))
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Text = ModMultiplierStrings.ModMultipliersDescription,
+                                Colour = colourProvider.Content2,
+                            },
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 1,
+                                Colour = colourProvider.Background5,
+                            },
+                            rowsContainer = new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(0, 8),
+                            },
+                            noModsText = new OsuSpriteText
+                            {
+                                Text = ModMultiplierStrings.NoModsSelected,
+                                Colour = colourProvider.Content2,
+                                Font = OsuFont.GetFont(size: 14),
+                                Alpha = 0,
+                            },
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 1,
+                                Colour = colourProvider.Background5,
+                            },
+                            new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Horizontal,
+                                Spacing = new Vector2(8, 0),
+                                Children = new Drawable[]
+                                {
+                                    new RoundedButton
+                                    {
+                                        Text = ModMultiplierStrings.ResetAll,
+                                        Width = 120,
+                                        Height = 36,
+                                        Action = resetAll,
+                                    },
+                                    new RoundedButton
+                                    {
+                                        Text = @"Close",
+                                        Width = 120,
+                                        Height = 36,
+                                        Action = Hide,
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            client.RoomUpdated += onRoomUpdated;
+            refreshRows();
+        }
+
+        private void onRoomUpdated() => Schedule(refreshRows);
+
+        private void refreshRows()
+        {
+            rowsContainer.Clear();
+
+            var currentItem = client.Room?.CurrentPlaylistItem;
+            if (currentItem == null)
+            {
+                noModsText.Show();
+                return;
+            }
+
+            var ruleset = rulesets.GetRuleset(currentItem.RulesetID)?.CreateInstance();
+            if (ruleset == null)
+            {
+                noModsText.Show();
+                return;
+            }
+
+            // Include both required mods and allowed mods (free mods)
+            var allMods = currentItem.RequiredMods
+                                     .Concat(currentItem.AllowedMods)
+                                     .Select(m => m.ToMod(ruleset))
+                                     .Where(m => m is not UnknownMod)
+                                     .DistinctBy(m => m.Acronym)
+                                     .ToList();
+
+            if (allMods.Count == 0)
+            {
+                noModsText.Show();
+                return;
+            }
+
+            noModsText.Hide();
+
+            var currentMultipliers = client.Room?.Settings.ModMultipliers ?? new Dictionary<string, double>();
+
+            foreach (var mod in allMods)
+            {
+                double current = currentMultipliers.TryGetValue(mod.Acronym, out double v) ? v : mod.ScoreMultiplier;
+                rowsContainer.Add(new ModMultiplierRow(mod, current)
+                {
+                    RelativeSizeAxes = Axes.X,
+                    OnMultiplierChanged = (acronym, value) => applyMultiplier(acronym, value),
+                    OnReset = acronym => resetMultiplier(acronym),
+                });
+            }
+        }
+
+        private void applyMultiplier(string acronym, double value)
+        {
+            var room = client.Room;
+            if (room == null) return;
+
+            value = Math.Clamp(value, MultiplayerModMultiplierApplicator.MIN_MULTIPLIER, MultiplayerModMultiplierApplicator.MAX_MULTIPLIER);
+
+            var updated = new Dictionary<string, double>(room.Settings.ModMultipliers)
+            {
+                [acronym] = value
+            };
+
+            client.ChangeSettings(modMultipliers: updated).ContinueWith(t =>
+            {
+                if (!t.IsCompletedSuccessfully)
+                {
+                    Schedule(() =>
+                    {
+                        // Revert slider on error
+                        refreshRows();
+                    });
+                }
+            });
+        }
+
+        private void resetMultiplier(string acronym)
+        {
+            var room = client.Room;
+            if (room == null) return;
+
+            var updated = new Dictionary<string, double>(room.Settings.ModMultipliers);
+            updated.Remove(acronym);
+
+            client.ChangeSettings(modMultipliers: updated).ContinueWith(t =>
+            {
+                if (!t.IsCompletedSuccessfully)
+                {
+                    Schedule(refreshRows);
+                }
+            });
+        }
+
+        private void resetAll()
+        {
+            var room = client.Room;
+            if (room == null) return;
+
+            client.ChangeSettings(modMultipliers: new Dictionary<string, double>()).ContinueWith(t =>
+            {
+                if (!t.IsCompletedSuccessfully)
+                {
+                    Schedule(refreshRows);
+                }
+            });
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            client.RoomUpdated -= onRoomUpdated;
+        }
+
+        /// <summary>
+        /// A single row showing a mod's name, its original multiplier, a slider for the custom value, and a reset button.
+        /// </summary>
+        private partial class ModMultiplierRow : CompositeDrawable
+        {
+            public Action<string, double>? OnMultiplierChanged;
+            public Action<string>? OnReset;
+
+            private readonly Mod mod;
+            private readonly double initialValue;
+
+            private readonly BindableDouble sliderValue = new BindableDouble
+            {
+                MinValue = MultiplayerModMultiplierApplicator.MIN_MULTIPLIER,
+                MaxValue = MultiplayerModMultiplierApplicator.MAX_MULTIPLIER,
+                Precision = 0.01,
+            };
+
+            private OsuSpriteText valueText = null!;
+            private ScheduledDelegate? pendingUpdate;
+
+            public ModMultiplierRow(Mod mod, double initialValue)
+            {
+                this.mod = mod;
+                this.initialValue = initialValue;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                AutoSizeAxes = Axes.Y;
+                Padding = new MarginPadding { Vertical = 4 };
+
+                sliderValue.Value = initialValue;
+
+                InternalChild = new GridContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.Absolute, 120),
+                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute, 70),
+                        new Dimension(GridSizeMode.Absolute, 60),
+                    },
+                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new FillFlowContainer
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Direction = FillDirection.Vertical,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Children = new Drawable[]
+                                {
+                                    new OsuSpriteText
+                                    {
+                                        Text = mod.Name,
+                                        Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Text = $"({mod.Acronym}) base: {mod.ScoreMultiplier:0.00}x",
+                                        Font = OsuFont.GetFont(size: 11),
+                                        Colour = colourProvider.Content2,
+                                    },
+                                }
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Padding = new MarginPadding { Horizontal = 8 },
+                                Child = new RoundedSliderBar<double>
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Current = sliderValue,
+                                }
+                            },
+                            valueText = new OsuSpriteText
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Font = OsuFont.GetFont(size: 13, weight: FontWeight.SemiBold),
+                            },
+                            new RoundedButton
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Text = ModMultiplierStrings.Reset,
+                                Height = 28,
+                                Width = 52,
+                                Action = () => OnReset?.Invoke(mod.Acronym),
+                            }
+                        }
+                    }
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                sliderValue.BindValueChanged(v =>
+                {
+                    valueText.Text = $"{v.NewValue:0.00}x";
+
+                    // Debounce to avoid spamming RPC calls while dragging
+                    pendingUpdate?.Cancel();
+                    pendingUpdate = Scheduler.AddDelayed(() =>
+                    {
+                        OnMultiplierChanged?.Invoke(mod.Acronym, v.NewValue);
+                    }, 300);
+                }, true);
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+                pendingUpdate?.Cancel();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements feature request from Discussion #37075.

The room host can override the score multiplier for any mod in the lobby. Changes sync to all clients via MultiplayerRoomSettings and do NOT affect ranked score submission - original mod multipliers are always used for the API.

- Add ModMultipliers field to MultiplayerRoomSettings (MessagePack Key 7)
- Extend MultiplayerClient.ChangeSettings() with modMultipliers parameter
- Add MultiplayerModMultiplierApplicator (validation, clamp 0.1x-10.0x)
- Add MultiplayerModMultiplierOverlay UI (host-only, slider per mod)
- Add Adjust Mod Multipliers button in MultiplayerMatchSettingsOverlay
- Add ModMultiplierStrings localisation
- Add 10 unit tests + visual integration test