### PR TITLE
Implement chat ticker

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatTicker.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatTicker.cs
@@ -98,8 +98,6 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("switch to public channel", () => testContainer.ChannelManager.CurrentChannel.Value = publicChannel);
 
-            AddToggleStep("toggle show ticker", b => config.SetValue(OsuSetting.ChatTicker, b));
-
             AddStep("receive public message", () => receiveMessage(friend, publicChannel, "Hello everyone"));
 
             AddStep("receive message containing mention", () => receiveMessage(friend, publicChannel, $"Hello {API.LocalUser.Value.Username.ToLowerInvariant()}!"));
@@ -109,6 +107,8 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("receive message from VIP containing mention", () => receiveMessage(importantPerson, publicChannel, $"Hello {API.LocalUser.Value.Username.ToLowerInvariant()}!"));
 
             AddStep("receive very long message", () => receiveMessage(importantPerson, publicChannel, string.Concat(Enumerable.Repeat("Hello everyone! ", 50))));
+
+            AddToggleStep("toggle show ticker", b => config.SetValue(OsuSetting.ChatTicker, b));
         }
 
         private void receiveMessage(APIUser sender, Channel channel, string content) => channel.AddNewMessages(createMessage(sender, channel, content));

--- a/osu.Game.Tests/Visual/Online/TestSceneChatTicker.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatTicker.cs
@@ -133,10 +133,10 @@ namespace osu.Game.Tests.Visual.Online
             };
 
             [Cached]
-            public ChatOverlay ChatOverlay { get; } = new ChatOverlay();
+            public ChatTicker ChatTicker { get; } = new ChatTicker();
 
             [Cached]
-            public ChatTicker ChatTicker { get; } = new ChatTicker();
+            public ChatOverlay ChatOverlay { get; } = new ChatOverlay();
 
             private readonly MessageNotifier messageNotifier = new MessageNotifier();
 

