### PR TITLE
Cancel collection creation with Escape

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
@@ -120,6 +120,10 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("change collection name", () =>
             {
                 placeholderItem.ChildrenOfType<TextBox>().First().Text = "test text";
+            });
+
+            AddStep("press escape", () =>
+            {
                 InputManager.Key(Key.Escape);
             });
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
@@ -105,6 +105,30 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestCancelCollectionCreationViaEscape()
+        {
+            DrawableCollectionListItem placeholderItem = null!;
+
+            AddStep("focus placeholder", () =>
+            {
+                InputManager.MoveMouseTo(placeholderItem = dialog.ChildrenOfType<DrawableCollectionListItem>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            assertCollectionCount(0);
+
+            AddStep("change collection name", () =>
+            {
+                placeholderItem.ChildrenOfType<TextBox>().First().Text = "test text";
+                InputManager.Key(Key.Escape);
+            });
+
+            assertCollectionCount(0);
+
+            AddAssert("last item is placeholder", () => !dialog.ChildrenOfType<DrawableCollectionListItem>().Last().Model.IsManaged);
+        }
+
+        [Test]
         public void TestAddCollectionViaPlaceholder()
         {
             DrawableCollectionListItem placeholderItem = null!;

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
@@ -130,6 +130,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             assertCollectionCount(0);
 
             AddAssert("last item is placeholder", () => !dialog.ChildrenOfType<DrawableCollectionListItem>().Last().Model.IsManaged);
+            AddAssert("textbox is not focused", () => !dialog.ChildrenOfType<FocusedTextBox>().Last().HasFocus);
         }
 
         [Test]

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -186,9 +186,12 @@ namespace osu.Game.Collections
 
             public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
             {
-                // Only respond to GlobalAction.Back
-                if (!base.OnPressed(e)) return false;
+                if (e.Action != GlobalAction.Back) return base.OnPressed(e);
 
+                // kill focus to cancel collection creation
+                // we need to do this before killing focus, otherwise the `HasFocus` check will just return early and do nothing
+                // let the base class handle text clearing, sfx playing etc.
+                base.OnPressed(e);
                 KillFocus();
                 return true;
             }

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -17,6 +17,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
@@ -125,7 +126,7 @@ namespace osu.Game.Collections
             }
         }
 
-        private partial class ItemTextBox : OsuTextBox
+        private partial class ItemTextBox : FocusedTextBox
         {
             protected override float LeftRightPadding => item_height / 2;
 
@@ -181,6 +182,15 @@ namespace osu.Game.Collections
                 {
                     PlaceholderText = CollectionsStrings.CreateNew;
                 }
+            }
+
+            public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+            {
+                // Only respond to GlobalAction.Back
+                if (!base.OnPressed(e)) return false;
+
+                KillFocus();
+                return true;
             }
         }
 

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -17,7 +17,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
@@ -130,6 +129,8 @@ namespace osu.Game.Collections
         {
             protected override float LeftRightPadding => item_height / 2;
 
+            protected override bool KillFocusOnBackKey => true;
+
             private const float count_text_size = 12;
 
             private readonly Live<BeatmapCollection> collection;
@@ -182,18 +183,6 @@ namespace osu.Game.Collections
                 {
                     PlaceholderText = CollectionsStrings.CreateNew;
                 }
-            }
-
-            public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
-            {
-                if (e.Action != GlobalAction.Back) return base.OnPressed(e);
-
-                // kill focus to cancel collection creation
-                // we need to do this before killing focus, otherwise the `HasFocus` check will just return early and do nothing
-                // let the base class handle text clearing, sfx playing etc.
-                base.OnPressed(e);
-                KillFocus();
-                return true;
             }
         }
 

--- a/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
@@ -26,6 +26,11 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         protected virtual bool ClearTextOnBackKey => true;
 
+        /// <summary>
+        /// Whether the text box should be unfocused on the first "back" key press.
+        /// </summary>
+        protected virtual bool KillFocusOnBackKey => false;
+
         public void TakeFocus()
         {
             if (!allowImmediateFocus)
@@ -83,17 +88,25 @@ namespace osu.Game.Graphics.UserInterface
 
             if (!HasFocus) return false;
 
+            bool handled = false;
+
             if (ClearTextOnBackKey && e.Action == GlobalAction.Back)
             {
                 if (Text.Length > 0)
                 {
                     Text = string.Empty;
                     PlayFeedbackSample(FeedbackSampleType.TextRemove);
-                    return true;
+                    handled = true;
                 }
             }
 
-            return false;
+            if (KillFocusOnBackKey && e.Action == GlobalAction.Back)
+            {
+                KillFocus();
+                handled = true;
+            }
+
+            return handled;
         }
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)


### PR DESCRIPTION
Use `FocusedTextBox` instead of `OsuTextBox` and kill focus when `GlobalAction.Back` is performed.

Closes #37333