### PR TITLE
Eagerly connect to latest server instance for best online experience

### DIFF
--- a/osu.Game/Online/IStatefulUserHubClient.cs
+++ b/osu.Game/Online/IStatefulUserHubClient.cs
@@ -26,5 +26,18 @@ namespace osu.Game.Online
         /// </list>
         /// </remarks>
         Task DisconnectRequested();
+
+        /// <summary>
+        /// Invoked when server begins a shutdown sequence.
+        /// </summary>
+        /// <remarks>
+        /// Server shutdowns are graceful.
+        ///
+        /// This will fire with hours of notice for clients to do what they need to and subsequently
+        /// disconnect. It's in the client's best interest to switch over to the new hubs as soon as
+        /// it can, so that the user can be on the same server as the majority of others (and avoid a
+        /// "server split" scenario where users are split across multiple shutting-down hubs).
+        /// </remarks>
+        Task ServerShuttingDown();
     }
 }

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +19,11 @@ namespace osu.Game.Online.Metadata
     public abstract partial class MetadataClient : Component, IMetadataClient, IMetadataServer
     {
         public abstract IBindable<bool> IsConnected { get; }
+
+        /// <summary>
+        /// A list of all watched multiplayer rooms (see <see cref="BeginWatchingMultiplayerRoom"/>).
+        /// </summary>
+        protected readonly HashSet<long> WatchedRooms = new HashSet<long>();
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -200,7 +206,7 @@ namespace osu.Game.Online.Metadata
 
         Task IStatefulUserHubClient.ServerShuttingDown()
         {
-            // TODO: check when we can disconnect and do so.
+            this.ReconnectWhenReady(IsConnected, () => WatchedRooms.Count == 0, Reconnect);
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -179,11 +179,20 @@ namespace osu.Game.Online.Metadata
 
         #region Disconnection handling
 
+        /// <summary>
+        /// Invoked just prior to disconnection.
+        /// </summary>
         public event Action? Disconnecting;
 
-        public virtual Task DisconnectRequested()
+        protected abstract Task DisconnectInternal();
+
+        Task IStatefulUserHubClient.DisconnectRequested()
         {
-            Schedule(() => Disconnecting?.Invoke());
+            Schedule(() =>
+            {
+                Disconnecting?.Invoke();
+                DisconnectInternal().FireAndForget();
+            });
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -187,6 +187,12 @@ namespace osu.Game.Online.Metadata
             return Task.CompletedTask;
         }
 
+        Task IStatefulUserHubClient.ServerShuttingDown()
+        {
+            // TODO: check when we can disconnect and do so.
+            return Task.CompletedTask;
+        }
+
         #endregion
     }
 }

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -184,6 +184,8 @@ namespace osu.Game.Online.Metadata
         /// </summary>
         public event Action? Disconnecting;
 
+        public abstract Task Reconnect();
+
         protected abstract Task DisconnectInternal();
 
         Task IStatefulUserHubClient.DisconnectRequested()

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -298,17 +298,16 @@ namespace osu.Game.Online.Metadata
             await connection.InvokeAsync(nameof(IMetadataServer.RefreshFriends)).ConfigureAwait(false);
         }
 
-        public override async Task DisconnectRequested()
-        {
-            await base.DisconnectRequested().ConfigureAwait(false);
-            if (connector != null)
-                await connector.Disconnect().ConfigureAwait(false);
-        }
-
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
             connector?.Dispose();
+        }
+
+        protected override async Task DisconnectInternal()
+        {
+            if (connector != null)
+                await connector.Disconnect().ConfigureAwait(false);
         }
     }
 }

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -304,6 +304,12 @@ namespace osu.Game.Online.Metadata
             connector?.Dispose();
         }
 
