### PR TITLE
Allow pinning skins to the top of the dropdown and cycling through favourites

### DIFF
--- a/osu.Game.Tests/Skins/TestSceneSkinPinning.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinPinning.cs
@@ -1,0 +1,163 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Testing;
+using osu.Game.Database;
+using osu.Game.Skinning;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Skins
+{
+    [HeadlessTest]
+    public partial class TestSceneSkinPinning : OsuTestScene
+    {
+        [Resolved]
+        private SkinManager skins { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        private List<Guid> seededIds = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            // Realm persists across tests in this fixture, so reset pin state up-front so
+            // ordering / cycle assertions never pick up stale items.
+            AddStep("reset pin state", () => realm.Write(r =>
+            {
+                foreach (var s in r.All<SkinInfo>())
+                    s.Pinned = false;
+            }));
+
+            AddStep("seed test skins", () =>
+            {
+                string tag = $"pinning-{Guid.NewGuid():N}";
+                seededIds = new List<Guid>();
+
+                realm.Write(r =>
+                {
+                    foreach (string suffix in new[] { "alpha", "bravo", "charlie" })
+                    {
+                        var info = new SkinInfo(name: $"{tag}-{suffix}", creator: "test", instantiationInfo: typeof(TrianglesSkin).AssemblyQualifiedName);
+                        r.Add(info);
+                        seededIds.Add(info.ID);
+                    }
+                });
+            });
+        }
+
+        [Test]
+        public void TestNewSkinIsUnpinnedByDefault()
+        {
+            AddAssert("seeded skins start unpinned", () => realm.Run(r => seededIds.All(id => !r.Find<SkinInfo>(id)!.Pinned)));
+        }
+
+        [Test]
+        public void TestTogglePinnedFlipsState()
+        {
+            AddStep("toggle pin on bravo", () => skins.TogglePinned(liveSkin(1)));
+            AddAssert("bravo is pinned", () => realm.Run(r => r.Find<SkinInfo>(seededIds[1])!.Pinned));
+
+            AddStep("toggle pin on bravo again", () => skins.TogglePinned(liveSkin(1)));
+            AddAssert("bravo is unpinned", () => realm.Run(r => !r.Find<SkinInfo>(seededIds[1])!.Pinned));
+        }
+
+        [Test]
+        public void TestPinnedSkinsSurfaceFirst()
+        {
+            AddStep("pin charlie", () => realm.Write(r => r.Find<SkinInfo>(seededIds[2])!.Pinned = true));
+
+            AddAssert("charlie precedes other seeded skins", () =>
+            {
+                var ids = seededIdsInDropdownOrder();
+                int charlie = ids.IndexOf(seededIds[2]);
+                return charlie >= 0 && ids.IndexOf(seededIds[0]) > charlie && ids.IndexOf(seededIds[1]) > charlie;
+            });
+        }
+
+        [Test]
+        public void TestPinnedBucketKeepsAlphabeticalOrder()
+        {
+            AddStep("pin alpha and charlie", () => realm.Write(r =>
+            {
+                r.Find<SkinInfo>(seededIds[0])!.Pinned = true;
+                r.Find<SkinInfo>(seededIds[2])!.Pinned = true;
+            }));
+
+            AddAssert("alpha precedes charlie ahead of bravo", () =>
+            {
+                var ids = seededIdsInDropdownOrder();
+                int alpha = ids.IndexOf(seededIds[0]);
+                int charlie = ids.IndexOf(seededIds[2]);
+                int bravo = ids.IndexOf(seededIds[1]);
+                return alpha >= 0 && charlie > alpha && bravo > charlie;
+            });
+        }
+
+        [Test]
+        public void TestCycleVisitsEverySkinByDefault()
+        {
+            assertCycleVisitsAllSeededSkins(favouritesOnly: false);
+        }
+
+        [Test]
+        public void TestCycleRestrictsToFavouritesWhenEnoughArePinned()
+        {
+            AddStep("pin alpha and charlie", () => realm.Write(r =>
+            {
+                r.Find<SkinInfo>(seededIds[0])!.Pinned = true;
+                r.Find<SkinInfo>(seededIds[2])!.Pinned = true;
+            }));
+            AddStep("select alpha", () => skins.CurrentSkinInfo.Value = liveSkin(0));
+
+            AddStep("cycle next", () => skins.SelectNextSkin(favouritesOnly: true));
+            AddAssert("now on a pinned skin", () => skins.CurrentSkinInfo.Value.PerformRead(s => s.Pinned));
+
+            AddStep("cycle next again", () => skins.SelectNextSkin(favouritesOnly: true));
+            AddAssert("still on a pinned skin", () => skins.CurrentSkinInfo.Value.PerformRead(s => s.Pinned));
+        }
+
+        [Test]
+        public void TestCycleFallsBackToAllSkinsWithFewerThanTwoPinned()
+        {
+            AddStep("pin only alpha", () => realm.Write(r => r.Find<SkinInfo>(seededIds[0])!.Pinned = true));
+
+            assertCycleVisitsAllSeededSkins(favouritesOnly: true);
+        }
+
+        private void assertCycleVisitsAllSeededSkins(bool favouritesOnly)
+        {
+            HashSet<Guid> visited = null!;
+
+            AddStep("select alpha", () => skins.CurrentSkinInfo.Value = liveSkin(0));
+            AddStep("walk the cycle", () =>
+            {
+                visited = new HashSet<Guid> { skins.CurrentSkinInfo.Value.ID };
+
+                int totalSkins = skins.GetAllUsableSkins().Count;
+
+                for (int i = 0; i < totalSkins * 2; i++)
+                {
+                    skins.SelectNextSkin(favouritesOnly);
+                    visited.Add(skins.CurrentSkinInfo.Value.ID);
+                }
+            });
+            AddAssert("every seeded skin was reached", () => seededIds.All(id => visited.Contains(id)));
+        }
+
+        private List<Guid> seededIdsInDropdownOrder()
+            => skins.GetAllUsableSkins()
+                    .Select(s => s.Value.ID)
+                    .Where(id => seededIds.Contains(id))
+                    .ToList();
+
+        private Live<SkinInfo> liveSkin(int index)
+            => realm.Run(r => r.Find<SkinInfo>(seededIds[index])!.ToLive(realm));
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Configuration
             // UI/selection defaults
             SetDefault(OsuSetting.Ruleset, string.Empty);
             SetDefault(OsuSetting.Skin, SkinInfo.ARGON_SKIN.ToString());
+            SetDefault(OsuSetting.CycleSkinsThroughFavoritesOnly, false);
 
             SetDefault(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Local);
             SetDefault(OsuSetting.BeatmapLeaderboardSortMode, LeaderboardSortMode.Score);
@@ -511,5 +512,6 @@ namespace osu.Game.Configuration
 
         DashboardSortMode,
         DashboardDisplayStyle,
+        CycleSkinsThroughFavoritesOnly,
     }
 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -101,8 +101,9 @@ namespace osu.Game.Database
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
+        /// 52   2026-05-06    Add SkinInfo.Pinned.
         /// </summary>
-        private const int schema_version = 51;
+        private const int schema_version = 52;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Graphics/UserInterface/HeartIcon.cs
+++ b/osu.Game/Graphics/UserInterface/HeartIcon.cs
@@ -1,0 +1,137 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    /// <summary>
+    /// A heart icon that toggles between an outline (inactive) and a filled pink (active)
+    /// state with a pop animation, optionally accompanied by a particle burst when transitioning
+    /// to the active state.
+    /// </summary>
+    public partial class HeartIcon : CompositeDrawable
+    {
+        private readonly SpriteIcon icon;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public HeartIcon()
+        {
+            InternalChildren = new Drawable[]
+            {
+                icon = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.Regular.Heart,
+                    RelativeSizeAxes = Axes.Both,
+                },
+            };
+        }
+
+        private const double pop_out_duration = 100;
+        private const double pop_in_duration = 500;
+
+        private bool active;
+
+        public void SetActive(bool active, bool withAnimation = false)
+        {
+            if (this.active == active)
+                return;
+
+            this.active = active;
+
+            FinishTransforms(true);
+
+            if (active)
+            {
+                transitionIcon(FontAwesome.Solid.Heart, colours.Pink1, emphasised: withAnimation);
+
+                if (withAnimation)
+                    playFavouriteAnimation();
+            }
+            else
+            {
+                transitionIcon(FontAwesome.Regular.Heart, colourProvider.Content2);
+            }
+        }
+
+        private void transitionIcon(IconUsage newIcon, Color4 colour, bool emphasised = false)
+        {
+            icon.ScaleTo(emphasised ? 0.5f : 0.8f, pop_out_duration, Easing.OutQuad)
+                .Then()
+                .FadeColour(colour)
+                .Schedule(() => icon.Icon = newIcon)
+                .ScaleTo(1, pop_in_duration, Easing.OutElasticHalf);
+        }
+
+        private void playFavouriteAnimation()
+        {
+            var circle = new FastCircle
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(0.5f),
+                Blending = BlendingParameters.Additive,
+                Alpha = 0,
+                Depth = float.MinValue,
+            };
+
+            AddInternal(circle);
+
+            circle.Delay(pop_out_duration)
+                  .FadeTo(0.35f)
+                  .FadeOut(1400, Easing.OutCubic)
+                  .ScaleTo(10f, 750, Easing.OutQuint)
+                  .Expire();
+
+            const int num_particles = 8;
+
+            static float randomFloat(float min, float max) => min + Random.Shared.NextSingle() * (max - min);
+
+            for (int i = 0; i < num_particles; i++)
+            {
+                double duration = randomFloat(600, 1000);
+                float angle = (i + randomFloat(0, 0.75f)) / num_particles * MathF.PI * 2;
+                var direction = new Vector2(MathF.Cos(angle), MathF.Sin(angle));
+                float distance = randomFloat(DrawWidth / 2, DrawWidth);
+
+                var particle = new FastCircle
+                {
+                    Position = direction * DrawWidth / 4,
+                    Size = new Vector2(3),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Blending = BlendingParameters.Additive,
+                    Alpha = 0,
+                    Depth = 2,
+                    Colour = colours.Pink,
+                };
+
+                AddInternal(particle);
+
+                particle
+                    .Delay(pop_out_duration)
+                    .FadeTo(0.5f)
+                    .MoveTo(direction * distance, 1300, Easing.OutQuint)
+                    .FadeOut(duration, Easing.Out)
+                    .ScaleTo(0.5f, duration)
+                    .Expire();
+            }
+        }
+    }
+}

