### PR TITLE
Consolidate object declaration name conventions

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
 
@@ -15,24 +14,23 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <summary>
         /// Evaluates the difficulty of fast aiming
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-            var osuPrevObj = current.Index > 0 ? (OsuDifficultyHitObject)current.Previous(0) : null;
+            var prevObj = currObj.Index > 0 ? (OsuDifficultyHitObject)currObj.Previous(0) : null;
 
-            double travelDistance = osuPrevObj?.LazyTravelDistance ?? 0;
-            double distance = travelDistance + osuCurrObj.LazyJumpDistance;
+            double travelDistance = prevObj?.LazyTravelDistance ?? 0;
+            double distance = travelDistance + currObj.LazyJumpDistance;
 
             double distanceScaled = Math.Min(distance, distance_cap) / distance_cap;
 
-            double strain = distanceScaled * 1000 / osuCurrObj.AdjustedDeltaTime;
+            double strain = distanceScaled * 1000 / currObj.AdjustedDeltaTime;
 
-            strain *= Math.Pow(osuCurrObj.SmallCircleBonus, 1.5);
+            strain *= Math.Pow(currObj.SmallCircleBonus, 1.5);
 
-            strain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+            strain *= highBpmBonus(currObj.AdjustedDeltaTime);
 
             return strain;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/AgilityEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -14,26 +13,25 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <summary>
         /// Evaluates the difficulty of fast aiming
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
             const double distance_cap = OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.2; // 1.2 circles distance between centers
 
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-            var osuPrevObj = current.Index > 0 ? (OsuDifficultyHitObject)current.Previous(0) : null;
+            var prevObj = currObj.Index > 0 ? (OsuDifficultyHitObject)currObj.Previous(0) : null;
 
-            double travelDistance = osuPrevObj?.LazyTravelDistance ?? 0;
-            double distance = travelDistance + osuCurrObj.LazyJumpDistance;
+            double travelDistance = prevObj?.LazyTravelDistance ?? 0;
+            double distance = travelDistance + currObj.LazyJumpDistance;
 
             double distanceScaled = Math.Min(distance, distance_cap) / distance_cap;
 
-            double agilityDifficulty = distanceScaled * 1000 / osuCurrObj.AdjustedDeltaTime;
+            double agilityDifficulty = distanceScaled * 1000 / currObj.AdjustedDeltaTime;
 
-            agilityDifficulty *= DiffUtils.Pow(osuCurrObj.SmallCircleBonus, 1.5);
+            agilityDifficulty *= DiffUtils.Pow(currObj.SmallCircleBonus, 1.5);
 
-            agilityDifficulty *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+            agilityDifficulty *= highBpmBonus(currObj.AdjustedDeltaTime);
 
             return agilityDifficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 return 0;
 
             var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
-            var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(1);
+            var prev1Obj = (OsuDifficultyHitObject)currObj.Previous(1);
 
             double currDistance = withSliderTravelDistance ? currObj.LazyJumpDistance : currObj.JumpDistance;
             double prevDistance = withSliderTravelDistance ? prevObj.LazyJumpDistance : prevObj.JumpDistance;
@@ -64,8 +64,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             if (currObj.Index > 2)
             {
                 double o1 = calculateOverlapFactor(currObj, prevObj);
-                double o2 = calculateOverlapFactor(currObj, prev2Obj);
-                double o3 = calculateOverlapFactor(prevObj, prev2Obj);
+                double o2 = calculateOverlapFactor(currObj, prev1Obj);
+                double o3 = calculateOverlapFactor(prevObj, prev1Obj);
 
                 overlappedNotesWeight = 1 - o1 * o2 * o3;
             }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             if (currObj.BaseObject is Spinner || currObj.Index <= 1 || currObj.Previous(0).BaseObject is Spinner)
                 return 0;
 
-            var nextObj = (OsuDifficultyHitObject?)currObj.Next(0);
             var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
             var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(1);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -17,44 +16,44 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <summary>
         /// Evaluates difficulty of "flow aim" - aiming pattern where player doesn't stop their cursor on every object and instead "flows" through them.
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, bool withSliderTravelDistance)
         {
-            if (current.BaseObject is Spinner || current.Index <= 1 || current.Previous(0).BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner || currObj.Index <= 1 || currObj.Previous(0).BaseObject is Spinner)
                 return 0;
 
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-            var osuLastObj = (OsuDifficultyHitObject)current.Previous(0);
-            var osuLastLastObj = (OsuDifficultyHitObject)current.Previous(1);
+            var nextObj = (OsuDifficultyHitObject?)currObj.Next(0);
+            var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
+            var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(1);
 
-            double currDistance = withSliderTravelDistance ? osuCurrObj.LazyJumpDistance : osuCurrObj.JumpDistance;
-            double prevDistance = withSliderTravelDistance ? osuLastObj.LazyJumpDistance : osuLastObj.JumpDistance;
+            double currDistance = withSliderTravelDistance ? currObj.LazyJumpDistance : currObj.JumpDistance;
+            double prevDistance = withSliderTravelDistance ? prevObj.LazyJumpDistance : prevObj.JumpDistance;
 
-            double currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+            double currVelocity = currDistance / currObj.AdjustedDeltaTime;
 
-            if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
+            if (prevObj.BaseObject is Slider && withSliderTravelDistance)
             {
                 // If the last object is a slider, then we extend the travel velocity through the slider into the current object.
-                double sliderDistance = osuLastObj.LazyTravelDistance + osuCurrObj.LazyJumpDistance;
-                currVelocity = Math.Max(currVelocity, sliderDistance / osuCurrObj.AdjustedDeltaTime);
+                double sliderDistance = prevObj.LazyTravelDistance + currObj.LazyJumpDistance;
+                currVelocity = Math.Max(currVelocity, sliderDistance / currObj.AdjustedDeltaTime);
             }
 
-            double prevVelocity = prevDistance / osuLastObj.AdjustedDeltaTime;
+            double prevVelocity = prevDistance / prevObj.AdjustedDeltaTime;
 
             double flowDifficulty = currVelocity;
 
             // Apply high circle size bonus to the base velocity.
             // We use reduced CS bonus here because the bonus was made for an evaluator with a different d/t scaling
-            flowDifficulty *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
+            flowDifficulty *= Math.Sqrt(currObj.SmallCircleBonus);
 
             // Rhythm changes are harder to flow
             flowDifficulty *= 1 + Math.Min(0.25,
-                Math.Pow((Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) - Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) / 50, 4));
+                Math.Pow((Math.Max(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime) - Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime)) / 50, 4));
 
-            if (osuCurrObj.Angle != null && osuLastObj.Angle != null)
+            if (currObj.Angle != null && prevObj.Angle != null)
             {
-                double angleDifference = Math.Abs(osuCurrObj.Angle.Value - osuLastObj.Angle.Value);
+                double angleDifference = Math.Abs(currObj.Angle.Value - prevObj.Angle.Value);
                 double angleDifferenceAdjusted = Math.Sin(angleDifference / 2) * 180.0;
-                double angularVelocity = angleDifferenceAdjusted / (osuCurrObj.AdjustedDeltaTime * 0.1);
+                double angularVelocity = angleDifferenceAdjusted / (currObj.AdjustedDeltaTime * 0.1);
 
                 // Low angular velocity flow (angles are consistent) is easier to follow than erratic flow
                 flowDifficulty *= 0.8 + Math.Sqrt(angularVelocity / 270.0);
@@ -63,21 +62,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             // If all three notes are overlapping - don't reward bonuses as you don't have to do additional movement
             double overlappedNotesWeight = 1;
 
-            if (current.Index > 2)
+            if (currObj.Index > 2)
             {
-                double o1 = calculateOverlapFactor(osuCurrObj, osuLastObj);
-                double o2 = calculateOverlapFactor(osuCurrObj, osuLastLastObj);
-                double o3 = calculateOverlapFactor(osuLastObj, osuLastLastObj);
+                double o1 = calculateOverlapFactor(currObj, prevObj);
+                double o2 = calculateOverlapFactor(currObj, prev2Obj);
+                double o3 = calculateOverlapFactor(prevObj, prev2Obj);
 
                 overlappedNotesWeight = 1 - o1 * o2 * o3;
             }
 
-            if (osuCurrObj.Angle != null)
+            if (currObj.Angle != null)
             {
                 // Acute angles are also hard to flow
                 // We square root velocity to make acute angle switches in streams aren't having difficulty higher than snap
                 flowDifficulty += Math.Sqrt(currVelocity) *
-                                  SnapAimEvaluator.CalcAngleAcuteness(osuCurrObj.Angle.Value) *
+                                  SnapAimEvaluator.CalcAngleAcuteness(currObj.Angle.Value) *
                                   overlappedNotesWeight;
             }
 
@@ -85,14 +84,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             {
                 if (withSliderTravelDistance)
                 {
-                    currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+                    currVelocity = currDistance / currObj.AdjustedDeltaTime;
                 }
 
                 // Scale with ratio of difference compared to 0.5 * max dist.
                 double distRatio = DifficultyCalculationUtils.Smoothstep(Math.Abs(prevVelocity - currVelocity) / Math.Max(prevVelocity, currVelocity), 0, 1);
 
                 // Reward for % distance up to 125 / strainTime for overlaps where velocity is still changing.
-                double overlapVelocityBuff = Math.Min(OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25 / Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime),
+                double overlapVelocityBuff = Math.Min(OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25 / Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime),
                     Math.Abs(prevVelocity - currVelocity));
 
                 flowDifficulty += overlapVelocityBuff *
@@ -101,10 +100,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                                   velocity_change_multiplier;
             }
 
-            if (osuCurrObj.BaseObject is Slider && withSliderTravelDistance)
+            if (currObj.BaseObject is Slider && withSliderTravelDistance)
             {
                 // Include slider velocity to make velocity more consistent with snap
-                flowDifficulty += osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
+                flowDifficulty += currObj.TravelDistance / currObj.TravelTime;
             }
 
             // Final velocity is being raised to a power because flow difficulty scales harder with both high distance and time, and we want to account for that

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             const double velocity_change_multiplier = 0.52;
 
-            var prev1Obj = (OsuDifficultyHitObject)currObj.Previous(1);
+            var prevObj1 = (OsuDifficultyHitObject)currObj.Previous(1);
 
             double currDistance = withSliderTravelDistance ? currObj.LazyJumpDistance : currObj.JumpDistance;
             double prevDistance = withSliderTravelDistance ? prevObj.LazyJumpDistance : prevObj.JumpDistance;
