### PR TITLE
Prevent crashes caused by DiscordPresence roomSecret when multiplayer lobby password is set to very long value.

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -210,8 +210,10 @@ namespace osu.Desktop
                     Password = room.Settings.Password,
                 };
 
-                if (client.HasRegisteredUriScheme)
-                    presence.Secrets.JoinSecret = JsonConvert.SerializeObject(roomSecret);
+                // Prevent join secret from being too long for Discord to handle. Prevents crashes but disables join button on Discord.
+                string roomSecretJson = JsonConvert.SerializeObject(roomSecret);
+                if (client.HasRegisteredUriScheme && Encoding.UTF8.GetByteCount(roomSecretJson) <= 128)
+                    presence.Secrets.JoinSecret = roomSecretJson;
 
                 // discord cannot handle both secrets and buttons at the same time, so we need to choose something.
                 // the multiplayer room seems more important.

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -210,8 +210,11 @@ namespace osu.Desktop
                     Password = room.Settings.Password,
                 };
 
-                if (client.HasRegisteredUriScheme)
-                    presence.Secrets.JoinSecret = JsonConvert.SerializeObject(roomSecret);
+                string roomSecretJson = JsonConvert.SerializeObject(roomSecret);
+
+                // Prevent join secret from being too long for Discord to handle. Prevents crashes but disables join button on Discord.
+                if (client.HasRegisteredUriScheme && Encoding.UTF8.GetByteCount(roomSecretJson) <= 128)
+                    presence.Secrets.JoinSecret = roomSecretJson;
 
                 // discord cannot handle both secrets and buttons at the same time, so we need to choose something.
                 // the multiplayer room seems more important.


### PR DESCRIPTION
Resolves: #37324

Original error log:
```
2026-04-16 18:34:29 [error]: DiscordRPC.Exceptions.StringOutOfRangeException: Length of string is out of range. Expected a value with a maximum length of 128
2026-04-16 18:34:29 [error]: at osu.Desktop.DiscordRichPresence.updatePresence(Boolean hideIdentifiableInformation)
2026-04-16 18:34:29 [error]: at osu.Desktop.DiscordRichPresence.<schedulePresenceUpdate>b__37_0()
```

Steps to reproduce:
Turn on full discord rich presence, create multiplayer lobby, set very long password
Everyone with full discord rich presence will crash

Discord sets a hard length limit on JoinSecret of 128 characters

<img width="740" height="157" alt="Image" src="https://github.com/user-attachments/assets/578a1163-37c6-4bc6-87bb-9e65c926977a" />

in ```osu.Game\Screens\OnlinePlay\Multiplayer\Match\MultiplayerMatchSettingsOverlay.cs::240``` passwords can be set for up to 255 characters. The password being assigned to the discord room in ```osu.Desktop\DiscordRichPresence.cs:210``` being too long can cause this crash to happen.

Thinking about it the real 'fix' to both being able to keep the 255 lobby password limit, and letting the discord parties work regardless of the password length would be using some sort of join code here. For now just adding a length limit check before updating the joinsecret in ```DiscordRichPresence.cs``` should prevent the crash, but if the password is too long the discord join button will just be disabled.