### PR TITLE
Nerf linear spacings in osu!catch

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
@@ -44,6 +44,30 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Evaluators
                                     / (CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 6) / sqrtStrain;
             }
 
+            // Linear spacing nerf.
+            double linearSpacingCount = 0;
+
+            for (int i = 0; i < Math.Min(current.Index, 10); i++)
+            {
+                var catchPrevObj = (CatchDifficultyHitObject)catchCurrent.Previous(i);
+
+                // Only same direction movements matter as they do not take any additional inputs.
+                if (Math.Sign(catchCurrent.DistanceMoved) != Math.Sign(catchPrevObj.DistanceMoved) || catchCurrent.DistanceMoved == 0 || catchPrevObj.DistanceMoved == 0)
+                    break;
+
+                double currentSpacing = Math.Abs(catchCurrent.DistanceMoved / catchCurrent.StrainTime);
+                double prevSpacing = Math.Abs(catchPrevObj.DistanceMoved / catchPrevObj.StrainTime);
+
+                double relativeDifference = Math.Abs(currentSpacing / prevSpacing - 1);
+
+                if (relativeDifference > 0.05)
+                    break;
+
+                linearSpacingCount++;
+            }
+
+            distanceAddition *= Math.Pow(0.7, linearSpacingCount);
+
             // Bonus for edge dashes.
             if (catchCurrent.LastObject.DistanceToHyperDash <= 20.0f)
             {


### PR DESCRIPTION
This change targets patterns which have no spacing variability and visually are linear. Such patterns don't require additional inputs and you can walk/dash through them.

In particular, [this map](https://osu.ppy.sh/beatmapsets/2485027#fruits/5454338) (ab)uses them to the point it was temporarily unranked.

The curve for the nerf was chosen arbitrarily, it just seems to do the job.