@@ -65,8 +65,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             if (currObj.Index > 2)
             {
                 double o1 = calculateOverlapFactor(currObj, prevObj);
-                double o2 = calculateOverlapFactor(currObj, prev1Obj);
-                double o3 = calculateOverlapFactor(prevObj, prev1Obj);
+                double o2 = calculateOverlapFactor(currObj, prevObj1);
+                double o3 = calculateOverlapFactor(prevObj, prevObj1);
 
                 overlappedNotesWeight = 1 - o1 * o2 * o3;
             }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -15,47 +14,46 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <summary>
         /// Evaluates difficulty of "flow aim" - aiming pattern where player doesn't stop their cursor on every object and instead "flows" through them.
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, bool withSliderTravelDistance)
         {
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-            var osuLastObj = (OsuDifficultyHitObject)current.Previous();
+            var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
 
-            if (current.BaseObject is Spinner || current.Index <= 1 || osuLastObj.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner || currObj.Index <= 1 || prevObj.BaseObject is Spinner)
                 return 0;
 
             const double velocity_change_multiplier = 0.52;
 
-            var osuLastLastObj = (OsuDifficultyHitObject)current.Previous(1);
+            var prev1Obj = (OsuDifficultyHitObject)currObj.Previous(1);
 
-            double currDistance = withSliderTravelDistance ? osuCurrObj.LazyJumpDistance : osuCurrObj.JumpDistance;
-            double prevDistance = withSliderTravelDistance ? osuLastObj.LazyJumpDistance : osuLastObj.JumpDistance;
+            double currDistance = withSliderTravelDistance ? currObj.LazyJumpDistance : currObj.JumpDistance;
+            double prevDistance = withSliderTravelDistance ? prevObj.LazyJumpDistance : prevObj.JumpDistance;
 
-            double currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+            double currVelocity = currDistance / currObj.AdjustedDeltaTime;
 
-            if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
+            if (prevObj.BaseObject is Slider && withSliderTravelDistance)
             {
                 // If the last object is a slider, then we extend the travel velocity through the slider into the current object.
-                double sliderDistance = osuLastObj.LazyTravelDistance + osuCurrObj.LazyJumpDistance;
-                currVelocity = Math.Max(currVelocity, sliderDistance / osuCurrObj.AdjustedDeltaTime);
+                double sliderDistance = prevObj.LazyTravelDistance + currObj.LazyJumpDistance;
+                currVelocity = Math.Max(currVelocity, sliderDistance / currObj.AdjustedDeltaTime);
             }
 
-            double prevVelocity = prevDistance / osuLastObj.AdjustedDeltaTime;
+            double prevVelocity = prevDistance / prevObj.AdjustedDeltaTime;
 
             double flowDifficulty = currVelocity;
 
             // Apply high circle size bonus to the base velocity.
             // We use reduced CS bonus here because the bonus was made for an evaluator with a different d/t scaling
-            flowDifficulty *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
+            flowDifficulty *= Math.Sqrt(currObj.SmallCircleBonus);
 
             // Rhythm changes are harder to flow
             flowDifficulty *= 1 + Math.Min(0.25,
-                DiffUtils.Pow((Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) - Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) / 50, 4));
+                DiffUtils.Pow((Math.Max(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime) - Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime)) / 50, 4));
 
-            if (osuCurrObj.Angle != null && osuLastObj.Angle != null)
+            if (currObj.Angle != null && prevObj.Angle != null)
             {
-                double angleDifference = Math.Abs(osuCurrObj.Angle.Value - osuLastObj.Angle.Value);
+                double angleDifference = Math.Abs(currObj.Angle.Value - prevObj.Angle.Value);
                 double angleDifferenceAdjusted = Math.Sin(angleDifference / 2) * 180.0;
-                double angularVelocity = angleDifferenceAdjusted / (osuCurrObj.AdjustedDeltaTime * 0.1);
+                double angularVelocity = angleDifferenceAdjusted / (currObj.AdjustedDeltaTime * 0.1);
 
                 // Low angular velocity flow (angles are consistent) is easier to follow than erratic flow
                 flowDifficulty *= 0.8 + Math.Sqrt(angularVelocity / 270.0);
@@ -64,20 +62,20 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             // If all three notes are overlapping - don't reward bonuses as you don't have to do additional movement
             double overlappedNotesWeight = 1;
 
-            if (current.Index > 2)
+            if (currObj.Index > 2)
             {
-                double o1 = calculateOverlapFactor(osuCurrObj, osuLastObj);
-                double o2 = calculateOverlapFactor(osuCurrObj, osuLastLastObj);
-                double o3 = calculateOverlapFactor(osuLastObj, osuLastLastObj);
+                double o1 = calculateOverlapFactor(currObj, prevObj);
+                double o2 = calculateOverlapFactor(currObj, prev1Obj);
+                double o3 = calculateOverlapFactor(prevObj, prev1Obj);
 
                 overlappedNotesWeight = 1 - o1 * o2 * o3;
             }
 
-            if (osuCurrObj.Angle != null)
+            if (currObj.Angle != null)
             {
                 // Acute angles are also hard to flow
                 flowDifficulty += currVelocity *
-                                  SnapAimEvaluator.CalcAngleAcuteness(osuCurrObj.Angle.Value) *
+                                  SnapAimEvaluator.CalcAngleAcuteness(currObj.Angle.Value) *
                                   overlappedNotesWeight;
             }
 
@@ -85,14 +83,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             {
                 if (withSliderTravelDistance)
                 {
-                    currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+                    currVelocity = currDistance / currObj.AdjustedDeltaTime;
                 }
 
                 // Scale with ratio of difference compared to 0.5 * max dist.
                 double distRatio = DiffUtils.Smoothstep(Math.Abs(prevVelocity - currVelocity) / Math.Max(prevVelocity, currVelocity), 0, 1);
 
                 // Reward for % distance up to 125 / strainTime for overlaps where velocity is still changing.
-                double overlapVelocityBuff = Math.Min(OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25 / Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime),
+                double overlapVelocityBuff = Math.Min(OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25 / Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime),
                     Math.Abs(prevVelocity - currVelocity));
 
                 flowDifficulty += overlapVelocityBuff *
@@ -101,10 +99,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                                   velocity_change_multiplier;
             }
 
-            if (osuCurrObj.BaseObject is Slider && withSliderTravelDistance)
+            if (currObj.BaseObject is Slider && withSliderTravelDistance)
             {
                 // Include slider velocity to make velocity more consistent with snap
-                flowDifficulty += osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
+                flowDifficulty += currObj.TravelDistance / currObj.TravelTime;
             }
 
             // Final velocity is being raised to a power because flow difficulty scales harder with both high distance and time, and we want to account for that

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -29,48 +28,47 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <item><description>and slider difficulty.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, bool withSliderTravelDistance)
         {
-            if (current.BaseObject is Spinner || current.Index <= 1 || current.Previous(0).BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner || currObj.Index <= 1 || currObj.Previous(0).BaseObject is Spinner)
                 return 0;
 
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-            var osuLastObj = (OsuDifficultyHitObject)current.Previous(0);
-            var osuLast2Obj = (OsuDifficultyHitObject)current.Previous(2);
+            var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
+            var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(2);
 
             const int radius = OsuDifficultyHitObject.NORMALISED_RADIUS;
             const int diameter = OsuDifficultyHitObject.NORMALISED_DIAMETER;
 
             // Calculate the velocity to the current hitobject, which starts with a base distance / time assuming the last object is a hitcircle.
-            double currDistance = withSliderTravelDistance ? osuCurrObj.LazyJumpDistance : osuCurrObj.JumpDistance;
-            double currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+            double currDistance = withSliderTravelDistance ? currObj.LazyJumpDistance : currObj.JumpDistance;
+            double currVelocity = currDistance / currObj.AdjustedDeltaTime;
 
             // But if the last object is a slider, then we extend the travel velocity through the slider into the current object.
-            if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
+            if (prevObj.BaseObject is Slider && withSliderTravelDistance)
             {
-                double sliderDistance = osuLastObj.LazyTravelDistance + osuCurrObj.LazyJumpDistance;
-                currVelocity = Math.Max(currVelocity, sliderDistance / osuCurrObj.AdjustedDeltaTime);
+                double sliderDistance = prevObj.LazyTravelDistance + currObj.LazyJumpDistance;
+                currVelocity = Math.Max(currVelocity, sliderDistance / currObj.AdjustedDeltaTime);
             }
 
-            double prevDistance = withSliderTravelDistance ? osuLastObj.LazyJumpDistance : osuLastObj.JumpDistance;
-            double prevVelocity = prevDistance / osuLastObj.AdjustedDeltaTime;
+            double prevDistance = withSliderTravelDistance ? prevObj.LazyJumpDistance : prevObj.JumpDistance;
+            double prevVelocity = prevDistance / prevObj.AdjustedDeltaTime;
 
             double aimStrain = currVelocity; // Start strain with regular velocity.
 
             // Penalize angle repetition.
-            aimStrain *= vectorAngleRepetition(osuCurrObj, osuLastObj);
+            aimStrain *= vectorAngleRepetition(currObj, prevObj);
 
-            if (osuCurrObj.Angle != null && osuLastObj.Angle != null)
+            if (currObj.Angle != null && prevObj.Angle != null)
             {
-                double currAngle = osuCurrObj.Angle.Value;
-                double lastAngle = osuLastObj.Angle.Value;
+                double currAngle = currObj.Angle.Value;
+                double lastAngle = prevObj.Angle.Value;
 
                 // Rewarding angles, take the smaller velocity as base.
                 double velocityInfluence = Math.Min(currVelocity, prevVelocity);
 
                 double acuteAngleBonus = 0;
 
-                if (Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) < 1.25 * Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) // If rhythms are the same.
+                if (Math.Max(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime) < 1.25 * Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime)) // If rhythms are the same.
                 {
                     acuteAngleBonus = CalcAngleAcuteness(currAngle);
 
@@ -78,7 +76,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                     acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, Math.Pow(CalcAngleAcuteness(lastAngle), 3)));
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
-                    acuteAngleBonus *= velocityInfluence * DifficultyCalculationUtils.Smootherstep(DifficultyCalculationUtils.MillisecondsToBPM(osuCurrObj.AdjustedDeltaTime, 2), 300, 400) *
+                    acuteAngleBonus *= velocityInfluence * DifficultyCalculationUtils.Smootherstep(DifficultyCalculationUtils.MillisecondsToBPM(currObj.AdjustedDeltaTime, 2), 300, 400) *
                                        DifficultyCalculationUtils.Smootherstep(currDistance, 0, diameter * 2);
                 }
 
@@ -89,12 +87,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
                 wideAngleBonus *= velocityInfluence;
 
-                if (osuLast2Obj != null)
+                if (prev2Obj != null)
                 {
                     // If objects just go back and forth through a middle point - don't give as much wide bonus
                     // Use Previous(2) and Previous(0) because angles calculation is done prevprev-prev-curr, so any object's angle's center point is always the previous object
-                    var lastBaseObject = (OsuHitObject)osuLastObj.BaseObject;
-                    var last2BaseObject = (OsuHitObject)osuLast2Obj.BaseObject;
+                    var lastBaseObject = (OsuHitObject)prevObj.BaseObject;
+                    var last2BaseObject = (OsuHitObject)prev2Obj.BaseObject;
 
                     float distance = (last2BaseObject.StackedPosition - lastBaseObject.StackedPosition).Length;
 
@@ -125,34 +123,34 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 if (withSliderTravelDistance)
                 {
                     // We want to use just the object jump without slider velocity when awarding differences
-                    currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+                    currVelocity = currDistance / currObj.AdjustedDeltaTime;
                 }
 
                 // Scale with ratio of difference compared to 0.5 * max dist.
                 double distRatio = DifficultyCalculationUtils.Smoothstep(Math.Abs(prevVelocity - currVelocity) / Math.Max(prevVelocity, currVelocity), 0, 1);
 
                 // Reward for % distance up to 125 / strainTime for overlaps where velocity is still changing.
-                double overlapVelocityBuff = Math.Min(diameter * 1.25 / Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime), Math.Abs(prevVelocity - currVelocity));
+                double overlapVelocityBuff = Math.Min(diameter * 1.25 / Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime), Math.Abs(prevVelocity - currVelocity));
 
                 double velocityChangeBonus = overlapVelocityBuff * distRatio;
 
                 // Penalize for rhythm changes.
-                velocityChangeBonus *= Math.Pow(Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) / Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime), 2);
+                velocityChangeBonus *= Math.Pow(Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime) / Math.Max(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime), 2);
 
                 aimStrain += velocityChangeBonus * velocity_change_multiplier;
             }
 
             // Reward sliders based on velocity.
-            if (osuCurrObj.BaseObject is Slider && withSliderTravelDistance)
+            if (currObj.BaseObject is Slider && withSliderTravelDistance)
             {
-                double sliderBonus = osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
+                double sliderBonus = currObj.TravelDistance / currObj.TravelTime;
                 aimStrain += (sliderBonus < 1 ? sliderBonus : Math.Pow(sliderBonus, 0.75)) * slider_multiplier;
             }
 
             // Apply high circle size bonus
