### PR TITLE
Make osu! logo heartbeat samples skinnable

### DIFF
--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -18,10 +18,12 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
+using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
+using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -58,8 +60,8 @@ namespace osu.Game.Screens.Menu
 
         protected virtual double BeatSampleVariance => 0.1;
 
-        protected Sample SampleBeat;
-        protected Sample SampleDownbeat;
+        protected ISample SampleBeat;
+        protected ISample SampleDownbeat;
 
         private readonly Container colourAndTriangles;
         private readonly TrianglesV2 triangles;
@@ -274,16 +276,39 @@ namespace osu.Game.Screens.Menu
                 Schedule(runnableAction);
         }
 
+        [Resolved]
+        private ISkinSource skinSource { get; set; }
+
+        protected AudioManager Audio { get; private set; }
+
         [BackgroundDependencyLoader]
         private void load(TextureStore textures, AudioManager audio)
         {
+            Audio = audio;
+
             sampleClick = audio.Samples.Get(@"Menu/osu-logo-select");
 
-            SampleBeat = audio.Samples.Get(@"Menu/osu-logo-heartbeat");
-            SampleDownbeat = audio.Samples.Get(@"Menu/osu-logo-downbeat");
+            LoadBeatSamples();
+            skinSource.SourceChanged += LoadBeatSamples;
 
             logo.Texture = textures.Get(@"Menu/logo");
             ripple.Texture = textures.Get(@"Menu/logo");
+        }
+
+        // loaded via the current skin (with a fallback to the default resources) so users can override
+        // these sounds via the skinning system, as described in the skinning wiki.
+        protected virtual void LoadBeatSamples()
+        {
+            SampleBeat = skinSource.GetSample(new SampleInfo(@"Menu/osu-logo-heartbeat")) ?? Audio.Samples.Get(@"Menu/osu-logo-heartbeat");
+            SampleDownbeat = skinSource.GetSample(new SampleInfo(@"Menu/osu-logo-downbeat")) ?? Audio.Samples.Get(@"Menu/osu-logo-downbeat");
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (skinSource != null)
+                skinSource.SourceChanged -= LoadBeatSamples;
         }
 
         private int lastBeatIndex;

--- a/osu.Game/Seasonal/OsuLogoChristmas.cs
+++ b/osu.Game/Seasonal/OsuLogoChristmas.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
@@ -22,7 +21,7 @@ namespace osu.Game.Seasonal
         protected override MenuLogoVisualisation CreateMenuLogoVisualisation() => new SeasonalMenuLogoVisualisation();
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures, AudioManager audio)
+        private void load(TextureStore textures)
         {
             LogoElements.Add(hat = new Sprite
             {
@@ -32,9 +31,12 @@ namespace osu.Game.Seasonal
                 Scale = new Vector2(-1, 1),
                 Texture = textures.Get(@"Menu/hat"),
             });
+        }
 
-            // override base samples with our preferred ones.
-            SampleDownbeat = SampleBeat = audio.Samples.Get(@"Menu/osu-logo-heartbeat-bell");
+        // override base samples with our preferred seasonal bell variant.
+        protected override void LoadBeatSamples()
+        {
+            SampleDownbeat = SampleBeat = Audio.Samples.Get(@"Menu/osu-logo-heartbeat-bell");
         }
 
         protected override void Update()


### PR DESCRIPTION
Closes #37318.

The [skinning wiki](https://osu.ppy.sh/wiki/en/Skinning/Sounds) lists `Menu/osu-logo-heartbeat` (and `osu-logo-downbeat`) as skinnable sounds, but `OsuLogo` was pulling them directly out of the default `AudioManager.Samples` store. That bypasses the skin layer entirely, so dropping a `heartbeat.wav` into a user skin folder did nothing (as reported in the issue).

This routes the lookup through the current `ISkinSource` first and falls back to the bundled sample when the skin doesn't provide one. I also hooked `SourceChanged` so the samples are re-queried when the user switches skin at runtime, matching the behaviour of other skinnable pieces (e.g. `StarFountain`). The seasonal Christmas logo keeps overriding with its bell variant through a new `LoadBeatSamples` virtual hook so its behaviour is unchanged.

Tested locally: placing a custom `heartbeat.wav` in a skin now plays while hovering the main menu cookie, and swapping skins while hovering picks up the new sound without a restart. The stable-side behaviour mentioned in the issue (where importing the skin there works) now matches here.