### PR TITLE
Fix incorrect score conversion in taiko due to not porting stable quirk

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -66,7 +66,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 drainLength = ((int)Math.Round(baseBeatmap.HitObjects[^1].StartTime) - (int)Math.Round(baseBeatmap.HitObjects[0].StartTime) - breakLength) / 1000;
             }
 
-            difficultyPeppyStars = LegacyRulesetExtensions.CalculateDifficultyPeppyStars(baseBeatmap.Difficulty, objectCount, drainLength);
+            var alteredDifficulty = baseBeatmap.Difficulty.Clone();
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManagerTaiko.cs#L78
+            alteredDifficulty.CircleSize = 2;
+
+            difficultyPeppyStars = LegacyRulesetExtensions.CalculateDifficultyPeppyStars(alteredDifficulty, objectCount, drainLength);
 
             LegacyScoreAttributes attributes = new LegacyScoreAttributes();
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -47,9 +47,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000014: Fix edge cases in conversion for osu! scores on selected beatmaps. Reconvert all scores.</description></item>
         /// <item><description>30000015: Fix osu! standardised score estimation algorithm violating basic invariants. Reconvert all scores.</description></item>
         /// <item><description>30000016: Fix taiko standardised score estimation algorithm not including swell tick score gain into bonus portion. Reconvert all scores.</description></item>
+        /// <item><description>30000017: Fix taiko standardised score estimation algorithm overestimating maximum achievable total due to missing quirk of uniformly setting CS=2. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000016;
+        public const int LATEST_VERSION = 30000017;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
- [x] Pending sheet generation & verification

Reported in [discord](https://discord.com/channels/188630481301012481/1097318920991559880/1493976971766403203).

> [!WARNING]
> The deployment of this fix, if accepted, will consist of:
>
> - recomputation of legacy scoring attributes for **all** taiko beatmaps (including converts),
> - reverification of **all** taiko legacy scores.

For *whatever* reason, stable taiko [decides to set circle size to 2 uniformly](https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManagerTaiko.cs#L78) in its maze-like virtual methods. This factors into `difficultyPeppyStars`, which makes `TaikoLegacyScoreSimulator` overestimate the maximum achievable score, which in turn ends up being an effective stable nerf *on top of* the 0.96x classic multiplier on the unified leaderboards of selected beatmaps.

Using an old data dump I once got to check https://github.com/ppy/osu/pull/26471, this may affect in the ballpark of 25% of all beatmaps (converts included).

Stable is a [REDACTED]ing [REDACTED] lorem ipsum [REDACTED] hippopotamus [REDACTED] with a bucket of [REDACTED] soup [REDACTED] with a bucket of [REDACTED] and a stick of dynamite [REDACTED] magical [REDACTED], alakazam.