### PR TITLE
Add pen input settings

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2026.416.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2026.428.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game/Configuration/DevelopmentOsuConfigManager.cs
+++ b/osu.Game/Configuration/DevelopmentOsuConfigManager.cs
@@ -9,8 +9,8 @@ namespace osu.Game.Configuration
     {
         protected override string Filename => base.Filename.Replace(".ini", ".dev.ini");
 
-        public DevelopmentOsuConfigManager(Storage storage)
-            : base(storage)
+        public DevelopmentOsuConfigManager(Storage storage, GameHost? host = null)
+            : base(storage, host)
         {
         }
     }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -2,12 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Input.Handlers.Pen;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps.Drawables.Cards;
@@ -30,9 +33,13 @@ namespace osu.Game.Configuration
 {
     public class OsuConfigManager : IniConfigManager<OsuSetting>, IGameplaySettings
     {
-        public OsuConfigManager(Storage storage)
+        private readonly GameHost? host;
+
+        public OsuConfigManager(Storage storage, GameHost? host = null)
             : base(storage)
         {
+            this.host = host;
+
             Migrate();
         }
 
@@ -273,6 +280,17 @@ namespace osu.Game.Configuration
                 // UI scaling on mobile platforms has been internally adjusted such that 1x UI scale looks correctly zoomed in than before.
                 if (RuntimeInfo.IsMobile)
                     GetBindable<float>(OsuSetting.UIScale).SetDefault();
+            }
+
+            if (combined < 20250428)
+            {
+                // Pen tablet sensitivity is now separated from cursor sensitivity.
+                // Most users will want the default to be what they already had set on cursor sensitivity so let's transfer it.
+                var mouseHandler = host?.AvailableInputHandlers.OfType<MouseHandler>().SingleOrDefault();
+                var penHandler = host?.AvailableInputHandlers.OfType<PenHandler>().SingleOrDefault();
+
+                if (penHandler != null && mouseHandler != null && penHandler.Sensitivity.IsDefault)
+                    penHandler.Sensitivity.Value = mouseHandler.Sensitivity.Value;
             }
         }
 

--- a/osu.Game/Localisation/MouseSettingsStrings.cs
+++ b/osu.Game/Localisation/MouseSettingsStrings.cs
@@ -79,6 +79,12 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString NeverConfine => new TranslatableString(getKey(@"never_confine"), @"Never");
 
+        /// <summary>
+        /// "Looking to change your pen tablet&#39;s sensitivity? Search for pen sensitivity instead."
+        /// </summary>
+        public static LocalisableString CursorSensitivityForTabletsElsewhere => new TranslatableString(getKey(@"cursor_sensitivity_for_tablets_elsewhere"),
+            @"Looking to change your pen tablet's sensitivity? Search for pen sensitivity instead.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/PenSettingsStrings.cs
+++ b/osu.Game/Localisation/PenSettingsStrings.cs
@@ -10,9 +10,9 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.PenSettings";
 
         /// <summary>
-        /// "Pen"
+        /// "Tablet (External)"
         /// </summary>
-        public static LocalisableString Pen => new TranslatableString(getKey(@"pen"), @"Pen");
+        public static LocalisableString TabletExternal => new TranslatableString(getKey(@"tablet_external"), @"Tablet (External)");
 
         /// <summary>
         /// "Cursor sensitivity"

--- a/osu.Game/Localisation/PenSettingsStrings.cs
+++ b/osu.Game/Localisation/PenSettingsStrings.cs
@@ -15,9 +15,9 @@ namespace osu.Game.Localisation
         public static LocalisableString TabletExternal => new TranslatableString(getKey(@"tablet_external"), @"Tablet (External)");
 
         /// <summary>
-        /// "Cursor sensitivity"
+        /// "Pen sensitivity"
         /// </summary>
-        public static LocalisableString CursorSensitivity => new TranslatableString(getKey(@"cursor_sensitivity"), @"Cursor sensitivity");
+        public static LocalisableString PenSensitivity => new TranslatableString(getKey(@"pen_sensitivity"), @"Pen sensitivity");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/PenSettingsStrings.cs
+++ b/osu.Game/Localisation/PenSettingsStrings.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class PenSettingsStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.PenSettings";
+
+        /// <summary>
+        /// "Pen"
+        /// </summary>
+        public static LocalisableString Pen => new TranslatableString(getKey(@"pen"), @"Pen");
+
+        /// <summary>
+        /// "Cursor sensitivity"
+        /// </summary>
+        public static LocalisableString CursorSensitivity => new TranslatableString(getKey(@"cursor_sensitivity"), @"Cursor sensitivity");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -541,8 +541,8 @@ namespace osu.Game
             Storage ??= host.Storage;
 
             LocalConfig ??= UseDevelopmentServer
-                ? new DevelopmentOsuConfigManager(Storage)
-                : new OsuConfigManager(Storage);
+                ? new DevelopmentOsuConfigManager(Storage, host)
+                : new OsuConfigManager(Storage, host);
 
             host.ExceptionThrown += onExceptionThrown;
         }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -26,6 +26,7 @@ using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Joystick;
 using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Input.Handlers.Pen;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Input.Handlers.Touch;
 using osu.Framework.IO.Stores;
