### PR TITLE
Fix beatmap DateAdded sorting when importing from osu!stable

### DIFF
--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -100,6 +100,91 @@ namespace osu.Game.Tests.Database
             });
         }
 
+        /// <summary>
+        /// When <c>osu!.db</c> provides a date for a folder, that date should take precedence over
+        /// the file system write time.
+        /// </summary>
+        [Test]
+        public void TestOsuDbDateTakesPrecedenceOverFileSystemDate()
+        {
+            RunTestWithRealmAsync(async (realm, storage) =>
+            {
+                using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+                using (var tmpStorage = new TemporaryNativeStorage("stable-songs-osudb"))
+                using (new RealmRulesetStore(realm, storage))
+                {
+                    var stableStorage = new StableStorage(tmpStorage.GetFullPath(""), host);
+                    var songsStorage = stableStorage.GetStorageForDirectory(StableStorage.STABLE_DEFAULT_SONGS_PATH);
+
+                    ZipFile.ExtractToDirectory(TestResources.GetQuickTestBeatmapForImport(), songsStorage.GetFullPath("renatus"));
+
+                    // Set file system date to something recent so we can confirm it is overridden.
+                    string[] beatmaps = Directory.GetFiles(songsStorage.GetFullPath("renatus"), "*.osu", SearchOption.TopDirectoryOnly);
+                    foreach (string b in beatmaps)
+                        File.SetLastWriteTimeUtc(b, new DateTime(2024, 1, 1, 0, 0, 0));
+
+                    var osuDbDate = new DateTimeOffset(new DateTime(2010, 5, 20, 8, 30, 0, DateTimeKind.Utc));
+
+                    // Use a subclass that injects a known date from a fake osu!.db.
+                    var importer = new TestLegacyBeatmapImporterWithOsuDb(
+                        new BeatmapImporter(storage, realm),
+                        new Dictionary<string, DateTimeOffset>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "renatus", osuDbDate }
+                        });
+
+                    await importer.ImportFromStableAsync(stableStorage);
+
+                    var importedSet = realm.Realm.All<BeatmapSetInfo>().Single();
+
+                    ClassicAssert.NotNull(importedSet);
+                    ClassicAssert.AreEqual(osuDbDate, importedSet.DateAdded);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Verifies that nested folders (e.g., "subdirectory\beatmap") are matched correctly
+        /// against osu!.db entries using relative paths.
+        /// </summary>
+        [Test]
+        public void TestNestedFolderDateFromOsuDb()
+        {
+            RunTestWithRealmAsync(async (realm, storage) =>
+            {
+                using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+                using (var tmpStorage = new TemporaryNativeStorage("stable-songs-nested"))
+                using (new RealmRulesetStore(realm, storage))
+                {
+                    var stableStorage = new StableStorage(tmpStorage.GetFullPath(""), host);
+                    var songsStorage = stableStorage.GetStorageForDirectory(StableStorage.STABLE_DEFAULT_SONGS_PATH);
+
+                    // Create a nested folder structure: Songs/subfolder/beatmap
+                    var subfolderStorage = songsStorage.GetStorageForDirectory("subfolder");
+                    ZipFile.ExtractToDirectory(TestResources.GetQuickTestBeatmapForImport(), subfolderStorage.GetFullPath("renatus"));
+
+                    var osuDbDate = new DateTimeOffset(new DateTime(2012, 8, 15, 10, 0, 0, DateTimeKind.Utc));
+
+                    // osu!.db stores nested folders with backslash separator on Windows.
+                    string nestedPath = Path.Combine("subfolder", "renatus");
+
+                    var importer = new TestLegacyBeatmapImporterWithOsuDb(
+                        new BeatmapImporter(storage, realm),
+                        new Dictionary<string, DateTimeOffset>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { nestedPath, osuDbDate }
+                        });
+
+                    await importer.ImportFromStableAsync(stableStorage);
+
+                    var importedSet = realm.Realm.All<BeatmapSetInfo>().Single();
+
+                    ClassicAssert.NotNull(importedSet);
+                    ClassicAssert.AreEqual(osuDbDate, importedSet.DateAdded);
+                }
+            });
+        }
+
         private class TestLegacyBeatmapImporter : LegacyBeatmapImporter
         {
             public TestLegacyBeatmapImporter()
@@ -108,6 +193,20 @@ namespace osu.Game.Tests.Database
             }
 
             public new IEnumerable<string> GetStableImportPaths(Storage storage) => base.GetStableImportPaths(storage);
+        }
+
+        private class TestLegacyBeatmapImporterWithOsuDb : LegacyBeatmapImporter
+        {
+            private readonly Dictionary<string, DateTimeOffset> dateAddedByFolder;
+
+            public TestLegacyBeatmapImporterWithOsuDb(IModelImporter<BeatmapSetInfo> importer, Dictionary<string, DateTimeOffset> dateAddedByFolder)
+                : base(importer)
+            {
+                this.dateAddedByFolder = dateAddedByFolder;
+            }
+
+            protected override Dictionary<string, DateTimeOffset>? ReadDateAddedFromStableDb(StableStorage stableStorage)
+                => dateAddedByFolder;
         }
     }
 }

