### PR TITLE
Pass list of active mods when calculating score multiplier

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public partial class CatchModFlashlight : ModFlashlight<CatchHitObject>
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.12 : 1;
 
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override string Name => "Floating Fruits";
         public override string Acronym => "FF";
         public override LocalisableString Description => "The fruits are... floating?";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override IconUsage? Icon => OsuIcon.ModFloatingFruits;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Beatmaps;
@@ -10,7 +11,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModHardRock : ModHardRock, IApplicableToBeatmapProcessor
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.12 : 1;
 
         public void ApplyToBeatmapProcessor(IBeatmapProcessor beatmapProcessor)
         {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Catch.Mods
     public class CatchModHidden : ModHidden, IApplicableToDrawableRuleset<CatchHitObject>
     {
         public override LocalisableString Description => @"Play with fading fruits.";
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.06 : 1;
 
         private const double fade_out_offset_multiplier = 0.6;
         private const double fade_out_duration_multiplier = 0.44;

--- a/osu.Game.Rulesets.Catch/Mods/CatchModMovingFast.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModMovingFast.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override string Acronym => "MF";
         public override LocalisableString Description => "Dashing by default, slow down!";
         public override ModType Type => ModType.Fun;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override IconUsage? Icon => OsuIcon.ModMovingFast;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax) };
 

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
                 Mod = doubleTime,
                 PassCondition = () => Player.ScoreProcessor.JudgedHits > 0
                                       && Player.ScoreProcessor.Accuracy.Value == 1
-                                      && Player.ScoreProcessor.TotalScore.Value == (long)(1_000_000 * doubleTime.ScoreMultiplier),
+                                      && Player.ScoreProcessor.TotalScore.Value == (long)(1_000_000 * doubleTime.ScoreMultiplier(new[] { doubleTime })),
                 Autoplay = false,
                 CreateBeatmap = () => new Beatmap
                 {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Beatmaps;
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => Name;
         public abstract int KeyCount { get; }
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 0.9;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.9;
         public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override string Acronym => "CS";
 
-        public override double ScoreMultiplier => 0.9;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.9;
 
         public override LocalisableString Description => "No more tricky speed changes!";
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -9,6 +10,7 @@ using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -20,7 +22,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => @"Decrease the playfield's viewing area.";
 
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         protected override CoverExpandDirection ExpandDirection => Direction.Value;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
@@ -10,6 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
         // make the map harder and is more of a personal preference.
         // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDualStages.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDualStages.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override LocalisableString Description => @"Double the stages, double the fun!";
         public override IconUsage? Icon => OsuIcon.ModDualStages;
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         private bool isForCurrentRuleset;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -16,7 +18,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => "FI";
         public override IconUsage? Icon => OsuIcon.ModFadeIn;
         public override LocalisableString Description => @"Keys appear out of nowhere!";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override bool ValidForFreestyleAsRequiredMod => false;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Layout;
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public partial class ManiaModFlashlight : ModFlashlight<ManiaHitObject>
     {
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override Type[] IncompatibleMods => new[] { typeof(ModHidden) };
 
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
@@ -10,7 +11,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModHardRock : ModHardRock, IApplicableToHitObject
     {
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override bool Ranked => false;
 
         public const double HIT_WINDOW_DIFFICULTY_MULTIPLIER = 1.4;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
@@ -30,7 +31,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         private const float coverage_increase_per_combo = 0.5f;
 
         public override LocalisableString Description => @"Keys fade out before you hit them!";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHoldOff.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHoldOff.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override string Acronym => "HO";
 
-        public override double ScoreMultiplier => 0.9;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.9;
 
         public override LocalisableString Description => @"Replaces all hold notes with normal notes.";
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Invert";
 
         public override string Acronym => "IN";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         public override LocalisableString Description => "Hold the keys. To the beat.";
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mods;
 
@@ -11,6 +12,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
         // make the map any harder and is more of a personal preference.
         // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Graphics.Sprites;
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => "No more timing the end of hold notes.";
 
-        public override double ScoreMultiplier => 0.9;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.9;
 
         public override IconUsage? Icon => OsuIcon.ModNoRelease;
 

--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public abstract partial class InputBlockingMod : Mod, IApplicableToDrawableRuleset<OsuHitObject>, IUpdatableByPlayfield
     {
-        public override double ScoreMultiplier => 1.0;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(OsuModCinema) };
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Name => "Approach Different";
         public override string Acronym => "AD";
         public override LocalisableString Description => "Never trust the approach circles...";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override IconUsage? Icon => OsuIcon.ModApproachDifferent;
 
         public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles), typeof(OsuModFreezeFrame) };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModAutopilot;
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => @"Automatic cursor movement - just follow the rhythm.";
-        public override double ScoreMultiplier => 0.1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.1;
 
         public override Type[] IncompatibleMods => new[]
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -30,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModBlinds;
         public override ModType Type => ModType.DifficultyIncrease;
 
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.12 : 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight) };
         public override bool Ranked => true;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModBloom;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "The cursor blooms into.. a larger cursor!";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         protected const float MIN_SIZE = 1;
         protected const float TRANSITION_DURATION = 100;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight), typeof(OsuModNoScope), typeof(ModTouchDevice) };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -34,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override LocalisableString Description => "Don't let their popping distract you!";
 
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         public override IconUsage? Icon => OsuIcon.ModBubbles;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -25,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModDepth;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "3D. Almost.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModFreezeFrame), typeof(ModWithVisibilityAdjustment) }).ToArray();
 
         private static readonly Vector3 camera_position = new Vector3(OsuPlayfield.BASE_SIZE.X * 0.5f, OsuPlayfield.BASE_SIZE.Y * 0.5f, -200);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public partial class OsuModFlashlight : ModFlashlight<OsuHitObject>, IApplicableToDrawableHitObject
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.12 : 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModBloom), typeof(OsuModBlinds) }).ToArray();
 
         private const double default_follow_delay = 120;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override IconUsage? Icon => OsuIcon.ModFreezeFrame;
 
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         public override LocalisableString Description => "Burn the notes into your memory.";
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModHardRock : ModHardRock, IApplicableToHitObject
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.06 : 1;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModMirror)).ToArray();
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Graphics;
@@ -24,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public Bindable<bool> OnlyFadeApproachCircles { get; } = new BindableBool();
 
         public override LocalisableString Description => @"Play with no approach circles and fading circles/sliders.";
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.06 : 1;
 
         public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn), typeof(OsuModDepth), typeof(OsuModFreezeFrame) };
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Sprites;
@@ -27,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModMagnetised;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "No need to chase the circles – your cursor is a magnet!";
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModRelax), typeof(OsuModRepel), typeof(OsuModBubbles), typeof(OsuModDepth) };
 
         [SettingSource("Attraction strength", "How strong the pull is.", 0)]

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override ModType Type => ModType.Fun;
 
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
         public abstract BindableNumber<float> StartScale { get; }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Sprites;
