### PR TITLE
Implement legacy break overlay

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
@@ -20,9 +20,9 @@ namespace osu.Game.Tests.Visual.Gameplay
     [TestFixture]
     public partial class TestSceneBreakTracker : OsuTestScene
     {
-        private readonly BreakOverlay breakOverlay;
+        private BreakOverlay breakOverlay;
 
-        private readonly TestBreakTracker breakTracker;
+        private TestBreakTracker breakTracker;
 
         private readonly IReadOnlyList<BreakPeriod> testBreaks = new List<BreakPeriod>
         {
@@ -30,7 +30,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             new BreakPeriod(6000, 13500),
         };
 
-        public TestSceneBreakTracker()
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
             Children = new Drawable[]
             {
@@ -51,13 +52,14 @@ namespace osu.Game.Tests.Visual.Gameplay
                     BreakTracker = breakTracker,
                 },
             };
-        }
+        });
 
         protected override void Update()
         {
             base.Update();
 
-            breakOverlay.Clock = breakTracker.Clock;
+            if (breakOverlay != null && breakTracker != null)
+                breakOverlay.Clock = breakTracker.Clock;
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLegacyBreak.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLegacyBreak.cs
@@ -1,0 +1,127 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Scoring;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    [TestFixture]
+    public partial class TestSceneLegacyBreak : SkinnableTestScene
+    {
+        [Resolved]
+        private SkinManager skins { get; set; } = null!;
+
+        private LegacyBreakOverlay? breakOverlay;
+
+        private TestBreakTracker? breakTracker;
+
+        private readonly IReadOnlyList<BreakPeriod> testBreaks = new List<BreakPeriod>
+        {
+            new BreakPeriod(1000, 5000),
+            new BreakPeriod(6000, 13500),
+        };
+
+        protected override Ruleset CreateRulesetForSkinProvider() => new OsuRuleset();
+
+        [SetUp]
+        public void SetUp()
+        {
+            Child = new SkinProvidingContainer(skins.DefaultClassicSkin)
+            {
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.White,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    breakTracker = new TestBreakTracker(),
+                    breakOverlay = new LegacyBreakOverlay(new OsuHealthProcessor(0))
+                    {
+                        ProcessCustomClock = false,
+                        BreakTracker = breakTracker,
+                    },
+                    new LetterboxOverlay
+                    {
+                        ProcessCustomClock = false,
+                        BreakTracker = breakTracker,
+                    },
+                }
+            };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (breakOverlay != null && breakTracker != null)
+                breakOverlay.Clock = breakTracker.Clock;
+        }
+
+        [Test]
+        public void TestShowBreaks()
+        {
+            addShowBreakStep(5);
+            addShowBreakStep(15);
+        }
+
+        private void addShowBreakStep(double seconds)
+        {
+            AddStep($"show '{seconds}s' break", () =>
+            {
+                breakTracker!.Breaks = new List<BreakPeriod>
+                {
+                    new BreakPeriod(Clock.CurrentTime, Clock.CurrentTime + seconds * 1000)
+                };
+            });
+        }
+
+        private partial class TestBreakTracker : BreakTracker
+        {
+            public readonly FramedClock FramedManualClock;
+
+            private readonly ManualClock manualClock;
+            private IFrameBasedClock originalClock;
+
+            public double ManualClockTime
+            {
+                get => manualClock.CurrentTime;
+                set => manualClock.CurrentTime = value;
+            }
+
+            public TestBreakTracker()
+                : base(0, new ScoreProcessor(new OsuRuleset()))
+            {
+                FramedManualClock = new FramedClock(manualClock = new ManualClock());
+                ProcessCustomClock = false;
+            }
+
+            public void ProgressTime()
+            {
+                FramedManualClock.ProcessFrame();
+                Update();
+            }
+
+            public void SwitchClock(bool setManual) => Clock = setManual ? FramedManualClock : originalClock;
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                originalClock = Clock;
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLegacyBreak.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLegacyBreak.cs
@@ -28,12 +28,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private TestBreakTracker? breakTracker;
 
-        private readonly IReadOnlyList<BreakPeriod> testBreaks = new List<BreakPeriod>
-        {
-            new BreakPeriod(1000, 5000),
-            new BreakPeriod(6000, 13500),
-        };
-
         protected override Ruleset CreateRulesetForSkinProvider() => new OsuRuleset();
 
         [SetUp]
@@ -94,7 +88,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             public readonly FramedClock FramedManualClock;
 
             private readonly ManualClock manualClock;
-            private IFrameBasedClock originalClock;
+            private IFrameBasedClock originalClock = null!;
 
             public double ManualClockTime
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLegacyBreak.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLegacyBreak.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected override Ruleset CreateRulesetForSkinProvider() => new OsuRuleset();
 
         [SetUp]
-        public void SetUp()
+        public void SetUp() => Schedule(() =>
         {
             Child = new SkinProvidingContainer(skins.DefaultClassicSkin)
             {
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     },
                 }
             };
-        }
+        });
 
         protected override void Update()
         {

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -151,6 +151,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
             SetDefault(OsuSetting.LightenDuringBreaks, true);
 
+            SetDefault(OsuSetting.LegacyBreakOverlay, false);
             SetDefault(OsuSetting.HitLighting, true);
             SetDefault(OsuSetting.StarFountains, true);
 
@@ -453,6 +454,7 @@ namespace osu.Game.Configuration
         NotifyOnPrivateMessage,
         NotifyOnFriendPresenceChange,
         UIHoldActivationDelay,
+        LegacyBreakOverlay,
         HitLighting,
         StarFountains,
         MenuBackgroundSource,

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -105,6 +105,11 @@ namespace osu.Game.Localisation
         public static LocalisableString AlwaysPlayFirstComboBreak => new TranslatableString(getKey(@"always_play_first_combo_break"), @"Always play first combo break sound");
 
         /// <summary>
+        /// "Legacy break overlay"
+        /// </summary>
+        public static LocalisableString LegacyBreakOverlay => new TranslatableString(getKey(@"break_overlay_style"), @"Legacy break overlay");
+
+        /// <summary>
         /// "Score display mode"
         /// </summary>
         public static LocalisableString ScoreDisplayMode => new TranslatableString(getKey(@"score_display_mode"), @"Score display mode");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -32,6 +32,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsItemV2(new FormCheckBox
                 {
+                    Caption = GameplaySettingsStrings.LegacyBreakOverlay,
+                    Current = config.GetBindable<bool>(OsuSetting.LegacyBreakOverlay),
+                }),
+                new SettingsItemV2(new FormCheckBox
+                {
                     Caption = GraphicsSettingsStrings.HitLighting,
                     Current = config.GetBindable<bool>(OsuSetting.HitLighting)
                 }),

--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Mods
             player.ApplyToBackground(b => b.IgnoreUserSettings.Value = true);
             player.DimmableStoryboard.IgnoreUserSettings.Value = true;
 
-            player.BreakOverlay.Hide();
+            player.BreakOverlayContainer.Hide();
             (player as ReplayPlayer)?.ReplayOverlay.Hide();
         }
 