+        public override async Task Reconnect()
+        {
+            if (connector != null)
+                await connector.Reconnect().ConfigureAwait(false);
+        }
+
         protected override async Task DisconnectInternal()
         {
             if (connector != null)

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -69,7 +69,8 @@ namespace osu.Game.Online.Metadata
                     connection.On<int, UserPresence?>(nameof(IMetadataClient.FriendPresenceUpdated), ((IMetadataClient)this).FriendPresenceUpdated);
                     connection.On<DailyChallengeInfo?>(nameof(IMetadataClient.DailyChallengeUpdated), ((IMetadataClient)this).DailyChallengeUpdated);
                     connection.On<MultiplayerRoomScoreSetEvent>(nameof(IMetadataClient.MultiplayerRoomScoreSet), ((IMetadataClient)this).MultiplayerRoomScoreSet);
-                    connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IMetadataClient)this).DisconnectRequested);
+                    connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IStatefulUserHubClient)this).DisconnectRequested);
+                    connection.On(nameof(IStatefulUserHubClient.ServerShuttingDown), ((IStatefulUserHubClient)this).ServerShuttingDown);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -110,6 +110,7 @@ namespace osu.Game.Online.Metadata
                 {
                     userPresences.Clear();
                     friendPresences.Clear();
+                    WatchedRooms.Clear();
                     dailyChallengeInfo.Value = null;
                     localUserPresence = default;
                 });
@@ -273,6 +274,8 @@ namespace osu.Game.Online.Metadata
             if (connector?.IsConnected.Value != true)
                 throw new OperationCanceledException();
 
+            WatchedRooms.Add(id);
+
             Debug.Assert(connection != null);
             var result = await connection.InvokeAsync<MultiplayerPlaylistItemStats[]>(nameof(IMetadataServer.BeginWatchingMultiplayerRoom), id).ConfigureAwait(false);
             Logger.Log($@"{nameof(OnlineMetadataClient)} began watching multiplayer room with ID {id}", LoggingTarget.Network);
@@ -283,6 +286,8 @@ namespace osu.Game.Online.Metadata
         {
             if (connector?.IsConnected.Value != true)
                 throw new OperationCanceledException();
+
+            WatchedRooms.Remove(id);
 
             Debug.Assert(connection != null);
             await connection.InvokeAsync(nameof(IMetadataServer.EndWatchingMultiplayerRoom), id).ConfigureAwait(false);

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -1223,6 +1223,8 @@ namespace osu.Game.Online.Multiplayer
 
         protected abstract Task DisconnectInternal();
 
+        public abstract Task Reconnect();
+
         Task IStatefulUserHubClient.DisconnectRequested()
         {
             Schedule(() =>

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -11,9 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Database;
-using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -116,11 +114,6 @@ namespace osu.Game.Online.Multiplayer
         /// Invoked when the multiplayer server has finished collating results.
         /// </summary>
         public event Action? ResultsReady;
-
-        /// <summary>
-        /// Invoked just prior to disconnection requested by the server via <see cref="IStatefulUserHubClient.DisconnectRequested"/>.
-        /// </summary>
-        public event Action? Disconnecting;
 
         public event Action<MultiplayerCountdown>? CountdownStarted;
 
@@ -488,8 +481,6 @@ namespace osu.Game.Online.Multiplayer
         public abstract Task ChangeState(MultiplayerUserState newState);
 
         public abstract Task ChangeBeatmapAvailability(BeatmapAvailability newBeatmapAvailability);
-
-        public abstract Task DisconnectInternal();
 
         public abstract Task ChangeUserStyle(int? beatmapId, int? rulesetId);
 
@@ -1081,21 +1072,7 @@ namespace osu.Game.Online.Multiplayer
             });
         }
 
-        Task IStatefulUserHubClient.DisconnectRequested()
-        {
-            Schedule(() =>
-            {
-                Disconnecting?.Invoke();
-                DisconnectInternal();
-            });
-            return Task.CompletedTask;
-        }
-
-        Task IStatefulUserHubClient.ServerShuttingDown()
-        {
-            // TODO: check when we can disconnect and do so.
-            return Task.CompletedTask;
-        }
+        #region Matchmaking / Ranked Play
 
         Task IMatchmakingClient.MatchmakingQueueJoined()
         {
@@ -1235,14 +1212,33 @@ namespace osu.Game.Online.Multiplayer
 
         public abstract Task MatchmakingSkipToNextStage();
 
-        private partial class MultiplayerInvitationNotification : UserAvatarNotification
-        {
-            protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
+        #endregion
 
-            public MultiplayerInvitationNotification(APIUser user, Room room)
-                : base(user, NotificationsStrings.InvitedYouToTheMultiplayer(user.Username, room.Name))
+        #region Disconnection handling
+
+        /// <summary>
+        /// Invoked just prior to disconnection.
+        /// </summary>
+        public event Action? Disconnecting;
+
+        protected abstract Task DisconnectInternal();
+
+        Task IStatefulUserHubClient.DisconnectRequested()
+        {
+            Schedule(() =>
             {
-            }
+                Disconnecting?.Invoke();
+                DisconnectInternal().FireAndForget();
+            });
+            return Task.CompletedTask;
         }
+
+        Task IStatefulUserHubClient.ServerShuttingDown()
+        {
+            // TODO: check when we can disconnect and do so.
+            return Task.CompletedTask;
+        }
+
+        #endregion
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -1091,6 +1091,12 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
+        Task IStatefulUserHubClient.ServerShuttingDown()
+        {
+            // TODO: check when we can disconnect and do so.
+            return Task.CompletedTask;
+        }
+
         Task IMatchmakingClient.MatchmakingQueueJoined()
         {
             Scheduler.Add(() => MatchmakingQueueJoined?.Invoke());

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -1237,7 +1237,7 @@ namespace osu.Game.Online.Multiplayer
 
         Task IStatefulUserHubClient.ServerShuttingDown()
         {
-            // TODO: check when we can disconnect and do so.
+            this.ReconnectWhenReady(IsConnected, () => room == null, Reconnect);
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/Multiplayer/MultiplayerClientExtensions.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClientExtensions.cs
@@ -5,7 +5,9 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.ExceptionExtensions;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Logging;
 using osu.Game.Utils;
 
@@ -42,6 +44,43 @@ namespace osu.Game.Online.Multiplayer
                     onSuccess?.Invoke();
                 }
             });