-            aimStrain *= osuCurrObj.SmallCircleBonus;
+            aimStrain *= currObj.SmallCircleBonus;
 
-            aimStrain *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+            aimStrain *= highBpmBonus(currObj.AdjustedDeltaTime);
 
             return aimStrain;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 return 0;
 
             var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
-            var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(2);
+            var prev3Obj = (OsuDifficultyHitObject)currObj.Previous(2);
 
             const int radius = OsuDifficultyHitObject.NORMALISED_RADIUS;
             const int diameter = OsuDifficultyHitObject.NORMALISED_DIAMETER;
@@ -87,14 +87,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
                 wideAngleBonus *= velocityInfluence;
 
-                if (prev2Obj != null)
+                if (prev3Obj != null)
                 {
                     // If objects just go back and forth through a middle point - don't give as much wide bonus
                     // Use Previous(2) and Previous(0) because angles calculation is done prevprev-prev-curr, so any object's angle's center point is always the previous object
-                    var lastBaseObject = (OsuHitObject)prevObj.BaseObject;
-                    var last2BaseObject = (OsuHitObject)prev2Obj.BaseObject;
+                    var prevBaseObject = (OsuHitObject)prevObj.BaseObject;
+                    var prev3BaseObject = (OsuHitObject)prev3Obj.BaseObject;
 
-                    float distance = (last2BaseObject.StackedPosition - lastBaseObject.StackedPosition).Length;
+                    float distance = (prev3BaseObject.StackedPosition - prevBaseObject.StackedPosition).Length;
 
                     if (distance < 1)
                     {

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 return 0;
 
             var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
-            var prev3Obj = (OsuDifficultyHitObject)currObj.Previous(2);
+            var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(2);
 
             const int radius = OsuDifficultyHitObject.NORMALISED_RADIUS;
             const int diameter = OsuDifficultyHitObject.NORMALISED_DIAMETER;
@@ -87,12 +87,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
                 wideAngleBonus *= velocityInfluence;
 
-                if (prev3Obj != null)
+                if (prev2Obj != null)
                 {
                     // If objects just go back and forth through a middle point - don't give as much wide bonus
                     // Use Previous(2) and Previous(0) because angles calculation is done prevprev-prev-curr, so any object's angle's center point is always the previous object
                     var prevBaseObject = (OsuHitObject)prevObj.BaseObject;
-                    var prev3BaseObject = (OsuHitObject)prev3Obj.BaseObject;
+                    var prev3BaseObject = (OsuHitObject)prev2Obj.BaseObject;
 
                     float distance = (prev3BaseObject.StackedPosition - prevBaseObject.StackedPosition).Length;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -92,9 +92,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                     // If objects just go back and forth through a middle point - don't give as much wide bonus
                     // Use Previous(2) and Previous(0) because angles calculation is done prevprev-prev-curr, so any object's angle's center point is always the previous object
                     var prevBaseObject = (OsuHitObject)prevObj.BaseObject;
-                    var prev3BaseObject = (OsuHitObject)prev2Obj.BaseObject;
+                    var prev2BaseObject = (OsuHitObject)prev2Obj.BaseObject;
 
-                    float distance = (prev3BaseObject.StackedPosition - prevBaseObject.StackedPosition).Length;
+                    float distance = (prev2BaseObject.StackedPosition - prevBaseObject.StackedPosition).Length;
 
                     if (distance < 1)
                     {

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -20,12 +19,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <item><description>and slider difficulty.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, bool withSliderTravelDistance)
         {
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-            var osuLastObj = (OsuDifficultyHitObject)current.Previous();
+            var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
 
-            if (current.BaseObject is Spinner || current.Index <= 1 || osuLastObj.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner || currObj.Index <= 1 || prevObj.BaseObject is Spinner)
                 return 0;
 
             const double wide_angle_multiplier = 9.67;
@@ -36,41 +34,41 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             // WARNING: Increasing this multiplier beyond 1.02 reduces difficulty as distance increases. Refer to the desmos link above the wiggle bonus calculation
             const double wiggle_multiplier = 1.02;
 
-            var osuLast2Obj = (OsuDifficultyHitObject)current.Previous(2);
+            var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(2);
 
             const int radius = OsuDifficultyHitObject.NORMALISED_RADIUS;
             const int diameter = OsuDifficultyHitObject.NORMALISED_DIAMETER;
 
             // Calculate the velocity to the current hitobject, which starts with a base distance / time assuming the last object is a hitcircle.
-            double currDistance = withSliderTravelDistance ? osuCurrObj.LazyJumpDistance : osuCurrObj.JumpDistance;
-            double currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+            double currDistance = withSliderTravelDistance ? currObj.LazyJumpDistance : currObj.JumpDistance;
+            double currVelocity = currDistance / currObj.AdjustedDeltaTime;
 
             // But if the last object is a slider, then we extend the travel velocity through the slider into the current object.
-            if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
+            if (prevObj.BaseObject is Slider && withSliderTravelDistance)
             {
-                double sliderDistance = osuLastObj.LazyTravelDistance + osuCurrObj.LazyJumpDistance;
-                currVelocity = Math.Max(currVelocity, sliderDistance / osuCurrObj.AdjustedDeltaTime);
+                double sliderDistance = prevObj.LazyTravelDistance + currObj.LazyJumpDistance;
+                currVelocity = Math.Max(currVelocity, sliderDistance / currObj.AdjustedDeltaTime);
             }
 
-            double prevDistance = withSliderTravelDistance ? osuLastObj.LazyJumpDistance : osuLastObj.JumpDistance;
-            double prevVelocity = prevDistance / osuLastObj.AdjustedDeltaTime;
+            double prevDistance = withSliderTravelDistance ? prevObj.LazyJumpDistance : prevObj.JumpDistance;
+            double prevVelocity = prevDistance / prevObj.AdjustedDeltaTime;
 
             double snapDifficulty = currVelocity; // Start difficulty with regular velocity.
 
             // Penalize angle repetition.
-            snapDifficulty *= vectorAngleRepetition(osuCurrObj, osuLastObj);
+            snapDifficulty *= vectorAngleRepetition(currObj, prevObj);
 
-            if (osuCurrObj.Angle != null && osuLastObj.Angle != null)
+            if (currObj.Angle != null && prevObj.Angle != null)
             {
-                double currAngle = osuCurrObj.Angle.Value;
-                double lastAngle = osuLastObj.Angle.Value;
+                double currAngle = currObj.Angle.Value;
+                double lastAngle = prevObj.Angle.Value;
 
                 // Rewarding angles, take the smaller velocity as base.
                 double velocityInfluence = Math.Min(currVelocity, prevVelocity);
 
                 double acuteAngleBonus = 0;
 
-                if (Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) < 1.25 * Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime)) // If rhythms are the same.
+                if (Math.Max(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime) < 1.25 * Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime)) // If rhythms are the same.
                 {
                     acuteAngleBonus = CalcAngleAcuteness(currAngle);
 
@@ -78,7 +76,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                     acuteAngleBonus *= 0.08 + 0.92 * (1 - Math.Min(acuteAngleBonus, DiffUtils.Pow(CalcAngleAcuteness(lastAngle), 3)));
 
                     // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
-                    acuteAngleBonus *= velocityInfluence * DiffUtils.Smootherstep(DiffUtils.MillisecondsToBPM(osuCurrObj.AdjustedDeltaTime, 2), 300, 400) *
+                    acuteAngleBonus *= velocityInfluence * DiffUtils.Smootherstep(DiffUtils.MillisecondsToBPM(currObj.AdjustedDeltaTime, 2), 300, 400) *
                                        DiffUtils.Smootherstep(currDistance, 0, diameter * 2);
                 }
 
@@ -89,25 +87,25 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
                 // Rescaling velocity for the wide angle bonus
                 const double wide_angle_time_scale = 1.45;
-                double wideAngleCurrVelocity = currDistance / DiffUtils.Pow(osuCurrObj.AdjustedDeltaTime, wide_angle_time_scale);
-                double wideAnglePrevVelocity = prevDistance / DiffUtils.Pow(osuLastObj.AdjustedDeltaTime, wide_angle_time_scale);
+                double wideAngleCurrVelocity = currDistance / DiffUtils.Pow(currObj.AdjustedDeltaTime, wide_angle_time_scale);
+                double wideAnglePrevVelocity = prevDistance / DiffUtils.Pow(prevObj.AdjustedDeltaTime, wide_angle_time_scale);
 
-                if (osuLastObj.BaseObject is Slider && withSliderTravelDistance)
+                if (prevObj.BaseObject is Slider && withSliderTravelDistance)
                 {
-                    double sliderDistance = osuLastObj.LazyTravelDistance + osuCurrObj.LazyJumpDistance;
-                    wideAngleCurrVelocity = Math.Max(wideAngleCurrVelocity, sliderDistance / DiffUtils.Pow(osuCurrObj.AdjustedDeltaTime, wide_angle_time_scale));
+                    double sliderDistance = prevObj.LazyTravelDistance + currObj.LazyJumpDistance;
+                    wideAngleCurrVelocity = Math.Max(wideAngleCurrVelocity, sliderDistance / DiffUtils.Pow(currObj.AdjustedDeltaTime, wide_angle_time_scale));
                 }
 
                 wideAngleBonus *= Math.Min(wideAngleCurrVelocity, wideAnglePrevVelocity);
 
-                if (osuLast2Obj != null)
+                if (prev2Obj != null)
                 {
                     // If objects just go back and forth through a middle point - don't give as much wide bonus
                     // Use Previous(2) and Previous(0) because angles calculation is done prevprev-prev-curr, so any object's angle's center point is always the previous object
-                    var lastBaseObject = (OsuHitObject)osuLastObj.BaseObject;
-                    var last2BaseObject = (OsuHitObject)osuLast2Obj.BaseObject;
+                    var prevBaseObject = (OsuHitObject)prevObj.BaseObject;
+                    var prev2BaseObject = (OsuHitObject)prev2Obj.BaseObject;
 
-                    float distance = (last2BaseObject.StackedPosition - lastBaseObject.StackedPosition).Length;
+                    float distance = (prev2BaseObject.StackedPosition - prevBaseObject.StackedPosition).Length;
 
                     if (distance < 1)
                     {
@@ -136,34 +134,34 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 if (withSliderTravelDistance)
                 {
                     // We want to use just the object jump without slider velocity when awarding differences
-                    currVelocity = currDistance / osuCurrObj.AdjustedDeltaTime;
+                    currVelocity = currDistance / currObj.AdjustedDeltaTime;
                 }
 
                 // Scale with ratio of difference compared to 0.5 * max dist.
                 double distRatio = DiffUtils.Smoothstep(Math.Abs(prevVelocity - currVelocity) / Math.Max(prevVelocity, currVelocity), 0, 1);
 
                 // Reward for % distance up to 125 / strainTime for overlaps where velocity is still changing.
-                double overlapVelocityBuff = Math.Min(diameter * 1.25 / Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime), Math.Abs(prevVelocity - currVelocity));
+                double overlapVelocityBuff = Math.Min(diameter * 1.25 / Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime), Math.Abs(prevVelocity - currVelocity));
 
                 double velocityChangeBonus = overlapVelocityBuff * distRatio;
 
                 // Penalize for rhythm changes.
-                velocityChangeBonus *= DiffUtils.Pow(Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime) / Math.Max(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime), 2);
+                velocityChangeBonus *= DiffUtils.Pow(Math.Min(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime) / Math.Max(currObj.AdjustedDeltaTime, prevObj.AdjustedDeltaTime), 2);
 
                 snapDifficulty += velocityChangeBonus * velocity_change_multiplier;
             }
 
             // Reward sliders based on velocity.
