### PR TITLE
Feature: Add Objects Remaining Counter HUD element

### DIFF
--- a/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The maximum number of hits that can be judged.
         /// </summary>
-        protected int MaxHits { get; private set; }
+        public int MaxHits { get; private set; }
 
         /// <summary>
         /// Whether <see cref="SimulateAutoplay"/> is currently running.

--- a/osu.Game/Screens/Play/HUD/ObjectsRemainingCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ObjectsRemainingCounter.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Screens.Play.HUD
+{
+    public partial class ObjectsRemainingCounter : RollingCounter<int>, ISerialisableDrawable
+    {
+        protected override double RollingDuration => 250;
+
+        [Resolved]
+        private ScoreProcessor scoreProcessor { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colour)
+        {
+            Colour = colour.YellowLighter;
+            Current.Value = DisplayedCount = 0;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (scoreProcessor != null)
+            {
+                scoreProcessor.NewJudgement += onJudgementChanged;
+                scoreProcessor.JudgementReverted += onJudgementChanged;
+                updateCount();
+            }
+        }
+
+        private void onJudgementChanged(JudgementResult _) => updateCount();
+
+        private void updateCount()
+        {
+            Current.Value = scoreProcessor.MaxHits - scoreProcessor.JudgedHits;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (scoreProcessor != null)
+            {
+                scoreProcessor.NewJudgement -= onJudgementChanged;
+                scoreProcessor.JudgementReverted -= onJudgementChanged;
+            }
+        }
+
+        protected override OsuSpriteText CreateSpriteText()
+            => base.CreateSpriteText().With(s => s.Font = s.Font.With(size: 20f, fixedWidth: true));
+
+        protected override LocalisableString FormatCount(int count)
+        {
+            return count.ToString();
+        }
+
+        protected override IHasText CreateText() => new TextComponent();
+
+        private partial class TextComponent : CompositeDrawable, IHasText
+        {
+            public LocalisableString Text
+            {
+                get => text.Text;
+                set => text.Text = value;
+            }
+
+            private readonly OsuSpriteText text;
+
+            public TextComponent()
+            {
+                AutoSizeAxes = Axes.Both;
+
+                InternalChild = new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Spacing = new Vector2(2),
+                    Children = new Drawable[]
+                    {
+                        text = new OsuSpriteText
+                        {
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            Font = OsuFont.Numeric.With(size: 16, fixedWidth: true)
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            Font = OsuFont.Numeric.With(size: 8),
+                            Text = @"REMAINING",
+                            Padding = new MarginPadding { Bottom = 2f },
+                        }
+                    }
+                };
+            }
+        }
+
+        public bool UsesFixedAnchor { get; set; }
+    }
+}

--- a/osu.Game/Screens/Play/HUD/ObjectsRemainingCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ObjectsRemainingCounter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -34,34 +35,29 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            if (scoreProcessor != null)
-            {
-                scoreProcessor.NewJudgement += onJudgementChanged;
-                scoreProcessor.JudgementReverted += onJudgementChanged;
-                updateCount();
-            }
+            scoreProcessor.NewJudgement += onJudgementChanged;
+            scoreProcessor.JudgementReverted += onJudgementChanged;
+            updateCount();
         }
 
         private void onJudgementChanged(JudgementResult _) => updateCount();
 
         private void updateCount()
         {
-            Current.Value = scoreProcessor.MaxHits - scoreProcessor.JudgedHits;
+            int remaining = scoreProcessor.MaxHits - scoreProcessor.JudgedHits;
+            Current.Value = remaining < 0 ? 0 : remaining;
         }
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
-
-            if (scoreProcessor != null)
+            if (IsNotNull())
             {
                 scoreProcessor.NewJudgement -= onJudgementChanged;
                 scoreProcessor.JudgementReverted -= onJudgementChanged;
             }
-        }
 
-        protected override OsuSpriteText CreateSpriteText()
-            => base.CreateSpriteText().With(s => s.Font = s.Font.With(size: 20f, fixedWidth: true));
+            base.Dispose(isDisposing);
+        }
 
         protected override LocalisableString FormatCount(int count)
         {
@@ -101,7 +97,7 @@ namespace osu.Game.Screens.Play.HUD
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
                             Font = OsuFont.Numeric.With(size: 8),
-                            Text = @"REMAINING",
+                            Text = new TranslatableString(@"objects_remaining_counter.remaining", @"REMAINING"),
                             Padding = new MarginPadding { Bottom = 2f },
                         }
                     }


### PR DESCRIPTION
Feature: Add "Objects Remaining" Counter HUD element

    File: osu.Game/Screens/Play/HUD/ObjectsRemainingCounter.cs

    Change: Created a new skinnable HUD element that displays the exact number of hit objects remaining in the beatmap.

    Rationale: Provides players with a clear numerical countdown of remaining objects, serving as a more precise alternative or supplement to the standard progress bar.

    Implementation Details:

        Inherits from RollingCounter<int> to provide smooth number transitions and animations.

        Implements ISerialisableDrawable, allowing full integration with the in-game Skin Editor (positioning, scaling, and skin-specific styling).

        Utilizes Dependency Injection to resolve ScoreProcessor and safely subscribes to NewJudgement and JudgementReverted events.

        Dynamically calculates the display value as MaxHits - JudgedHits, ensuring zero gameplay latency and accurate tracking even if a judgement is reverted (e.g., in specific mod scenarios).

        Note: Requires MaxHits to be exposed publicly in JudgementProcessor.cs.