### PR TITLE
Add ability to sync metadata across difficulties in editor setup

### DIFF
--- a/osu.Game/Localisation/EditorDialogsStrings.cs
+++ b/osu.Game/Localisation/EditorDialogsStrings.cs
@@ -75,6 +75,11 @@ namespace osu.Game.Localisation
         public static LocalisableString DeleteDifficultyDetails(string difficultyName, int objectCount) => new TranslatableString(getKey(@"delete_difficulty_details"), @"Difficulty ""{0}"" with {1} objects", difficultyName, objectCount);
 
         /// <summary>
+        /// "This overwrites artist, title, source, and tags on all other difficulties. This cannot be undone."
+        /// </summary>
+        public static LocalisableString SyncMetadataConfirmationBody => new TranslatableString(getKey(@"sync_metadata_confirmation_body"), @"This overwrites artist, title, source, and tags on all other difficulties. This cannot be undone.");
+
+        /// <summary>
         /// "All Bookmarks"
         /// </summary>
         public static LocalisableString AllBookmarks => new TranslatableString(getKey(@"all_bookmarks"), @"All Bookmarks");

--- a/osu.Game/Localisation/EditorSetupStrings.cs
+++ b/osu.Game/Localisation/EditorSetupStrings.cs
@@ -219,6 +219,18 @@ namespace osu.Game.Localisation
         public static LocalisableString ApplyToThisDifficulty => new TranslatableString(getKey(@"apply_to_this_difficulty"), @"Only apply to this difficulty");
 
         /// <summary>
+        /// "Sync metadata with all difficulties"
+        /// </summary>
+        public static LocalisableString SyncMetadataWithAllDifficulties =>
+            new TranslatableString(getKey(@"sync_metadata_with_all_difficulties"), @"Sync metadata with all difficulties");
+
+        /// <summary>
+        /// "Copies artist, title, source, and tags to all difficulties."
+        /// </summary>
+        public static LocalisableString SyncMetadataWithAllDifficultiesTooltip => new TranslatableString(getKey(@"sync_metadata_with_all_difficulties_tooltip"),
+            @"Copies artist, title, source, and tags to all difficulties.");
+
+        /// <summary>
         /// "Ruleset ({0})"
         /// </summary>
         public static LocalisableString RulesetHeader(string arg0) => new TranslatableString(getKey(@"ruleset"), @"Ruleset ({0})", arg0);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1528,24 +1528,33 @@ namespace osu.Game.Screens.Edit
             loader?.CancelPendingDifficultySwitch();
         }
 
-        public Task<bool> SaveAndReload()
+        public Task<bool> SaveAndReload(bool withDialog = true)
         {
             var tcs = new TaskCompletionSource<bool>();
 
-            dialogOverlay.Push(new SaveAndReloadEditorDialog(
-                reload: () =>
+            void performReload()
+            {
+                bool reloadedSuccessfully = attemptMutationOperation(() =>
                 {
-                    bool reloadedSuccessfully = attemptMutationOperation(() =>
-                    {
-                        if (!Save())
-                            return false;
+                    if (!Save()) return false;
 
-                        SwitchToDifficulty(editorBeatmap.BeatmapInfo);
-                        return true;
-                    });
-                    tcs.SetResult(reloadedSuccessfully);
-                },
-                cancel: () => tcs.SetResult(false)));
+                    SwitchToDifficulty(editorBeatmap.BeatmapInfo);
+                    return true;
+                });
+                tcs.SetResult(reloadedSuccessfully);
+            }
+
+            if (withDialog)
+            {
+                dialogOverlay.Push(new SaveAndReloadEditorDialog(
+                    reload: performReload,
+                    cancel: () => tcs.SetResult(false)));
+            }
+            else
+            {
+                performReload();
+            }
+
             return tcs.Task;
         }
 

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -100,7 +100,12 @@ namespace osu.Game.Screens.Edit.Setup
                 if (b.Equals(current))
                     continue;
 