@@ -28,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModRepel;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Hit objects run away!";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModMagnetised), typeof(OsuModBubbles), typeof(OsuModDepth) };
 
         [SettingSource("Repulsion strength", "How strong the repulsion is.", 0)]

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModSpinIn;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Circles spin in. No approach circles.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         // todo: this mod needs to be incompatible with "hidden" due to forcing the circle to remain opaque,
         // further implementation will be required for supporting that.

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModSpunOut;
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => @"Spinners will be automatically completed.";
-        public override double ScoreMultiplier => 0.9;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.9;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(OsuModAutopilot), typeof(OsuModTargetPractice) };
         public override bool Ranked => UsesDefaultConfiguration;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Graphics.Sprites;
@@ -29,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModStrictTracking;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => @"Once you start a slider, follow precisely or get a miss.";
-        public override double ScoreMultiplier => 1.0;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModClassic), typeof(OsuModTargetPractice) };
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Conversion;
         public override IconUsage? Icon => OsuIcon.ModTargetPractice;
         public override LocalisableString Description => @"Practice keeping up with the beat of the song.";
-        public override double ScoreMultiplier => 0.1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.1;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModTraceable;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Put your faith in the approach circles...";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override bool Ranked => true;
 
         public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles), typeof(OsuModDepth) };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModTransform;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Everything rotates. EVERYTHING.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModFreezeFrame), typeof(OsuModDepth) }).ToArray();
 
         private float theta;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModWiggle;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "They just won't stay still...";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModTransform), typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModDepth) };
 
         private const int wiggle_duration = 100; // (ms) Higher = fewer wiggles

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModConstantSpeed.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModConstantSpeed.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override string Name => "Constant Speed";
         public override string Acronym => "CS";
