### PR TITLE
Persist last queued pool in ranked play screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private BackgroundQueueNotification? backgroundNotification;
         private bool isBackgrounded;
-        private MatchmakingPool? lastJoinedPool;
+        public MatchmakingPool? LastJoinedPool;
 
         protected override void LoadComplete()
         {
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         public void JoinQueue(MatchmakingPool pool)
         {
             client.MatchmakingJoinQueue(pool.Id).FireAndForget();
-            lastJoinedPool = pool;
+            LastJoinedPool = pool;
         }
 
         /// <summary>
@@ -75,8 +75,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         /// </summary>
         public void RejoinQueue()
         {
-            if (lastJoinedPool != null)
-                JoinQueue(lastJoinedPool);
+            if (LastJoinedPool != null)
+                JoinQueue(LastJoinedPool);
         }
 
         /// <summary>
@@ -150,8 +150,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             if (backgroundNotification != null)
                 return;
 
-            Debug.Assert(lastJoinedPool != null);
-            notifications?.Post(backgroundNotification = new BackgroundQueueNotification(this, lastJoinedPool.Type));
+            Debug.Assert(LastJoinedPool != null);
+            notifications?.Post(backgroundNotification = new BackgroundQueueNotification(this, LastJoinedPool.Type));
         }
 
         private void closeNotifications()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private BackgroundQueueNotification? backgroundNotification;
         private bool isBackgrounded;
-        public MatchmakingPool? LastJoinedPool;
+        public MatchmakingPool? LastJoinedPool { get; private set; }
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -346,8 +346,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 availablePools.Value = pools;
 
                 // Default to the currently queueing pool, or fallback to the user's ruleset for the initial pool selection.
-                MatchmakingPool? queueingPool = queue.CurrentState.Value == MatchmakingScreenState.Queueing ? pools.FirstOrDefault(p => p.Id == queue.LastJoinedPool?.Id) : null;
-                selectedPool.Value = queueingPool ?? pools.FirstOrDefault(p => p.RulesetId == ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
+                MatchmakingPool? lastQueuedPool = pools.FirstOrDefault(p => p.Id == queue.LastJoinedPool?.Id);
+                selectedPool.Value = lastQueuedPool ?? pools.FirstOrDefault(p => p.RulesetId == ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
             });
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -345,8 +345,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 availablePools.Value = pools;
 
-                // Default to the user's ruleset for the initial pool selection.
-                selectedPool.Value = pools.FirstOrDefault(p => p.RulesetId == ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
+                // Default to the currently queueing pool, or fallback to the user's ruleset for the initial pool selection.
+                MatchmakingPool? queueingPool = queue.CurrentState.Value == MatchmakingScreenState.Queueing ? pools.FirstOrDefault(p => p.Id == queue.LastJoinedPool?.Id) : null;
+                selectedPool.Value = queueingPool ?? pools.FirstOrDefault(p => p.RulesetId == ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
             });
         }
 


### PR DESCRIPTION
Closes #37443

Previously it would select the first pool that matches the user's current ruleset.

At first I tried passing the `MatchmakingPool` object to the notification and have it passed back to the screen, but with that method only clicking the notification would show the correct pool, if you enter ranked play normally then it would show the "default" pool instead.
This method needed fewer changes too.