### PR TITLE
Add toggle to apply speed mods to menu and song select music.

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -238,6 +238,8 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.DashboardSortMode, UserSortCriteria.LastVisit);
             SetDefault(OsuSetting.DashboardDisplayStyle, OverlayPanelDisplayStyle.Card);
+
+            SetDefault(OsuSetting.SpeedAffectsMenuMusic, true);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -493,5 +495,7 @@ namespace osu.Game.Configuration
 
         DashboardSortMode,
         DashboardDisplayStyle,
+
+        SpeedAffectsMenuMusic,
     }
 }

--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -109,7 +109,6 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release_stream_confirmation"), @"Are you sure you want to run a potentially unstable version of the game?");
 
-
         /// <summary>
         /// "Speed alterations affect main menu and song select music"
         /// </summary>

--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -109,6 +109,12 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ChangeReleaseStreamConfirmation => new TranslatableString(getKey(@"change_release_stream_confirmation"), @"Are you sure you want to run a potentially unstable version of the game?");
 
+
+        /// <summary>
+        /// "Speed alterations affect main menu and song select music"
+        /// </summary>
+        public static LocalisableString SpeedAffectsMenuMusic => new TranslatableString(getKey(@"speed_affects_menu_music"), @"Speed alterations affect main menu and song select music");
+
         /// <summary>
         /// "If you run into issues starting the game, you can usually run the installer from the official site to recover."
         /// </summary>

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -55,6 +55,14 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     Caption = GameplaySettingsStrings.BackgroundBlur,
                     Current = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur),
                 }),
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = GeneralSettingsStrings.SpeedAffectsMenuMusic,
+                    Current = config.GetBindable<bool>(OsuSetting.SpeedAffectsMenuMusic),
+                })
+                {
+                    Keywords = new[] { @"speed", @"dt", @"nc", @"ht", @"double", @"half", @"time" },
+                },
             };
         }
     }

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -61,6 +61,8 @@ namespace osu.Game.Screens.Menu
 
         public override bool? AllowGlobalTrackControl => true;
 
+        protected override bool ApplySpeedModsToMenuMusic => speedAffectsMenuMusic.Value;
+
         private MenuSideFlashes sideFlashes;
 
         protected ButtonSystem Buttons;
@@ -97,6 +99,7 @@ namespace osu.Game.Screens.Menu
         private Bindable<double> holdDelay;
         private Bindable<bool> loginDisplayed;
         private Bindable<bool> showMobileDisclaimer;
+        private Bindable<bool> speedAffectsMenuMusic;
 
         private HoldToExitGameOverlay holdToExitGameOverlay;
 
@@ -125,6 +128,7 @@ namespace osu.Game.Screens.Menu
             holdDelay = config.GetBindable<double>(OsuSetting.UIHoldActivationDelay);
             loginDisplayed = statics.GetBindable<bool>(Static.LoginOverlayDisplayed);
             showMobileDisclaimer = config.GetBindable<bool>(OsuSetting.ShowMobileDisclaimer);
+            speedAffectsMenuMusic = config.GetBindable<bool>(OsuSetting.SpeedAffectsMenuMusic);
 
             if (host.CanExit)
             {
@@ -247,6 +251,8 @@ namespace osu.Game.Screens.Menu
         {
             base.LoadComplete();
             GetContainingInputManager();
+
+            speedAffectsMenuMusic.BindValueChanged(_ => musicController.ApplyModTrackAdjustments = speedAffectsMenuMusic.Value, true);
         }
 
         public void ReturnToOsuLogo() => Buttons.State = ButtonSystemState.Initial;

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -101,6 +101,11 @@ namespace osu.Game.Screens
 
         public virtual bool? ApplyModTrackAdjustments => null;
 
+        /// <summary>
+        /// Whether to allow speed/time mods to affect the track in menu screens.
+        /// </summary>
+        protected virtual bool ApplySpeedModsToMenuMusic => true;
+
         public virtual bool? AllowGlobalTrackControl => null;
 
         public Bindable<WorkingBeatmap> Beatmap { get; private set; } = null!;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Screens.Select
 
         private NoResultsPlaceholder noResultsPlaceholder = null!;
 
-        public override bool? ApplyModTrackAdjustments => true;
+        protected override bool ApplySpeedModsToMenuMusic => speedAffectsMenuMusic.Value;
 
         public override bool ShowFooter => true;
 
@@ -168,12 +168,15 @@ namespace osu.Game.Screens.Select
 
         private Bindable<bool> configBackgroundBlur = null!;
         private Bindable<bool> showConvertedBeatmaps = null!;
+        private Bindable<bool> speedAffectsMenuMusic = null!;
 
         private IDisposable? modSelectOverlayRegistration;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, OsuConfigManager config)
         {
+            speedAffectsMenuMusic = config.GetBindable<bool>(OsuSetting.SpeedAffectsMenuMusic);
+
             errorSample = audio.Samples.Get(@"UI/generic-error");
 
             AddRangeInternal(new Drawable[]
@@ -382,6 +385,8 @@ namespace osu.Game.Screens.Select
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            speedAffectsMenuMusic.BindValueChanged(_ => music.ApplyModTrackAdjustments = speedAffectsMenuMusic.Value, true);
 
             modSelectOverlayRegistration = overlayManager?.RegisterBlockingOverlay(modSelectOverlay);
 


### PR DESCRIPTION
Implements a toggle that makes the speed altering mods have no effect on music in the main menu and the song select. 

There are 2 discussions requesting this feature, #37301 and #31016 