### PR TITLE
Reorder main menu buttons

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -56,6 +56,9 @@ namespace osu.Game.Screens.Menu
 
         private OsuLogo? logo;
 
+        private readonly MainMenuButton exitButton;
+        private bool canExit;
+
         /// <summary>
         /// Assign the <see cref="OsuLogo"/> that this ButtonSystem should manage the position of.
         /// </summary>
@@ -69,7 +72,7 @@ namespace osu.Game.Screens.Menu
                 this.logo.Action = onOsuLogo;
 
                 // osuLogo.SizeForFlow relies on loading to be complete.
-                buttonArea.Flow.Position = new Vector2(WEDGE_WIDTH * 2 - (BUTTON_WIDTH + this.logo.SizeForFlow / 4), 0);
+                buttonArea.Flow.Position = new Vector2(WEDGE_WIDTH * 2 - (BUTTON_WIDTH + this.logo.SizeForFlow / 4) + (canExit ? BUTTON_WIDTH / 2 : 0), 0);
 
                 updateLogoState();
             }
@@ -109,29 +112,21 @@ namespace osu.Game.Screens.Menu
 
             buttonArea.AddRange(new Drawable[]
             {
+                exitButton = new MainMenuButton(ButtonSystemStrings.Exit, string.Empty, OsuIcon.CrossCircle, new Color4(40, 40, 40, 255), (_, e) => OnExit?.Invoke(e), Key.Q),
                 new MainMenuButton(ButtonSystemStrings.Settings, string.Empty, OsuIcon.Settings, new Color4(85, 85, 85, 255), (_, _) => OnSettings?.Invoke(), Key.O, Key.S)
                 {
                     Padding = new MarginPadding { Right = WEDGE_WIDTH },
                 },
                 backButton = new MainMenuButton(ButtonSystemStrings.Back, @"back-to-top", OsuIcon.PrevCircle, new Color4(51, 58, 94, 255), (_, _) =>
                 {
-                    switch (State)
-                    {
-                        case ButtonSystemState.Multi:
-                            State = ButtonSystemState.Play;
-                            break;
-
-                        default:
-                            State = ButtonSystemState.TopLevel;
-                            break;
-                    }
+                    State = ButtonSystemState.TopLevel;
                 })
                 {
                     Padding = new MarginPadding { Right = WEDGE_WIDTH },
                     VisibleStateMin = ButtonSystemState.Play,
                     VisibleStateMax = ButtonSystemState.Edit,
                 },
-                logoTrackingContainer.LogoFacade.With(d => d.Scale = new Vector2(0.74f))
+                logoTrackingContainer.LogoFacade.With(d => d.Scale = new Vector2(0.74f)),
             });
 
             buttonArea.Flow.CentreTarget = logoTrackingContainer.LogoFacade;
@@ -149,11 +144,14 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, IdleTracker? idleTracker, GameHost host)
         {
+            canExit = host.CanExit;
+            if (!canExit)
+                buttonArea.Remove(exitButton, true);
+
             buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Solo, @"button-default-select", OsuIcon.Player, new Color4(102, 68, 204, 255), (_, _) => OnSolo?.Invoke(), Key.P)
             {
                 Padding = new MarginPadding { Left = WEDGE_WIDTH },
             });
-            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Multi, @"button-default-select", OsuIcon.Online, new Color4(94, 63, 186, 255), (_, _) => State = ButtonSystemState.Multi, Key.M));
             buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Playlists, @"button-default-select", OsuIcon.Tournament, new Color4(94, 63, 186, 255), onPlaylists, Key.L));
             buttonsPlay.Add(new DailyChallengeButton(@"button-daily-select", new Color4(94, 63, 186, 255), onDailyChallenge, Key.D));
             buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
@@ -163,8 +161,6 @@ namespace osu.Game.Screens.Menu
                 Padding = new MarginPadding { Left = WEDGE_WIDTH }
             });
             buttonsMulti.Add(new MainMenuButton(ButtonSystemStrings.RankedPlay, @"button-daily-select", FontAwesome.Solid.Crown, new Color4(94, 63, 186, 255), onRankedPlay, Key.R));
-            // disabled for now to give ranked play space.
-            // buttonsMulti.Add(new MainMenuButton(ButtonSystemStrings.QuickPlay, @"button-daily-select", FontAwesome.Solid.Bolt, new Color4(94, 63, 186, 255), onQuickPlay, Key.Q));
             buttonsMulti.ForEach(b => b.VisibleState = ButtonSystemState.Multi);
 
             buttonsEdit.Add(new MainMenuButton(EditorStrings.BeatmapEditor.ToLower(), @"button-default-select", OsuIcon.Beatmap, new Color4(238, 170, 0, 255), (_, _) => OnEditBeatmap?.Invoke(), Key.B,
@@ -175,17 +171,14 @@ namespace osu.Game.Screens.Menu
             buttonsEdit.Add(new MainMenuButton(SkinEditorStrings.SkinEditor.ToLower(), @"button-default-select", OsuIcon.SkinB, new Color4(220, 160, 0, 255), (_, _) => OnEditSkin?.Invoke(), Key.S));
             buttonsEdit.ForEach(b => b.VisibleState = ButtonSystemState.Edit);
 
-            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), (_, _) => State = ButtonSystemState.Play, Key.P, Key.M,
-                Key.L)
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), (_, _) => State = ButtonSystemState.Play, Key.P)
             {
                 Padding = new MarginPadding { Left = WEDGE_WIDTH },
             });
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Multi, @"button-play-select", OsuIcon.Online, new Color4(94, 63, 186, 255), (_, _) => State = ButtonSystemState.Multi, Key.M));
             buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Edit, @"button-play-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), (_, _) => State = ButtonSystemState.Edit, Key.E));
             buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Browse, @"button-default-select", OsuIcon.Beatmap, new Color4(165, 204, 0, 255), (_, _) => OnBeatmapListing?.Invoke(), Key.B,
                 Key.D));
-
-            if (host.CanExit)
-                buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Exit, string.Empty, OsuIcon.CrossCircle, new Color4(238, 51, 153, 255), (_, e) => OnExit?.Invoke(e), Key.Q));
 
             buttonArea.AddRange(buttonsMulti);
             buttonArea.AddRange(buttonsPlay);


### PR DESCRIPTION
This reorganizes the main menu buttons to expose the new Ranked Play and other multiplayer features more directly - it uses the following layout:

- exit 
- settings

[osu! logo]

- play
    - solo
    - playlists
    - daily challenge
- multi
    - lounge
    - ranked play
- edit
    - beatmap editor
    - skin editor
- browse

This also moves the Exit button to the left of the screen to keep visual balance with the osu! logo - let me know if this should be moved back to the right - if it stays on the left, I'd be tempted to suggest adding the "are you sure?" popup when clicking it as well, just to avoid people accidentally exiting out due to muscle memory

Alternatively, it could go in the full bottom left of the screen, though that feels very out of place compared to the rest.

<img width="3840" height="2131" alt="image" src="https://github.com/user-attachments/assets/91e0a8ab-4bcf-4adc-a9db-bd1ec3d4105e" />

https://github.com/user-attachments/assets/c27cb011-35cc-4329-bea2-26462baf90aa

Main part I'm concerned about is how I'm removing the Exit button if the platform doesn't support it, but I don't really have any better ideas of how to handle it. First time working with the codebase so please point me in the right direction if there's a better way to do this!

Here's how it'd look with the exit button in it's normal place:
<img width="1970" height="1091" alt="image" src="https://github.com/user-attachments/assets/49535554-a0de-4d04-b011-88d7b94fb90b" />
