### PR TITLE
Implement animation for `RankedPlayBottomOrnament`

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayBottomOrnament.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayBottomOrnament.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using osu.Game.Screens.OnlinePlay.Matchmaking;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    public partial class TestSceneRankedPlayBottomOrnament : OsuTestScene
+    {
+        private RankedPlayBottomOrnament ornament = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create", () => Child = new Container
+            {
+                Width = 400,
+                Height = 24,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.Gray,
+                    },
+                    ornament = new RankedPlayBottomOrnament(),
+                }
+            });
+        }
+
+        [Test]
+        public void TestAnimations()
+        {
+            AddStep("hide", () => ornament.Hide());
+            AddStep("show", () => ornament.Show());
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayBottomOrnament.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayBottomOrnament.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osu.Game.Screens.OnlinePlay.Matchmaking;
 using osuTK.Graphics;
 
@@ -13,12 +12,11 @@ namespace osu.Game.Tests.Visual.RankedPlay
 {
     public partial class TestSceneRankedPlayBottomOrnament : OsuTestScene
     {
-        private TestOrnament ornament = null!;
+        private readonly TestOrnament ornament;
 
-        [SetUpSteps]
-        public void SetUpSteps()
+        public TestSceneRankedPlayBottomOrnament()
         {
-            AddStep("create", () => Child = new Container
+            Child = new Container
             {
                 Width = 400,
                 Height = 24,
@@ -33,7 +31,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     },
                     ornament = new TestOrnament(),
                 }
-            });
+            };
         }
 
         [Test]
@@ -48,7 +46,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             public new float Progress
             {
-                get => base.Progress;
                 set => base.Progress = value;
             }
         }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayBottomOrnament.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayBottomOrnament.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
 {
     public partial class TestSceneRankedPlayBottomOrnament : OsuTestScene
     {
-        private RankedPlayBottomOrnament ornament = null!;
+        private TestOrnament ornament = null!;
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4.Gray,
                     },
-                    ornament = new RankedPlayBottomOrnament(),
+                    ornament = new TestOrnament(),
                 }
             });
         }
@@ -41,6 +41,16 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("hide", () => ornament.Hide());
             AddStep("show", () => ornament.Show());
+            AddSliderStep("Progress", 0f, 1f, 0f, p => ornament.Progress = p);
+        }
+
+        private partial class TestOrnament : RankedPlayBottomOrnament
+        {
+            public new float Progress
+            {
+                get => base.Progress;
+                set => base.Progress = value;
+            }
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -40,19 +41,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         private Circle centerLine = null!;
         private Circle centerLineThick = null!;
 
-        private float progress;
+        private readonly Bindable<float> progressBindable = new Bindable<float>();
 
         protected float Progress
         {
-            get => progress;
-            set
-            {
-                if (progress == value)
-                    return;
-
-                progress = value;
-                recomputePaths(value);
-            }
+            get => progressBindable.Value;
+            set => progressBindable.Value = value;
         }
 
         public RankedPlayBottomOrnament()
@@ -147,6 +141,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                     Text = ButtonSystemStrings.RankedPlay.ToUpper(),
                 },
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            progressBindable.BindValueChanged(progress => recomputePaths(progress.NewValue), true);
         }
 
         private readonly List<Vector2> vertices = new List<Vector2>();

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         private Circle centerLine = null!;
         private Circle centerLineThick = null!;
 
-        private float progress = 0f;
+        private float progress;
 
         protected float Progress
         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -9,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Lines;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
@@ -35,30 +37,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         private Path pathLeft = null!;
         private Path pathRight = null!;
 
-        private Path pathCenter = null!;
-        private Path pathCenterWide = null!;
+        private Circle centerLine = null!;
+        private Circle centerLineThick = null!;
 
-        // TODO: remove this jank after we've migrated to .NET 10
-        private float progressStartInternal = 0.5f;
-        private float progressEndInternal = 0.5f;
+        private float progress = 0f;
 
