### PR TITLE
Add Precise Tapping mod

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
@@ -121,6 +121,38 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         });
 
         [Test]
+        public void TestMisaimOnLaterObjectDoesNotRegisterHit() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModPreciseTapping(),
+            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 1
+                                  && Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Great) == 1,
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 500,
+                        Position = new Vector2(100),
+                    },
+                    new HitCircle
+                    {
+                        StartTime = 700,
+                        Position = new Vector2(200, 100),
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(595, new Vector2(200, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(596, new Vector2(200, 100)),
+                new OsuReplayFrame(700, new Vector2(200, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(701, new Vector2(200, 100)),
+            }
+        });
+
+        [Test]
         public void TestPressBlockedByAlternateIsNotCountedAsExtra() => CreateModTest(new ModTestData
         {
             Mods = new Mod[] { new OsuModAlternate(), new OsuModPreciseTapping() },

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
@@ -1,0 +1,122 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests.Mods
+{
+    public partial class TestSceneOsuModPreciseTapping : OsuModTestScene
+    {
+        [Test]
+        public void TestPressWithoutHitMissesNextObject() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModPreciseTapping(),
+            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 1,
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 500,
+                        Position = new Vector2(100),
+                    },
+                    new HitCircle
+                    {
+                        StartTime = 1000,
+                        Position = new Vector2(200, 100),
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(250, new Vector2(300, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(251, new Vector2(300, 100)),
+                new OsuReplayFrame(500, new Vector2(100), OsuAction.LeftButton),
+            }
+        });
+
+        [Test]
+        public void TestExtraPressDoesNotChainMissNextObject() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModPreciseTapping(),
+            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 1
+                                  && Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Great) == 1,
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 500,
+                        Position = new Vector2(100),
+                    },
+                    new HitCircle
+                    {
+                        StartTime = 700,
+                        Position = new Vector2(200, 100),
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(400, new Vector2(300, 300), OsuAction.LeftButton),
+                new OsuReplayFrame(401, new Vector2(300, 300)),
+                new OsuReplayFrame(500, new Vector2(100), OsuAction.LeftButton),
+                new OsuReplayFrame(501, new Vector2(100)),
+                new OsuReplayFrame(700, new Vector2(200, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(701, new Vector2(200, 100)),
+            }
+        });
+
+        [Test]
+        public void TestExtraPressDuringSliderMissesNextObject() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModPreciseTapping(),
+            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 1,
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Slider
+                    {
+                        StartTime = 500,
+                        Position = new Vector2(100),
+                        Path = new SliderPath(PathType.LINEAR, new[]
+                        {
+                            Vector2.Zero,
+                            new Vector2(100, 0),
+                        }),
+                    },
+                    new HitCircle
+                    {
+                        StartTime = 1500,
+                        Position = new Vector2(300, 100),
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(500, new Vector2(100), OsuAction.LeftButton),
+                new OsuReplayFrame(700, new Vector2(150, 100), OsuAction.LeftButton, OsuAction.RightButton),
+                new OsuReplayFrame(701, new Vector2(150, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(900, new Vector2(200, 100)),
+                new OsuReplayFrame(1500, new Vector2(300, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(1501, new Vector2(300, 100)),
+            }
+        });
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Mods;
@@ -116,6 +117,40 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 new OsuReplayFrame(900, new Vector2(200, 100)),
                 new OsuReplayFrame(1500, new Vector2(300, 100), OsuAction.LeftButton),
                 new OsuReplayFrame(1501, new Vector2(300, 100)),
+            }
+        });
+
+        [Test]
+        public void TestPressBlockedByAlternateIsNotCountedAsExtra() => CreateModTest(new ModTestData
+        {
+            Mods = new Mod[] { new OsuModAlternate(), new OsuModPreciseTapping() },
+            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Great) == 2
+                                  && Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 0,
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 500,
+                        Position = new Vector2(100),
+                    },
+                    new HitCircle
+                    {
+                        StartTime = 1000,
+                        Position = new Vector2(200, 100),
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(500, new Vector2(100), OsuAction.LeftButton),
+                new OsuReplayFrame(501, new Vector2(100)),
+                new OsuReplayFrame(700, new Vector2(150, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(701, new Vector2(150, 100)),
+                new OsuReplayFrame(1000, new Vector2(200, 100), OsuAction.RightButton),
+                new OsuReplayFrame(1001, new Vector2(200, 100)),
             }
         });
     }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPreciseTapping.cs
@@ -49,11 +49,10 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         });
 
         [Test]
-        public void TestExtraPressDoesNotChainMissNextObject() => CreateModTest(new ModTestData
+        public void TestExtraPressChainMissesNextObject() => CreateModTest(new ModTestData
         {
             Mod = new OsuModPreciseTapping(),
-            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 1
-                                  && Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Great) == 1,
+            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 2,
             Autoplay = false,
             CreateBeatmap = () => new Beatmap
             {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModAutoplay : ModAutoplay
     {
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModAutopilot), typeof(OsuModSpunOut), typeof(OsuModAlternate), typeof(OsuModSingleTap) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModAutopilot), typeof(OsuModSpunOut), typeof(OsuModAlternate), typeof(OsuModSingleTap), typeof(OsuModPreciseTapping) }).ToArray();
 
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedUser { Username = "Autoplay" });

