### PR TITLE
Refactor: Modernize HitResult classification methods

### DIFF
--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -225,22 +225,16 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Whether a <see cref="HitResult"/> is a non-tick and non-bonus result.
         /// </summary>
-        public static bool IsBasic(this HitResult result)
+        public static bool IsBasic(this HitResult result) => result switch
         {
-            switch (result)
-            {
-                // LegacyComboIncrease is a special non-gameplay type which is neither a basic, tick, bonus, or accuracy-affecting result.
-                case HitResult.LegacyComboIncrease:
-                    return false;
+            // LegacyComboIncrease is a special non-gameplay type which is neither a basic, tick, bonus, or accuracy-affecting result.
+            HitResult.LegacyComboIncrease => false,
 
-                // ComboBreak is a special type that only affects combo. It cannot be considered as basic, tick, bonus, or accuracy-affecting.
-                case HitResult.ComboBreak:
-                    return false;
+            // ComboBreak is a special type that only affects combo. It cannot be considered as basic, tick, bonus, or accuracy-affecting.
+            HitResult.ComboBreak => false,
 
-                default:
-                    return IsScorable(result) && !IsTick(result) && !IsBonus(result);
-            }
-        }
+            _ => IsScorable(result) && !IsTick(result) && !IsBonus(result)
+        };
 
         /// <summary>
         /// Whether a <see cref="HitResult"/> should be counted as a tick.
@@ -325,26 +319,19 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Whether a <see cref="HitResult"/> is scorable.
         /// </summary>
-        public static bool IsScorable(this HitResult result)
+        public static bool IsScorable(this HitResult result) => result switch
         {
-            switch (result)
-            {
-                // LegacyComboIncrease is not actually scorable (in terms of usable by rulesets for that purpose), but needs to be defined as such to be correctly included in statistics output.
-                case HitResult.LegacyComboIncrease:
-                    return true;
+            // LegacyComboIncrease is not actually scorable (in terms of usable by rulesets for that purpose), but needs to be defined as such to be correctly included in statistics output.
+            HitResult.LegacyComboIncrease => true,
 
-                // ComboBreak is its own type that affects score via combo.
-                case HitResult.ComboBreak:
-                    return true;
+            // ComboBreak is its own type that affects score via combo.
+            HitResult.ComboBreak => true,
 
-                case HitResult.SliderTailHit:
-                    return true;
+            HitResult.SliderTailHit => true,
 
-                default:
-                    // Note that IgnoreHit and IgnoreMiss are excluded as they do not affect score.
-                    return result >= HitResult.Miss && result < HitResult.IgnoreMiss;
-            }
-        }
+            // Note that IgnoreHit and IgnoreMiss are excluded as they do not affect score.
+            _ => result >= HitResult.Miss && result < HitResult.IgnoreMiss
+        };
 
         /// <summary>
         /// An array of all scorable <see cref="HitResult"/>s.


### PR DESCRIPTION
Refactor: Modernize HitResult classification methods

    File: osu.Game/Rulesets/Scoring/HitResult.cs

    Change: Modernized 8 core classification methods: AffectsCombo, AffectsAccuracy, IsBasic, IsTick, IsBonus, IsMiss, IsHit, and IsScorable.

    Rationale: Converted verbose legacy switch/case statements into modern C# expression-bodied switch expressions.

    Implementation Details:

        Drastically reduces line count and "boilerplate" code.

        Improves visual readability by presenting logic as a concise truth table.

        Enforces exhaustive returns at compile-time, preventing accidental bugs caused by forgotten break statements or unhandled cases (fall-through bugs).

        Aligns the HitResult logic with the modern architectural style used in newer parts of the osu-lazer codebase.