### PR TITLE
Ranked Play: Fix stutter when entering queue screen

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayMatchPanel.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayMatchPanel.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
@@ -19,51 +20,54 @@ namespace osu.Game.Tests.Visual.RankedPlay
         [Test]
         public void TestLeftWin()
         {
-            AddStep("add panel", () => Child = new RankedPlayMatchPanel(new RankedPlayRoomState
+            AddStep("add panel", () => Child = new DelayedLoadWrapper(new RankedPlayMatchPanel(new RankedPlayRoomState
             {
                 Users =
                 {
                     { 1, new RankedPlayUserInfo { Rating = 0, Life = 800_000, RoundsWon = 3 } },
                     { 2, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 1 } }
                 }
-            })
+            }), 0)
             {
                 Anchor = Anchor.Centre,
-                Origin = Anchor.Centre
+                Origin = Anchor.Centre,
+                Width = 280
             });
         }
 
         [Test]
         public void TestRightWin()
         {
-            AddStep("add panel", () => Child = new RankedPlayMatchPanel(new RankedPlayRoomState
+            AddStep("add panel", () => Child = new DelayedLoadWrapper(new RankedPlayMatchPanel(new RankedPlayRoomState
             {
                 Users =
                 {
                     { 1, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 3 } },
                     { 2, new RankedPlayUserInfo { Rating = 0, Life = 800_000, RoundsWon = 1 } }
                 }
-            })
+            }), 0)
             {
                 Anchor = Anchor.Centre,
-                Origin = Anchor.Centre
+                Origin = Anchor.Centre,
+                Width = 280
             });
         }
 
         [Test]
         public void TestDraw()
         {
-            AddStep("add panel", () => Child = new RankedPlayMatchPanel(new RankedPlayRoomState
+            AddStep("add panel", () => Child = new DelayedLoadWrapper(new RankedPlayMatchPanel(new RankedPlayRoomState
             {
                 Users =
                 {
                     { 1, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 3 } },
                     { 2, new RankedPlayUserInfo { Rating = 0, Life = 200_000, RoundsWon = 1 } }
                 }
-            })
+            }), 0)
             {
                 Anchor = Anchor.Centre,
-                Origin = Anchor.Centre
+                Origin = Anchor.Centre,
+                Width = 280
             });
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
@@ -26,6 +26,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 {
+    [LongRunningLoad]
     public partial class RankedPlayMatchPanel : CompositeDrawable
     {
         [Resolved]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private Container mainContent = null!;
         private CloudVisualisation cloud = null!;
         private RatingDistributionGraph ratingGraph = null!;
-        private FillFlowContainer<RankedPlayMatchPanel> resultPanelContainer = null!;
+        private FillFlowContainer resultPanelContainer = null!;
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -209,7 +209,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                                         {
                                                             RelativeSizeAxes = Axes.Both,
                                                             ScrollbarOverlapsContent = false,
-                                                            Child = resultPanelContainer = new FillFlowContainer<RankedPlayMatchPanel>
+                                                            Child = resultPanelContainer = new FillFlowContainer
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
                                                                 AutoSizeAxes = Axes.Y,
@@ -368,7 +368,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             foreach (var state in status.RecentMatches.OfType<RankedPlayRoomState>())
             {
-                resultPanelContainer.Insert(-resultPanelContainer.Count, new RankedPlayMatchPanel(state)
+                resultPanelContainer.Insert(-resultPanelContainer.Count, new DelayedLoadWrapper(new RankedPlayMatchPanel(state)
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Width = 1
+                }, 0)
                 {
                     RelativeSizeAxes = Axes.X,
                     Width = 0.48f


### PR DESCRIPTION
The panels look up the online APIUser models. Maybe I could do this by doing the lookups async inside `RankedPlayMatchPanel`, but this will probably do for now?