### PR TITLE
Ranked Play: Add damage breakdown and individual multipliers

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayStageOverlay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayStageOverlay.cs
@@ -40,9 +40,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
         [Test]
         public void TestBasic()
         {
-            double multiplier = 1.0;
-
-            AddSliderStep<double>("set multiplier", 1, 5, 2, value => multiplier = value);
             AddStep("create", () => Child = new RankedPlayStageOverlay("Pick Phase", RankedPlayColourScheme.BLUE)
             {
                 PickingUser = new APIUser
@@ -50,7 +47,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     Id = 2,
                     Username = "peppy",
                 },
-                Multiplier = multiplier,
             });
         }
 
@@ -64,7 +60,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     Id = 226597,
                     Username = "WWWWWWWWWWWWWWWWWWWW",
                 },
-                Multiplier = 2,
             });
         }
 
@@ -78,7 +73,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     Id = 2,
                     Username = "peppy",
                 },
-                Multiplier = 2,
             });
             AddStep("create red", () => Child = new RankedPlayStageOverlay("Pick Phase", RankedPlayColourScheme.RED)
             {
@@ -87,7 +81,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     Id = 2,
                     Username = "peppy",
                 },
-                Multiplier = 2,
             });
         }
     }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
@@ -40,8 +40,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         }
 
         [Test]
-        [Explicit("Test exercises correct stopping of audio playback. Has no assertions, only useful when checked manually by a human.")]
-        public void TestAllSamplesStopOnExit()
+        public void TestDamageBreakdown()
         {
             AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
             {
@@ -53,13 +52,34 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     {
                         userInfo.DamageInfo = new RankedPlayDamageInfo
                         {
-                            RawDamage = 123_456,
-                            Damage = 123_456,
-                            OldLife = 500_000,
-                            NewLife = 500_000 - 123_456,
+                            RawDamage = 600_000,
+                            Damage = 1_100_000,
+                            OldLife = 1_000_000,
+                            NewLife = 1,
+                            Sources =
+                            [
+                                new RankedPlayDamageSource
+                                {
+                                    Type = RankedPlayDamageType.Attack,
+                                    RawValue = 500_000,
+                                    Damage = 500_000
+                                },
+                                new RankedPlayDamageSource
+                                {
+                                    Type = RankedPlayDamageType.Multiplier,
+                                    RawValue = 2,
+                                    Damage = 500_000
+                                },
+                                new RankedPlayDamageSource
+                                {
+                                    Type = RankedPlayDamageType.Bonus,
+                                    RawValue = 100_000,
+                                    Damage = 100_000
+                                }
+                            ]
                         };
 
-                        userInfo.Life = 500_000 - 123_456;
+                        userInfo.Life = 653_088;
                     }
                     else
                     {
@@ -73,8 +93,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     }
                 }
             }).WaitSafely());
-            AddWaitStep("wait for samples to start playing", 5);
-            AddRepeatStep("exit", () => screen.Exit(), 2);
         }
 
         [Test]
@@ -93,7 +111,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                             RawDamage = 123_456,
                             Damage = 123_456,
                             OldLife = 500_000,
-                            NewLife = 500_000 - 123_456,
+                            NewLife = 500_000 - 123_456
                         };
 
                         userInfo.Life = 500_000 - 123_456;
@@ -200,6 +218,44 @@ namespace osu.Game.Tests.Visual.RankedPlay
                     }
                 }
             }).WaitSafely());
+        }
+
+        [Test]
+        [Explicit("Test exercises correct stopping of audio playback. Has no assertions, only useful when checked manually by a human.")]
+        public void TestAllSamplesStopOnExit()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
+            {
+                int losingPlayer = state.Users.Keys.First();
+
+                foreach (var (id, userInfo) in state.Users)
+                {
+                    if (id == losingPlayer)
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 123_456,
+                            Damage = 123_456,
+                            OldLife = 500_000,
+                            NewLife = 500_000 - 123_456,
+                        };
+
+                        userInfo.Life = 500_000 - 123_456;
+                    }
+                    else
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 0,
+                            Damage = 0,
+                            OldLife = 1_000_000,
+                            NewLife = 1_000_000,
+                        };
+                    }
+                }
+            }).WaitSafely());
+            AddWaitStep("wait for samples to start playing", 5);
+            AddRepeatStep("exit", () => screen.Exit(), 2);
         }
 
         private void setupRequestHandler()

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
@@ -56,27 +56,47 @@ namespace osu.Game.Tests.Visual.RankedPlay
                             Damage = 1_100_000,
                             OldLife = 1_000_000,
                             NewLife = 1,