-        public override double ScoreMultiplier => 0.9;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.9;
         public override LocalisableString Description => "No more tricky speed changes!";
         public override IconUsage? Icon => OsuIcon.ModConstantSpeed;
         public override ModType Type => ModType.Conversion;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Layout;
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public partial class TaikoModFlashlight : ModFlashlight<TaikoHitObject>
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.12 : 1;
 
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
@@ -9,7 +10,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModHardRock : ModHardRock
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.06 : 1;
 
         /// <summary>
         /// Multiplier factor added to the scrolling speed.

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mods;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
     public class TaikoModHidden : ModHidden, IApplicableToDrawableRuleset<TaikoHitObject>
     {
         public override LocalisableString Description => @"Beats fade out before you hit them!";
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => UsesDefaultConfiguration ? 1.06 : 1;
 
         /// <summary>
         /// How far away from the hit target should hitobjects start to fade out.

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override string Name => "Simplified Rhythm";
         public override string Acronym => "SR";
-        public override double ScoreMultiplier => 0.6;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.6;
         public override LocalisableString Description => "Simplify tricky rhythms!";
         public override IconUsage? Icon => OsuIcon.ModSimplifiedRhythm;
         public override ModType Type => ModType.DifficultyReduction;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override LocalisableString Description => @"One key for dons, one key for kats.";
 
         public override bool Ranked => true;
-        public override double ScoreMultiplier => 1.0;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema) };
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override LocalisableString Description => @"Dons become kats, kats become dons";
         public override IconUsage? Icon => OsuIcon.ModSwap;
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModRandom)).ToArray();
         public override bool Ranked => true;
 

--- a/osu.Game.Tests/Mods/ModSettingsTest.cs
+++ b/osu.Game.Tests/Mods/ModSettingsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
@@ -91,7 +92,7 @@ namespace osu.Game.Tests.Mods
         {
             public override string Name => "Non-matching setting type mod";
             public override LocalisableString Description => "Description";
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
             public override ModType Type => ModType.Conversion;
 
             [SettingSource("Test setting")]

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -402,7 +402,7 @@ namespace osu.Game.Tests.Mods
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
             public override string Acronym => string.Empty;
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
             public override bool HasImplementation => true;
             public override bool ValidForMultiplayer => false;
             public override bool ValidForMultiplayerAsFreeMod => false;
@@ -413,7 +413,7 @@ namespace osu.Game.Tests.Mods
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
             public override string Acronym => string.Empty;
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
             public override bool HasImplementation => true;
             public override bool ValidForMultiplayerAsFreeMod => false;
         }
@@ -422,7 +422,7 @@ namespace osu.Game.Tests.Mods
         {
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
             public override string Acronym => string.Empty;
             public override bool HasImplementation => true;
             public override bool ValidForFreestyleAsRequiredMod => false;

--- a/osu.Game.Tests/Mods/TestCustomisableModRuleset.cs
+++ b/osu.Game.Tests/Mods/TestCustomisableModRuleset.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Mods
 
         public abstract class TestModCustomisable : Mod, IApplicableMod
         {
-            public override double ScoreMultiplier => 1.0;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1.0;
 
             public override LocalisableString Description => "This is a customisable test mod.";
 

--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => nameof(ModA);
             public override string Acronym => nameof(ModA);
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModIncompatibleWithA), typeof(ModIncompatibleWithAAndB) };
         }
@@ -171,7 +171,7 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => nameof(ModB);
             public override LocalisableString Description => string.Empty;
             public override string Acronym => nameof(ModB);
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModIncompatibleWithAAndB) };
         }
@@ -181,7 +181,7 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => nameof(ModC);
             public override string Acronym => nameof(ModC);
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         }
 
         private class ModIncompatibleWithA : Mod
@@ -189,7 +189,7 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => $"Incompatible With {nameof(ModA)}";
             public override string Acronym => $"Incompatible With {nameof(ModA)}";
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModA) };
         }
@@ -208,7 +208,7 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => $"Incompatible With {nameof(ModA)} and {nameof(ModB)}";
             public override string Acronym => $"Incompatible With {nameof(ModA)} and {nameof(ModB)}";
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModA), typeof(ModB) };
         }

--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             [SettingSource("Test")]
             public BindableNumber<double> TestSetting { get; } = new BindableDouble
