### PR TITLE
Change editor grid slider adjustments to be relative to centre

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -125,13 +125,23 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 startPositionXSlider = new ExpandableSlider<float>
                 {
-                    Current = StartPositionX,
+                    Current = new BindableFloat
+                    {
+                        MinValue = -OsuPlayfield.BASE_SIZE.X / 2,
+                        MaxValue = OsuPlayfield.BASE_SIZE.X / 2,
+                        Precision = 0.1f,
+                    },
                     KeyboardStep = 1,
                     ExpandedLabelText = "X offset",
                 },
                 startPositionYSlider = new ExpandableSlider<float>
                 {
-                    Current = StartPositionY,
+                    Current = new BindableFloat
+                    {
+                        MinValue = -OsuPlayfield.BASE_SIZE.Y / 2,
+                        MaxValue = OsuPlayfield.BASE_SIZE.Y / 2,
+                        Precision = 0.1f,
+                    },
                     KeyboardStep = 1,
                     ExpandedLabelText = "Y offset",
                 },
@@ -186,14 +196,26 @@ namespace osu.Game.Rulesets.Osu.Edit
             StartPositionX.BindValueChanged(x =>
             {
                 startPositionXSlider.ContractedLabelText = $"X: {x.NewValue:#,0.##}";
+                startPositionXSlider.Current.Value = x.NewValue - OsuPlayfield.BASE_SIZE.X / 2;
                 StartPosition.Value = new Vector2(x.NewValue, StartPosition.Value.Y);
             }, true);
 
             StartPositionY.BindValueChanged(y =>
             {
                 startPositionYSlider.ContractedLabelText = $"Y: {y.NewValue:#,0.##}";
+                startPositionYSlider.Current.Value = y.NewValue - OsuPlayfield.BASE_SIZE.Y / 2;
                 StartPosition.Value = new Vector2(StartPosition.Value.X, y.NewValue);
             }, true);
+
+            startPositionXSlider.Current.BindValueChanged(x =>
+            {
+                StartPositionY.Value = x.NewValue + OsuPlayfield.BASE_SIZE.X / 2;
+            });
+
+            startPositionYSlider.Current.BindValueChanged(y =>
+            {
+                StartPositionY.Value = y.NewValue + OsuPlayfield.BASE_SIZE.Y / 2;
+            });
 
             StartPosition.BindValueChanged(pos =>
             {

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             startPositionXSlider.Current.BindValueChanged(x =>
             {
-                StartPositionY.Value = x.NewValue + OsuPlayfield.BASE_SIZE.X / 2;
+                StartPositionX.Value = x.NewValue + OsuPlayfield.BASE_SIZE.X / 2;
             });
 
             startPositionYSlider.Current.BindValueChanged(y =>


### PR DESCRIPTION
As requested in https://github.com/ppy/osu/discussions/37734.

Quick one, seems beneficial.