### PR TITLE
Add empty hand check to moveCardFocus

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
@@ -211,5 +211,14 @@ namespace osu.Game.Tests.Visual.RankedPlay
             });
             AddStep("release mouse", () => InputManager.ReleaseButton(MouseButton.Left));
         }
+
+        [Test]
+        public void TestKeyboardSelectionWithoutCards()
+        {
+            AddAssert("no cards", () => !handOfCards.Cards.Any());
+            AddStep("right arrow", () => InputManager.Key(Key.Right));
+            AddStep("left arrow", () => InputManager.Key(Key.Left));
+            AddAssert("card not selected", () => !handOfCards.Selection.Any());
+        }
     }
 }

--- a/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
@@ -218,7 +218,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddAssert("no cards", () => !handOfCards.Cards.Any());
             AddStep("right arrow", () => InputManager.Key(Key.Right));
             AddStep("left arrow", () => InputManager.Key(Key.Left));
-            AddAssert("card not selected", () => !handOfCards.Selection.Any());
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Hand/PlayerHandOfCards.cs
@@ -200,6 +200,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand
         {
             var cards = GetCardsInDisplayOrder();
 
+            if (cards.Count == 0)
+                return;
+
             int currentIndex = cards.FindIndex(c => c.HasFocus);
 
             // default behaviour is to start from either end of the cards if no card is focused currently


### PR DESCRIPTION
Resolves #37486

Original error log:
```
2026-04-22 21:47:58 [error]: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
2026-04-22 21:47:58 [error]: at System.Collections.Generic.List`1.get_Item(Int32 index)
2026-04-22 21:47:58 [error]: at osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand.PlayerHandOfCards.moveCardFocus(Int32 direction)
2026-04-22 21:47:58 [error]: at osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand.PlayerHandOfCards.OnKeyDown(KeyDownEvent e)
```

Currently, ```osu.Game\Screens\OnlinePlay\Matchmaking\RankedPlay\Hand\PlayerHandOfCards.cs::moveCardFocus``` does not account for the hand being empty (cards.Count ==0 ), and will attempt to move the card focus in the given direction regardless, which causes the above index out of range error.

Added empty hand check to moveCardFocus, and a matching test case to TestScenePlayerCardHand.cs

New test case before changes, recreating the error:
<img width="986" height="232" alt="image" src="https://github.com/user-attachments/assets/daa62081-c776-44bd-b0d2-382b2dac7938" />

After:
<img width="638" height="223" alt="image" src="https://github.com/user-attachments/assets/d6dcd8b8-8caf-42e3-9999-93dfe3fb6452" />