### PR TITLE
Fix `sliderFactor` using incorrect aim rating conversion curve

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             int totalHits = beatmap.HitObjects.Count;
 
             double sliderFactor = aimDifficultyValue > 0
-                ? calculateDifficultyRating(aimNoSlidersDifficultyValue) / calculateDifficultyRating(aimDifficultyValue) // TODO: this is intentionally left incorrect
+                ? calculateAimDifficultyRating(aimNoSlidersDifficultyValue) / calculateAimDifficultyRating(aimDifficultyValue)
                 : 1;
 
             double aimRating = calculateAimDifficultyRating(aimDifficultyValue);


### PR DESCRIPTION
Requires 

- [x] https://github.com/ppy/osu/pull/37621
- [x] https://github.com/ppy/osu/pull/37623

Part 3
