### PR TITLE
Make Taiko hit fly away animation speed match osu!stable

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDoubleTime.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDoubleTime.cs
@@ -11,12 +11,10 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {
-            switch (drawable)
+            //Increase flying time to match stable. Because osu!stable does not make flying hits go faster with DoubleTime
+            if (drawable is DrawableTaikoHitObject taiko)
             {
-                case DrawableTaikoHitObject taiko:
-                    //Increase flying time to match stable. Because osu!stable does not make flying hits go faster with DoubleTime
-                    taiko.FlyingTimeAfterHit = 300 * 1.5f;
-                    break;
+                taiko.FlyingTimeAfterHit = 300.0 * SpeedChange.Value;
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDoubleTime.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDoubleTime.cs
@@ -2,10 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModDoubleTime : ModDoubleTime
+    public class TaikoModDoubleTime : ModDoubleTime, IApplicableToDrawableHitObject
     {
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+        {
+            switch (drawable)
+            {
+                case DrawableTaikoHitObject taiko:
+                    //Increase flying time to match stable. Because osu!stable does not make flying hits go faster with DoubleTime
+                    taiko.FlyingTimeAfterHit = 300 * 1.5f;
+                    break;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHalfTime.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHalfTime.cs
@@ -2,10 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModHalfTime : ModHalfTime
+    public class TaikoModHalfTime : ModHalfTime, IApplicableToDrawableHitObject
     {
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+        {
+            switch (drawable)
+            {
+                case DrawableTaikoHitObject taiko:
+                    //Increase flying time to match stable. Because osu!stable does not make flying hits go faster with DoubleTime
+                    taiko.FlyingTimeAfterHit = 300 * 0.75f;
+                    break;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModWindDown.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModWindDown.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Logging;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModWindDown.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModWindDown.cs
@@ -1,13 +1,14 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Logging;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModHalfTime : ModHalfTime, IApplicableToDrawableHitObject
+    public class TaikoModWindDown : ModWindDown, IApplicableToDrawableHitObject
     {
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModWindUp.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModWindUp.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mods;
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Taiko.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModHalfTime : ModHalfTime, IApplicableToDrawableHitObject
+    public class TaikoModWindUp : ModWindUp, IApplicableToDrawableHitObject
     {
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -10,9 +10,11 @@ using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Framework.Timing;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
+using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -20,6 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
     public partial class DrawableHit : DrawableTaikoStrongableHitObject<Hit, Hit.StrongNestedHit>
     {
+
         /// <summary>
         /// A list of keys which can result in hits for this HitObject.
         /// </summary>
@@ -162,17 +165,16 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     // If we're far enough away from the left stage, we should bring ourselves in front of it
                     ProxyContent();
 
-                    const float gravity_time = 300;
                     const float gravity_travel_height = 200;
 
                     if (SnapJudgementLocation)
                         MainPiece.MoveToX(-X);
 
-                    this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
+                    this.ScaleTo(0.8f, FlyingTimeAfterHit * 2, Easing.OutQuad);
 
-                    this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)
+                    this.MoveToY(-gravity_travel_height, FlyingTimeAfterHit, Easing.Out)
                         .Then()
-                        .MoveToY(gravity_travel_height * 2, gravity_time * 2, Easing.In);
+                        .MoveToY(gravity_travel_height * 2, FlyingTimeAfterHit * 2, Easing.In);
 
                     this.FadeOut(800);
                     break;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -10,11 +10,9 @@ using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
-using osu.Framework.Timing;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
-using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -22,7 +20,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
     public partial class DrawableHit : DrawableTaikoStrongableHitObject<Hit, Hit.StrongNestedHit>
     {
-
         /// <summary>
         /// A list of keys which can result in hits for this HitObject.
         /// </summary>

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// <summary>
         /// Length of the animation of the taiko note flying away after hit
         /// </summary>
-        public float FlyingTimeAfterHit = 300;
+        public double FlyingTimeAfterHit = 300;
 
         /// <summary>
         /// Whether the location of the hit should be snapped to the hit target before animating.

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -26,6 +26,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private readonly Container nonProxiedContent;
 
         /// <summary>
+        /// Length of the animation of the taiko note flying away after hit
+        /// </summary>
+        public float FlyingTimeAfterHit = 300;
+
+        /// <summary>
         /// Whether the location of the hit should be snapped to the hit target before animating.
         /// </summary>
         /// <remarks>

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -172,7 +172,7 @@ namespace osu.Game.Rulesets.Taiko
                 case ModType.Fun:
                     return new Mod[]
                     {
-                        new MultiMod(new ModWindUp(), new ModWindDown()),
+                        new MultiMod(new TaikoModWindUp(), new TaikoModWindDown()),
                         new TaikoModMuted(),
                         new ModAdaptiveSpeed()
                     };


### PR DESCRIPTION
Hi, this is my first time contributing so I apologize in advance for any mistakes.

This PR addresses the fact that osu!lazer currently scales the animation that makes the notes fly away in osu! taiko after they've been hit with both HT and DT. This just makes it match osu!stable which does not scale those animations.

Motivation for this PR came after both I and some other people have been trying to play DT/HT in the osu!lazer client, and realised how disorienting/harder to read Taiko DT is with this change.

I tried running InspectCode to make sure my code was fine, though I'm not surefully run? This was my output.

```
JetBrains Inspect Code 2025.2.3
Running on x64 OS in x64 architecture, .NET 9.0.0 under Microsoft Windows 10.0.26100
Warning: Unable to start tracking D:\.Source\osu\Templates\Rulesets\ruleset-scrolling-example\.editorconfig in RdProjectId (  id = 21)/RdTargetFramework (  name = "net8.0"), it's already tracked. Caller StartTracking:28
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET program, but dotnet-nvika does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
```
Though I imagine my changes are small enough to not have very major issues 😅

I chose to modify both the rate changing mods directly, as my first attempts to change the Clock of DrawableHit directly wasn't successful (also would've probably been rather messy). Due to my unfamiliarity with the codebase I'm sure how I've implemented it isn't ideal, it does repeat the same lines of code for every rate changing mod which isn't ideal, so if there is a way to apply this in a more central way that you could point me to me I would definetly fix that right up.

DrawableTaikoHitObject gets a new public property which controls how long the animation is, which then all the rate changing mods modify after having been made to implement IApplicableToDrawableHitObject. The way I've implemented it necessitated the creation of a TaikoModWindUp and TaikoModWindDown.