-                            Sources =
-                            [
-                                new RankedPlayDamageSource
-                                {
-                                    Type = RankedPlayDamageType.Attack,
-                                    RawValue = 500_000,
-                                    Damage = 500_000
-                                },
-                                new RankedPlayDamageSource
-                                {
-                                    Type = RankedPlayDamageType.Multiplier,
-                                    RawValue = 2,
-                                    Damage = 500_000
-                                },
-                                new RankedPlayDamageSource
-                                {
-                                    Type = RankedPlayDamageType.Bonus,
-                                    RawValue = 100_000,
-                                    Damage = 100_000
-                                }
-                            ]
+                            DirectDamage = 500_000,
+                            Multiplier = 2,
+                            BonusDamage = 100_000
+                        };
+
+                        userInfo.Life = 653_088;
+                    }
+                    else
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 0,
+                            Damage = 0,
+                            OldLife = 1_000_000,
+                            NewLife = 1_000_000,
+                        };
+                    }
+                }
+            }).WaitSafely());
+        }
+
+        [Test]
+        public void TestDamageBreakdownWithNegativeValues()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
+            {
+                int losingPlayer = state.Users.Keys.First();
+
+                foreach (var (id, userInfo) in state.Users)
+                {
+                    if (id == losingPlayer)
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 500_000,
+                            Damage = 200_000,
+                            OldLife = 1_000_000,
+                            NewLife = 800_000,
+                            DirectDamage = 600_000,
+                            Multiplier = 0.5,
+                            BonusDamage = -100_000
                         };
 
                         userInfo.Life = 653_088;

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
@@ -40,82 +40,6 @@ namespace osu.Game.Tests.Visual.RankedPlay
         }
 
         [Test]
-        public void TestDamageBreakdown()
-        {
-            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
-            {
-                int losingPlayer = state.Users.Keys.First();
-
-                foreach (var (id, userInfo) in state.Users)
-                {
-                    if (id == losingPlayer)
-                    {
-                        userInfo.DamageInfo = new RankedPlayDamageInfo
-                        {
-                            RawDamage = 600_000,
-                            Damage = 1_100_000,
-                            OldLife = 1_000_000,
-                            NewLife = 1,
-                            DirectDamage = 500_000,
-                            Multiplier = 2,
-                            BonusDamage = 100_000
-                        };
-
-                        userInfo.Life = 653_088;
-                    }
-                    else
-                    {
-                        userInfo.DamageInfo = new RankedPlayDamageInfo
-                        {
-                            RawDamage = 0,
-                            Damage = 0,
-                            OldLife = 1_000_000,
-                            NewLife = 1_000_000,
-                        };
-                    }
-                }
-            }).WaitSafely());
-        }
-
-        [Test]
-        public void TestDamageBreakdownWithNegativeValues()
-        {
-            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
-            {
-                int losingPlayer = state.Users.Keys.First();
-
-                foreach (var (id, userInfo) in state.Users)
-                {
-                    if (id == losingPlayer)
-                    {
-                        userInfo.DamageInfo = new RankedPlayDamageInfo
-                        {
-                            RawDamage = 500_000,
-                            Damage = 200_000,
-                            OldLife = 1_000_000,
-                            NewLife = 800_000,
-                            DirectDamage = 600_000,
-                            Multiplier = 0.5,
-                            BonusDamage = -100_000
-                        };
-
-                        userInfo.Life = 653_088;
-                    }
-                    else
-                    {
-                        userInfo.DamageInfo = new RankedPlayDamageInfo
-                        {
-                            RawDamage = 0,
-                            Damage = 0,
-                            OldLife = 1_000_000,
-                            NewLife = 1_000_000,
-                        };
-                    }
-                }
-            }).WaitSafely());
-        }
-
-        [Test]
         public void TestBasic()
         {
             AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
@@ -276,6 +200,82 @@ namespace osu.Game.Tests.Visual.RankedPlay
             }).WaitSafely());
             AddWaitStep("wait for samples to start playing", 5);
             AddRepeatStep("exit", () => screen.Exit(), 2);
