### PR TITLE
Add support for grouping by keys in song select for osu!mania

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -98,9 +98,9 @@ namespace osu.Game.Rulesets.Mania
             return false;
         }
 
-        public bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        public bool FilterMayChangeFromMods(FilterCriteria criteria, ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
-            if (includedKeyCounts.Count != LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT)
+            if (includedKeyCounts.Count != LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT || criteria.Group == GroupMode.Variant)
             {
                 // Interpreting as the Mod type is required for equality comparison.
                 HashSet<Mod> oldSet = mods.OldValue.OfType<ManiaKeyMod>().AsEnumerable<Mod>().ToHashSet();

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -327,6 +327,8 @@ namespace osu.Game.Rulesets.Mania
 
         public override RulesetSettingsSubsection CreateSettings() => new ManiaSettingsSubsection(this);
 
+        public override LocalisableString VariantDescription => "Keys";
+
         public override IEnumerable<int> AvailableVariants
         {
             get
@@ -498,6 +500,9 @@ namespace osu.Game.Rulesets.Mania
 
         public int GetKeyCount(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
             => ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), mods);
+
+        public override int GetVariantForBeatmap(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
+            => GetKeyCount(beatmapInfo, mods);
     }
 
     public enum PlayfieldType

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -660,7 +660,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria) => match;
             public bool TryParseCustomKeywordCriteria(string key, Operator op, string value) => false;
 
-            public bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods) => false;
+            public bool FilterMayChangeFromMods(FilterCriteria criteria, ValueChangedEvent<IReadOnlyList<Mod>> mods) => false;
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -559,7 +559,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
                 return false;
             }
 
-            public bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods) => false;
+            public bool FilterMayChangeFromMods(FilterCriteria criteria, ValueChangedEvent<IReadOnlyList<Mod>> mods) => false;
         }
 
         private static readonly object[] correct_date_query_examples =

--- a/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
@@ -59,8 +59,9 @@ namespace osu.Game.Rulesets.Filter
         /// <summary>
         /// Whether to reapply the filter as a result of the given change in applied mods.
         /// </summary>
+        /// <param name="criteria">The current filter criteria.</param>
         /// <param name="mods">The change in mods.</param>
         /// <returns>Whether the filter should be re-applied.</returns>
-        bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods);
+        bool FilterMayChangeFromMods(FilterCriteria criteria, ValueChangedEvent<IReadOnlyList<Mod>> mods);
     }
 }

--- a/osu.Game/Rulesets/ILegacyRuleset.cs
+++ b/osu.Game/Rulesets/ILegacyRuleset.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring.Legacy;
 
 namespace osu.Game.Rulesets
@@ -16,11 +13,6 @@ namespace osu.Game.Rulesets
         /// Identifies the server-side ID of a legacy ruleset.
         /// </summary>
         int LegacyID { get; }
-
-        /// <summary>
-        /// Retrieves the number of mania keys required to play the beatmap.
-        /// </summary>
-        int GetKeyCount(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null) => 0;
 
         ILegacyScoreSimulator CreateLegacyScoreSimulator();
     }

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -313,11 +313,22 @@ namespace osu.Game.Rulesets
         public virtual IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => Array.Empty<KeyBinding>();
 
         /// <summary>
+        /// Text that describes what variants in a ruleset are.
+        /// Override this to provide better copy than the generic "Variant" text which may not tell users much.
+        /// </summary>
+        public virtual LocalisableString VariantDescription => "Variant";
+
+        /// <summary>
         /// Gets the name for a key binding variant. This is used for display in the settings overlay.
         /// </summary>
         /// <param name="variant">The variant.</param>
         /// <returns>A descriptive name of the variant.</returns>
         public virtual LocalisableString GetVariantName(int variant) => string.Empty;
