### PR TITLE
Stop all samples when exiting ranked play results screen early

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;
+using osu.Framework.Screens;
 using osu.Framework.Utils;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -36,6 +37,44 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddUntilStep("screen loaded", () => screen.IsLoaded);
 
             setupRequestHandler();
+        }
+
+        [Test]
+        [Explicit("Test exercises correct stopping of audio playback. Has no assertions, only useful when checked manually by a human.")]
+        public void TestAllSamplesStopOnExit()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
+            {
+                int losingPlayer = state.Users.Keys.First();
+
+                foreach (var (id, userInfo) in state.Users)
+                {
+                    if (id == losingPlayer)
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 123_456,
+                            Damage = 123_456,
+                            OldLife = 500_000,
+                            NewLife = 500_000 - 123_456,
+                        };
+
+                        userInfo.Life = 500_000 - 123_456;
+                    }
+                    else
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 0,
+                            Damage = 0,
+                            OldLife = 1_000_000,
+                            NewLife = 1_000_000,
+                        };
+                    }
+                }
+            }).WaitSafely());
+            AddWaitStep("wait for samples to start playing", 5);
+            AddRepeatStep("exit", () => screen.Exit(), 2);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -376,6 +376,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     return true;
                 }
 
+                ActiveSubScreen?.OnExiting(null);
                 backgroundMusic.Stop();
                 previewTrackManager.StopAnyPlaying(this);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
@@ -8,6 +8,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
@@ -59,17 +60,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             private RankedPlayDamageInfo losingDamageInfo = null!;
 
-            private Sample resultsAppearSample = null!;
-            private Sample dmgFlySample = null!;
-            private Sample dmgHitSample = null!;
-            private Sample hpDownSample = null!;
-            private Sample playerAppearSample = null!;
-            private Sample pseudoScoreCounterSample = null!;
-            private Sample scoreTickSample = null!;
-            private Sample gradePassSample = null!;
-            private Sample gradePassSsSample = null!;
-            private Sample gradeFailSample = null!;
-            private Sample gradeFailDSample = null!;
+            private AudioContainer sampleContainer = null!;
+            private DrawableSample resultsAppearSample = null!;
+            private DrawableSample dmgFlySample = null!;
+            private DrawableSample dmgHitSample = null!;
+            private DrawableSample hpDownSample = null!;
+            private DrawableSample playerAppearSample = null!;
+            private DrawableSample pseudoScoreCounterSample = null!;
+            private DrawableSample scoreTickSample = null!;
+            private DrawableSample gradePassSample = null!;
+            private DrawableSample gradePassSsSample = null!;
+            private DrawableSample gradeFailSample = null!;
+            private DrawableSample gradeFailDSample = null!;
             private SampleChannel? playerScoreTickChannel;
             private SampleChannel? opponentScoreTickChannel;
             private readonly BindableDouble playerScoreTickPitch = new BindableDouble();
@@ -288,17 +290,23 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     }
                 });
 
-                resultsAppearSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/results-appear");
-                dmgFlySample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/dmg-fly");
-                dmgHitSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/dmg-hit");
-                hpDownSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/hp-down");
-                playerAppearSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/players-appear");
-                pseudoScoreCounterSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/pseudo-score-counter");
-                scoreTickSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/score-tick");
-                gradePassSample = audio.Samples.Get(@"Results/rank-impact-pass");
-                gradePassSsSample = audio.Samples.Get(@"Results/rank-impact-pass-ss");
-                gradeFailSample = audio.Samples.Get(@"Results/rank-impact-fail");
-                gradeFailDSample = audio.Samples.Get(@"Results/rank-impact-fail-d");
+                AddInternal(sampleContainer = new AudioContainer
+                {
+                    Children = new Drawable[]
+                    {
+                        resultsAppearSample = new DrawableSample(audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/results-appear")),
+                        dmgFlySample = new DrawableSample(audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/dmg-fly")),
+                        dmgHitSample = new DrawableSample(audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/dmg-hit")),
+                        hpDownSample = new DrawableSample(audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/hp-down")),
+                        playerAppearSample = new DrawableSample(audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/players-appear")),
+                        pseudoScoreCounterSample = new DrawableSample(audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/pseudo-score-counter")),
+                        scoreTickSample = new DrawableSample(audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/Results/score-tick")),
+                        gradePassSample = new DrawableSample(audio.Samples.Get(@"Results/rank-impact-pass")),
+                        gradePassSsSample = new DrawableSample(audio.Samples.Get(@"Results/rank-impact-pass-ss")),
+                        gradeFailSample = new DrawableSample(audio.Samples.Get(@"Results/rank-impact-fail")),
+                        gradeFailDSample = new DrawableSample(audio.Samples.Get(@"Results/rank-impact-fail-d")),
+                    }
+                });
             }
 
             protected override void LoadComplete()
@@ -526,7 +534,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 }
             }
 
-            private Sample getRankSample(ScoreRank rank)
+            private DrawableSample getRankSample(ScoreRank rank)
             {
                 switch (rank)
                 {
@@ -555,6 +563,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     return 1;
 
                 return (int)Math.Floor(Math.Log10(value)) + 1;
+            }
+
+            public void StopAllSamples()
+            {
+                sampleContainer.Volume.Value = 0;
+                playerScoreTickChannel?.Stop();
+                opponentScoreTickChannel?.Stop();
             }
 
             private partial class DamageParticle : Triangle

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private IBindable<RulesetInfo> globalRuleset { get; set; } = null!;
 
         private LoadingSpinner loadingSpinner = null!;
+        private MainPanel? mainPanel;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -123,7 +124,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                         OpponentScore = opponentScore,
                         PlayerDamageInfo = matchInfo.RoomState.Users[localUserId].DamageInfo!,
                         OpponentDamageInfo = matchInfo.RoomState.Users[opponentId].DamageInfo!,
-                    }, AddInternal);
+                    }, loaded =>
+                    {
+                        AddInternal(loaded);
+                        mainPanel = loaded;
+                    });
                 });
             }
             catch (Exception e)
@@ -135,6 +140,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             {
                 Scheduler.Add(() => loadingSpinner.Hide());
             }
+        }
+
+        public override void OnExiting(RankedPlaySubScreen? next)
+        {
+            mainPanel?.StopAllSamples();
+            base.OnExiting(next);
         }
     }
 }


### PR DESCRIPTION
Intends to close https://github.com/ppy/osu/issues/37408.

I have got to say, the way ranked play apparently re-invents screen sub-stacks *again* in a slightly different way to everything else before had me *very* confused as to why things I would expect to get called aren't getting called.