### PR TITLE
Fix crash when fetching top local rank in song select

### DIFF
--- a/osu.Game/Screens/Select/PanelLocalRankDisplay.cs
+++ b/osu.Game/Screens/Select/PanelLocalRankDisplay.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Select
             ScoreInfo? topScore = sender
                                   // doing these post realm filter is most efficient.
                                   .Where(s => s.UserID == api.LocalUser.Value.Id || s.UserID <= 1)
-                                  .Where(s => s.Ruleset.ShortName == ruleset.Value.ShortName)
+                                  .Where(s => ruleset.Value.Equals(s.Ruleset))
                                   .MaxBy(info => (info.TotalScore, -info.Date.UtcDateTime.Ticks));
 
             setRankFromScore(topScore);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/37715.

The user's database contains several scores in which `ScoreInfo.Ruleset` is null. How this happened, I'm not sure, it's probably custom rulesets.

The proper way to handle this would be to mark `ScoreInfo.Ruleset` as nullable and deal with the hundred files of fallout, and also the fact that `ScoreInfo` is an overloaded mess of a model that is sometimes a database model and sometimes a post-converted online structure with things backfilled to fit and I'm just not wanting to waste a week here, so I'm choosing to look away.

Sidebar: You can't just put a null-propagating operator in the previous conditional too because analysers will scream that `Ruleset` can't *possibly* be null! So this uses `RulesetInfo.Equals(RulesetInfo?)` because that can sorta-kinda handle nulls.