+
+        /// <summary>
+        /// Start a background process to disconnect/reconnect as soon as a specific condition is met.
+        /// </summary>
+        /// <remarks>
+        /// If a reconnect happens via another means, this will abort attempts.
+        /// We only want to reconnect once.
+        /// </remarks>
+        /// <param name="client">The client to operate on.</param>
+        /// <param name="isConnected">Connected state of client.</param>
+        /// <param name="readyFunction">The condition which should be <c>true</c> to continue with the shutdown.</param>
+        /// <param name="reconnectFunction">The method to run to perform the reconnect.</param>
+        public static void ReconnectWhenReady(this IStatefulUserHubClient client, IBindable<bool> isConnected, Func<bool> readyFunction, Func<Task> reconnectFunction)
+        {
+            Task.Run(async () =>
+            {
+                bool didReconnect = false;
+                var connected = isConnected.GetBoundCopy();
+                connected.ValueChanged += _ => didReconnect = true;
+
+                string clientName = client.GetType().ReadableName();
+
+                Logger.Log($"{clientName} has signalled shutdown");
+
+                while (!readyFunction())
+                {
+                    Logger.Log($"{clientName} shutdown waiting for idle conditions...");
+                    await Task.Delay(10000).ConfigureAwait(false);
+                }
+
+                Logger.Log($"{clientName} disconnecting due to shutdown signal");
+                if (!didReconnect)
+                    await reconnectFunction().ConfigureAwait(false);
+
+                connected.UnbindAll();
+            }).FireAndForget();
+        }
 
         public static string? GetHubExceptionMessage(this Exception exception)
         {

--- a/osu.Game/Online/Multiplayer/MultiplayerInvitationNotification.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerInvitationNotification.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Localisation;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Online.Multiplayer
+{
+    public partial class MultiplayerInvitationNotification : UserAvatarNotification
+    {
+        protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
+
+        public MultiplayerInvitationNotification(APIUser user, Room room)
+            : base(user, NotificationsStrings.InvitedYouToTheMultiplayer(user.Username, room.Name))
+        {
+        }
+    }
+}

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -442,6 +442,12 @@ namespace osu.Game.Online.Multiplayer
             connector?.Dispose();
         }
 
+        public override async Task Reconnect()
+        {
+            if (connector != null)
+                await connector.Reconnect().ConfigureAwait(false);
+        }
+
         protected override async Task DisconnectInternal()
         {
             if (connector != null)

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -10,15 +10,15 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Game.Online.API;
-using osu.Game.Online.Rooms;
-using osu.Game.Overlays.Notifications;
 using osu.Game.Localisation;
+using osu.Game.Online.API;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Matchmaking.Responses;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.RankedPlay;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Online.Multiplayer
 {
@@ -91,7 +91,8 @@ namespace osu.Game.Online.Multiplayer
                     connection.On<RankedPlayCardItem, MultiplayerPlaylistItem>(nameof(IRankedPlayClient.RankedPlayCardRevealed), ((IRankedPlayClient)this).RankedPlayCardRevealed);
                     connection.On<RankedPlayCardItem>(nameof(IRankedPlayClient.RankedPlayCardPlayed), ((IRankedPlayClient)this).RankedPlayCardPlayed);
 
-                    connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IMultiplayerClient)this).DisconnectRequested);
+                    connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IStatefulUserHubClient)this).DisconnectRequested);
+                    connection.On(nameof(IStatefulUserHubClient.ServerShuttingDown), ((IStatefulUserHubClient)this).ServerShuttingDown);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -335,14 +335,6 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync(nameof(IMultiplayerServer.VoteToSkipIntro));
         }
 
