### PR TITLE
Fix ranked play chat deselecting when typing shift-numbers

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -155,6 +155,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             if (e.Repeat || Contracted || Cards.Any(static c => c.CardDragged))
                 return false;
 
+            if (e.ShiftPressed || e.ControlPressed)
+                return false;
+
             switch (e.Key)
             {
                 case >= Key.Number1 and <= Key.Number9:

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             if (e.Repeat || Contracted || Cards.Any(static c => c.CardDragged))
                 return false;
 
-            if (e.ShiftPressed || e.ControlPressed)
+            if (e.ShiftPressed || e.ControlPressed || e.AltPressed || e.SuperPressed)
                 return false;
 
             switch (e.Key)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/37434