### PR TITLE
Fix viewing beatmap details in ranked play not working

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCardContent.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCardContent.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
         public MenuItem[] ContextMenuItems =>
         [
-            new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, () => beatmapSetOverlay?.ShowBeatmapSet(Beatmap.BeatmapSet))
+            new OsuMenuItem(ContextMenuStrings.ViewBeatmap, MenuItemType.Highlighted, () => beatmapSetOverlay?.FetchAndShowBeatmap(Beatmap.OnlineID))
         ];
     }
 }


### PR DESCRIPTION
https://discord.com/channels/188630481301012481/1440912440224120882/1495066077175222422

Haven't really tested whether this works - dev server is also lacking data in general, however relying on the previous example set by quick play:

https://github.com/ppy/osu/blob/1168c477d95f019aea2b676ef51db4ab6cd7253f/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs#L418-L421