-            if (osuCurrObj.BaseObject is Slider && withSliderTravelDistance)
+            if (currObj.BaseObject is Slider && withSliderTravelDistance)
             {
-                double sliderBonus = osuCurrObj.TravelDistance / osuCurrObj.TravelTime;
+                double sliderBonus = currObj.TravelDistance / currObj.TravelTime;
                 snapDifficulty += (sliderBonus < 1 ? sliderBonus : DiffUtils.Pow(sliderBonus, 0.75)) * slider_multiplier;
             }
 
             // Apply high circle size bonus
-            snapDifficulty *= osuCurrObj.SmallCircleBonus;
+            snapDifficulty *= currObj.SmallCircleBonus;
 
-            snapDifficulty *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+            snapDifficulty *= highBpmBonus(currObj.AdjustedDeltaTime);
 
             return snapDifficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             // WARNING: Increasing this multiplier beyond 1.02 reduces difficulty as distance increases. Refer to the desmos link above the wiggle bonus calculation
             const double wiggle_multiplier = 1.02;
 
-            var prev2Obj = (OsuDifficultyHitObject)currObj.Previous(2);
+            var prevObj2 = (OsuDifficultyHitObject)currObj.Previous(2);
 
             const int radius = OsuDifficultyHitObject.NORMALISED_RADIUS;
             const int diameter = OsuDifficultyHitObject.NORMALISED_DIAMETER;
@@ -98,12 +98,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
                 wideAngleBonus *= Math.Min(wideAngleCurrVelocity, wideAnglePrevVelocity);
 
