### PR TITLE
Remember friend status filter when reopening friends list panel

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -245,6 +245,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.DashboardSortMode, UserSortCriteria.LastVisit);
             SetDefault(OsuSetting.DashboardDisplayStyle, OverlayPanelDisplayStyle.Card);
+            SetDefault(OsuSetting.DashboardFriendStatusFilter, OnlineStatus.All);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -511,5 +512,6 @@ namespace osu.Game.Configuration
 
         DashboardSortMode,
         DashboardDisplayStyle,
+        DashboardFriendStatusFilter,
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -245,7 +245,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.DashboardSortMode, UserSortCriteria.LastVisit);
             SetDefault(OsuSetting.DashboardDisplayStyle, OverlayPanelDisplayStyle.Card);
-            SetDefault(OsuSetting.DashboardFriendStatusFilter, OnlineStatus.All);
+            SetDefault(OsuSetting.DashboardStatusFilter, OnlineStatus.All);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -512,6 +512,6 @@ namespace osu.Game.Configuration
 
         DashboardSortMode,
         DashboardDisplayStyle,
-        DashboardFriendStatusFilter,
+        DashboardStatusFilter,
     }
 }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            config.BindWith(OsuSetting.DashboardFriendStatusFilter, Current);
+            config.BindWith(OsuSetting.DashboardStatusFilter, Current);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendOnlineStreamControl.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Game.Configuration;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Metadata;
@@ -33,6 +34,12 @@ namespace osu.Game.Overlays.Dashboard.Friends
                 OnlineStatus.Online,
                 OnlineStatus.Offline
             ];
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            config.BindWith(OsuSetting.DashboardFriendStatusFilter, Current);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
The friend status filter resets to "All" every time the friend list panel is reopened, or when switching back from other tabs ("currently online" and "user search").
I created a statusFilter property in DashboardOverlay, which is bound to the current item of streamControl in FriendDisplay to save this setting. Filter setting will still reset to "All" after reopening the whole game.

Changes:
- Added `statusFilter` to `DashboardOverlay`
- Exposed `StatusFilter` bindable in `FriendDisplay`
- Bound `FriendOnlineStreamControl.Current` to the shared filter

This is only a small change, so I didn't write any test. (I have manually tested it)