### PR TITLE
Show ranked play rankings in `RankingsOverlay`

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("User performance", createPerformanceTable);
             AddStep("User scores", createScoreTable);
             AddStep("Country scores", createCountryTable);
+            AddStep("Ranked play ladder", createRankedTable);
         }
 
         private void createCountryTable()
@@ -151,6 +152,26 @@ namespace osu.Game.Tests.Visual.Online
         {
             onLoadStarted();
             loadTable(new ScoresTable(1, createUserStatistics()));
+        }
+
+        private void createRankedTable()
+        {
+            onLoadStarted();
+            loadTable(new MatchmakingTable(1, new List<APIUserMatchmakingStatistics>
+            {
+                new APIUserMatchmakingStatistics
+                {
+                    User = new APIUser
+                    {
+                        Username = "first active user",
+                        CountryCode = CountryCode.JP,
+                        Active = true,
+                    },
+                    FirstPlacements = 10,
+                    Plays = 20,
+                    Rating = 1500,
+                },
+            }));
         }
 
         private void onLoadStarted()

--- a/osu.Game/Online/API/Requests/GetMatchmakingPoolsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetMatchmakingPoolsRequest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetMatchmakingPoolsRequest : APIRequest<List<APIMatchmakingPool>>
+    {
+        public readonly RulesetInfo Ruleset;
+
+        public GetMatchmakingPoolsRequest(RulesetInfo ruleset)
+        {
+            Ruleset = ruleset;
+        }
+
+        protected override string Target => @$"rankings/ranked-play/{Ruleset.ShortName}";
+    }
+}

