### PR TITLE
Implement duels for ranked play

### DIFF
--- a/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
@@ -39,6 +39,12 @@ namespace osu.Game.Online.Matchmaking
         Task MatchmakingRoomInvitedWithParams(MatchmakingRoomInvitationParams invitation);
 
         /// <summary>
+        /// Signals that the user has been issued a duel by another user.
+        /// </summary>
+        /// <param name="issue">Contains the parameters for the duel.</param>
+        Task MatchmakingDuelIssued(MatchmakingDuelIssuedParams issue);
+
+        /// <summary>
         /// Signals that the matchmaking room is ready to be opened.
         /// </summary>
         Task MatchmakingRoomReady(long roomId, string password);

--- a/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
@@ -41,6 +41,18 @@ namespace osu.Game.Online.Matchmaking
         Task MatchmakingAcceptInvitation();
 
         /// <summary>
+        /// Issues a matchmaking duel.
+        /// </summary>
+        /// <param name="request">Describes the duel.</param>
+        Task<MatchmakingIssueDuelResponse> MatchmakingIssueDuel(MatchmakingIssueDuelRequest request);
+
+        /// <summary>
+        /// Accepts a matchmaking duel invitation.
+        /// </summary>
+        /// <param name="request">Describes the duel.</param>
+        Task<MatchmakingAcceptDuelResponse> MatchmakingAcceptDuel(MatchmakingAcceptDuelRequest request);
+
+        /// <summary>
         /// Declines a matchmaking room invitation.
         /// </summary>
         Task MatchmakingDeclineInvitation();

--- a/osu.Game/Online/Matchmaking/MatchmakingDuelIssuedParams.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingDuelIssuedParams.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingDuelIssuedParams
+    {
+        [Key(0)]
+        public Guid Id { get; set; }
+
+        [Key(1)]
+        public int UserId { get; set; }
+
+        [Key(2)]
+        public MatchmakingPool Pool { get; set; } = new MatchmakingPool();
+    }
+}

--- a/osu.Game/Online/Matchmaking/MatchmakingPool.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingPool.cs
@@ -26,6 +26,31 @@ namespace osu.Game.Online.Matchmaking
         [Key(4)]
         public MatchmakingPoolType Type { get; set; } = MatchmakingPoolType.QuickPlay;
 
+        [IgnoreMember]
+        public string DisplayName
+        {
+            get
+            {
+                switch (RulesetId)
+                {
+                    case 0:
+                        return $"osu! ({Name})";
+
+                    case 1:
+                        return $"osu!taiko ({Name})";
+
+                    case 2:
+                        return $"osu!catch ({Name})";
+
+                    case 3:
+                        return $"osu!mania {Variant}K ({Name})";
+
+                    default:
+                        return Name;
+                }
+            }
+        }
+
         public bool Equals(MatchmakingPool? other)
             => other != null
                && Id == other.Id

--- a/osu.Game/Online/Matchmaking/Requests/MatchmakingAcceptDuelRequest.cs
+++ b/osu.Game/Online/Matchmaking/Requests/MatchmakingAcceptDuelRequest.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Requests
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingAcceptDuelRequest
+    {
+        [Key(0)]
+        public Guid Id { get; set; }
+    }
+}

--- a/osu.Game/Online/Matchmaking/Requests/MatchmakingIssueDuelRequest.cs
+++ b/osu.Game/Online/Matchmaking/Requests/MatchmakingIssueDuelRequest.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Requests
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingIssueDuelRequest
+    {
+        [Key(0)]
+        public int UserId { get; set; }
+
+        [Key(1)]
+        public int PoolId { get; set; }
+    }
+}

--- a/osu.Game/Online/Matchmaking/Responses/MatchmakingAcceptDuelResponse.cs
+++ b/osu.Game/Online/Matchmaking/Responses/MatchmakingAcceptDuelResponse.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Responses
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingAcceptDuelResponse
+    {
+    }
+}

