### PR TITLE
Fix opening changelog overlay from settings in development

### DIFF
--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -82,16 +82,16 @@ namespace osu.Game.Overlays
 
             Show();
 
+            string[] split = version.Split('-');
+
+            if (split.Length < 2)
+                return;
+
+            string versionPart = split[0];
+            string updateStream = split[1];
+
             performAfterFetch(() =>
             {
-                string[] split = version.Split('-');
-
-                if (split.Length < 2)
-                    return;
-
-                string versionPart = split[0];
-                string updateStream = split[1];
-
                 var build = builds.Find(b => b.Version == versionPart && b.UpdateStream.Name == updateStream)
                             ?? Streams.Find(s => s.Name == updateStream)?.LatestBuild;
 

--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -84,8 +84,13 @@ namespace osu.Game.Overlays
 
             performAfterFetch(() =>
             {
-                string versionPart = version.Split('-')[0];
-                string updateStream = version.Split('-')[1];
+                string[] split = version.Split('-');
+
+                if (split.Length < 2)
+                    return;
+
+                string versionPart = split[0];
+                string updateStream = split[1];
 
                 var build = builds.Find(b => b.Version == versionPart && b.UpdateStream.Name == updateStream)
                             ?? Streams.Find(s => s.Name == updateStream)?.LatestBuild;


### PR DESCRIPTION
Just a small fix for crash that occures when clicking `local debug` in settings footer.