### PR TITLE
Restore editor mode when changing difficulty

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
@@ -115,6 +115,27 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestEditorRestoresModeOnReload()
+        {
+            prepareBeatmap();
+            openEditor();
+
+            makeMetadataChange(commit: false);
+
+            Editor editor1 = null!;
+
+            AddStep("store current editor", () => editor1 = getEditor());
+
+            AddStep("reload", () => getEditor().SwitchToDifficulty(getEditorBeatmap().BeatmapInfo));
+            AddUntilStep("save dialog displayed", () => Game.ChildrenOfType<DialogOverlay>().SingleOrDefault()?.CurrentDialog is PromptForSaveDialog);
+            AddStep("confirm", () => InputManager.Key(Key.Number1));
+
+            AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor && editor.ReadyForUse);
+            AddAssert("editor is new instance", () => getEditor() != editor1);
+            AddAssert("mode is still song setup", () => getEditor().Mode.Value == EditorScreenMode.SongSetup);
+        }
+
+        [Test]
         public void TestChangeMetadataExitWhileTextboxFocusedPromptsSave()
         {
             AddStep("switch ruleset", () => Game.Ruleset.Value = new ManiaRuleset().RulesetInfo);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -513,6 +513,7 @@ namespace osu.Game.Screens.Edit
         /// </param>
         public EditorState GetState([CanBeNull] RulesetInfo nextRuleset = null) => new EditorState
         {
+            Mode = Mode.Value,
             Time = clock.CurrentTimeAccurate,
             ClipboardContent = nextRuleset == null || editorBeatmap.BeatmapInfo.Ruleset.ShortName == nextRuleset.ShortName ? Clipboard.Content.Value : string.Empty
         };
@@ -523,6 +524,7 @@ namespace osu.Game.Screens.Edit
         /// <param name="state">The state to restore.</param>
         public void RestoreState([NotNull] EditorState state) => Schedule(() =>
         {
+            Mode.Value = state.Mode;
             clock.Seek(state.Time);
             Clipboard.Content.Value = state.ClipboardContent;
         });

--- a/osu.Game/Screens/Edit/EditorState.cs
+++ b/osu.Game/Screens/Edit/EditorState.cs
@@ -9,6 +9,11 @@ namespace osu.Game.Screens.Edit
     public class EditorState
     {
         /// <summary>
+        /// The current editor mode.
+        /// </summary>
+        public EditorScreenMode Mode { get; set; }
+
+        /// <summary>
         /// The current audio time.
         /// </summary>
         public double Time { get; set; }


### PR DESCRIPTION
When editing metadata, it's annoying that the editor returns to compose mode when switching between difficulties. This fixes that fallacy.

Supersedes and closes https://github.com/ppy/osu/pull/36724.