--- a/osu.Game/Online/Matchmaking/Responses/MatchmakingIssueDuelResponse.cs
+++ b/osu.Game/Online/Matchmaking/Responses/MatchmakingIssueDuelResponse.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Responses
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingIssueDuelResponse
+    {
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -133,6 +133,7 @@ namespace osu.Game.Online.Multiplayer
         public event Action? MatchmakingQueueJoined;
         public event Action? MatchmakingQueueLeft;
         public event Action<MatchmakingRoomInvitationParams>? MatchmakingRoomInvited;
+        public event Action<MatchmakingDuelIssuedParams>? MatchmakingDuelIssued;
         public event Action<long, string>? MatchmakingRoomReady;
         public event Action<MatchmakingLobbyStatus>? MatchmakingLobbyStatusChanged;
         public event Action<MatchmakingQueueStatus>? MatchmakingQueueStatusChanged;
@@ -1115,6 +1116,12 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
+        Task IMatchmakingClient.MatchmakingDuelIssued(MatchmakingDuelIssuedParams issue)
+        {
+            Scheduler.Add(() => MatchmakingDuelIssued?.Invoke(issue));
+            return Task.CompletedTask;
+        }
+
         Task IMatchmakingClient.MatchmakingRoomReady(long roomId, string password)
         {
             Scheduler.Add(() => MatchmakingRoomReady?.Invoke(roomId, password));
@@ -1222,6 +1229,10 @@ namespace osu.Game.Online.Multiplayer
         public abstract Task MatchmakingLeaveQueue();
 
         public abstract Task MatchmakingAcceptInvitation();
+
+        public abstract Task<MatchmakingIssueDuelResponse> MatchmakingIssueDuel(MatchmakingIssueDuelRequest request);
+
+        public abstract Task<MatchmakingAcceptDuelResponse> MatchmakingAcceptDuel(MatchmakingAcceptDuelRequest request);
 
         public abstract Task MatchmakingDeclineInvitation();
 

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Online.Multiplayer
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueJoined), ((IMatchmakingClient)this).MatchmakingQueueJoined);
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueLeft), ((IMatchmakingClient)this).MatchmakingQueueLeft);
                     connection.On<MatchmakingRoomInvitationParams>(nameof(IMatchmakingClient.MatchmakingRoomInvitedWithParams), ((IMatchmakingClient)this).MatchmakingRoomInvitedWithParams);
+                    connection.On<MatchmakingDuelIssuedParams>(nameof(IMatchmakingClient.MatchmakingDuelIssued), ((IMatchmakingClient)this).MatchmakingDuelIssued);
                     connection.On<long, string>(nameof(IMatchmakingClient.MatchmakingRoomReady), ((IMatchmakingClient)this).MatchmakingRoomReady);
                     connection.On<MatchmakingLobbyStatus>(nameof(IMatchmakingClient.MatchmakingLobbyStatusChanged), ((IMatchmakingClient)this).MatchmakingLobbyStatusChanged);
                     connection.On<MatchmakingQueueStatus>(nameof(IMatchmakingClient.MatchmakingQueueStatusChanged), ((IMatchmakingClient)this).MatchmakingQueueStatusChanged);
@@ -414,6 +415,24 @@ namespace osu.Game.Online.Multiplayer
 
             Debug.Assert(connection != null);
             return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingAcceptInvitation));
+        }
+
+        public override Task<MatchmakingIssueDuelResponse> MatchmakingIssueDuel(MatchmakingIssueDuelRequest request)
+        {
+            if (!IsConnected.Value)
+                return Task.FromResult(new MatchmakingIssueDuelResponse());
+
+            Debug.Assert(connection != null);
+            return connection.InvokeAsync<MatchmakingIssueDuelResponse>(nameof(IMatchmakingServer.MatchmakingIssueDuel), request);
+        }
+
+        public override Task<MatchmakingAcceptDuelResponse> MatchmakingAcceptDuel(MatchmakingAcceptDuelRequest request)
+        {
+            if (!IsConnected.Value)
+                return Task.FromResult(new MatchmakingAcceptDuelResponse());
+
+            Debug.Assert(connection != null);
+            return connection.InvokeAsync<MatchmakingAcceptDuelResponse>(nameof(IMatchmakingServer.MatchmakingAcceptDuel), request);
         }
 
         public override Task MatchmakingDeclineInvitation()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -1,19 +1,23 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Screens;
+using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
+using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -31,16 +35,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
     public partial class QueueController : Component
     {
         public readonly Bindable<ScreenQueue.MatchmakingScreenState> CurrentState = new Bindable<ScreenQueue.MatchmakingScreenState>();
+        public readonly Bindable<MatchmakingPool?> SelectedPool = new Bindable<MatchmakingPool?>();
+        public MatchmakingPool? LastJoinedPool { get; private set; }
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
 
         [Resolved]
+        private UserLookupCache users { get; set; } = null!;
+
+        [Resolved]
         private INotificationOverlay? notifications { get; set; }
 
         private BackgroundQueueNotification? backgroundNotification;
-        private bool isBackgrounded;
-        public MatchmakingPool? LastJoinedPool { get; private set; }
+
+        private bool isBackgrounded = true;
 
         protected override void LoadComplete()
         {
@@ -50,6 +59,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             client.MatchmakingQueueJoined += onMatchmakingQueueJoined;
             client.MatchmakingQueueLeft += onMatchmakingQueueLeft;
             client.MatchmakingRoomInvited += onMatchmakingRoomInvited;
+            client.MatchmakingDuelIssued += onMatchmakingDuelIssued;
             client.MatchmakingRoomReady += onMatchmakingRoomReady;
         }
 
@@ -89,7 +99,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 return;
 
             isBackgrounded = true;
-            postNotification();
+
+            if (CurrentState.Value == ScreenQueue.MatchmakingScreenState.Queueing)
+                postNotification();
         }
 
         /// <summary>