--- a/osu.Game/Screens/Play/Break/LegacyBreakArrows.cs
+++ b/osu.Game/Screens/Play/Break/LegacyBreakArrows.cs
@@ -9,11 +9,11 @@ using osuTK;
 
 namespace osu.Game.Screens.Play.Break
 {
-    public partial class WarningArrows : SkinReloadableDrawable
+    public partial class LegacyBreakArrows : SkinReloadableDrawable
     {
         private readonly Sprite[] sprites;
 
-        public WarningArrows()
+        public LegacyBreakArrows()
         {
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Play/Break/LegacyBreakArrows.cs
+++ b/osu.Game/Screens/Play/Break/LegacyBreakArrows.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
@@ -11,6 +12,8 @@ namespace osu.Game.Screens.Play.Break
 {
     public partial class LegacyBreakArrows : SkinReloadableDrawable
     {
+        private Texture? playWarningArrowTextureFallback;
+
         private readonly Sprite[] sprites;
 
         public LegacyBreakArrows()
@@ -54,6 +57,14 @@ namespace osu.Game.Screens.Play.Break
             };
         }
 
+        [BackgroundDependencyLoader]
+        private void load(SkinManager skins)
+        {
+            var defaultLegacySkin = skins.DefaultClassicSkin;
+
+            playWarningArrowTextureFallback = defaultLegacySkin.GetTexture(@"play-warningarrow");
+        }
+
         protected override void SkinChanged(ISkinSource skin)
         {
             Texture? arrowWarningTexture = skin.GetTexture(@"arrow-warning");
@@ -62,12 +73,18 @@ namespace osu.Game.Screens.Play.Break
 
             bool newerTextureAvailable = arrowWarningTexture != null;
             var arrowColour = !newerTextureAvailable && skinVersion >= 2.0m ? Colour4.Red : Colour4.White;
-            Texture arrowTexture = newerTextureAvailable ? arrowWarningTexture! : playWarningArrowTexture!;
+            Texture? arrowTexture = newerTextureAvailable ? arrowWarningTexture : playWarningArrowTexture;
+
+            if (arrowTexture == null)
+            {
+                arrowColour = Colour4.Red;
+                arrowTexture = playWarningArrowTextureFallback;
+            }
 
             foreach (var sprite in sprites)
             {
-                sprite.Size = Vector2.Zero;
                 sprite.Texture = arrowTexture;
+                sprite.Size = arrowTexture?.DisplaySize ?? Vector2.Zero;
                 sprite.Colour = arrowColour;
             }
         }

--- a/osu.Game/Screens/Play/Break/WarningArrows.cs
+++ b/osu.Game/Screens/Play/Break/WarningArrows.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Screens.Play.Break
+{
+    public partial class WarningArrows : SkinReloadableDrawable
+    {
+        private readonly Sprite[] sprites;
+
+        public WarningArrows()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChildren = sprites = new[]
+            {
+                new Sprite
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(1, 1),
+                    X = 128,
+                    Y = 160,
+                },
+                new Sprite
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(-1, 1),
+                    X = -128,
+                    Y = 160,
+                },
+                new Sprite
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(1, 1),
+                    X = 128,
+                    Y = -160,
+                },
+                new Sprite
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(-1, 1),
+                    X = -128,
+                    Y = -160,
+                },
+            };
+        }
+
+        protected override void SkinChanged(ISkinSource skin)
+        {
+            Texture? arrowWarningTexture = skin.GetTexture(@"arrow-warning");
+            Texture? playWarningArrowTexture = skin.GetTexture(@"play-warningarrow");
+            decimal? skinVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
+
+            bool newerTextureAvailable = arrowWarningTexture != null;
+            var arrowColour = !newerTextureAvailable && skinVersion >= 2.0m ? Colour4.Red : Colour4.White;
+            Texture arrowTexture = newerTextureAvailable ? arrowWarningTexture! : playWarningArrowTexture!;
+
+            foreach (var sprite in sprites)
+            {
+                sprite.Size = Vector2.Zero;
+                sprite.Texture = arrowTexture;
+                sprite.Colour = arrowColour;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Play
 
         private readonly Sprite sectionFailSprite;
         private readonly Sprite sectionPassSprite;
-        private readonly WarningArrows warningArrows;
+        private readonly LegacyBreakArrows legacyBreakArrows;
 
         public required BreakTracker BreakTracker { get; init; }
 
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Play
                     Origin = Anchor.Centre,
                     Alpha = 0,
                 },
-                warningArrows = new WarningArrows
+                legacyBreakArrows = new LegacyBreakArrows
                 {
                     Alpha = 0,
                 },
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Play
             {
                 sectionPassSprite.Alpha = 0;
                 sectionFailSprite.Alpha = 0;
-                warningArrows.Alpha = 0;
+                legacyBreakArrows.Alpha = 0;
                 return;
             }
 
@@ -106,7 +106,7 @@ namespace osu.Game.Screens.Play
                 resultSprite.Alpha = Interpolation.ValueAt(t, 1f, 0f, h + 1400, h + 1600);
             }
 
