### PR TITLE
Hide user tags section on beatmap overlay if beatmap doesn't have user tags

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -23,18 +23,19 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private readonly Box successRateBackground;
         private readonly Box background;
-        private readonly MetadataSection<string[]?> userTags;
 
         public readonly Bindable<APIBeatmapSet> BeatmapSet = new Bindable<APIBeatmapSet>();
         public readonly Bindable<APIBeatmap> Beatmap = new Bindable<APIBeatmap>();
 
         public Info()
         {
-            SuccessRate successRate;
             MetadataSectionNominators nominators;
-            MetadataSection source, mapperTags;
+            MetadataSectionSource source;
             MetadataSectionGenre genre;
             MetadataSectionLanguage language;
+            MetadataSectionUserTags userTags;
+            MetadataSectionMapperTags mapperTags;
+            SuccessRate successRate;
 
             RelativeSizeAxes = Axes.X;
             Height = base_height;
@@ -115,21 +116,15 @@ namespace osu.Game.Overlays.BeatmapSet
             {
                 nominators.Metadata = (b.NewValue?.CurrentNominations ?? Array.Empty<BeatmapSetOnlineNomination>(), b.NewValue?.RelatedUsers ?? Array.Empty<APIUser>());
                 source.Metadata = b.NewValue?.Source ?? string.Empty;
-                mapperTags.Metadata = b.NewValue?.Tags ?? string.Empty;
-                updateUserTags();
                 genre.Metadata = b.NewValue?.Genre ?? new BeatmapSetOnlineGenre { Id = (int)SearchGenre.Unspecified };
                 language.Metadata = b.NewValue?.Language ?? new BeatmapSetOnlineLanguage { Id = (int)SearchLanguage.Unspecified };
+                mapperTags.Metadata = b.NewValue?.Tags ?? string.Empty;
             });
             Beatmap.BindValueChanged(b =>
             {
+                userTags.Metadata = b.NewValue?.GetTopUserTags().Select(t => t.Tag.Name).ToArray();
                 successRate.Beatmap = b.NewValue;
-                updateUserTags();
             });
-        }
-
-        private void updateUserTags()
-        {
-            userTags.Metadata = Beatmap.Value?.GetTopUserTags().Select(t => t.Tag.Name).ToArray();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Overlays.BeatmapSet
             });
             Beatmap.BindValueChanged(b =>
             {
-                userTags.Metadata = b.NewValue?.GetTopUserTags().Select(t => t.Tag.Name).ToArray();
+                userTags.Metadata = b.NewValue?.GetTopUserTags().Select(t => t.Tag.Name).ToArray() ?? Array.Empty<string>();
                 successRate.Beatmap = b.NewValue;
             });
         }

--- a/osu.Game/Overlays/BeatmapSet/MetadataSectionUserTags.cs
+++ b/osu.Game/Overlays/BeatmapSet/MetadataSectionUserTags.cs
@@ -2,17 +2,32 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.Chat;
 
 namespace osu.Game.Overlays.BeatmapSet
 {
-    public partial class MetadataSectionUserTags : MetadataSection<string[]?>
+    public partial class MetadataSectionUserTags : MetadataSection<string[]>
     {
         private readonly Action<string>? searchAction;
 
+        public override string[] Metadata
+        {
+            set
+            {
+                if (value.Length == 0)
+                {
+                    this.FadeOut(TRANSITION_DURATION);
+                    return;
+                }
+
+                base.Metadata = value;
+            }
+        }
+
         public MetadataSectionUserTags(Action<string>? searchAction = null)
-            : base(MetadataType.UserTags, null)
+            : base(MetadataType.UserTags)
         {
             this.searchAction = searchAction;
         }


### PR DESCRIPTION
this empty section constantly caught my eye, now it matches web

| master | `osu-web` | PR |
|-|-|-|
| <img width="256" height="322" alt="image" src="https://github.com/user-attachments/assets/f856498d-6ba1-4390-997d-c5c2bcd6483b" /> | <img width="196" height="293" alt="image" src="https://github.com/user-attachments/assets/a517b5c5-8ef1-490d-91ca-e5d76b36e7f1" /> | <img width="262" height="322" alt="image" src="https://github.com/user-attachments/assets/f452f601-6223-4f69-8035-4d2ce3dd0839" /> |
| <img width="272" height="314" alt="image" src="https://github.com/user-attachments/assets/7486f706-5d18-4841-b8a6-f91ebf631636" /> | <img width="194" height="238" alt="image" src="https://github.com/user-attachments/assets/30124fc1-9668-4321-b2d2-0e6ae1699e0f" /> | <img width="258" height="259" alt="image" src="https://github.com/user-attachments/assets/3a317f70-bb4a-42ce-9d56-e25c2302800c" /> |

also slightly reordered some local variables for convenience, can be reverted if you want to keep previous order
