### PR TITLE
Attempt to fix ranked play preview tracks not stopping when entering gameplay

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -8,9 +8,11 @@ using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand;
 using osuTK.Input;
 
@@ -213,6 +215,42 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddStep("change player 1 health", () => MultiplayerClient.RankedPlayChangeUserState(MultiplayerClient.LocalUser!.UserID, state => state.Life = 250_000).WaitSafely());
             AddWaitStep("wait", 5);
             AddStep("change player 2 health", () => MultiplayerClient.RankedPlayChangeUserState(2, state => state.Life = 250_000).WaitSafely());
+        }
+
+        [Test]
+        public void TestPreviewStopsOnEnteringGameplay()
+        {
+            AddStep("join other user", () => MultiplayerClient.AddUser(new APIUser { Id = 2 }));
+
+            AddStep("load screen", () => LoadScreen(screen = new RankedPlayScreen(MultiplayerClient.ClientRoom!)));
+
+            var requestHandler = new BeatmapRequestHandler();
+
+            AddStep("setup request handler", () => ((DummyAPIAccess)API).HandleRequest = requestHandler.HandleRequest);
+
+            AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActiveUserId = 1001).WaitSafely());
+
+            for (int i = 0; i < 3; i++)
+            {
+                int i2 = i;
+                AddStep("reveal card", () => MultiplayerClient.RankedPlayRevealCard(hand => hand[i2], new MultiplayerPlaylistItem
+                {
+                    ID = i2,
+                    BeatmapID = requestHandler.Beatmaps[i2].OnlineID
+                }).WaitSafely());
+            }
+
+            AddStep("hover first card", () => InputManager.MoveMouseTo(this.ChildrenOfType<PlayerHandOfCards>().Single().Cards.First()));
+            AddUntilStep("preview playing", () => this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().Any(p => p.IsRunning), () => Is.True);
+
+            AddWaitStep("wait", 1);
+            AddStep("play beatmap", () => MultiplayerClient.PlayUserCard(1001, hand => hand[0]).WaitSafely());
+
+            AddStep("set warmup", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.GameplayWarmup).WaitSafely());
+            AddUntilStep("preview running", () => this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().Any(p => p.IsRunning), () => Is.True);
+
+            AddStep("load requested", () => ((IMultiplayerClient)MultiplayerClient).LoadRequested());
+            AddUntilStep("preview stopped", () => this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().Any(p => p.IsRunning), () => Is.False);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
             private OsuColour colours { get; set; } = null!;
 
             [Resolved]
-            private RankedPlayScreen rankedPlayScreen { get; set; } = null!;
+            private RankedPlayScreen? rankedPlayScreen { get; set; }
 
             public readonly IBindable<SongPreviewContainer?> CurrentPlayingPreview = new Bindable<SongPreviewContainer?>();
 
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 // - https://github.com/ppy/osu-framework/pull/6728
                 // - https://github.com/ppy/osu/pull/37218
                 // - https://github.com/ppy/osu/pull/37453
-                if (!rankedPlayScreen.IsCurrentScreen())
+                if (rankedPlayScreen?.IsCurrentScreen() == false)
                     return;
 
                 bool shouldBePlaying = CurrentPlayingPreview.Value == this;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
+using osu.Framework.Screens;
 using osu.Framework.Timing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -46,6 +47,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             [Resolved]
             private OsuColour colours { get; set; } = null!;
+
+            [Resolved]
+            private RankedPlayScreen rankedPlayScreen { get; set; } = null!;
 
             public readonly IBindable<SongPreviewContainer?> CurrentPlayingPreview = new Bindable<SongPreviewContainer?>();
 
@@ -108,6 +112,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
             private void updatePlayingState()
             {
                 if (previewTrack?.IsLoaded != true)
+                    return;
+
+                // TODO: the ranked play screen current check should not be required. `IPreviewTrackOwner` should be handling all of this.
+                // the reason why all of this logic is so wonky and `Update()`-based is because of framework breakage that causes hard crashes
+                // in inopportune threading arrangements.
+                // read:
+                // - https://github.com/ppy/osu-framework/pull/6727
+                // - https://github.com/ppy/osu-framework/pull/6728
+                // - https://github.com/ppy/osu/pull/37218
+                // - https://github.com/ppy/osu/pull/37453
+                if (!rankedPlayScreen.IsCurrentScreen())
                     return;
 
                 bool shouldBePlaying = CurrentPlayingPreview.Value == this;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/37471 probably.

This is a dogshit change but I have no better.

This regressed in https://github.com/ppy/osu/pull/37453 because of trying to work around the framework bug which makes attempting to start or stop the track in certain threading scenarios kill the game.

Changing the playback logic to be `Update()`-based broke `.StopAnyPlaying()` calls. In particular this one.

https://github.com/ppy/osu/blob/71356a9455e0738b942371e3f78134e8b14ec7ab/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs#L361

So to fix attempt to manually check whether the ranked play screen is still current in the update loop jank so that it doesn't restart the track if it was stopped by the screen suspending.

How confident am I that this won't break in some eldritch threading scenario? Not very! ~~I can sprinkle a `StopAnyPlaying()` in `MultiplayerPlayerLoader` if it helps. That one *should* theoretically be safer. But also double the dogshit.~~ I realise now that that wouldn't even work.

Note that I previously tried to fix the framework bug that causes all this in https://github.com/ppy/osu-framework/pull/6727. That PR was briefly reverted in https://github.com/ppy/osu-framework/pull/6728 because it started failing CI game-side due to some other audio-related safety issue that I haven't investigated yet but @smoogipoo apparently has vague awareness of.

Anyone thinking they can do better is cordially invited to try.

The other choice is just reverting all of my attempts and just accepting that players on single thread shall be indiscriminately and randomly smited for trying to play on single thread.