+        }
+
+        [Test]
+        public void TestDamageBreakdown()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
+            {
+                int losingPlayer = state.Users.Keys.First();
+
+                foreach (var (id, userInfo) in state.Users)
+                {
+                    if (id == losingPlayer)
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 600_000,
+                            Damage = 1_100_000,
+                            OldLife = 1_000_000,
+                            NewLife = 1,
+                            DirectDamage = 500_000,
+                            Multiplier = 2,
+                            BonusDamage = 100_000
+                        };
+
+                        userInfo.Life = 653_088;
+                    }
+                    else
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 0,
+                            Damage = 0,
+                            OldLife = 1_000_000,
+                            NewLife = 1_000_000,
+                        };
+                    }
+                }
+            }).WaitSafely());
+        }
+
+        [Test]
+        public void TestDamageBreakdownWithNegativeValues()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results, state =>
+            {
+                int losingPlayer = state.Users.Keys.First();
+
+                foreach (var (id, userInfo) in state.Users)
+                {
+                    if (id == losingPlayer)
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 500_000,
+                            Damage = 200_000,
+                            OldLife = 1_000_000,
+                            NewLife = 800_000,
+                            DirectDamage = 600_000,
+                            Multiplier = 0.5,
+                            BonusDamage = -100_000
+                        };
+
+                        userInfo.Life = 653_088;
+                    }
+                    else
+                    {
+                        userInfo.DamageInfo = new RankedPlayDamageInfo
+                        {
+                            RawDamage = 0,
+                            Damage = 0,
+                            OldLife = 1_000_000,
+                            NewLife = 1_000_000,
+                        };
+                    }
+                }
+            }).WaitSafely());
         }
 
         private void setupRequestHandler()

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScreen.cs
@@ -81,30 +81,36 @@ namespace osu.Game.Tests.Visual.RankedPlay
             {
                 int losingPlayer = state.Users.Keys.First();
 
-                state.DamageMultiplier = 2;
+                state.DamageMultiplier = 1.5;
 
                 foreach (var (id, userInfo) in state.Users)
                 {
                     if (id == losingPlayer)
                     {
+                        userInfo.DamageMultiplier = 0.5;
                         userInfo.DamageInfo = new RankedPlayDamageInfo
                         {
                             RawDamage = 123_456,
                             Damage = 123_456 * 2,
                             OldLife = 1_000_000,
                             NewLife = 1_000_000 - 123_456 * 2,
+                            Multiplier = 2,
+                            DirectDamage = 123_456,
                         };
 
                         userInfo.Life = 1_000_000 - 123_456 * 2;
                     }
                     else
                     {
+                        userInfo.DamageMultiplier = 0.5;
                         userInfo.DamageInfo = new RankedPlayDamageInfo
                         {
                             RawDamage = 0,
                             Damage = 0,
                             OldLife = 1_000_000,
                             NewLife = 1_000_000,
+                            Multiplier = 2,
+                            DirectDamage = 0,
                         };
                     }
                 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
                 return false;
 
             return Damage == other.Damage
-                   && Damage == other.RawDamage
+                   && RawDamage == other.RawDamage
                    && OldLife == other.OldLife
                    && NewLife == other.NewLife
                    && DirectDamage == other.DirectDamage

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using MessagePack;
 
 namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
@@ -35,79 +34,27 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         [Key(3)]
         public int NewLife { get; set; }
 
-        /// <summary>
-        /// Describes each source of damage.
-        /// </summary>
         [Key(4)]
-        public List<RankedPlayDamageSource> Sources { get; set; } = [];
+        public int DirectDamage { get; set; }
+
+        [Key(5)]
+        public double Multiplier { get; set; } = 1;
+
+        [Key(6)]
+        public int BonusDamage { get; set; }
 
         public bool Equals(RankedPlayDamageInfo? other)
         {
             if (other == null)
                 return false;
 
-            if (Damage != other.Damage || RawDamage != other.RawDamage || OldLife != other.OldLife || NewLife != other.NewLife)
-                return false;
-
-            if (Sources.Count != other.Sources.Count)
-                return false;
-
-            for (int i = 0; i < Sources.Count; i++)
-            {
-                if (!Sources[i].Equals(other.Sources[i]))
-                    return false;
-            }
-
-            return true;
+            return Damage == other.Damage
+                   && Damage == other.RawDamage
+                   && OldLife == other.OldLife
+                   && NewLife == other.NewLife
+                   && DirectDamage == other.DirectDamage
+                   && Multiplier == other.Multiplier
+                   && BonusDamage == other.BonusDamage;
         }
-    }
-
-    [Serializable]
-    [MessagePackObject]
-    public class RankedPlayDamageSource : IEquatable<RankedPlayDamageSource>
-    {
-        /// <summary>
-        /// The damage source.
-        /// </summary>
-        [Key(0)]
-        public RankedPlayDamageType Type { get; set; }
-
-        /// <summary>
-        /// Raw value of this damage source (e.g. multiplier, score, etc).
-        /// </summary>
-        [Key(1)]
-        public double RawValue { get; set; }
-
-        /// <summary>
-        /// Total amount of damage dealt from this source.
-        /// </summary>
-        [Key(2)]
-        public int Damage { get; set; }
-
-        public bool Equals(RankedPlayDamageSource? other)
-        {
-            if (other == null)
-                return false;
-
-            return Type == other.Type && RawValue == other.RawValue && Damage == other.Damage;
-        }
-    }
-
-    public enum RankedPlayDamageType
-    {
-        /// <summary>
-        /// Score damage dealt directly by the opposing player.
-        /// </summary>
-        Attack,
-
-        /// <summary>
-        /// Damage inflicted through the damage multiplier.
-        /// </summary>
-        Multiplier,
-
-        /// <summary>
-        /// Base damage dealt for winning a round.
-        /// </summary>
-        Bonus
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
@@ -12,12 +12,14 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
     {
         /// <summary>
         /// Total amount of damage dealt.
+        /// Calculated as <see cref="DirectDamage"/> * <see cref="Multiplier"/> + <see cref="BonusDamage"/>.
         /// </summary>
         [Key(0)]
         public int Damage { get; set; }
 
         /// <summary>
         /// Damage dealt before multipliers are applied.
+        /// Calculated as <see cref="DirectDamage"/> + <see cref="BonusDamage"/>.
         /// </summary>
         [Key(1)]
         public int RawDamage { get; set; }
@@ -34,12 +36,21 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         [Key(3)]
         public int NewLife { get; set; }
 
+        /// <summary>
+        /// Direct damage dealt based on score difference.
+        /// </summary>
         [Key(4)]
         public int DirectDamage { get; set; }
 
+        /// <summary>
+        /// The multiplier of <see cref="DirectDamage"/>.
+        /// </summary>
         [Key(5)]
         public double Multiplier { get; set; } = 1;
 
+        /// <summary>
+        /// Damage dealt for winning a round.
+        /// </summary>
         [Key(6)]
         public int BonusDamage { get; set; }
 

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using MessagePack;
 
 namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
@@ -14,43 +15,99 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// Total amount of damage dealt.
         /// </summary>
         [Key(0)]
-        public required int Damage { get; init; }
+        public int Damage { get; set; }
 
         /// <summary>
         /// Damage dealt before multipliers are applied.
         /// </summary>
         [Key(1)]
-        public required int RawDamage { get; init; }
+        public int RawDamage { get; set; }
 
         /// <summary>
         /// Life before damage was applied.
         /// </summary>
         [Key(2)]
-        public required int OldLife { get; init; }
+        public int OldLife { get; set; }
 
         /// <summary>
         /// Life after damage was applied.
         /// </summary>
         [Key(3)]
-        public required int NewLife { get; init; }
+        public int NewLife { get; set; }
+
+        /// <summary>
+        /// Describes each source of damage.
+        /// </summary>
+        [Key(4)]
+        public List<RankedPlayDamageSource> Sources { get; set; } = [];
 
         public bool Equals(RankedPlayDamageInfo? other)
         {
-            if (other is null) return false;
-            if (ReferenceEquals(this, other)) return true;
+            if (other == null)
+                return false;
 
-            return Damage == other.Damage && RawDamage == other.RawDamage && OldLife == other.OldLife && NewLife == other.NewLife;
+            if (Damage != other.Damage || RawDamage != other.RawDamage || OldLife != other.OldLife || NewLife != other.NewLife)
+                return false;
+
+            if (Sources.Count != other.Sources.Count)
+                return false;
+
+            for (int i = 0; i < Sources.Count; i++)
+            {
+                if (!Sources[i].Equals(other.Sources[i]))
+                    return false;
+            }
+
+            return true;
         }
+    }
 
-        public override bool Equals(object? obj)
+    [Serializable]
+    [MessagePackObject]
+    public class RankedPlayDamageSource : IEquatable<RankedPlayDamageSource>
+    {
+        /// <summary>
+        /// The damage source.
+        /// </summary>
+        [Key(0)]
+        public RankedPlayDamageType Type { get; set; }
+
+        /// <summary>
+        /// Raw value of this damage source (e.g. multiplier, score, etc).
+        /// </summary>
+        [Key(1)]
+        public double RawValue { get; set; }
+
+        /// <summary>
+        /// Total amount of damage dealt from this source.
+        /// </summary>
+        [Key(2)]
+        public int Damage { get; set; }
+
+        public bool Equals(RankedPlayDamageSource? other)
         {
-            if (obj is null) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
+            if (other == null)
+                return false;
 
-            return Equals((RankedPlayDamageInfo)obj);
+            return Type == other.Type && RawValue == other.RawValue && Damage == other.Damage;
         }
+    }
 
-        public override int GetHashCode() => HashCode.Combine(Damage, RawDamage, OldLife, NewLife);
+    public enum RankedPlayDamageType
+    {
+        /// <summary>
+        /// Score damage dealt directly by the opposing player.
+        /// </summary>
+        Attack,
+
+        /// <summary>
+        /// Damage inflicted through the damage multiplier.
+        /// </summary>
+        Multiplier,
+
+        /// <summary>
+        /// Base damage dealt for winning a round.
+        /// </summary>
+        Bonus
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayDamageInfo.cs
@@ -14,6 +14,10 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// Total amount of damage dealt.
         /// Calculated as <see cref="DirectDamage"/> * <see cref="Multiplier"/> + <see cref="BonusDamage"/>.
         /// </summary>
+        /// <remarks>
+        /// Not required since adding additional properties (<see cref="DirectDamage"/> / <see cref="BonusDamage"/> / <see cref="Multiplier"/>).
+        /// Could potentially be replaced with a property doing the above calculation.
+        /// </remarks>
         [Key(0)]
         public int Damage { get; set; }
 
@@ -21,6 +25,10 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// Damage dealt before multipliers are applied.
         /// Calculated as <see cref="DirectDamage"/> + <see cref="BonusDamage"/>.
         /// </summary>
+        /// <remarks>
+        /// Not required since adding additional properties (<see cref="DirectDamage"/> / <see cref="BonusDamage"/> / <see cref="Multiplier"/>).
+        /// Can potentially be removed in the future.
+        /// </remarks>
         [Key(1)]
         public int RawDamage { get; set; }
 

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// A multiplier applied to life point damage.
         /// </summary>
         [Key(2)]
-        public double DamageMultiplier { get; set; } = 1;
+        public double DamageMultiplier { get; set; } = 0.5;
 
         /// <summary>
         /// A dictionary containing all users in the room.

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
@@ -54,6 +54,6 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// This player's individual damage multiplier.
         /// </summary>
         [Key(6)]
-        public double DamageMultiplier { get; set; } = 1;
+        public double DamageMultiplier { get; set; } = 0.5;
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
@@ -49,5 +49,11 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// </summary>
         [Key(5)]
         public int RoundsWon { get; set; }
+
+        /// <summary>
+        /// This player's individual damage multiplier.
+        /// </summary>
+        [Key(6)]
+        public double DamageMultiplier { get; set; } = 1;
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -227,7 +227,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             if (!roomState.Users.TryGetValue(user.Id, out var userInfo))
                 return;
 
-            double totalMultiplier = roomState.DamageMultiplier * userInfo.DamageMultiplier;
+            double totalMultiplier = roomState.DamageMultiplier + userInfo.DamageMultiplier;
             damageMultiplierText.Text = $"{totalMultiplier.ToStandardFormattedString(maxDecimalDigits: 1)}x damage";
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -222,12 +221,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         private void updateDamageMultiplier()
         {
-            var userInfo = (client.Room?.MatchState as RankedPlayRoomState)?.Users.GetValueOrDefault(user.Id);
-
-            if (userInfo == null)
+            if (client.Room?.MatchState is not RankedPlayRoomState roomState)
                 return;
 
-            damageMultiplierText.Text = $"{userInfo.DamageMultiplier.ToStandardFormattedString(maxDecimalDigits: 1)}x damage";
+            if (!roomState.Users.TryGetValue(user.Id, out var userInfo))
+                return;
+
+            double totalMultiplier = roomState.DamageMultiplier * userInfo.DamageMultiplier;
+            damageMultiplierText.Text = $"{totalMultiplier.ToStandardFormattedString(maxDecimalDigits: 1)}x damage";
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -79,6 +79,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 ? Anchor.CentreRight
                 : Anchor.CentreLeft;
 
+            var lastStandAnchor = (contentAnchor & Anchor.x0) != 0
+                ? Anchor.CentreLeft
+                : Anchor.CentreRight;
+
             InternalChildren =
             [
                 new CircularContainer
@@ -131,12 +135,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                                 },
                                 lastStandText = new OsuSpriteText
                                 {
-                                    Anchor = contentAnchor,
-                                    Origin = contentAnchor,
+                                    Anchor = lastStandAnchor,
+                                    Origin = lastStandAnchor,
                                     Text = "Last Stand!",
                                     Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
                                     Alpha = 0,
-                                    AlwaysPresent = true
                                 }
                             ]
                         },

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -14,12 +15,14 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
 using osu.Game.Users.Drawables;
 using osuTK;
@@ -36,13 +39,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             Value = 1_000_000,
         };
 
+        public HealthBar HealthDisplay { get; private set; } = null!;
+
         private readonly APIUser user;
         private readonly Anchor contentAnchor;
         private readonly RankedPlayColourScheme colourScheme;
 
         private BufferedContainer grayScaleContainer = null!;
-
         private OsuSpriteText beatmapState = null!;
+        private OsuSpriteText damageMultiplierText = null!;
 
         private BeatmapAvailability availability = BeatmapAvailability.Unknown();
 
@@ -69,6 +74,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             var beatmapStateAnchor = (contentAnchor & Anchor.x0) != 0
                 ? Anchor.CentreLeft
                 : Anchor.CentreRight;
+
+            var damageMultiplierAnchor = (contentAnchor & Anchor.x0) != 0
+                ? Anchor.CentreRight
+                : Anchor.CentreLeft;
 
             InternalChildren =
             [
@@ -104,6 +113,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                     Direction = FillDirection.Vertical,
                     Children =
                     [
+                        new Container
+                        {
+                            Anchor = contentAnchor,
+                            Origin = contentAnchor,
+                            RelativeSizeAxes = Axes.X,
+                            Height = 16,
+                            Padding = new MarginPadding { Horizontal = 4, Vertical = 6 },
+                            Child = damageMultiplierText = new OsuSpriteText
+                            {
+                                Anchor = damageMultiplierAnchor,
+                                Origin = damageMultiplierAnchor,
+                                Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
+                                UseFullGlyphHeight = false,
+                            }
+                        },
                         HealthDisplay = new HealthBar(colourScheme, (contentAnchor & Anchor.x0) != 0, shear)
                         {
                             Health = { BindTarget = Health },
@@ -145,8 +169,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             ];
         }
 
-        public HealthBar HealthDisplay { get; private set; } = null!;
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -158,9 +180,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             });
 
             client.RoomUpdated += onRoomUpdated;
