### PR TITLE
Stop song preview when entering spectator

### DIFF
--- a/osu.Game/Screens/Play/SoloSpectatorScreen.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorScreen.cs
@@ -275,5 +275,11 @@ namespace osu.Game.Screens.Play
             previewTrackManager.StopAnyPlaying(this);
             return base.OnExiting(e);
         }
+
+        public override void OnSuspending(ScreenTransitionEvent e)
+        {
+            previewTrackManager.StopAnyPlaying(this);
+            base.OnSuspending(e);
+        }
     }
 }


### PR DESCRIPTION
Song preview keeps playing when clicking "Start Watching" on `SoloSpectatorScreen`. Making `SoloSpectatorScreen` suspends the screen rather than exiting it, so neither `clearDisplay()` nor `OnExiting()` fire.

Closes: https://github.com/ppy/osu/issues/36987