### PR TITLE
Add report dropdown to ranked play chat

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneBubbleChatHistory.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneBubbleChatHistory.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Chat;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 
 namespace osu.Game.Tests.Visual.RankedPlay
@@ -27,7 +28,11 @@ namespace osu.Game.Tests.Visual.RankedPlay
         public void TestPostMessages()
         {
             int messageId = 1;
-            AddRepeatStep("post message", () => history.PostMessage(new APIUser { Id = 2 }, $"message {messageId++}"), 20);
+            AddRepeatStep("post message", () => history.PostMessage(new Message
+            {
+                Sender = new APIUser { Id = 2 },
+                Content = $"message {messageId++}"
+            }), 20);
         }
 
         [Test]
@@ -38,7 +43,13 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddStep("post some messages", () =>
             {
                 for (int i = 0; i < 10; i++)
-                    history.PostMessage(new APIUser { Id = 2 }, $"message {i}");
+                {
+                    history.PostMessage(new Message
+                    {
+                        Sender = new APIUser { Id = 2 },
+                        Content = $"message {i}",
+                    });
+                }
             });
 
             AddWaitStep("wait a bit", 10);

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayChat.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayChat.cs
@@ -65,6 +65,16 @@ namespace osu.Game.Tests.Visual.RankedPlay
 
             postLocalUserMessage("this is a message from the local user");
             postOpponentMessage("this is a message from the opponent");
+            AddStep("add long message", () => testChannel.AddNewMessages(new Message(messageIdSequence++)
+            {
+                Timestamp = DateTimeOffset.Now,
+                Sender = new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy"
+                },
+                Content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget neque non leo placerat sollicitudin eget sit amet sem. Aenean ut ipsum et nulla lobortis viverra ut eget odio.",
+            }));
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
@@ -7,20 +7,27 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Cursor;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Overlays.Chat;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users.Drawables;
 using osuTK;
@@ -28,7 +35,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 {
-    public partial class RankedPlayChatDisplay : VisibilityContainer, IKeyBindingHandler<GlobalAction>
+    public partial class RankedPlayChatDisplay : VisibilityContainer, IKeyBindingHandler<GlobalAction>, IFocusManager
     {
         [Resolved]
         private ChannelManager? channelManager { get; set; }
@@ -38,54 +45,71 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         private readonly MultiplayerRoom room;
 
+        private Container content = null!;
         private ChatTextBox textbox = null!;
         private BubbleChatHistory chatHistory = null!;
 
         private Channel? channel;
 
+        private IFocusManager parentFocusManager = null!;
+
         private const float width = 320;
 
         public RankedPlayChatDisplay(MultiplayerRoom room)
         {
-            Size = new Vector2(width, 160);
+            AutoSizeAxes = Axes.Both;
             this.room = room;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChildren = new Drawable[]
+            InternalChild = new ChatContextMenuContainer
             {
-                textbox = new ChatTextBox
+                AutoSizeAxes = Axes.Both,
+                Anchor = Anchor.BottomRight,
+                Origin = Anchor.BottomRight,
+                Child = content = new Container
                 {
+                    AutoSizeAxes = Axes.Both,
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,
-                    RelativeSizeAxes = Axes.X,
-                    Height = 30,
-                    CornerRadius = 10,
-                    ReleaseFocusOnCommit = true,
-                    HoldFocus = false,
-                    Focus = onFocusGained,
-                    FocusLost = onFocusLost
-                },
-                new Container
-                {
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre,
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Bottom = 35 },
-                    Child = chatHistory = new BubbleChatHistory
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.X
+                        textbox = new ChatTextBox
+                        {
+                            Anchor = Anchor.BottomRight,
+                            Origin = Anchor.BottomRight,
+                            Width = width,
+                            Height = 30,
+                            CornerRadius = 10,
+                            ReleaseFocusOnCommit = true,
+                            HoldFocus = false,
+                            Focus = onFocusGained,
+                            FocusLost = onFocusLost
+                        },
+                        new Container
+                        {
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            AutoSizeAxes = Axes.Y,
+                            Width = width * 1.5f,
+                            Padding = new MarginPadding { Bottom = 35 },
+                            Child = chatHistory = new BubbleChatHistory
+                            {
+                                RelativeSizeAxes = Axes.X
+                            }
+                        }
                     }
-                }
+                },
             };
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            parentFocusManager = GetContainingFocusManager()!;
 
             resetPlaceholderText();
             textbox.OnCommit += onCommit;
@@ -113,7 +137,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private void onNewMessagesArrived(IEnumerable<Message> bundle)
         {
             foreach (var message in bundle)
-                chatHistory.PostMessage(message.Sender, message.Content);
+                chatHistory.PostMessage(message);
         }
 
         private void onFocusGained()
@@ -163,6 +187,20 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
         }
 
+        public void TriggerFocusContention(Drawable? triggerSource)
+        {
+            if (triggerSource == null || triggerSource.IsRootedAt(content))
+                parentFocusManager.TriggerFocusContention(triggerSource);
+        }
+
+        public bool ChangeFocus(Drawable? potentialFocusTarget)
+        {
+            if (potentialFocusTarget == null || potentialFocusTarget.IsRootedAt(content))
+                return parentFocusManager.ChangeFocus(potentialFocusTarget);
+
+            return false;
+        }
+
         protected override void PopIn()
         {
             FinishTransforms();
@@ -187,6 +225,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
             if (channel != null)
                 channel.NewMessagesArrived -= onNewMessagesArrived;
+        }
+
+        private partial class ChatContextMenuContainer : OsuContextMenuContainer
+        {
+            public ChatContextMenuContainer()
+            {
+                Content.Anchor = Anchor.BottomRight;
+                Content.Origin = Anchor.BottomRight;
+            }
         }
 
         private partial class ChatTextBox : StandAloneChatDisplay.ChatTextBox