@@ -131,11 +143,23 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private void onMatchmakingRoomInvited(MatchmakingRoomInvitationParams invitation) => Scheduler.Add(() =>
         {
+            if (isBackgrounded)
+                postNotification();
+
             CurrentState.Value = ScreenQueue.MatchmakingScreenState.PendingAccept;
 
             backgroundNotification?.Complete(invitation);
             backgroundNotification = null;
         });
+
+        private void onMatchmakingDuelIssued(MatchmakingDuelIssuedParams duel)
+        {
+            users.GetUserAsync(duel.UserId)
+                 .ContinueWith(u => Scheduler.Add(() =>
+                 {
+                     notifications?.Post(new DuelNotification(u.GetResultSafely()!, duel));
+                 }), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
 
         private void onMatchmakingRoomReady(long roomId, string password) => Scheduler.Add(() =>
         {
@@ -151,8 +175,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             if (backgroundNotification != null)
                 return;
 
-            Debug.Assert(LastJoinedPool != null);
-            notifications?.Post(backgroundNotification = new BackgroundQueueNotification(this, LastJoinedPool.Type));
+            notifications?.Post(backgroundNotification = new BackgroundQueueNotification(this));
         }
 
         private void closeNotifications()
@@ -188,15 +211,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             private MultiplayerClient client { get; set; } = null!;
 
             private readonly QueueController controller;
-            private readonly MatchmakingPoolType poolType;
 
             private Notification? foundNotification;
             private Sample? matchFoundSample;
 
-            public BackgroundQueueNotification(QueueController controller, MatchmakingPoolType poolType)
+            public BackgroundQueueNotification(QueueController controller)
             {
                 this.controller = controller;
-                this.poolType = poolType;
             }
 
             [BackgroundDependencyLoader]
@@ -211,7 +232,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                         if (s is ScreenIntro || s is ScreenQueue)
                             return;
 
-                        s.Push(new ScreenIntro(poolType));
+                        s.Push(new ScreenIntro(MatchmakingPoolType.RankedPlay));
                     }, [typeof(ScreenIntro), typeof(ScreenQueue)]);
 
                     // Closed when appropriate by SearchInForeground().
@@ -279,6 +300,27 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     Icon = FontAwesome.Solid.Bolt;
                     IconContent.Colour = ColourInfo.GradientVertical(colours.YellowDark, colours.YellowLight);
                 }
