### PR TITLE
Fix discord multiplayer invites

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="10.0.5" />
-    <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
+    <PackageReference Include="DiscordRichPresence" Version="1.5.0.51" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
   <ItemGroup Label="Resources">

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="10.0.5" />
+    <!-- Held back due to invite bug in newer versions. See https://github.com/Lachee/discord-rpc-csharp/issues/286-->
     <PackageReference Include="DiscordRichPresence" Version="1.5.0.51" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>


### PR DESCRIPTION
Downgrade the `DiscordRichPresence` package until https://github.com/Lachee/discord-rpc-csharp/issues/286 is resolved.

Also reported on [discord](https://discord.com/channels/188630481301012481/1097318920991559880/1497244317801119866) before.

I don't know if it's reproducible for everyone, but at least for me it is on both Windows and Linux, and also for everyone I asked to try inviting.

Closes #37626