--- a/osu.Game/Localisation/SkinSettingsStrings.cs
+++ b/osu.Game/Localisation/SkinSettingsStrings.cs
@@ -30,6 +30,26 @@ namespace osu.Game.Localisation
         public static LocalisableString SkinLayoutEditor => new TranslatableString(getKey(@"skin_layout_editor"), @"Skin layout editor");
 
         /// <summary>
+        /// "Pin"
+        /// </summary>
+        public static LocalisableString PinSkin => new TranslatableString(getKey(@"pin_skin"), @"Pin");
+
+        /// <summary>
+        /// "Unpin"
+        /// </summary>
+        public static LocalisableString UnpinSkin => new TranslatableString(getKey(@"unpin_skin"), @"Unpin");
+
+        /// <summary>
+        /// "Cycle through favourites only"
+        /// </summary>
+        public static LocalisableString CycleSkinsThroughFavoritesOnly => new TranslatableString(getKey(@"cycle_skins_through_favorites_only"), @"Cycle through favourites only");
+
+        /// <summary>
+        /// "Restrict the next/previous skin keybinds to pinned skins only."
+        /// </summary>
+        public static LocalisableString CycleSkinsThroughFavoritesOnlyDescription => new TranslatableString(getKey(@"cycle_skins_through_favorites_only_description"), @"Restrict the next/previous skin keybinds to pinned skins only.");
+
+        /// <summary>
         /// "Gameplay cursor size"
         /// </summary>
         public static LocalisableString GameplayCursorSize => new TranslatableString(getKey(@"gameplay_cursor_size"), @"Gameplay cursor size");

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1566,14 +1566,14 @@ namespace osu.Game
                     if (skinEditor.State.Value == Visibility.Visible)
                         return false;
 
