### PR TITLE
Rewrite ranked play card song preview playback logic to hopefully work around framework breakage

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             private readonly Container overlayLayer;
 
-            private bool shouldBePlaying => Enabled.Value && CardHovered.Value;
-
             [Resolved]
             private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
@@ -77,33 +75,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 ];
             }
 
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                Enabled.BindValueChanged(enabled =>
-                {
-                    if (!enabled.NewValue)
-                    {
-                        previewTrack?.Stop();
-                        return;
-                    }
-
-                    if (shouldBePlaying)
-                    {
-                        startPreviewIfAvailable();
-                    }
-                });
-
-                CardHovered.BindValueChanged(selected =>
-                {
-                    if (selected.NewValue && shouldBePlaying)
-                    {
-                        startPreviewIfAvailable();
-                    }
-                });
-            }
-
             private PreviewTrack? previewTrack;
 
             public void LoadPreview(APIBeatmap beatmap)
@@ -126,13 +97,31 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                     {
                         TrackRunning = { BindTarget = trackRunning }
                     });
-
-                    if (shouldBePlaying)
-                        startPreviewIfAvailable();
                 });
             }
 
-            private void startPreviewIfAvailable() => previewTrack?.Start();
+            protected override void Update()
+            {
+                base.Update();
+
+                updatePlayingState();
+            }
+
+            private void updatePlayingState()
+            {
+                if (previewTrack?.IsLoaded != true)
+                    return;
+
+                bool shouldBePlaying = Enabled.Value && CardHovered.Value;
+
+                if (shouldBePlaying == previewTrack.IsRunning)
+                    return;
+
+                if (shouldBePlaying)
+                    previewTrack.Start();
+                else
+                    previewTrack.Stop();
+            }
 
             #region IBeatSyncProvider implementation
 


### PR DESCRIPTION
Similar idea to https://github.com/ppy/osu/commit/622216d8911832c39fa4e126b2810e4e0f46cbf7 (which was included in https://github.com/ppy/osu/pull/37218).

Probably closes https://github.com/ppy/osu/issues/37420.

I wouldn't be myself if I didn't remark that the WTF/sec on ranked play code continues to be quite high as I fix these issues. Like, look at the old code: why does `Enabled` becoming false stop the preview track, but `CardHovered` becoming false *doesn't*? Even though `shouldBePlaying` was explicitly defined as derived from *both flags*? Maybe me changing this to be actually consistent incurs a behaviour change, but like... I can't tell if it is a bug or not.

Not to mention this nugget:

https://github.com/ppy/osu/blob/0e9664bfdfa69b4b26ff9cf84615c4b83a195a0e/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs#L107
https://github.com/ppy/osu/blob/0e9664bfdfa69b4b26ff9cf84615c4b83a195a0e/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs#L47-L50

What is this naming even?