### PR TITLE
Allow spectator and replay gameplay to load even when window is inactive

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -85,6 +85,12 @@ namespace osu.Game.Screens.Play
 
         protected Task? DisposalTask { get; private set; }
 
+        /// <summary>
+        /// By default, the loader screen will block until the window is focused.
+        /// Can be overridden by setting this to <c>false</c>.
+        /// </summary>
+        protected bool WindowShouldBeActiveForGameplayStart { get; init; } = true;
+
         private FillFlowContainer disclaimers = null!;
         private GridContainer sideContent = null!;
 
@@ -125,7 +131,7 @@ namespace osu.Game.Screens.Play
         }
 
         protected virtual bool ReadyForGameplay =>
-            host.IsActive.Value &&
+            (!WindowShouldBeActiveForGameplayStart || host.IsActive.Value) &&
             // not ready if the user is hovering one of the panes (logo is excluded), unless they are idle.
             (IsHovered || osuLogo?.IsHovered == true || idleTracker.IsIdle.Value)
             // not ready if the user is dragging a slider or otherwise.

--- a/osu.Game/Screens/Play/ReplayPlayerLoader.cs
+++ b/osu.Game/Screens/Play/ReplayPlayerLoader.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Screens.Play
                 throw new ArgumentException($"{nameof(score)} must have a non-null {nameof(score.Replay)}.", nameof(score));
 
             Score = score.ScoreInfo;
+            WindowShouldBeActiveForGameplayStart = false;
         }
 
         public override void OnEntering(ScreenTransitionEvent e)

--- a/osu.Game/Screens/Play/SpectatorPlayerLoader.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayerLoader.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Screens.Play
                 throw new ArgumentException($"{nameof(score)} must have a non-null {nameof(score.Replay)}.", nameof(score));
 
             Score = score.ScoreInfo;
+            WindowShouldBeActiveForGameplayStart = false;
         }
 
         public override void OnEntering(ScreenTransitionEvent e)


### PR DESCRIPTION
This used to be the case, but recently changed with the introduction of [pausing when inactive](https://github.com/ppy/osu/pull/37100). The change was intended to work for local gameplay modes, but it makes less sense for spectator/replay where you may want to be watching in the background while doing something else.

Raised via email.