-        private float progressStart
+        protected float Progress
         {
-            get => progressStartInternal;
+            get => progress;
             set
             {
-                progressStartInternal = value;
-                Scheduler.AddOnce(recomputePaths);
-            }
-        }
+                if (progress == value)
+                    return;
 
-        private float progressEnd
-        {
-            get => progressEndInternal;
-            set
-            {
-                progressEndInternal = value;
-                Scheduler.AddOnce(recomputePaths);
+                progress = value;
+                recomputePaths(value);
             }
         }
 
@@ -96,7 +89,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         {
             Width = width;
             Height = height;
-            Alpha = 0;
 
             Masking = true;
 
@@ -121,26 +113,26 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                     {
                         pathLeft = new SmoothPath
                         {
-                            AutoSizeAxes = Axes.None,
-                            RelativeSizeAxes = Axes.Both,
+                            Origin = Anchor.BottomRight,
                             PathRadius = 1,
                         },
-                        pathCenter = new SmoothPath
+                        centerLine = new Circle
                         {
-                            AutoSizeAxes = Axes.None,
-                            RelativeSizeAxes = Axes.Both,
-                            PathRadius = 1,
+                            RelativeSizeAxes = Axes.X,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Y = 1,
+                            Height = 2,
                         },
-                        pathCenterWide = new SmoothPath
+                        centerLineThick = new Circle
                         {
-                            AutoSizeAxes = Axes.None,
-                            RelativeSizeAxes = Axes.Both,
-                            PathRadius = 2,
+                            RelativeSizeAxes = Axes.X,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Height = 4,
                         },
                         pathRight = new SmoothPath
                         {
-                            AutoSizeAxes = Axes.None,
-                            RelativeSizeAxes = Axes.Both,
                             PathRadius = 1,
                         },
                     },
@@ -157,29 +149,43 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
             };
         }
 
-        private void recomputePaths()
+        private readonly List<Vector2> vertices = new List<Vector2>();
+
+        private void recomputePaths(float newProgress)
         {
-            List<Vector2> vertices = new List<Vector2>();
-            sliderPath.GetPathToProgress(vertices, progressStart, progressEnd);
+            centerLineThick.Width = Math.Clamp(newProgress, 0f, 0.7f);
+            centerLine.Width = Math.Clamp(newProgress, 0f, 0.85f);
 
-            if (progressStart >= 0.15 && progressEnd <= 0.85)
-                pathCenterWide.Vertices = vertices;
-
-            if (progressStart >= 0.075 && progressEnd <= 0.925)
-                pathCenter.Vertices = vertices;
-
-            if (progressStart <= 0.05)
+            if (newProgress > 0.9f)
             {
-                List<Vector2> verticesLeft = new List<Vector2>();
-                sliderPath.GetPathToProgress(verticesLeft, progressStart, 0.05);
-                pathLeft.Vertices = verticesLeft;
+                pathLeft.Alpha = 1;
+                pathRight.Alpha = 1;
+
+                vertices.Clear();
+                sliderPath.GetPathToProgress(vertices, 0.5f - newProgress * 0.5f, 0.05f);
+
+                Vector2 lastVertex = vertices[^1];
+                Vector2 firstVertex = vertices[0];
+                for (int i = 0; i < vertices.Count; i++)
+                    vertices[i] -= firstVertex;
+
+                pathLeft.Vertices = vertices;
+                pathLeft.Position = pathLeft.PositionInBoundingBox(lastVertex);
+
+                vertices.Clear();
+                sliderPath.GetPathToProgress(vertices, 0.95f, 0.5f + newProgress * 0.5f);
+
+                firstVertex = vertices[0];
+                for (int i = 0; i < vertices.Count; i++)
+                    vertices[i] -= firstVertex;
+
+                pathRight.Vertices = vertices;
+                pathRight.Position = pathRight.PositionInBoundingBox(firstVertex) - new Vector2(pathRight.PathRadius * 2);
             }
-
-            if (progressEnd >= 0.95)
+            else
             {
-                List<Vector2> verticesRight = new List<Vector2>();
-                sliderPath.GetPathToProgress(verticesRight, 0.95, progressEnd);
-                pathRight.Vertices = verticesRight;
+                pathLeft.Alpha = 0;
+                pathRight.Alpha = 0;
             }
         }
 
