### PR TITLE
Hide break info when HUD Overlay visibility is disabled

### DIFF
--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -49,7 +49,6 @@ namespace osu.Game.Screens.Play
 
         private readonly IBindable<Period?> currentPeriod = new Bindable<Period?>();
         private Bindable<HUDVisibilityMode> configVisibilityMode;
-        // private readonly List<Drawable> hideTargets;
 
         public BreakOverlay(ScoreProcessor scoreProcessor)
         {
@@ -146,7 +145,7 @@ namespace osu.Game.Screens.Play
             // Logger.Log($"configVisibilityMode = {configVisibilityMode.Value:G}");
             if (configVisibilityMode.Value == HUDVisibilityMode.Never)
             {
-                Logger.Log($"configVisibilityMode = Never, hiding break info");
+                Logger.Log("configVisibilityMode = Never, hiding break info");
                 info.Hide();
             }
             else

--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable disable
+
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -9,8 +12,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Logging;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -43,6 +48,8 @@ namespace osu.Game.Screens.Play
         private readonly BreakInfo info;
 
         private readonly IBindable<Period?> currentPeriod = new Bindable<Period?>();
+        private Bindable<HUDVisibilityMode> configVisibilityMode;
+        // private readonly List<Drawable> hideTargets;
 
         public BreakOverlay(ScoreProcessor scoreProcessor)
         {
@@ -116,10 +123,17 @@ namespace osu.Game.Screens.Play
             };
         }
 
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuConfigManager config)
+        {
+            configVisibilityMode = config.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode);
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
+            configVisibilityMode.BindValueChanged(_ => updateInfoVisibility(), true);
             info.AccuracyDisplay.Current.BindTo(scoreProcessor.Accuracy);
             ((IBindable<ScoreRank>)info.GradeDisplay.Current).BindTo(scoreProcessor.Rank);
 
@@ -127,6 +141,19 @@ namespace osu.Game.Screens.Play
             currentPeriod.BindValueChanged(updateDisplay, true);
         }
 
+        private void updateInfoVisibility()
+        {
+            // Logger.Log($"configVisibilityMode = {configVisibilityMode.Value:G}");
+            if (configVisibilityMode.Value == HUDVisibilityMode.Never)
+            {
+                Logger.Log($"configVisibilityMode = Never, hiding break info");
+                info.Hide();
+            }
+            else
+            {
+                info.Show();
+            }
+        }
         private float remainingTimeForCurrentPeriod =>
             currentPeriod.Value == null ? 0 : (float)Math.Max(0, (currentPeriod.Value.Value.End - Time.Current - BREAK_FADE_DURATION) / currentPeriod.Value.Value.Duration);
 

--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -142,10 +142,12 @@ namespace osu.Game.Screens.Play
 
         private void updateInfoVisibility()
         {
-            // Logger.Log($"configVisibilityMode = {configVisibilityMode.Value:G}");
+            // If HUD Overlay Visibility is set to Never, the user probably
+            // doesn't want to see their current stats.
+            // Therefore, hide the info/stats portion of the break overlay.
             if (configVisibilityMode.Value == HUDVisibilityMode.Never)
             {
-                Logger.Log("configVisibilityMode = Never, hiding break info");
+                Logger.Log("configVisibilityMode == Never, hiding break info");
                 info.Hide();
             }
             else


### PR DESCRIPTION

https://github.com/user-attachments/assets/421848af-f86f-4659-b9da-efc99f351ad3

When the HUD overlay is hidden (Shift+Tab), the user probably doesn't want to see their rank/accuracy. This hides the info text while the mode is set to `Never`, but keeps it showing when set to `Hide during gameplay` (since breaks aren't gameplay)/`Always`.

This patch is dedicated to the insane heart rate increase I just had 3 hours ago when I realized I was on 100% accuracy.

Uses OsuConfigManager like HUDOverlay.cs in [osu.Game/Screens/Play/HUDOverlay.cs](https://github.com/ppy/osu/blob/a3b8b9aee9beb43ff10817e3bb6d9b6e82e36d1c/osu.Game/Screens/Play/HUDOverlay.cs#L77)