-                if (prev2Obj != null)
+                if (prevObj2 != null)
                 {
                     // If objects just go back and forth through a middle point - don't give as much wide bonus
                     // Use Previous(2) and Previous(0) because angles calculation is done prevprev-prev-curr, so any object's angle's center point is always the previous object
                     var prevBaseObject = (OsuHitObject)prevObj.BaseObject;
-                    var prev2BaseObject = (OsuHitObject)prev2Obj.BaseObject;
+                    var prev2BaseObject = (OsuHitObject)prevObj2.BaseObject;
 
                     float distance = (prev2BaseObject.StackedPosition - prevBaseObject.StackedPosition).Length;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Mods;
@@ -32,13 +31,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         /// <item><description>and whether the hidden mod is enabled.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, IReadOnlyList<Mod> mods)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, IReadOnlyList<Mod> mods)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
-            var osuCurrent = (OsuDifficultyHitObject)current;
-            var osuHitObject = (OsuHitObject)(osuCurrent.BaseObject);
+            var osuHitObject = (OsuHitObject)(currObj.BaseObject);
 
             double scalingFactor = 52.0 / osuHitObject.Radius;
             double smallDistNerf = 1.0;
@@ -46,43 +44,43 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             double result = 0.0;
 
-            OsuDifficultyHitObject lastObj = osuCurrent;
+            OsuDifficultyHitObject lastLoopObj = currObj;
 
             double angleRepeatCount = 0.0;
 
             // This is iterating backwards in time from the current object.
-            for (int i = 0; i < Math.Min(current.Index, 10); i++)
+            for (int i = 0; i < Math.Min(currObj.Index, 10); i++)
             {
-                var currentObj = (OsuDifficultyHitObject)current.Previous(i);
-                var currentHitObject = (OsuHitObject)(currentObj.BaseObject);
+                var loopObj = (OsuDifficultyHitObject)currObj.Previous(i);
+                var loopHitObject = (OsuHitObject)(loopObj.BaseObject);
 
-                cumulativeStrainTime += lastObj.AdjustedDeltaTime;
+                cumulativeStrainTime += lastLoopObj.AdjustedDeltaTime;
 
-                if (!(currentObj.BaseObject is Spinner))
+                if (!(loopObj.BaseObject is Spinner))
                 {
-                    double jumpDistance = (osuHitObject.StackedPosition - currentHitObject.StackedEndPosition).Length;
+                    double jumpDistance = (osuHitObject.StackedPosition - loopHitObject.StackedEndPosition).Length;
 
                     // We want to nerf objects that can be easily seen within the Flashlight circle radius.
                     if (i == 0)
                         smallDistNerf = Math.Min(1.0, jumpDistance / 75.0);
 
                     // We also want to nerf stacks so that only the first object of the stack is accounted for.
-                    double stackNerf = Math.Min(1.0, (currentObj.LazyJumpDistance / scalingFactor) / 25.0);
+                    double stackNerf = Math.Min(1.0, (loopObj.LazyJumpDistance / scalingFactor) / 25.0);
 
                     // Bonus based on how visible the object is.
-                    double opacityBonus = 1.0 + max_opacity_bonus * (1.0 - osuCurrent.OpacityAt(currentHitObject.StartTime, mods.OfType<OsuModHidden>().Any(m => !m.OnlyFadeApproachCircles.Value)));
+                    double opacityBonus = 1.0 + max_opacity_bonus * (1.0 - currObj.OpacityAt(loopHitObject.StartTime, mods.OfType<OsuModHidden>().Any(m => !m.OnlyFadeApproachCircles.Value)));
 
                     result += stackNerf * opacityBonus * scalingFactor * jumpDistance / cumulativeStrainTime;
 
-                    if (currentObj.Angle != null && osuCurrent.Angle != null)
+                    if (loopObj.Angle != null && currObj.Angle != null)
                     {
                         // Objects further back in time should count less for the nerf.
-                        if (Math.Abs(currentObj.Angle.Value - osuCurrent.Angle.Value) < 0.02)
+                        if (Math.Abs(loopObj.Angle.Value - currObj.Angle.Value) < 0.02)
                             angleRepeatCount += Math.Max(1.0 - 0.1 * i, 0.0);
                     }
                 }
 
-                lastObj = currentObj;
+                lastLoopObj = loopObj;
             }
 
             result = Math.Pow(smallDistNerf * result, 2.0);
@@ -96,13 +94,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             double sliderBonus = 0.0;
 
-            if (osuCurrent.BaseObject is Slider osuSlider)
+            if (currObj.BaseObject is Slider osuSlider)
             {
                 // Invert the scaling factor to determine the true travel distance independent of circle size.
-                double pixelTravelDistance = osuCurrent.LazyTravelDistance / scalingFactor;
+                double pixelTravelDistance = currObj.LazyTravelDistance / scalingFactor;
 
                 // Reward sliders based on velocity.
-                sliderBonus = Math.Pow(Math.Max(0.0, pixelTravelDistance / osuCurrent.TravelTime - min_velocity), 0.5);
+                sliderBonus = Math.Pow(Math.Max(0.0, pixelTravelDistance / currObj.TravelTime - min_velocity), 0.5);
 
                 // Longer sliders require more memorisation.
                 sliderBonus *= pixelTravelDistance;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
@@ -25,9 +24,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         /// <item><description>and whether the hidden mod is enabled.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, IReadOnlyList<Mod> mods)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, IReadOnlyList<Mod> mods)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
             const double max_opacity_bonus = 0.4;
@@ -38,8 +37,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             const double min_angle_multiplier = 0.2;
 
-            var osuCurrent = (OsuDifficultyHitObject)current;
-            var osuHitObject = (OsuHitObject)(osuCurrent.BaseObject);
+            var osuHitObject = (OsuHitObject)(currObj.BaseObject);
 
             double scalingFactor = 52.0 / osuHitObject.Radius;
             double smallDistNerf = 1.0;
@@ -47,43 +45,43 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             double flashlightDifficulty = 0.0;
 
-            OsuDifficultyHitObject lastObj = osuCurrent;
+            OsuDifficultyHitObject lastLoopObj = currObj;
 
             double angleRepeatCount = 0.0;
 
             // This is iterating backwards in time from the current object.
-            for (int i = 0; i < Math.Min(current.Index, 10); i++)
+            for (int i = 0; i < Math.Min(currObj.Index, 10); i++)
             {
-                var currentObj = (OsuDifficultyHitObject)current.Previous(i);
-                var currentHitObject = (OsuHitObject)(currentObj.BaseObject);
+                var loopObj = (OsuDifficultyHitObject)currObj.Previous(i);
+                var loopHitObject = (OsuHitObject)(loopObj.BaseObject);
 
-                cumulativeStrainTime += lastObj.AdjustedDeltaTime;
+                cumulativeStrainTime += lastLoopObj.AdjustedDeltaTime;
 
-                if (!(currentObj.BaseObject is Spinner))
+                if (!(loopObj.BaseObject is Spinner))
                 {
-                    double jumpDistance = (osuHitObject.StackedPosition - currentHitObject.StackedEndPosition).Length;
+                    double jumpDistance = (osuHitObject.StackedPosition - loopHitObject.StackedEndPosition).Length;
 
                     // We want to nerf objects that can be easily seen within the Flashlight circle radius.
                     if (i == 0)
                         smallDistNerf = Math.Min(1.0, jumpDistance / 75.0);
 
                     // We also want to nerf stacks so that only the first object of the stack is accounted for.
-                    double stackNerf = Math.Min(1.0, (currentObj.LazyJumpDistance / scalingFactor) / 25.0);
+                    double stackNerf = Math.Min(1.0, (loopObj.LazyJumpDistance / scalingFactor) / 25.0);
 
                     // Bonus based on how visible the object is.
-                    double opacityBonus = 1.0 + max_opacity_bonus * (1.0 - osuCurrent.OpacityAt(currentHitObject.StartTime, mods.OfType<OsuModHidden>().Any(m => !m.OnlyFadeApproachCircles.Value)));
+                    double opacityBonus = 1.0 + max_opacity_bonus * (1.0 - currObj.OpacityAt(loopHitObject.StartTime, mods.OfType<OsuModHidden>().Any(m => !m.OnlyFadeApproachCircles.Value)));
 
                     flashlightDifficulty += stackNerf * opacityBonus * scalingFactor * jumpDistance / cumulativeStrainTime;
 
-                    if (currentObj.Angle != null && osuCurrent.Angle != null)
+                    if (loopObj.Angle != null && currObj.Angle != null)
                     {
                         // Objects further back in time should count less for the nerf.
-                        if (Math.Abs(currentObj.Angle.Value - osuCurrent.Angle.Value) < 0.02)
+                        if (Math.Abs(loopObj.Angle.Value - currObj.Angle.Value) < 0.02)
                             angleRepeatCount += Math.Max(1.0 - 0.1 * i, 0.0);
                     }
                 }
 
-                lastObj = currentObj;
+                lastLoopObj = loopObj;
             }
 
             flashlightDifficulty = DiffUtils.Pow(smallDistNerf * flashlightDifficulty, 2);
@@ -97,13 +95,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             double sliderBonus = 0.0;
 
-            if (osuCurrent.BaseObject is Slider osuSlider)
+            if (currObj.BaseObject is Slider osuSlider)
             {
                 // Invert the scaling factor to determine the true travel distance independent of circle size.
-                double pixelTravelDistance = osuCurrent.LazyTravelDistance / scalingFactor;
+                double pixelTravelDistance = currObj.LazyTravelDistance / scalingFactor;
 
                 // Reward sliders based on velocity.
-                sliderBonus = DiffUtils.Pow(Math.Max(0.0, pixelTravelDistance / osuCurrent.TravelTime - min_velocity), 0.5);
+                sliderBonus = DiffUtils.Pow(Math.Max(0.0, pixelTravelDistance / currObj.TravelTime - min_velocity), 0.5);
 
                 // Longer sliders require more memorisation.
                 sliderBonus *= pixelTravelDistance;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -23,13 +22,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double minimum_angle_relevancy_time = 2000; // 2 seconds
         private const double maximum_angle_relevancy_time = 200;
 
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool hidden)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, bool hidden)
         {
-            if (current.BaseObject is Spinner || current.Index == 0)
+            if (currObj.BaseObject is Spinner || currObj.Index == 0)
                 return 0;
 
-            var currObj = (OsuDifficultyHitObject)current;
-            var nextObj = (OsuDifficultyHitObject)current.Next(0);
+            var nextObj = (OsuDifficultyHitObject)currObj.Next(0);
 
             double velocity = Math.Max(1, currObj.LazyJumpDistance / currObj.AdjustedDeltaTime); // Only allow velocity to buff
 
@@ -131,10 +129,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Apply a soft cap to general HD reading to account for partial memorization
             hiddenDifficulty = Math.Pow(hiddenDifficulty, 0.4) * hidden_multiplier;
 
-            var previousObj = (OsuDifficultyHitObject)currObj.Previous(0);
+            var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
 
             // Buff perfect stacks only if current note is completely invisible at the time you click the previous note.
-            if (currObj.LazyJumpDistance == 0 && currObj.OpacityAt(previousObj.BaseObject.StartTime, true) == 0 && previousObj.StartTime > currObj.StartTime - currObj.Preempt)
+            if (currObj.LazyJumpDistance == 0 && currObj.OpacityAt(prevObj.BaseObject.StartTime, true) == 0 && prevObj.StartTime > currObj.StartTime - currObj.Preempt)
                 hiddenDifficulty += hidden_multiplier * 2500 / Math.Pow(currObj.AdjustedDeltaTime, 1.5); // Perfect stacks are harder the less time between notes
 
             return hiddenDifficulty;
@@ -163,15 +161,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         }
 
         // Returns a list of objects that are visible on screen at the point in time the current object becomes visible.
-        private static IEnumerable<OsuDifficultyHitObject> retrievePastVisibleObjects(OsuDifficultyHitObject current)
+        private static IEnumerable<OsuDifficultyHitObject> retrievePastVisibleObjects(OsuDifficultyHitObject currObj)
         {
-            for (int i = 0; i < current.Index; i++)
+            for (int i = 0; i < currObj.Index; i++)
             {
-                OsuDifficultyHitObject hitObject = (OsuDifficultyHitObject)current.Previous(i);
+                OsuDifficultyHitObject hitObject = (OsuDifficultyHitObject)currObj.Previous(i);
 
                 if (hitObject.IsNull() ||
-                    current.StartTime - hitObject.StartTime > reading_window_size ||
-                    hitObject.StartTime < current.StartTime - current.Preempt) // Current object not visible at the time object needs to be clicked
+                    currObj.StartTime - hitObject.StartTime > reading_window_size ||
+                    hitObject.StartTime < currObj.StartTime - currObj.Preempt) // Current object not visible at the time object needs to be clicked
                     break;
 
                 yield return hitObject;
@@ -179,22 +177,22 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         }
 
         // Returns the density of objects visible at the point in time the current object needs to be clicked capped by the reading window.
-        private static double retrieveCurrentVisibleObjectDensity(OsuDifficultyHitObject current)
+        private static double retrieveCurrentVisibleObjectDensity(OsuDifficultyHitObject currObj)
         {
             double visibleObjectCount = 0;
 
-            OsuDifficultyHitObject? hitObject = (OsuDifficultyHitObject)current.Next(0);
+            OsuDifficultyHitObject? hitObject = (OsuDifficultyHitObject)currObj.Next(0);
 
             while (hitObject != null)
             {
-                if (hitObject.StartTime - current.StartTime > reading_window_size ||
-                    current.StartTime < hitObject.StartTime - hitObject.Preempt) // Object not visible at the time current object needs to be clicked.
+                if (hitObject.StartTime - currObj.StartTime > reading_window_size ||
+                    currObj.StartTime < hitObject.StartTime - hitObject.Preempt) // Object not visible at the time current object needs to be clicked.
                     break;
 
-                double timeBetweenCurrAndLoopObj = hitObject.StartTime - current.StartTime;
+                double timeBetweenCurrAndLoopObj = hitObject.StartTime - currObj.StartTime;
                 double timeNerfFactor = getTimeNerfFactor(timeBetweenCurrAndLoopObj);
 
-                visibleObjectCount += hitObject.OpacityAt(current.BaseObject.StartTime, false) * timeNerfFactor;
+                visibleObjectCount += hitObject.OpacityAt(currObj.BaseObject.StartTime, false) * timeNerfFactor;
 
                 hitObject = (OsuDifficultyHitObject?)hitObject.Next(0);
             }
@@ -205,19 +203,19 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         // Returns a factor of how often the current object's angle has been repeated in a certain time frame.
         // It does this by checking the difference in angle between current and past objects and sums them based on a range of similarity.
         // https://www.desmos.com/calculator/eb057a4822
-        private static double getConstantAngleNerfFactor(OsuDifficultyHitObject current)
+        private static double getConstantAngleNerfFactor(OsuDifficultyHitObject currObj)
         {
             double constantAngleCount = 0;
             int index = 0;
             double currentTimeGap = 0;
 
-            OsuDifficultyHitObject loopObjPrev0 = current;
-            OsuDifficultyHitObject? loopObjPrev1 = null;
-            OsuDifficultyHitObject? loopObjPrev2 = null;
+            OsuDifficultyHitObject lastLoopObj = currObj;
+            OsuDifficultyHitObject? lastLoopObj2 = null;
+            OsuDifficultyHitObject? lastLoopObj3 = null;
 
             while (currentTimeGap < minimum_angle_relevancy_time)
             {
-                var loopObj = (OsuDifficultyHitObject)current.Previous(index);
+                var loopObj = (OsuDifficultyHitObject)currObj.Previous(index);
 
                 if (loopObj.IsNull())
                     break;
@@ -225,21 +223,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 // Account less for objects that are close to the time limit.
                 double longIntervalFactor = 1 - DifficultyCalculationUtils.ReverseLerp(loopObj.AdjustedDeltaTime, maximum_angle_relevancy_time, minimum_angle_relevancy_time);
 
-                if (loopObj.Angle.IsNotNull() && current.Angle.IsNotNull())
+                if (loopObj.Angle.IsNotNull() && currObj.Angle.IsNotNull())
                 {
-                    double angleDifference = Math.Abs(current.Angle.Value - loopObj.Angle.Value);
+                    double angleDifference = Math.Abs(currObj.Angle.Value - loopObj.Angle.Value);
                     double angleDifferenceAlternating = Math.PI;
 
-                    if (loopObjPrev0.Angle != null && loopObjPrev1?.Angle != null && loopObjPrev2?.Angle != null)
+                    if (lastLoopObj.Angle != null && lastLoopObj2?.Angle != null && lastLoopObj3?.Angle != null)
                     {
-                        angleDifferenceAlternating = Math.Abs(loopObjPrev1.Angle.Value - loopObj.Angle.Value);
-                        angleDifferenceAlternating += Math.Abs(loopObjPrev2.Angle.Value - loopObjPrev0.Angle.Value);
+                        angleDifferenceAlternating = Math.Abs(lastLoopObj2.Angle.Value - loopObj.Angle.Value);
+                        angleDifferenceAlternating += Math.Abs(lastLoopObj3.Angle.Value - lastLoopObj.Angle.Value);
 
                         double weight = 1.0;
 
                         // Be sure that one of the angles is very sharp, when other is wide
-                        weight *= DifficultyCalculationUtils.ReverseLerp(Math.Min(loopObj.Angle.Value, loopObjPrev0.Angle.Value) * 180 / Math.PI, 20, 5);
-                        weight *= DifficultyCalculationUtils.ReverseLerp(Math.Max(loopObj.Angle.Value, loopObjPrev0.Angle.Value) * 180 / Math.PI, 60, 120);
+                        weight *= DifficultyCalculationUtils.ReverseLerp(Math.Min(loopObj.Angle.Value, lastLoopObj.Angle.Value) * 180 / Math.PI, 20, 5);
+                        weight *= DifficultyCalculationUtils.ReverseLerp(Math.Max(loopObj.Angle.Value, lastLoopObj.Angle.Value) * 180 / Math.PI, 60, 120);
 
                         // Lerp between max angle difference and rescaled alternating difference, with more harsh scaling compared to normal difference
                         angleDifferenceAlternating = double.Lerp(Math.PI, 0.1 * angleDifferenceAlternating, weight);
@@ -250,12 +248,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     constantAngleCount += Math.Cos(3 * Math.Min(double.DegreesToRadians(30), Math.Min(angleDifference, angleDifferenceAlternating) * stackFactor)) * longIntervalFactor;
                 }
 
-                currentTimeGap = current.StartTime - loopObj.StartTime;
+                currentTimeGap = currObj.StartTime - loopObj.StartTime;
                 index++;
 
-                loopObjPrev2 = loopObjPrev1;
-                loopObjPrev1 = loopObjPrev0;
-                loopObjPrev0 = loopObj;
+                lastLoopObj3 = lastLoopObj2;
+                lastLoopObj2 = lastLoopObj;
+                lastLoopObj = loopObj;
             }
 
             return Math.Clamp(2 / constantAngleCount, 0.2, 1);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -15,13 +14,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double reading_window_size = 3000; // 3 seconds
         private const double distance_influence_threshold = OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.5; // 1.5 circles distance between centers
 
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool hidden)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj, bool hidden)
         {
-            if (current.BaseObject is Spinner || current.Index == 0)
+            if (currObj.BaseObject is Spinner || currObj.Index == 0)
                 return 0;
 
-            var currObj = (OsuDifficultyHitObject)current;
-            var nextObj = (OsuDifficultyHitObject)current.Next(0);
+            var nextObj = (OsuDifficultyHitObject)currObj.Next(0);
 
             double velocity = Math.Max(1, currObj.LazyJumpDistance / currObj.AdjustedDeltaTime); // Only allow velocity to buff
 
@@ -131,10 +129,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Apply a soft cap to general HD reading to account for partial memorization
             hiddenDifficulty = DiffUtils.Pow(hiddenDifficulty, 0.4) * hidden_multiplier;
 
-            var previousObj = (OsuDifficultyHitObject)currObj.Previous(0);
+            var prevObj = (OsuDifficultyHitObject)currObj.Previous(0);
 
             // Buff perfect stacks only if current note is completely invisible at the time you click the previous note.
-            if (currObj.LazyJumpDistance == 0 && currObj.OpacityAt(previousObj.BaseObject.StartTime, true) == 0 && previousObj.StartTime > currObj.StartTime - currObj.Preempt)
+            if (currObj.LazyJumpDistance == 0 && currObj.OpacityAt(prevObj.BaseObject.StartTime, true) == 0 && prevObj.StartTime > currObj.StartTime - currObj.Preempt)
                 hiddenDifficulty += hidden_multiplier * 2500 / DiffUtils.Pow(currObj.AdjustedDeltaTime, 1.5); // Perfect stacks are harder the less time between notes
 
             return hiddenDifficulty;
@@ -163,15 +161,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         }
 
         // Returns a list of objects that are visible on screen at the point in time the current object becomes visible.
-        private static IEnumerable<OsuDifficultyHitObject> retrievePastVisibleObjects(OsuDifficultyHitObject current)
+        private static IEnumerable<OsuDifficultyHitObject> retrievePastVisibleObjects(OsuDifficultyHitObject currObj)
         {
-            for (int i = 0; i < current.Index; i++)
+            for (int i = 0; i < currObj.Index; i++)
             {
-                OsuDifficultyHitObject hitObject = (OsuDifficultyHitObject)current.Previous(i);
+                OsuDifficultyHitObject hitObject = (OsuDifficultyHitObject)currObj.Previous(i);
 
                 if (hitObject == null ||
-                    current.StartTime - hitObject.StartTime > reading_window_size ||
-                    hitObject.StartTime < current.StartTime - current.Preempt) // Current object not visible at the time object needs to be clicked
+                    currObj.StartTime - hitObject.StartTime > reading_window_size ||
+                    hitObject.StartTime < currObj.StartTime - currObj.Preempt) // Current object not visible at the time object needs to be clicked
                     break;
 
                 yield return hitObject;
@@ -179,22 +177,22 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         }
 
         // Returns the density of objects visible at the point in time the current object needs to be clicked capped by the reading window.
-        private static double retrieveCurrentVisibleObjectDensity(OsuDifficultyHitObject current)
+        private static double retrieveCurrentVisibleObjectDensity(OsuDifficultyHitObject currObj)
         {
             double visibleObjectCount = 0;
 
-            OsuDifficultyHitObject? hitObject = (OsuDifficultyHitObject)current.Next(0);
+            OsuDifficultyHitObject? hitObject = (OsuDifficultyHitObject)currObj.Next(0);
 
             while (hitObject != null)
             {
-                if (hitObject.StartTime - current.StartTime > reading_window_size ||
-                    current.StartTime < hitObject.StartTime - hitObject.Preempt) // Object not visible at the time current object needs to be clicked.
+                if (hitObject.StartTime - currObj.StartTime > reading_window_size ||
+                    currObj.StartTime < hitObject.StartTime - hitObject.Preempt) // Object not visible at the time current object needs to be clicked.
                     break;
 
-                double timeBetweenCurrAndLoopObj = hitObject.StartTime - current.StartTime;
+                double timeBetweenCurrAndLoopObj = hitObject.StartTime - currObj.StartTime;
                 double timeNerfFactor = getTimeNerfFactor(timeBetweenCurrAndLoopObj);
 
-                visibleObjectCount += hitObject.OpacityAt(current.BaseObject.StartTime, false) * timeNerfFactor;
+                visibleObjectCount += hitObject.OpacityAt(currObj.BaseObject.StartTime, false) * timeNerfFactor;
 
                 hitObject = (OsuDifficultyHitObject?)hitObject.Next(0);
             }
@@ -205,7 +203,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         // Returns a factor of how often the current object's angle has been repeated in a certain time frame.
         // It does this by checking the difference in angle between current and past objects and sums them based on a range of similarity.
         // https://www.desmos.com/calculator/eb057a4822
-        private static double getConstantAngleNerfFactor(OsuDifficultyHitObject current)
+        private static double getConstantAngleNerfFactor(OsuDifficultyHitObject currObj)
         {
             const double minimum_angle_relevancy_time = 2000; // 2 seconds
             const double maximum_angle_relevancy_time = 200;
@@ -214,13 +212,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             int index = 0;
             double currentTimeGap = 0;
 
-            OsuDifficultyHitObject loopObjPrev0 = current;
-            OsuDifficultyHitObject? loopObjPrev1 = null;
-            OsuDifficultyHitObject? loopObjPrev2 = null;
+            OsuDifficultyHitObject lastLoopObj = currObj;
+            OsuDifficultyHitObject? lastLoopObj2 = null;
+            OsuDifficultyHitObject? lastLoopObj3 = null;
 
             while (currentTimeGap < minimum_angle_relevancy_time)
             {
-                var loopObj = (OsuDifficultyHitObject)current.Previous(index);
+                var loopObj = (OsuDifficultyHitObject)currObj.Previous(index);
 
                 if (loopObj == null)
                     break;
@@ -228,21 +226,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 // Account less for objects that are close to the time limit.
                 double longIntervalFactor = 1 - DiffUtils.ReverseLerp(loopObj.AdjustedDeltaTime, maximum_angle_relevancy_time, minimum_angle_relevancy_time);
 
-                if (loopObj.Angle != null && current.Angle != null)
+                if (loopObj.Angle != null && currObj.Angle != null)
                 {
-                    double angleDifference = Math.Abs(current.Angle.Value - loopObj.Angle.Value);
+                    double angleDifference = Math.Abs(currObj.Angle.Value - loopObj.Angle.Value);
                     double angleDifferenceAlternating = Math.PI;
 
-                    if (loopObjPrev0.Angle != null && loopObjPrev1?.Angle != null && loopObjPrev2?.Angle != null)
+                    if (lastLoopObj.Angle != null && lastLoopObj2?.Angle != null && lastLoopObj3?.Angle != null)
                     {
-                        angleDifferenceAlternating = Math.Abs(loopObjPrev1.Angle.Value - loopObj.Angle.Value);
-                        angleDifferenceAlternating += Math.Abs(loopObjPrev2.Angle.Value - loopObjPrev0.Angle.Value);
+                        angleDifferenceAlternating = Math.Abs(lastLoopObj2.Angle.Value - loopObj.Angle.Value);
+                        angleDifferenceAlternating += Math.Abs(lastLoopObj3.Angle.Value - lastLoopObj.Angle.Value);
 
                         double weight = 1.0;
 
                         // Be sure that one of the angles is very sharp, when other is wide
-                        weight *= DiffUtils.ReverseLerp(Math.Min(loopObj.Angle.Value, loopObjPrev0.Angle.Value) * 180 / Math.PI, 20, 5);
-                        weight *= DiffUtils.ReverseLerp(Math.Max(loopObj.Angle.Value, loopObjPrev0.Angle.Value) * 180 / Math.PI, 60, 120);
+                        weight *= DiffUtils.ReverseLerp(Math.Min(loopObj.Angle.Value, lastLoopObj.Angle.Value) * 180 / Math.PI, 20, 5);
+                        weight *= DiffUtils.ReverseLerp(Math.Max(loopObj.Angle.Value, lastLoopObj.Angle.Value) * 180 / Math.PI, 60, 120);
 
                         // Lerp between max angle difference and rescaled alternating difference, with more harsh scaling compared to normal difference
                         angleDifferenceAlternating = double.Lerp(Math.PI, 0.1 * angleDifferenceAlternating, weight);
@@ -253,12 +251,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     constantAngleCount += Math.Cos(3 * Math.Min(double.DegreesToRadians(30), Math.Min(angleDifference, angleDifferenceAlternating) * stackFactor)) * longIntervalFactor;
                 }
 
-                currentTimeGap = current.StartTime - loopObj.StartTime;
+                currentTimeGap = currObj.StartTime - loopObj.StartTime;
                 index++;
 
-                loopObjPrev2 = loopObjPrev1;
-                loopObjPrev1 = loopObjPrev0;
-                loopObjPrev0 = loopObj;
+                lastLoopObj3 = lastLoopObj2;
+                lastLoopObj2 = lastLoopObj;
+                lastLoopObj = loopObj;
             }
 
             return Math.Clamp(2 / constantAngleCount, 0.2, 1);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                 // Use custom cap value to ensure that at this point delta time is actually zero
                 double currDelta = Math.Max(loopObj.DeltaTime, 1e-7);
                 double prevDelta = Math.Max(loopPrevObj.DeltaTime, 1e-7);
-                double lastDelta = Math.Max(loopPrev2Obj.DeltaTime, 1e-7);
+                double prev2Delta = Math.Max(loopPrev2Obj.DeltaTime, 1e-7);
 
                 // calculate how much current delta difference deserves a rhythm bonus
                 // this function is meant to reduce rhythm bonus for deltas that are multiples of each other (i.e 100 and 200)
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                             effectiveRatio *= 0.5;
 
                         // previous increase happened a note ago, 1/1->1/2-1/4, dont want to buff this.
-                        if (lastDelta > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
+                        if (prev2Delta > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
                             effectiveRatio *= 0.125;
 
                         // repeated island size (ex: triplet -> triplet)

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -22,14 +21,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
             double rhythmComplexitySum = 0;
 
-            double deltaDifferenceEpsilon = ((OsuDifficultyHitObject)current).HitWindow(HitResult.Great) * 0.3;
+            double deltaDifferenceEpsilon = ((OsuDifficultyHitObject)currObj).HitWindow(HitResult.Great) * 0.3;
 
             var island = new Island(deltaDifferenceEpsilon);
             var previousIsland = new Island(deltaDifferenceEpsilon);
@@ -42,33 +41,33 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
 
             bool firstDeltaSwitch = false;
 
-            int historicalNoteCount = Math.Min(current.Index, history_objects_max);
+            int historicalNoteCount = Math.Min(currObj.Index, history_objects_max);
 
             int rhythmStart = 0;
 
-            while (rhythmStart < historicalNoteCount - 2 && current.StartTime - current.Previous(rhythmStart).StartTime < history_time_max)
+            while (rhythmStart < historicalNoteCount - 2 && currObj.StartTime - currObj.Previous(rhythmStart).StartTime < history_time_max)
                 rhythmStart++;
 
-            OsuDifficultyHitObject prevObj = (OsuDifficultyHitObject)current.Previous(rhythmStart);
-            OsuDifficultyHitObject lastObj = (OsuDifficultyHitObject)current.Previous(rhythmStart + 1);
+            var loopPrevObj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart);
+            var loopPrev2Obj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart + 1);
 
             // we go from the furthest object back to the current one
             for (int i = rhythmStart; i > 0; i--)
             {
-                OsuDifficultyHitObject currObj = (OsuDifficultyHitObject)current.Previous(i - 1);
-                if (currObj.BaseObject is Spinner)
+                var loopObj = (OsuDifficultyHitObject)currObj.Previous(i - 1);
+                if (loopObj.BaseObject is Spinner)
                     continue;
 
                 // scales note 0 to 1 from history to now
-                double timeDecay = (history_time_max - (current.StartTime - currObj.StartTime)) / history_time_max;
+                double timeDecay = (history_time_max - (currObj.StartTime - loopObj.StartTime)) / history_time_max;
                 double noteDecay = (double)(historicalNoteCount - i) / historicalNoteCount;
 
                 double currHistoricalDecay = Math.Min(noteDecay, timeDecay); // either we're limited by time or limited by object count.
 
                 // Use custom cap value to ensure that at this point delta time is actually zero
-                double currDelta = Math.Max(currObj.DeltaTime, 1e-7);
-                double prevDelta = Math.Max(prevObj.DeltaTime, 1e-7);
-                double lastDelta = Math.Max(lastObj.DeltaTime, 1e-7);
+                double currDelta = Math.Max(loopObj.DeltaTime, 1e-7);
+                double prevDelta = Math.Max(loopPrevObj.DeltaTime, 1e-7);
+                double lastDelta = Math.Max(loopPrev2Obj.DeltaTime, 1e-7);
 
                 // calculate how much current delta difference deserves a rhythm bonus
                 // this function is meant to reduce rhythm bonus for deltas that are multiples of each other (i.e 100 and 200)
@@ -84,12 +83,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                 // if previous object is a slider it might be easier to tap since you don't have to do a whole tapping motion
                 // while a full deltatime might end up some weird ratio the "unpress->tap" motion might be simple
                 // for example a slider-circle-circle pattern should be evaluated as a regular triple and not as a single->double
-                if (prevObj.BaseObject is Slider)
+                if (loopPrevObj.BaseObject is Slider)
                 {
-                    double sliderLazyEndDelta = currObj.MinimumJumpTime;
+                    double sliderLazyEndDelta = loopObj.MinimumJumpTime;
                     double sliderLazyDeltaDifference = Math.Max(sliderLazyEndDelta, currDelta) / Math.Min(sliderLazyEndDelta, currDelta);
 
-                    double sliderRealEndDelta = currObj.LastObjectEndDeltaTime;
+                    double sliderRealEndDelta = loopObj.LastObjectEndDeltaTime;
                     double sliderRealDeltaDifference = Math.Max(sliderRealEndDelta, currDelta) / Math.Min(sliderRealEndDelta, currDelta);
 
                     double sliderEffectiveRatio = Math.Min(getEffectiveRatio(sliderLazyDeltaDifference), getEffectiveRatio(sliderRealDeltaDifference));
@@ -106,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     else
                     {
                         // bpm change is into slider, this is easy acc window
-                        if (currObj.BaseObject is Slider)
+                        if (loopObj.BaseObject is Slider)
                             effectiveRatio *= 0.5;
 
                         // repeated island polarity (2 -> 4, 3 -> 5)
@@ -144,7 +143,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                         }
 
                         // scale down the difficulty if the object is doubletappable
-                        double doubletapness = prevObj.GetDoubletapness(currObj);
+                        double doubletapness = loopPrevObj.GetDoubletapness(loopObj);
                         effectiveRatio *= 1 - doubletapness * 0.75;
 
                         rhythmComplexitySum += Math.Sqrt(effectiveRatio * startRatio) * currHistoricalDecay;
@@ -165,12 +164,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     firstDeltaSwitch = true;
 
                     // bpm change is into slider, this is easy acc window
-                    if (currObj.BaseObject is Slider)
+                    if (loopObj.BaseObject is Slider)
                         effectiveRatio *= 0.6;
 
                     // bpm change was from a slider, this is easier typically than circle -> circle
                     // unintentional side effect is that bursts with kicksliders at the ends might have lower difficulty than bursts without sliders
-                    if (prevObj.BaseObject is Slider)
+                    if (loopPrevObj.BaseObject is Slider)
                         effectiveRatio *= 0.6;
 
                     startRatio = effectiveRatio;
@@ -178,8 +177,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     island = new Island((int)currDelta, deltaDifferenceEpsilon);
                 }
 
-                lastObj = prevObj;
-                prevObj = currObj;
+                loopPrev2Obj = loopPrevObj;
+                loopPrevObj = loopObj;
             }
 
             return Math.Sqrt(4 + rhythmComplexitySum * rhythm_overall_multiplier) / 2.0; // produces multiplier that can be applied to strain. range [1, infinity) (not really though);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
 
             double rhythmComplexitySum = 0;
 
-            double deltaDifferenceEpsilon = ((OsuDifficultyHitObject)currObj).HitWindow(HitResult.Great) * 0.3;
+            double deltaDifferenceEpsilon = currObj.HitWindow(HitResult.Great) * 0.3;
 
             var island = new Island(deltaDifferenceEpsilon);
             var previousIsland = new Island(deltaDifferenceEpsilon);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                 rhythmStart++;
 
             var loopPrevObj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart);
-            var loopPrev2Obj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart + 1);
+            var loopPrev1Obj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart + 1);
 
             // we go from the furthest object back to the current one
             for (int i = rhythmStart; i > 0; i--)
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                 // Use custom cap value to ensure that at this point delta time is actually zero
                 double currDelta = Math.Max(loopObj.DeltaTime, 1e-7);
                 double prevDelta = Math.Max(loopPrevObj.DeltaTime, 1e-7);
-                double prev2Delta = Math.Max(loopPrev2Obj.DeltaTime, 1e-7);
+                double prev1Delta = Math.Max(loopPrev1Obj.DeltaTime, 1e-7);
 
                 // calculate how much current delta difference deserves a rhythm bonus
                 // this function is meant to reduce rhythm bonus for deltas that are multiples of each other (i.e 100 and 200)
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                             effectiveRatio *= 0.5;
 
                         // previous increase happened a note ago, 1/1->1/2-1/4, dont want to buff this.
-                        if (prev2Delta > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
+                        if (prev1Delta > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
                             effectiveRatio *= 0.125;
 
                         // repeated island size (ex: triplet -> triplet)
@@ -177,7 +177,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     island = new Island((int)currDelta, deltaDifferenceEpsilon);
                 }
 
-                loopPrev2Obj = loopPrevObj;
+                loopPrev1Obj = loopPrevObj;
                 loopPrevObj = loopObj;
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -16,9 +15,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
             const int history_time_max = 5 * 1000; // 5 seconds
@@ -27,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
 
             double rhythmComplexitySum = 0;
 
-            double deltaDifferenceEpsilon = ((OsuDifficultyHitObject)current).HitWindowGreat * 0.3;
+            double deltaDifferenceEpsilon = currObj.HitWindowGreat * 0.3;
 
             var island = new Island(int.MaxValue);
             var previousIsland = new Island(int.MaxValue);
@@ -38,26 +37,26 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
 
             bool firstDeltaSwitch = false;
 
-            int historicalNoteCount = Math.Min(current.Index, history_objects_max);
+            int historicalNoteCount = Math.Min(currObj.Index, history_objects_max);
 
             int rhythmStart = 0;
 
-            while (rhythmStart < historicalNoteCount - 2 && current.StartTime - current.Previous(rhythmStart).StartTime < history_time_max)
+            while (rhythmStart < historicalNoteCount - 2 && currObj.StartTime - currObj.Previous(rhythmStart).StartTime < history_time_max)
                 rhythmStart++;
 
-            OsuDifficultyHitObject prevObj = (OsuDifficultyHitObject)current.Previous(rhythmStart);
-            OsuDifficultyHitObject prevPrevObj = (OsuDifficultyHitObject)current.Previous(rhythmStart + 1);
+            var loopPrevObj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart);
+            var loopPrev1Obj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart + 1);
 
             // we go from the furthest object back to the current one
             for (int i = rhythmStart; i > 0; i--)
             {
-                OsuDifficultyHitObject currObj = (OsuDifficultyHitObject)current.Previous(i - 1);
+                OsuDifficultyHitObject loopObj = (OsuDifficultyHitObject)currObj.Previous(i - 1);
 
                 if (currObj.BaseObject is Spinner)
                     continue;
 
                 // scales note 0 to 1 from history to now
-                double timeDecay = (history_time_max - (current.StartTime - currObj.StartTime)) / history_time_max;
+                double timeDecay = (history_time_max - (currObj.StartTime - loopObj.StartTime)) / history_time_max;
                 double noteDecay = (double)(historicalNoteCount - i) / historicalNoteCount;
 
                 double currHistoricalDecay = Math.Min(noteDecay, timeDecay); // either we're limited by time or limited by object count.
@@ -65,8 +64,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                 // Use custom cap value to ensure that at this point delta time is actually zero
                 const double delta_min_value = 1e-7;
 
-                double currDelta = Math.Max(currObj.DeltaTime, delta_min_value);
-                double prevDelta = Math.Max(prevObj.DeltaTime, delta_min_value);
+                double currDelta = Math.Max(loopObj.DeltaTime, delta_min_value);
+                double prevDelta = Math.Max(loopPrevObj.DeltaTime, delta_min_value);
 
                 double deltaDifference = Math.Abs(prevDelta - currDelta);
 
@@ -88,12 +87,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                 // if previous object is a slider it might be easier to tap since you don't have to do a whole tapping motion
                 // while a full deltatime might end up some weird ratio the "unpress->tap" motion might be simple
                 // for example a slider-circle-circle pattern should be evaluated as a regular triple and not as a single->double
-                if (prevObj.BaseObject is Slider)
+                if (loopPrevObj.BaseObject is Slider)
                 {
-                    double sliderLazyEndDelta = currObj.MinimumJumpTime;
+                    double sliderLazyEndDelta = loopObj.MinimumJumpTime;
                     double sliderLazyDeltaDifferenceRatio = Math.Max(sliderLazyEndDelta, currDelta) / Math.Min(sliderLazyEndDelta, currDelta);
 
-                    double sliderRealEndDelta = currObj.LastObjectEndDeltaTime;
+                    double sliderRealEndDelta = loopObj.LastObjectEndDeltaTime;
                     double sliderRealDeltaDifferenceRatio = Math.Max(sliderRealEndDelta, currDelta) / Math.Min(sliderRealEndDelta, currDelta);
 
                     double sliderEffectiveDifficulty = Math.Min(getEffectiveDifficulty(sliderLazyDeltaDifferenceRatio), getEffectiveDifficulty(sliderRealDeltaDifferenceRatio));
@@ -111,7 +110,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     if (deltaDifference > deltaDifferenceEpsilon)
                     {
                         // bpm change is into slider, this is easy acc window
-                        if (currObj.BaseObject is Slider)
+                        if (loopObj.BaseObject is Slider)
                             effectiveDifficulty *= 0.5;
 
                         // repeated island polarity (2 -> 4, 3 -> 5)
@@ -119,7 +118,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                             effectiveDifficulty *= 0.5;
 
                         // previous increase happened a note ago, 1/1->1/2-1/4, dont want to buff this.
-                        if (Math.Max(prevPrevObj.DeltaTime, delta_min_value) > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
+                        if (Math.Max(loopPrev1Obj.DeltaTime, delta_min_value) > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
                             effectiveDifficulty *= 0.125;
 
                         // repeated island size (ex: triplet -> triplet)
@@ -155,7 +154,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                             islands.Add(island);
 
                         // scale down the difficulty if the object is double-tappable
-                        effectiveDifficulty *= 1 - prevObj.CalculateDoubleTapFeasibility(currObj) * 0.75;
+                        effectiveDifficulty *= 1 - loopPrevObj.CalculateDoubleTapFeasibility(currObj) * 0.75;
 
                         if (island.DeltaCount > 1)
                         {
@@ -182,12 +181,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     firstDeltaSwitch = true;
 
                     // bpm change is into slider, this is easy acc window
-                    if (currObj.BaseObject is Slider)
+                    if (loopObj.BaseObject is Slider)
                         effectiveDifficulty *= 0.6;
 
                     // bpm change was from a slider, this is easier typically than circle -> circle
                     // unintentional side effect is that bursts with kicksliders at the ends might have lower difficulty than bursts without sliders
-                    if (prevObj.BaseObject is Slider)
+                    if (loopPrevObj.BaseObject is Slider)
                         effectiveDifficulty *= 0.6;
 
                     startDifficulty = effectiveDifficulty;
@@ -195,8 +194,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     island = new Island((int)currDelta);
                 }
 
-                prevPrevObj = prevObj;
-                prevObj = currObj;
+                loopPrev1Obj = loopPrevObj;
+                loopPrevObj = loopObj;
             }
 
             // If the current island is long we don't want the sum to have as big of an effect

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                 rhythmStart++;
 
             var loopPrevObj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart);
-            var loopPrev1Obj = (OsuDifficultyHitObject)currObj.Previous(rhythmStart + 1);
+            var loopPrevObj1 = (OsuDifficultyHitObject)currObj.Previous(rhythmStart + 1);
 
             // we go from the furthest object back to the current one
             for (int i = rhythmStart; i > 0; i--)
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                             effectiveDifficulty *= 0.5;
 
                         // previous increase happened a note ago, 1/1->1/2-1/4, dont want to buff this.
-                        if (Math.Max(loopPrev1Obj.DeltaTime, delta_min_value) > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
+                        if (Math.Max(loopPrevObj1.DeltaTime, delta_min_value) > prevDelta + deltaDifferenceEpsilon && prevDelta > currDelta + deltaDifferenceEpsilon)
                             effectiveDifficulty *= 0.125;
 
                         // repeated island size (ex: triplet -> triplet)
@@ -194,7 +194,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                     island = new Island((int)currDelta);
                 }
 
-                loopPrev1Obj = loopPrevObj;
+                loopPrevObj1 = loopPrevObj;
                 loopPrevObj = loopObj;
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/SpeedEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -22,19 +21,17 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
         /// <item><description>and how easily they can be cheesed.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-
-            double strainTime = osuCurrObj.AdjustedDeltaTime;
-            double doubletapness = 1.0 - osuCurrObj.GetDoubletapness((OsuDifficultyHitObject?)osuCurrObj.Next(0));
+            double strainTime = currObj.AdjustedDeltaTime;
+            double doubletapness = 1.0 - currObj.GetDoubletapness((OsuDifficultyHitObject?)currObj.Next(0));
 
             // Cap deltatime to the OD 300 hitwindow.
             // 0.93 is derived from making sure 260bpm OD8 streams aren't nerfed harshly, whilst 0.92 limits the effect of the cap.
-            strainTime /= Math.Clamp((strainTime / osuCurrObj.HitWindow(HitResult.Great)) / 0.93, 0.92, 1);
+            strainTime /= Math.Clamp((strainTime / currObj.HitWindow(HitResult.Great)) / 0.93, 0.92, 1);
 
             // speedBonus will be 0.0 for BPM < 200
             double speedBonus = 0.0;
@@ -46,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
             // Base difficulty with all bonuses
             double difficulty = (1 + speedBonus) * 1000 / strainTime;
 
-            difficulty *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+            difficulty *= highBpmBonus(currObj.AdjustedDeltaTime);
 
             // Apply penalty if there's doubletappable doubles
             return difficulty * doubletapness;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/SpeedEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -18,22 +17,20 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
         /// <item><description>and how easily they can be cheesed.</description></item>
         /// </list>
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        public static double EvaluateDifficultyOf(OsuDifficultyHitObject currObj)
         {
-            if (current.BaseObject is Spinner)
+            if (currObj.BaseObject is Spinner)
                 return 0;
 
             const double min_speed_bonus = 200; // 200 BPM 1/4th
             const double speed_balancing_factor = 40;
 
-            var osuCurrObj = (OsuDifficultyHitObject)current;
-
-            double strainTime = osuCurrObj.AdjustedDeltaTime;
-            double doubleTapFeasibility = 1.0 - osuCurrObj.CalculateDoubleTapFeasibility((OsuDifficultyHitObject?)osuCurrObj.Next(0));
+            double strainTime = currObj.AdjustedDeltaTime;
+            double doubleTapFeasibility = 1.0 - currObj.CalculateDoubleTapFeasibility((OsuDifficultyHitObject?)currObj.Next(0));
 
             // Cap deltatime to the OD 300 hitwindow.
             // 0.93 is derived from making sure 260bpm OD8 streams aren't nerfed harshly, whilst 0.92 limits the effect of the cap.
-            strainTime /= Math.Clamp((strainTime / osuCurrObj.HitWindowGreat) / 0.93, 0.92, 1);
+            strainTime /= Math.Clamp((strainTime / currObj.HitWindowGreat) / 0.93, 0.92, 1);
 
             // speedBonus will be 0.0 for BPM < 200
             double speedBonus = 0.0;
@@ -45,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
             // Base difficulty with all bonuses
             double speedDifficulty = (1 + speedBonus) * 1000 / strainTime;
 
-            speedDifficulty *= highBpmBonus(osuCurrObj.AdjustedDeltaTime);
+            speedDifficulty *= highBpmBonus(currObj.AdjustedDeltaTime);
 
             // Apply penalty if there's doubletappable doubles
             return speedDifficulty * doubleTapFeasibility;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -57,11 +57,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         protected override double StrainValueAt(DifficultyHitObject current)
         {
-            double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            double decay = strainDecay(osuCurrObj.AdjustedDeltaTime);
 
-            double snapDifficulty = SnapAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skillMultiplierSnap;
-            double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(current) * skillMultiplierAgility;
-            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skillMultiplierFlow;
+            double snapDifficulty = SnapAimEvaluator.EvaluateDifficultyOf(osuCurrObj, IncludeSliders) * skillMultiplierSnap;
+            double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(osuCurrObj) * skillMultiplierAgility;
+            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(osuCurrObj, IncludeSliders) * skillMultiplierFlow;
 
             double totalDifficulty = calculateTotalValue(snapDifficulty, agilityDifficulty, flowDifficulty);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -43,10 +43,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (Mods.Any(m => m is OsuModAutopilot))
                 return 0;
 
-            double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            double decay = strainDecay(osuCurrObj.AdjustedDeltaTime);
 
             currentStrain *= decay;
-            currentStrain += calculateAdjustedDifficulty(current) * (1 - decay);
+            currentStrain += calculateAdjustedDifficulty(osuCurrObj) * (1 - decay);
 
             if (current.BaseObject is Slider)
                 sliderStrains.Add(currentStrain);
@@ -54,15 +55,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return currentStrain;
         }
 
-        private double calculateAdjustedDifficulty(DifficultyHitObject current)
+        private double calculateAdjustedDifficulty(OsuDifficultyHitObject osuCurrObj)
         {
             const double skill_multiplier_snap = 70.9;
             const double skill_multiplier_agility = 2.35;
             const double skill_multiplier_flow = 242.0;
 
-            double snapDifficulty = SnapAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skill_multiplier_snap;
-            double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(current) * skill_multiplier_agility;
-            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skill_multiplier_flow;
+            double snapDifficulty = SnapAimEvaluator.EvaluateDifficultyOf(osuCurrObj, IncludeSliders) * skill_multiplier_snap;
+            double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(osuCurrObj) * skill_multiplier_agility;
+            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(osuCurrObj, IncludeSliders) * skill_multiplier_flow;
 
             double totalDifficulty = calculateTotalValue(snapDifficulty, agilityDifficulty, flowDifficulty);
 
@@ -72,7 +73,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                 totalDifficulty *= 1.0 - magnetisedStrength;
             }
 
-            totalDifficulty *= 0.985 + DiffUtils.Pow(Math.Max(0, ((OsuDifficultyHitObject)current).OverallDifficulty), 2) / 4000;
+            totalDifficulty *= 0.985 + DiffUtils.Pow(Math.Max(0, osuCurrObj.OverallDifficulty), 2) / 4000;
 
             return totalDifficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
@@ -31,8 +32,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         protected override double StrainValueAt(DifficultyHitObject current)
         {
-            currentStrain *= strainDecay(current.DeltaTime);
-            currentStrain += FlashlightEvaluator.EvaluateDifficultyOf(current, Mods) * skillMultiplier;
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            currentStrain *= strainDecay(osuCurrObj.AdjustedDeltaTime);
+            currentStrain += FlashlightEvaluator.EvaluateDifficultyOf(osuCurrObj, Mods) * skillMultiplier;
 
             return currentStrain;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -39,15 +39,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (!Mods.Any(m => m is OsuModFlashlight))
                 return 0;
 
-            currentStrain *= strainDecay(current.DeltaTime);
-            currentStrain += calculateAdjustedDifficulty(current) * skill_multiplier;
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            currentStrain *= strainDecay(osuCurrObj.AdjustedDeltaTime);
+            currentStrain += calculateAdjustedDifficulty(osuCurrObj) * skill_multiplier;
 
             return currentStrain;
         }
 
-        private double calculateAdjustedDifficulty(DifficultyHitObject current)
+        private double calculateAdjustedDifficulty(OsuDifficultyHitObject osuCurrObj)
         {
-            double difficulty = FlashlightEvaluator.EvaluateDifficultyOf(current, Mods);
+            double difficulty = FlashlightEvaluator.EvaluateDifficultyOf(osuCurrObj, Mods);
 
             if (Mods.Any(m => m is OsuModTouchDevice))
                 difficulty = DiffUtils.Pow(difficulty, 0.9);
@@ -70,7 +71,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (Mods.Any(m => m is OsuModAutopilot))
                 difficulty *= 0.4;
 
-            difficulty *= 0.985 + DiffUtils.Pow(Math.Max(0, ((OsuDifficultyHitObject)current).OverallDifficulty), 2) / 4000;
+            difficulty *= 0.985 + DiffUtils.Pow(Math.Max(0, osuCurrObj.OverallDifficulty), 2) / 4000;
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
@@ -37,11 +38,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
             objectList.Add(current);
 
-            double decay = strainDecay(current.DeltaTime);
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            double decay = strainDecay(osuCurrObj.AdjustedDeltaTime);
 
             currentDifficulty *= decay;
 
-            currentDifficulty += ReadingEvaluator.EvaluateDifficultyOf(current, hasHiddenMod) * (1 - decay) * skillMultiplier;
+            currentDifficulty += ReadingEvaluator.EvaluateDifficultyOf(osuCurrObj, hasHiddenMod) * (1 - decay) * skillMultiplier;
 
             return currentDifficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -39,10 +39,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             const double skill_multiplier = 2.5;
             const double reduced_difficulty_duration = 60 * 1000;
 
-            double decay = strainDecay(current.DeltaTime);
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            double decay = strainDecay(osuCurrObj.AdjustedDeltaTime);
 
             currentStrain *= decay;
-            currentStrain += calculateAdjustedDifficulty(current) * (1 - decay) * skill_multiplier;
+            currentStrain += calculateAdjustedDifficulty(osuCurrObj) * (1 - decay) * skill_multiplier;
 
             // This currently operates under the assumption that `ObjectDifficultyOf` is called once per object, and in order.
             // Under that assumption, we can trust that `current.StartTime` refers to the start time of the first object in the case that `reducedDuration` is yet to be set.
@@ -55,9 +56,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return currentStrain;
         }
 
-        private double calculateAdjustedDifficulty(DifficultyHitObject current)
+        private double calculateAdjustedDifficulty(OsuDifficultyHitObject osuCurrObj)
         {
-            double difficulty = ReadingEvaluator.EvaluateDifficultyOf(current, hasHiddenMod);
+            double difficulty = ReadingEvaluator.EvaluateDifficultyOf(osuCurrObj, hasHiddenMod);
 
             if (Mods.Any(m => m is OsuModTouchDevice))
                 difficulty = DiffUtils.Pow(difficulty, 0.89);
@@ -74,7 +75,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (Mods.Any(m => m is OsuModAutopilot))
                 difficulty *= 0.1;
 
-            difficulty *= 0.825 + DiffUtils.Pow(Math.Max(0, ((OsuDifficultyHitObject)current).OverallDifficulty), 2.2) / 1125.0;
+            difficulty *= 0.825 + DiffUtils.Pow(Math.Max(0, osuCurrObj.OverallDifficulty), 2.2) / 1125.0;
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             currentDifficulty *= decay;
             currentDifficulty += SpeedEvaluator.EvaluateDifficultyOf(osuCurrObj) * (1 - decay) * skillMultiplier;
 
-            double currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
+            double currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(osuCurrObj);
 
             double totalDifficulty = currentDifficulty * currentRhythm;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -39,10 +39,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         protected override double ObjectDifficultyOf(DifficultyHitObject current)
         {
-            double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            double decay = strainDecay(osuCurrObj.AdjustedDeltaTime);
 
             currentDifficulty *= decay;
-            currentDifficulty += SpeedEvaluator.EvaluateDifficultyOf(current) * (1 - decay) * skillMultiplier;
+            currentDifficulty += SpeedEvaluator.EvaluateDifficultyOf(osuCurrObj) * (1 - decay) * skillMultiplier;
 
             double currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -39,12 +39,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (Mods.Any(m => m is OsuModRelax))
                 return 0;
 
-            double decay = strainDecay(((OsuDifficultyHitObject)current).AdjustedDeltaTime);
+            var osuCurrObj = (OsuDifficultyHitObject)current;
+            double decay = strainDecay(osuCurrObj.AdjustedDeltaTime);
 
             currentStrain *= decay;
-            currentStrain += calculateAdjustedDifficulty(current) * (1 - decay) * skill_multiplier;
+            currentStrain += calculateAdjustedDifficulty(osuCurrObj) * (1 - decay) * skill_multiplier;
 
-            double currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
+            double currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(osuCurrObj);
 
             double totalStrain = currentStrain * currentRhythm;
 
@@ -54,9 +55,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return totalStrain;
         }
 
-        private double calculateAdjustedDifficulty(DifficultyHitObject current)
+        private double calculateAdjustedDifficulty(OsuDifficultyHitObject osuCurrObj)
         {
-            double difficulty = SpeedEvaluator.EvaluateDifficultyOf(current);
+            double difficulty = SpeedEvaluator.EvaluateDifficultyOf(osuCurrObj);
 
             if (Mods.Any(m => m is OsuModAutopilot))
                 difficulty *= 0.5;


### PR DESCRIPTION
This pr aims to unify all the variable names for object declarations in the various evaluators and skills for the osu ruleset. To achieve better clarity in the naming the casting for the object types has been moved outside the evaluators and into the skills, which also unified some more use cases like the strain decay delta times. The chosen naming convention is up for debate, especially the ones regarding loop objects.