### PR TITLE
Ranked Play: Fix chat temporarily appearing during intro

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Transforms;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -29,7 +28,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 {
-    public partial class RankedPlayChatDisplay : CompositeDrawable, IKeyBindingHandler<GlobalAction>
+    public partial class RankedPlayChatDisplay : VisibilityContainer, IKeyBindingHandler<GlobalAction>
     {
         [Resolved]
         private ChannelManager? channelManager { get; set; }
@@ -164,7 +163,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
         }
 
-        public void Appear()
+        protected override void PopIn()
         {
             FinishTransforms();
 
@@ -174,12 +173,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 .FadeIn(240, Easing.OutCubic);
         }
 
-        public TransformSequence<RankedPlayChatDisplay> Disappear()
+        protected override void PopOut()
         {
             FinishTransforms();
 
-            return this.FadeOut(240, Easing.InOutCubic)
-                       .MoveToY(150f, 240, Easing.InOutCubic);
+            this.FadeOut(240, Easing.InOutCubic)
+                .MoveToY(150f, 240, Easing.InOutCubic);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                     Bottom = 10,
                                     Right = 10
                                 },
-                                Alpha = 0,
+                                State = { Value = Visibility.Hidden }
                             },
                             new HamburgerMenu
                             {
@@ -277,9 +277,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 backgroundMusic.Play();
 
             if (stage is RankedPlayStage.RoundWarmup && matchInfo.CurrentRound == 1)
-                chat.Disappear();
+                chat.State.Value = Visibility.Hidden;
             else
-                chat.Appear();
+                chat.State.Value = Visibility.Visible;
 
             switch (stage)
             {
@@ -333,7 +333,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         public override void OnSuspending(ScreenTransitionEvent e)
         {
-            chat.Disappear();
             backgroundMusic.Stop();
             previewTrackManager.StopAnyPlaying(this);
 
@@ -383,7 +382,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             base.OnResuming(e);
 
-            chat.Appear();
             if (e.Last is not MultiplayerPlayerLoader playerLoader)
                 return;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -271,17 +271,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private void onStageChanged(RankedPlayStage stage)
         {
-            chat.Appear();
-
             if (stage is RankedPlayStage.GameplayWarmup or RankedPlayStage.Gameplay)
                 backgroundMusic.Stop();
             else
                 backgroundMusic.Play();
 
+            if (stage is RankedPlayStage.RoundWarmup && matchInfo.CurrentRound == 1)
+                chat.Disappear();
+            else
+                chat.Appear();
+
             switch (stage)
             {
                 case RankedPlayStage.RoundWarmup when matchInfo.CurrentRound == 1:
-                    chat.Disappear();
                     ShowScreen(new IntroScreen());
                     break;
 


### PR DESCRIPTION
I was kind of lazy with the disappear/appear stuff. Made it properly set the required state at the correct time now.

Made a second fix to change it into a visibility container, so that bindable states are deduped. On `master` it would re-appear from the bottom with every stage change.