### PR TITLE
Apply different workaround to fix ranked play single thread audio issues

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -8,9 +8,11 @@ using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand;
 using osuTK.Input;
 
@@ -213,6 +215,42 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddStep("change player 1 health", () => MultiplayerClient.RankedPlayChangeUserState(MultiplayerClient.LocalUser!.UserID, state => state.Life = 250_000).WaitSafely());
             AddWaitStep("wait", 5);
             AddStep("change player 2 health", () => MultiplayerClient.RankedPlayChangeUserState(2, state => state.Life = 250_000).WaitSafely());
+        }
+
+        [Test]
+        public void TestPreviewStopsOnEnteringGameplay()
+        {
+            AddStep("join other user", () => MultiplayerClient.AddUser(new APIUser { Id = 2 }));
+
+            AddStep("load screen", () => LoadScreen(screen = new RankedPlayScreen(MultiplayerClient.ClientRoom!)));
+
+            var requestHandler = new BeatmapRequestHandler();
+
+            AddStep("setup request handler", () => ((DummyAPIAccess)API).HandleRequest = requestHandler.HandleRequest);
+
+            AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActiveUserId = 1001).WaitSafely());
+
+            for (int i = 0; i < 3; i++)
+            {
+                int i2 = i;
+                AddStep("reveal card", () => MultiplayerClient.RankedPlayRevealCard(hand => hand[i2], new MultiplayerPlaylistItem
+                {
+                    ID = i2,
+                    BeatmapID = requestHandler.Beatmaps[i2].OnlineID
+                }).WaitSafely());
+            }
+
+            AddStep("hover first card", () => InputManager.MoveMouseTo(this.ChildrenOfType<PlayerHandOfCards>().Single().Cards.First()));
+            AddUntilStep("preview playing", () => this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().Any(p => p.IsRunning), () => Is.True);
+
+            AddWaitStep("wait", 1);
+            AddStep("play beatmap", () => MultiplayerClient.PlayUserCard(1001, hand => hand[0]).WaitSafely());
+
+            AddStep("set warmup", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.GameplayWarmup).WaitSafely());
+            AddUntilStep("preview running", () => this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().Any(p => p.IsRunning), () => Is.True);
+
+            AddStep("load requested", () => ((IMultiplayerClient)MultiplayerClient).LoadRequested());
+            AddUntilStep("preview stopped", () => this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().Any(p => p.IsRunning), () => Is.False);
         }
     }
 }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneSongPreview.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneSongPreview.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Online.API;
@@ -14,9 +15,9 @@ namespace osu.Game.Tests.Visual.RankedPlay
 {
     public partial class TestSceneSongPreview : RankedPlayTestScene
     {
-        private readonly BeatmapRequestHandler requestHandler = new BeatmapRequestHandler();
+        private readonly Bindable<bool> previewEnabled = new BindableBool(true);
 
-        private PlayerHandOfCards handOfCards = null!;
+        private readonly BeatmapRequestHandler requestHandler = new BeatmapRequestHandler();
 
         public override void SetUpSteps()
         {
@@ -26,6 +27,8 @@ namespace osu.Game.Tests.Visual.RankedPlay
 
             AddStep("add cards", () =>
             {
+                PlayerHandOfCards handOfCards;
+
                 Child = handOfCards = new PlayerHandOfCards
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -35,10 +38,15 @@ namespace osu.Game.Tests.Visual.RankedPlay
                 };
 
                 foreach (var beatmap in requestHandler.Beatmaps.Take(3))
-                    handOfCards.AddCard(new RevealedRankedPlayCardWithPlaylistItem(beatmap));
+                {
+                    handOfCards.AddCard(new RevealedRankedPlayCardWithPlaylistItem(beatmap), handCard =>
+                    {
+                        handCard.Card.SongPreviewEnabled.BindTarget = previewEnabled;
+                    });
+                }
             });
 
-            AddUntilStep("load tracks", () => this.ChildrenOfType<RankedPlayCard>().All(card => card.SongPreview.TrackLoaded));
+            AddUntilStep("load tracks", () => this.ChildrenOfType<RankedPlayCard>().All(card => card.PreviewTrackLoaded));
         }
 
         [Test]
@@ -46,25 +54,25 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("move mouse to first card", () => InputManager.MoveMouseTo(getCard(0)));
 
-            AddAssert("first track running", () => getCard(0).SongPreview.IsRunning);
-            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.SongPreview.IsRunning) == 1);
+            AddAssert("first track running", () => getCard(0).PreviewTrackRunning);
+            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
 
             AddStep("move mouse to second card", () => InputManager.MoveMouseTo(getCard(1)));
