### PR TITLE
Add ALSA exclusive-access notice for audio devices on Linux

### DIFF
--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -114,6 +114,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString WasapiNotice => new TranslatableString(getKey(@"wasapi_notice"), @"Due to reduced latency, your audio offset will need to be adjusted when enabling this setting. Generally expect to subtract 20 - 60 ms from your known value.");
 
+        /// <summary>
+        /// "Note that you've selected a device with an exclusive-access driver, which means that you won't be able to hear sounds from other apps while in use by osu!. Also, to initialize it correctly, first ensure it's not being actively used by other applications. You may need to restart osu! and wait a moment to for it de-initialize if you've just used it through other audio driver."
+        /// </summary>
+        public static LocalisableString AlsaExclusiveNotice => new TranslatableString(getKey(@"alsa_exclusive_notice"), @"Note that you've selected a device with an exclusive-access driver, which means that you won't be able to hear sounds from other apps while in use by osu!. Also, to initialize it correctly, first ensure it's not being actively used by other applications. You may need to restart osu! and wait a moment to for it de-initialize if you've just used it through other audio driver.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -17,6 +17,10 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 {
     public partial class AudioDevicesSettings : SettingsSubsection
     {
+        // An example driver name of an ALSA device will look like this: "hw:4,0".
+        // For contrast, Pipewire Server and Default devices will have driver names called respectively "pipewire" and "default".
+        public const string LINUX_ALSA_DEVICE_DRIVER_PREFIX = "hw:";
+
         protected override LocalisableString Header => AudioSettingsStrings.AudioDevicesHeader;
 
         [Resolved]
@@ -27,6 +31,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
         private FormCheckBox? wasapiExperimental;
 
         private readonly Bindable<SettingsNote.Data?> wasapiExperimentalNote = new Bindable<SettingsNote.Data?>();
+        private readonly Bindable<SettingsNote.Data?> alsaExclusiveDeviceNote = new Bindable<SettingsNote.Data?>();
 
         [BackgroundDependencyLoader]
         private void load()
@@ -38,9 +43,12 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                     Caption = AudioSettingsStrings.OutputDevice,
                 })
                 {
-                    Keywords = new[] { "speaker", "headphone", "output" }
+                    Keywords = new[] { "speakers", "headphones", "output" },
+                    Note = { BindTarget = alsaExclusiveDeviceNote },
                 },
             };
+
+            dropdown.Current.ValueChanged += d => onDeviceSelected(d.NewValue);
 
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
             {
@@ -78,10 +86,24 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
             }
         }
 
+        private void onDeviceSelected(string selectedDevice)
+        {
+            string? currentDriver = audio.AudioDeviceNames.Where(d => d.Name == selectedDevice).Select(d => d.Driver).FirstOrDefault();
+
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux && currentDriver.IsNotNull() && currentDriver.StartsWith(LINUX_ALSA_DEVICE_DRIVER_PREFIX, System.StringComparison.Ordinal))
+            {
+                alsaExclusiveDeviceNote.Value = new SettingsNote.Data(AudioSettingsStrings.AlsaExclusiveNotice, SettingsNote.Type.Warning);
+            }
+            else
+            {
+                alsaExclusiveDeviceNote.Value = null;
+            }
+        }
+
         private void updateItems()
         {
             var deviceItems = new List<string> { string.Empty };
-            deviceItems.AddRange(audio.AudioDeviceNames);
+            deviceItems.AddRange(audio.AudioDeviceNames.Select(d => d.Name));
 
             string preferredDeviceName = audio.AudioDevice.Value;
             if (deviceItems.All(kv => kv != preferredDeviceName))


### PR DESCRIPTION
Depends on framework PR: https://github.com/ppy/osu-framework/pull/6738

Adds a note that pops up once user on Linux selects ALSA device. These devices are available and work but require knowledge that:
1. it won't init if it's already being used, usually by pipewire;
2. other sounds in the system won't play while osu has it grabbed

The above is not obvious. It took me a while to figure it out, and I've seen others being surprised by this behavior too, for instance:
- https://github.com/ppy/osu/discussions/26974#discussioncomment-8350737
- https://github.com/ppy/osu/discussions/26765#discussion-6144562

<img height="300" alt="image" src="https://github.com/user-attachments/assets/473f8eed-608c-4324-a5ee-0202ca6a4431" />

I know the proposed note is a bit long. An alternative I considered is removing the last 2 sentences of the note, and displaying them only after getting "Busy" message from bass init.