### PR TITLE
Don't search for users when no search query is provided

### DIFF
--- a/osu.Game/Overlays/Dashboard/UserSearch/UserSearchDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/UserSearch/UserSearchDisplay.cs
@@ -160,6 +160,12 @@ namespace osu.Game.Overlays.Dashboard.UserSearch
 
         private void performSearch()
         {
+            if (string.IsNullOrEmpty(searchTextBox.Current.Value))
+            {
+                loading.Value = false;
+                return;
+            }
+
             loading.Value = true;
             var getUsersRequest = new SearchUsersRequest(searchTextBox.Current.Value);
             getUsersRequest.Success += showResults;

--- a/osu.Game/Overlays/Dashboard/UserSearch/UserSearchDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/UserSearch/UserSearchDisplay.cs
@@ -149,12 +149,6 @@ namespace osu.Game.Overlays.Dashboard.UserSearch
                 return;
             }
 
-            if (string.IsNullOrEmpty(searchTextBox.Current.Value))
-            {
-                loading.Value = false;
-                return;
-            }
-
             queryChangedDebounce = Scheduler.AddDelayed(performSearch, 500);
         }
 


### PR DESCRIPTION
Doesn't make much sense and looks to be stressing the server a bit (results take some time to return). Just a quick fix.