### PR TITLE
Fix queue screen crashes on mobile

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RatingDistributionGraph.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Layout;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -521,7 +522,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             protected override void Update()
             {
                 base.Update();
-                Width = Parent!.DrawWidth / Parent.ScreenSpaceDrawQuad.Width;
+                if (Precision.DefinitelyBigger(Parent!.ScreenSpaceDrawQuad.Width, 0))
+                    Width = Parent.DrawWidth / Parent.ScreenSpaceDrawQuad.Width;
             }
         }
 
@@ -533,7 +535,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             protected override void Update()
             {
                 base.Update();
-                Height = Parent!.DrawHeight / Parent.ScreenSpaceDrawQuad.Height;
+                if (Precision.DefinitelyBigger(Parent!.ScreenSpaceDrawQuad.Height, 0))
+                    Height = Parent!.DrawHeight / Parent.ScreenSpaceDrawQuad.Height;
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -124,7 +125,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                         RowDimensions =
                         [
                             new Dimension(),
-                            new Dimension(GridSizeMode.Relative, 0.35f)
+                            new Dimension(GridSizeMode.Relative, RuntimeInfo.IsMobile ? 0.55f : 0.35f)
                         ],
                         Content = new[]
                         {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/37345

Aside from https://github.com/ppy/osu/commit/9f4b1c8b8dbba68f815af61bf46824cfb25b2d3b, this also tweaks the grid sizings on mobile which were the secondary cause of the android crashes. I'm bothering because it looked awful even with the primary crash fixed.

Only tested on android. I wanted to test visually on iOS but rider doesn't want to talk to xcode *or* my iPhone anymore, so I give up.

| before | after |
| :-: | :-: |
| <img width="2400" height="1080" alt="Screenshot_2026-04-20-12-04-17-44_25a1a32208bbcdc1d450b7aa854bb161" src="https://github.com/user-attachments/assets/e9bac850-7256-4a0d-8358-992490e1381d" /> | <img width="2400" height="1080" alt="Screenshot_2026-04-20-12-07-35-26_25a1a32208bbcdc1d450b7aa854bb161" src="https://github.com/user-attachments/assets/a525485e-f2b5-4252-ae50-dc84c29945ec" /> |
