### PR TITLE
Add distance factor to anti-doubletap

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
@@ -194,7 +195,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
                 double speedRatio = currDeltaTime / Math.Max(currDeltaTime, deltaDifference);
                 double windowRatio = Math.Pow(Math.Min(1, currDeltaTime / HitWindow(HitResult.Great)), 5);
 
-                return 1.0 - Math.Pow(speedRatio, 1 - windowRatio);
+                // Can't doubletap if circles don't intersect
+                double distanceFactor = Math.Pow(DifficultyCalculationUtils.ReverseLerp(LazyJumpDistance, NORMALISED_DIAMETER, NORMALISED_RADIUS), 2);
+
+                return 1.0 - Math.Pow(speedRatio, distanceFactor * (1 - windowRatio));
             }
 
             return 0;


### PR DESCRIPTION
Circles that are spaced from each other can't be doubletapped, therefore they were excluded from the low OD penalty in speed.