### PR TITLE
Don't consider user toggles for beatmap skin/samples when in editor

### DIFF
--- a/osu.Game.Tests/Skins/TestSceneBeatmapSkinLookupDisables.cs
+++ b/osu.Game.Tests/Skins/TestSceneBeatmapSkinLookupDisables.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Tests.Skins
     public partial class TestSceneBeatmapSkinLookupDisables : OsuTestScene
     {
         private UserSkinSource userSource;
+        private BeatmapSkinProvidingContainer beatmapSkinProvider;
         private BeatmapSkinSource beatmapSource;
         private SkinRequester requester;
 
@@ -36,7 +37,7 @@ namespace osu.Game.Tests.Skins
         public void SetUp() => Schedule(() =>
         {
             Add(new SkinProvidingContainer(userSource = new UserSkinSource())
-                .WithChild(new BeatmapSkinProvidingContainer(beatmapSource = new BeatmapSkinSource())
+                .WithChild(beatmapSkinProvider = new BeatmapSkinProvidingContainer(beatmapSource = new BeatmapSkinSource())
                     .WithChild(requester = new SkinRequester())));
         });
 
@@ -44,7 +45,7 @@ namespace osu.Game.Tests.Skins
         [TestCase(true)]
         public void TestDrawableLookup(bool allowBeatmapLookups)
         {
-            AddStep($"Set beatmap skin enabled to {allowBeatmapLookups}", () => config.SetValue(OsuSetting.BeatmapSkins, allowBeatmapLookups));
+            AddStep($"Set beatmap skin enabled to {allowBeatmapLookups}", () => beatmapSkinProvider.BeatmapSkins.Value = allowBeatmapLookups);
 
             string expected = allowBeatmapLookups ? "beatmap" : "user";
 
@@ -55,7 +56,7 @@ namespace osu.Game.Tests.Skins
         [TestCase(true)]
         public void TestProviderLookup(bool allowBeatmapLookups)
         {
-            AddStep($"Set beatmap skin enabled to {allowBeatmapLookups}", () => config.SetValue(OsuSetting.BeatmapSkins, allowBeatmapLookups));
+            AddStep($"Set beatmap skin enabled to {allowBeatmapLookups}", () => beatmapSkinProvider.BeatmapSkins.Value = allowBeatmapLookups);
 
             ISkin expected() => allowBeatmapLookups ? beatmapSource : userSource;
 

--- a/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
+++ b/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
@@ -17,8 +17,6 @@ namespace osu.Game.Screens.Edit
             : base(editorBeatmap.PlayableBeatmap.BeatmapInfo.Ruleset.CreateInstance(), editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin?.Skin)
         {
             beatmapSkin = editorBeatmap.BeatmapSkin;
-
-            AllowSettingsLevelDisables = false;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
+++ b/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Screens.Edit
             : base(editorBeatmap.PlayableBeatmap.BeatmapInfo.Ruleset.CreateInstance(), editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin?.Skin)
         {
             beatmapSkin = editorBeatmap.BeatmapSkin;
+
+            AllowSettingsLevelDisables = false;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -287,6 +287,10 @@ namespace osu.Game.Screens.Play
             dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor, HealthProcessor, Beatmap.Value.Storyboard, PlayingState));
 
             var rulesetSkinProvider = new RulesetSkinProvidingContainer(ruleset, playableBeatmap, Beatmap.Value.Skin);
+            config.BindWith(OsuSetting.BeatmapSkins, rulesetSkinProvider.BeatmapSkins);
+            config.BindWith(OsuSetting.BeatmapColours, rulesetSkinProvider.BeatmapColours);
+            config.BindWith(OsuSetting.BeatmapHitsounds, rulesetSkinProvider.BeatmapHitsounds);
+
             GameplayClockContainer.Add(new GameplayScrollWheelHandling());
 
             // needs to exist in frame stable content, but is used by underlay layers so make sure assigned early.

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -124,7 +124,8 @@ namespace osu.Game.Screens.Play
                 Origin = Anchor.TopCentre,
             });
 
-            AddInternal(new RulesetSkinProvidingContainer(GameplayState.Ruleset, GameplayState.Beatmap, Beatmap.Value.Skin)
+            RulesetSkinProvidingContainer rulesetSkinProvider;
+            AddInternal(rulesetSkinProvider = new RulesetSkinProvidingContainer(GameplayState.Ruleset, GameplayState.Beatmap, Beatmap.Value.Skin)
             {
                 Child = failIndicator = new ReplayFailIndicator(GameplayClockContainer)
                 {
@@ -138,6 +139,9 @@ namespace osu.Game.Screens.Play
                     }
                 }
             });
+            config.BindWith(OsuSetting.BeatmapSkins, rulesetSkinProvider.BeatmapSkins);
+            config.BindWith(OsuSetting.BeatmapColours, rulesetSkinProvider.BeatmapColours);
+            config.BindWith(OsuSetting.BeatmapHitsounds, rulesetSkinProvider.BeatmapHitsounds);
         }
 
         protected override void PrepareReplay()

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Audio;
-using osu.Game.Configuration;
-using osu.Game.Storyboards;
 
 namespace osu.Game.Skinning
 {
@@ -15,55 +12,19 @@ namespace osu.Game.Skinning
     /// </summary>
     public partial class BeatmapSkinProvidingContainer : SkinProvidingContainer
     {
-        private Bindable<bool> beatmapSkins = null!;
-        private Bindable<bool> beatmapColours = null!;
-        private Bindable<bool> beatmapHitsounds = null!;
+        public BindableWithCurrent<bool> BeatmapSkins = new BindableWithCurrent<bool>(true);
+        public BindableWithCurrent<bool> BeatmapColours = new BindableWithCurrent<bool>(true);
+        public BindableWithCurrent<bool> BeatmapHitsounds = new BindableWithCurrent<bool>(true);
 
-        protected override bool AllowConfigurationLookup
-        {
-            get
-            {
-                if (beatmapSkins == null)
-                    throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
+        protected override bool AllowConfigurationLookup => BeatmapSkins.Value;
 
-                return beatmapSkins.Value;
-            }
-        }
+        protected override bool AllowColourLookup => BeatmapColours.Value;
 
-        protected override bool AllowColourLookup
-        {
-            get
-            {
-                if (beatmapColours == null)
-                    throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
+        protected override bool AllowDrawableLookup(ISkinComponentLookup lookup) => BeatmapSkins.Value;
 
-                return beatmapColours.Value;
-            }
-        }
+        protected override bool AllowTextureLookup(string componentName) => BeatmapSkins.Value;
 
-        protected override bool AllowDrawableLookup(ISkinComponentLookup lookup)
-        {
-            if (beatmapSkins == null)
-                throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
-
-            return beatmapSkins.Value;
-        }
-
-        protected override bool AllowTextureLookup(string componentName)
-        {
-            if (beatmapSkins == null)
-                throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
-
-            return beatmapSkins.Value;
-        }
-
-        protected override bool AllowSampleLookup(ISampleInfo sampleInfo)
-        {
-            if (beatmapSkins == null)
-                throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
-
-            return sampleInfo is StoryboardSampleInfo || beatmapHitsounds.Value;
-        }
+        protected override bool AllowSampleLookup(ISampleInfo sampleInfo) => BeatmapHitsounds.Value;
 
         private readonly ISkin skin;
         private readonly ISkin? classicFallback;
@@ -77,23 +38,12 @@ namespace osu.Game.Skinning
             this.classicFallback = classicFallback;
         }
 
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-        {
-            var config = parent.Get<OsuConfigManager>();
-
-            beatmapSkins = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
-            beatmapColours = config.GetBindable<bool>(OsuSetting.BeatmapColours);
-            beatmapHitsounds = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
-
-            return base.CreateChildDependencies(parent);
-        }
-
         [BackgroundDependencyLoader]
         private void load(SkinManager skins)
         {
-            beatmapSkins.BindValueChanged(_ => TriggerSourceChanged());
-            beatmapColours.BindValueChanged(_ => TriggerSourceChanged());
-            beatmapHitsounds.BindValueChanged(_ => TriggerSourceChanged());
+            BeatmapSkins.BindValueChanged(_ => TriggerSourceChanged());
+            BeatmapColours.BindValueChanged(_ => TriggerSourceChanged());
+            BeatmapHitsounds.BindValueChanged(_ => TriggerSourceChanged());
 
             currentSkin = skins.CurrentSkin.GetBoundCopy();
             currentSkin.BindValueChanged(_ =>

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -19,10 +19,17 @@ namespace osu.Game.Skinning
         private Bindable<bool> beatmapColours = null!;
         private Bindable<bool> beatmapHitsounds = null!;
 
+        /// <summary>
+        /// Whether user settings (like "beatmap hitsounds) should be considered to allow disabling certain beatmap components.
+        /// </summary>
+        public bool AllowSettingsLevelDisables { get; init; } = true;
+
         protected override bool AllowConfigurationLookup
         {
             get
             {
+                if (!AllowSettingsLevelDisables) return true;
+
                 if (beatmapSkins == null)
                     throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -34,6 +41,8 @@ namespace osu.Game.Skinning
         {
             get
             {
+                if (!AllowSettingsLevelDisables) return true;
+
                 if (beatmapColours == null)
                     throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -43,6 +52,8 @@ namespace osu.Game.Skinning
 
         protected override bool AllowDrawableLookup(ISkinComponentLookup lookup)
         {
+            if (!AllowSettingsLevelDisables) return true;
+
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -51,6 +62,8 @@ namespace osu.Game.Skinning
 
         protected override bool AllowTextureLookup(string componentName)
         {
+            if (!AllowSettingsLevelDisables) return true;
+
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -59,6 +72,8 @@ namespace osu.Game.Skinning
 
         protected override bool AllowSampleLookup(ISampleInfo sampleInfo)
         {
+            if (!AllowSettingsLevelDisables) return true;
+
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -19,17 +19,10 @@ namespace osu.Game.Skinning
         private Bindable<bool> beatmapColours = null!;
         private Bindable<bool> beatmapHitsounds = null!;
 
-        /// <summary>
-        /// Whether user settings (like "beatmap hitsounds) should be considered to allow disabling certain beatmap components.
-        /// </summary>
-        public bool AllowSettingsLevelDisables { get; init; } = true;
-
         protected override bool AllowConfigurationLookup
         {
             get
             {
-                if (!AllowSettingsLevelDisables) return true;
-
                 if (beatmapSkins == null)
                     throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -41,8 +34,6 @@ namespace osu.Game.Skinning
         {
             get
             {
-                if (!AllowSettingsLevelDisables) return true;
-
                 if (beatmapColours == null)
                     throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -52,8 +43,6 @@ namespace osu.Game.Skinning
 
         protected override bool AllowDrawableLookup(ISkinComponentLookup lookup)
         {
-            if (!AllowSettingsLevelDisables) return true;
-
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -62,8 +51,6 @@ namespace osu.Game.Skinning
 
         protected override bool AllowTextureLookup(string componentName)
         {
-            if (!AllowSettingsLevelDisables) return true;
-
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
@@ -72,8 +59,6 @@ namespace osu.Game.Skinning
 
         protected override bool AllowSampleLookup(ISampleInfo sampleInfo)
         {
-            if (!AllowSettingsLevelDisables) return true;
-
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Skinning
         /// </remarks>
         protected override bool AllowFallingBackToParent => false;
 
+        protected bool AllowSettingsLevelDisables { get; init; } = true;
+
         protected override Container<Drawable> Content { get; } = new Container
         {
             RelativeSizeAxes = Axes.Both,
@@ -54,6 +56,7 @@ namespace osu.Game.Skinning
         {
             InternalChild = new BeatmapSkinProvidingContainer(GetRulesetTransformedSkin(beatmapSkin), GetRulesetTransformedSkin(skinManager.DefaultClassicSkin))
             {
+                AllowSettingsLevelDisables = AllowSettingsLevelDisables,
                 Child = Content,
             };
         }

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.IO.Stores;
@@ -25,6 +26,10 @@ namespace osu.Game.Skinning
     /// </summary>
     public partial class RulesetSkinProvidingContainer : SkinProvidingContainer
     {
+        public BindableWithCurrent<bool> BeatmapSkins = new BindableWithCurrent<bool>(true);
+        public BindableWithCurrent<bool> BeatmapColours = new BindableWithCurrent<bool>(true);
+        public BindableWithCurrent<bool> BeatmapHitsounds = new BindableWithCurrent<bool>(true);
+
         protected readonly Ruleset Ruleset;
         protected readonly IBeatmap Beatmap;
 
@@ -55,6 +60,9 @@ namespace osu.Game.Skinning
             InternalChild = new BeatmapSkinProvidingContainer(GetRulesetTransformedSkin(beatmapSkin), GetRulesetTransformedSkin(skinManager.DefaultClassicSkin))
             {
                 Child = Content,
+                BeatmapSkins = BeatmapSkins,
+                BeatmapColours = BeatmapColours,
+                BeatmapHitsounds = BeatmapHitsounds,
             };
         }
 

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Skinning
         /// </remarks>
         protected override bool AllowFallingBackToParent => false;
 
-        protected bool AllowSettingsLevelDisables { get; init; } = true;
-
         protected override Container<Drawable> Content { get; } = new Container
         {
             RelativeSizeAxes = Axes.Both,
@@ -56,7 +54,6 @@ namespace osu.Game.Skinning
         {
             InternalChild = new BeatmapSkinProvidingContainer(GetRulesetTransformedSkin(beatmapSkin), GetRulesetTransformedSkin(skinManager.DefaultClassicSkin))
             {
-                AllowSettingsLevelDisables = AllowSettingsLevelDisables,
                 Child = Content,
             };
         }


### PR DESCRIPTION
As far as I can tell this matches stable expectations. As with most things editor, it doesn't make sense to skin a beatmap and then want to edit the beatmap without that skin applied, ever.

---

As mentioned in https://github.com/ppy/osu/discussions/37607.

Could probably be implemented in five different ways, this is just the simplest that came to me. Well aware this is adding even more faff on top of the config/disable/toggles for this stuff, but feels required for editor sanity.