+            onRoomUpdated();
         }
 
         private void onRoomUpdated()
+        {
+            updateBeatmapState();
+            updateDamageMultiplier();
+        }
+
+        private void updateBeatmapState()
         {
             var multiplayerUser = client.Room?.Users.SingleOrDefault(u => u.UserID == user.Id);
 
@@ -189,6 +218,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                     beatmapState.Text = "Importing...";
                     break;
             }
+        }
+
+        private void updateDamageMultiplier()
+        {
+            var userInfo = (client.Room?.MatchState as RankedPlayRoomState)?.Users.GetValueOrDefault(user.Id);
+
+            if (userInfo == null)
+                return;
+
+            damageMultiplierText.Text = $"{userInfo.DamageMultiplier.ToStandardFormattedString(maxDecimalDigits: 1)}x damage";
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -249,7 +249,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 if (screen.ShowStageOverlay)
                 {
                     APIUser? pickingUser = null;
-                    double? multiplier = matchInfo.Stage.Value < RankedPlayStage.CardPlay ? null : matchInfo.RoomState.DamageMultiplier;
                     RankedPlayColourScheme colourScheme = RankedPlayColourScheme.BLUE;
 
                     if (matchInfo.Stage.Value == RankedPlayStage.CardPlay && matchInfo.RoomState.ActiveUser != null)
@@ -261,7 +260,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     stageOverlayContainer.Add(new RankedPlayStageOverlay(screen.StageHeading, colourScheme)
                     {
                         PickingUser = pickingUser,
-                        Multiplier = multiplier,
                     });
 
                     rankedPlayBackground.ColourScheme = colourScheme;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayStageOverlay.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
-using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
@@ -25,7 +24,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private readonly RankedPlayColourScheme colourScheme;
 
         public APIUser? PickingUser { get; init; }
-        public double? Multiplier { get; init; }
 
         private FillFlowContainer displayContainer = null!;
         private FillFlowContainer detailsContainer = null!;
@@ -148,18 +146,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             Colour = colourScheme.Primary,
                         },
                     },