+            }
+        }
+
+        private partial class DuelNotification : SimpleNotification
+        {
+            [Resolved]
+            private MultiplayerClient client { get; set; } = null!;
+
+            public DuelNotification(APIUser user, MatchmakingDuelIssuedParams duel)
+            {
+                Text = $"{user.Username} challenged you to a duel ({duel.Pool.DisplayName}). Click to accept.";
+
+                Activated = () =>
+                {
+                    client.MatchmakingAcceptDuel(new MatchmakingAcceptDuelRequest
+                    {
+                        Id = duel.Id
+                    }).FireAndForget();
+
+                    return true;
+                };
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -36,7 +36,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
     {
         public readonly Bindable<ScreenQueue.MatchmakingScreenState> CurrentState = new Bindable<ScreenQueue.MatchmakingScreenState>();
         public readonly Bindable<MatchmakingPool?> SelectedPool = new Bindable<MatchmakingPool?>();
-        public MatchmakingPool? LastJoinedPool { get; private set; }
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
@@ -70,7 +69,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         public void JoinQueue(MatchmakingPool pool)
         {
             client.MatchmakingJoinQueue(pool.Id).FireAndForget();
-            LastJoinedPool = pool;
         }
 
         /// <summary>
@@ -86,8 +84,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         /// </summary>
         public void RejoinQueue()
         {
-            if (LastJoinedPool != null)
-                JoinQueue(LastJoinedPool);
+            if (SelectedPool.Value != null)
+                JoinQueue(SelectedPool.Value);
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -50,6 +50,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private bool isBackgrounded = true;
 
+        private int? lastDuelUser;
+        private MatchmakingPool? lastDuelPool;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -68,6 +71,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         /// <param name="pool">The pool to join.</param>
         public void JoinQueue(MatchmakingPool pool)
         {
+            lastDuelUser = null;
+            lastDuelPool = null;
+
             client.MatchmakingJoinQueue(pool.Id).FireAndForget();
         }
 
@@ -76,7 +82,33 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         /// </summary>
         public void LeaveQueue()
         {
+            lastDuelUser = null;
+            lastDuelPool = null;
+
             client.MatchmakingLeaveQueue().FireAndForget();
+        }
+
+        public void IssueDuel(MatchmakingPool pool, int userId)
+        {
+            lastDuelUser = userId;
+            lastDuelPool = pool;
+
+            client.MatchmakingIssueDuel(new MatchmakingIssueDuelRequest
+            {
+                PoolId = pool.Id,
+                UserId = userId
+            }).FireAndForget();
+        }
+
+        public void AcceptDuel(MatchmakingDuelIssuedParams duel)
+        {
+            lastDuelUser = duel.UserId;
+            lastDuelPool = duel.Pool;
+
+            client.MatchmakingAcceptDuel(new MatchmakingAcceptDuelRequest
+            {
+                Id = duel.Id
+            }).FireAndForget();
         }
 
         /// <summary>
@@ -84,7 +116,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         /// </summary>
         public void RejoinQueue()
         {
-            if (SelectedPool.Value != null)
+            if (lastDuelUser != null && lastDuelPool != null)
+                IssueDuel(lastDuelPool, lastDuelUser.Value);
+            else if (SelectedPool.Value != null)
                 JoinQueue(SelectedPool.Value);
         }
 
@@ -155,7 +189,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             users.GetUserAsync(duel.UserId)
                  .ContinueWith(u => Scheduler.Add(() =>
                  {
-                     notifications?.Post(new DuelNotification(u.GetResultSafely()!, duel));
+                     notifications?.Post(new DuelNotification(this, u.GetResultSafely()!, duel));
                  }), TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
@@ -303,20 +337,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private partial class DuelNotification : SimpleNotification
         {
-            [Resolved]
-            private MultiplayerClient client { get; set; } = null!;
-
-            public DuelNotification(APIUser user, MatchmakingDuelIssuedParams duel)
+            public DuelNotification(QueueController controller, APIUser user, MatchmakingDuelIssuedParams duel)
             {
                 Text = $"{user.Username} challenged you to a duel ({duel.Pool.DisplayName}). Click to accept.";
 
                 Activated = () =>
                 {
-                    client.MatchmakingAcceptDuel(new MatchmakingAcceptDuelRequest
-                    {
-                        Id = duel.Id
-                    }).FireAndForget();
-
+                    controller.AcceptDuel(duel);
                     return true;
                 };
             }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -353,8 +353,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 availablePools.Value = pools;
 
                 // Default to the currently queueing pool, or fallback to the user's ruleset for the initial pool selection.
-                MatchmakingPool? lastQueuedPool = pools.FirstOrDefault(p => p.Id == queue.LastJoinedPool?.Id);
-                selectedPool.Value = lastQueuedPool ?? pools.FirstOrDefault(p => p.RulesetId == ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
+                selectedPool.Value ??= pools.FirstOrDefault(p => p.RulesetId == ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
             });
         }
 
@@ -456,7 +455,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             switch (currentState.Value)
             {
                 default:
-                    selectedPool.Value = null!;
                     client.MatchmakingLeaveLobby().FireAndForget();
                     queue.SearchInBackground();
                     return false;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -75,6 +75,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         [Resolved]
         private MusicController music { get; set; } = null!;
 
+        [Resolved]
+        private DashboardOverlay? dashboardOverlay { get; set; }
+
         private readonly IBindable<MatchmakingScreenState> currentState = new Bindable<MatchmakingScreenState>();
 
         private readonly Bindable<MatchmakingPool[]> availablePools = new Bindable<MatchmakingPool[]>([]);
@@ -330,10 +333,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 }
             }
 
+            client.MatchmakingLobbyStatusChanged += onMatchmakingLobbyStatusChanged;
+
             currentState.BindTo(queue.CurrentState);
             currentState.BindValueChanged(s => SetState(s.NewValue));
-            client.MatchmakingLobbyStatusChanged += onMatchmakingLobbyStatusChanged;
+
+            selectedPool.BindTo(queue.SelectedPool);
             selectedPool.BindValueChanged(onSelectedPoolChanged, true);
+
             populateAvailablePools().FireAndForget();
         }
 
@@ -446,14 +453,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             if (base.OnExiting(e))
                 return true;
 
-            client.MatchmakingLeaveLobby().FireAndForget();
-
             switch (currentState.Value)
             {
                 default:
-                    return false;
-
-                case MatchmakingScreenState.Queueing:
+                    selectedPool.Value = null!;
+                    client.MatchmakingLeaveLobby().FireAndForget();
                     queue.SearchInBackground();
                     return false;
 
@@ -487,11 +491,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             switch (newState)
             {
                 case MatchmakingScreenState.Idle:
+                    LinkFlowContainer duelHint;
+
                     mainContent.Child = new FillFlowContainer
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        AutoSizeAxes = Axes.Both,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
                         Direction = FillDirection.Vertical,
                         Spacing = new Vector2(10),
                         Children = new Drawable[]
@@ -517,9 +524,20 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                     queue.JoinQueue(selectedPool.Value);
                                 },
                                 Text = "Begin queueing",
+                            },
+                            duelHint = new LinkFlowContainer
+                            {
+                                TextAnchor = Anchor.TopCentre,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
                             }
                         }
                     };
+
+                    duelHint.AddText("Open the ");
+                    duelHint.AddLink("dashboard", () => dashboardOverlay?.Show());
+                    duelHint.AddText(" to duel another player!");
+
                     break;
 
                 case MatchmakingScreenState.Queueing:

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -916,6 +916,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return Task.CompletedTask;
         }
 
