### PR TITLE
Feature: Implement automatic global audio offset calibration

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -109,6 +109,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.AudioOffset, 0, -500.0, 500.0, 1);
 
+            SetDefault(OsuSetting.AutomaticallyAdjustGlobalAudioOffset, false);
             SetDefault(OsuSetting.AutomaticallyAdjustBeatmapOffset, false);
 
             // Input
@@ -490,6 +491,7 @@ namespace osu.Game.Configuration
         LastOnlineTagsPopulation,
 
         AutomaticallyAdjustBeatmapOffset,
+        AutomaticallyAdjustGlobalAudioOffset,
 
         DashboardSortMode,
         DashboardDisplayStyle,

--- a/osu.Game/Configuration/SessionAverageHitErrorTracker.cs
+++ b/osu.Game/Configuration/SessionAverageHitErrorTracker.cs
@@ -23,12 +23,16 @@ namespace osu.Game.Configuration
 
         private readonly Bindable<ScoreInfo?> latestScore = new Bindable<ScoreInfo?>();
 
+        private readonly Bindable<bool> autoAdjustGlobalOffset = new Bindable<bool>();
+
         [Resolved]
         private OsuConfigManager configManager { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load(SessionStatics statics)
         {
+            configManager.BindWith(OsuSetting.AutomaticallyAdjustGlobalAudioOffset, autoAdjustGlobalOffset);
+
             statics.BindWith(Static.LastLocalUserScore, latestScore);
             latestScore.BindValueChanged(score => calculateAverageHitError(score.NewValue), true);
         }
@@ -53,6 +57,17 @@ namespace osu.Game.Configuration
 
             double globalOffset = configManager.Get<double>(OsuSetting.AudioOffset);
             averageHitErrorHistory.Add(new DataPoint(medianError, globalOffset));
+
+            if (autoAdjustGlobalOffset.Value && averageHitErrorHistory.Count >= 3)
+            {
+                double suggested = Math.Round(averageHitErrorHistory.Average(dataPoint => dataPoint.SuggestedGlobalAudioOffset));
+
+                if (Math.Abs(suggested - globalOffset) >= 1)
+                {
+                    configManager.SetValue(OsuSetting.AudioOffset, suggested);
+                    ClearHistory();
+                }
+            }
         }
 
         public void ClearHistory() => averageHitErrorHistory.Clear();

--- a/osu.Game/Configuration/SessionAverageHitErrorTracker.cs
+++ b/osu.Game/Configuration/SessionAverageHitErrorTracker.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -100,6 +100,16 @@ namespace osu.Game.Localisation
         public static LocalisableString AdjustBeatmapOffsetAutomaticallyTooltip => new TranslatableString(getKey(@"adjust_beatmap_offset_automatically_tooltip"), @"If enabled, the offset suggested from last play on a beatmap is automatically applied.");
 
         /// <summary>
+        /// "Adjust global audio offset automatically"
+        /// </summary>
+        public static LocalisableString AdjustGlobalAudioOffsetAutomatically => new TranslatableString(getKey(@"adjust_global_audio_offset_automatically"), @"Adjust global audio offset automatically");
+
+        /// <summary>
+        /// "If enabled, the global offset will slowly adjust itself over time based on your average hit error."
+        /// </summary>
+        public static LocalisableString AdjustGlobalAudioOffsetAutomaticallyTooltip => new TranslatableString(getKey(@"adjust_global_audio_offset_automatically_tooltip"), @"If enabled, the global offset will slowly adjust itself over time based on your average hit error.");
+
+        /// <summary>
         /// "Use experimental audio mode"
         /// </summary>
         public static LocalisableString WasapiLabel => new TranslatableString(getKey(@"wasapi_label"), @"Use experimental audio mode");

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -105,9 +105,9 @@ namespace osu.Game.Localisation
         public static LocalisableString AdjustGlobalAudioOffsetAutomatically => new TranslatableString(getKey(@"adjust_global_audio_offset_automatically"), @"Adjust global audio offset automatically");
 
         /// <summary>
-        /// "If enabled, the global offset will slowly adjust itself over time based on your average hit error."
+        /// "If enabled, the global offset will slowly adjust itself over time based on your recent hit error."
         /// </summary>
-        public static LocalisableString AdjustGlobalAudioOffsetAutomaticallyTooltip => new TranslatableString(getKey(@"adjust_global_audio_offset_automatically_tooltip"), @"If enabled, the global offset will slowly adjust itself over time based on your average hit error.");
+        public static LocalisableString AdjustGlobalAudioOffsetAutomaticallyTooltip => new TranslatableString(getKey(@"adjust_global_audio_offset_automatically_tooltip"), @"If enabled, the global offset will slowly adjust itself over time based on your recent hit error.");
 
         /// <summary>
         /// "Use experimental audio mode"

--- a/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
@@ -30,6 +30,12 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 },
                 new SettingsItemV2(new FormCheckBox
                 {
+                    Caption = AudioSettingsStrings.AdjustGlobalAudioOffsetAutomatically,
+                    HintText = AudioSettingsStrings.AdjustGlobalAudioOffsetAutomaticallyTooltip,
+                    Current = config.GetBindable<bool>(OsuSetting.AutomaticallyAdjustGlobalAudioOffset),
+                }),
+                new SettingsItemV2(new FormCheckBox
+                {
                     Caption = AudioSettingsStrings.AdjustBeatmapOffsetAutomatically,
                     HintText = AudioSettingsStrings.AdjustBeatmapOffsetAutomaticallyTooltip,
                     Current = config.GetBindable<bool>(OsuSetting.AutomaticallyAdjustBeatmapOffset),


### PR DESCRIPTION
Feature: Automatic Global Audio Offset Calibration

    Files: OsuConfigManager.cs, OffsetSettings.cs, AudioSettingsStrings.cs, SessionAverageHitErrorTracker.cs

    Change: Introduced a new setting (AutomaticallyAdjustGlobalAudioOffset) that continuously tracks and adjusts the player's global audio offset.

    Rationale: Finding the perfect audio offset is a notorious pain point for players due to varying hardware latency (keyboard switches, monitors).

    Implementation Details: * Modified the background SessionAverageHitErrorTracker.

        If the setting is enabled, the tracker averages the median hit error over the last 3 played beatmaps.

        If the suggested offset differs by ≥ 1ms from the current setting, it seamlessly updates the AudioOffset configuration and clears the history.

        This allows the game to self-calibrate to the player's natural reaction time and hardware latency without manual wizard intervention.