### PR TITLE
Preserve legacy Background event offsets in beatmap encode/decode

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -217,6 +217,25 @@ namespace osu.Game.Tests.Beatmaps.Formats
         }
 
         [Test]
+        public void TestBackgroundOffsetsRoundTrip()
+        {
+            var beatmap = new Beatmap();
+            var meta = beatmap.BeatmapInfo.Metadata;
+            meta.BackgroundFile = "test bg.jpg";
+            meta.BackgroundOffsetX = 10.25f;
+            meta.BackgroundOffsetY = -42f;
+
+            var encoded = EncodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty)));
+            encoded.Position = 0;
+
+            var decoded = new LegacyBeatmapDecoder { ApplyOffsets = false }.Decode(new LineBufferedReader(encoded));
+
+            Assert.That(decoded.BeatmapInfo.Metadata.BackgroundFile, Is.EqualTo(meta.BackgroundFile));
+            Assert.That(decoded.BeatmapInfo.Metadata.BackgroundOffsetX, Is.EqualTo(meta.BackgroundOffsetX));
+            Assert.That(decoded.BeatmapInfo.Metadata.BackgroundOffsetY, Is.EqualTo(meta.BackgroundOffsetY));
+        }
+
+        [Test]
         public void TestEncodeStabilityOfSliderWithFractionalCoordinates()
         {
             Slider originalSlider = new Slider

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -433,6 +433,8 @@ namespace osu.Game.Beatmaps
                         PreviewTime = decoded.Metadata.PreviewTime,
                         AudioFile = decoded.Metadata.AudioFile,
                         BackgroundFile = decoded.Metadata.BackgroundFile,
+                        BackgroundOffsetX = decoded.Metadata.BackgroundOffsetX,
+                        BackgroundOffsetY = decoded.Metadata.BackgroundOffsetY,
                     };
 
                     var beatmap = new BeatmapInfo(ruleset, difficulty, metadata)

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -61,6 +61,16 @@ namespace osu.Game.Beatmaps
         public string AudioFile { get; set; } = string.Empty;
         public string BackgroundFile { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Horizontal offset in pixels of the legacy Background event (fourth column in <c>[Events]</c>).
+        /// </summary>
+        public float BackgroundOffsetX { get; set; }
+
+        /// <summary>
+        /// Vertical offset in pixels of the legacy Background event (fifth column in <c>[Events]</c>).
+        /// </summary>
+        public float BackgroundOffsetY { get; set; }
+
         public BeatmapMetadata(RealmUser? user = null)
         {
             Author = user ?? new RealmUser();
@@ -85,7 +95,9 @@ namespace osu.Game.Beatmaps
             Tags = Tags,
             PreviewTime = PreviewTime,
             AudioFile = AudioFile,
-            BackgroundFile = BackgroundFile
+            BackgroundFile = BackgroundFile,
+            BackgroundOffsetX = BackgroundOffsetX,
+            BackgroundOffsetY = BackgroundOffsetY
         };
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -465,9 +465,16 @@ namespace osu.Game.Beatmaps.Formats
                         break;
 
                     case LegacyEventType.Background:
-                        beatmap.BeatmapInfo.Metadata.BackgroundFile = CleanFilename(split[2]);
+                    {
+                        var metadata = beatmap.BeatmapInfo.Metadata;
+                        metadata.BackgroundFile = CleanFilename(split[2]);
+                        if (split.Length > 3)
+                            metadata.BackgroundOffsetX = Parsing.ParseFloat(split[3], Parsing.MAX_COORDINATE_VALUE);
+                        if (split.Length > 4)
+                            metadata.BackgroundOffsetY = Parsing.ParseFloat(split[4], Parsing.MAX_COORDINATE_VALUE);
                         lineSupportedByEncoder = true;
                         break;
+                    }
 
                     case LegacyEventType.Break:
                         double start = getOffsetTime(Parsing.ParseDouble(split[1]));

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -152,7 +152,10 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine("[Events]");
 
             if (!string.IsNullOrEmpty(beatmap.BeatmapInfo.Metadata.BackgroundFile))
-                writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Background},0,\"{beatmap.BeatmapInfo.Metadata.BackgroundFile}\",0,0"));
+            {
+                var metadata = beatmap.BeatmapInfo.Metadata;
+                writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Background},0,\"{metadata.BackgroundFile}\",{metadata.BackgroundOffsetX},{metadata.BackgroundOffsetY}"));
+            }
 
             foreach (var b in beatmap.Breaks)
                 writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Break},{b.StartTime},{b.EndTime}"));

--- a/osu.Game/Beatmaps/IBeatmapMetadataInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapMetadataInfo.cs
@@ -62,6 +62,16 @@ namespace osu.Game.Beatmaps
         /// </summary>
         string BackgroundFile { get; }
 
+        /// <summary>
+        /// Horizontal offset in pixels of the legacy Background event (fourth column in <c>[Events]</c>).
+        /// </summary>
+        float BackgroundOffsetX { get; }
+
+        /// <summary>
+        /// Vertical offset in pixels of the legacy Background event (fifth column in <c>[Events]</c>).
+        /// </summary>
+        float BackgroundOffsetY { get; }
+
         bool IEquatable<IBeatmapMetadataInfo>.Equals(IBeatmapMetadataInfo? other)
         {
             if (other == null)
@@ -76,7 +86,9 @@ namespace osu.Game.Beatmaps
                    && Tags == other.Tags
                    && PreviewTime == other.PreviewTime
                    && AudioFile == other.AudioFile
-                   && BackgroundFile == other.BackgroundFile;
+                   && BackgroundFile == other.BackgroundFile
+                   && BackgroundOffsetX.Equals(other.BackgroundOffsetX)
+                   && BackgroundOffsetY.Equals(other.BackgroundOffsetY);
         }
     }
 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -101,8 +101,9 @@ namespace osu.Game.Database
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
+        /// 52   2026-04-21    Add Background offset fields to BeatmapMetadata.
         /// </summary>
-        private const int schema_version = 51;
+        private const int schema_version = 52;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.


### PR DESCRIPTION
The reason why this change matters is osu!taiko.

While this may be irrelevant in other modes, osu!taiko has been using these values since the dawn of time to control the background alignment to properly fit the playfield. We currently even have a ranking criteria [rule, instructions](https://osu.ppy.sh/wiki/en/Ranking_criteria/osu%21taiko#:~:text=Do%20not%20leave,move%20it%20up.), and a [guideline](https://osu.ppy.sh/wiki/en/Ranking_criteria/osu%21taiko#:~:text=Avoid%20covering%20essential%20parts%20of%20the%20background%20with%20the%20taiko%20playfield.) dedicated to this parameter.

Its absence from lazer parsing causes issues with exports, and more critically with BSS where background offsets get lost on upload, leading to [disqualifications like this](https://osu.ppy.sh/beatmapsets/2439392/discussion/-/generalAll#/5384223). The only workaround is to rely on stable's BSS, which raises the question: why use lazer BSS at all for a taiko map’s final update? Updating through stable also wipes version history, effectively undermining that feature altogether.