-            warningArrows.Alpha = t > e - 1300 && t < e && (int)(e - t) / 100 % 2 == 0 ? 1 : 0;
+            legacyBreakArrows.Alpha = t > e - 1300 && t < e && (int)(e - t) / 100 % 2 == 0 ? 1 : 0;
         }
 
         private void updateDisplay(ValueChangedEvent<Period?> period)

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Audio;
+using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play.Break;
@@ -18,6 +19,13 @@ namespace osu.Game.Screens.Play
 {
     public partial class LegacyBreakOverlay : SkinReloadableDrawable
     {
+        private const int pass_blink_duration = 100;
+        private const int pass_last_blink_duration = 1000;
+        private const int pass_last_fade_out_duration = 200;
+
+        private const int arrows_blink_duration = 100;
+        private const int arrows_blink_times = 7;
+
         private readonly HealthProcessor healthProcessor;
 
         private ISample? sectionFailSample;
@@ -30,6 +38,7 @@ namespace osu.Game.Screens.Play
         public required BreakTracker BreakTracker { get; init; }
 
         private readonly IBindable<Period?> currentPeriod = new Bindable<Period?>();
+        private Period? lastBreak;
 
         public LegacyBreakOverlay(HealthProcessor healthProcessor)
         {
@@ -81,9 +90,7 @@ namespace osu.Game.Screens.Play
         {
             base.Update();
 
-            var b = currentPeriod.Value;
-
-            if (b == null)
+            if (lastBreak == null)
             {
                 sectionPassSprite.Alpha = 0;
                 sectionFailSprite.Alpha = 0;
@@ -92,21 +99,34 @@ namespace osu.Game.Screens.Play
             }
 
             double t = Time.Current;
-            double s = b.Value.Start;
-            double d = b.Value.Duration;
-            double e = b.Value.End;
-            double h = s + d / 2;
+            double s = lastBreak.Value.Start;
+            double e = lastBreak.Value.End + BreakOverlay.BREAK_FADE_DURATION;
+            double h = s + lastBreak.Value.Duration / 2;
+
+            if (t < s || t > e)
+            {
+                lastBreak = null;
+                return;
+            }
 
             Sprite resultSprite = healthProcessor.Health.Value >= 0.5 ? sectionPassSprite : sectionFailSprite;
 
-            resultSprite.Alpha = (t > h && t < h + 100) || (t > h + 200 && t < h + 300) || (t > h + 400 && t < h + 1400) ? 1 : 0;
+            double vs = h;
+            resultSprite.Alpha = t > vs && t < vs + pass_blink_duration ? 1 : 0;
 
-            if (t > h + 1400 && t < h + 1600)
-            {
-                resultSprite.Alpha = Interpolation.ValueAt(t, 1f, 0f, h + 1400, h + 1600);
-            }
+            vs += pass_blink_duration * 2;
+            resultSprite.Alpha = t > vs && t < vs + pass_blink_duration ? 1 : resultSprite.Alpha;
 
-            legacyBreakArrows.Alpha = t > e - 1300 && t < e && (int)(e - t) / 100 % 2 == 0 ? 1 : 0;
+            vs += pass_blink_duration * 2;
+            resultSprite.Alpha = t > vs && t < vs + pass_last_blink_duration ? 1 : resultSprite.Alpha;
+
+            vs += pass_last_blink_duration;
+
+            if (t > vs && t < vs + pass_last_fade_out_duration)
+                resultSprite.Alpha = Interpolation.ValueAt(t, 1f, 0f, vs, vs + pass_last_fade_out_duration);
+
+            vs = e - arrows_blink_times * arrows_blink_duration * 2 - arrows_blink_duration;
+            legacyBreakArrows.Alpha = t > vs && t < e && (int)(e - t) / arrows_blink_duration % 2 == 0 ? 1 : 0;
         }
 
         private void updateDisplay(ValueChangedEvent<Period?> period)
@@ -115,6 +135,8 @@ namespace osu.Game.Screens.Play
 
             if (period.NewValue == null)
                 return;
+
+            lastBreak = period.NewValue;
 
             ISample? resultSample = healthProcessor.Health.Value >= 0.5 ? sectionPassSample : sectionFailSample;
             var b = period.NewValue.Value;

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -5,7 +5,6 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
@@ -23,10 +22,8 @@ namespace osu.Game.Screens.Play
         private ISample? sectionFailSample;
         private ISample? sectionPassSample;
 
-        private Texture? sectionFailTexture;
-        private Texture? sectionPassTexture;
-
-        private readonly Sprite resultSprite;
+        private readonly Sprite sectionFailSprite;
+        private readonly Sprite sectionPassSprite;
         private readonly WarningArrows warningArrows;
 
         public required BreakTracker BreakTracker { get; init; }
@@ -40,7 +37,13 @@ namespace osu.Game.Screens.Play
 
             InternalChildren = new Drawable[]
             {
-                resultSprite = new Sprite
+                sectionFailSprite = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Alpha = 0,
+                },
+                sectionPassSprite = new Sprite
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -58,11 +61,11 @@ namespace osu.Game.Screens.Play
             sectionFailSample = skin.GetSample(new SampleInfo(@"Gameplay/sectionfail"));
             sectionPassSample = skin.GetSample(new SampleInfo(@"Gameplay/sectionpass"));
 
-            sectionFailTexture = skin.GetTexture(@"section-fail");
-            sectionPassTexture = skin.GetTexture(@"section-pass");
+            sectionFailSprite.Size = Vector2.Zero;
+            sectionFailSprite.Texture = skin.GetTexture(@"section-fail");
 
-            if (IsLoaded)
-                updateDisplay(currentPeriod.Value);
+            sectionPassSprite.Size = Vector2.Zero;
+            sectionPassSprite.Texture = skin.GetTexture(@"section-pass");
         }
 
         protected override void LoadComplete()
@@ -81,23 +84,20 @@ namespace osu.Game.Screens.Play
                 return;
 
             ISample? resultSample;
-            Texture? resultTexture;
+            Sprite resultSprite;
 
             if (healthProcessor.Health.Value >= 0.5)
             {
                 resultSample = sectionPassSample;
-                resultTexture = sectionPassTexture;
+                resultSprite = sectionPassSprite;
             }
             else
             {
                 resultSample = sectionFailSample;
-                resultTexture = sectionFailTexture;
+                resultSprite = sectionFailSprite;
             }
 
             var b = period.Value;
-
-            resultSprite.Size = Vector2.Zero;
-            resultSprite.Texture = resultTexture;
 
             // TODO Improve blinking behavior while rewinding
             using (BeginAbsoluteSequence(b.Start))

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play.Break;
+using osu.Game.Skinning;
+using osu.Game.Utils;
+using osuTK;
+
+namespace osu.Game.Screens.Play
+{
+    public partial class LegacyBreakOverlay : SkinReloadableDrawable
+    {
+        private readonly HealthProcessor healthProcessor;
+
+        private ISample? sectionFailSample;
+        private ISample? sectionPassSample;
+
+        private Texture? sectionFailTexture;
+        private Texture? sectionPassTexture;
+
+        private readonly Sprite resultSprite;
+        private readonly WarningArrows warningArrows;
+
+        public required BreakTracker BreakTracker { get; init; }
+
+        private readonly IBindable<Period?> currentPeriod = new Bindable<Period?>();
+
+        public LegacyBreakOverlay(HealthProcessor healthProcessor)
+        {
+            this.healthProcessor = healthProcessor;
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                resultSprite = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Alpha = 0,
+                },
+                warningArrows = new WarningArrows
+                {
+                    Alpha = 0,
+                },
+            };
+        }
+
+        protected override void SkinChanged(ISkinSource skin)
+        {
+            sectionFailSample = skin.GetSample(new SampleInfo(@"Gameplay/sectionfail"));
+            sectionPassSample = skin.GetSample(new SampleInfo(@"Gameplay/sectionpass"));
+
+            sectionFailTexture = skin.GetTexture(@"section-fail");
+            sectionPassTexture = skin.GetTexture(@"section-pass");
+
+            if (IsLoaded)
+                updateDisplay(currentPeriod.Value);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            currentPeriod.BindTo(BreakTracker.CurrentPeriod);
+            currentPeriod.BindValueChanged(period => updateDisplay(period.NewValue), true);
+        }
+
+        private void updateDisplay(Period? period)
+        {
+            Scheduler.CancelDelayedTasks();
+
+            if (period == null)
+                return;
+
+            ISample? resultSample;
+            Texture? resultTexture;
+
+            if (healthProcessor.Health.Value >= 0.5)
+            {
+                resultSample = sectionPassSample;
+                resultTexture = sectionPassTexture;
+            }
+            else
+            {
+                resultSample = sectionFailSample;
+                resultTexture = sectionFailTexture;
+            }
+
+            var b = period.Value;
+
+            resultSprite.Size = Vector2.Zero;
+            resultSprite.Texture = resultTexture;
+
+            // TODO Improve blinking behavior while rewinding
+            using (BeginAbsoluteSequence(b.Start))
+            {
+                using (BeginDelayedSequence(b.Duration / 2))
+                {
+                    Schedule(() =>
+                    {
+                        if (IsPresent
+                            && (Clock as IFrameStableClock)?.IsRewinding == false
+                            && (Clock as IFrameStableClock)?.IsPaused.Value == false
+                            && (Clock as IFrameStableClock)?.IsCatchingUp.Value == false)
+                            resultSample?.Play();
+                    });
+
+                    resultSprite.FadeIn().Delay(100).FadeOut().Delay(100).Loop(0, 1)
+                                .FadeIn().Delay(1000).FadeOut(200);
+                }
+
+                using (BeginDelayedSequence(b.Duration - 1300))
+                {
+                    warningArrows.FadeIn().Delay(100).FadeOut().Delay(100).Loop(0, 6);
+                }
+
+                using (BeginDelayedSequence(b.Duration))
+                {
+                    resultSprite.FadeOut();
+                    warningArrows.FadeOut();
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Audio;
-using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play.Break;
@@ -145,8 +144,10 @@ namespace osu.Game.Screens.Play
             {
                 Schedule(() =>
                 {
-                    var clock = (IFrameStableClock)Clock;
-                    if (IsPresent && !clock.IsRewinding && !clock.IsPaused.Value && !clock.IsCatchingUp.Value)
+                    bool isRewinding = (Clock as IGameplayClock)?.IsRewinding ?? false;
+                    bool isPaused = (Clock as IGameplayClock)?.IsPaused.Value ?? false;
+                    bool isCatchingUp = (Clock as IFrameStableClock)?.IsCatchingUp.Value ?? false;
+                    if (IsPresent && !isRewinding && !isPaused && !isCatchingUp)
                         resultSample?.Play();
                 });
             }

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -123,10 +123,8 @@ namespace osu.Game.Screens.Play
             {
                 Schedule(() =>
                 {
-                    if (IsPresent
-                        && (Clock as IFrameStableClock)?.IsRewinding == false
-                        && (Clock as IFrameStableClock)?.IsPaused.Value == false
-                        && (Clock as IFrameStableClock)?.IsCatchingUp.Value == false)
+                    var clock = (IFrameStableClock)Clock;
+                    if (IsPresent && !clock.IsRewinding && !clock.IsPaused.Value && !clock.IsCatchingUp.Value)
                         resultSample?.Play();
                 });
             }

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -5,6 +5,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
@@ -76,6 +77,38 @@ namespace osu.Game.Screens.Play
             currentPeriod.BindValueChanged(period => updateDisplay(period.NewValue), true);
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            var b = currentPeriod.Value;
+
+            if (b == null)
+            {
+                sectionPassSprite.Alpha = 0;
+                sectionFailSprite.Alpha = 0;
+                warningArrows.Alpha = 0;
+                return;
+            }
+
+            double t = Time.Current;
+            double s = b.Value.Start;
+            double d = b.Value.Duration;
+            double e = b.Value.End;
+            double h = s + d / 2;
+
+            Sprite resultSprite = healthProcessor.Health.Value >= 0.5 ? sectionPassSprite : sectionFailSprite;
+
+            resultSprite.Alpha = (t > h && t < h + 100) || (t > h + 200 && t < h + 300) || (t > h + 400 && t < h + 1400) ? 1 : 0;
+
+            if (t > h + 1400 && t < h + 1600)
+            {
+                resultSprite.Alpha = Interpolation.ValueAt(t, 1f, 0f, h + 1400, h + 1600);
+            }
+
+            warningArrows.Alpha = t > e - 1300 && t < e && (int)(e - t) / 100 % 2 == 0 ? 1 : 0;
+        }
+
         private void updateDisplay(Period? period)
         {
             Scheduler.CancelDelayedTasks();
@@ -83,50 +116,19 @@ namespace osu.Game.Screens.Play
             if (period == null)
                 return;
 
-            ISample? resultSample;
-            Sprite resultSprite;
-
-            if (healthProcessor.Health.Value >= 0.5)
-            {
-                resultSample = sectionPassSample;
-                resultSprite = sectionPassSprite;
-            }
-            else
-            {
-                resultSample = sectionFailSample;
-                resultSprite = sectionFailSprite;
-            }
-
+            ISample? resultSample = healthProcessor.Health.Value >= 0.5 ? sectionPassSample : sectionFailSample;
             var b = period.Value;
 
-            // TODO Improve blinking behavior while rewinding
-            using (BeginAbsoluteSequence(b.Start))
+            using (BeginAbsoluteSequence(b.Start + b.Duration / 2))
             {
-                using (BeginDelayedSequence(b.Duration / 2))
+                Schedule(() =>
                 {
-                    Schedule(() =>
-                    {
-                        if (IsPresent
-                            && (Clock as IFrameStableClock)?.IsRewinding == false
-                            && (Clock as IFrameStableClock)?.IsPaused.Value == false
-                            && (Clock as IFrameStableClock)?.IsCatchingUp.Value == false)
-                            resultSample?.Play();
-                    });
-
-                    resultSprite.FadeIn().Delay(100).FadeOut().Delay(100).Loop(0, 1)
-                                .FadeIn().Delay(1000).FadeOut(200);
-                }
-
-                using (BeginDelayedSequence(b.Duration - 1300))
-                {
-                    warningArrows.FadeIn().Delay(100).FadeOut().Delay(100).Loop(0, 6);
-                }
-
-                using (BeginDelayedSequence(b.Duration))
-                {
-                    resultSprite.FadeOut();
-                    warningArrows.FadeOut();
-                }
+                    if (IsPresent
+                        && (Clock as IFrameStableClock)?.IsRewinding == false
+                        && (Clock as IFrameStableClock)?.IsPaused.Value == false
+                        && (Clock as IFrameStableClock)?.IsCatchingUp.Value == false)
+                        resultSample?.Play();
+                });
             }
         }
     }

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Screens.Play
             base.LoadComplete();
 
             currentPeriod.BindTo(BreakTracker.CurrentPeriod);
-            currentPeriod.BindValueChanged(period => updateDisplay(period.NewValue), true);
+            currentPeriod.BindValueChanged(updateDisplay, true);
         }
 
         protected override void Update()
@@ -109,15 +109,15 @@ namespace osu.Game.Screens.Play
             warningArrows.Alpha = t > e - 1300 && t < e && (int)(e - t) / 100 % 2 == 0 ? 1 : 0;
         }
 