@@ -202,7 +202,7 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TMTR";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]
             public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1.5)

--- a/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             [SettingSource("Test")]
             public BindableNumber<double> TestSetting { get; } = new BindableDouble
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TMTR";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]
             public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1.5)
@@ -148,7 +148,7 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
             [SettingSource("Test")]
             public Bindable<TestEnum> TestSetting { get; } = new Bindable<TestEnum>();

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -222,12 +222,12 @@ namespace osu.Game.Tests.Resources
 
         private class TestModHardRock : ModHardRock
         {
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         }
 
         private class TestModDoubleTime : ModDoubleTime
         {
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFooterButtonMods.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFooterButtonMods.cs
@@ -109,7 +109,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void assertModsMultiplier(IEnumerable<Mod> mods)
         {
-            double multiplier = mods.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier);
+            var modsList = mods.ToArray();
+            double multiplier = modsList.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier(modsList));
             string expectedValue = ModUtils.FormatScoreMultiplier(multiplier).ToString();
 
             AddAssert($"Displayed multiplier is {expectedValue}", () => footerButtonMods.ChildrenOfType<OsuSpriteText>().First(t => t.Text.ToString().Contains('x')).Text.ToString(), () => Is.EqualTo(expectedValue));

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
@@ -244,7 +244,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1.0;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1.0;
             public override string Acronym => "Test";
         }
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("two panels active", () => modSelectOverlay.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
             AddAssert("mod multiplier correct", () =>
             {
-                double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier);
+                double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier(SelectedMods.Value));
                 return Precision.AlmostEquals(multiplier, this.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
@@ -137,7 +137,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("two panels active", () => modSelectOverlay.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
             AddAssert("mod multiplier correct", () =>
             {
-                double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier);
+                double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier(SelectedMods.Value));
                 return Precision.AlmostEquals(multiplier, this.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
@@ -1143,7 +1143,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             public override string Name => "Unimplemented mod";
             public override string Acronym => "UM";
             public override LocalisableString Description => "A mod that is not implemented.";
-            public override double ScoreMultiplier => 1;
+            public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
             public override ModType Type => ModType.Conversion;
         }
 

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Database
             double modMultiplier = 1;
 
             foreach (var mod in score.Mods)
-                modMultiplier *= mod.ScoreMultiplier;
+                modMultiplier *= mod.ScoreMultiplier(score.Mods);
 
             return (long)Math.Round((1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore) * modMultiplier);
 
@@ -352,7 +352,7 @@ namespace osu.Game.Database
             long maximumLegacyBaseScore = maximumLegacyAccuracyScore + maximumLegacyComboScore;
             double bonusProportion = Math.Max(0, ((long)score.LegacyTotalScore - maximumLegacyBaseScore) * maximumLegacyBonusRatio);
 
-            double modMultiplier = score.Mods.Select(m => m.ScoreMultiplier).Aggregate(1.0, (c, n) => c * n);
+            double modMultiplier = score.Mods.Aggregate(1.0, (c, m) => c * m.ScoreMultiplier(score.Mods));
 
             long convertedTotalScoreWithoutMods;
 

--- a/osu.Game/Overlays/Mods/ModSelectFooterContent.cs
+++ b/osu.Game/Overlays/Mods/ModSelectFooterContent.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Overlays.Mods
                 double multiplier = 1.0;
 
                 foreach (var mod in ActiveMods.Value)
-                    multiplier *= mod.ScoreMultiplier;
+                    multiplier *= mod.ScoreMultiplier(ActiveMods.Value);
 
                 rankingInformationDisplay.ModMultiplier.Value = multiplier;
                 rankingInformationDisplay.Ranked.Value = ActiveMods.Value.All(m => m.Ranked);

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -83,8 +83,7 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// The score multiplier of this mod.
         /// </summary>
-        [JsonIgnore]
-        public abstract double ScoreMultiplier { get; }
+        public abstract double ScoreMultiplier(IReadOnlyCollection<Mod> mods);
 
         /// <summary>
         /// Returns true if this mod is implemented (and playable).

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.DifficultyIncrease;
 
-        public override double ScoreMultiplier => 1.0;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1.0;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModEasyWithExtraLives), typeof(ModPerfect) }).ToArray();
 

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.Fun;
 
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.5;
 
         public sealed override bool ValidForMultiplayer => false;
         public sealed override bool ValidForMultiplayerAsFreeMod => false;

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModAutoplay;
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => "Watch a perfect automated play through the song.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         public sealed override bool UserPlayable => false;
         public sealed override bool ValidForMultiplayer => false;

