### PR TITLE
Hide beatmap download notification in ranked play

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -27,13 +28,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
 
         [Resolved]
-        private BeatmapModelDownloader beatmapDownloader { get; set; } = null!;
-
-        [Resolved]
         private OsuConfigManager config { get; set; } = null!;
+
+        private BeatmapModelDownloader beatmapDownloader { get; set; } = null!;
 
         private CancellationTokenSource? downloadCheckCancellation;
         private int? lastDownloadCheckedBeatmapId;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            dependencies.CacheAs(beatmapDownloader = new BeatmapModelDownloader(parent.Get<BeatmapManager>(), parent.Get<IAPIProvider>()));
+            return dependencies;
+        }
 
         protected override void LoadComplete()
         {


### PR DESCRIPTION
Similar implementation to `BundledBeatmapDownloader`. The notification should not be cancellable, but there's no easy way to do that right now other than hiding the notification altogether.

The beatmap availability status visible on the corner pieces is probably a little too small/hides importance, but that will be addressed later to make up for this.