-                    SkinManager.SelectNextSkin();
+                    SkinManager.SelectNextSkin(LocalConfig.Get<bool>(OsuSetting.CycleSkinsThroughFavoritesOnly));
                     return true;
 
                 case GlobalAction.PreviousSkin:
                     if (skinEditor.State.Value == Visibility.Visible)
                         return false;
 
-                    SkinManager.SelectPreviousSkin();
+                    SkinManager.SelectPreviousSkin(LocalConfig.Get<bool>(OsuSetting.CycleSkinsThroughFavoritesOnly));
                     return true;
             }
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
+using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -55,7 +56,7 @@ namespace osu.Game.Overlays.Settings.Sections
         private IDisposable realmSubscription;
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load([CanBeNull] SkinEditorOverlay skinEditor)
+        private void load(OsuConfigManager config, [CanBeNull] SkinEditorOverlay skinEditor)
         {
             Children = new Drawable[]
             {
@@ -80,10 +81,20 @@ namespace osu.Game.Overlays.Settings.Sections
                         new DeleteSkinButton { Padding = new MarginPadding { Left = 2.5f }, RelativeSizeAxes = Axes.X, Width = 1 / 3f },
                     }
                 },
+                new SkinFavouriteButton(),
                 new SettingsButtonV2
                 {
                     Text = SkinSettingsStrings.SkinLayoutEditor,
                     Action = () => skinEditor?.ToggleVisibility(),
+                },
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = SkinSettingsStrings.CycleSkinsThroughFavoritesOnly,
+                    HintText = SkinSettingsStrings.CycleSkinsThroughFavoritesOnlyDescription,
+                    Current = config.GetBindable<bool>(OsuSetting.CycleSkinsThroughFavoritesOnly),
+                })
+                {
+                    Keywords = new[] { "skin", "cycle", "favourite", "favorite", "pin", "hotkey", "keybind" },
                 },
             };
         }