-        private void updateDisplay(Period? period)
+        private void updateDisplay(ValueChangedEvent<Period?> period)
         {
             Scheduler.CancelDelayedTasks();
 
-            if (period == null)
+            if (period.NewValue == null)
                 return;
 
             ISample? resultSample = healthProcessor.Health.Value >= 0.5 ? sectionPassSample : sectionFailSample;
-            var b = period.Value;
+            var b = period.NewValue.Value;
 
             using (BeginAbsoluteSequence(b.Start + b.Duration / 2))
             {

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Scoring;
@@ -29,6 +31,9 @@ namespace osu.Game.Screens.Play
 
         private ISample? sectionFailSample;
         private ISample? sectionPassSample;
+
+        private Texture? sectionFailTextureFallback;
+        private Texture? sectionPassTextureFallback;
 
         private readonly Sprite sectionFailSprite;
         private readonly Sprite sectionPassSprite;
@@ -65,16 +70,25 @@ namespace osu.Game.Screens.Play
             };
         }
 
+        [BackgroundDependencyLoader]
+        private void load(SkinManager skins)
+        {
+            var defaultLegacySkin = skins.DefaultClassicSkin;
+
+            sectionFailTextureFallback = defaultLegacySkin.GetTexture(@"section-fail");
+            sectionPassTextureFallback = defaultLegacySkin.GetTexture(@"section-pass");
+        }
+
         protected override void SkinChanged(ISkinSource skin)
         {
             sectionFailSample = skin.GetSample(new SampleInfo(@"Gameplay/sectionfail"));
             sectionPassSample = skin.GetSample(new SampleInfo(@"Gameplay/sectionpass"));
 
-            sectionFailSprite.Size = Vector2.Zero;
-            sectionFailSprite.Texture = skin.GetTexture(@"section-fail");
+            sectionFailSprite.Texture = skin.GetTexture(@"section-fail") ?? sectionFailTextureFallback;
+            sectionFailSprite.Size = sectionFailSprite.Texture?.DisplaySize ?? Vector2.Zero;
 
-            sectionPassSprite.Size = Vector2.Zero;
-            sectionPassSprite.Texture = skin.GetTexture(@"section-pass");
+            sectionPassSprite.Texture = skin.GetTexture(@"section-pass") ?? sectionPassTextureFallback;
+            sectionPassSprite.Size = sectionPassSprite.Texture?.DisplaySize ?? Vector2.Zero;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Play/LegacyBreakOverlay.cs
+++ b/osu.Game/Screens/Play/LegacyBreakOverlay.cs
@@ -18,11 +18,11 @@ namespace osu.Game.Screens.Play
 {
     public partial class LegacyBreakOverlay : SkinReloadableDrawable
     {
-        private const int pass_blink_duration = 100;
+        private const int pass_blink_interval = 100;
         private const int pass_last_blink_duration = 1000;
         private const int pass_last_fade_out_duration = 200;
 
-        private const int arrows_blink_duration = 100;
+        private const int arrows_blink_interval = 100;
         private const int arrows_blink_times = 7;
 
         private readonly HealthProcessor healthProcessor;
@@ -98,11 +98,11 @@ namespace osu.Game.Screens.Play
             }
 
             double t = Time.Current;
-            double s = lastBreak.Value.Start;
-            double e = lastBreak.Value.End + BreakOverlay.BREAK_FADE_DURATION;
-            double h = s + lastBreak.Value.Duration / 2;
+            double breakStart = lastBreak.Value.Start;
+            double breakEnd = lastBreak.Value.End + BreakOverlay.BREAK_FADE_DURATION;
+            double breakHalf = breakStart + lastBreak.Value.Duration / 2;
 
-            if (t < s || t > e)
+            if (t < breakStart || t > breakEnd)
             {
                 lastBreak = null;
                 return;
@@ -110,13 +110,13 @@ namespace osu.Game.Screens.Play
 
             Sprite resultSprite = healthProcessor.Health.Value >= 0.5 ? sectionPassSprite : sectionFailSprite;
 
-            double vs = h;
-            resultSprite.Alpha = t > vs && t < vs + pass_blink_duration ? 1 : 0;
+            double vs = breakHalf;
+            resultSprite.Alpha = t > vs && t < vs + pass_blink_interval ? 1 : 0;
 
-            vs += pass_blink_duration * 2;
-            resultSprite.Alpha = t > vs && t < vs + pass_blink_duration ? 1 : resultSprite.Alpha;
+            vs += pass_blink_interval * 2;
+            resultSprite.Alpha = t > vs && t < vs + pass_blink_interval ? 1 : resultSprite.Alpha;
 
-            vs += pass_blink_duration * 2;
+            vs += pass_blink_interval * 2;
             resultSprite.Alpha = t > vs && t < vs + pass_last_blink_duration ? 1 : resultSprite.Alpha;
 
             vs += pass_last_blink_duration;
@@ -124,8 +124,8 @@ namespace osu.Game.Screens.Play
             if (t > vs && t < vs + pass_last_fade_out_duration)
                 resultSprite.Alpha = Interpolation.ValueAt(t, 1f, 0f, vs, vs + pass_last_fade_out_duration);
 
-            vs = e - arrows_blink_times * arrows_blink_duration * 2 - arrows_blink_duration;
-            legacyBreakArrows.Alpha = t > vs && t < e && (int)(e - t) / arrows_blink_duration % 2 == 0 ? 1 : 0;
+            vs = breakEnd - arrows_blink_times * arrows_blink_interval * 2 - arrows_blink_interval;
+            legacyBreakArrows.Alpha = t > vs && t < breakEnd && (int)(breakEnd - t) / arrows_blink_interval % 2 == 0 ? 1 : 0;
         }
 
         private void updateDisplay(ValueChangedEvent<Period?> period)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -145,6 +145,12 @@ namespace osu.Game.Screens.Play
 
         public BreakOverlay BreakOverlay;
 
+        public LegacyBreakOverlay LegacyBreakOverlay;
+
+        private readonly Bindable<bool> useLegacyBreakOverlay = new BindableBool();
+
+        public Container BreakOverlayContainer;
+
         private LetterboxOverlay letterboxOverlay;
 
         /// <summary>
@@ -368,7 +374,7 @@ namespace osu.Game.Screens.Play
             {
                 HUDOverlay.ShowHud.Value = false;
                 HUDOverlay.ShowHud.Disabled = true;
-                BreakOverlay.Hide();
+                BreakOverlayContainer.Hide();
             }
 
             DrawableRuleset.FrameStableClock.WaitingOnFrames.BindValueChanged(waiting =>
@@ -427,6 +433,14 @@ namespace osu.Game.Screens.Play
 
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
             IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
+
+            config.BindWith(OsuSetting.LegacyBreakOverlay, useLegacyBreakOverlay);
+            useLegacyBreakOverlay.BindValueChanged(useLegacy =>
+            {
+                bool isOsuOrFruits = ruleset.ShortName == "osu" || ruleset.ShortName == "fruits";
+                BreakOverlay.Alpha = useLegacy.NewValue ? 0 : 1;
+                LegacyBreakOverlay.Alpha = useLegacy.NewValue && isOsuOrFruits ? 1 : 0;
+            }, true);
         }
 
         protected virtual GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart);
@@ -495,11 +509,24 @@ namespace osu.Game.Screens.Play
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre
                     },
