### PR TITLE
Fall back to using `APIUser.Statistics` for rank in `UserPanel`

### DIFF
--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Users
             // We can't colour the properly because we don't have the required percentile data.
 
             Colour = Colours.BlueLighter,
-            Text = User.Rank?.Rank?.ToLocalisableString("\\##,##0") ?? string.Empty,
+            Text = (User.Rank?.Rank ?? User.Statistics.GlobalRank)?.ToLocalisableString("\\##,##0") ?? string.Empty,
         };
 
         protected UpdateableAvatar CreateAvatar() => new UpdateableAvatar(User, false);


### PR DESCRIPTION
Fixes friend list not showing global rank of the users.
I think #37709 can be closed without any further client-side changes after `osu-web` is made to return global rank on user searches.