-                copySyncedMetadataTo(source, b.Metadata);
+                b.Metadata.ArtistUnicode = source.ArtistUnicode;
+                b.Metadata.Artist = source.Artist;
+                b.Metadata.TitleUnicode = source.TitleUnicode;
+                b.Metadata.Title = source.Title;
+                b.Metadata.Source = source.Source;
+                b.Metadata.Tags = source.Tags;
 
                 try
                 {
@@ -115,16 +120,6 @@ namespace osu.Game.Screens.Edit.Setup
 
             // Persist the current difficulty and align with how resource changes re-save the current beatmap.
             editor?.Save();
-        }
-
-        private static void copySyncedMetadataTo(BeatmapMetadata source, BeatmapMetadata target)
-        {
-            target.ArtistUnicode = source.ArtistUnicode;
-            target.Artist = source.Artist;
-            target.TitleUnicode = source.TitleUnicode;
-            target.Title = source.Title;
-            target.Source = source.Source;
-            target.Tags = source.Tags;
         }
 
         private TTextBox createTextBox<TTextBox>(LocalisableString label)

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Edit.Setup
                 try
                 {
                     var beatmapWorking = beatmaps.GetWorkingBeatmap(b);
-                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset));
+                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset), beatmapWorking.GetSkin());
                 }
                 catch (Exception e)
                 {

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -113,7 +113,8 @@ namespace osu.Game.Screens.Edit.Setup
                 }
                 catch (Exception e)
                 {
-                    Logger.Error(e, $"Failed to sync metadata to {b.GetDisplayTitle()}");
+                    Logger.Error(e, $@"Failed to sync metadata to {b.GetDisplayTitle()}");
+                    return;
                 }
             }
 

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -66,13 +66,7 @@ namespace osu.Game.Screens.Edit.Setup
                     Text = EditorSetupStrings.SyncMetadataWithAllDifficulties,
                     TooltipText = EditorSetupStrings.SyncMetadataWithAllDifficultiesTooltip,
                     Margin = new MarginPadding { Top = 10 },
-                    Action = () =>
-                    {
-                        if (working.Value.BeatmapSetInfo.Beatmaps.Count <= 1)
-                            return;
-
-                        dialogOverlay?.Push(new SyncMetadataConfirmationDialog(syncMetadataToAllOtherDifficulties));
-                    },
+                    Action = () => dialogOverlay?.Push(new SyncMetadataConfirmationDialog(syncMetadataToAllOtherDifficulties)),
                     Enabled = { Value = working.Value.BeatmapSetInfo.Beatmaps.Count > 1 }
                 }
             };
@@ -108,8 +102,8 @@ namespace osu.Game.Screens.Edit.Setup
 
                 try
                 {
-                    var beatmapWorking = beatmaps.GetWorkingBeatmap(b);
-                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset), beatmapWorking.GetSkin());
+                    var targetWorking = beatmaps.GetWorkingBeatmap(b);
+                    beatmaps.Save(b, targetWorking.GetPlayableBeatmap(b.Ruleset), targetWorking.GetSkin());
                 }
                 catch (Exception e)
                 {

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -118,7 +118,8 @@ namespace osu.Game.Screens.Edit.Setup
             }
 
             // Persist the current difficulty and align with how resource changes re-save the current beatmap.