-            AddAssert("second track running", () => getCard(1).SongPreview.IsRunning);
-            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.SongPreview.IsRunning) == 1);
 
-            AddStep("disable preview", () => handOfCards.CurrentPlayingPreview.Value = null);
-            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.SongPreview.IsRunning));
+            AddAssert("second track running", () => getCard(1).PreviewTrackRunning);
+            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.PreviewTrackRunning) == 1);
+
+            AddStep("disable preview", () => previewEnabled.Value = false);
+
+            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
 
             AddStep("move mouse to third card", () => InputManager.MoveMouseTo(getCard(2)));
-            AddAssert("third track running", () => getCard(2).SongPreview.IsRunning);
 
-            AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
-            AddAssert("third track running", () => getCard(2).SongPreview.IsRunning);
+            AddAssert("no tracks running", () => !this.ChildrenOfType<RankedPlayCard>().Any(c => c.PreviewTrackRunning));
 
-            AddStep("move mouse to second card", () => InputManager.MoveMouseTo(getCard(1)));
-            AddAssert("second track running", () => getCard(1).SongPreview.IsRunning);
-            AddAssert("only one track running", () => this.ChildrenOfType<RankedPlayCard>().Count(c => c.SongPreview.IsRunning) == 1);
+            AddStep("enable preview", () => previewEnabled.Value = true);
+
+            AddAssert("third track running", () => getCard(2).PreviewTrackRunning);
         }
 
         private RankedPlayCard getCard(int index) => this.ChildrenOfType<RankedPlayCard>().ElementAt(index);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
+using osu.Framework.Threading;
 using osu.Framework.Timing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -85,7 +86,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 {
                     if (!enabled.NewValue)
                     {
-                        previewTrack?.Stop();
+                        stopPreviewIfAvailable();
                         return;
                     }
 
@@ -132,7 +133,44 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 });
             }
 
-            private void startPreviewIfAvailable() => previewTrack?.Start();
+            // The following weirdness is a workaround for single-threaded crashes when
+            // attempting to start a track before it's fully loaded.
+            //
+            // See https://github.com/ppy/osu-framework/pull/6727
+            //     https://github.com/ppy/osu/pull/37473
+            private ScheduledDelegate? trackStartStopAction;
+
+            private void startPreviewIfAvailable()
+            {
+                if (previewTrack == null)
+                    return;
+
+                trackStartStopAction?.Cancel();
+
+                if (!previewTrack.TrackLoaded)
+                {
+                    trackStartStopAction = Schedule(startPreviewIfAvailable);
+                    return;
+                }
+
+                previewTrack?.Start();
+            }
+
+            private void stopPreviewIfAvailable()
+            {
+                if (previewTrack == null)
+                    return;
+
+                trackStartStopAction?.Cancel();
+
+                if (!previewTrack.TrackLoaded)
+                {
+                    trackStartStopAction = Schedule(stopPreviewIfAvailable);
+                    return;
+                }
+
+                previewTrack?.Stop();
+            }
 
             #region IBeatSyncProvider implementation
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -45,6 +45,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             private readonly Container overlayLayer;
 
+            private bool shouldBePlaying => Enabled.Value && CardHovered.Value;
+
             [Resolved]
             private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
@@ -75,6 +77,33 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 ];
             }
 
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Enabled.BindValueChanged(enabled =>
+                {
+                    if (!enabled.NewValue)
+                    {
+                        previewTrack?.Stop();
+                        return;
+                    }
+
+                    if (shouldBePlaying)
+                    {
+                        startPreviewIfAvailable();
+                    }
+                });
+
+                CardHovered.BindValueChanged(selected =>
+                {
+                    if (selected.NewValue && shouldBePlaying)
+                    {
+                        startPreviewIfAvailable();
+                    }
+                });
+            }
+
             private PreviewTrack? previewTrack;
 
             public void LoadPreview(APIBeatmap beatmap)
