### PR TITLE
Add bottom 'ornament' overlay to ranked play

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/VsSequence.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/VsSequence.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                 vsText.ScaleTo(0.4f, 1300, Easing.OutExpo);
             }
 
-            delay += 850;
+            delay += delay_first;
 
             impactDelay = delay;
 
@@ -187,8 +187,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                 this.Delay(3200).FadeOut(300).Expire();
             }
 
-            delay += 3350;
+            delay += delay_final;
         }
+
+        private const double delay_first = 850;
+        private const double delay_final = 3350;
+
+        public const double INTRO_LENGTH = delay_first + delay_final;
 
         private partial class UserDisplay : CompositeDrawable
         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private readonly Container<RankedPlaySubScreen> screenContainer;
         private readonly RankedPlayChatDisplay chat;
 
-        private RankedPlayBottomOrnament ornamentOverlay = null!;
+        private RankedPlayBottomOrnament ornament = null!;
         private IDisposable? ornamentOverlayRegistration;
 
         private IBindable<RankedPlayStage> stage = null!;
@@ -166,7 +166,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             stage = matchInfo.Stage.GetBoundCopy();
             sampleStart = audio.Samples.Get(@"SongSelect/confirm-selection");
 
-            LoadComponent(ornamentOverlay = new RankedPlayBottomOrnament
+            LoadComponent(ornament = new RankedPlayBottomOrnament
             {
                 Anchor = Anchor.BottomCentre,
                 Origin = Anchor.BottomCentre,
@@ -208,8 +208,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 },
             ]);
 
-            ornamentOverlayRegistration = overlayManager.RegisterBlockingOverlay(ornamentOverlay);
-            ornamentOverlay.Show();
+            ornamentOverlayRegistration = overlayManager.RegisterBlockingOverlay(ornament);
+            ornament.Show();
 
             stage.BindValueChanged(e => onStageChanged(e.NewValue));
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -181,6 +181,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             client.UserStateChanged += onUserStateChanged;
             client.LoadRequested += onLoadRequested;
 
+            Scheduler.AddDelayed(() => ornament.Show(), VsSequence.INTRO_LENGTH);
+
             int localUserId = api.LocalUser.Value.OnlineID;
             int opponentUserId = ((RankedPlayRoomState)client.Room!.MatchState!).Users.Keys.Single(it => it != localUserId);
 
@@ -209,7 +211,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             ]);
 
             ornamentOverlayRegistration = overlayManager.RegisterBlockingOverlay(ornament);
-            ornament.Show();
 
             stage.BindValueChanged(e => onStageChanged(e.NewValue));
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -373,6 +373,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                 client.LeaveRoom().FireAndForget();
 
+                ornamentOverlayRegistration?.Dispose();
+                ornamentOverlayRegistration = null;
+
                 if (retryRequested)
                     controller?.RejoinQueue();
 
@@ -424,6 +427,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             client.LoadRequested -= onLoadRequested;
 
             ornamentOverlayRegistration?.Dispose();
+            ornamentOverlayRegistration = null;
 
             base.Dispose(isDisposing);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -68,6 +69,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private IDialogOverlay dialogOverlay { get; set; } = null!;
 
         [Resolved]
+        private IOverlayManager overlayManager { get; set; } = null!;
+
+        [Resolved]
         private AudioManager audio { get; set; } = null!;
 
         [Resolved]
@@ -84,6 +88,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private readonly Container stageOverlayContainer;
         private readonly Container<RankedPlaySubScreen> screenContainer;
         private readonly RankedPlayChatDisplay chat;
+
+        private RankedPlayBottomOrnament ornamentOverlay = null!;
+        private IDisposable? ornamentOverlayRegistration;
 
         private IBindable<RankedPlayStage> stage = null!;
 
@@ -158,6 +165,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             stage = matchInfo.Stage.GetBoundCopy();
             sampleStart = audio.Samples.Get(@"SongSelect/confirm-selection");
+
+            LoadComponent(ornamentOverlay = new RankedPlayBottomOrnament
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+            });
         }
 
         protected override void LoadComplete()
@@ -194,6 +207,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     }
                 },
             ]);
+
+            ornamentOverlayRegistration = overlayManager.RegisterBlockingOverlay(ornamentOverlay);
+            ornamentOverlay.Show();
 
             stage.BindValueChanged(e => onStageChanged(e.NewValue));
         }
@@ -405,6 +421,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             client.RoomUpdated -= onRoomUpdated;
             client.UserStateChanged -= onUserStateChanged;
             client.LoadRequested -= onLoadRequested;
+
+            ornamentOverlayRegistration?.Dispose();
 
             base.Dispose(isDisposing);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -38,12 +38,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
 
+        protected override bool StartHidden => true;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
             Width = width;
             Height = height;
+            Alpha = 0;
+
             Masking = true;