@@ -189,15 +195,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         protected override void PopIn()
         {
             this.FadeIn(duration, easing)
-                .TransformTo(nameof(progressStart), 0f, duration, easing)
-                .TransformTo(nameof(progressEnd), 1f, duration, easing);
+                .TransformTo(nameof(Progress), 1f, duration, easing);
         }
 
         protected override void PopOut()
         {
             this.FadeOut(duration, easing)
-                .TransformTo(nameof(progressStart), 0.5f, duration, easing)
-                .TransformTo(nameof(progressEnd), 0.5f, duration, easing);
+                .TransformTo(nameof(Progress), 0f, duration, easing);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Lines;
-using osu.Framework.Layout;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
@@ -28,7 +27,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         private const int width = 400;
         private const int height = 24;
 
+        protected override bool StartHidden => true;
         protected override bool BlockPositionalInput => false;
+
+        private readonly SliderPath sliderPath;
 
         private Path pathLeft = null!;
         private Path pathRight = null!;
@@ -36,9 +38,58 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
         private Path pathCenter = null!;
         private Path pathCenterWide = null!;
 
-        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
+        // TODO: remove this jank after we've migrated to .NET 10
+        private float progressStartInternal = 0.5f;
+        private float progressEndInternal = 0.5f;
 
-        protected override bool StartHidden => true;
+        private float progressStart
+        {
+            get => progressStartInternal;
+            set
+            {
+                progressStartInternal = value;
+                Scheduler.AddOnce(recomputePaths);
+            }
+        }
+
+        private float progressEnd
+        {
+            get => progressEndInternal;
+            set
+            {
+                progressEndInternal = value;
+                Scheduler.AddOnce(recomputePaths);
+            }
+        }
+
+        public RankedPlayBottomOrnament()
+        {
+            const int top = 2; // to account for the middle segment being twice as wide
+            const int bottom = 10;
+            const int curve_smoothness = 5;
+
+            const int left_start = 0;
+            const int left_corner = 10;
+            const int left_end = 20;
+            var diagonalDirLeft = (new Vector2(left_start, bottom) - new Vector2(left_corner, top)).Normalized();
+
+            const float right_start = width;
+            const float right_corner = right_start - 10;
+            const float right_end = right_start - 20;
+            var diagonalDirRight = (new Vector2(right_start, bottom) - new Vector2(right_corner, top)).Normalized();
+
+            sliderPath = new SliderPath(new[]
+            {
+                new PathControlPoint(new Vector2(left_start, bottom), PathType.BEZIER),
+                new PathControlPoint(new Vector2(left_corner, top) + diagonalDirLeft * curve_smoothness),
+                new PathControlPoint(new Vector2(left_corner, top)),
+                new PathControlPoint(new Vector2(left_end, top), PathType.LINEAR),
+                new PathControlPoint(new Vector2(right_end, top), PathType.BEZIER),
+                new PathControlPoint(new Vector2(right_corner, top)),
+                new PathControlPoint(new Vector2(right_corner, top) + diagonalDirRight * curve_smoothness),
+                new PathControlPoint(new Vector2(right_start, bottom)),
+            });
+        }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -108,71 +159,45 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         private void recomputePaths()
         {
-            const int top = 2; // to account for the middle segment being twice as wide
-            const int bottom = 10;
-            const int curve_smoothness = 5;
-
-            pathCenter.AddVertex(new Vector2(30, top));
-            pathCenter.AddVertex(new Vector2(DrawWidth - 30, top));
-
-            pathCenterWide.AddVertex(new Vector2(60, top));
-            pathCenterWide.AddVertex(new Vector2(DrawWidth - 60, top));
-
-            const int left_start = 0;
-            const int left_corner = 10;
-            const int left_end = 20;
-
             List<Vector2> vertices = new List<Vector2>();
-            var diagonalDirLeft = (new Vector2(left_start, bottom) - new Vector2(left_corner, top)).Normalized();
+            sliderPath.GetPathToProgress(vertices, progressStart, progressEnd);
 
-            var sliderPathLeft = new SliderPath(new[]
+            if (progressStart >= 0.15 && progressEnd <= 0.85)
+                pathCenterWide.Vertices = vertices;
+
+            if (progressStart >= 0.075 && progressEnd <= 0.925)
+                pathCenter.Vertices = vertices;
+
+            if (progressStart <= 0.05)
             {
-                new PathControlPoint(new Vector2(left_start, bottom), PathType.LINEAR),
-                new PathControlPoint(new Vector2(left_corner, top) + diagonalDirLeft * curve_smoothness, PathType.BEZIER),
-                new PathControlPoint(new Vector2(left_corner, top)),
-                new PathControlPoint(new Vector2(left_end, top), PathType.LINEAR),
-            });
+                List<Vector2> verticesLeft = new List<Vector2>();
+                sliderPath.GetPathToProgress(verticesLeft, progressStart, 0.05);
+                pathLeft.Vertices = verticesLeft;
+            }
 
-            sliderPathLeft.GetPathToProgress(vertices, 0.0, 1.0);
-            pathLeft.Vertices = vertices;
-
-            float rightStart = DrawWidth;
-            float rightCorner = rightStart - 10;
-            float rightEnd = rightStart - 20;
-
-            var diagonalDirRight = (new Vector2(rightStart, bottom) - new Vector2(rightCorner, top)).Normalized();
-            var sliderPathRight = new SliderPath(new[]
+            if (progressEnd >= 0.95)
             {
-                new PathControlPoint(new Vector2(rightStart, bottom), PathType.LINEAR),
-                new PathControlPoint(new Vector2(rightCorner, top) + diagonalDirRight * curve_smoothness, PathType.BEZIER),
-                new PathControlPoint(new Vector2(rightCorner, top)),
-                new PathControlPoint(new Vector2(rightEnd, top), PathType.LINEAR),
-            });
-
-            sliderPathRight.GetPathToProgress(vertices, 0.0, 1.0);
-            pathRight.Vertices = vertices;
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (!layout.IsValid)
-            {
-                recomputePaths();
-                layout.Validate();
+                List<Vector2> verticesRight = new List<Vector2>();
+                sliderPath.GetPathToProgress(verticesRight, 0.95, progressEnd);
+                pathRight.Vertices = verticesRight;
             }
         }
 
