### PR TITLE
Add `Cover` mod to osu!catch

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModCover.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModCover.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Catch.Mods;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Mods
+{
+    public partial class TestSceneCatchModCover : ModTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
+
+        [TestCase(0.2f)]
+        [TestCase(0.5f)]
+        [TestCase(0.8f)]
+        public void TestCoverTop(float coverage) => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModCover
+            {
+                Direction = { Value = CoverExpandDirection.AlongScroll },
+                Coverage = { Value = coverage }
+            },
+            PassCondition = () => true
+        });
+
+        [TestCase(0.2f)]
+        [TestCase(0.5f)]
+        [TestCase(0.8f)]
+        public void TestCoverBottom(float coverage) => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModCover
+            {
+                Direction = { Value = CoverExpandDirection.AgainstScroll },
+                Coverage = { Value = coverage }
+            },
+            PassCondition = () => true
+        });
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModCover.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModCover.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
         {
             Mod = new CatchModCover
             {
-                Direction = { Value = CoverExpandDirection.AlongScroll },
+                Direction = { Value = CatchCoverDirection.Top },
                 Coverage = { Value = coverage }
             },
             PassCondition = () => true
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
         {
             Mod = new CatchModCover
             {
-                Direction = { Value = CoverExpandDirection.AgainstScroll },
+                Direction = { Value = CatchCoverDirection.Bottom },
                 Coverage = { Value = coverage }
             },
             PassCondition = () => true

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Catch
                         new CatchModHardRock(),
                         new MultiMod(new CatchModSuddenDeath(), new CatchModPerfect()),
                         new MultiMod(new CatchModDoubleTime(), new CatchModNightcore()),
-                        new CatchModHidden(),
+                        new CatchModHidden(), new CatchModCover(),
                         new CatchModFlashlight(),
                         new ModAccuracyChallenge(),
                     };

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -24,8 +23,8 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override IconUsage? Icon => OsuIcon.ModCover;
         public override LocalisableString Description => @"Decrease the playfield's viewing area.";
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => new[] { typeof(CatchModHidden), typeof(CatchModFlashlight)};
-        public override bool Ranked => false;
+        public override Type[] IncompatibleMods => new[] { typeof(CatchModHidden), typeof(CatchModFlashlight) };
+        public override bool Ranked => true;
 
         [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
         public BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)
@@ -36,9 +35,8 @@ namespace osu.Game.Rulesets.Catch.Mods
             Default = 0.5f,
         };
 
-        [SettingSource("Direction", "The direction on which the cover is applied")]
-        public Bindable<CoverExpandDirection> Direction { get; } = new Bindable<CoverExpandDirection>();
-
+        [SettingSource("Position", "Where the cover should be placed.")]
+        public Bindable<CatchCoverDirection> Direction { get; } = new Bindable<CatchCoverDirection>();
         private const double fade_fraction = 0.16;
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
@@ -46,10 +44,10 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            if (hitObject is not DrawableCatchHitObject catchDrawable) 
+            if (hitObject is not DrawableCatchHitObject catchDrawable)
                 return;
 
-            if (Direction.Value == CoverExpandDirection.AlongScroll && state != ArmedState.Idle)
+            if (Direction.Value == CatchCoverDirection.Top && state != ArmedState.Idle)
                 return;
 
             if (catchDrawable.NestedHitObjects.Any())
@@ -73,41 +71,35 @@ namespace osu.Game.Rulesets.Catch.Mods
             double preempt = hitObject.TimePreempt;
             double spawnTime = hitObject.StartTime - preempt;
 
-            double fade_duration = preempt * fade_fraction;
+            double fadeDuration = preempt * fade_fraction;
 
-            if (Direction.Value == CoverExpandDirection.AlongScroll)
+            if (Direction.Value == CatchCoverDirection.Top)
             {
                 double boundaryTime = spawnTime + (preempt * Coverage.Value);
-                double fadeStartTime = boundaryTime - fade_duration;
+                double fadeStartTime = boundaryTime - fadeDuration;
 
                 using (drawable.BeginAbsoluteSequence(double.MinValue))
                     drawable.FadeTo(0);
 
                 using (drawable.BeginAbsoluteSequence(fadeStartTime))
-                    drawable.FadeIn(fade_duration);
+                    drawable.FadeIn(fadeDuration);
             }
             else
             {
                 double boundaryTime = spawnTime + (preempt * (1 - Coverage.Value));
 
                 using (drawable.BeginAbsoluteSequence(boundaryTime))
-                    drawable.FadeOut(fade_duration);
+                    drawable.FadeOut(fadeDuration);
             }
         }
     }
 
