### PR TITLE
Fix illegible star rating text colour in ranked play intro animation

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneStarRatingSequence.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneStarRatingSequence.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    [TestFixture]
+    public partial class TestSceneStarRatingSequence : OsuTestScene
+    {
+        [Test]
+        public void TestBasicAppearance()
+        {
+            float starRating = 5;
+
+            AddSliderStep("set star rating", 0f, 10, 5, sr => starRating = sr);
+            AddStep("play sequence", () =>
+            {
+                StarRatingSequence sequence;
+
+                Child = sequence = new StarRatingSequence
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                };
+                double delay = 0;
+                sequence.Play(ref delay, starRating);
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneStarRatingSequence.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneStarRatingSequence.cs
@@ -8,7 +8,7 @@ using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro;
 namespace osu.Game.Tests.Visual.RankedPlay
 {
     [TestFixture]
-    public partial class TestSceneStarRatingSequence : OsuTestScene
+    public partial class TestSceneStarRatingSequence : RankedPlayTestScene
     {
         [Test]
         public void TestBasicAppearance()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
@@ -43,13 +43,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
             Origin = Anchor.Centre;
             Alpha = 0;
 
-            Masking = true;
-            CornerRadius = 10;
-
             InternalChild = new Container
             {
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,
+                Masking = true,
+                CornerRadius = 10,
                 Children = new Drawable[]
                 {
                     new Box
@@ -226,6 +225,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                     };
 
                     centerContainer.Add(container);
+                    // Avoid text getting masked out by inner containers
+                    AddInternal(container.CreateProxy());
 
                     container.FadeInFromZero(200)
                              .ScaleTo(0)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                         RelativePositionAxes = Axes.X,
                         X = starRating * 0.1f,
                         Y = 34,
-                        Colour = colours.ForStarDifficulty(starRating),
+                        Colour = starRating < OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF ? colours.ForStarDifficulty(starRating) : colours.ForStarDifficultyText(starRating),
                         Spacing = new Vector2(4, 0),
                         Children =
                         [

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
@@ -14,8 +14,8 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 {
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
         private float lastTickStdDev;
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour, AudioManager audio)
+        private void load(OsuColour colour, OverlayColourProvider overlayColourProvider, AudioManager audio)
         {
             Width = 600;
             AutoSizeAxes = Axes.Y;
@@ -54,8 +54,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                 {
                     new Box
                     {
-                        Colour = Color4.Black,
-                        Alpha = 0.2f,
+                        Colour = overlayColourProvider.Background5,
+                        Alpha = 0.8f,
                         RelativeSizeAxes = Axes.Both,
                     },
                     new FillFlowContainer
@@ -88,7 +88,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                                     new Box
                                     {
                                         Alpha = 0.4f,
-                                        Colour = Color4.Black,
+                                        Colour = overlayColourProvider.Background4,
                                         RelativeSizeAxes = Axes.Both,
                                     },
                                     bars = new Container<Bar>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/37406.

I almost applied

```diff
diff --git a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
index 318572d28f..76719a7de8 100644
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
@@ -5,8 +5,10 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
@@ -134,6 +136,14 @@ private void load(OsuColour colour, AudioManager audio)
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     Colour = colour.ForStarDifficulty(Math.Max(difficulty, 0.1)),
+                    EdgeEffect = difficulty < OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF
+                        ? default
+                        : new EdgeEffectParameters
+                        {
+                            Type = EdgeEffectType.Glow,
+                            Colour = colour.ForStarDifficultyText(difficulty).Opacity((difficulty - OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF) / (10 - OsuColour.STAR_DIFFICULTY_DEFINED_COLOUR_CUTOFF) / 2),
+                            Radius = 4
+                        },
                     Height = 0
                 });

```

as a bonus but I'm not that confident in myself.