### PR TITLE
Display score bar display in ranked play gameplay

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayPlayer.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Specialized;
+using System.Linq;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Multiplayer;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class RankedPlayPlayer : MultiplayerPlayer
+    {
+        private readonly MultiplayerRoomUser localUser;
+        private readonly MultiplayerRoomUser opponentUser;
+
+        public RankedPlayPlayer(Room room, PlaylistItem playlistItem, MultiplayerRoomUser localUser, MultiplayerRoomUser opponentUser)
+            : base(room, playlistItem, [localUser, opponentUser])
+        {
+            this.localUser = localUser;
+            this.opponentUser = opponentUser;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            LeaderboardProvider.Scores.CollectionChanged += scoresUpdated;
+        }
+
+        private void scoresUpdated(object? sender, NotifyCollectionChangedEventArgs args)
+        {
+            // `MultiplayerLeaderboardProvider.Scores` is being populated asynchronously since it needs
+            // to load user details from the API. Because of that, the bindables containing total scores
+            // are not immediately available after loading the player.
+            // We wait until the list has two members (which is always the case in ranked play)
+            // until binding the score display.
+            if (LeaderboardProvider.Scores.Count != 2)
+                return;
+
+            bindScoreDisplay();
+            LeaderboardProvider.Scores.CollectionChanged -= scoresUpdated;
+        }
+
+        private void bindScoreDisplay()
+        {
+            ScoreDisplay.Alpha = 1;
+
+            // Team 1 in `MatchScoreDisplay` is red, so we've got to bind those in a counterintuitive order.
+            // TODO: implement a custom component for this
+            ScoreDisplay.Team1Score.BindTarget = LeaderboardProvider.Scores.Single(s => s.User.OnlineID == opponentUser.UserID).TotalScore;
+            ScoreDisplay.Team2Score.BindTarget = LeaderboardProvider.Scores.Single(s => s.User.OnlineID == localUser.UserID).TotalScore;
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -28,7 +28,6 @@ using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Volume;
 using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Components;
-using osu.Game.Screens.OnlinePlay.Matchmaking.Match.Gameplay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
@@ -283,7 +282,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private void onLoadRequested() => Scheduler.Add(() =>
         {
             sampleStart?.Play();
-            this.Push(new MultiplayerPlayerLoader(() => new ScreenGameplay(new Room(room), new PlaylistItem(client.Room!.CurrentPlaylistItem), room.Users.ToArray())));
+
+            var localRoomUser = room.Users.Single(u => u.UserID == localUser.OnlineID);
+            var opponentRoomUser = room.Users.Single(u => u.UserID == opponentUser.OnlineID);
+
+            this.Push(new MultiplayerPlayerLoader(() => new RankedPlayPlayer(
+                new Room(room),
+                new PlaylistItem(client.Room!.CurrentPlaylistItem),
+                localRoomUser,
+                opponentRoomUser
+            )));
         });
 
         private void onStageChanged(RankedPlayStage stage)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -40,9 +40,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private LoadingLayer loadingDisplay = null!;
 
         [Cached(typeof(IGameplayLeaderboardProvider))]
-        private readonly MultiplayerLeaderboardProvider leaderboardProvider;
+        protected readonly MultiplayerLeaderboardProvider LeaderboardProvider;
 
-        private GameplayMatchScoreDisplay teamScoreDisplay = null!;
+        protected GameplayMatchScoreDisplay ScoreDisplay { get; private set; } = null!;
         private GameplayChatDisplay chat = null!;
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 ShowLeaderboard = true,
             })
         {
-            leaderboardProvider = new MultiplayerLeaderboardProvider(users);
+            LeaderboardProvider = new MultiplayerLeaderboardProvider(users);
         }
 
         [BackgroundDependencyLoader]
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 Children = new Drawable[]
                 {
                     chat = new GameplayChatDisplay(Room),
-                    teamScoreDisplay = new GameplayMatchScoreDisplay
+                    ScoreDisplay = new GameplayMatchScoreDisplay
                     {
                         Expanded = { BindTarget = HUDOverlay.ShowHud },
                         Alpha = 0,
@@ -93,15 +93,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 Origin = Anchor.BottomRight,
             }, d => HUDOverlay.BottomRightElements.Insert(-1, d));
 
-            LoadComponentAsync(leaderboardProvider, loaded =>
+            LoadComponentAsync(LeaderboardProvider, loaded =>
             {
                 AddInternal(loaded);
 
                 if (loaded.HasTeams)
                 {
-                    teamScoreDisplay.Alpha = 1;
-                    teamScoreDisplay.Team1Score.BindTarget = leaderboardProvider.TeamScores.First().Value;
-                    teamScoreDisplay.Team2Score.BindTarget = leaderboardProvider.TeamScores.Last().Value;
+                    ScoreDisplay.Alpha = 1;
+                    ScoreDisplay.Team1Score.BindTarget = LeaderboardProvider.TeamScores.First().Value;
+                    ScoreDisplay.Team2Score.BindTarget = LeaderboardProvider.TeamScores.Last().Value;
                 }
             });
 
@@ -243,8 +243,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             Debug.Assert(Room.RoomID != null);
 
-            return leaderboardProvider.TeamScores.Count == 2
-                ? new MultiplayerTeamResultsScreen(score, Room.RoomID.Value, PlaylistItem, leaderboardProvider.TeamScores)
+            return LeaderboardProvider.TeamScores.Count == 2
+                ? new MultiplayerTeamResultsScreen(score, Room.RoomID.Value, PlaylistItem, LeaderboardProvider.TeamScores)
                 {
                     IsLocalPlay = true,
                 }


### PR DESCRIPTION
Currently it's using the same one as the Team VS multiplayer lobbies, which doesn't look the best since the red team/player is on the left, where for ranked play it would make more sense for it to be other way around (since local player is blue).

Either way for ranked play this should eventually use a custom component. This PR is more concerned with getting the score bindables out of `MultiplayerLeaderboardProvider` in a decent way. Would be great if reviews focused on this part.

[Screencast_20260416_160732.webm](https://github.com/user-attachments/assets/71f7c915-7f39-4bb6-bf99-29bf6bb5256c)
