### PR TITLE
Implement Min and Max Extended Information for Difficulty Adjust

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -42,7 +42,24 @@ namespace osu.Game.Rulesets.Catch.Mods
             get
             {
                 if (!IsExactlyOneSettingChanged(CircleSize, ApproachRate, OverallDifficulty, DrainRate))
+                {
+                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value
+                        && DrainRate.ExtendedMaxValue == DrainRate.Value
+                        && CircleSize.ExtendedMaxValue == CircleSize.Value
+                        && ApproachRate.ExtendedMaxValue == ApproachRate.Value) return "MAX+";
+
+                    if (OverallDifficulty.MaxValue == OverallDifficulty.Value
+                        && DrainRate.MaxValue == DrainRate.Value
+                        && CircleSize.MaxValue == CircleSize.Value
+                        && ApproachRate.MaxValue == ApproachRate.Value) return "MAX";
+
+                    if (OverallDifficulty.MinValue == OverallDifficulty.Value
+                        && DrainRate.MinValue == DrainRate.Value
+                        && CircleSize.MinValue == CircleSize.Value
+                        && ApproachRate.MinValue == ApproachRate.Value) return "MIN";
+
                     return string.Empty;
+                }
 
                 if (!CircleSize.IsDefault) return format("CS", CircleSize);
                 if (!ApproachRate.IsDefault) return format("AR", ApproachRate);

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Extensions;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
@@ -17,5 +18,32 @@ namespace osu.Game.Rulesets.Mania.Mods
             ExtendedMinValue = -15,
             ReadCurrentFromDifficulty = diff => diff.OverallDifficulty,
         };