--- a/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModCinema : ModCinema<OsuHitObject>
     {
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModMagnetised), typeof(OsuModAutopilot), typeof(OsuModSpunOut), typeof(OsuModAlternate), typeof(OsuModSingleTap), typeof(OsuModRepel) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModMagnetised), typeof(OsuModAutopilot), typeof(OsuModSpunOut), typeof(OsuModAlternate), typeof(OsuModSingleTap), typeof(OsuModRepel), typeof(OsuModPreciseTapping) }).ToArray();
 
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedUser { Username = "Autoplay" });

--- a/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
@@ -106,30 +106,20 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 var tappable = mod.getNextTappable();
 
-                if (tappable != null)
+                if (tappable == null)
+                    return true;
+
+                tappable.HitArea.OnPressed(e);
+
+                if (tappable.Result?.IsHit == true)
+                    mod.penaltyActive = true;
+                else if (tappable.Result?.HasResult != true && mod.penaltyActive)
                 {
-                    bool wasActive = mod.penaltyActive;
-
-                    Scheduler.Add(() =>
-                    {
-                        if (tappable.Result?.IsHit == true)
-                        {
-                            mod.penaltyActive = true;
-                            return;
-                        }
-
-                        if (tappable.Result?.HasResult == true)
-                            return;
-
-                        if (!wasActive)
-                            return;
-
-                        tappable.MissForcefully();
-                        mod.penaltyActive = false;
-                    });
+                    tappable.MissForcefully();
+                    mod.penaltyActive = false;
                 }
 
-                return false;
+                return true;
             }
 
             public void OnReleased(KeyBindingReleaseEvent<OsuAction> e)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