--- a/osu.Game.Tests/Visual/Online/TestSceneChatTicker.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatTicker.cs
@@ -1,0 +1,169 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Configuration;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Chat;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    [TestFixture]
+    public partial class TestSceneChatTicker : OsuManualInputManagerTestScene
+    {
+        private APIUser friend;
+        private APIUser importantPerson;
+        private Channel publicChannel;
+        private Channel privateMessageChannel;
+        private TestContainer testContainer;
+
+        private int messageIdCounter;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            if (API is DummyAPIAccess daa)
+            {
+                daa.HandleRequest = dummyAPIHandleRequest;
+            }
+
+            friend = new APIUser { Id = 0, Username = "SomeFriend" };
+            importantPerson = new APIUser { Username = @"i-am-important", Id = 42, Colour = "#250cc9" };
+            publicChannel = new Channel { Id = 1, Name = "#osu" };
+            privateMessageChannel = new Channel(friend) { Id = 2, Name = friend.Username, Type = ChannelType.PM };
+
+            Schedule(() =>
+            {
+                Child = testContainer = new TestContainer(API, new[] { publicChannel, privateMessageChannel })
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            });
+        });
+
+        private bool dummyAPIHandleRequest(APIRequest request)
+        {
+            switch (request)
+            {
+                case GetMessagesRequest messagesRequest:
+                    messagesRequest.TriggerSuccess(new List<Message>(0));
+                    return true;
+
+                case CreateChannelRequest createChannelRequest:
+                    var apiChatChannel = new APIChatChannel
+                    {
+                        RecentMessages = new List<Message>(0),
+                        ChannelID = (int)createChannelRequest.Channel.Id
+                    };
+                    createChannelRequest.TriggerSuccess(apiChatChannel);
+                    return true;
+
+                case ListChannelsRequest listChannelsRequest:
+                    listChannelsRequest.TriggerSuccess(new List<Channel>(1) { publicChannel });
+                    return true;
+
+                case GetUpdatesRequest updatesRequest:
+                    updatesRequest.TriggerSuccess(new GetUpdatesResponse
+                    {
+                        Messages = new List<Message>(0),
+                        Presence = new List<Channel>(0)
+                    });
+                    return true;
+
+                case JoinChannelRequest joinChannelRequest:
+                    joinChannelRequest.TriggerSuccess();
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        [Test]
+        public void TestChatTicker()
+        {
+            AddStep("switch to public channel", () => testContainer.ChannelManager.CurrentChannel.Value = publicChannel);
+
+            AddToggleStep("toggle show ticker", b => config.SetValue(OsuSetting.ChatTicker, b));
+
+            AddStep("receive public message", () => receiveMessage(friend, publicChannel, "Hello everyone"));
+
+            AddStep("receive message containing mention", () => receiveMessage(friend, publicChannel, $"Hello {API.LocalUser.Value.Username.ToLowerInvariant()}!"));
+
+            AddStep("receive message from VIP", () => receiveMessage(importantPerson, publicChannel, "Hello everyone!"));
+
+            AddStep("receive message from VIP containing mention", () => receiveMessage(importantPerson, publicChannel, $"Hello {API.LocalUser.Value.Username.ToLowerInvariant()}!"));
+
+            AddStep("receive very long message", () => receiveMessage(importantPerson, publicChannel, string.Concat(Enumerable.Repeat("Hello everyone! ", 50))));
+        }
+
+        private void receiveMessage(APIUser sender, Channel channel, string content) => channel.AddNewMessages(createMessage(sender, channel, content));
+
+        private Message createMessage(APIUser sender, Channel channel, string content) => new Message(messageIdCounter++)
+        {
+            Content = content,
+            Sender = sender,
+            ChannelId = channel.Id
+        };
+
+        private partial class TestContainer : Container
+        {
+            [Cached]
+            public ChannelManager ChannelManager { get; }
+
+            [Cached(typeof(INotificationOverlay))]
+            public NotificationOverlay NotificationOverlay { get; } = new NotificationOverlay
+            {
+                Anchor = Anchor.TopRight,
+                Origin = Anchor.TopRight,
+            };
+
+            [Cached]
+            public ChatOverlay ChatOverlay { get; } = new ChatOverlay();
+
+            [Cached]
+            public ChatTicker ChatTicker { get; } = new ChatTicker();
+
+            private readonly MessageNotifier messageNotifier = new MessageNotifier();
+
+            private readonly Channel[] channels;
+
+            public TestContainer(IAPIProvider api, Channel[] channels)
+            {
+                this.channels = channels;
+                ChannelManager = new ChannelManager(api);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Children = new Drawable[]
+                {
+                    ChannelManager,
+                    ChatOverlay,
+                    ChatTicker,
+                    messageNotifier,
+                };
+
+                ((BindableList<Channel>)ChannelManager.AvailableChannels).AddRange(channels);
+
+                foreach (var channel in channels)
+                    ChannelManager.JoinChannel(channel);
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
@@ -12,6 +12,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Configuration;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -31,6 +32,9 @@ namespace osu.Game.Tests.Visual.Online
         private TestContainer testContainer;
 
         private int messageIdCounter;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
 
         [SetUp]
         public void Setup() => Schedule(() =>
@@ -222,6 +226,41 @@ namespace osu.Game.Tests.Visual.Online
             AddAssert("no notifications fired", () => testContainer.NotificationOverlay.UnreadCount.Value == 0);
         }
 
+        [Test]
+        public void TestChatTicker()
+        {
+            AddStep("switch to public channel", () => testContainer.ChannelManager.CurrentChannel.Value = publicChannel);
+
+            AddStep("receive message on channel", () => receiveMessage(friend, publicChannel, "Hello everyone!"));
+            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+
+            AddStep("toggle show ticker on", () => config.SetValue(OsuSetting.ChatTicker, true));
+
+            AddStep("receive message on channel", () => receiveMessage(friend, publicChannel, "Hello everyone!"));
+            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+
+            AddStep("close overlay", () => testContainer.ChatOverlay.Hide());
+
+            AddStep("receive PM", () => receiveMessage(friend, privateMessageChannel, "hey hey"));
+            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+
+            AddStep("receive message on channel", () => receiveMessage(friend, publicChannel, "Hello everyone!"));
+            AddAssert("ticker is present", () => testContainer.ChatTicker.State.Value == Visibility.Visible);
+
+            AddStep("receive last message only", () =>
+            {
+                List<Message> messages = new List<Message> { createMessage(friend, publicChannel, "This should be my first message") };
+                messages.AddRange(Enumerable.Range(0, 10).Select(i => createMessage(friend, publicChannel, $"Hey hey {i}")));
+                messages.Add(createMessage(friend, publicChannel, "This should be my last message."));
+
+                publicChannel.AddNewMessages(messages.ToArray());
+            });
+            AddAssert("ticker is present", () => testContainer.ChatTicker.State.Value == Visibility.Visible);
+
+            AddStep("toggle show ticker off", () => config.SetValue(OsuSetting.ChatTicker, false));
+            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+        }
+
         private void receiveMessage(APIUser sender, Channel channel, string content) => channel.AddNewMessages(createMessage(sender, channel, content));
 
         private Message createMessage(APIUser sender, Channel channel, string content) => new Message(messageIdCounter++)
@@ -254,6 +293,9 @@ namespace osu.Game.Tests.Visual.Online
             [Cached]
             public ChatOverlay ChatOverlay { get; } = new ChatOverlay();
 
+            [Cached]
+            public ChatTicker ChatTicker { get; } = new ChatTicker();
+
             private readonly MessageNotifier messageNotifier = new MessageNotifier();
 
             private readonly Channel[] channels;
@@ -271,6 +313,7 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     ChannelManager,
                     ChatOverlay,
+                    ChatTicker,
                     NotificationOverlay,
                     messageNotifier,
                 };

--- a/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Tests.Visual.Online
             publicChannel = new Channel { Id = 1, Name = "#osu" };
             privateMessageChannel = new Channel(friend) { Id = 2, Name = friend.Username, Type = ChannelType.PM };
 
+            config.SetValue(OsuSetting.ChatTicker, false);
+
             Schedule(() =>
             {
                 Child = testContainer = new TestContainer(API, new[] { publicChannel, privateMessageChannel })
@@ -232,20 +234,20 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("switch to public channel", () => testContainer.ChannelManager.CurrentChannel.Value = publicChannel);
 
             AddStep("receive message on channel", () => receiveMessage(friend, publicChannel, "Hello everyone!"));
-            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+            AddAssert("ticker is hidden", () => !testContainer.ChatTicker.IsPresent);
 
             AddStep("toggle show ticker on", () => config.SetValue(OsuSetting.ChatTicker, true));
 
             AddStep("receive message on channel", () => receiveMessage(friend, publicChannel, "Hello everyone!"));
-            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+            AddAssert("ticker is hidden", () => !testContainer.ChatTicker.IsPresent);
 
             AddStep("close overlay", () => testContainer.ChatOverlay.Hide());
 
             AddStep("receive PM", () => receiveMessage(friend, privateMessageChannel, "hey hey"));
-            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+            AddAssert("ticker is hidden", () => !testContainer.ChatTicker.IsPresent);
 
             AddStep("receive message on channel", () => receiveMessage(friend, publicChannel, "Hello everyone!"));
-            AddAssert("ticker is present", () => testContainer.ChatTicker.State.Value == Visibility.Visible);
+            AddAssert("ticker is present", () => testContainer.ChatTicker.IsPresent);
 
             AddStep("receive last message only", () =>
             {
@@ -255,10 +257,10 @@ namespace osu.Game.Tests.Visual.Online
 
                 publicChannel.AddNewMessages(messages.ToArray());
             });
-            AddAssert("ticker is present", () => testContainer.ChatTicker.State.Value == Visibility.Visible);
+            AddAssert("ticker is present", () => testContainer.ChatTicker.IsPresent);
 
             AddStep("toggle show ticker off", () => config.SetValue(OsuSetting.ChatTicker, false));
-            AddAssert("ticker is hidden", () => testContainer.ChatTicker.State.Value == Visibility.Hidden);
+            AddAssert("ticker is hidden", () => !testContainer.ChatTicker.IsPresent);
         }
 
         private void receiveMessage(APIUser sender, Channel channel, string content) => channel.AddNewMessages(createMessage(sender, channel, content));

--- a/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
@@ -293,10 +293,10 @@ namespace osu.Game.Tests.Visual.Online
             };
 
             [Cached]
-            public ChatOverlay ChatOverlay { get; } = new ChatOverlay();
+            public ChatTicker ChatTicker { get; } = new ChatTicker();
 
             [Cached]
-            public ChatTicker ChatTicker { get; } = new ChatTicker();
+            public ChatOverlay ChatOverlay { get; } = new ChatOverlay();
 
             private readonly MessageNotifier messageNotifier = new MessageNotifier();
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -103,6 +103,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.ShowOnlineExplicitContent, false);
 
+            SetDefault(OsuSetting.ChatTicker, false);
             SetDefault(OsuSetting.NotifyOnUsernameMentioned, true);
             SetDefault(OsuSetting.NotifyOnPrivateMessage, true);
             SetDefault(OsuSetting.NotifyOnFriendPresenceChange, true);
@@ -449,6 +450,7 @@ namespace osu.Game.Configuration
         ScalingBackgroundDim,
         UIScale,
         IntroSequence,
+        ChatTicker,
         NotifyOnUsernameMentioned,
         NotifyOnPrivateMessage,
         NotifyOnFriendPresenceChange,

--- a/osu.Game/Graphics/Containers/OsuClickableContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuClickableContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -16,6 +17,8 @@ namespace osu.Game.Graphics.Containers
     {
         private readonly HoverSampleSet sampleSet;
 
+        public readonly Bindable<bool> MuteSounds = new Bindable<bool>();
+
         private readonly Container content = new Container { RelativeSizeAxes = Axes.Both };
 
         private HoverSounds samples = null!;
@@ -28,7 +31,7 @@ namespace osu.Game.Graphics.Containers
 
         protected override Container<Drawable> Content => content;
 
-        protected virtual HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet) { Enabled = { BindTarget = Enabled } };
+        protected virtual HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet) { Enabled = { BindTarget = Enabled }, MuteSounds = { BindTarget = MuteSounds } };
 
         public OsuClickableContainer(HoverSampleSet sampleSet = HoverSampleSet.Default)
         {

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -55,7 +55,12 @@ namespace osu.Game.Graphics.UserInterface
             return base.OnClick(e);
         }
 
-        public void PlayClickSample() =>
+        public void PlayClickSample()
+        {
+            if (MuteSounds.Value)
+                return;
+
             SamplePlaybackHelper.PlayWithRandomPitch(Enabled.Value ? sampleClick : sampleClickDisabled, pitchVariation: 0.01);
+        }
     }
 }

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Graphics.UserInterface
     {
         public readonly Bindable<bool> Enabled = new Bindable<bool>(true);
 
+        public readonly Bindable<bool> MuteSounds = new Bindable<bool>();
+
         private Sample sampleHover;
 
         protected readonly HoverSampleSet SampleSet;
@@ -40,7 +42,7 @@ namespace osu.Game.Graphics.UserInterface
 
         public override void PlayHoverSample()
         {
-            if (!Enabled.Value)
+            if (!Enabled.Value || MuteSounds.Value)
                 return;
 
             SamplePlaybackHelper.PlayWithRandomPitch(sampleHover, pitchVariation: 0.02);

--- a/osu.Game/Localisation/OnlineSettingsStrings.cs
+++ b/osu.Game/Localisation/OnlineSettingsStrings.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Localisation
         public static LocalisableString AlertsAndPrivacyHeader => new TranslatableString(getKey(@"alerts_and_privacy_header"), @"Alerts and Privacy");
 
         /// <summary>
+        /// "Chat ticker"
+        /// </summary>
+        public static LocalisableString ChatTicker => new TranslatableString(getKey(@"chat_ticker"), @"Chat ticker");
+
+        /// <summary>
         /// "Show a notification when someone mentions your name"
         /// </summary>
         public static LocalisableString NotifyOnMentioned => new TranslatableString(getKey(@"notify_on_mentioned"), @"Show a notification when someone mentions your name");

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Online.Chat
 
             var sortedMessages = messages.OrderByDescending(m => m.Id);
 
-            if (channelManager.CurrentChannel.Value == channel)
+            if (!chatOverlay.IsPresent && channelManager.CurrentChannel.Value == channel)
                 chatTicker.PostMessage(sortedMessages.First());
 
             // Only send notifications if ChatOverlay or the target channel aren't visible, or if the window is unfocused

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Online.Chat
         private ChatOverlay chatOverlay { get; set; }
 
         [Resolved]
+        private ChatTicker chatTicker { get; set; }
+
+        [Resolved]
         private ChannelManager channelManager { get; set; }
 
         [Resolved]
@@ -99,11 +102,16 @@ namespace osu.Game.Online.Chat
             if (channel == null)
                 return;
 
+            var sortedMessages = messages.OrderByDescending(m => m.Id);
+
+            if (channelManager.CurrentChannel.Value == channel)
+                chatTicker.PostMessage(sortedMessages.First());
+
             // Only send notifications if ChatOverlay or the target channel aren't visible, or if the window is unfocused
             if (chatOverlay.IsPresent && channelManager.CurrentChannel.Value == channel && host.IsActive.Value)
                 return;
 
-            foreach (var message in messages.OrderByDescending(m => m.Id))
+            foreach (var message in sortedMessages)
             {
                 // ignore messages that already have been read
                 if (message.Id <= channel.LastReadId)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -203,8 +203,6 @@ namespace osu.Game
 
         private FPSCounter fpsCounter;
 
-        private ChatTicker chatTicker;
-
         private VolumeOverlay volume;
 
         private OsuLogo osuLogo;
@@ -1208,7 +1206,7 @@ namespace osu.Game
             var rankingsOverlay = loadComponentSingleFile(new RankingsOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(channelManager = new ChannelManager(API), Add, true);
             loadComponentSingleFile(chatOverlay = new ChatOverlay(), overlayContent.Add, true);
-            loadComponentSingleFile(chatTicker = new ChatTicker(), topMostOverlayContent.Add, true);
+            loadComponentSingleFile(new ChatTicker(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(new MessageNotifier(), Add, true);
             loadComponentSingleFile(Settings = new SettingsOverlay(), leftFloatingOverlayContent.Add, true);
             loadComponentSingleFile(changelogOverlay = new ChangelogOverlay(), overlayContent.Add, true);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1148,6 +1148,15 @@ namespace osu.Game
             ScreenStack.ScreenPushed += screenPushed;
             ScreenStack.ScreenExited += screenExited;
 
+            loadComponentSingleFile(new ChatTicker(), topMostOverlayContent.Add, true);
+
+            loadComponentSingleFile(fpsCounter = new FPSCounter
+            {
+                Anchor = Anchor.BottomRight,
+                Origin = Anchor.BottomRight,
+                Margin = new MarginPadding(5),
+            }, topMostOverlayContent.Add);
+
             if (!IsDeployedBuild)
                 loadComponentSingleFile(devBuildBanner = new DevBuildBanner(), ScreenContainer.Add);
 
@@ -1206,7 +1215,6 @@ namespace osu.Game
             var rankingsOverlay = loadComponentSingleFile(new RankingsOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(channelManager = new ChannelManager(API), Add, true);
             loadComponentSingleFile(chatOverlay = new ChatOverlay(), overlayContent.Add, true);
-            loadComponentSingleFile(new ChatTicker(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(new MessageNotifier(), Add, true);
             loadComponentSingleFile(Settings = new SettingsOverlay(), leftFloatingOverlayContent.Add, true);
             loadComponentSingleFile(changelogOverlay = new ChangelogOverlay(), overlayContent.Add, true);
@@ -1230,13 +1238,6 @@ namespace osu.Game
             loadComponentSingleFile(new AccountCreationOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile<IDialogOverlay>(new DialogOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
-
-            loadComponentSingleFile(fpsCounter = new FPSCounter
-            {
-                Anchor = Anchor.BottomRight,
-                Origin = Anchor.BottomRight,
-                Margin = new MarginPadding(5),
-            }, topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add);
             loadComponentSingleFile<BeatmapStore>(detachedBeatmapStore = new RealmDetachedBeatmapStore(), Add, true);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -203,6 +203,8 @@ namespace osu.Game
 
         private FPSCounter fpsCounter;
 
+        private ChatTicker chatTicker;
+
         private VolumeOverlay volume;
 
         private OsuLogo osuLogo;
@@ -1148,13 +1150,6 @@ namespace osu.Game
             ScreenStack.ScreenPushed += screenPushed;
             ScreenStack.ScreenExited += screenExited;
 
-            loadComponentSingleFile(fpsCounter = new FPSCounter
-            {
-                Anchor = Anchor.BottomRight,
-                Origin = Anchor.BottomRight,
-                Margin = new MarginPadding(5),
-            }, topMostOverlayContent.Add);
-
             if (!IsDeployedBuild)
                 loadComponentSingleFile(devBuildBanner = new DevBuildBanner(), ScreenContainer.Add);
 
@@ -1213,6 +1208,7 @@ namespace osu.Game
             var rankingsOverlay = loadComponentSingleFile(new RankingsOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(channelManager = new ChannelManager(API), Add, true);
             loadComponentSingleFile(chatOverlay = new ChatOverlay(), overlayContent.Add, true);
+            loadComponentSingleFile(chatTicker = new ChatTicker(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(new MessageNotifier(), Add, true);
             loadComponentSingleFile(Settings = new SettingsOverlay(), leftFloatingOverlayContent.Add, true);
             loadComponentSingleFile(changelogOverlay = new ChangelogOverlay(), overlayContent.Add, true);
@@ -1236,6 +1232,13 @@ namespace osu.Game
             loadComponentSingleFile(new AccountCreationOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile<IDialogOverlay>(new DialogOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
+
+            loadComponentSingleFile(fpsCounter = new FPSCounter
+            {
+                Anchor = Anchor.BottomRight,
+                Origin = Anchor.BottomRight,
+                Margin = new MarginPadding(5),
+            }, topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add);
             loadComponentSingleFile<BeatmapStore>(detachedBeatmapStore = new RealmDetachedBeatmapStore(), Add, true);

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -54,6 +54,8 @@ namespace osu.Game.Overlays.Chat
 
         protected virtual float UsernameWidth => 150;
 
+        protected virtual bool UsernameIsClickable => true;
+
         [Resolved]
         private ChannelManager? chatManager { get; set; }
 
@@ -196,6 +198,8 @@ namespace osu.Game.Overlays.Chat
                                 Margin = new MarginPadding { Horizontal = Spacing },
                                 AccentColour = UsernameColour,
                                 Inverted = !string.IsNullOrEmpty(message.Sender.Colour),
+                                Enabled = { Value = UsernameIsClickable },
+                                MuteSounds = { Value = !UsernameIsClickable },
                             },
                             drawableContentFlow = new LinkFlowContainer(styleMessageContent)
                             {

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Chat
 
         protected virtual float UsernameWidth => 150;
 
-        protected virtual bool UsernameIsClickable => true;
+        protected bool UsernameIsClickable { get; init; }
 
         [Resolved]
         private ChannelManager? chatManager { get; set; }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Chat
 
         protected virtual float UsernameWidth => 150;
 
-        protected bool UsernameIsClickable { get; init; }
+        protected bool UsernameIsClickable { get; init; } = true;
 
         [Resolved]
         private ChannelManager? chatManager { get; set; }

--- a/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
+++ b/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
@@ -7,12 +7,14 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Resources.Localisation.Web;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osuTK;
+using ChatStrings = osu.Game.Resources.Localisation.Web.ChatStrings;
 
 namespace osu.Game.Overlays.Chat
 {
@@ -21,7 +23,7 @@ namespace osu.Game.Overlays.Chat
         public Drawable DragBar { get; private set; } = null!;
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, TextureStore textures)
+        private void load(OverlayColourProvider colourProvider, OsuConfigManager config)
         {
             Children = new[]
             {
@@ -67,7 +69,17 @@ namespace osu.Game.Overlays.Chat
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Colour = colourProvider.Background4,
-                }
+                },
+                new OsuCheckbox
+                {
+                    LabelText = OnlineSettingsStrings.ChatTicker,
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    RelativeSizeAxes = Axes.None,
+                    Padding = new MarginPadding { Horizontal = 10, },
+                    Width = 150,
+                    Current = config.GetBindable<bool>(OsuSetting.ChatTicker)
+                },
             };
         }
 

--- a/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
+++ b/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
@@ -8,13 +8,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
-using ChatStrings = osu.Game.Resources.Localisation.Web.ChatStrings;
 
 namespace osu.Game.Overlays.Chat
 {
@@ -23,7 +20,7 @@ namespace osu.Game.Overlays.Chat
         public Drawable DragBar { get; private set; } = null!;
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, OsuConfigManager config)
+        private void load(OverlayColourProvider colourProvider)
         {
             Children = new[]
             {
@@ -69,17 +66,7 @@ namespace osu.Game.Overlays.Chat
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Colour = colourProvider.Background4,
-                },
-                new OsuCheckbox
-                {
-                    LabelText = OnlineSettingsStrings.ChatTicker,
-                    Anchor = Anchor.CentreRight,
-                    Origin = Anchor.CentreRight,
-                    RelativeSizeAxes = Axes.None,
-                    Padding = new MarginPadding { Horizontal = 10, },
-                    Width = 150,
-                    Current = config.GetBindable<bool>(OsuSetting.ChatTicker)
-                },
+                }
             };
         }
 

--- a/osu.Game/Overlays/Chat/DrawableChatUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableChatUsername.cs
@@ -231,6 +231,16 @@ namespace osu.Game.Overlays.Chat
             profileOverlay?.ShowUser(user);
         }
 
+        protected override bool OnClick(ClickEvent e)
+        {
+            if (!Enabled.Value)
+            {
+                return false;
+            }
+
+            return base.OnClick(e);
+        }
+
         protected override bool OnHover(HoverEvent e)
         {
             if (Enabled.Value)

--- a/osu.Game/Overlays/Chat/DrawableChatUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableChatUsername.cs
@@ -233,7 +233,10 @@ namespace osu.Game.Overlays.Chat
 
         protected override bool OnHover(HoverEvent e)
         {
-            colouredDrawable.FadeColour(AccentColour.Lighten(0.6f), 30, Easing.OutQuint);
+            if (Enabled.Value)
+            {
+                colouredDrawable.FadeColour(AccentColour.Lighten(0.6f), 30, Easing.OutQuint);
+            }
 
             return base.OnHover(e);
         }
@@ -242,7 +245,10 @@ namespace osu.Game.Overlays.Chat
         {
             base.OnHoverLost(e);
 
-            colouredDrawable.FadeColour(AccentColour, 800, Easing.OutQuint);
+            if (Enabled.Value)
+            {
+                colouredDrawable.FadeColour(AccentColour, 800, Easing.OutQuint);
+            }
         }
     }
 }

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -66,6 +66,9 @@ namespace osu.Game.Overlays
         [Resolved]
         private ChannelManager channelManager { get; set; } = null!;
 
+        [Resolved]
+        private ChatTicker chatTicker { get; set; } = null!;
+
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
 
@@ -200,6 +203,8 @@ namespace osu.Game.Overlays
 
             textBar.OnSearchTermsChanged += searchTerms => channelListing.SearchTerm = searchTerms;
             textBar.OnChatMessageCommitted += handleChatMessage;
+
+            State.BindValueChanged(_ => chatTicker.PostMessage(null));
         }
 
         /// <summary>

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Overlays
         private ChannelManager channelManager { get; set; } = null!;
 
         [Resolved]
-        private ChatTicker chatTicker { get; set; } = null!;
+        private ChatTicker? chatTicker { get; set; }
 
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
@@ -204,7 +204,8 @@ namespace osu.Game.Overlays
             textBar.OnSearchTermsChanged += searchTerms => channelListing.SearchTerm = searchTerms;
             textBar.OnChatMessageCommitted += handleChatMessage;
 
-            State.BindValueChanged(_ => chatTicker.PostMessage(null));
+            if (chatTicker != null)
+                State.BindValueChanged(_ => chatTicker.PostMessage(null));
         }
 
         /// <summary>

--- a/osu.Game/Overlays/ChatTicker.cs
+++ b/osu.Game/Overlays/ChatTicker.cs
@@ -19,9 +19,6 @@ namespace osu.Game.Overlays
 
         private TickerLine? tickerLine;
 
-        [Resolved]
-        private ChatOverlay chatOverlay { get; set; } = null!;
-
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
@@ -43,8 +40,6 @@ namespace osu.Game.Overlays
         {
             base.LoadComplete();
 
-            chatOverlay.State.BindValueChanged(_ => PostMessage(null));
-
             showChatTicker.BindValueChanged(showTicker =>
             {
                 PostMessage(null);
@@ -54,7 +49,7 @@ namespace osu.Game.Overlays
 
         public void PostMessage(Message? message)
         {
-            if (message == null || chatOverlay.IsPresent || !showChatTicker.Value)
+            if (message == null || !showChatTicker.Value)
             {
                 PopOut();
                 return;

--- a/osu.Game/Overlays/ChatTicker.cs
+++ b/osu.Game/Overlays/ChatTicker.cs
@@ -72,11 +72,11 @@ namespace osu.Game.Overlays
         {
             protected override float Spacing => 5;
             protected override float UsernameWidth => 90;
-            protected override bool UsernameIsClickable => false;
 
             public TickerLine(Message message)
                 : base(message)
             {
+                UsernameIsClickable = true;
             }
         }
     }

--- a/osu.Game/Overlays/ChatTicker.cs
+++ b/osu.Game/Overlays/ChatTicker.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Online.Chat;
+using osu.Game.Overlays.Chat;
+
+namespace osu.Game.Overlays
+{
+    public partial class ChatTicker : VisibilityContainer
+    {
+        private readonly BindableBool showChatTicker = new BindableBool();
+
+        private TickerLine? tickerLine;
+
+        [Resolved]
+        private ChatOverlay chatOverlay { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            Height = 18;
+            RelativeSizeAxes = Axes.X;
+            Anchor = Anchor.BottomCentre;
+            Origin = Anchor.BottomCentre;
+
+            AddRange(new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = OsuColour.Gray(0.1f),
+                }
+            });
+
+            config.BindWith(OsuSetting.ChatTicker, showChatTicker);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            chatOverlay.State.BindValueChanged(_ => PostMessage(null));
+            showChatTicker.BindValueChanged(_ => PostMessage(null), true);
+        }
+
+        public void PostMessage(Message? message)
+        {
+            if (message == null || chatOverlay.IsPresent || !showChatTicker.Value)
+            {
+                State.Value = Visibility.Hidden;
+                return;
+            }
+
+            if (tickerLine != null)
+                RemoveInternal(tickerLine, false);
+
+            AddInternal(tickerLine = new TickerLine(message));
+
+            State.Value = Visibility.Visible;
+            var seq = this.FadeOutFromOne(10000);
+            seq.OnComplete(_ => PostMessage(null));
+        }
+
+        protected override void PopIn() => this.FadeIn(100);
+
+        protected override void PopOut() => this.FadeOut(100);
+
+        protected partial class TickerLine : ChatLine
+        {
+            protected override float Spacing => 5;
+            protected override float UsernameWidth => 90;
+            protected override bool UsernameIsClickable => false;
+
+            public TickerLine(Message message)
+                : base(message)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/ChatTicker.cs
+++ b/osu.Game/Overlays/ChatTicker.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Overlays
             public TickerLine(Message message)
                 : base(message)
             {
-                UsernameIsClickable = true;
+                UsernameIsClickable = false;
             }
         }
     }

--- a/osu.Game/Overlays/ChatTicker.cs
+++ b/osu.Game/Overlays/ChatTicker.cs
@@ -44,14 +44,19 @@ namespace osu.Game.Overlays
             base.LoadComplete();
 
             chatOverlay.State.BindValueChanged(_ => PostMessage(null));
-            showChatTicker.BindValueChanged(_ => PostMessage(null), true);
+
+            showChatTicker.BindValueChanged(showTicker =>
+            {
+                PostMessage(null);
+                State.Value = showTicker.NewValue ? Visibility.Visible : Visibility.Hidden;
+            }, true);
         }
 
         public void PostMessage(Message? message)
         {
             if (message == null || chatOverlay.IsPresent || !showChatTicker.Value)
             {
-                State.Value = Visibility.Hidden;
+                PopOut();
                 return;
             }
 
@@ -60,11 +65,12 @@ namespace osu.Game.Overlays
 
             Add(tickerLine = new TickerLine(message));
 
-            State.Value = Visibility.Visible;
-            this.FadeOutFromOne(10000).OnComplete(_ => State.Value = Visibility.Hidden);
+            this.FadeOutFromOne(10000);
         }
 
-        protected override void PopIn() => this.FadeIn(100);
+        protected override void PopIn()
+        {
+        }
 
         protected override void PopOut() => this.FadeOut(100);
 

--- a/osu.Game/Overlays/ChatTicker.cs
+++ b/osu.Game/Overlays/ChatTicker.cs
@@ -61,8 +61,7 @@ namespace osu.Game.Overlays
             Add(tickerLine = new TickerLine(message));
 
             State.Value = Visibility.Visible;
-            var seq = this.FadeOutFromOne(10000);
-            seq.OnComplete(_ => PostMessage(null));
+            this.FadeOutFromOne(10000).OnComplete(_ => State.Value = Visibility.Hidden);
         }
 
         protected override void PopIn() => this.FadeIn(100);

--- a/osu.Game/Overlays/ChatTicker.cs
+++ b/osu.Game/Overlays/ChatTicker.cs
@@ -30,13 +30,10 @@ namespace osu.Game.Overlays
             Anchor = Anchor.BottomCentre;
             Origin = Anchor.BottomCentre;
 
-            AddRange(new Drawable[]
+            Add(new Box
             {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = OsuColour.Gray(0.1f),
-                }
+                RelativeSizeAxes = Axes.Both,
+                Colour = OsuColour.Gray(0.1f),
             });
 
             config.BindWith(OsuSetting.ChatTicker, showChatTicker);
@@ -59,9 +56,9 @@ namespace osu.Game.Overlays
             }
 
             if (tickerLine != null)
-                RemoveInternal(tickerLine, false);
+                Remove(tickerLine, false);
 
-            AddInternal(tickerLine = new TickerLine(message));
+            Add(tickerLine = new TickerLine(message));
 
             State.Value = Visibility.Visible;
             var seq = this.FadeOutFromOne(10000);

--- a/osu.Game/Overlays/Settings/Sections/Online/AlertsAndPrivacySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/AlertsAndPrivacySettings.cs
@@ -21,6 +21,11 @@ namespace osu.Game.Overlays.Settings.Sections.Online
             {
                 new SettingsItemV2(new FormCheckBox
                 {
+                    Caption = OnlineSettingsStrings.ChatTicker,
+                    Current = config.GetBindable<bool>(OsuSetting.ChatTicker)
+                }),
+                new SettingsItemV2(new FormCheckBox
+                {
                     Caption = OnlineSettingsStrings.NotifyOnMentioned,
                     Current = config.GetBindable<bool>(OsuSetting.NotifyOnUsernameMentioned)
                 }),


### PR DESCRIPTION
Closes #5117.

My only concern is off-screen text rendering of long messages because `ChatLine`'s text flow doesn't have single line mode or trimming functionality. Probably shouldn't worry too much about it when messages are limited by length server-side.

# Changes
* Added chat ticker drawable
* Added chat ticker related tests to `TestSceneChatTicker` and `TestSceneMessageNotifier`
* Added `MuteSounds` property to `OsuClickableContainer` to remove unwanted sounds from `DrawableChatUsername`
* Added chat ticker property to settings ~~and chat overlay like in stable~~

# Demo video
https://github.com/user-attachments/assets/ff6b51d1-abd0-42eb-8095-0b157d15ad7c