-                    BreakOverlay = new BreakOverlay(ScoreProcessor)
+                    BreakOverlayContainer = new Container
                     {
-                        Clock = DrawableRuleset.FrameStableClock,
-                        ProcessCustomClock = false,
-                        BreakTracker = breakTracker,
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            BreakOverlay = new BreakOverlay(ScoreProcessor)
+                            {
+                                Clock = DrawableRuleset.FrameStableClock,
+                                ProcessCustomClock = false,
+                                BreakTracker = breakTracker,
+                            },
+                            LegacyBreakOverlay = new LegacyBreakOverlay(HealthProcessor)
+                            {
+                                Clock = DrawableRuleset.FrameStableClock,
+                                ProcessCustomClock = false,
+                                BreakTracker = breakTracker,
+                            },
+                        }
                     },
                     // display the cursor above some HUD elements.
                     DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-resources/pull/422
- Closes https://github.com/ppy/osu/issues/9783

Spent 2 days trying to fix rewinding with sequences. Well... I'm open to hear how to implement it in a "less hacky way".

~~Also is it fine that Argon and Triangles will just play section pass/fail sound?~~ Fallbacks to legacy textures.

# Demo

Demo features legacy break overlay with [IJN Yamashiro V2](https://osu.ppy.sh/community/forums/topics/1004844), Classic, Retro and Argon skins.


https://github.com/user-attachments/assets/4474088a-934b-46c2-bcb6-e3fe4dc75228