-        public override Task DisconnectInternal()
-        {
-            if (connector == null)
-                return Task.CompletedTask;
-
-            return connector.Disconnect();
-        }
-
         public override Task DiscardCards(RankedPlayCardItem[] cards)
         {
             if (!IsConnected.Value)
@@ -448,6 +440,12 @@ namespace osu.Game.Online.Multiplayer
         {
             base.Dispose(isDisposing);
             connector?.Dispose();
+        }
+
+        protected override async Task DisconnectInternal()
+        {
+            if (connector != null)
+                await connector.Disconnect().ConfigureAwait(false);
         }
     }
 }

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -46,6 +46,7 @@ namespace osu.Game.Online.Spectator
                     connection.On<SpectatorUser[]>(nameof(ISpectatorClient.UserStartedWatching), ((ISpectatorClient)this).UserStartedWatching);
                     connection.On<int>(nameof(ISpectatorClient.UserEndedWatching), ((ISpectatorClient)this).UserEndedWatching);
                     connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IStatefulUserHubClient)this).DisconnectRequested);
+                    connection.On(nameof(IStatefulUserHubClient.ServerShuttingDown), ((IStatefulUserHubClient)this).ServerShuttingDown);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -125,12 +125,8 @@ namespace osu.Game.Online.Spectator
 
         protected override async Task DisconnectInternal()
         {
-            await base.DisconnectInternal().ConfigureAwait(false);
-
-            if (connector == null)
-                return;
-
-            await connector.Disconnect().ConfigureAwait(false);
+            if (connector != null)
+                await connector.Disconnect().ConfigureAwait(false);
         }
     }
 }

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -123,6 +123,12 @@ namespace osu.Game.Online.Spectator
             return connection.InvokeAsync(nameof(ISpectatorServer.EndWatchingUser), userId);
         }
 
+        public override async Task Reconnect()
+        {
+            if (connector != null)
+                await connector.Reconnect().ConfigureAwait(false);
+        }
+
         protected override async Task DisconnectInternal()
         {
             if (connector != null)

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -453,7 +453,7 @@ namespace osu.Game.Online.Spectator
 
         Task IStatefulUserHubClient.ServerShuttingDown()
         {
-            // TODO: check when we can disconnect and do so.
+            this.ReconnectWhenReady(IsConnected, () => watchedUsersRefCounts.Count == 0, Reconnect);
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -209,6 +209,12 @@ namespace osu.Game.Online.Spectator
             return Task.CompletedTask;
         }
 
+        Task IStatefulUserHubClient.ServerShuttingDown()
+        {
+            // TODO: check when we can disconnect and do so.
+            return Task.CompletedTask;
+        }
+
         public void BeginPlaying(long? scoreToken, GameplayState state, Score score)
         {
             // This schedule is only here to match the one below in `EndPlaying`.

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -439,6 +439,8 @@ namespace osu.Game.Online.Spectator
 
         protected abstract Task DisconnectInternal();
 
+        public abstract Task Reconnect();
+
         Task IStatefulUserHubClient.DisconnectRequested()
         {
             Schedule(() =>

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -76,11 +76,6 @@ namespace osu.Game.Online.Spectator
         public event Action<int, long>? OnUserScoreProcessed;
 
         /// <summary>
-        /// Invoked just prior to disconnection requested by the server via <see cref="IStatefulUserHubClient.DisconnectRequested"/>.
-        /// </summary>
-        public event Action? Disconnecting;
-
-        /// <summary>
         /// A dictionary containing all users currently being watched, with the number of watching components for each user.
         /// </summary>
         private readonly Dictionary<int, int> watchedUsersRefCounts = new Dictionary<int, int>();
@@ -200,18 +195,6 @@ namespace osu.Game.Online.Spectator
                 watchingUsers.RemoveAll(u => u.OnlineID == userId);
             });
 
-            return Task.CompletedTask;
-        }
-
-        Task IStatefulUserHubClient.DisconnectRequested()
-        {
-            Schedule(() => DisconnectInternal().FireAndForget());
-            return Task.CompletedTask;
-        }
-
-        Task IStatefulUserHubClient.ServerShuttingDown()
-        {
-            // TODO: check when we can disconnect and do so.
             return Task.CompletedTask;
         }
 
@@ -379,12 +362,6 @@ namespace osu.Game.Online.Spectator
 
         protected abstract Task StopWatchingUserInternal(int userId);
 
-        protected virtual Task DisconnectInternal()
-        {
-            Disconnecting?.Invoke();
-            return Task.CompletedTask;
-        }
-
         protected override void Update()
         {
             base.Update();
@@ -452,5 +429,32 @@ namespace osu.Game.Online.Spectator
                 });
             });
         }
