### PR TITLE
Hide red failing layer in ranked play

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Gameplay/ScreenGameplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/Gameplay/ScreenGameplay.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.Gameplay
     public partial class ScreenGameplay : MultiplayerPlayer
     {
         public ScreenGameplay(Room room, PlaylistItem playlistItem, MultiplayerRoomUser[] users)
-            : base(room, playlistItem, users)
+            : base(room, playlistItem, users, showFailingOverlay: false)
         {
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -51,13 +51,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// <param name="room">The room.</param>
         /// <param name="playlistItem">The playlist item to be played.</param>
         /// <param name="users">The users which are participating in this game.</param>
-        public MultiplayerPlayer(Room room, PlaylistItem playlistItem, MultiplayerRoomUser[] users)
+        /// <param name="showFailingOverlay">Whether to show the red failing overlay.</param>
+        public MultiplayerPlayer(Room room, PlaylistItem playlistItem, MultiplayerRoomUser[] users, bool showFailingOverlay = true)
             : base(room, playlistItem, new PlayerConfiguration
             {
                 AllowPause = false,
                 AllowRestart = false,
                 AutomaticallySkipIntro = room.AutoSkip,
                 ShowLeaderboard = true,
+                ShowFailingOverlay = showFailingOverlay
             })
         {
             leaderboardProvider = new MultiplayerLeaderboardProvider(users);

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -117,7 +117,12 @@ namespace osu.Game.Screens.Play
 
             Children = new[]
             {
-                CreateFailingLayer(),
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = configuration.ShowFailingOverlay ? 1 : 0,
+                    Child = CreateFailingLayer()
+                },
                 //Needs to be initialized before skinnable drawables.
                 judgementCountController = new JudgementCountController(),
                 clicksPerSecondController = new ClicksPerSecondController(),

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -39,5 +39,10 @@ namespace osu.Game.Screens.Play
         /// Whether the gameplay leaderboard should be shown.
         /// </summary>
         public bool ShowLeaderboard { get; set; }
+
+        /// <summary>
+        /// Whether to show the red failing overlay.
+        /// </summary>
+        public bool ShowFailingOverlay { get; set; } = true;
     }
 }


### PR DESCRIPTION
In ranked play, scores are always counted regardless of whether they are a fail or a pass. Beyond that, there's also no concept of revival in multiplayer right now, so players are just stuck at 0 HP with a red overlay.

Not doing what `ModNoFail` does, which is to hide the healthbar altogether, because some user skins use the healthbar to skin a gameplay border.