@@ -220,7 +267,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
             private readonly Container<MessageBubble> messageContainer;
 
-            private bool expanded;
+            private readonly BindableBool expanded = new BindableBool();
 
             private Sample messageReceivedSample = null!;
             private double? lastSamplePlayback;
@@ -247,7 +294,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             /// </summary>
             public void Collapse()
             {
-                expanded = false;
+                expanded.Value = false;
 
                 foreach (var child in messageContainer.Reverse().Take(max_length).Reverse())
                 {
@@ -265,7 +312,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             /// </summary>
             public void Expand()
             {
-                expanded = true;
+                expanded.Value = true;
 
                 foreach (var child in messageContainer.Reverse().Take(max_length))
                     child.Show();
@@ -274,15 +321,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             /// <summary>
             /// Posts a message.
             /// </summary>
-            /// <param name="user">The user that posted the message.</param>
-            /// <param name="content">The message content.</param>
-            public void PostMessage(APIUser user, string content)
+            /// <param name="message">The message.</param>
+            public void PostMessage(Message message)
             {
-                var newMessage = new MessageBubble(user, content)
+                var newMessage = new MessageBubble(message)
                 {
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,
-                    PostTime = Time.Current
+                    PostTime = Time.Current,
+                    Expanded = { BindTarget = expanded },
                 };
 
                 messageContainer.Add(newMessage);
@@ -314,7 +361,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 playSample();
 
                 // If not in the expanded state, hide the new message after a short while.
-                if (!expanded)
+                if (!expanded.Value)
                 {
                     using (BeginDelayedSequence(time_before_disappear))
                         newMessage.Hide();
@@ -330,19 +377,25 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 lastSamplePlayback = Time.Current;
             }
 
-            private partial class MessageBubble : CompositeDrawable
+            private partial class MessageBubble : CompositeDrawable, IHasContextMenu, IHasPopover
             {
-                private readonly APIUser user;
-                private readonly string message;
+                private readonly Message message;
 
                 /// <summary>
                 /// The time at which this message was posted.
                 /// </summary>
                 public required double PostTime { get; init; }
 
-                public MessageBubble(APIUser user, string message)
+                /// <summary>
+                /// Whether the message history is currently in an expanded state.
+                /// </summary>
+                public readonly IBindable<bool> Expanded = new BindableBool();
+
+                private const int text_offset = 20;
+                private const int padding = 8;
+
+                public MessageBubble(Message message)
                 {
-                    this.user = user;
                     this.message = message;
                     AutoSizeAxes = Axes.Both;
 
@@ -368,14 +421,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                                 new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = api.LocalUser.Value.Id == user.Id
+                                    Colour = api.LocalUser.Value.Id == message.SenderId
                                         ? RankedPlayColourScheme.BLUE.PrimaryDarkest
                                         : RankedPlayColourScheme.RED.PrimaryDarkest,
                                 },
                                 new Container
                                 {
                                     AutoSizeAxes = Axes.Both,
-                                    Padding = new MarginPadding(8),
+                                    Padding = new MarginPadding(padding),
                                     Children = new Drawable[]
                                     {
                                         new CircularContainer
@@ -384,7 +437,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                                             Origin = Anchor.CentreLeft,
                                             Size = new Vector2(16),
                                             Masking = true,
-                                            Child = new UpdateableAvatar(user)
+                                            Child = new UpdateableAvatar(message.Sender)
                                             {
                                                 DelayedLoad = false,
                                                 RelativeSizeAxes = Axes.Both
@@ -392,12 +445,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                                         },
                                         new OsuTextFlowContainer
                                         {
-                                            X = 20,
-                                            MaximumSize = new Vector2(width * 1.5f, 0),
+                                            X = text_offset,
+                                            MaximumSize = new Vector2(width * 1.5f - text_offset - padding * 2, 0),
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             AutoSizeAxes = Axes.Both,
-                                            Text = message,
+                                            Text = message.Content,
                                         }
                                     }
                                 }
@@ -415,6 +468,31 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 public override void Hide()
                 {
                     this.FadeOut(200, Easing.OutQuint);
+                }
+
+                public MenuItem[]? ContextMenuItems
+                {
+                    get
+                    {
+                        if (!Expanded.Value)
+                            return null;
+
+                        if (message.Sender.Equals(APIUser.SYSTEM_USER))
+                            return null;
+
+                        if (message.Sender.Equals(api.LocalUser.Value))
+                            return null;
+
+                        return [new OsuMenuItem(UsersStrings.ReportButtonText, MenuItemType.Destructive, this.ShowPopover)];
+                    }
+                }
+
+                public Popover? GetPopover()
+                {
+                    if (message.Sender.Equals(api.LocalUser.Value))
+                        return null;
+
+                    return new ReportChatPopover(message);
                 }
             }
         }


### PR DESCRIPTION
Probably shouldn't be reviewed/merged before #37638, #37647, #37651 (mainly because that PR series refactors the report popovers to work better here).

This commit adds a dropdown menu to ranked play chat messages, with an option to report said message. However, this isn't fully working yet due to some focus shenanigans:

* the chat history is only displayed when the chat textbox is in focus,
* selecting the report option in a dropdown kills focus on the textbox, hiding the messages, which in turn causes the report popover to expire (see attached video)

Because of that, this PR is for now mostly an RFC concerning the changes I've made to the actual chat display. I think the report popover will need to be refactored to some sort of fullscreen overlay (`DialogOverlay` maybe?) since this is the second time I have to fight those (previous being #36335).

[Screencast_20260503_081506.webm](https://github.com/user-attachments/assets/d3d37d77-0679-4110-b136-22e7d6a08775)