--- a/osu.Game/Online/API/Requests/GetMatchmakingRankingRequest.cs
+++ b/osu.Game/Online/API/Requests/GetMatchmakingRankingRequest.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetMatchmakingRankingRequest : APIRequest<GetMatchmakingRankingResponse>
+    {
+        public readonly RulesetInfo Ruleset;
+        public readonly APIMatchmakingPool Pool;
+
+        public GetMatchmakingRankingRequest(RulesetInfo ruleset, APIMatchmakingPool pool)
+        {
+            Ruleset = ruleset;
+            Pool = pool;
+        }
+
+        protected override string Target => $"rankings/ranked-play/{Ruleset.ShortName}/{Pool.Id}";
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/APIMatchmakingPool.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIMatchmakingPool.cs
@@ -21,5 +21,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         [JsonProperty("variant_id")]
         public int VariantId { get; set; }
+
+        public override string ToString() => Name;
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APIUserMatchmakingStatistics.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUserMatchmakingStatistics.cs
@@ -7,6 +7,9 @@ namespace osu.Game.Online.API.Requests.Responses
 {
     public class APIUserMatchmakingStatistics
     {
+        [JsonProperty("user")]
+        public APIUser User = new APIUser();
+
         [JsonProperty("user_id")]
         public int UserId;
 

--- a/osu.Game/Online/API/Requests/Responses/GetMatchmakingRankingResponse.cs
+++ b/osu.Game/Online/API/Requests/Responses/GetMatchmakingRankingResponse.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class GetMatchmakingRankingResponse : ResponseWithCursor
+    {
+        [JsonProperty("ranking")]
+        public List<APIUserMatchmakingStatistics> Users = [];
+    }
+}

--- a/osu.Game/Overlays/Rankings/MatchmakingLayout.cs
+++ b/osu.Game/Overlays/Rankings/MatchmakingLayout.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays.Rankings.Tables;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Overlays.Rankings
+{
+    public partial class MatchmakingLayout : CompositeDrawable
+    {
+        public readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
+
+        private readonly Bindable<APIMatchmakingPool> selectedPool = new Bindable<APIMatchmakingPool>();
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        private CancellationTokenSource? cancellationToken;
+        private GetMatchmakingPoolsRequest? getPoolsRequest;
+        private GetMatchmakingRankingRequest? getRankingRequest;
+
+        private MatchmakingPoolSelector selector = null!;
+        private Container content = null!;
+        private LoadingLayer loading = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new ReverseChildIDFillFlowContainer<Drawable>
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    selector = new MatchmakingPoolSelector
+                    {
+                        Current = selectedPool,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Children = new Drawable[]
+                        {
+                            content = new Container
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Margin = new MarginPadding { Vertical = 10 }
+                            },
+                            loading = new LoadingLayer(true)
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            selectedPool.BindValueChanged(_ => onPoolChanged());
+            Ruleset.BindValueChanged(_ => onRulesetChanged());
+
+            getMatchmakingPools();
+        }
+
+        private void getMatchmakingPools()
+        {
+            getPoolsRequest?.Cancel();
+
+            getPoolsRequest = new GetMatchmakingPoolsRequest(Ruleset.Value);
+            getPoolsRequest.Success += response => Schedule(() => selector.Pools = response);
+            api.Queue(getPoolsRequest);
+        }
+
+        private void onRulesetChanged()
+        {
+            if (!selector.Pools.Any())
+                return;
+
+            selectedPool.TriggerChange();
+        }
+
+        private void onPoolChanged()
+        {
+            loading.Show();
+
+            cancellationToken?.Cancel();
+            getRankingRequest?.Cancel();
+
+            getRankingRequest = new GetMatchmakingRankingRequest(Ruleset.Value, selectedPool.Value);
+            getRankingRequest.Success += onSuccess;
+
+            api.Queue(getRankingRequest);
+        }
+
+        private void onSuccess(GetMatchmakingRankingResponse response)
+        {
+            LoadComponentAsync(new MatchmakingTable(1, response.Users), loaded =>
+            {
+                content.Clear();
+                content.Add(loaded);
+
+                loading.Hide();
+            }, (cancellationToken = new CancellationTokenSource()).Token);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            getPoolsRequest?.Cancel();
+            getRankingRequest?.Cancel();
+            cancellationToken?.Cancel();
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game/Overlays/Rankings/MatchmakingPoolSelector.cs
+++ b/osu.Game/Overlays/Rankings/MatchmakingPoolSelector.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Overlays.Rankings
+{
+    public partial class MatchmakingPoolSelector : CompositeDrawable, IHasCurrentValue<APIMatchmakingPool>
+    {
+        private readonly BindableWithCurrent<APIMatchmakingPool> current = new BindableWithCurrent<APIMatchmakingPool>();
+
+        public Bindable<APIMatchmakingPool> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        public IEnumerable<APIMatchmakingPool> Pools
+        {
+            get => dropdown.Items;
+            set => dropdown.Items = value;
+        }
+
+        private readonly Box background;
+        private readonly RankingSelectorDropdown<APIMatchmakingPool> dropdown;
+
+        public MatchmakingPoolSelector()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChildren = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
+                    Child = new Container
+                    {
+                        Margin = new MarginPadding { Vertical = 20 },
+                        RelativeSizeAxes = Axes.X,
+                        Height = 40,
+                        Depth = -float.MaxValue,
+                        Child = dropdown = new RankingSelectorDropdown<APIMatchmakingPool>
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Current = Current
+                        }
+                    },
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            background.Colour = colourProvider.Dark3;
+        }
+    }
+}

--- a/osu.Game/Overlays/Rankings/RankingSelectorDropdown.cs
+++ b/osu.Game/Overlays/Rankings/RankingSelectorDropdown.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Overlays.Rankings
+{
+    public partial class RankingSelectorDropdown<T> : OsuDropdown<T>
+        where T : class
+    {
+        private OsuDropdownMenu menu = null!;
+
+        protected override DropdownMenu CreateMenu() => menu = (OsuDropdownMenu)base.CreateMenu().With(m => m.MaxHeight = 400);
+
+        protected override DropdownHeader CreateHeader() => new RankingSelectorDropdownHeader();
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            menu.BackgroundColour = colourProvider.Background5;
+            menu.HoverColour = colourProvider.Background4;
+            menu.SelectionColour = colourProvider.Background3;
+        }
+
+        private partial class RankingSelectorDropdownHeader : OsuDropdownHeader
+        {
+            public RankingSelectorDropdownHeader()
+            {
+                AutoSizeAxes = Axes.Y;
+                Text.Font = OsuFont.GetFont(size: 15);
+                Text.Padding = new MarginPadding { Vertical = 1.5f }; // osu-web line-height difference compensation
+                Foreground.Padding = new MarginPadding { Horizontal = 10, Vertical = 15 };
+                Margin = Chevron.Margin = new MarginPadding(0);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                BackgroundColour = colourProvider.Background6.Opacity(0.5f);
+                // osu-web adds a 0.6 opacity container on top of the 0.5 base one when hovering, 0.8 on a single container here matches the resulting colour
+                BackgroundColourHover = colourProvider.Background6.Opacity(0.8f);
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -55,6 +55,7 @@ namespace osu.Game.Overlays.Rankings
                     case RankingsScope.Score:
                     case RankingsScope.Country:
                     case RankingsScope.Playlists:
+                    case RankingsScope.Matchmaking:
                         return true;
 
                     default:

--- a/osu.Game/Overlays/Rankings/RankingsScope.cs
+++ b/osu.Game/Overlays/Rankings/RankingsScope.cs
@@ -20,6 +20,9 @@ namespace osu.Game.Overlays.Rankings
         [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypePlaylists))]
         Playlists,
 
+        [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypeMatchmaking))]
+        Matchmaking,
+
         [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypeKudosu))]
         Kudosu,
     }

--- a/osu.Game/Overlays/Rankings/SpotlightSelector.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightSelector.cs
@@ -10,14 +10,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osuTK;
 using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Online.API.Requests;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
@@ -42,7 +40,7 @@ namespace osu.Game.Overlays.Rankings
         }
 
         private readonly Box background;
-        private readonly SpotlightsDropdown dropdown;
+        private readonly RankingSelectorDropdown<APISpotlight> dropdown;
         private readonly InfoColumn startDateColumn;
         private readonly InfoColumn endDateColumn;
         private readonly InfoColumn mapCountColumn;