-            editor?.Save();
+            // The reload is a crude measure to ensure places like the verify tab do not continue showing problems with mismatching metadata.
+            editor?.SaveAndReload(withDialog: false);
         }
 
         private TTextBox createTextBox<TTextBox>(LocalisableString label)

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -50,42 +50,31 @@ namespace osu.Game.Screens.Edit.Setup
         [BackgroundDependencyLoader]
         private void load(SetupScreen? setupScreen)
         {
-            ArtistTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Artist);
-            RomanisedArtistTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedArtist);
-            TitleTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Title);
-            RomanisedTitleTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedTitle);
-            creatorTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Creator);
-            difficultyTextBox = createTextBox<FormTextBox>(EditorSetupStrings.DifficultyName);
-            sourceTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoSource);
-            tagsTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoMapperTags);
-
-            var syncMetadataButton = new RoundedButton
-            {
-                RelativeSizeAxes = Axes.X,
-                Text = EditorSetupStrings.SyncMetadataWithAllDifficulties,
-                TooltipText = EditorSetupStrings.SyncMetadataWithAllDifficultiesTooltip,
-                Margin = new MarginPadding { Top = 10 },
-                Action = () =>
-                {
-                    if (working.Value.BeatmapSetInfo.Beatmaps.Count <= 1)
-                        return;
-
-                    dialogOverlay?.Push(new SyncMetadataConfirmationDialog(syncMetadataToAllOtherDifficulties));
-                },
-            };
-            syncMetadataButton.Enabled.Value = working.Value.BeatmapSetInfo.Beatmaps.Count > 1;
-
             Children = new Drawable[]
             {
-                ArtistTextBox,
-                RomanisedArtistTextBox,
-                TitleTextBox,
-                RomanisedTitleTextBox,
-                creatorTextBox,
-                difficultyTextBox,
-                sourceTextBox,
-                tagsTextBox,
-                syncMetadataButton,
+                ArtistTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Artist),
+                RomanisedArtistTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedArtist),
+                TitleTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Title),
+                RomanisedTitleTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedTitle),
+                creatorTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Creator),
+                difficultyTextBox = createTextBox<FormTextBox>(EditorSetupStrings.DifficultyName),
+                sourceTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoSource),
+                tagsTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoMapperTags),
+                new RoundedButton
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Text = EditorSetupStrings.SyncMetadataWithAllDifficulties,
+                    TooltipText = EditorSetupStrings.SyncMetadataWithAllDifficultiesTooltip,
+                    Margin = new MarginPadding { Top = 10 },
+                    Action = () =>
+                    {
+                        if (working.Value.BeatmapSetInfo.Beatmaps.Count <= 1)
+                            return;
+
+                        dialogOverlay?.Push(new SyncMetadataConfirmationDialog(syncMetadataToAllOtherDifficulties));
+                    },
+                    Enabled = { Value = working.Value.BeatmapSetInfo.Beatmaps.Count > 1 }
+                }
             };
 
             if (setupScreen != null)

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Edit.Setup
                 try
                 {
                     var beatmapWorking = beatmaps.GetWorkingBeatmap(b);
-                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset), beatmapWorking.GetSkin());
+                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset));
                 }
                 catch (Exception e)
                 {

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -1,14 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Localisation;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Resources.Localisation.Web;
 using osu.Game.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Edit.Setup
 {
@@ -33,25 +37,94 @@ namespace osu.Game.Screens.Edit.Setup
         [Resolved]
         private Editor? editor { get; set; }
 
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> working { get; set; } = null!;
+
         [BackgroundDependencyLoader]
         private void load(SetupScreen? setupScreen)
         {
-            Children = new[]
+            ArtistTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Artist);
+            RomanisedArtistTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedArtist);
+            TitleTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Title);
+            RomanisedTitleTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedTitle);
+            creatorTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Creator);
+            difficultyTextBox = createTextBox<FormTextBox>(EditorSetupStrings.DifficultyName);
+            sourceTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoSource);
+            tagsTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoMapperTags);
+
+            var syncMetadataButton = new RoundedButton
             {
-                ArtistTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Artist),
-                RomanisedArtistTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedArtist),
-                TitleTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Title),
-                RomanisedTitleTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedTitle),
-                creatorTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Creator),
-                difficultyTextBox = createTextBox<FormTextBox>(EditorSetupStrings.DifficultyName),
-                sourceTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoSource),
-                tagsTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoMapperTags)
+                RelativeSizeAxes = Axes.X,
+                Text = EditorSetupStrings.SyncMetadataWithAllDifficulties,
+                TooltipText = EditorSetupStrings.SyncMetadataWithAllDifficultiesTooltip,
+                Action = syncMetadataToAllOtherDifficulties,
+                Margin = new MarginPadding { Top = 10 },
+            };
+            syncMetadataButton.Enabled.Value = working.Value.BeatmapSetInfo.Beatmaps.Count > 1;
+
+            Children = new Drawable[]
+            {
+                ArtistTextBox,
+                RomanisedArtistTextBox,
+                TitleTextBox,
+                RomanisedTitleTextBox,
+                creatorTextBox,
+                difficultyTextBox,
+                sourceTextBox,
+                tagsTextBox,
+                syncMetadataButton,
             };
 
             if (setupScreen != null)
                 setupScreen.MetadataChanged += reloadMetadata;
 
             reloadMetadata();