--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "BR";
         public override IconUsage? Icon => OsuIcon.ModBarrelRoll;
         public override LocalisableString Description => "The whole playfield is on a wheel!";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
         {

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override string Acronym => "CL";
 
-        public override double ScoreMultiplier => 0.96;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.96;
 
         public override IconUsage? Icon => OsuIcon.ModClassic;
 

--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -51,6 +52,6 @@ namespace osu.Game.Rulesets.Mods
             track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjust);
         }
 
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => rateAdjustHelper.ScoreMultiplier;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override IconUsage? Icon => OsuIcon.ModDifficultyAdjust;
 
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.5;
 
         public override bool RequiresConfiguration => true;
 

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -57,6 +57,6 @@ namespace osu.Game.Rulesets.Mods
             rateAdjustHelper.ApplyToTrack(track);
         }
 
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => rateAdjustHelper.ScoreMultiplier;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "EZ";
         public override IconUsage? Icon => OsuIcon.ModEasy;
         public override ModType Type => ModType.DifficultyReduction;
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock), typeof(ModDifficultyAdjust) };
         public override bool Ranked => UsesDefaultConfiguration;
         public override bool ValidForFreestyleAsRequiredMod => true;

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -57,6 +57,6 @@ namespace osu.Game.Rulesets.Mods
             rateAdjustHelper.ApplyToTrack(track);
         }
 
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => rateAdjustHelper.ScoreMultiplier;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 
@@ -12,6 +13,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "MR";
         public override IconUsage? Icon => OsuIcon.ModMirror;
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -25,7 +26,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModMuted;
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override bool Ranked => true;
         public override bool ValidForFreestyleAsRequiredMod => true;
     }

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
@@ -62,7 +63,7 @@ namespace osu.Game.Rulesets.Mods
             track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjust);
         }
 
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => rateAdjustHelper.ScoreMultiplier;
     }
 
     public abstract partial class ModNightcore<TObject> : ModNightcore, IApplicableToDrawableRuleset<TObject>

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModNoFail;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "You can't fail, no matter what.";
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModFailCondition), typeof(ModCinema) };
         public override bool Ranked => UsesDefaultConfiguration;
         public override bool ValidForFreestyleAsRequiredMod => true;

--- a/osu.Game/Rulesets/Mods/ModNoMod.cs
+++ b/osu.Game/Rulesets/Mods/ModNoMod.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "No Mod";
         public override string Acronym => "NM";
         public override LocalisableString Description => "No mods applied.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override IconUsage? Icon => OsuIcon.ModNoMod;
         public override ModType Type => ModType.System;
     }

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "NS";
         public override ModType Type => ModType.Fun;
         public override IconUsage? Icon => OsuIcon.ModNoScope;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override bool Ranked => true;
 
         /// <summary>

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "PF";
         public override IconUsage? Icon => OsuIcon.ModPerfect;
         public override ModType Type => ModType.DifficultyIncrease;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override LocalisableString Description => "SS or quit.";
         public override bool Ranked => true;
         public override bool ValidForFreestyleAsRequiredMod => true;

--- a/osu.Game/Rulesets/Mods/ModRandom.cs
+++ b/osu.Game/Rulesets/Mods/ModRandom.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "RD";
         public override ModType Type => ModType.Conversion;
         public override IconUsage? Icon => OsuIcon.ModRandom;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> Seed { get; } = new Bindable<int?>();

--- a/osu.Game/Rulesets/Mods/ModRelax.cs
+++ b/osu.Game/Rulesets/Mods/ModRelax.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "RX";
         public override IconUsage? Icon => OsuIcon.ModRelax;
         public override ModType Type => ModType.Automation;
-        public override double ScoreMultiplier => 0.1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.1;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay) };
     }
 }

--- a/osu.Game/Rulesets/Mods/ModScoreV2.cs
+++ b/osu.Game/Rulesets/Mods/ModScoreV2.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModScoreV2;
         public override ModType Type => ModType.System;
         public override LocalisableString Description => "Score set on earlier osu! versions with the V2 scoring algorithm active.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override bool UserPlayable => false;
         public override bool ValidForMultiplayer => false;
         public override bool ValidForMultiplayerAsFreeMod => false;

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModSuddenDeath;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Miss and fail.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public override bool Ranked => true;
         public override bool ValidForFreestyleAsRequiredMod => true;
 