+
+        /// <summary>
+        /// Returns the ID of the variant that is applicable for the given <paramref name="beatmapInfo"/>, given the current active <paramref name="mods"/>.
+        /// </summary>
+        public virtual int GetVariantForBeatmap(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null) => 0;
 
         /// <summary>
         /// For rulesets which support legacy (osu-stable) replay conversion, this method will create an empty replay frame

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -10,6 +10,8 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.Carousel;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Utils;
@@ -230,6 +232,16 @@ namespace osu.Game.Screens.Select
                 {
                     var favouriteBeatmapSets = GetFavouriteBeatmapSets();
                     return getGroupsBy(b => defineGroupByFavourites(b, favouriteBeatmapSets), items);
+                }
+
+                case GroupMode.Variant:
+                {
+                    var rulesetInstance = criteria.Ruleset?.CreateInstance();
+
+                    if (rulesetInstance == null || rulesetInstance.AvailableVariants.Count() <= 1)
+                        goto case GroupMode.None;
+
+                    return getGroupsBy(b => defineGroupByVariant(rulesetInstance, b, criteria.Mods), items);
                 }
 
                 default:
@@ -478,6 +490,13 @@ namespace osu.Game.Screens.Select
                 return new GroupDefinition(0, "Favourites").Yield();
 
             return [];
+        }
+
+        private IEnumerable<GroupDefinition> defineGroupByVariant(Ruleset rulesetInstance, BeatmapInfo beatmap, IReadOnlyList<Mod>? mods = null)
+        {
+            int variant = rulesetInstance.GetVariantForBeatmap(beatmap, mods);
+            var name = rulesetInstance.GetVariantName(variant);
+            return new GroupDefinition(variant, name).Yield();
         }
 
         private record GroupMapping(GroupDefinition? Group, List<CarouselItem> ItemsInGroup);

--- a/osu.Game/Screens/Select/Filter/GroupMode.cs
+++ b/osu.Game/Screens/Select/Filter/GroupMode.cs
@@ -55,5 +55,8 @@ namespace osu.Game.Screens.Select.Filter
 
         [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Title))]
         Title,
+
+        // purposefully unlocalised - `Ruleset.VariantDescription` is the intended localisation insertion point
+        Variant,
     }
 }

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
@@ -44,7 +45,7 @@ namespace osu.Game.Screens.Select
         private ShearedToggleButton showConvertedBeatmapsButton = null!;
         private DifficultyRangeSlider difficultyRangeSlider = null!;
         private ShearedDropdown<SortMode> sortDropdown = null!;
-        private ShearedDropdown<GroupMode> groupDropdown = null!;
+        private ShearedDropdown<GroupModeDropdownItem> groupDropdown = null!;
         private CollectionDropdown collectionDropdown = null!;
 
         /// <summary>
@@ -190,10 +191,9 @@ namespace osu.Game.Screens.Select
                                                 Items = Enum.GetValues<SortMode>(),
                                             },
                                             Empty(),
-                                            groupDropdown = new ShearedDropdown<GroupMode>(SongSelectStrings.Group)
+                                            groupDropdown = new GroupModeDropdown(SongSelectStrings.Group)
                                             {
                                                 RelativeSizeAxes = Axes.X,
-                                                Items = Enum.GetValues<GroupMode>(),
                                             },
                                             Empty(),
                                             collectionDropdown = new CollectionDropdown
@@ -225,7 +225,6 @@ namespace osu.Game.Screens.Select
             difficultyRangeSlider.UpperBound = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
             config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmapsButton.Active);
             config.BindWith(OsuSetting.SongSelectSortingMode, sortDropdown.Current);
-            config.BindWith(OsuSetting.SongSelectGroupMode, groupDropdown.Current);
 
             ruleset.BindValueChanged(_ => updateCriteria());
             mods.BindValueChanged(m =>
@@ -240,7 +239,7 @@ namespace osu.Game.Screens.Select
                     return;
 
                 var rulesetCriteria = currentCriteria.RulesetCriteria;
-                if (rulesetCriteria?.FilterMayChangeFromMods(m) == true)
+                if (rulesetCriteria?.FilterMayChangeFromMods(currentCriteria, m) == true)
                     updateCriteria();
             });
 
@@ -261,7 +260,7 @@ namespace osu.Game.Screens.Select
             });
             collectionsSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>(), (collections, changeSet) =>
             {
-                if (changeSet != null && groupDropdown.Current.Value == GroupMode.Collections)
+                if (changeSet != null && groupDropdown.Current.Value.Value == GroupMode.Collections)
                     updateCriteria();
             });
 
