### PR TITLE
Do not cache null values in beatmap lookup cache

### DIFF
--- a/osu.Game/Database/BeatmapLookupCache.cs
+++ b/osu.Game/Database/BeatmapLookupCache.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Database
 {
     public partial class BeatmapLookupCache : OnlineLookupCache<int, APIBeatmap, GetBeatmapsRequest>
     {
+        protected override bool CacheNullValues => false;
+
         /// <summary>
         /// Perform an API lookup on the specified beatmap, populating a <see cref="APIBeatmap"/> model.
         /// </summary>


### PR DESCRIPTION
RFC.

The reason I'm bringing this up is https://github.com/ppy/osu/issues/37383.

In this case, the retrieval of the beatmap failed on a timeout:

```
2026-04-19 02:43:10 [verbose]: Request to https://osu.ppy.sh/api/v2/beatmaps/?ids[]=5090069 failed with System.Net.WebException: Request to https://osu.ppy.sh/api/v2/beatmaps/?ids[]=5090069 timed out after 10 seconds idle (read 0 bytes, retried 0 times)..
2026-04-19 02:43:10 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapsRequest (System.Net.WebException: Request to https://osu.ppy.sh/api/v2/beatmaps/?ids[]=5090069 timed out after 10 seconds idle (read 0 bytes, retried 0 times).)
```

```
2026-04-19 02:43:10 [error]: Failed to load beatmap 5090069 for playlistItem 0.
2026-04-19 02:43:10 [verbose]: ⚠️ Failed to load beatmap 5090069 for playlistItem 0.
```

This fails at

https://github.com/ppy/osu/blob/0e9664bfdfa69b4b26ff9cf84615c4b83a195a0e/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs#L167-L171

Just this failing wouldn't cause the game to soft-lock; when I suppress the lookup locally, the game continues as normal. *However*, suppressing the lookup is not the same as the lookup *failing*, because a failed lookup will write a null to the cache, which means that when a beatmap download is initiated later in

https://github.com/ppy/osu/blob/1b488949e13568c23faa0d88b18c8036f4a7dbc8/osu.Game/Screens/OnlinePlay/Matchmaking/Match/ScreenMatchmaking.cs#L308-L320

it'll just do nothing and the user will be stuck, even though they could very well attempt to download the beatmap here if the lookup were to succeed on the second go.

To a degree changing the whole cache for this could be viewed as the tail wagging the dog, but I think in general caching nulls here seems pretty anti-user. From within the client I would generally not expect very many complete misses when looking up beatmaps.

Note that this wouldn't soft-lock the match anymore since https://github.com/ppy/osu-server-spectator/pull/471. It's just another step in making degradation less impactful.