@@ -74,10 +72,11 @@ namespace osu.Game.Overlays.Rankings
                             new Container
                             {
                                 Margin = new MarginPadding { Vertical = 20 },
+                                Padding = new MarginPadding { Vertical = 20 },
                                 RelativeSizeAxes = Axes.X,
                                 Height = 40,
                                 Depth = -float.MaxValue,
-                                Child = dropdown = new SpotlightsDropdown
+                                Child = dropdown = new RankingSelectorDropdown<APISpotlight>
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     Current = Current
@@ -172,44 +171,6 @@ namespace osu.Game.Overlays.Rankings
             private void load(OverlayColourProvider colourProvider)
             {
                 valueText.Colour = colourProvider.Content2;
-            }
-        }
-
-        private partial class SpotlightsDropdown : OsuDropdown<APISpotlight>
-        {
-            private OsuDropdownMenu menu;
-
-            protected override DropdownMenu CreateMenu() => menu = (OsuDropdownMenu)base.CreateMenu().With(m => m.MaxHeight = 400);
-
-            protected override DropdownHeader CreateHeader() => new SpotlightsDropdownHeader();
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                menu.BackgroundColour = colourProvider.Background5;
-                menu.HoverColour = colourProvider.Background4;
-                menu.SelectionColour = colourProvider.Background3;
-                Padding = new MarginPadding { Vertical = 20 };
-            }
-
-            private partial class SpotlightsDropdownHeader : OsuDropdownHeader
-            {
-                public SpotlightsDropdownHeader()
-                {
-                    AutoSizeAxes = Axes.Y;
-                    Text.Font = OsuFont.GetFont(size: 15);
-                    Text.Padding = new MarginPadding { Vertical = 1.5f }; // osu-web line-height difference compensation
-                    Foreground.Padding = new MarginPadding { Horizontal = 10, Vertical = 15 };
-                    Margin = Chevron.Margin = new MarginPadding(0);
-                }
-
-                [BackgroundDependencyLoader]
-                private void load(OverlayColourProvider colourProvider)
-                {
-                    BackgroundColour = colourProvider.Background6.Opacity(0.5f);
-                    // osu-web adds a 0.6 opacity container on top of the 0.5 base one when hovering, 0.8 on a single container here matches the resulting colour
-                    BackgroundColourHover = colourProvider.Background6.Opacity(0.8f);
-                }
             }
         }
     }

--- a/osu.Game/Overlays/Rankings/Tables/MatchmakingTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/MatchmakingTable.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Users;
+using osu.Game.Users.Drawables;
+using osuTK;
+
+namespace osu.Game.Overlays.Rankings.Tables
+{
+    public partial class MatchmakingTable : RankingsTable<APIUserMatchmakingStatistics>
+    {
+        public MatchmakingTable(int page, IReadOnlyList<APIUserMatchmakingStatistics> rankings)
+            : base(page, rankings)
+        {
+        }
+
+        protected override RankingsTableColumn[] CreateAdditionalHeaders() => new[]
+        {
+            new RankingsTableColumn(RankingsStrings.MatchmakingWins, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.MatchmakingPlays, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.MatchmakingRating, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize), true),
+        };
+
+        protected override Drawable[] CreateAdditionalContent(APIUserMatchmakingStatistics item) => new Drawable[]
+        {
+            new ColouredRowText
+            {
+                Text = item.FirstPlacements.ToLocalisableString(@"N0"),
+            },
+            new ColouredRowText
+            {
+                Text = item.Plays.ToLocalisableString(@"N0"),
+            },
+            new RowText
+            {
+                Text = item.Rating.ToLocalisableString(@"N0"),
+            },
+        };
+
+        protected override CountryCode GetCountryCode(APIUserMatchmakingStatistics item) => item.User.CountryCode;
+
+        protected override Drawable[] CreateFlagContent(APIUserMatchmakingStatistics item)
+        {
+            var username = new LinkFlowContainer(t => t.Font = OsuFont.GetFont(size: TEXT_SIZE, italics: true))
+            {
+                AutoSizeAxes = Axes.X,
+                RelativeSizeAxes = Axes.Y,
+                TextAnchor = Anchor.CentreLeft
+            };
+            username.AddUserLink(item.User);
+            return [new UpdateableTeamFlag(item.User.Team) { Size = new Vector2(40, 20) }, username];
+        }
+    }
+}

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -108,6 +108,15 @@ namespace osu.Game.Overlays
                 return;
             }
 
+            if (Header.Current.Value == RankingsScope.Matchmaking)
+            {
+                LoadDisplay(new MatchmakingLayout
+                {
+                    Ruleset = { BindTarget = ruleset },
+                });
+                return;
+            }
+
             var request = createScopedRequest();
             lastRequest = request;
 


### PR DESCRIPTION
Depends on https://github.com/ppy/osu-web/pull/12940.

Still unsure on the naming of some things, as you can find both
`Matchmaking` and `RankedPlay`, and the whole thing still effectively
covers any matchmaking pools we might ever have in the backend.

Also the requests don't implement any pagination yet, since that part is
still being discussed in the web-side PR, and additionally, if I
understand correctly, the client isn't doing any pagination on the
rankings anyway.