@@ -131,7 +142,55 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private partial class SkinDropdown : FormDropdown<Live<SkinInfo>>
         {
-            protected override LocalisableString GenerateItemText(Live<SkinInfo> item) => item.ToString();
+            protected override LocalisableString GenerateItemText(Live<SkinInfo> item)
+                => item.PerformRead(s => s.Pinned ? $"♥ {s}" : s.ToString());
+        }
+
+        public partial class SkinFavouriteButton : SettingsButtonV2
+        {
+            [Resolved]
+            private SkinManager skins { get; set; }
+
+            private Bindable<Skin> currentSkin;
+            private HeartIcon heart;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Action = togglePin;
+
+                Content.Add(heart = new HeartIcon
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    X = 16,
+                    Size = new Vector2(16),
+                });
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                currentSkin = skins.CurrentSkin.GetBoundCopy();
+                currentSkin.BindValueChanged(_ => updateState());
+                currentSkin.BindDisabledChanged(_ => updateState(), true);
+            }
+
+            private void updateState(bool withAnimation = false)
+            {
+                bool currentlyPinned = currentSkin.Value.SkinInfo.PerformRead(s => s.Pinned);
+                heart.SetActive(currentlyPinned, withAnimation);
+                Text = currentlyPinned ? SkinSettingsStrings.UnpinSkin : SkinSettingsStrings.PinSkin;
+                Enabled.Value = !currentSkin.Disabled;
+            }
+
+            private void togglePin()
+            {
+                skins.TogglePinned(skins.CurrentSkinInfo.Value);
+                // CurrentSkin.ValueChanged isn't fired by a pinned-flag mutation; refresh manually.
+                updateState(withAnimation: currentSkin.Value.SkinInfo.PerformRead(s => s.Pinned));
+            }
         }
 
         public partial class RenameSkinButton : SettingsButtonV2, IHasPopover

