### PR TITLE
Synchronise ranked play text box with gameplay text box

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
@@ -191,7 +191,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             base.Dispose(isDisposing);
 
             if (channel != null)
+            {
                 channel.NewMessagesArrived -= onNewMessagesArrived;
+                textbox.Current.UnbindFrom(channel.TextBoxMessage);
+            }
         }
 
         private partial class ChatTextBox : StandAloneChatDisplay.ChatTextBox

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -42,8 +41,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private ChatTextBox textbox = null!;
         private BubbleChatHistory chatHistory = null!;
 
-        [Cached]
-        private Bindable<Channel?> channel = new Bindable<Channel?>();
+        private Channel? channel;
 
         private const float width = 320;
 
@@ -51,8 +49,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
             Size = new Vector2(width, 160);
             this.room = room;
-
-            channel.BindValueChanged(channelChanged);
         }
 
         [BackgroundDependencyLoader]
@@ -94,9 +90,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             resetPlaceholderText();
             textbox.OnCommit += onCommit;
 
-            channel.Value = channelManager?.JoinChannel(new Channel { Id = room.ChannelID, Type = ChannelType.Multiplayer, Name = $"#lazermp_{room.RoomID}" });
-            if (channel.Value != null)
-                channel.Value.NewMessagesArrived += onNewMessagesArrived;
+            channel = channelManager?.JoinChannel(new Channel { Id = room.ChannelID, Type = ChannelType.Multiplayer, Name = $"#lazermp_{room.RoomID}" });
+            if (channel != null)
+                channel.NewMessagesArrived += onNewMessagesArrived;
         }
 
         private void onCommit(TextBox sender, bool newText)
@@ -107,9 +103,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 return;
 
             if (text[0] == '/')
-                channelManager?.PostCommand(text[1..], channel.Value);
+                channelManager?.PostCommand(text[1..], channel);
             else
-                channelManager?.PostMessage(text, target: channel.Value);
+                channelManager?.PostMessage(text, target: channel);
 
             textbox.Text = string.Empty;
         }
@@ -163,16 +159,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             return false;
         }
 
-        private void channelChanged(ValueChangedEvent<Channel?> e)
-        {
-            if (e.OldValue != null)
-                textbox.Current.UnbindFrom(e.OldValue.TextBoxMessage);
-
-            if (e.NewValue == null) return;
-
-            textbox.Current.BindTo(e.NewValue.TextBoxMessage);
-        }
-
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
         }
@@ -199,8 +185,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
             base.Dispose(isDisposing);
 
-            if (channel.Value != null)
-                channel.Value.NewMessagesArrived -= onNewMessagesArrived;
+            if (channel != null)
+                channel.NewMessagesArrived -= onNewMessagesArrived;
         }
 
         private partial class ChatTextBox : StandAloneChatDisplay.ChatTextBox

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
@@ -91,8 +91,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             textbox.OnCommit += onCommit;
 
             channel = channelManager?.JoinChannel(new Channel { Id = room.ChannelID, Type = ChannelType.Multiplayer, Name = $"#lazermp_{room.RoomID}" });
+
             if (channel != null)
+            {
                 channel.NewMessagesArrived += onNewMessagesArrived;
+
+                textbox.Current.BindTo(channel.TextBoxMessage);
+            }
         }
 
         private void onCommit(TextBox sender, bool newText)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -41,7 +42,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private ChatTextBox textbox = null!;
         private BubbleChatHistory chatHistory = null!;
 
-        private Channel? channel;
+        [Cached]
+        private Bindable<Channel?> channel = new Bindable<Channel?>();
 
         private const float width = 320;
 
@@ -49,6 +51,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
             Size = new Vector2(width, 160);
             this.room = room;
+
+            channel.BindValueChanged(channelChanged);
         }
 
         [BackgroundDependencyLoader]
@@ -90,9 +94,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             resetPlaceholderText();
             textbox.OnCommit += onCommit;
 
-            channel = channelManager?.JoinChannel(new Channel { Id = room.ChannelID, Type = ChannelType.Multiplayer, Name = $"#lazermp_{room.RoomID}" });
-            if (channel != null)
-                channel.NewMessagesArrived += onNewMessagesArrived;
+            channel.Value = channelManager?.JoinChannel(new Channel { Id = room.ChannelID, Type = ChannelType.Multiplayer, Name = $"#lazermp_{room.RoomID}" });
+            if (channel.Value != null)
+                channel.Value.NewMessagesArrived += onNewMessagesArrived;
         }
 
         private void onCommit(TextBox sender, bool newText)
@@ -103,9 +107,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 return;
 
             if (text[0] == '/')
-                channelManager?.PostCommand(text[1..], channel);
+                channelManager?.PostCommand(text[1..], channel.Value);
             else
-                channelManager?.PostMessage(text, target: channel);
+                channelManager?.PostMessage(text, target: channel.Value);
 
             textbox.Text = string.Empty;
         }
@@ -159,6 +163,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             return false;
         }
 
+        private void channelChanged(ValueChangedEvent<Channel?> e)
+        {
+            if (e.OldValue != null)
+                textbox.Current.UnbindFrom(e.OldValue.TextBoxMessage);
+
+            if (e.NewValue == null) return;
+
+            textbox.Current.BindTo(e.NewValue.TextBoxMessage);
+        }
+
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
         }
@@ -185,8 +199,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
             base.Dispose(isDisposing);
 
-            if (channel != null)
-                channel.NewMessagesArrived -= onNewMessagesArrived;
+            if (channel.Value != null)
+                channel.Value.NewMessagesArrived -= onNewMessagesArrived;
         }
 
         private partial class ChatTextBox : StandAloneChatDisplay.ChatTextBox


### PR DESCRIPTION
I am not sure if it was intentionally not included, but with quick play the unsent text input would be transferred to the gameplay state. This video shows how it currently acts:

https://github.com/user-attachments/assets/03bc42cd-65fc-403a-a9f6-1739ba38855a

But I have used some of the logic in the `channelChanged` function from  `StandAloneChatDisplay`, and managed to get the text boxes to synchronise in the gameplay state.

https://github.com/user-attachments/assets/f70745ad-9ce2-44a4-a50d-7b28d63414b7

