### PR TITLE
Unify damage multiplayer formatting

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayStageOverlay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayStageOverlay.cs
@@ -40,6 +40,9 @@ namespace osu.Game.Tests.Visual.RankedPlay
         [Test]
         public void TestBasic()
         {
+            double multiplier = 1.0;
+
+            AddSliderStep<double>("set multiplier", 1, 5, 2, value => multiplier = value);
             AddStep("create", () => Child = new RankedPlayStageOverlay("Pick Phase", RankedPlayColourScheme.BLUE)
             {
                 PickingUser = new APIUser
@@ -47,7 +50,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     Id = 2,
                     Username = "peppy",
                 },
-                Multiplier = 2,
+                Multiplier = multiplier,
             });
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
@@ -158,7 +159,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Origin = Anchor.CentreLeft,
                     UseFullGlyphHeight = false,
                     Font = OsuFont.Torus.With(size: 32),
-                    Text = $"{Multiplier:N0}x damage",
+                    Text = $"{Multiplier.Value.ToStandardFormattedString(maxDecimalDigits: 1)}x damage",
                 });
             }
 


### PR DESCRIPTION
Previously the current stage overlay would not display the decimal part of the damage multiplier.

Resolves #37357.