+
+        #region Disconnection handling
+
+        /// <summary>
+        /// Invoked just prior to disconnection.
+        /// </summary>
+        public event Action? Disconnecting;
+
+        protected abstract Task DisconnectInternal();
+
+        Task IStatefulUserHubClient.DisconnectRequested()
+        {
+            Schedule(() =>
+            {
+                Disconnecting?.Invoke();
+                DisconnectInternal().FireAndForget();
+            });
+            return Task.CompletedTask;
+        }
+
+        Task IStatefulUserHubClient.ServerShuttingDown()
+        {
+            // TODO: check when we can disconnect and do so.
+            return Task.CompletedTask;
+        }
+
+        #endregion
     }
 }

--- a/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
+++ b/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
@@ -140,5 +140,11 @@ namespace osu.Game.Tests.Visual.Metadata
         {
             isConnected.Value = true;
         }
+
+        protected override Task DisconnectInternal()
+        {
+            Disconnect();
+            return Task.CompletedTask;
+        }
     }
 }

--- a/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
+++ b/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
@@ -136,9 +136,11 @@ namespace osu.Game.Tests.Visual.Metadata
             dailyChallengeInfo.Value = null;
         }
 
-        public void Reconnect()
+        public override Task Reconnect()
         {
             isConnected.Value = true;
+
+            return Task.CompletedTask;
         }
 
         protected override Task DisconnectInternal()

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -830,6 +830,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return Task.CompletedTask;
         }
 
+        public override Task Reconnect()
+        {
+            return Task.CompletedTask;
+        }
+
         public async Task ChangeMatchRoomState(MatchRoomState state)
         {
             Debug.Assert(ServerRoom != null);

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -824,9 +824,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return MessagePackSerializer.Deserialize<T>(serialized, SignalRUnionWorkaroundResolver.OPTIONS);
         }
 
-        public override Task DisconnectInternal()
+        protected override Task DisconnectInternal()
         {
-            isConnected.Value = false;
+            Disconnect();
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -204,10 +204,10 @@ namespace osu.Game.Tests.Visual.Spectator
             });
         }
 
-        protected override async Task DisconnectInternal()
+        protected override Task DisconnectInternal()
         {
-            await base.DisconnectInternal().ConfigureAwait(false);
             isConnected.Value = false;
+            return Task.CompletedTask;
         }
     }
 }

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -209,5 +209,11 @@ namespace osu.Game.Tests.Visual.Spectator
             isConnected.Value = false;
             return Task.CompletedTask;
         }
+
+        public override Task Reconnect()
+        {
+            isConnected.Value = true;
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
Client side requirements for making the client connect as soon as possible, based on how the client is being used. This is especially important with the introduction of ranked play: previously the worst case scenario would be that you couldn't join a multiplayer room (or spectate a user) and this was [automatically handled](https://github.com/ppy/osu/blob/f66e2c432fdb08db46477c4fa08ca74e551d037f/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs#L115-L121) mostly*, but now, if you leave the game open for a while, you can potentially be stuck queueing in ranked play with no users remaining on your server.

Some samples of how this looks follow. Do note that the client is showing "Server is shutting down" errors. This is only going to happen in local debug environments – In production, when you reconnect to the endpoint you will always get a non-shutting-down instance.

Idle scenario:

https://github.com/user-attachments/assets/dd47fdf6-8d49-48e3-a19f-b196a581070b

Non-idle scenario:

https://github.com/user-attachments/assets/dfc8a41a-83fb-4b08-94b4-9595faf88294

* Spectator isn't handled properly, as one example.