--- a/osu.Game/Screens/Select/BeatmapTitleWedge.FavouriteButton.cs
+++ b/osu.Game/Screens/Select/BeatmapTitleWedge.FavouriteButton.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -253,121 +252,5 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private partial class HeartIcon : CompositeDrawable
-        {
-            private readonly SpriteIcon icon;
-
-            [Resolved]
-            private OverlayColourProvider colourProvider { get; set; } = null!;
-
-            [Resolved]
-            private OsuColour colours { get; set; } = null!;
-
-            public HeartIcon()
-            {
-                InternalChildren = new Drawable[]
-                {
-                    icon = new SpriteIcon
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Icon = FontAwesome.Regular.Heart,
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                };
-            }
-
-            private const double pop_out_duration = 100;
-            private const double pop_in_duration = 500;
-
-            private bool active;
-
-            public void SetActive(bool active, bool withAnimation = false)
-            {
-                if (this.active == active)
-                    return;
-
-                this.active = active;
-
-                FinishTransforms(true);
-
-                if (active)
-                {
-                    transitionIcon(FontAwesome.Solid.Heart, colours.Pink1, emphasised: withAnimation);
-
-                    if (withAnimation)
-                        playFavouriteAnimation();
-                }
-                else
-                {
-                    transitionIcon(FontAwesome.Regular.Heart, colourProvider.Content2);
-                }
-            }
-
-            private void transitionIcon(IconUsage newIcon, Color4 colour, bool emphasised = false)
-            {
-                icon.ScaleTo(emphasised ? 0.5f : 0.8f, pop_out_duration, Easing.OutQuad)
-                    .Then()
-                    .FadeColour(colour)
-                    .Schedule(() => icon.Icon = newIcon)
-                    .ScaleTo(1, pop_in_duration, Easing.OutElasticHalf);
-            }
-
-            private void playFavouriteAnimation()
-            {
-                var circle = new FastCircle
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Scale = new Vector2(0.5f),
-                    Blending = BlendingParameters.Additive,
-                    Alpha = 0,
-                    Depth = float.MinValue,
-                };
-
-                AddInternal(circle);
-
-                circle.Delay(pop_out_duration)
-                      .FadeTo(0.35f)
-                      .FadeOut(1400, Easing.OutCubic)
-                      .ScaleTo(10f, 750, Easing.OutQuint)
-                      .Expire();
-
-                const int num_particles = 8;
-
-                static float randomFloat(float min, float max) => min + Random.Shared.NextSingle() * (max - min);
-
-                for (int i = 0; i < num_particles; i++)
-                {
-                    double duration = randomFloat(600, 1000);
-                    float angle = (i + randomFloat(0, 0.75f)) / num_particles * MathF.PI * 2;
-                    var direction = new Vector2(MathF.Cos(angle), MathF.Sin(angle));
-                    float distance = randomFloat(DrawWidth / 2, DrawWidth);
-
-                    var particle = new FastCircle
-                    {
-                        Position = direction * DrawWidth / 4,
-                        Size = new Vector2(3),
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Blending = BlendingParameters.Additive,
-                        Alpha = 0,
-                        Depth = 2,
-                        Colour = colours.Pink,
-                    };
-
-                    AddInternal(particle);
-
-                    particle
-                        .Delay(pop_out_duration)
-                        .FadeTo(0.5f)
-                        .MoveTo(direction * distance, 1300, Easing.OutQuint)
-                        .FadeOut(duration, Easing.Out)
-                        .ScaleTo(0.5f, duration)
-                        .Expire();
-                }
-            }
-        }
     }
 }

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -40,6 +40,11 @@ namespace osu.Game.Skinning
 
         public bool Protected { get; set; }
 