+        }
+
+        private void syncMetadataToAllOtherDifficulties()
+        {
+            if (working.Value.BeatmapSetInfo.Beatmaps.Count <= 1)
+                return;
+
+            applyMetadata();
+
+            var set = working.Value.BeatmapSetInfo;
+            var current = Beatmap.BeatmapInfo;
+            var source = Beatmap.Metadata;
+
+            foreach (var b in set.Beatmaps)
+            {
+                if (b.Equals(current))
+                    continue;
+
+                copySyncedMetadataTo(source, b.Metadata);
+
+                try
+                {
+                    var beatmapWorking = beatmaps.GetWorkingBeatmap(b);
+                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset), beatmapWorking.GetSkin());
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, $"Failed to sync metadata to {b.GetDisplayTitle()}");
+                }
+            }
+
+            // Persist the current difficulty and align with how resource changes re-save the current beatmap.
+            editor?.Save();
+        }
+
+        private static void copySyncedMetadataTo(BeatmapMetadata source, BeatmapMetadata target)
+        {
+            target.ArtistUnicode = source.ArtistUnicode;
+            target.Artist = source.Artist;
+            target.TitleUnicode = source.TitleUnicode;
+            target.Title = source.Title;
+            target.Source = source.Source;
+            target.Tags = source.Tags;
         }
 
         private TTextBox createTextBox<TTextBox>(LocalisableString label)

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -12,6 +12,7 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
+using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Edit.Setup
@@ -43,6 +44,9 @@ namespace osu.Game.Screens.Edit.Setup
         [Resolved]
         private IBindable<WorkingBeatmap> working { get; set; } = null!;
 
+        [Resolved]
+        private IDialogOverlay? dialogOverlay { get; set; }
+
         [BackgroundDependencyLoader]
         private void load(SetupScreen? setupScreen)
         {
@@ -60,8 +64,14 @@ namespace osu.Game.Screens.Edit.Setup
                 RelativeSizeAxes = Axes.X,
                 Text = EditorSetupStrings.SyncMetadataWithAllDifficulties,
                 TooltipText = EditorSetupStrings.SyncMetadataWithAllDifficultiesTooltip,
-                Action = syncMetadataToAllOtherDifficulties,
                 Margin = new MarginPadding { Top = 10 },
+                Action = () =>
+                {
+                    if (working.Value.BeatmapSetInfo.Beatmaps.Count <= 1)
+                        return;
+
+                    dialogOverlay?.Push(new SyncMetadataConfirmationDialog(syncMetadataToAllOtherDifficulties));
+                },
             };
             syncMetadataButton.Enabled.Value = working.Value.BeatmapSetInfo.Beatmaps.Count > 1;
 

--- a/osu.Game/Screens/Edit/SyncMetadataConfirmationDialog.cs
+++ b/osu.Game/Screens/Edit/SyncMetadataConfirmationDialog.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Dialog;
+
+namespace osu.Game.Screens.Edit
+{
+    public partial class SyncMetadataConfirmationDialog : DangerousActionDialog
+    {
+        public SyncMetadataConfirmationDialog(Action syncAction)
+        {
+            BodyText = EditorDialogsStrings.SyncMetadataConfirmationBody;
+            DangerousAction = syncAction;
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/e8f67f68-1f36-45ef-a50b-3284a8350ffd

This has been a pain point in both lazer and stable, and people usually use external tools for this kind of stuff for stable.