### PR TITLE
Fix non-default mod settings allowing for duplicate freestyle mod selection in multiplayer

### DIFF
--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -7,8 +7,10 @@ using System.Linq;
 using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
@@ -31,6 +33,17 @@ namespace osu.Game.Tests.Mods
             var mod = new Mock<CustomMod1>();
             Assert.That(ModUtils.CheckCompatibleSet(new[] { mod.Object, mod.Object }, out var invalid), Is.False);
             Assert.That(invalid, Is.EquivalentTo(new[] { mod.Object }));
+        }
+
+        [Test]
+        public void TestModIsNotCompatibleWithItselfEvenIfSettingsDiffer()
+        {
+            var mod1 = new Mock<CustomMod3>();
+            var mod2 = new Mock<CustomMod3>();
+            mod2.Setup(m => m.Setting).Returns(new BindableBool(true));
+
+            Assert.That(ModUtils.CheckCompatibleSet(new[] { mod1.Object, mod2.Object }, out var invalid), Is.False);
+            Assert.That(invalid, Is.EquivalentTo(new[] { mod2.Object }));
         }
 
         [Test]
@@ -395,6 +408,12 @@ namespace osu.Game.Tests.Mods
 
         public abstract class CustomMod2 : Mod, IModCompatibilitySpecification
         {
+        }
+
+        public abstract class CustomMod3 : Mod, IModCompatibilitySpecification
+        {
+            [SettingSource("Setting")]
+            public virtual BindableBool Setting { get; } = new BindableBool();
         }
 
         private class InvalidMultiplayerMod : Mod

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -342,7 +342,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                         RequiredMods =
                         [
-                            new APIMod(new OsuModSuddenDeath() { FailOnSliderTail = { Value = true } }),
+                            new APIMod(new OsuModSuddenDeath { FailOnSliderTail = { Value = true } }),
                         ],
                         AllowedMods = [],
                         Freestyle = true

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -331,6 +331,33 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
+        public void TestModSelectOverlayNonDefaultSettings()
+        {
+            AddStep("add playlist item", () =>
+            {
+                room.Playlist =
+                [
+                    new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
+                    {
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                        RequiredMods = new[]
+                        {
+                            new APIMod(new OsuModSuddenDeath() { FailOnSliderTail = { Value = true }}),
+                        },
+                        AllowedMods = [],
+                        Freestyle = true
+                    }
+                ];
+            });
+            ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
+
+            AddUntilStep("wait for join", () => RoomJoined);
+
+            ClickButtonWhenEnabled<UserModSelectButton>();
+            AddAssert("sudden death not visible", () => this.ChildrenOfType<MultiplayerUserModSelectOverlay>().Single().ChildrenOfType<ModPanel>().Single(m => m.Mod is ModSuddenDeath).Visible == false);
+        }
+
+        [Test]
         public void TestChangeSettingsButtonVisibleForHost()
         {
             AddStep("add playlist item", () =>

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -340,10 +340,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
                     {
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
-                        RequiredMods = new[]
-                        {
-                            new APIMod(new OsuModSuddenDeath() { FailOnSliderTail = { Value = true }}),
-                        },
+                        RequiredMods =
+                        [
+                            new APIMod(new OsuModSuddenDeath() { FailOnSliderTail = { Value = true } }),
+                        ],
                         AllowedMods = [],
                         Freestyle = true
                     }

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Utils
                 {
                     var m = mods[j];
 
-                    if (candidate.Equals(m))
+                    if (candidate.GetType() == m.GetType())
                     {
                         invalidMods ??= new List<Mod>();
                         invalidMods.Add(m);


### PR DESCRIPTION
Fixes a bug that allowed for selecting the same mod twice in multiplayer if the playlist entry has non-default settings for a required mod.
This happens due to a strict equality mod check in the mod set compatibility check function, which only considers mods duplicates if their settings are exactly the same. Replacing with a more lenient `Type` check fixes this.

Adds a regression test for this behavior

Fixes https://github.com/ppy/osu/issues/37625.