+
             EdgeEffect = new EdgeEffectParameters
             {
                 Colour = colours.Yellow.Opacity(0.15f),
@@ -161,12 +166,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         protected override void PopIn()
         {
-            this.FadeIn(300, Easing.OutQuint);
+            this.FadeIn(500, Easing.OutQuint);
+            // TODO: animate this better.
         }
 
         protected override void PopOut()
         {
-            this.FadeOut(300, Easing.OutQuint);
+            this.FadeOut(500, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -91,6 +91,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                 },
                 new OsuSpriteText
                 {
+                    Y = 4,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Font = OsuFont.Torus.With(size: 10, weight: FontWeight.Bold),

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         protected override bool StartHidden => true;
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load()
         {
             Width = width;
             Height = height;
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
             EdgeEffect = new EdgeEffectParameters
             {
-                Colour = colours.Yellow.Opacity(0.15f),
+                Colour = Color4Extensions.FromHex("#15061e").Opacity(0.8f),
                 Type = EdgeEffectType.Glow,
                 Radius = height * 2,
                 Roundness = height * 2,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -1,0 +1,171 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Lines;
+using osu.Framework.Layout;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking
+{
+    /// <summary>
+    /// A small component intended to be always present at the bottom of all ranked play screens
+    /// to indicate a ranked play session is in progress.
+    /// </summary>
+    public partial class RankedPlayBottomOrnament : OverlayContainer
+    {
+        private const int width = 400;
+        private const int height = 24;
+
+        protected override bool BlockPositionalInput => false;
+
+        private Path pathLeft = null!;
+        private Path pathRight = null!;
+
+        private Path pathCenter = null!;
+        private Path pathCenterWide = null!;
+
+        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            Width = width;
+            Height = height;
+            Masking = true;
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Colour = colours.Yellow.Opacity(0.15f),
+                Type = EdgeEffectType.Glow,
+                Radius = height * 2,
+                Roundness = height * 2,
+                Offset = new Vector2(0, height / 2f),
+            };
+
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 10,
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Children = new Drawable[]
+                    {
+                        pathLeft = new SmoothPath
+                        {
+                            AutoSizeAxes = Axes.None,
+                            RelativeSizeAxes = Axes.Both,
+                            PathRadius = 1,
+                        },
+                        pathCenter = new SmoothPath
+                        {
+                            AutoSizeAxes = Axes.None,
+                            RelativeSizeAxes = Axes.Both,
+                            PathRadius = 1,
+                        },
+                        pathCenterWide = new SmoothPath
+                        {
+                            AutoSizeAxes = Axes.None,
+                            RelativeSizeAxes = Axes.Both,
+                            PathRadius = 2,
+                        },
+                        pathRight = new SmoothPath
+                        {
+                            AutoSizeAxes = Axes.None,
+                            RelativeSizeAxes = Axes.Both,
+                            PathRadius = 1,
+                        },
+                    },
+                },
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Font = OsuFont.Torus.With(size: 10, weight: FontWeight.Bold),
+                    Spacing = new Vector2(3, 0),
+                    Text = ButtonSystemStrings.RankedPlay.ToUpper(),
+                },
+            };
+        }
+
+        private void recomputePaths()
+        {
+            const int top = 2; // to account for the middle segment being twice as wide
+            const int bottom = 10;
+            const int curve_smoothness = 5;
+
+            pathCenter.AddVertex(new Vector2(30, top));
+            pathCenter.AddVertex(new Vector2(DrawWidth - 30, top));
+
+            pathCenterWide.AddVertex(new Vector2(60, top));
+            pathCenterWide.AddVertex(new Vector2(DrawWidth - 60, top));
+
+            const int left_start = 0;
+            const int left_corner = 10;
+            const int left_end = 20;
+
+            List<Vector2> vertices = new List<Vector2>();
+            var diagonalDirLeft = (new Vector2(left_start, bottom) - new Vector2(left_corner, top)).Normalized();
+
+            var sliderPathLeft = new SliderPath(new[]
+            {
+                new PathControlPoint(new Vector2(left_start, bottom), PathType.LINEAR),
+                new PathControlPoint(new Vector2(left_corner, top) + diagonalDirLeft * curve_smoothness, PathType.BEZIER),
+                new PathControlPoint(new Vector2(left_corner, top)),
+                new PathControlPoint(new Vector2(left_end, top), PathType.LINEAR),
+            });
+
+            sliderPathLeft.GetPathToProgress(vertices, 0.0, 1.0);
+            pathLeft.Vertices = vertices;
+
+            float rightStart = DrawWidth;
+            float rightCorner = rightStart - 10;
+            float rightEnd = rightStart - 20;
+
+            var diagonalDirRight = (new Vector2(rightStart, bottom) - new Vector2(rightCorner, top)).Normalized();
+            var sliderPathRight = new SliderPath(new[]
+            {
+                new PathControlPoint(new Vector2(rightStart, bottom), PathType.LINEAR),
+                new PathControlPoint(new Vector2(rightCorner, top) + diagonalDirRight * curve_smoothness, PathType.BEZIER),
+                new PathControlPoint(new Vector2(rightCorner, top)),
+                new PathControlPoint(new Vector2(rightEnd, top), PathType.LINEAR),
+            });
+
+            sliderPathRight.GetPathToProgress(vertices, 0.0, 1.0);
+            pathRight.Vertices = vertices;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!layout.IsValid)
+            {
+                recomputePaths();
+                layout.Validate();
+            }
+        }
+
+        protected override void PopIn()
+        {
+            this.FadeIn(300, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            this.FadeOut(300, Easing.OutQuint);
+        }
+    }
+}


### PR DESCRIPTION
This commit adds an always present overlay to all ranked play screens, meant to indicate to the user that a ranked play session in currently in progress.

This has been largely inspired by the pre-shader argon healthbar code. It shouldn't have the same performance concerns, however, since the paths are only calculated once when loading the drawable (and eventually when it is resized, if ever).

`RankedPlayScreen`:

<img width="1838" height="1353" alt="image" src="https://github.com/user-attachments/assets/c621d759-a88f-49f0-b0df-3a6da90eca65" />

Gameplay:

<img width="1838" height="1353" alt="image" src="https://github.com/user-attachments/assets/ee848d06-3878-4cbb-bd4b-de2c4bcfa688" />

Currently the drawable overlaps with some components, but it will be resolved in later pull requests.