@@ -290,7 +289,7 @@ namespace osu.Game.Screens.Select
             {
                 SelectedBeatmapSet = ScopedBeatmapSet.Value,
                 Sort = sortDropdown.Current.Value,
-                Group = groupDropdown.Current.Value,
+                Group = groupDropdown.Current.Value?.Value ?? GroupMode.None,
                 AllowConvertedBeatmaps = showConvertedBeatmapsButton.Active.Value,
                 Ruleset = ruleset.Value,
                 Mods = mods.Value,
@@ -386,5 +385,102 @@ namespace osu.Game.Screens.Select
                 }
             }
         }
+
+        private partial class GroupModeDropdown : ShearedDropdown<GroupModeDropdownItem>
+        {
+            [Resolved]
+            private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+            private Bindable<GroupMode> configGroupMode { get; } = new Bindable<GroupMode>();
+
+            public GroupModeDropdown(LocalisableString label)
+                : base(label)
+            {
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuConfigManager config)
+            {
+                config.BindWith(OsuSetting.SongSelectGroupMode, configGroupMode);
+            }
+
+            protected override void LoadAsyncComplete()
+            {
+                // Bindings set up intentionally in `LoadAsyncComplete()` rather than `LoadComplete()` as normal
+                // to avoid double-filter on entering song select with the "variant" group mode engaged.
+                ruleset.BindValueChanged(_ =>
+                {
+                    updateAvailableItems();
+                    updateCurrentFromConfig();
+                }, true);
+                configGroupMode.BindValueChanged(_ => updateCurrentFromConfig());
+                Current.BindValueChanged(currentChanged);
+
+                // Ordering important - base call must run *after* the above bindings
+                // because the bindings set up `Items`, and the base call is responsible for calling `GenerateItemText()`.
+                base.LoadAsyncComplete();
+            }
+
+            private void updateAvailableItems()
+            {
+                var rulesetInstance = ruleset.Value.CreateInstance();
+                var items = new List<GroupModeDropdownItem>();
+
+                foreach (var item in Enum.GetValues<GroupMode>())
+                {
+                    switch (item)
+                    {
+                        default:
+                            items.Add(new GroupModeDropdownItem(item, item.GetLocalisableDescription()));
+                            break;
+
+                        case GroupMode.Variant:
+                            if (rulesetInstance.AvailableVariants.Count() <= 1)
+                                break;
+
+                            items.Add(new GroupModeDropdownItem(GroupMode.Variant, rulesetInstance.VariantDescription));
+                            break;
+                    }
+                }
+
+                Items = items.ToArray();
+            }
+
+            private bool synchronisingBindables;
+
+            private void updateCurrentFromConfig()
+            {
+                if (synchronisingBindables)
+                    return;
+
+                synchronisingBindables = true;
+                // Only rulesets that actually have variants expose and support the "variant" grouping mode.
+                // If it's missing, default to no grouping.
+                Current.Value = Items.SingleOrDefault(i => i.Value == configGroupMode.Value) ?? Items.Single(i => i.Value == GroupMode.None);
+                synchronisingBindables = false;
+            }
+
+            private void currentChanged(ValueChangedEvent<GroupModeDropdownItem> current)
+            {
+                if (synchronisingBindables)
+                    return;
+
+                // Only rulesets that actually have variants expose and support the "variant" grouping mode.
+                // If it's missing, code above will revert to no grouping, which also incurs a `Current` change.
+                // However, for better user experience, don't write the new value out to config in this scenario
+                // so that the variant grouping is re-engaged on switching to a ruleset that has variant support
+                // (this also persists across game restarts).
+                if (current.OldValue.Value == GroupMode.Variant && Items.All(i => i.Value != GroupMode.Variant))
+                    return;
+
+                synchronisingBindables = true;
+                configGroupMode.Value = current.NewValue.Value;
+                synchronisingBindables = false;
+            }
+
+            protected override LocalisableString GenerateItemText(GroupModeDropdownItem item) => item.Text;
+        }
+
+        private record GroupModeDropdownItem(GroupMode Value, LocalisableString Text);
     }
 }