+        private const int duration = 1200;
+        private const Easing easing = Easing.OutExpo;
+
         protected override void PopIn()
         {
-            this.FadeIn(500, Easing.OutQuint);
-            // TODO: animate this better.
+            this.FadeIn(duration, easing)
+                .TransformTo(nameof(progressStart), 0f, duration, easing)
+                .TransformTo(nameof(progressEnd), 1f, duration, easing);
         }
 
         protected override void PopOut()
         {
-            this.FadeOut(500, Easing.OutQuint);
+            this.FadeOut(duration, easing)
+                .TransformTo(nameof(progressStart), 0.5f, duration, easing)
+                .TransformTo(nameof(progressEnd), 0.5f, duration, easing);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlayBottomOrnament.cs
@@ -194,12 +194,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         protected override void PopIn()
         {
+            this.MoveToY(5)
+                .Delay(550)
+                .MoveToY(0, duration - 550, easing);
+
             this.FadeIn(duration, easing)
                 .TransformTo(nameof(Progress), 1f, duration, easing);
         }
 
         protected override void PopOut()
         {
+            this.MoveToY(5, duration / 2f, Easing.In);
+
             this.FadeOut(duration, easing)
                 .TransformTo(nameof(Progress), 0f, duration, easing);
         }


### PR DESCRIPTION
Based off of https://github.com/ppy/osu/pull/37478 with some improvements such as:
* Simpler `progress` handling (single adjustable value instead of 2)
* 2 less drawable paths (replaced with circlular containers)
* Reworked remaining paths to have as little texture sizes as possible