### PR TITLE
Remove points statistic from `MatchmakingStatsTooltip`

### DIFF
--- a/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsTooltip.cs
@@ -71,7 +71,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     new TableColumn(dimension: new Dimension(GridSizeMode.AutoSize)),
                     new TableColumn(RankingsStrings.MatchmakingWins, dimension: new Dimension(GridSizeMode.AutoSize)),
                     new TableColumn(RankingsStrings.MatchmakingPlays, dimension: new Dimension(GridSizeMode.AutoSize)),
-                    new TableColumn(RankingsStrings.MatchmakingPoints, dimension: new Dimension(GridSizeMode.AutoSize)),
                     new TableColumn(RankingsStrings.MatchmakingRating, dimension: new Dimension(GridSizeMode.AutoSize)),
                 ],
                 RowSize = new Dimension(GridSizeMode.AutoSize),
@@ -91,7 +90,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 new StatisticText(colourProvider) { Text = $"#{stat.Rank:N0}" },
                 new StatisticText(colourProvider) { Text = stat.FirstPlacements.ToString("N0") },
                 new StatisticText(colourProvider) { Text = stat.Plays.ToString("N0") },
-                new StatisticText(colourProvider) { Text = stat.TotalPoints.ToString("N0") },
                 new StatisticText(colourProvider) { Text = stat.Rating.ToString("N0") + (stat.IsRatingProvisional ? "*" : string.Empty) }
             ];
         }


### PR DESCRIPTION
matches web

| master | `osu-web` | PR |
|-|-|-|
| <img width="335" height="81" alt="image" src="https://github.com/user-attachments/assets/942fc6c0-488b-49b8-97d4-d2d81eeeed92" /> | <img width="307" height="83" alt="image" src="https://github.com/user-attachments/assets/3ade843e-c735-4697-bf89-622de2d23d9c" /> | <img width="338" height="135" alt="image" src="https://github.com/user-attachments/assets/5867023b-145d-4836-ba95-9e2bdd9e1bbc" /> |