### PR TITLE
Add beatmap leaderboard scope to config

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.Ruleset, string.Empty);
             SetDefault(OsuSetting.Skin, SkinInfo.ARGON_SKIN.ToString());
 
-            SetDefault(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Leaderboards);
+            SetDefault(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Ranking);
             SetDefault(OsuSetting.BeatmapLeaderboardScope, BeatmapLeaderboardScope.Local);
             SetDefault(OsuSetting.BeatmapLeaderboardSortMode, LeaderboardSortMode.Score);
             SetDefault(OsuSetting.BeatmapDetailModsFilter, false);
@@ -324,7 +324,7 @@ namespace osu.Game.Configuration
                             break;
                     }
 
-                    SetValue(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Leaderboards);
+                    SetValue(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Ranking);
                     SetValue(OsuSetting.BeatmapLeaderboardScope, leaderboardScope);
                 }
             }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -294,6 +294,40 @@ namespace osu.Game.Configuration
                 if (penHandler != null && mouseHandler != null && penHandler.Sensitivity.IsDefault)
                     penHandler.Sensitivity.Value = mouseHandler.Sensitivity.Value;
             }
+
+            if (combined < 20260513)
+            {
+                var beatmapDetailTab = Get<BeatmapDetailTab>(OsuSetting.BeatmapDetailTab);
+
+                if (beatmapDetailTab != BeatmapDetailTab.Details)
+                {
+                    var leaderboardScope = BeatmapLeaderboardScope.Local;
+
+                    switch (beatmapDetailTab)
+                    {
+#pragma warning disable CS0618 // Type or member is obsolete
+                        case BeatmapDetailTab.Country:
+                            leaderboardScope = BeatmapLeaderboardScope.Country;
+                            break;
+
+                        case BeatmapDetailTab.Friends:
+                            leaderboardScope = BeatmapLeaderboardScope.Friend;
+                            break;
+
+                        case BeatmapDetailTab.Team:
+                            leaderboardScope = BeatmapLeaderboardScope.Team;
+                            break;
+
+                        case BeatmapDetailTab.Global:
+#pragma warning restore CS0618 // Type or member is obsolete
+                            leaderboardScope = BeatmapLeaderboardScope.Global;
+                            break;
+                    }
+
+                    SetValue(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Leaderboards);
+                    SetValue(OsuSetting.BeatmapLeaderboardScope, leaderboardScope);
+                }
+            }
         }
 
         public override TrackedSettings CreateTrackedSettings()

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -24,6 +24,7 @@ using osu.Game.Overlays.Mods.Input;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
+using osu.Game.Screens.Play.Leaderboards;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Skinning;
@@ -49,7 +50,8 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.Ruleset, string.Empty);
             SetDefault(OsuSetting.Skin, SkinInfo.ARGON_SKIN.ToString());
 
-            SetDefault(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Local);
+            SetDefault(OsuSetting.BeatmapDetailTab, BeatmapDetailTab.Leaderboards);
+            SetDefault(OsuSetting.BeatmapLeaderboardScope, BeatmapLeaderboardScope.Local);
             SetDefault(OsuSetting.BeatmapLeaderboardSortMode, LeaderboardSortMode.Score);
             SetDefault(OsuSetting.BeatmapDetailModsFilter, false);
 
@@ -411,6 +413,7 @@ namespace osu.Game.Configuration
         MenuParallax,
         Prefer24HourTime,
         BeatmapDetailTab,
+        BeatmapLeaderboardScope,
         BeatmapLeaderboardSortMode,
         BeatmapDetailModsFilter,
         Username,

--- a/osu.Game/Screens/Select/BeatmapDetailTab.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailTab.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Screens.Select
         Details,
 
         /// <summary>
-        /// Leaderboards.
+        /// Ranking.
         /// </summary>
-        Leaderboards,
+        Ranking,
 
         /// <summary>
         /// Local leaderboards.

--- a/osu.Game/Screens/Select/BeatmapDetailTab.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailTab.cs
@@ -11,28 +11,8 @@ namespace osu.Game.Screens.Select
         Details,
 
         /// <summary>
-        /// Local leaderboards.
+        /// Leaderboards.
         /// </summary>
-        Local,
-
-        /// <summary>
-        /// Country leaderboards.
-        /// </summary>
-        Country,
-
-        /// <summary>
-        /// Global leaderboards.
-        /// </summary>
-        Global,
-
-        /// <summary>
-        /// Friend leaderboards.
-        /// </summary>
-        Friends,
-
-        /// <summary>
-        /// Team leaderboards.
-        /// </summary>
-        Team
+        Leaderboards,
     }
 }