+
+        public override string ExtendedIconInformation
+        {
+            get
+            {
+                if (!IsExactlyOneSettingChanged(OverallDifficulty, DrainRate))
+                {
+                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value
+                        && DrainRate.ExtendedMaxValue == DrainRate.Value) return "MAX+";
+                    if (OverallDifficulty.MaxValue == OverallDifficulty.Value
+                        && DrainRate.MaxValue == DrainRate.Value) return "MAX";
+                    if (OverallDifficulty.ExtendedMinValue == OverallDifficulty.Value
+                        && DrainRate.MinValue == DrainRate.Value) return "MIN+";
+                    if (OverallDifficulty.MinValue == OverallDifficulty.Value
+                        && DrainRate.MinValue == DrainRate.Value) return "MIN";
+
+                    return string.Empty;
+                }
+
+                if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
+                if (!DrainRate.IsDefault) return format("HP", DrainRate);
+
+                return string.Empty;
+
+                string format(string acronym, DifficultyBindable bindable) => $"{acronym}{bindable.Value!.Value.ToStandardFormattedString(1)}";
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -44,7 +44,29 @@ namespace osu.Game.Rulesets.Osu.Mods
             get
             {
                 if (!IsExactlyOneSettingChanged(CircleSize, ApproachRate, OverallDifficulty, DrainRate))
+                {
+                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value
+                        && DrainRate.ExtendedMaxValue == DrainRate.Value
+                        && CircleSize.ExtendedMaxValue == CircleSize.Value
+                        && ApproachRate.ExtendedMaxValue == ApproachRate.Value) return "MAX+";
+
+                    if (OverallDifficulty.MaxValue == OverallDifficulty.Value
+                        && DrainRate.MaxValue == DrainRate.Value
+                        && CircleSize.MaxValue == CircleSize.Value
+                        && ApproachRate.MaxValue == ApproachRate.Value) return "MAX";
+
+                    if (OverallDifficulty.MinValue == OverallDifficulty.Value
+                        && DrainRate.MinValue == DrainRate.Value
+                        && CircleSize.MinValue == CircleSize.Value
+                        && ApproachRate.ExtendedMinValue == ApproachRate.Value) return "MIN+";
+
+                    if (OverallDifficulty.MinValue == OverallDifficulty.Value
+                        && DrainRate.MinValue == DrainRate.Value
+                        && CircleSize.MinValue == CircleSize.Value
+                        && ApproachRate.MinValue == ApproachRate.Value) return "MIN";
+
                     return string.Empty;
+                }
 
                 if (!CircleSize.IsDefault) return format("CS", CircleSize);
                 if (!ApproachRate.IsDefault) return format("AR", ApproachRate);

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -26,7 +26,21 @@ namespace osu.Game.Rulesets.Taiko.Mods
             get
             {
                 if (!IsExactlyOneSettingChanged(ScrollSpeed, OverallDifficulty, DrainRate))
+                {
+                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value
+                        && DrainRate.ExtendedMaxValue == DrainRate.Value
+                        && ScrollSpeed.MaxValue == ScrollSpeed.Value) return "MAX+";
+
+                    if (OverallDifficulty.MaxValue == OverallDifficulty.Value
+                        && DrainRate.MaxValue == DrainRate.Value
+                        && ScrollSpeed.MaxValue == ScrollSpeed.Value) return "MAX";
+
+                    if (OverallDifficulty.MinValue == OverallDifficulty.Value
+                        && DrainRate.MinValue == DrainRate.Value
+                        && ScrollSpeed.MinValue == ScrollSpeed.Value) return "MIN";
+
                     return string.Empty;
+                }
 
                 if (!ScrollSpeed.IsDefault) return format("SC", ScrollSpeed, 2);
                 if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty, 1);

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -74,7 +74,11 @@ namespace osu.Game.Rulesets.Mods
             get
             {
                 if (!IsExactlyOneSettingChanged(OverallDifficulty, DrainRate))
+                {
+                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value && DrainRate.ExtendedMaxValue == DrainRate.Value) return "MAX!";
+
                     return string.Empty;
+                }
 
                 if (!OverallDifficulty.IsDefault) return format("OD", OverallDifficulty);
                 if (!DrainRate.IsDefault) return format("HP", DrainRate);

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -75,9 +75,12 @@ namespace osu.Game.Rulesets.Mods
             {
                 if (!IsExactlyOneSettingChanged(OverallDifficulty, DrainRate))
                 {
-                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value && DrainRate.ExtendedMaxValue == DrainRate.Value) return "MAX+";
-                    if (OverallDifficulty.MaxValue == OverallDifficulty.Value && DrainRate.MaxValue == DrainRate.Value) return "MAX";
-                    if (OverallDifficulty.MinValue == OverallDifficulty.Value && DrainRate.MinValue == DrainRate.Value) return "MIN";
+                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value
+                        && DrainRate.ExtendedMaxValue == DrainRate.Value) return "MAX+";
+                    if (OverallDifficulty.MaxValue == OverallDifficulty.Value
+                        && DrainRate.MaxValue == DrainRate.Value) return "MAX";
+                    if (OverallDifficulty.MinValue == OverallDifficulty.Value
+                        && DrainRate.MinValue == DrainRate.Value) return "MIN";
 
                     return string.Empty;
                 }

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -75,7 +75,9 @@ namespace osu.Game.Rulesets.Mods
             {
                 if (!IsExactlyOneSettingChanged(OverallDifficulty, DrainRate))
                 {
-                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value && DrainRate.ExtendedMaxValue == DrainRate.Value) return "MAX!";
+                    if (OverallDifficulty.ExtendedMaxValue == OverallDifficulty.Value && DrainRate.ExtendedMaxValue == DrainRate.Value) return "MAX+";
+                    if (OverallDifficulty.MaxValue == OverallDifficulty.Value && DrainRate.MaxValue == DrainRate.Value) return "MAX";
+                    if (OverallDifficulty.MinValue == OverallDifficulty.Value && DrainRate.MinValue == DrainRate.Value) return "MIN";
 
                     return string.Empty;
                 }


### PR DESCRIPTION
This PR aims to add new extended information to DA when all value adjustments are set to minimum or maximum and when extended limits are turned on and reached it'll show min+ or max+. 
I've made this PR, because in multiplayer when you select DA and play OD15 in mania it'll show OD15 but If you add HP11 extended information will be empty so others wont see that you play OD15 unless they hover at the mod directly. 
Mania is the most noticeable because it only has 2 values.

mania max+:
<img width="395" height="178" alt="image" src="https://github.com/user-attachments/assets/c92af5d8-5d95-4b4b-ba73-fa63e411d4a2" />

ctb max:
<img width="413" height="211" alt="image" src="https://github.com/user-attachments/assets/3cc6a46f-da82-4c7d-8466-c1c60960a9d0" />


std min+:
<img width="382" height="172" alt="image" src="https://github.com/user-attachments/assets/e3f64cb6-060c-454a-8c0c-34a3ca75ea42" />

taiko min:
<img width="381" height="174" alt="image" src="https://github.com/user-attachments/assets/e7d682ae-60ba-4464-a3ba-6dc18e451419" />