+        /// <summary>
+        /// Whether the user has pinned this skin to the top of their skin list.
+        /// </summary>
+        public bool Pinned { get; set; }
+
         public virtual Skin CreateInstance(IStorageResourceProvider resources)
         {
             var type = string.IsNullOrEmpty(InstantiationInfo)

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -139,7 +139,8 @@ namespace osu.Game.Skinning
 
         /// <summary>
         /// Returns the dropdown ordering for use mainly by the skin selection UI.
-        /// Inserts the defaults first, then 'random skin', then custom ones.
+        /// Pinned skins surface first (preserving the underlying defaults / random / alphabetical
+        /// ordering within the unpinned bucket).
         /// Returns a list of <see cref="Live{SkinInfo}"/> items.
         /// </summary>
         public IList<Live<SkinInfo>> GetAllUsableSkins()
@@ -164,10 +165,18 @@ namespace osu.Game.Skinning
 
                 foreach (var s in userSkins)
                     skins.Add(s);
+
+                // OrderBy is stable, so equal-Pinned entries keep the category ordering established above.
+                skins = skins.OrderByDescending(s => s.Value.Pinned).ToList();
             });
 
             return skins;
         }
+
+        /// <summary>
+        /// Toggles the pinned state of the given skin.
+        /// </summary>
+        public void TogglePinned(Live<SkinInfo> skin) => skin.PerformWrite(s => s.Pinned = !s.Pinned);
 
         public void SelectRandomSkin()
         {
@@ -197,7 +206,7 @@ namespace osu.Game.Skinning
             });
         }
 
-        private void cycleSkins(int direction)
+        private void cycleSkins(int direction, bool favouritesOnly)
         {
             Debug.Assert(direction != 0);
 
@@ -206,6 +215,16 @@ namespace osu.Game.Skinning
                 return;
 
             var skins = GetAllUsableSkins();
+
+            if (favouritesOnly)
+            {
+                var favourites = skins.Where(s => s.Value.Pinned).ToList();
+
+                // Fall back to the full list when there aren't enough pinned skins to cycle through;
+                // otherwise the keybind would silently no-op or lock onto a single entry.
+                if (favourites.Count >= 2)
+                    skins = favourites;
+            }
 
             int i = skins.IndexOf(CurrentSkinInfo.Value);
 
@@ -224,12 +243,14 @@ namespace osu.Game.Skinning
         /// <summary>
         /// Cycle one skin backward.
         /// </summary>
-        public void SelectPreviousSkin() => cycleSkins(-1);
+        /// <param name="favouritesOnly">When <c>true</c>, restrict the cycle to pinned skins (with a fallback to all skins if fewer than two are pinned).</param>
+        public void SelectPreviousSkin(bool favouritesOnly = false) => cycleSkins(-1, favouritesOnly);
 
         /// <summary>
         /// Cycle one skin forward.
         /// </summary>
-        public void SelectNextSkin() => cycleSkins(1);
+        /// <param name="favouritesOnly">When <c>true</c>, restrict the cycle to pinned skins (with a fallback to all skins if fewer than two are pinned).</param>
+        public void SelectNextSkin(bool favouritesOnly = false) => cycleSkins(1, favouritesOnly);
 
         /// <summary>
         /// Retrieve a <see cref="Skin"/> instance for the provided <see cref="SkinInfo"/>


### PR DESCRIPTION
Closes #23534.

https://github.com/user-attachments/assets/5a651282-df53-4f2e-b3ba-c374e4bba66f

The pin button reuses the heart from `BeatmapTitleWedge.FavouriteButton`, extracted to a top-level `HeartIcon` component so both surfaces share the same outline/filled-pink transition and pop animation. Pinned skins also show a `♥` prefix in the dropdown text. (The 'Favourite Button' uses an animation that fills the background pink, and in this implementation it looks a bit awkward, but I didn't mind it too much, was just trying to reuse what was there.) 
I don't know if the asymmetry that the `HeartIcon` creates on the left side of the button is desirable, it looks good in my eyes, but I understand it's inconsistent with the rest of the settings, can be changed/removed.

The pinned skins float to the top of the skin dropdown, and the next/previous-skin hotkeys can be restricted to favourites only (toggle at the bottom of the skin settings section). The favourites-only cycle falls back to the full list when fewer than two skins are pinned (so the keybind never gets stuck on a single entry :P)
I generally don't care about 90% of the skins I have, and now that I could pin them, it just feels right to have this option too, but need to hear feedback from devs.

Realm schema bumped 51→52 (just the new bool, no migration body needed). Tests in `TestSceneSkinPinning` cover the sort, toggle, cycle filter, and the <2-pinned fallback.