### PR TITLE
Add beatmap panel to the ranked play results screen

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 {
     public abstract partial class BeatmapCard : OsuClickableContainer, IHasContextMenu
     {
-        public const float TRANSITION_DURATION = 340;
+        public const float TRANSITION_DURATION = 360;
         public const float CORNER_RADIUS = 8;
 
         public const float WIDTH = 345;

--- a/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
@@ -174,6 +174,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
             // By limiting the width we avoid this box showing up as an outline around the drawables that are on top of it.
             background.ResizeWidthTo(buttonAreaWidth + BeatmapCard.CORNER_RADIUS, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            background.FadeTo(ShowDetails.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
 
             background.FadeColour(downloadTracker.State.Value == DownloadState.LocallyAvailable ? colours.Lime0 : colourProvider.Background3, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
             buttons.FadeTo(ShowDetails.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
@@ -16,8 +16,11 @@ using osu.Framework.Utils;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
+using osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osuTK;
 using osuTK.Graphics;
@@ -33,6 +36,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             public required RankedPlayDamageInfo PlayerDamageInfo { get; init; }
             public required RankedPlayDamageInfo OpponentDamageInfo { get; init; }
 
+            public required APIBeatmap Beatmap { get; init; }
+            public required Mod[] Mods { get; init; }
+
             [Resolved]
             private RankedPlayMatchInfo matchInfo { get; set; } = null!;
 
@@ -44,6 +50,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             private readonly Bindable<Visibility> cornerPieceVisibility = new Bindable<Visibility>();
             private readonly Bindable<float> scoreBarProgress = new Bindable<float>();
 
+            private Drawable beatmapPanel = null!;
             private PanelScaffold panelScaffold = null!;
             private Box flash = null!;
             private ScoreDetails playerScoreDetails = null!;
@@ -85,6 +92,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                             .Select(it => it.Value.DamageInfo)
                                             .OfType<RankedPlayDamageInfo>()
                                             .MaxBy(it => it.Damage)!;
+
+                AddInternal(new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = cardSize,
+                    Child = beatmapPanel = new Container
+                    {
+                        Anchor = Anchor.TopRight,
+                        Origin = Anchor.BottomRight,
+                        Margin = new MarginPadding { Bottom = 10 },
+                        Scale = new Vector2(1.1f),
+                        Size = new Vector2(MatchmakingSelectPanel.WIDTH, MatchmakingSelectPanel.HEIGHT),
+                        Child = new MatchmakingSelectPanel.CardContentBeatmap(Beatmap, Mods)
+                    }
+                });
 
                 AddInternal(panelScaffold = new PanelScaffold
                 {
@@ -323,6 +346,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 double delay = 0;
 
                 resultsAppearSample.Play();
+
+                beatmapPanel.FadeOut()
+                            .Delay(800)
+                            .FadeIn(300);
 
                 panelScaffold.FadeIn(100)
                              .ResizeTo(0)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
@@ -13,12 +13,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
@@ -45,7 +47,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private RankedPlayMatchInfo matchInfo { get; set; } = null!;
 
         [Resolved]
+        private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> globalBeatmap { get; set; } = null!;
+
+        [Resolved]
         private IBindable<RulesetInfo> globalRuleset { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<IReadOnlyList<Mod>> globalMods { get; set; } = null!;
 
         private LoadingSpinner loadingSpinner = null!;
         private MainPanel? mainPanel;
@@ -55,10 +66,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             CornerPieceVisibility.Value = Visibility.Hidden;
 
-            AddInternal(loadingSpinner = new LoadingSpinner
+            AddRangeInternal(new Drawable[]
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre
+                loadingSpinner = new LoadingSpinner
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                },
             });
         }
 
@@ -70,9 +84,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             fetchFinalScores().FireAndForget();
         }
-
-        [Resolved]
-        private IBindable<WorkingBeatmap> working { get; set; } = null!;
 
         private async Task fetchFinalScores()
         {
@@ -92,7 +103,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                 List<MultiplayerScore> apiScores = await scoreLookup.Task.ConfigureAwait(false);
 
-                ScoreInfo[] scores = apiScores.Select(s => s.CreateScoreInfo(scoreManager, rulesets, working.Value.BeatmapInfo)).ToArray();
+                ScoreInfo[] scores = apiScores.Select(s => s.CreateScoreInfo(scoreManager, rulesets, globalBeatmap.Value.BeatmapInfo)).ToArray();
 
                 Debug.Assert(scores.Length <= 2);
 
@@ -113,6 +124,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     User = new APIUser { Id = opponentId }
                 };
 
+                // Should complete instantaneously due to prior lookups.
+                APIBeatmap beatmap = (await beatmapLookupCache.GetBeatmapAsync(globalBeatmap.Value.BeatmapInfo.OnlineID).ConfigureAwait(false))!;
+
                 Schedule(() =>
                 {
                     LoadComponentAsync(new MainPanel
@@ -124,6 +138,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                         OpponentScore = opponentScore,
                         PlayerDamageInfo = matchInfo.RoomState.Users[localUserId].DamageInfo!,
                         OpponentDamageInfo = matchInfo.RoomState.Users[opponentId].DamageInfo!,
+                        Beatmap = beatmap,
+                        Mods = globalMods.Value.ToArray(),
                     }, loaded =>
                     {
                         AddInternal(loaded);


### PR DESCRIPTION
Different take to / supersedes / closes https://github.com/ppy/osu/pull/37550

Just going for minimal lines of code compared to the PR above, by reusing the quick play panel which is in a pretty good state.

<img width="1298" height="864" alt="image" src="https://github.com/user-attachments/assets/409e163d-d7ea-4c07-874f-aaca7e145221" />