@@ -1,0 +1,140 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
+using osu.Game.Utils;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public partial class OsuModPreciseTapping : Mod, IApplicableToDrawableRuleset<OsuHitObject>, IUpdatableByPlayfield
+    {
+        public override string Name => @"Precise Tapping";
+        public override string Acronym => @"PT";
+        public override LocalisableString Description => @"Extra key presses count as misses.";
+        public override double ScoreMultiplier => 1.0;
+        public override ModType Type => ModType.Conversion;
+        public override bool Ranked => true;
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(OsuModCinema) };
+
+        private DrawableOsuRuleset ruleset = null!;
+
+        private PeriodTracker nonGameplayPeriods = null!;
+
+        private IFrameStableClock gameplayClock = null!;
+
+        private bool penaltyActive = true;
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
+        {
+            ruleset = (DrawableOsuRuleset)drawableRuleset;
+            ruleset.KeyBindingInputManager.Add(new InputInterceptor(this));
+
+            var periods = new List<Period>();
+
+            if (drawableRuleset.Objects.Any())
+            {
+                periods.Add(new Period(int.MinValue, getValidJudgementTime(ruleset.Objects.First()) - 1));
+
+                foreach (BreakPeriod b in drawableRuleset.Beatmap.Breaks)
+                    periods.Add(new Period(b.StartTime, getValidJudgementTime(ruleset.Objects.First(h => h.StartTime >= b.EndTime)) - 1));
+
+                static double getValidJudgementTime(HitObject hitObject) => hitObject.StartTime - hitObject.HitWindows.WindowFor(HitResult.Meh);
+            }
+
+            nonGameplayPeriods = new PeriodTracker(periods);
+
+            gameplayClock = drawableRuleset.FrameStableClock;
+        }
+
+        public void Update(Playfield playfield)
+        {
+            if (gameplayClock.IsRewinding || nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
+                penaltyActive = true;
+        }
+
+        private DrawableHitCircle? getNextTappable()
+        {
+            foreach (var alive in ruleset.Playfield.HitObjectContainer.AliveObjects)
+            {
+                DrawableHitCircle? circle = alive switch
+                {
+                    DrawableSlider slider => slider.HeadCircle,
+                    DrawableHitCircle hitCircle => hitCircle,
+                    _ => null
+                };
+
+                if (circle != null && circle.Result?.HasResult != true)
+                    return circle;
+            }
+
+            return null;
+        }
+
+        private partial class InputInterceptor : Component, IKeyBindingHandler<OsuAction>
+        {
+            private readonly OsuModPreciseTapping mod;
+
+            public InputInterceptor(OsuModPreciseTapping mod)
+            {
+                this.mod = mod;
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
+            {
+                if (e.Action != OsuAction.LeftButton && e.Action != OsuAction.RightButton)
+                    return false;
+
+                if (mod.nonGameplayPeriods.IsInAny(mod.gameplayClock.CurrentTime))
+                    return false;
+
+                if (mod.gameplayClock.IsRewinding)
+                    return false;
+
+                var tappable = mod.getNextTappable();
+
+                if (tappable != null)
+                {
+                    bool wasActive = mod.penaltyActive;
+
+                    Scheduler.Add(() =>
+                    {
+                        if (tappable.Result?.IsHit == true)
+                        {
+                            mod.penaltyActive = true;
+                            return;
+                        }
+
+                        if (tappable.Result?.HasResult == true)
+                            return;
+
+                        if (!wasActive)
+                            return;
+
+                        tappable.MissForcefully();
+                        mod.penaltyActive = false;
+                    });
+                }
+
+                return false;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<OsuAction> e)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
             ruleset = (DrawableOsuRuleset)drawableRuleset;
-            ruleset.KeyBindingInputManager.Add(new InputInterceptor(this));
+            ruleset.Playfield.AttachInputInterceptor(new InputInterceptor(this));
 
             var periods = new List<Period>();
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModPreciseTapping.cs
@@ -20,7 +20,7 @@ using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public partial class OsuModPreciseTapping : Mod, IApplicableToDrawableRuleset<OsuHitObject>, IUpdatableByPlayfield
+    public partial class OsuModPreciseTapping : Mod, IApplicableToDrawableRuleset<OsuHitObject>
     {
         public override string Name => @"Precise Tapping";
         public override string Acronym => @"PT";
@@ -35,8 +35,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         private PeriodTracker nonGameplayPeriods = null!;
 
         private IFrameStableClock gameplayClock = null!;
-
-        private bool penaltyActive = true;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
@@ -58,12 +56,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             nonGameplayPeriods = new PeriodTracker(periods);
 
             gameplayClock = drawableRuleset.FrameStableClock;
-        }
-
-        public void Update(Playfield playfield)
-        {
-            if (gameplayClock.IsRewinding || nonGameplayPeriods.IsInAny(gameplayClock.CurrentTime))
-                penaltyActive = true;
         }
 
         private DrawableHitCircle? getNextTappable()
@@ -111,13 +103,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 tappable.HitArea.OnPressed(e);
 
-                if (tappable.Result?.IsHit == true)
-                    mod.penaltyActive = true;
-                else if (tappable.Result?.HasResult != true && mod.penaltyActive)
-                {
+                if (tappable.Result?.HasResult != true)
                     tappable.MissForcefully();
-                    mod.penaltyActive = false;
-                }
 
                 return true;
             }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => @"You don't need to click. Give your clicking/tapping fingers a break from the heat of things.";
 
         public override Type[] IncompatibleMods =>
-            base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot), typeof(OsuModMagnetised), typeof(OsuModAlternate), typeof(OsuModSingleTap) }).ToArray();
+            base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot), typeof(OsuModMagnetised), typeof(OsuModAlternate), typeof(OsuModSingleTap), typeof(OsuModPreciseTapping) }).ToArray();
 
         /// <summary>
         /// How early before a hitobject's start time to trigger a hit.

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -189,7 +189,8 @@ namespace osu.Game.Rulesets.Osu
                         new OsuModClassic(),
                         new OsuModRandom(),
                         new OsuModMirror(),
-                        new MultiMod(new OsuModAlternate(), new OsuModSingleTap())
+                        new MultiMod(new OsuModAlternate(), new OsuModSingleTap()),
+                        new OsuModPreciseTapping()
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -190,7 +190,8 @@ namespace osu.Game.Rulesets.Osu
                         new OsuModClassic(),
                         new OsuModRandom(),
                         new OsuModMirror(),
-                        new MultiMod(new OsuModAlternate(), new OsuModSingleTap())
+                        new MultiMod(new OsuModAlternate(), new OsuModSingleTap()),
+                        new OsuModPreciseTapping()
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -217,6 +217,8 @@ namespace osu.Game.Rulesets.Osu.UI
             AddInternal(resumeInputBlocker);
         }
 
+        public void AttachInputInterceptor(Drawable interceptor) => AddInternal(interceptor);
+
         private partial class ProxyContainer : LifetimeManagementContainer
         {
             public void Add(Drawable proxy) => AddInternal(proxy);


### PR DESCRIPTION
Precise tapping makes additional unnecessary key presses cause misses. Misses are created by forcing a miss onto the next object to avoid issues around diff calc having too many judgements.

I read a discussion about people wanting this and I personally really enjoy playing with this mod for practicing finger control. Not sure if new mods are even being considered at this time.

Some things to consider:
- I didn't know what category to put it under but conversion is probably fine? 
- it doesn't have a mod icon 
- ApplyToDrawableRuleset among other code is just ripped from InputBlockingMod but having this extend InputBlockingMods seemed wrong semantically so idk what is better


I can't easily find all the related discussions I remember reading before here are a couple:
- https://github.com/ppy/osu/discussions/13064
- https://github.com/ppy/osu/discussions/30770