--- a/osu.Game.Tests/Database/OsuDbReaderTest.cs
+++ b/osu.Game.Tests/Database/OsuDbReaderTest.cs
@@ -1,0 +1,295 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using osu.Game.Database;
+
+namespace osu.Game.Tests.Database
+{
+    /// <summary>
+    /// Tests for <see cref="OsuDbReader"/> using hand-crafted minimal <c>osu!.db</c> streams.
+    /// </summary>
+    [TestFixture]
+    public class OsuDbReaderTest
+    {
+        /// <summary>
+        /// A single beatmap entry with a known modification time should be returned correctly.
+        /// </summary>
+        [Test]
+        public void TestReadDateAddedByFolder()
+        {
+            var expectedDate = new DateTimeOffset(new DateTime(2015, 6, 1, 12, 0, 0, DateTimeKind.Utc));
+
+            using var stream = buildMinimalOsuDb(version: 20191106, folderName: "241526 Renatus", lastModifiedTicks: expectedDate.UtcTicks);
+            var result = OsuDbReader.ReadDateAddedByFolder(stream);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.ContainsKey("241526 Renatus"), Is.True);
+            Assert.That(result["241526 Renatus"], Is.EqualTo(expectedDate));
+        }
+
+        /// <summary>
+        /// When multiple beatmap entries share the same folder (different difficulties),
+        /// the reader should keep the earliest modification time.
+        /// </summary>
+        [Test]
+        public void TestEarliestDateKeptForSameFolder()
+        {
+            var earlier = new DateTimeOffset(new DateTime(2014, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            var later = new DateTimeOffset(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            using var stream = buildOsuDbWithTwoEntries(
+                version: 20191106,
+                folderName: "shared-folder",
+                ticks1: later.UtcTicks,
+                ticks2: earlier.UtcTicks);
+
+            var result = OsuDbReader.ReadDateAddedByFolder(stream);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!["shared-folder"], Is.EqualTo(earlier));
+        }
+
+        /// <summary>
+        /// Verifies that the legacy entry-size prefix (present in versions &lt; 20191106) is handled correctly.
+        /// </summary>
+        [Test]
+        public void TestLegacyVersionWithSizePrefix()
+        {
+            var expectedDate = new DateTimeOffset(new DateTime(2013, 3, 15, 8, 0, 0, DateTimeKind.Utc));
+
+            using var stream = buildMinimalOsuDb(version: 20130815, folderName: "legacy-folder", lastModifiedTicks: expectedDate.UtcTicks);
+            var result = OsuDbReader.ReadDateAddedByFolder(stream);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!["legacy-folder"], Is.EqualTo(expectedDate));
+        }
+
+        /// <summary>
+        /// Verifies that beatmap entries with invalid ticks values are skipped gracefully.
+        /// </summary>
+        [Test]
+        public void TestInvalidTicksAreSkipped()
+        {
+            using var stream = buildMinimalOsuDb(version: 20191106, folderName: "invalid-ticks", lastModifiedTicks: -1);
+            var result = OsuDbReader.ReadDateAddedByFolder(stream);
+
+            // The entry should be skipped, resulting in an empty dictionary.
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.Count, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies that when one entry has invalid ticks but another is valid, only the valid one is kept.
+        /// </summary>
+        [Test]
+        public void TestMixedValidAndInvalidTicks()
+        {
+            var validDate = new DateTimeOffset(new DateTime(2015, 6, 1, 12, 0, 0, DateTimeKind.Utc));
+
+            using var stream = buildOsuDbWithTwoEntries(
+                version: 20191106,
+                folderName: "mixed-folder",
+                ticks1: -1, // invalid
+                ticks2: validDate.UtcTicks); // valid
+
+            var result = OsuDbReader.ReadDateAddedByFolder(stream);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.ContainsKey("mixed-folder"), Is.True);
+            Assert.That(result["mixed-folder"], Is.EqualTo(validDate));
+        }
+
+        /// <summary>
+        /// Verifies that files with unreasonable beatmap counts are rejected gracefully.
+        /// </summary>
+        [Test]
+        public void TestUnreasonableBeatmapCountIsRejected()
+        {
+            var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true);
+
+            bw.Write(20191106); // version
+            bw.Write(1);        // folder count
+            bw.Write(true);     // account unlocked
+            bw.Write(0L);       // unlock date
+            writeOsuString(bw, "TestPlayer");
+            bw.Write(2_000_000); // unreasonable beatmap count (> 1 million)
+
+            ms.Position = 0;
+
+            var result = OsuDbReader.ReadDateAddedByFolder(ms);
+
+            // Should return empty dictionary, not crash.
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.Count, Is.EqualTo(0));
+        }
+
+        // ─── helpers ────────────────────────────────────────────────────────────────
+
+        private static MemoryStream buildMinimalOsuDb(int version, string folderName, long lastModifiedTicks)
+        {
+            var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true);
+
+            writeHeader(bw, version, beatmapCount: 1);
+            writeBeatmapEntry(bw, version, folderName, lastModifiedTicks);
+            bw.Write(0); // user permissions
+
+            ms.Position = 0;
+            return ms;
+        }
+
+        private static MemoryStream buildOsuDbWithTwoEntries(int version, string folderName, long ticks1, long ticks2)
+        {
+            var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true);
+
+            writeHeader(bw, version, beatmapCount: 2);
+            writeBeatmapEntry(bw, version, folderName, ticks1);
+            writeBeatmapEntry(bw, version, folderName, ticks2);
+            bw.Write(0); // user permissions
+
+            ms.Position = 0;
+            return ms;
+        }
+
+        private static void writeHeader(BinaryWriter bw, int version, int beatmapCount)
+        {
+            bw.Write(version);
+            bw.Write(1);       // folder count
+            bw.Write(true);    // account unlocked
+            bw.Write(0L);      // date account will be unlocked (ticks)
+            writeOsuString(bw, "TestPlayer");
+            bw.Write(beatmapCount);
+        }
+
+        private static void writeBeatmapEntry(BinaryWriter bw, int version, string folderName, long lastModifiedTicks)
+        {
+            long startPos = bw.BaseStream.Position;
+
+            if (version < 20191106)
+                bw.Write(0); // size placeholder – patched at the end
+
+            writeOsuString(bw, "Artist");
+            writeOsuString(bw, "ArtistUnicode");
+            writeOsuString(bw, "Title");
+            writeOsuString(bw, "TitleUnicode");
+            writeOsuString(bw, "Creator");
+            writeOsuString(bw, "Hard");
+            writeOsuString(bw, "audio.mp3");
+            writeOsuString(bw, "abc123md5hash");
+            writeOsuString(bw, "beatmap.osu");
+            bw.Write((byte)4);    // ranked status
+            bw.Write((short)100); // hit circles
+            bw.Write((short)50);  // sliders
+            bw.Write((short)5);   // spinners
+            bw.Write(lastModifiedTicks); // last modification time (Windows ticks)
+
+            if (version < 20140609)
+            {
+                bw.Write((byte)5);
+                bw.Write((byte)4);
+                bw.Write((byte)6);
+                bw.Write((byte)7);
+            }
+            else
+            {
+                bw.Write(9.0f);
+                bw.Write(4.0f);
+                bw.Write(6.0f);
+                bw.Write(8.0f);
+            }
+
+            bw.Write(1.4); // slider velocity
+
+            if (version >= 20140609)
+            {
+                // 4 rulesets, 0 star-rating pairs each
+                for (int r = 0; r < 4; r++)
+                    bw.Write(0);
+            }
+
+            bw.Write(180);    // drain time
+            bw.Write(240000); // total time
+            bw.Write(5000);   // preview time
+
+            bw.Write(1); // timing point count
+            bw.Write(180.0); // BPM
+            bw.Write(0.0);   // offset
+            bw.Write(true);  // inherited
+
+            bw.Write(12345);   // difficulty ID
+            bw.Write(67890);   // beatmap ID
+            bw.Write(0);       // thread ID
+            bw.Write((byte)0); // grade osu!
+            bw.Write((byte)0); // grade taiko
+            bw.Write((byte)0); // grade catch
+            bw.Write((byte)0); // grade mania
+            bw.Write((short)0); // local offset
+            bw.Write(0.7f);    // stack leniency
+            bw.Write((byte)0); // gameplay mode
+            writeOsuString(bw, string.Empty); // source
+            writeOsuString(bw, string.Empty); // tags
+            bw.Write((short)0); // online offset
+            writeOsuString(bw, string.Empty); // title font
+            bw.Write(true);    // unplayed
+            bw.Write(0L);      // last played
+            bw.Write(false);   // is osz2
+            writeOsuString(bw, folderName);
+            bw.Write(0L);      // last checked
+            bw.Write(false);   // ignore sound
+            bw.Write(false);   // ignore skin
+            bw.Write(false);   // disable storyboard
+            bw.Write(false);   // disable video
+            bw.Write(false);   // visual override
+
+            if (version < 20140609)
+                bw.Write((short)0); // unknown
+
+            bw.Write(0);       // last modification time (duplicate)
+            bw.Write((byte)0); // mania scroll speed
+
+            if (version < 20191106)
+            {
+                long endPos = bw.BaseStream.Position;
+                int entrySize = (int)(endPos - startPos - 4);
+                bw.BaseStream.Position = startPos;
+                bw.Write(entrySize);
+                bw.BaseStream.Position = endPos;
+            }
+        }
+
+        /// <summary>
+        /// Writes a string in the osu!.db format: 0x0b prefix + ULEB128 length + UTF-8 bytes.
+        /// An empty string is written as 0x0b + 0x00.
+        /// </summary>
+        private static void writeOsuString(BinaryWriter bw, string value)
+        {
+            if (value == null)
+            {
+                bw.Write((byte)0x00);
+                return;
+            }
+
+            bw.Write((byte)0x0b);
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            writeUleb128(bw, (uint)bytes.Length);
+            bw.BaseStream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static void writeUleb128(BinaryWriter bw, uint value)
+        {
+            do
+            {
+                byte b = (byte)(value & 0x7F);
+                value >>= 7;
+                if (value != 0) b |= 0x80;
+                bw.Write(b);
+            } while (value != 0);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -164,12 +164,12 @@ namespace osu.Game.Beatmaps
 
         protected override bool ShouldDeleteArchive(string path) => HandledExtensions.Contains(Path.GetExtension(path).ToLowerInvariant());
 
-        protected override void Populate(BeatmapSetInfo beatmapSet, ArchiveReader? archive, Realm realm, CancellationToken cancellationToken = default)
+        protected override void Populate(BeatmapSetInfo beatmapSet, ArchiveReader? archive, Realm realm, ImportParameters parameters, CancellationToken cancellationToken = default)
         {
             if (archive != null)
                 beatmapSet.Beatmaps.AddRange(createBeatmapDifficulties(beatmapSet, realm));
 
-            beatmapSet.DateAdded = getDateAdded(archive);
+            beatmapSet.DateAdded = getDateAdded(archive, parameters);
 
             foreach (BeatmapInfo b in beatmapSet.Beatmaps)
             {
@@ -335,25 +335,43 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// Determine the date a given beatmapset has been added to the game.
-        /// For legacy imports, we can use the oldest file write time for any `.osu` file in the directory.
-        /// For any other import types, use "now".
+        /// If <paramref name="parameters"/> contains a <see cref="ImportParameters.DateAdded"/> override (e.g. from <c>osu!.db</c>),
+        /// that value is used directly.
+        /// For legacy directory imports, the oldest <c>.osu</c> file write time is used as a fallback.
+        /// For any other import types, "now" is used.
         /// </summary>
-        private DateTimeOffset getDateAdded(ArchiveReader? reader)
+        private DateTimeOffset getDateAdded(ArchiveReader? reader, ImportParameters parameters)
         {
+            if (parameters.DateAdded.HasValue)
+                return parameters.DateAdded.Value;
+
             DateTimeOffset dateAdded = DateTimeOffset.UtcNow;
 
             if (reader is DirectoryArchiveReader legacyReader)
             {
-                var beatmaps = reader.Filenames.Where(f => f.EndsWith(".osu", StringComparison.OrdinalIgnoreCase));
+                var beatmaps = reader.Filenames.Where(f => f.EndsWith(".osu", StringComparison.OrdinalIgnoreCase)).ToList();
 
-                dateAdded = File.GetLastWriteTimeUtc(legacyReader.GetFullPath(beatmaps.First()));
-
-                foreach (string beatmapName in beatmaps)
+                if (beatmaps.Count > 0)
                 {
-                    var currentDateAdded = File.GetLastWriteTimeUtc(legacyReader.GetFullPath(beatmapName));
+                    try
+                    {
+                        dateAdded = File.GetLastWriteTimeUtc(legacyReader.GetFullPath(beatmaps[0]));
 
-                    if (currentDateAdded < dateAdded)
-                        dateAdded = currentDateAdded;
+                        foreach (string beatmapName in beatmaps)
+                        {
+                            var currentDateAdded = File.GetLastWriteTimeUtc(legacyReader.GetFullPath(beatmapName));
+
+                            if (currentDateAdded < dateAdded)
+                                dateAdded = currentDateAdded;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        // If we can't read file timestamps, fall back to current time.
+                        // This can happen if files are deleted during import or due to permission issues.
+                        Logger.Log($"Failed to read file timestamps for date added: {e.Message}", LoggingTarget.Database, LogLevel.Debug);
+                        dateAdded = DateTimeOffset.UtcNow;
+                    }
                 }
             }
 

--- a/osu.Game/Database/ImportParameters.cs
+++ b/osu.Game/Database/ImportParameters.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Game.Database
 {
     public struct ImportParameters
@@ -27,5 +29,11 @@ namespace osu.Game.Database
         /// This is useful for cases where an import <em>must</em> complete even if gameplay is in progress.
         /// </summary>
         public bool ImportImmediately { get; set; }
+
+        /// <summary>
+        /// When set, overrides the automatically-determined "date added" for the imported model.
+        /// Used during stable imports to preserve the original date from <c>osu!.db</c>.
+        /// </summary>
+        public DateTimeOffset? DateAdded { get; set; }
     }
 }

--- a/osu.Game/Database/ImportTask.cs
+++ b/osu.Game/Database/ImportTask.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
 using osu.Framework.Extensions;
 using osu.Game.IO.Archives;
@@ -23,6 +24,12 @@ namespace osu.Game.Database
         /// An optional stream which provides the file content.
         /// </summary>
         public Stream? Stream { get; }
+
+        /// <summary>
+        /// When set, overrides the automatically-determined "date added" for the imported model.
+        /// Used during stable imports to preserve the original date from <c>osu!.db</c>.
+        /// </summary>
+        public DateTimeOffset? DateAdded { get; set; }
 
         /// <summary>
         /// Construct a new import task from a path (on a local filesystem).

--- a/osu.Game/Database/LegacyBeatmapImporter.cs
+++ b/osu.Game/Database/LegacyBeatmapImporter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -57,6 +58,50 @@ namespace osu.Game.Database
             }
 
             return paths;
+        }
+
+        /// <summary>
+        /// Reads the <c>osu!.db</c> from the stable installation root and returns a mapping of
+        /// folder name (relative to Songs, case-insensitive) to the date the beatmap set was added.
+        /// Returns <see langword="null"/> when the database is unavailable or cannot be parsed.
+        /// </summary>
+        protected virtual Dictionary<string, DateTimeOffset>? ReadDateAddedFromStableDb(StableStorage stableStorage)
+            => OsuDbReader.ReadDateAddedByFolder(stableStorage);
+
+        protected override IEnumerable<ImportTask> CreateImportTasks(Storage songsStorage, StableStorage stableStorage)
+        {
+            var dateAddedByFolder = ReadDateAddedFromStableDb(stableStorage);
+
+            foreach (string path in GetStableImportPaths(songsStorage))
+            {
+                var task = new ImportTask(path);
+
+                if (dateAddedByFolder != null)
+                {
+                    // The folder name stored in osu!.db is relative to the Songs directory.
+                    // For nested folders (e.g., "subdirectory\beatmap"), we need to compute the relative path.
+                    string songsRoot = songsStorage.GetFullPath(string.Empty);
+                    string? relativePath = Path.GetRelativePath(songsRoot, path);
+
+                    if (!string.IsNullOrEmpty(relativePath) && relativePath != ".")
+                    {
+                        // Normalize path separators for cross-platform compatibility.
+                        // osu!.db on Windows uses backslash, but we may be importing on Linux/macOS.
+                        // Try both forward and backward slash variants.
+                        string normalizedPath = relativePath.Replace('/', '\\');
+                        string alternativePath = relativePath.Replace('\\', '/');
+
+                        if (dateAddedByFolder.TryGetValue(normalizedPath, out var dateAdded))
+                            task.DateAdded = dateAdded;
+                        else if (dateAddedByFolder.TryGetValue(alternativePath, out dateAdded))
+                            task.DateAdded = dateAdded;
+                        else if (dateAddedByFolder.TryGetValue(relativePath, out dateAdded))
+                            task.DateAdded = dateAdded;
+                    }
+                }
+
+                yield return task;
+            }
         }
 
         public LegacyBeatmapImporter(IModelImporter<BeatmapSetInfo> importer)

--- a/osu.Game/Database/LegacyModelImporter.cs
+++ b/osu.Game/Database/LegacyModelImporter.cs
@@ -59,11 +59,18 @@ namespace osu.Game.Database
 
             return Task.Run(async () =>
             {
-                var tasks = GetStableImportPaths(storage).Select(p => new ImportTask(p)).ToArray();
+                var tasks = CreateImportTasks(storage, stableStorage).ToArray();
 
                 await Importer.Import(tasks, new ImportParameters { Batch = true, PreferHardLinks = true }).ConfigureAwait(false);
             });
         }
+
+        /// <summary>
+        /// Creates the <see cref="ImportTask"/>s for all items found in the stable storage.
+        /// Override to attach additional metadata (e.g. <see cref="ImportTask.DateAdded"/>) to each task.
+        /// </summary>
+        protected virtual IEnumerable<ImportTask> CreateImportTasks(Storage storage, StableStorage stableStorage)
+            => GetStableImportPaths(storage).Select(p => new ImportTask(p));
 
         /// <summary>
         /// Run any required traversal operations on the stable storage location before performing operations.

--- a/osu.Game/Database/OsuDbReader.cs
+++ b/osu.Game/Database/OsuDbReader.cs
@@ -1,0 +1,244 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.IO.Legacy;
+
+namespace osu.Game.Database
+{
+    /// <summary>
+    /// Reads beatmap metadata from an osu!stable <c>osu!.db</c> file.
+    /// See https://github.com/ppy/osu/wiki/Legacy-database-file-structure for the format specification.
+    /// </summary>
+    public static class OsuDbReader
+    {
+        private const string database_name = "osu!.db";
+
+        /// <summary>
+        /// Attempts to read the <c>osu!.db</c> file from the given stable storage and returns a mapping
+        /// of beatmap folder name (relative to Songs) to the earliest "last modification time" among all
+        /// beatmaps in that folder.  This is the closest approximation to "date added" available in the
+        /// stable database.
+        /// </summary>
+        /// <param name="stableStorage">The root of the osu!stable installation.</param>
+        /// <returns>
+        /// A dictionary keyed by folder name (case-insensitive) with the corresponding date, or
+        /// <see langword="null"/> if the database could not be read.
+        /// </returns>
+        public static Dictionary<string, DateTimeOffset>? ReadDateAddedByFolder(Storage stableStorage)
+        {
+            if (!stableStorage.Exists(database_name))
+                return null;
+
+            try
+            {
+                using var stream = stableStorage.GetStream(database_name);
+                return ReadDateAddedByFolder(stream);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Failed to read {database_name}: {e.Message}", LoggingTarget.Database, LogLevel.Error);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Reads a mapping of beatmap folder name to earliest "last modification time" from the given
+        /// <c>osu!.db</c> stream.  Exposed for testing.
+        /// </summary>
+        public static Dictionary<string, DateTimeOffset>? ReadDateAddedByFolder(Stream stream)
+        {
+            try
+            {
+                return readDateAddedByFolder(stream);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Failed to parse {database_name}: {e.Message}", LoggingTarget.Database, LogLevel.Error);
+                return null;
+            }
+        }
+
+        private static Dictionary<string, DateTimeOffset> readDateAddedByFolder(Stream stream)
+        {
+            var result = new Dictionary<string, DateTimeOffset>(StringComparer.OrdinalIgnoreCase);
+
+            using var sr = new SerializationReader(stream);
+
+            int version = sr.ReadInt32();
+            sr.ReadInt32(); // folder count
+            sr.ReadBoolean(); // account unlocked
+            sr.ReadDateTime(); // date account will be unlocked
+            sr.ReadString(); // player name
+
+            int beatmapCount = sr.ReadInt32();
+
+            // Sanity check: prevent reading corrupted files with unreasonable beatmap counts.
+            // A typical large collection has ~50k beatmaps; anything beyond 1 million is suspicious.
+            if (beatmapCount < 0 || beatmapCount > 1_000_000)
+            {
+                Logger.Log($"Suspicious beatmap count ({beatmapCount}) in {database_name}, aborting parse.", LoggingTarget.Database, LogLevel.Error);
+                return result;
+            }
+
+            for (int i = 0; i < beatmapCount; i++)
+            {
+                // Size in bytes of the beatmap entry – only present before version 20191106.
+                if (version < 20191106)
+                    sr.ReadInt32();
+
+                sr.ReadString(); // artist name
+                sr.ReadString(); // artist name unicode
+                sr.ReadString(); // song title
+                sr.ReadString(); // song title unicode
+                sr.ReadString(); // creator name
+                sr.ReadString(); // difficulty name
+                sr.ReadString(); // audio file name
+                sr.ReadString(); // MD5 hash
+                sr.ReadString(); // .osu file name
+                sr.ReadByte();   // ranked status
+                sr.ReadInt16();  // hit circles
+                sr.ReadInt16();  // sliders
+                sr.ReadInt16();  // spinners
+
+                long ticks = sr.ReadInt64();
+
+                // Validate ticks to prevent ArgumentOutOfRangeException.
+                // Corrupted or malformed osu!.db files may contain invalid values.
+                DateTimeOffset? lastModified = null;
+
+                if (ticks >= DateTime.MinValue.Ticks && ticks <= DateTime.MaxValue.Ticks)
+                {
+                    lastModified = new DateTimeOffset(new DateTime(ticks, DateTimeKind.Utc));
+                }
+                else
+                {
+                    Logger.Log($"Invalid ticks value ({ticks}) in {database_name}, skipping beatmap entry.", LoggingTarget.Database, LogLevel.Debug);
+                }
+
+                // Approach rate, circle size, HP drain, overall difficulty
+                if (version < 20140609)
+                {
+                    sr.ReadByte();
+                    sr.ReadByte();
+                    sr.ReadByte();
+                    sr.ReadByte();
+                }
+                else
+                {
+                    sr.ReadSingle();
+                    sr.ReadSingle();
+                    sr.ReadSingle();
+                    sr.ReadSingle();
+                }
+
+                sr.ReadDouble(); // slider velocity
+
+                if (version >= 20140609)
+                {
+                    // Star rating pairs for each ruleset (osu!, taiko, catch, mania)
+                    for (int r = 0; r < 4; r++)
+                    {
+                        int pairCount = sr.ReadInt32();
+
+                        // Sanity check: prevent reading corrupted data with unreasonable pair counts.
+                        // If we encounter this, the stream is likely corrupted and we cannot safely continue.
+                        if (pairCount < 0 || pairCount > 100_000)
+                        {
+                            Logger.Log($"Suspicious star rating pair count ({pairCount}) in {database_name}, aborting parse.", LoggingTarget.Database, LogLevel.Error);
+                            return result;
+                        }
+
+                        for (int p = 0; p < pairCount; p++)
+                        {
+                            if (version >= 20250107)
+                            {
+                                // Int-Float pair: 0x08, Int, 0x0c, Float
+                                sr.ReadByte();
+                                sr.ReadInt32();
+                                sr.ReadByte();
+                                sr.ReadSingle();
+                            }
+                            else
+                            {
+                                // Int-Double pair: 0x08, Int, 0x0d, Double
+                                sr.ReadByte();
+                                sr.ReadInt32();
+                                sr.ReadByte();
+                                sr.ReadDouble();
+                            }
+                        }
+                    }
+                }
+
+                sr.ReadInt32(); // drain time
+                sr.ReadInt32(); // total time
+                sr.ReadInt32(); // preview time
+
+                int timingPointCount = sr.ReadInt32();
+
+                // Sanity check: prevent reading corrupted data with unreasonable timing point counts.
+                // If we encounter this, the stream is likely corrupted and we cannot safely continue.
+                if (timingPointCount < 0 || timingPointCount > 100_000)
+                {
+                    Logger.Log($"Suspicious timing point count ({timingPointCount}) in {database_name}, aborting parse.", LoggingTarget.Database, LogLevel.Error);
+                    return result;
+                }
+                
+                for (int t = 0; t < timingPointCount; t++)
+                {
+                    sr.ReadDouble(); // BPM
+                    sr.ReadDouble(); // offset
+                    sr.ReadBoolean(); // inherited
+                }
+
+                sr.ReadInt32(); // difficulty ID
+                sr.ReadInt32(); // beatmap ID
+                sr.ReadInt32(); // thread ID
+                sr.ReadByte();  // grade osu!
+                sr.ReadByte();  // grade taiko
+                sr.ReadByte();  // grade catch
+                sr.ReadByte();  // grade mania
+                sr.ReadInt16(); // local offset
+                sr.ReadSingle(); // stack leniency
+                sr.ReadByte();  // gameplay mode
+                sr.ReadString(); // song source
+                sr.ReadString(); // song tags
+                sr.ReadInt16(); // online offset
+                sr.ReadString(); // title font
+                sr.ReadBoolean(); // unplayed
+                sr.ReadInt64(); // last played time
+                sr.ReadBoolean(); // is osz2
+
+                string folderName = sr.ReadString() ?? string.Empty;
+
+                sr.ReadInt64(); // last checked against repo
+                sr.ReadBoolean(); // ignore beatmap sound
+                sr.ReadBoolean(); // ignore beatmap skin
+                sr.ReadBoolean(); // disable storyboard
+                sr.ReadBoolean(); // disable video
+                sr.ReadBoolean(); // visual override
+
+                if (version < 20140609)
+                    sr.ReadInt16(); // unknown
+
+                sr.ReadInt32(); // last modification time (duplicate)
+                sr.ReadByte();  // mania scroll speed
+
+                if (string.IsNullOrEmpty(folderName) || !lastModified.HasValue)
+                    continue;
+
+                // Keep the earliest modification time across all difficulties in the same folder,
+                // as that best represents when the set was first added.
+                if (!result.TryGetValue(folderName, out var existing) || lastModified.Value < existing)
+                    result[folderName] = lastModified.Value;
+            }
+
+            return result;
+        }
+    }
+}

--- a/osu.Game/Database/OsuDbReader.cs
+++ b/osu.Game/Database/OsuDbReader.cs
@@ -188,7 +188,7 @@ namespace osu.Game.Database
                     Logger.Log($"Suspicious timing point count ({timingPointCount}) in {database_name}, aborting parse.", LoggingTarget.Database, LogLevel.Error);
                     return result;
                 }
-                
+
                 for (int t = 0; t < timingPointCount; t++)
                 {
                     sr.ReadDouble(); // BPM

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -253,6 +253,10 @@ namespace osu.Game.Database
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Allow per-task date override to take precedence over the shared parameters value.
+            if (task.DateAdded.HasValue)
+                parameters.DateAdded = task.DateAdded;
+
             Live<TModel>? import;
             using (ArchiveReader reader = task.GetReader())
                 import = await importFromArchive(reader, parameters, cancellationToken).ConfigureAwait(false);
@@ -398,7 +402,7 @@ namespace osu.Game.Database
                 using (var transaction = realm.BeginWrite())
                 {
                     // TODO: we may want to run this outside of the transaction.
-                    Populate(item, archive, realm, cancellationToken);
+                    Populate(item, archive, realm, parameters, cancellationToken);
 
                     // Populate() may have adjusted file content (see SkinImporter.updateSkinIniMetadata), so regardless of whether a fast check was done earlier, let's
                     // check for existing items a second time.
@@ -540,8 +544,9 @@ namespace osu.Game.Database
         /// <param name="model">The model to populate.</param>
         /// <param name="archive">The archive to use as a reference for population. May be null.</param>
         /// <param name="realm">The current realm context.</param>
+        /// <param name="parameters">Parameters that further configure the import process.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        protected abstract void Populate(TModel model, ArchiveReader? archive, Realm realm, CancellationToken cancellationToken = default);
+        protected abstract void Populate(TModel model, ArchiveReader? archive, Realm realm, ImportParameters parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Perform any final actions before the import to database executes.

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Scoring
 
         public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);
 
-        protected override void Populate(ScoreInfo model, ArchiveReader? archive, Realm realm, CancellationToken cancellationToken = default)
+        protected override void Populate(ScoreInfo model, ArchiveReader? archive, Realm realm, ImportParameters parameters, CancellationToken cancellationToken = default)
         {
             Debug.Assert(model.BeatmapInfo != null);
 

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Skinning
             }).ConfigureAwait(false);
         }
 
-        protected override void Populate(SkinInfo model, ArchiveReader? archive, Realm realm, CancellationToken cancellationToken = default)
+        protected override void Populate(SkinInfo model, ArchiveReader? archive, Realm realm, ImportParameters parameters, CancellationToken cancellationToken = default)
         {
             var skinInfoFile = model.GetFile(skin_info_file);
 


### PR DESCRIPTION
Resolves discussion #37209.

When importing beatmaps from osu!stable, the DateAdded field now correctly reflects the original date from stable's osu!.db instead of using random filesystem timestamps from the mass import operation.

Implementation:
- Add OsuDbReader to parse osu!.db and extract folder->date mappings
- Add DateAdded property to ImportTask for per-task date override
- Add DateAdded to ImportParameters for pipeline propagation
- Update RealmArchiveModelImporter.Populate signature to accept ImportParameters
- Update BeatmapImporter.getDateAdded to use parameters.DateAdded with fallback
- Update SkinImporter and ScoreImporter signatures to match base class
- Add CreateImportTasks virtual method to LegacyModelImporter
- Override CreateImportTasks in LegacyBeatmapImporter to read osu!.db

Features:
- Graceful degradation when osu!.db unavailable (falls back to filesystem dates)
- Cross-platform path separator handling (Windows/Linux/macOS)
- Defensive parsing with sanity checks for corrupted data
- Support for nested beatmap folders
- Comprehensive test coverage (9 tests total)

Tests:
- OsuDbReaderTest: 6 unit tests covering parsing, edge cases, invalid data
- LegacyBeatmapImporterTest: 3 integration tests for date precedence and nested folders