-    public enum CoverExpandDirection
+    public enum CatchCoverDirection
     {
-        /// <summary>
-        /// The cover expands along the scrolling direction.
-        /// </summary>
-        [Description("Along scroll")]
-        AlongScroll,
+        [Description("Top")]
+        Top,
 
-        /// <summary>
-        /// The cover expands against the scrolling direction.
-        /// </summary>
-        [Description("Against scroll")]
-        AgainstScroll
+        [Description("Bottom")]
+        Bottom
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         [SettingSource("Position", "Where the cover should be placed.")]
         public Bindable<CatchCoverDirection> Direction { get; } = new Bindable<CatchCoverDirection>();
+
         private const double fade_fraction = 0.16;
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
@@ -45,7 +45,8 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            if (hitObject is not DrawableCatchHitObject catchDrawable) return;
+            if (hitObject is not DrawableCatchHitObject catchDrawable) 
+                return;
 
             if (Direction.Value == CoverExpandDirection.AlongScroll && state != ArmedState.Idle)
                 return;
@@ -78,7 +79,6 @@ namespace osu.Game.Rulesets.Catch.Mods
                 double boundaryTime = spawnTime + (preempt * Coverage.Value);
                 double fadeStartTime = boundaryTime - fade_duration;
 
-                drawable.Alpha = 0;
                 using (drawable.BeginAbsoluteSequence(double.MinValue))
                     drawable.FadeTo(0);
 
@@ -88,9 +88,6 @@ namespace osu.Game.Rulesets.Catch.Mods
             else
             {
                 double boundaryTime = spawnTime + (preempt * (1 - Coverage.Value));
-
-                using (drawable.BeginAbsoluteSequence(spawnTime))
-                    drawable.FadeIn();
 
                 using (drawable.BeginAbsoluteSequence(boundaryTime))
                     drawable.FadeOut(fade_duration);

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override LocalisableString Description => @"Decrease the playfield's viewing area.";
         public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => new[] { typeof(CatchModHidden), typeof(CatchModFlashlight)};
+        public override bool Ranked => false;
 
         [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
         public BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCover.cs
@@ -1,0 +1,115 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.ComponentModel;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Catch.Mods
+{
+    public class CatchModCover : ModHidden
+    {
+        public override string Name => "Cover";
+        public override string Acronym => "CO";
+        public override IconUsage? Icon => OsuIcon.ModCover;
+        public override LocalisableString Description => @"Decrease the playfield's viewing area.";
+        public override double ScoreMultiplier => 1;
+        public override Type[] IncompatibleMods => new[] { typeof(CatchModHidden), typeof(CatchModFlashlight)};
+
+        [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
+        public BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)
+        {
+            Precision = 0.01f,
+            MinValue = 0.2f,
+            MaxValue = 0.8f,
+            Default = 0.5f,
+        };
+
+        [SettingSource("Direction", "The direction on which the cover is applied")]
+        public Bindable<CoverExpandDirection> Direction { get; } = new Bindable<CoverExpandDirection>();
+
+        private const double fade_fraction = 0.16;
+
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
+            => ApplyNormalVisibilityState(hitObject, state);
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+            if (hitObject is not DrawableCatchHitObject catchDrawable) return;
+
+            if (Direction.Value == CoverExpandDirection.AlongScroll && state != ArmedState.Idle)
+                return;
+
+            if (catchDrawable.NestedHitObjects.Any())
+            {
+                foreach (var nested in catchDrawable.NestedHitObjects)
+                {
+                    if (nested is DrawableCatchHitObject nestedCatch)
+                        applyCoverEffect(nestedCatch);
+                }
+            }
+            else
+            {
+                applyCoverEffect(catchDrawable);
+            }
+        }
+
+        private void applyCoverEffect(DrawableCatchHitObject drawable)
+        {
+            var hitObject = drawable.HitObject;
+
+            double preempt = hitObject.TimePreempt;
+            double spawnTime = hitObject.StartTime - preempt;
+
+            double fade_duration = preempt * fade_fraction;
+
+            if (Direction.Value == CoverExpandDirection.AlongScroll)
+            {
+                double boundaryTime = spawnTime + (preempt * Coverage.Value);
+                double fadeStartTime = boundaryTime - fade_duration;
+
+                drawable.Alpha = 0;
+                using (drawable.BeginAbsoluteSequence(double.MinValue))
+                    drawable.FadeTo(0);
+
+                using (drawable.BeginAbsoluteSequence(fadeStartTime))
+                    drawable.FadeIn(fade_duration);
+            }
+            else
+            {
+                double boundaryTime = spawnTime + (preempt * (1 - Coverage.Value));
+
+                using (drawable.BeginAbsoluteSequence(spawnTime))
+                    drawable.FadeIn();
+
+                using (drawable.BeginAbsoluteSequence(boundaryTime))
+                    drawable.FadeOut(fade_duration);
+            }
+        }
+    }
+
+    public enum CoverExpandDirection
+    {
+        /// <summary>
+        /// The cover expands along the scrolling direction.
+        /// </summary>
+        [Description("Along scroll")]
+        AlongScroll,
+
+        /// <summary>
+        /// The cover expands against the scrolling direction.
+        /// </summary>
+        [Description("Against scroll")]
+        AgainstScroll
+    }
+}

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
@@ -14,6 +15,7 @@ namespace osu.Game.Rulesets.Catch.Mods
     public partial class CatchModFlashlight : ModFlashlight<CatchHitObject>
     {
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
+        public override Type[] IncompatibleMods => new[] { typeof(CatchModCover) };
 
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -17,6 +18,7 @@ namespace osu.Game.Rulesets.Catch.Mods
     {
         public override LocalisableString Description => @"Play with fading fruits.";
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
+        public override Type[] IncompatibleMods => new[] { typeof(CatchModCover) };
 
         private const double fade_out_offset_multiplier = 0.6;
         private const double fade_out_duration_multiplier = 0.44;


### PR DESCRIPTION
This PR aims to port the `Cover` mod from osu!mania to osu!catch. 
More detailed discussion of the proposal can be found here: #37139

Right now the score multiplier is set to 1.0x and `Ranked` is set to `true`. But I think this needs confirmation from the PP team.

Here's how the mod looks:

1. Covering the top of the playfield

https://github.com/user-attachments/assets/5a8e1b21-e034-4b05-8d71-743a7df08196

2. Covering the bottom of the playfield

https://github.com/user-attachments/assets/7dffef27-1063-4551-a51a-b94071d02138