--- a/osu.Game/Rulesets/Mods/ModSynesthesia.cs
+++ b/osu.Game/Rulesets/Mods/ModSynesthesia.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Synesthesia";
         public override string Acronym => "SY";
         public override LocalisableString Description => "Colours hit objects based on the rhythm.";
-        public override double ScoreMultiplier => 0.8;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.8;
         public override IconUsage? Icon => OsuIcon.ModSynesthesia;
         public override ModType Type => ModType.Fun;
     }

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         public const double FINAL_RATE_PROGRESS = 0.75f;
 
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0.5;
 
         [SettingSource("Initial rate", "The starting speed of the track", SettingControlType = typeof(MultiplierSettingsSlider))]
         public abstract BindableNumber<double> InitialRate { get; }

--- a/osu.Game/Rulesets/Mods/ModTouchDevice.cs
+++ b/osu.Game/Rulesets/Mods/ModTouchDevice.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
         public sealed override string Acronym => "TD";
         public sealed override IconUsage? Icon => OsuIcon.ModTouchDevice;
         public sealed override LocalisableString Description => "Automatically applied to plays on devices with a touchscreen.";
-        public sealed override double ScoreMultiplier => 1;
+        public sealed override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 1;
         public sealed override ModType Type => ModType.System;
         public sealed override bool ValidForMultiplayer => false;
         public sealed override bool ValidForMultiplayerAsFreeMod => false;

--- a/osu.Game/Rulesets/Mods/MultiMod.cs
+++ b/osu.Game/Rulesets/Mods/MultiMod.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Localisation;
 
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => string.Empty;
         public override string Acronym => string.Empty;
         public override LocalisableString Description => string.Empty;
-        public override double ScoreMultiplier => 0;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0;
 
         public Mod[] Mods { get; }
 

--- a/osu.Game/Rulesets/Mods/UnknownMod.cs
+++ b/osu.Game/Rulesets/Mods/UnknownMod.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.Mods
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => $"Unknown mod ({OriginalAcronym})";
         public override string Acronym => $"{OriginalAcronym}??";
         public override LocalisableString Description => "This mod could not be resolved by the game.";
-        public override double ScoreMultiplier => 0;
+        public override double ScoreMultiplier(IReadOnlyCollection<Mod> mods) => 0;
 
         public override bool UserPlayable => false;
         public override bool ValidForMultiplayer => false;

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Rulesets.Scoring
                 scoreMultiplier = 1;
 
                 foreach (var m in mods.NewValue)
-                    scoreMultiplier *= m.ScoreMultiplier;
+                    scoreMultiplier *= m.ScoreMultiplier(mods.NewValue);
 
                 updateScore();
                 updateRank();

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -261,7 +261,7 @@ namespace osu.Game.Scoring.Legacy
             double modMultiplier = 1;
 
             foreach (var mod in score.Mods)
-                modMultiplier *= mod.ScoreMultiplier;
+                modMultiplier *= mod.ScoreMultiplier(score.Mods);
 
             score.TotalScoreWithoutMods = (long)Math.Round(score.TotalScore / modMultiplier);
         }

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.Tooltip.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.Tooltip.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Select
                         double multiplier = 1.0;
 
                         foreach (var mod in value.Mods)
-                            multiplier *= mod.ScoreMultiplier;
+                            multiplier *= mod.ScoreMultiplier(value.Mods);
 
                         var generalStatistics = new[]
                         {

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Screens.Select
                 modDisplay.FadeIn(duration, easing);
             }
 
-            double multiplier = Current.Value?.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier) ?? 1;
+            double multiplier = Current.Value?.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier(Current.Value)) ?? 1;
             multiplierText.Text = ModUtils.FormatScoreMultiplier(multiplier);
 
             if (multiplier > 1)


### PR DESCRIPTION
Required to support some changes in the ongoing mod multipliers work.

With the existing set of multipliers there are no changes expected here, but have changed some mods locally and tested this works as expected.

To support this server-side, a game bump alongside any multiplier changes should be enough. Score reverification is the only place this matters, and it falls back onto `StandardisedScoreMigrationTools` so no code changes necessary.