-                });
-            }
-
-            if (Multiplier != null)
-            {
-                detailsContainer.Add(new OsuSpriteText
-                {
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
-                    UseFullGlyphHeight = false,
-                    Font = OsuFont.Torus.With(size: 32),
-                    Text = $"{Multiplier.Value.ToStandardFormattedString(maxDecimalDigits: 1)}x damage",
                 });
             }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -61,7 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             private OsuSpriteText flyingDamageText = null!;
 
             private FillFlowContainer damageBreakdownContainer = null!;
-            private OsuSpriteText damageBreakdownDamageText = null!;
+            private OsuSpriteText damageBreakdownValueText = null!;
             private OsuSpriteText damageBreakdownSourceText = null!;
 
             private ScoreBar playerScoreBar = null!;
@@ -303,7 +304,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                 Alpha = 0,
                                 Children =
                                 [
-                                    damageBreakdownDamageText = new OsuSpriteText
+                                    damageBreakdownValueText = new OsuSpriteText
                                     {
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.Centre,
@@ -405,17 +406,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     playerScoreCounter.TransformValueTo(PlayerScore.TotalScore, score_text_duration - 500);
                     opponentScoreCounter.TransformValueTo(OpponentScore.TotalScore, score_text_duration - 500);
 
-                    int attackDamage;
-
-                    if (losingDamageInfo.Sources.Count == 0)
-                    {
-                        // This fallback only exists for if the client and server are slightly out-of-date. It can be removed momentarily.
-                        attackDamage = losingDamageInfo.Damage;
-                    }
-                    else
-                        attackDamage = losingDamageInfo.Sources.SingleOrDefault(b => b.Type == RankedPlayDamageType.Attack)?.Damage ?? 0;
-
-                    damageCounter.TransformValueTo(attackDamage, score_text_duration - 500);
+                    damageCounter.TransformValueTo(losingDamageInfo.DirectDamage, score_text_duration - 500);
 
                     long maxAchievableScore = Math.Max(
                         Math.Max(PlayerScore.TotalScore, OpponentScore.TotalScore),
@@ -504,32 +495,34 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                 delay += 800;
 
-                bool displayedBreakdown = false;
+                List<(int rawDamage, string displayValue, string source)> damageBreakdowns = [];
 
-                foreach (var breakdown in losingDamageInfo.Sources)
+                if (!Precision.AlmostEquals(1, losingDamageInfo.Multiplier))
                 {
-                    if (breakdown.Type == RankedPlayDamageType.Attack)
-                    {
-                        // Displayed as part of the initial animation.
-                        continue;
-                    }
+                    damageBreakdowns.Add((
+                        (int)Math.Ceiling(losingDamageInfo.DirectDamage * (losingDamageInfo.Multiplier - 1)),
+                        $"x{losingDamageInfo.Multiplier.ToStandardFormattedString(maxDecimalDigits: 1)}",
+                        "multiplier"
+                    ));
+                }
 
+                if (losingDamageInfo.BonusDamage != 0)
+                {
+                    damageBreakdowns.Add((
+                        losingDamageInfo.BonusDamage,
+                        $"{losingDamageInfo.BonusDamage:+#,##0;-#,##0}",
+                        "bonus"
+                    ));
+                }
+
+                foreach (var breakdown in damageBreakdowns)
+                {
                     using (BeginDelayedSequence(delay))
                     {
                         Schedule(() =>
                         {
-                            switch (breakdown.Type)
-                            {
-                                case RankedPlayDamageType.Multiplier:
-                                    damageBreakdownDamageText.Text = $"x{breakdown.RawValue.ToStandardFormattedString(maxDecimalDigits: 1)}";
-                                    damageBreakdownSourceText.Text = "multiplier";
-                                    break;
-
-                                case RankedPlayDamageType.Bonus:
-                                    damageBreakdownDamageText.Text = $"+{breakdown.Damage:N0}";
-                                    damageBreakdownSourceText.Text = "bonus";
-                                    break;
-                            }
+                            damageBreakdownValueText.Text = breakdown.displayValue;
+                            damageBreakdownSourceText.Text = breakdown.source;
                         });
 
                         damageBreakdownContainer.MoveToX(120)
@@ -542,7 +535,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                             Schedule(() =>
                             {
-                                damageCounter.SetValueInstantly(damageCounter.Value + breakdown.Damage);
+                                damageCounter.SetValueInstantly(damageCounter.Value + breakdown.rawDamage);
                                 damageCounter
                                     .ScaleTo(new Vector2(1.25f), 200, Easing.OutQuint)
                                     .Then()
@@ -552,10 +545,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     }
 
                     delay += 1400;
-                    displayedBreakdown = true;
                 }
 
-                if (displayedBreakdown)
+                if (damageBreakdowns.Count > 0)
                     delay += 600;
 
                 bool playerTookDamage = OpponentScore.TotalScore > PlayerScore.TotalScore;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             private RankedPlayMatchInfo matchInfo { get; set; } = null!;
 
             [Resolved]
-            private OsuColour colour { get; set; } = null!;
+            private OsuColour colours { get; set; } = null!;
 
             private static Vector2 cardSize => new Vector2(950, 550);
 
@@ -59,6 +59,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             private RankedPlayScoreCounter opponentScoreCounter = null!;
             private RankedPlayScoreCounter damageCounter = null!;
             private OsuSpriteText flyingDamageText = null!;
+
+            private FillFlowContainer damageBreakdownContainer = null!;
+            private OsuSpriteText damageBreakdownDamageText = null!;
+            private OsuSpriteText damageBreakdownSourceText = null!;
+
             private ScoreBar playerScoreBar = null!;
             private ScoreBar opponentScoreBar = null!;
             private OsuSpriteText roundNumber = null!;
@@ -287,24 +292,35 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                         BypassAutoSizeAxes = Axes.Both,
                                         Alpha = 0,
                                     },
-                                    new OsuSpriteText
+                                ]
+                            },
+                            damageBreakdownContainer = new FillFlowContainer
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(-5),
+                                Alpha = 0,
+                                Children =
+                                [
+                                    damageBreakdownDamageText = new OsuSpriteText
                                     {
-                                        BypassAutoSizeAxes = Axes.Both,
-                                        Text = $"{matchInfo.RoomState.DamageMultiplier.ToStandardFormattedString(maxDecimalDigits: 1)}x",
-                                        Anchor = Anchor.CentreRight,
+                                        Anchor = Anchor.Centre,
                                         Origin = Anchor.Centre,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 42),
-                                        Rotation = 30,
-                                        Alpha = 0,
-                                        Colour = colour.RedLight
+                                        Font = OsuFont.GetFont(size: 22, weight: FontWeight.SemiBold),
+                                        Colour = colours.Yellow
                                     },
+                                    damageBreakdownSourceText = new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Font = OsuFont.GetFont(size: 16),
+                                    }
                                 ]
                             },
                             new OsuSpriteText
                             {
-                                Text = Precision.AlmostEquals(matchInfo.RoomState.DamageMultiplier, 1)
-                                    ? "Damage"
-                                    : $"Damage {matchInfo.RoomState.DamageMultiplier.ToStandardFormattedString(maxDecimalDigits: 1)}x",
+                                Text = "Damage",
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.Centre,
                                 Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 22),