@@ -670,6 +671,9 @@ namespace osu.Game
 
                 case TouchHandler th:
                     return new TouchSettings(th);
+
+                case PenHandler ph:
+                    return new PenSettings(ph);
 
                 case MidiHandler:
                     return new InputSubsection(handler);

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -74,6 +74,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 })
                 {
                     Keywords = new[] { "speed", "velocity" },
+                    Note = { Value = FrameworkEnvironment.UseSDL3 ? new SettingsNote.Data(MouseSettingsStrings.CursorSensitivityForTabletsElsewhere, SettingsNote.Type.Informational) : null }
                 },
                 new SettingsItemV2(confineMouseModeSetting = new FormEnumDropdown<OsuConfineMouseMode>
                 {

--- a/osu.Game/Overlays/Settings/Sections/Input/PenSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/PenSettings.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 new SettingsItemV2(new FormSliderBar<double>
                 {
-                    Caption = PenSettingsStrings.CursorSensitivity,
+                    Caption = PenSettingsStrings.PenSensitivity,
                     Current = handlerSensitivity,
                     KeyboardStep = 0.01f,
                     TransferValueOnCommit = true,

--- a/osu.Game/Overlays/Settings/Sections/Input/PenSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/PenSettings.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Handlers.Pen;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+
+namespace osu.Game.Overlays.Settings.Sections.Input
+{
+    public partial class PenSettings : InputSubsection
+    {
+        private readonly PenHandler penHandler;
+
+        protected override LocalisableString Header => PenSettingsStrings.Pen;
+
+        private Bindable<double> handlerSensitivity = null!;
+
+        public PenSettings(PenHandler penHandler)
+            : base(penHandler)
+        {
+            this.penHandler = penHandler;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            handlerSensitivity = penHandler.Sensitivity.GetBoundCopy();
+
+            AddRange(new Drawable[]
+            {
+                new SettingsItemV2(new FormSliderBar<double>
+                {
+                    Caption = PenSettingsStrings.CursorSensitivity,
+                    Current = handlerSensitivity,
+                    KeyboardStep = 0.01f,
+                    TransferValueOnCommit = true,
+                    LabelFormat = v => $@"{v:0.##}x",
+                    TooltipFormat = v => $@"{v:0.##}x",
+                })
+                {
+                    Keywords = new[] { "speed", "velocity" },
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Input/PenSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/PenSettings.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
     {
         private readonly PenHandler penHandler;
 
-        protected override LocalisableString Header => PenSettingsStrings.Pen;
+        protected override LocalisableString Header => PenSettingsStrings.TabletExternal;
 
         private Bindable<double> handlerSensitivity = null!;
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -39,7 +39,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2026.416.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2026.428.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.427.0" />
     <PackageReference Include="Sentry" Version="6.2.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -17,6 +17,6 @@
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2026.416.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2026.428.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- depends on https://github.com/ppy/osu-framework/pull/6737

Adds simple input settings section for pens that allows disabling the handler and adjusting sensitivity. The section appears in-between Tablet and Touch, and only on SDL3 (desktop and mobile). The pen sensitivity is completely independent from mouse sensitivity.

<img width="537" height="149" alt="image" src="https://github.com/user-attachments/assets/448eebba-84ea-4daf-8428-3bd07739bd6f" />

<br>

Keep in mind that the "Confine mouse cursor to window" mouse setting also affects pens, feel free to suggest UX improvements. Also, toggling "High precision mouse" might affect pens on certain configurations.

Edit: added image with updated header. Previously, it was "Device: Pen".