### PR TITLE
Refactor audio preview logic in ranked play cards to match expectations while hopefully not looking buggy anymore

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneSongPreview.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneSongPreview.cs
@@ -58,21 +58,36 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
 
             AddStep("move mouse to second card", () => InputManager.MoveMouseTo(getCard(1)));
-
             AddAssert("second track running", () => getCard(1).PreviewTrackRunning);
             AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
 
             AddStep("disable preview", () => previewEnabled.Value = false);
-
             AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
 
             AddStep("move mouse to third card", () => InputManager.MoveMouseTo(getCard(2)));
-
             AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
 
             AddStep("enable preview", () => previewEnabled.Value = true);
-
             AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
+
+            AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
+            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
+
+            AddStep("disable preview", () => previewEnabled.Value = false);
+            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
+
+            AddStep("enable preview", () => previewEnabled.Value = true);
+            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
+
+            AddStep("move mouse to third card", () => InputManager.MoveMouseTo(getCard(2)));
+            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
+
+            AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
+            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
+
+            AddStep("move mouse to second card", () => InputManager.MoveMouseTo(getCard(1)));
+            AddAssert("second track running", () => getCard(1).PreviewTrackRunning);
+            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
         }
 
         private RankedPlayCard getCard(int index) => this.ChildrenOfType<RankedPlayCard>().ElementAt(index);

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneSongPreview.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneSongPreview.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Online.API;
@@ -15,9 +14,9 @@ namespace osu.Game.Tests.Visual.RankedPlay
 {
     public partial class TestSceneSongPreview : RankedPlayTestScene
     {
-        private readonly Bindable<bool> previewEnabled = new BindableBool(true);
-
         private readonly BeatmapRequestHandler requestHandler = new BeatmapRequestHandler();
+
+        private PlayerHandOfCards handOfCards = null!;
 
         public override void SetUpSteps()
         {
@@ -27,8 +26,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
 
             AddStep("add cards", () =>
             {
-                PlayerHandOfCards handOfCards;
-
                 Child = handOfCards = new PlayerHandOfCards
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -38,15 +35,10 @@ namespace osu.Game.Tests.Visual.RankedPlay
                 };
 
                 foreach (var beatmap in requestHandler.Beatmaps.Take(3))
-                {
-                    handOfCards.AddCard(new RevealedRankedPlayCardWithPlaylistItem(beatmap), handCard =>
-                    {
-                        handCard.Card.SongPreviewEnabled.BindTarget = previewEnabled;
-                    });
-                }
+                    handOfCards.AddCard(new RevealedRankedPlayCardWithPlaylistItem(beatmap));
             });
 
-            AddUntilStep("load tracks", () => this.ChildrenOfType<RankedPlayCard>().All(card => card.PreviewTrackLoaded));
+            AddUntilStep("load tracks", () => this.ChildrenOfType<RankedPlayCard>().All(card => card.SongPreview.TrackLoaded));
         }
 
         [Test]
@@ -54,40 +46,25 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("move mouse to first card", () => InputManager.MoveMouseTo(getCard(0)));
 
-            AddAssert("first track running", () => getCard(0).PreviewTrackRunning);
-            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
+            AddAssert("first track running", () => getCard(0).SongPreview.IsRunning);
+            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.SongPreview.IsRunning) == 1);
 
             AddStep("move mouse to second card", () => InputManager.MoveMouseTo(getCard(1)));
-            AddAssert("second track running", () => getCard(1).PreviewTrackRunning);
-            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
+            AddAssert("second track running", () => getCard(1).SongPreview.IsRunning);
+            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.SongPreview.IsRunning) == 1);
 
-            AddStep("disable preview", () => previewEnabled.Value = false);
-            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
-
-            AddStep("move mouse to third card", () => InputManager.MoveMouseTo(getCard(2)));
-            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
-
-            AddStep("enable preview", () => previewEnabled.Value = true);
-            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
-
-            AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
-            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
-
-            AddStep("disable preview", () => previewEnabled.Value = false);
-            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
-
-            AddStep("enable preview", () => previewEnabled.Value = true);
-            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
+            AddStep("disable preview", () => handOfCards.CurrentPlayingPreview.Value = null);
+            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.SongPreview.IsRunning));
 
             AddStep("move mouse to third card", () => InputManager.MoveMouseTo(getCard(2)));
-            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
+            AddAssert("third track running", () => getCard(2).SongPreview.IsRunning);
 
             AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