@@ -389,7 +405,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     playerScoreCounter.TransformValueTo(PlayerScore.TotalScore, score_text_duration - 500);
                     opponentScoreCounter.TransformValueTo(OpponentScore.TotalScore, score_text_duration - 500);
 
-                    damageCounter.TransformValueTo(losingDamageInfo.Damage, score_text_duration - 500);
+                    int attackDamage;
+
+                    if (losingDamageInfo.Sources.Count == 0)
+                    {
+                        // This fallback only exists for if the client and server are slightly out-of-date. It can be removed momentarily.
+                        attackDamage = losingDamageInfo.Damage;
+                    }
+                    else
+                        attackDamage = losingDamageInfo.Sources.SingleOrDefault(b => b.Type == RankedPlayDamageType.Attack)?.Damage ?? 0;
+
+                    damageCounter.TransformValueTo(attackDamage, score_text_duration - 500);
 
                     long maxAchievableScore = Math.Max(
                         Math.Max(PlayerScore.TotalScore, OpponentScore.TotalScore),
@@ -477,6 +503,60 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 }
 
                 delay += 800;
+
+                bool displayedBreakdown = false;
+
+                foreach (var breakdown in losingDamageInfo.Sources)
+                {
+                    if (breakdown.Type == RankedPlayDamageType.Attack)
+                    {
+                        // Displayed as part of the initial animation.
+                        continue;
+                    }
+
+                    using (BeginDelayedSequence(delay))
+                    {
+                        Schedule(() =>
+                        {
+                            switch (breakdown.Type)
+                            {
+                                case RankedPlayDamageType.Multiplier:
+                                    damageBreakdownDamageText.Text = $"x{breakdown.RawValue.ToStandardFormattedString(maxDecimalDigits: 1)}";
+                                    damageBreakdownSourceText.Text = "multiplier";
+                                    break;
+
+                                case RankedPlayDamageType.Bonus:
+                                    damageBreakdownDamageText.Text = $"+{breakdown.Damage:N0}";
+                                    damageBreakdownSourceText.Text = "bonus";
+                                    break;
+                            }
+                        });
+
+                        damageBreakdownContainer.MoveToX(120)
+                                                .FadeInFromZero(400);
+
+                        using (BeginDelayedSequence(1000))
+                        {
+                            damageBreakdownContainer.MoveTo(Vector2.Zero, 400, Easing.OutQuint)
+                                                    .FadeOut(200, Easing.OutQuint);
+
+                            Schedule(() =>
+                            {
+                                damageCounter.SetValueInstantly(damageCounter.Value + breakdown.Damage);
+                                damageCounter
+                                    .ScaleTo(new Vector2(1.25f), 200, Easing.OutQuint)
+                                    .Then()
+                                    .ScaleTo(Vector2.One, 200);
+                            });
+                        }
+                    }
+
+                    delay += 1400;
+                    displayedBreakdown = true;
+                }
+
+                if (displayedBreakdown)
+                    delay += 600;
 
                 bool playerTookDamage = OpponentScore.TotalScore > PlayerScore.TotalScore;
                 double loserPanDirection = playerTookDamage ? -OsuGameBase.SFX_STEREO_STRENGTH : OsuGameBase.SFX_STEREO_STRENGTH;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.MainPanel.cs