--- a/osu.Game/Screens/Select/BeatmapDetailTab.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailTab.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Game.Screens.Select
 {
     public enum BeatmapDetailTab
@@ -14,5 +16,50 @@ namespace osu.Game.Screens.Select
         /// Leaderboards.
         /// </summary>
         Leaderboards,
+
+        /// <summary>
+        /// Local leaderboards.
+        /// </summary>
+        /// <remarks>
+        /// Provided for compatibility with older clients - can be removed 20261113.
+        /// </remarks>
+        [Obsolete("Use BeatmapLeaderboardScope instead")]
+        Local,
+
+        /// <summary>
+        /// Country leaderboards.
+        /// </summary>
+        /// <remarks>
+        /// Provided for compatibility with older clients - can be removed 20261113.
+        /// </remarks>
+        [Obsolete("Use BeatmapLeaderboardScope instead")]
+        Country,
+
+        /// <summary>
+        /// Global leaderboards.
+        /// </summary>
+        /// <remarks>
+        /// For compatibility with older clients - can be removed 20261113.
+        /// </remarks>
+        [Obsolete("Use BeatmapLeaderboardScope instead")]
+        Global,
+
+        /// <summary>
+        /// Friend leaderboards.
+        /// </summary>
+        /// <remarks>
+        /// For compatibility with older clients - can be removed 20261113.
+        /// </remarks>
+        [Obsolete("Use BeatmapLeaderboardScope instead")]
+        Friends,
+
+        /// <summary>
+        /// Team leaderboards.
+        /// </summary>
+        /// <remarks>
+        /// For compatibility with older clients - can be removed 20261113.
+        /// </remarks>
+        [Obsolete("Use BeatmapLeaderboardScope instead")]
+        Team
     }
 }

--- a/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Screens.Select
 
             public IBindable<BeatmapLeaderboardScope> Scope => scopeDropdown.Current;
 
+            private readonly Bindable<BeatmapLeaderboardScope> configLeaderboardScope = new Bindable<BeatmapLeaderboardScope>();
+
             private readonly Bindable<BeatmapDetailTab> configDetailTab = new Bindable<BeatmapDetailTab>();
 
             public IBindable<LeaderboardSortMode> Sorting => sortDropdown.Current;
@@ -105,6 +107,7 @@ namespace osu.Game.Screens.Select
                 };
 
                 config.BindWith(OsuSetting.BeatmapDetailTab, configDetailTab);
+                config.BindWith(OsuSetting.BeatmapLeaderboardScope, configLeaderboardScope);
                 config.BindWith(OsuSetting.BeatmapLeaderboardSortMode, configLeaderboardSortMode);
                 config.BindWith(OsuSetting.BeatmapDetailModsFilter, selectedModsToggle.Active);
             }
@@ -113,7 +116,7 @@ namespace osu.Game.Screens.Select
             {
                 base.LoadComplete();
 
-                scopeDropdown.Current.Value = tryMapDetailTabToLeaderboardScope(configDetailTab.Value) ?? scopeDropdown.Current.Value;
+                scopeDropdown.Current.Value = configLeaderboardScope.Value;
                 scopeDropdown.Current.BindValueChanged(_ => updateConfigDetailTab());
 
                 tabControl.Current.Value = configDetailTab.Value == BeatmapDetailTab.Details ? Selection.Details : Selection.Ranking;
@@ -152,59 +155,11 @@ namespace osu.Game.Screens.Select
                         return;
 
                     case Selection.Ranking:
-                        configDetailTab.Value = mapLeaderboardScopeToDetailTab(scopeDropdown.Current.Value);
+                        configLeaderboardScope.Value = scopeDropdown.Current.Value;
                         return;
 
                     default:
                         throw new ArgumentOutOfRangeException(nameof(tabControl.Current.Value), tabControl.Current.Value, null);
-                }
-            }
-
-            private static BeatmapLeaderboardScope? tryMapDetailTabToLeaderboardScope(BeatmapDetailTab tab)
-            {
-                switch (tab)
-                {
-                    case BeatmapDetailTab.Local:
-                        return BeatmapLeaderboardScope.Local;
-
-                    case BeatmapDetailTab.Country:
-                        return BeatmapLeaderboardScope.Country;
-
-                    case BeatmapDetailTab.Global:
-                        return BeatmapLeaderboardScope.Global;
-
-                    case BeatmapDetailTab.Friends:
-                        return BeatmapLeaderboardScope.Friend;
-
-                    case BeatmapDetailTab.Team:
-                        return BeatmapLeaderboardScope.Team;
-
-                    default:
-                        return null;
-                }
-            }
-
-            private static BeatmapDetailTab mapLeaderboardScopeToDetailTab(BeatmapLeaderboardScope scope)
-            {
-                switch (scope)
-                {
-                    case BeatmapLeaderboardScope.Local:
-                        return BeatmapDetailTab.Local;
-
-                    case BeatmapLeaderboardScope.Country:
-                        return BeatmapDetailTab.Country;
-
-                    case BeatmapLeaderboardScope.Global:
-                        return BeatmapDetailTab.Global;
-
-                    case BeatmapLeaderboardScope.Friend:
-                        return BeatmapDetailTab.Friends;
-
-                    case BeatmapLeaderboardScope.Team:
-                        return BeatmapDetailTab.Team;
-
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(scope), scope, null);
                 }
             }
 

--- a/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
@@ -165,6 +165,7 @@ namespace osu.Game.Screens.Select
 
             #endregion
 
+            // TODO: remove and replace with `BeatmapDetailTab` - 20261113.
             public enum Selection
             {
                 [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.Details))]


### PR DESCRIPTION
Now that song select V1 has been removed, I think this is a good time to resolve #35640

The current implementation is simple, it just separates out the option but doesn't handle migration.

As a result, there is a one time exception notification shown to the user about being unable to parse the config string.
What should be done about that?

One option I thought of is to still keep the old enum variants so that the parsing is successful, then add a migration that moves over the leaderboard scope setting. But I'm not sure if it's a good idea to keep _basically-redundant_ variants of the enum.