-            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
+            AddAssert("third track running", () => getCard(2).SongPreview.IsRunning);
 
             AddStep("move mouse to second card", () => InputManager.MoveMouseTo(getCard(1)));
-            AddAssert("second track running", () => getCard(1).PreviewTrackRunning);
-            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
+            AddAssert("second track running", () => getCard(1).SongPreview.IsRunning);
+            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.SongPreview.IsRunning) == 1);
         }
 
         private RankedPlayCard getCard(int index) => this.ChildrenOfType<RankedPlayCard>().ElementAt(index);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -31,10 +31,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
         {
             private const double minimum_beat_length = 800;
 
-            public readonly Bindable<bool> Enabled = new BindableBool(true);
-
-            public readonly Bindable<bool> CardHovered = new BindableBool(true);
-
             public bool TrackLoaded => previewTrack?.TrackLoaded ?? false;
 
             public bool IsRunning => previewTrack?.IsRunning ?? false;
@@ -50,6 +46,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             [Resolved]
             private OsuColour colours { get; set; } = null!;
+
+            public readonly IBindable<SongPreviewContainer?> CurrentPlayingPreview = new Bindable<SongPreviewContainer?>();
 
             public SongPreviewContainer()
             {
@@ -112,7 +110,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 if (previewTrack?.IsLoaded != true)
                     return;
 
-                bool shouldBePlaying = Enabled.Value && CardHovered.Value;
+                bool shouldBePlaying = CurrentPlayingPreview.Value == this;
 
                 if (shouldBePlaying == previewTrack.IsRunning)
                     return;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs
@@ -31,28 +31,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
         private readonly IBindable<MultiplayerPlaylistItem?> playlistItem;
 
-        public readonly Bindable<bool> SongPreviewEnabled = new BindableBool(true);
-
         private readonly Container content;
         private readonly Container cardContent;
         private readonly Container shadow;
         private readonly SelectionOutline selectionOutline;
-        private readonly SongPreviewContainer songPreviewContainer;
+        public readonly SongPreviewContainer SongPreview;
 
         public bool ShowSelectionOutline
         {
             set => selectionOutline.FadeTo(value ? 1 : 0, 50);
         }
 
-        public bool PlayAudioPreview
-        {
-            set => songPreviewContainer.CardHovered.Value = value;
-        }
-
         public float Elevation;
-
-        public bool PreviewTrackLoaded => songPreviewContainer.TrackLoaded;
-        public bool PreviewTrackRunning => songPreviewContainer.IsRunning;
 
         private Sample? cardFlipSample;
 
@@ -67,9 +57,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             playlistItem = item.PlaylistItem.GetBoundCopy();
 
-            InternalChild = songPreviewContainer = new SongPreviewContainer
+            InternalChild = SongPreview = new SongPreviewContainer
             {
-                Enabled = { BindTarget = SongPreviewEnabled },
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -173,7 +162,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
             Schedule(() =>
             {
                 SetContent(new RankedPlayCardContent(beatmap));
-                songPreviewContainer.LoadPreview(beatmap);
+                SongPreview.LoadPreview(beatmap);
             });
         });
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -253,13 +253,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             foreach (var item in discardedCards)
             {
-                if (!playerHand.RemoveCard(item, out var card, out Quad drawQuad))
+                if (!playerHand.DetachCard(item, out var card, out Quad drawQuad))
                     return;
 
                 card.Anchor = Anchor.Centre;
                 card.Origin = Anchor.Centre;
 
-                card.SongPreviewEnabled.Value = false;
+                if (playerHand.CurrentPlayingPreview.Value == card.SongPreview)
+                    playerHand.CurrentPlayingPreview.Value = null;
 
                 card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
 
@@ -333,7 +334,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             foreach (var item in matchInfo.PlayerCards)
             {
-                if (playerHand.RemoveCard(item, out var card, out Quad drawQuad))
+                if (playerHand.DetachCard(item, out var card, out Quad drawQuad))
                 {
                     card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -104,7 +104,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 handOfCards.OnCardStateChanged(this, state);
 
                 Card.ShowSelectionOutline = state.NewValue.Selected;
-                Card.PlayAudioPreview = state.NewValue.Hovered;
 
                 switch (state.NewValue.Pressed, state.OldValue.Pressed)
                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
         public void AddCard(RankedPlayCardWithPlaylistItem item, Action<HandCard>? setupAction = null) => AddCard(new RankedPlayCard(item), setupAction);
 
-        public void AddCard(RankedPlayCard card, Action<HandCard>? setupAction = null)
+        public virtual void AddCard(RankedPlayCard card, Action<HandCard>? setupAction = null)
         {
             if (cardLookup.ContainsKey(card.Item.Card))
                 return;
@@ -159,7 +159,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// <param name="card">Contained <see cref="RankedPlayCard"/></param>
         /// <param name="screenSpaceDrawQuad"><see cref="Drawable.ScreenSpaceDrawQuad"/> of the removed card</param>
         /// <returns>Whether a card was found for the provided item</returns>
-        public bool RemoveCard(RankedPlayCardWithPlaylistItem item, [MaybeNullWhen(false)] out RankedPlayCard card, out Quad screenSpaceDrawQuad)
+        public virtual bool DetachCard(RankedPlayCardWithPlaylistItem item, [MaybeNullWhen(false)] out RankedPlayCard card, out Quad screenSpaceDrawQuad)
         {
             if (!cardLookup.Remove(item.Card, out var drawable))
             {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Online.RankedPlay;
@@ -82,6 +84,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// </summary>
         public IEnumerable<RankedPlayCardWithPlaylistItem> Selection => selection.Select(it => it.Card.Item);
 
+        /// <summary>
+        /// The currently-playing preview.
+        /// </summary>
+        /// <remarks>
+        /// Note that due to how cards get detached and handed off between multiple <see cref="HandOfCards"/> instances and non-hand containers,
+        /// DI cannot be reliably used to pass this bindable down to children
+        /// because it'll only work for the first <see cref="PlayerHandOfCards"/> that <see cref="RankedPlayCard"/>s bind to.
+        /// Instead, <see cref="AddCard"/> and <see cref="DetachCard"/> overrides in this class set up this bindable manually as cards are handed off between stages.
+        /// </remarks>
+        public readonly Bindable<RankedPlayCard.SongPreviewContainer?> CurrentPlayingPreview = new Bindable<RankedPlayCard.SongPreviewContainer?>();
+
         private readonly BindableBool allowSelection = new BindableBool();
 
         private const int select_samples = 1;
@@ -109,6 +122,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             AllowSelection = allowSelection.GetBoundCopy(),
             PlayAction = PlayCardAction,
         };
+
+        public override void AddCard(RankedPlayCard card, Action<HandCard>? setupAction = null)
+        {
+            base.AddCard(card, setupAction);
+            card.SongPreview.CurrentPlayingPreview.BindTo(CurrentPlayingPreview);
+        }
+
+        public override bool DetachCard(RankedPlayCardWithPlaylistItem item, [MaybeNullWhen(false)] out RankedPlayCard card, out Quad screenSpaceDrawQuad)
+        {
+            bool result = base.DetachCard(item, out card, out screenSpaceDrawQuad);
+            card?.SongPreview.CurrentPlayingPreview.UnbindFrom(CurrentPlayingPreview);
+            return result;
+        }
 
         private void cardClicked(PlayerHandCard card)
         {
@@ -144,6 +170,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         protected override void OnCardStateChanged(HandCard card, ValueChangedEvent<RankedPlayCardState> evt)
         {
             StateChanged?.Invoke();
+
+            if (evt.NewValue.Hovered)
+                CurrentPlayingPreview.Value = card.Card.SongPreview;
 
             base.OnCardStateChanged(card, evt);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             {
                 RankedPlayCard? card;
 
-                if (opponentHand.RemoveCard(item, out card, out var drawQuad))
+                if (opponentHand.DetachCard(item, out card, out var drawQuad))
                 {
                     card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
                 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             RankedPlayCard? card;
 
-            if (playerHand.RemoveCard(item, out card, out var drawQuad))
+            if (playerHand.DetachCard(item, out card, out var drawQuad))
             {
                 card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
             }


### PR DESCRIPTION
RFC.

See https://github.com/ppy/osu/pull/37453#issuecomment-4289403735 for why.

Of note:

- To facilitate mutual exclusivity of playback `PlayerHandOfCards` maintains a bindable pointing at the currently playing song preview.
- Because of how card drawables are passed between multiple parenting drawables, some of which are and some of which are not `PlayerHandOfCards` instances, DI fails horribly at working with this bindable unless it is manually managed. See relevant overrides in `PlayerHandOfCards`.
- I renamed one of the overloads of `HandOfCards.RemoveCard()` to  `DetachCard()` because I found the fact that there are two overloads of one method that do WILDLY DIFFERENT THINGS utterly *asinine*. (One  overload scrapes the `RankedPlayCard` out for you to plop elsewhere. One *drops it on the floor entirely*.)

This took way too long to write.