### PR TITLE
Added Dimming when Multiple Overlays are Opened

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -229,14 +229,6 @@ namespace osu.Game
 
         private ScreenStackFooter screenStackFooter;
 
-        private DialogOverlay dialogOverlay;
-
-        private NotificationOverlay notificationOverlay;
-
-        private LoginOverlay loginOverlay;
-
-        private NowPlayingOverlay nowPlayingOverlay;
-
         private readonly string[] args;
 
         private readonly List<OsuFocusedOverlayContainer> focusedOverlays = new List<OsuFocusedOverlayContainer>();
@@ -280,13 +272,25 @@ namespace osu.Game
 
         private void updateRightFloatingOverlayDim()
         {
-            bool notificationDim = notificationOverlay?.State.Value == Visibility.Visible;
-            bool loginDim = loginOverlay?.State.Value == Visibility.Visible;
-            bool nowPlayingDim = nowPlayingOverlay?.State.Value == Visibility.Visible;
+            var overlays = rightFloatingOverlayContent?.Children.OfType<OverlayContainer>().ToList();
 
-            loginOverlay?.FadeColour(nowPlayingDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
-            notificationOverlay?.FadeColour(nowPlayingDim || loginDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
-            overlayContent?.FadeColour(nowPlayingDim || loginDim || notificationDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+            for (int i = 0; i < overlays.Count; i++)
+            {
+                bool shouldDim = overlays.Skip(i + 1).Any(o => o.State.Value == Visibility.Visible);
+                overlays[i].FadeColour(shouldDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+            }
+            bool anyVisible = overlays.Any(o => o.State.Value == Visibility.Visible);
+            overlayContent.FadeColour(anyVisible ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+        }
+
+        private void updateDialogDim()
+        {
+            var overlays = topMostOverlayContent.Children.OfType<DialogOverlay>().ToList();
+
+            bool anyVisible = overlays.Any(o => o.State.Value == Visibility.Visible);
+
+            overlayOffsetContainer.FadeColour(anyVisible ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+            Toolbar.FadeColour(anyVisible ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
         }
         IDisposable IOverlayManager.RegisterBlockingOverlay(OverlayContainer overlayContainer)
         {
@@ -1209,14 +1213,14 @@ namespace osu.Game
 
             loadComponentSingleFile(onScreenDisplay, Add, true);
 
-            loadComponentSingleFile<INotificationOverlay>(notificationOverlay = Notifications.With(d =>
+            loadComponentSingleFile<INotificationOverlay>(Notifications.With(d =>
             {
                 d.Anchor = Anchor.TopRight;
                 d.Origin = Anchor.TopRight;
             }), d =>
             {
                 rightFloatingOverlayContent.Add(d);
-                notificationOverlay.State.BindValueChanged(_ => updateRightFloatingOverlayDim());
+                ((OverlayContainer)d).State.BindValueChanged(_ => updateRightFloatingOverlayDim());
             }, true);
 
             loadComponentSingleFile(legacyImportManager, Add);
@@ -1243,37 +1247,31 @@ namespace osu.Game
             loadComponentSingleFile(wikiOverlay = new WikiOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(skinEditor = new SkinEditorOverlay(ScreenContainer), overlayContent.Add, true);
 
-            loadComponentSingleFile(loginOverlay = new LoginOverlay
+            loadComponentSingleFile(new LoginOverlay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
             }, d =>
             {
                 rightFloatingOverlayContent.Add(d);
-                loginOverlay.State.BindValueChanged(_ => updateRightFloatingOverlayDim());
+                ((OverlayContainer)d).State.BindValueChanged(_ => updateRightFloatingOverlayDim());
             }, true);
 
-            loadComponentSingleFile(nowPlayingOverlay = new NowPlayingOverlay
+            loadComponentSingleFile(new NowPlayingOverlay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
             }, d =>
             {
                 rightFloatingOverlayContent.Add(d);
-                nowPlayingOverlay.State.BindValueChanged(_ => updateRightFloatingOverlayDim());
+                ((OverlayContainer)d).State.BindValueChanged(_ => updateRightFloatingOverlayDim());
             }, true);
 
             loadComponentSingleFile(new AccountCreationOverlay(), topMostOverlayContent.Add, true);
-            loadComponentSingleFile<IDialogOverlay>(dialogOverlay = new DialogOverlay(), d =>
+            loadComponentSingleFile<IDialogOverlay>(new DialogOverlay(), d =>
             {
                 topMostOverlayContent.Add(d);
-                dialogOverlay.State.BindValueChanged(state =>
-                {
-                    bool dim = state.NewValue == Visibility.Visible;
-                    overlayContent.FadeColour(dim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
-                    leftFloatingOverlayContent.FadeColour(dim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
-                    Toolbar.FadeColour(dim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
-                });
+                ((OverlayContainer)d).State.BindValueChanged(_ => updateDialogDim());
             }, true);
 
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -272,13 +272,14 @@ namespace osu.Game
 
         private void updateRightFloatingOverlayDim()
         {
-            var overlays = rightFloatingOverlayContent?.Children.OfType<OverlayContainer>().ToList();
+            var overlays = rightFloatingOverlayContent.Children.OfType<OverlayContainer>().ToList();
 
             for (int i = 0; i < overlays.Count; i++)
             {
                 bool shouldDim = overlays.Skip(i + 1).Any(o => o.State.Value == Visibility.Visible);
                 overlays[i].FadeColour(shouldDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
             }
+
             bool anyVisible = overlays.Any(o => o.State.Value == Visibility.Visible);
             overlayContent.FadeColour(anyVisible ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
         }
@@ -292,6 +293,7 @@ namespace osu.Game
             overlayOffsetContainer.FadeColour(anyVisible ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
             Toolbar.FadeColour(anyVisible ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
         }
+
         IDisposable IOverlayManager.RegisterBlockingOverlay(OverlayContainer overlayContainer)
         {
             if (overlayContainer.Parent != null)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -229,6 +229,14 @@ namespace osu.Game
 
         private ScreenStackFooter screenStackFooter;
 
+        private DialogOverlay dialogOverlay;
+
+        private NotificationOverlay notificationOverlay;
+
+        private LoginOverlay loginOverlay;
+
+        private NowPlayingOverlay nowPlayingOverlay;
+
         private readonly string[] args;
 
         private readonly List<OsuFocusedOverlayContainer> focusedOverlays = new List<OsuFocusedOverlayContainer>();
@@ -270,6 +278,16 @@ namespace osu.Game
         private void updateBlockingOverlayFade() =>
             ScreenContainer.FadeColour(visibleBlockingOverlays.Any() ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
 
+        private void updateRightFloatingOverlayDim()
+        {
+            bool notificationDim = notificationOverlay?.State.Value == Visibility.Visible;
+            bool loginDim = loginOverlay?.State.Value == Visibility.Visible;
+            bool nowPlayingDim = nowPlayingOverlay?.State.Value == Visibility.Visible;
+
+            loginOverlay?.FadeColour(nowPlayingDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+            notificationOverlay?.FadeColour(nowPlayingDim || loginDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+            overlayContent?.FadeColour(nowPlayingDim || loginDim || notificationDim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+        }
         IDisposable IOverlayManager.RegisterBlockingOverlay(OverlayContainer overlayContainer)
         {
             if (overlayContainer.Parent != null)
@@ -1191,11 +1209,15 @@ namespace osu.Game
 
             loadComponentSingleFile(onScreenDisplay, Add, true);
 
-            loadComponentSingleFile<INotificationOverlay>(Notifications.With(d =>
+            loadComponentSingleFile<INotificationOverlay>(notificationOverlay = Notifications.With(d =>
             {
                 d.Anchor = Anchor.TopRight;
                 d.Origin = Anchor.TopRight;
-            }), rightFloatingOverlayContent.Add, true);
+            }), d =>
+            {
+                rightFloatingOverlayContent.Add(d);
+                notificationOverlay.State.BindValueChanged(_ => updateRightFloatingOverlayDim());
+            }, true);
 
             loadComponentSingleFile(legacyImportManager, Add);
 
@@ -1221,20 +1243,39 @@ namespace osu.Game
             loadComponentSingleFile(wikiOverlay = new WikiOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(skinEditor = new SkinEditorOverlay(ScreenContainer), overlayContent.Add, true);
 
-            loadComponentSingleFile(new LoginOverlay
+            loadComponentSingleFile(loginOverlay = new LoginOverlay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
-            }, rightFloatingOverlayContent.Add, true);
+            }, d =>
+            {
+                rightFloatingOverlayContent.Add(d);
+                loginOverlay.State.BindValueChanged(_ => updateRightFloatingOverlayDim());
+            }, true);
 
-            loadComponentSingleFile(new NowPlayingOverlay
+            loadComponentSingleFile(nowPlayingOverlay = new NowPlayingOverlay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
-            }, rightFloatingOverlayContent.Add, true);
+            }, d =>
+            {
+                rightFloatingOverlayContent.Add(d);
+                nowPlayingOverlay.State.BindValueChanged(_ => updateRightFloatingOverlayDim());
+            }, true);
 
             loadComponentSingleFile(new AccountCreationOverlay(), topMostOverlayContent.Add, true);
-            loadComponentSingleFile<IDialogOverlay>(new DialogOverlay(), topMostOverlayContent.Add, true);
+            loadComponentSingleFile<IDialogOverlay>(dialogOverlay = new DialogOverlay(), d =>
+            {
+                topMostOverlayContent.Add(d);
+                dialogOverlay.State.BindValueChanged(state =>
+                {
+                    bool dim = state.NewValue == Visibility.Visible;
+                    overlayContent.FadeColour(dim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+                    leftFloatingOverlayContent.FadeColour(dim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+                    Toolbar.FadeColour(dim ? OsuColour.Gray(0.5f) : Color4.White, 500, Easing.OutQuint);
+                });
+            }, true);
+
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add);


### PR DESCRIPTION
Fixes #36613

Added logic that dims the `overlayContent` (wikis, play area, skin editor,...), the `leftFloatingOverlayContent` (settings area), and the top toolbar when a `dialogOverlay` or confirm button appears on the screen. Additionally created an `updateRightFloatingOverlayDim` function that checks if the `notification` bar, `login `box, and `now playing` box is open. Dimming priority for right floating overlays: `now playing` > `login` > `notification` > `overlayContent`. 

Before:

https://github.com/user-attachments/assets/1b3f68a5-32f0-4ac2-a8ee-edb496c15d88

After:

https://github.com/user-attachments/assets/41b39ce7-618d-4b51-9dd4-7a077ff52695