@@ -97,31 +126,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                     {
                         TrackRunning = { BindTarget = trackRunning }
                     });
+
+                    if (shouldBePlaying)
+                        startPreviewIfAvailable();
                 });
             }
 
-            protected override void Update()
-            {
-                base.Update();
-
-                updatePlayingState();
-            }
-
-            private void updatePlayingState()
-            {
-                if (previewTrack?.IsLoaded != true)
-                    return;
-
-                bool shouldBePlaying = Enabled.Value && CardHovered.Value;
-
-                if (shouldBePlaying == previewTrack.IsRunning)
-                    return;
-
-                if (shouldBePlaying)
-                    previewTrack.Start();
-                else
-                    previewTrack.Stop();
-            }
+            private void startPreviewIfAvailable() => previewTrack?.Start();
 
             #region IBeatSyncProvider implementation
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.SongPreview.cs
@@ -31,6 +31,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
         {
             private const double minimum_beat_length = 800;
 
+            public readonly Bindable<bool> Enabled = new BindableBool(true);
+
+            public readonly Bindable<bool> CardHovered = new BindableBool(true);
+
             public bool TrackLoaded => previewTrack?.TrackLoaded ?? false;
 
             public bool IsRunning => previewTrack?.IsRunning ?? false;
@@ -46,8 +50,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             [Resolved]
             private OsuColour colours { get; set; } = null!;
-
-            public readonly IBindable<SongPreviewContainer?> CurrentPlayingPreview = new Bindable<SongPreviewContainer?>();
 
             public SongPreviewContainer()
             {
@@ -110,7 +112,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                 if (previewTrack?.IsLoaded != true)
                     return;
 
-                bool shouldBePlaying = CurrentPlayingPreview.Value == this;
+                bool shouldBePlaying = Enabled.Value && CardHovered.Value;
 
                 if (shouldBePlaying == previewTrack.IsRunning)
                     return;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCard.cs
@@ -31,18 +31,28 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
         private readonly IBindable<MultiplayerPlaylistItem?> playlistItem;
 
+        public readonly Bindable<bool> SongPreviewEnabled = new BindableBool(true);
+
         private readonly Container content;
         private readonly Container cardContent;
         private readonly Container shadow;
         private readonly SelectionOutline selectionOutline;
-        public readonly SongPreviewContainer SongPreview;
+        private readonly SongPreviewContainer songPreviewContainer;
 
         public bool ShowSelectionOutline
         {
             set => selectionOutline.FadeTo(value ? 1 : 0, 50);
         }
 
+        public bool PlayAudioPreview
+        {
+            set => songPreviewContainer.CardHovered.Value = value;
+        }
+
         public float Elevation;
+
+        public bool PreviewTrackLoaded => songPreviewContainer.TrackLoaded;
+        public bool PreviewTrackRunning => songPreviewContainer.IsRunning;
 
         private Sample? cardFlipSample;
 
@@ -57,8 +67,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
 
             playlistItem = item.PlaylistItem.GetBoundCopy();
 
-            InternalChild = SongPreview = new SongPreviewContainer
+            InternalChild = songPreviewContainer = new SongPreviewContainer
             {
+                Enabled = { BindTarget = SongPreviewEnabled },
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -162,7 +173,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
             Schedule(() =>
             {
                 SetContent(new RankedPlayCardContent(beatmap));
-                SongPreview.LoadPreview(beatmap);
+                songPreviewContainer.LoadPreview(beatmap);
             });
         });
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -253,14 +253,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             foreach (var item in discardedCards)
             {
-                if (!playerHand.DetachCard(item, out var card, out Quad drawQuad))
+                if (!playerHand.RemoveCard(item, out var card, out Quad drawQuad))
                     return;
 
                 card.Anchor = Anchor.Centre;
                 card.Origin = Anchor.Centre;
 
-                if (playerHand.CurrentPlayingPreview.Value == card.SongPreview)
-                    playerHand.CurrentPlayingPreview.Value = null;
+                card.SongPreviewEnabled.Value = false;
 
                 card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
 
@@ -334,7 +333,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             foreach (var item in matchInfo.PlayerCards)
             {
-                if (playerHand.DetachCard(item, out var card, out Quad drawQuad))
+                if (playerHand.RemoveCard(item, out var card, out Quad drawQuad))
                 {
                     card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.HandCard.cs
@@ -104,6 +104,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
                 handOfCards.OnCardStateChanged(this, state);
 
                 Card.ShowSelectionOutline = state.NewValue.Selected;
+                Card.PlayAudioPreview = state.NewValue.Hovered;
 
                 switch (state.NewValue.Pressed, state.OldValue.Pressed)
                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/HandOfCards.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
 
         public void AddCard(RankedPlayCardWithPlaylistItem item, Action<HandCard>? setupAction = null) => AddCard(new RankedPlayCard(item), setupAction);
 
-        public virtual void AddCard(RankedPlayCard card, Action<HandCard>? setupAction = null)
+        public void AddCard(RankedPlayCard card, Action<HandCard>? setupAction = null)
         {
             if (cardLookup.ContainsKey(card.Item.Card))
                 return;
@@ -159,7 +159,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// <param name="card">Contained <see cref="RankedPlayCard"/></param>
         /// <param name="screenSpaceDrawQuad"><see cref="Drawable.ScreenSpaceDrawQuad"/> of the removed card</param>
         /// <returns>Whether a card was found for the provided item</returns>
-        public virtual bool DetachCard(RankedPlayCardWithPlaylistItem item, [MaybeNullWhen(false)] out RankedPlayCard card, out Quad screenSpaceDrawQuad)
+        public bool RemoveCard(RankedPlayCardWithPlaylistItem item, [MaybeNullWhen(false)] out RankedPlayCard card, out Quad screenSpaceDrawQuad)
         {
             if (!cardLookup.Remove(item.Card, out var drawable))
             {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Online.RankedPlay;
@@ -84,17 +82,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         /// </summary>
         public IEnumerable<RankedPlayCardWithPlaylistItem> Selection => selection.Select(it => it.Card.Item);
 
-        /// <summary>
-        /// The currently-playing preview.
-        /// </summary>
-        /// <remarks>
-        /// Note that due to how cards get detached and handed off between multiple <see cref="HandOfCards"/> instances and non-hand containers,
-        /// DI cannot be reliably used to pass this bindable down to children
-        /// because it'll only work for the first <see cref="PlayerHandOfCards"/> that <see cref="RankedPlayCard"/>s bind to.
-        /// Instead, <see cref="AddCard"/> and <see cref="DetachCard"/> overrides in this class set up this bindable manually as cards are handed off between stages.
-        /// </remarks>
-        public readonly Bindable<RankedPlayCard.SongPreviewContainer?> CurrentPlayingPreview = new Bindable<RankedPlayCard.SongPreviewContainer?>();
-
         private readonly BindableBool allowSelection = new BindableBool();
 
         private const int select_samples = 1;
@@ -122,19 +109,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
             AllowSelection = allowSelection.GetBoundCopy(),
             PlayAction = PlayCardAction,
         };
-
-        public override void AddCard(RankedPlayCard card, Action<HandCard>? setupAction = null)
-        {
-            base.AddCard(card, setupAction);
-            card.SongPreview.CurrentPlayingPreview.BindTo(CurrentPlayingPreview);
-        }
-
-        public override bool DetachCard(RankedPlayCardWithPlaylistItem item, [MaybeNullWhen(false)] out RankedPlayCard card, out Quad screenSpaceDrawQuad)
-        {
-            bool result = base.DetachCard(item, out card, out screenSpaceDrawQuad);
-            card?.SongPreview.CurrentPlayingPreview.UnbindFrom(CurrentPlayingPreview);
-            return result;
-        }
 
         private void cardClicked(PlayerHandCard card)
         {
@@ -170,9 +144,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         protected override void OnCardStateChanged(HandCard card, ValueChangedEvent<RankedPlayCardState> evt)
         {
             StateChanged?.Invoke();
-
-            if (evt.NewValue.Hovered)
-                CurrentPlayingPreview.Value = card.Card.SongPreview;
 
             base.OnCardStateChanged(card, evt);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/OpponentPickScreen.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             {
                 RankedPlayCard? card;
 
-                if (opponentHand.DetachCard(item, out card, out var drawQuad))
+                if (opponentHand.RemoveCard(item, out card, out var drawQuad))
                 {
                     card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
                 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             RankedPlayCard? card;
 
-            if (playerHand.DetachCard(item, out card, out var drawQuad))
+            if (playerHand.RemoveCard(item, out card, out var drawQuad))
             {
                 card.MatchScreenSpaceDrawQuad(drawQuad, CenterRow);
             }


### PR DESCRIPTION
Thing to make release happen.

Reverts #37453
Reverts #37463
Alternative to #37473

Not that I disagree with any of these but I'm just looking to return to what works so we can do a release because we're on a clock here for other reasons.

Test which should work but doesn't, so I'm not adding:

```diff
diff --git a/osu.Game.Tests/Visual/RankedPlay/TestSceneOpponentPickScreen.cs b/osu.Game.Tests/Visual/RankedPlay/TestSceneOpponentPickScreen.cs
index f747004bbd..eb8e360d1e 100644
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneOpponentPickScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneOpponentPickScreen.cs
@@ -1,12 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Extensions;
+using osu.Framework.Testing;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand;
 
 namespace osu.Game.Tests.Visual.RankedPlay
 {
@@ -14,6 +19,8 @@ public partial class TestSceneOpponentPickScreen : RankedPlayTestScene
     {
         private RankedPlayScreen screen = null!;
 
+        private readonly BeatmapRequestHandler requestHandler = new BeatmapRequestHandler();
+
         public override void SetUpSteps()
         {
             base.SetUpSteps();
@@ -26,8 +33,6 @@ public override void SetUpSteps()
             AddStep("load screen", () => LoadScreen(screen = new RankedPlayScreen(MultiplayerClient.ClientRoom!)));
             AddUntilStep("screen loaded", () => screen.IsLoaded);
 
-            var requestHandler = new BeatmapRequestHandler();
-
             AddStep("setup request handler", () => ((DummyAPIAccess)API).HandleRequest = requestHandler.HandleRequest);
 
             AddStep("set pick state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActiveUserId = 2).WaitSafely());
@@ -44,7 +49,11 @@ public override void SetUpSteps()
                     }).WaitSafely();
                 }
             });
+        }
 
+        [Test]
+        public void TestBasic()
+        {
             AddWaitStep("wait", 15);
 
             AddStep("play beatmap", () => MultiplayerClient.PlayUserCard(2, hand => hand[0]).WaitSafely());
@@ -54,5 +63,29 @@ public override void SetUpSteps()
                 BeatmapID = requestHandler.Beatmaps[0].OnlineID
             }).WaitSafely());
         }
+
+        [Test]
+        public void TestPickPreviewPlayedOnOpponentPick()
+        {
+            RankedPlayCard.SongPreviewContainer? originalPreview = null;
+
+            AddStep("hover first card",
+                () => InputManager.MoveMouseTo(this.ChildrenOfType<PlayerHandOfCards>().Single().Cards
+                                                   .First(c => c.Item.PlaylistItem.Value != null && c.Item.PlaylistItem.Value.BeatmapID != requestHandler.Beatmaps[0].OnlineID)));
+            AddUntilStep("preview playing", () => originalPreview = this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().FirstOrDefault(p => p.IsRunning), () => Is.Not.Null);
+
+            AddStep("play beatmap", () => MultiplayerClient.PlayUserCard(2, hand => hand[0]).WaitSafely());
+            AddStep("reveal card", () => MultiplayerClient.RankedPlayRevealUserCard(2, hand => hand[0], new MultiplayerPlaylistItem
+            {
+                ID = 0,
+                BeatmapID = requestHandler.Beatmaps[0].OnlineID
+            }).WaitSafely());
+
+            AddUntilStep("wait for original preview stopped", () => originalPreview?.IsRunning, () => Is.False);
+
+            AddUntilStep("preview playing is opponent's pick",
+                () => ((RankedPlayCard)this.ChildrenOfType<RankedPlayCard.SongPreviewContainer>().SingleOrDefault(p => p.IsRunning)?.Parent!).Item.PlaylistItem.Value?.BeatmapID,
+                () => Is.EqualTo(requestHandler.Beatmaps[0].OnlineID));
+        }
     }
 }

```