--- a/osu.Game/Screens/Select/PanelBeatmap.cs
+++ b/osu.Game/Screens/Select/PanelBeatmap.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -13,6 +14,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
@@ -35,7 +37,7 @@ namespace osu.Game.Screens.Select
 
         private StarCounter starCounter = null!;
         private ConstrainedIconContainer difficultyIcon = null!;
-        private OsuSpriteText keyCountText = null!;
+        private OsuSpriteText variantText = null!;
         private StarRatingDisplay starRatingDisplay = null!;
         private PanelLocalRankDisplay localRank = null!;
         private OsuSpriteText difficultyText = null!;
@@ -139,7 +141,7 @@ namespace osu.Game.Screens.Select
                                     Padding = new MarginPadding { Bottom = 4 },
                                     Children = new Drawable[]
                                     {
-                                        keyCountText = new OsuSpriteText
+                                        variantText = new OsuSpriteText
                                         {
                                             Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
                                             Anchor = Anchor.BottomLeft,
@@ -286,18 +288,18 @@ namespace osu.Game.Screens.Select
             if (Item == null)
                 return;
 
-            if (ruleset.Value.OnlineID == 3)
-            {
-                // Account for mania differences locally for now.
-                // Eventually this should be handled in a more modular way, allowing rulesets to add more information to the panel.
-                ILegacyRuleset legacyRuleset = (ILegacyRuleset)ruleset.Value.CreateInstance();
-                int keyCount = legacyRuleset.GetKeyCount(beatmap, mods.Value);
+            var rulesetInstance = ruleset.Value.CreateInstance();
 
-                keyCountText.Alpha = 1;
-                keyCountText.Text = $"[{keyCount}K] ";
+            if (rulesetInstance.AvailableVariants.Count() > 1)
+            {
+                int variant = rulesetInstance.GetVariantForBeatmap(beatmap, mods.Value);
+                var variantName = rulesetInstance.GetVariantName(variant);
+
+                variantText.Alpha = 1;
+                variantText.Text = LocalisableString.Interpolate($"[{variantName}] ");
             }
             else
-                keyCountText.Alpha = 0;
+                variantText.Alpha = 0;
         }
 
         public override MenuItem[] ContextMenuItems

--- a/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -301,15 +302,15 @@ namespace osu.Game.Screens.Select
             if (Item == null)
                 return;
 
-            if (ruleset.Value.OnlineID == 3)
+            var rulesetInstance = ruleset.Value.CreateInstance();
+
+            if (rulesetInstance.AvailableVariants.Count() > 1)
             {
-                // Account for mania differences locally for now.
-                // Eventually this should be handled in a more modular way, allowing rulesets to add more information to the panel.
-                ILegacyRuleset legacyRuleset = (ILegacyRuleset)ruleset.Value.CreateInstance();
-                int keyCount = legacyRuleset.GetKeyCount(beatmap, mods.Value);
+                int variant = rulesetInstance.GetVariantForBeatmap(beatmap, mods.Value);
+                var variantName = rulesetInstance.GetVariantName(variant);
 
                 keyCountText.Alpha = 1;
-                keyCountText.Text = $"[{keyCount}K] ";
+                keyCountText.Text = LocalisableString.Interpolate($"[{variantName}] ");
             }
             else
                 keyCountText.Alpha = 0;


### PR DESCRIPTION
https://github.com/user-attachments/assets/edfc8d06-4f04-4876-84a5-dfc83a18f160

Of note:

- Supports both native beatmaps and converts
- Supports key mods (changing key mods will trigger song select refilter when key count grouping is engaged)
- The option to group by keys is only visible when mania ruleset is active
- If the user selects key count grouping and then switches to another ruleset, song select will fall back to no grouping, but this change will not be written back to config. Only the user changing the grouping mode manually will reflect in config changes. This is done so that key grouping persists across ruleset changes, and this even survives game restarts.

---

I've only done some light behaviour testing on this because this feature needs a lot of subjective shot calls and I don't want to commit too deep before I get a temperature check on the shot calls I made here.

In particular some performance profiling of https://github.com/ppy/osu/commit/7de8f70b1dbbdf2e3f13ba10faf25329abf6468d may be warranted.