+        public override Task<MatchmakingIssueDuelResponse> MatchmakingIssueDuel(MatchmakingIssueDuelRequest request)
+        {
+            return Task.FromResult(new MatchmakingIssueDuelResponse());
+        }
+
+        public override Task<MatchmakingAcceptDuelResponse> MatchmakingAcceptDuel(MatchmakingAcceptDuelRequest request)
+        {
+            return Task.FromResult(new MatchmakingAcceptDuelResponse());
+        }
+
         public override Task MatchmakingDeclineInvitation()
         {
             return Task.CompletedTask;

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -22,9 +22,11 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Localisation;
+using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens;
+using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
 using osu.Game.Screens.Play;
 using osu.Game.Users.Drawables;
 using osuTK;
@@ -82,6 +84,9 @@ namespace osu.Game.Users
 
         [Resolved]
         private MetadataClient? metadataClient { get; set; }
+
+        [Resolved]
+        private QueueController? queueController { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -180,6 +185,21 @@ namespace osu.Game.Users
                                 multiplayerClient!.InvitePlayer(User.Id);
                         }));
                     }
+
+                    if (canDuelUser())
+                    {
+                        items.Add(new OsuMenuItem("Duel", MenuItemType.Standard, () =>
+                        {
+                            if (canDuelUser())
+                            {
+                                multiplayerClient!.MatchmakingIssueDuel(new MatchmakingIssueDuelRequest
+                                {
+                                    UserId = User.Id,
+                                    PoolId = queueController!.SelectedPool.Value!.Id
+                                });
+                            }
+                        }));
+                    }
                 }
 
                 return items.ToArray();
@@ -187,6 +207,7 @@ namespace osu.Game.Users
                 bool isUserOnline() => metadataClient?.GetPresence(User.OnlineID) != null;
                 bool canInviteUser() => isUserOnline() && multiplayerClient?.Room?.Users.All(u => u.UserID != User.Id) == true;
                 bool isUserBlocked() => api.LocalUserState.Blocks.Any(b => b.TargetID == User.OnlineID);
+                bool canDuelUser() => isUserOnline() && queueController?.SelectedPool.Value != null;
             }
         }
 

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -22,7 +22,6 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Localisation;
-using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens;
@@ -191,13 +190,7 @@ namespace osu.Game.Users
                         items.Add(new OsuMenuItem("Duel", MenuItemType.Standard, () =>
                         {
                             if (canDuelUser())
-                            {
-                                multiplayerClient!.MatchmakingIssueDuel(new MatchmakingIssueDuelRequest
-                                {
-                                    UserId = User.Id,
-                                    PoolId = queueController!.SelectedPool.Value!.Id
-                                });
-                            }
+                                queueController?.IssueDuel(queueController.SelectedPool.Value!, User.Id);
                         }));
                     }
                 }


### PR DESCRIPTION
I've seen this suggested quite a bit and is a pretty easy implementation all things considered.

For now, while on the queue screen, you can open up the dashboard overlay and select another player to duel. This will bring you into an unranked lobby.

https://github.com/user-attachments/assets/712897a9-9350-4741-899d-59662c722e43