@@ -500,7 +500,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 if (!Precision.AlmostEquals(1, losingDamageInfo.Multiplier))
                 {
                     damageBreakdowns.Add((
-                        (int)Math.Ceiling(losingDamageInfo.DirectDamage * (losingDamageInfo.Multiplier - 1)),
+                        (int)Math.Ceiling(losingDamageInfo.DirectDamage * losingDamageInfo.Multiplier) - losingDamageInfo.DirectDamage,
                         $"x{losingDamageInfo.Multiplier.ToStandardFormattedString(maxDecimalDigits: 1)}",
                         "multiplier"
                     ));


### PR DESCRIPTION
- Added a small breakdown animation to the results screen.
- Added individual multiplier text to user corner pieces.
- Removed global multiplier text from the stage overlay, since we're going with individual multipliers.

https://github.com/user-attachments/assets/47cec478-6ad5-49fa-9f69-b6df079ce41c

(This is dev design and I'm focusing on functionality rather than presentation for now.)

The implementation might be over-engineered a bit, but I'm not sure on the final structure of things and I want to give a bit of elasticity to the system, so I've frankensteined a new "damage sources" list inside `RankedPlayDamageInfo` that the results screen uses to display the breakdown.

If the server doesn't provide a breakdown (e.g. by client and server being slightly out-of-date), the results screen will behave as it does on current `master`. In other words this is forwards/backwards compatible.