### PR TITLE
Add client-side support for slots in multiplayer rooms

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -1206,6 +1206,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("style selection screen closed", () => this.ChildrenOfType<MultiplayerMatchFreestyleSelect>().SingleOrDefault()?.IsCurrentScreen() != true);
         }
 
+        [Test]
+        public void TestMaxParticipantsAndSlots()
+        {
+            createRoom(() => new Room
+            {
+                Name = "Test Room",
+                Password = "password",
+                Playlist =
+                [
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
+                    {
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                    }
+                ],
+                MaxParticipants = 10
+            });
+
+            AddStep("turn max participants off", () => multiplayerClient.ChangeSettings(maxParticipants: null));
+            AddStep("turn max participants back on", () => multiplayerClient.ChangeSettings(maxParticipants: 8));
+        }
+
         private void enterGameplay()
         {
             pressReadyButton();

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -56,6 +57,68 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
+        public void TestSlots()
+        {
+            setUpList();
+            AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.Current.Value).Distinct().Count() == 1);
+
+            AddStep("add user", () => MultiplayerClient.AddUser(new APIUser
+            {
+                Id = 3,
+                Username = "Second",
+                CoverUrl = TestResources.COVER_IMAGE_3,
+            }));
+
+            AddAssert("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.Current.Value).Distinct().Count() == 2);
+
+            AddStep("introduce slots", () => MultiplayerClient.ChangeMatchRoomState(new StandardMatchRoomState
+            {
+                Slots = [null, 3, null, null, 1001, null, null]
+            }).WaitSafely());
+
+            AddStep("click first slot", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ParticipantPanel>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("slots changed", () => ((StandardMatchRoomState)MultiplayerClient.ClientRoom!.MatchState!).Slots,
+                () => Is.EquivalentTo(new int?[] { 1001, 3, null, null, null, null, null }));
+
+            AddStep("click second slot", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ParticipantPanel>().ElementAt(1));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("slots not changed", () => ((StandardMatchRoomState)MultiplayerClient.ClientRoom!.MatchState!).Slots,
+                () => Is.EquivalentTo(new int?[] { 1001, 3, null, null, null, null, null }));
+
+            AddStep("click last slot", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ParticipantPanel>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("slots changed", () => ((StandardMatchRoomState)MultiplayerClient.ClientRoom!.MatchState!).Slots,
+                () => Is.EquivalentTo(new int?[] { null, 3, null, null, null, null, 1001 }));
+
+            AddStep("shuffle slots", () => MultiplayerClient.ChangeMatchRoomState(new StandardMatchRoomState
+            {
+                Slots = [null, null, 1001, null, null, null, 3]
+            }).WaitSafely());
+            AddStep("remove slots", () => MultiplayerClient.ChangeMatchRoomState(new StandardMatchRoomState
+            {
+                Slots = [null, 3, null, 1001]
+            }).WaitSafely());
+            AddStep("add slots", () => MultiplayerClient.ChangeMatchRoomState(new StandardMatchRoomState
+            {
+                Slots = [null, null, 3, null, 1001, null]
+            }).WaitSafely());
+            AddStep("turn off slots", () => MultiplayerClient.ChangeMatchRoomState(new StandardMatchRoomState
+            {
+                Slots = null
+            }).WaitSafely());
+        }
+
+        [Test]
         public void TestAddReferee()
         {
             setUpList();
@@ -86,7 +149,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.Current.Value).Distinct().Count() == 2);
 
-            AddStep("kick null user", () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.User == null)
+            AddStep("kick null user", () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.User?.User == null)
                                                 .ChildrenOfType<ParticipantPanel.KickButton>().Single().TriggerClick());
 
             AddUntilStep("null user kicked", () => MultiplayerClient.ClientRoom.AsNonNull().Users.Count == 1);
@@ -111,7 +174,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("remove host", () => MultiplayerClient.RemoveUser(API.LocalUser.Value));
 
-            AddAssert("single panel is for second user", () => this.ChildrenOfType<ParticipantPanel>().Single().Current.Value.UserID == secondUser?.Id);
+            AddAssert("single panel is for second user", () => this.ChildrenOfType<ParticipantPanel>().Single().Current.Value.User?.UserID == secondUser?.Id);
         }
 
         [Test]
@@ -150,7 +213,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddRepeatStep("increment progress", () =>
             {
-                float progress = this.ChildrenOfType<ParticipantPanel>().Single().Current.Value.BeatmapAvailability.DownloadProgress ?? 0;
+                float progress = this.ChildrenOfType<ParticipantPanel>().Single().Current.Value.User?.BeatmapAvailability.DownloadProgress ?? 0;
                 MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(progress + RNG.NextSingle(0.1f)));
             }, 25);
 
@@ -195,16 +258,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
             }));
 
             AddUntilStep("first user crown visible",
-                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 1001).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.User?.UserID == 1001).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
             AddUntilStep("second user crown hidden",
-                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 3).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.User?.UserID == 3).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
 
             AddStep("make second user host", () => MultiplayerClient.TransferHost(3));
 
             AddUntilStep("first user crown visible",
-                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 1001).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.User?.UserID == 1001).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
             AddUntilStep("second user crown hidden",
-                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.UserID == 3).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
+                () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.Current.Value.User?.UserID == 3).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
         }
 
         [Test]
@@ -221,8 +284,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("make second user host", () => MultiplayerClient.TransferHost(3));
             AddAssert("second user above first", () =>
             {
-                var first = this.ChildrenOfType<ParticipantPanel>().Single(u => u.Current.Value.UserID == 1001);
-                var second = this.ChildrenOfType<ParticipantPanel>().Single(u => u.Current.Value.UserID == 3);
+                var first = this.ChildrenOfType<ParticipantPanel>().Single(u => u.Current.Value.User?.UserID == 1001);
+                var second = this.ChildrenOfType<ParticipantPanel>().Single(u => u.Current.Value.User?.UserID == 3);
                 return second.ScreenSpaceDrawQuad.TopLeft.Y < first.ScreenSpaceDrawQuad.TopLeft.Y;
             });
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -179,6 +179,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
+        public void TestSetAndUnsetMaxParticipants()
+        {
+            RoomPanel panel = null!;
+            Room room = null!;
+
+            AddStep("create room", () => Child = panel = createLoungeRoom(room = new Room
+            {
+                Name = "A room",
+                Type = MatchType.HeadToHead,
+            }));
+
+            AddUntilStep("wait for panel load", () => panel.ChildrenOfType<DrawableRoomParticipantsList>().Any());
+            AddStep("set max participants", () => room.MaxParticipants = 5);
+            AddStep("unset max participants", () => room.MaxParticipants = null);
+        }
+
+        [Test]
         public void TestMultiplayerRooms()
         {
             AddStep("create rooms", () => Child = new FillFlowContainer

--- a/osu.Game/Online/Multiplayer/ChangeSlotRequest.cs
+++ b/osu.Game/Online/Multiplayer/ChangeSlotRequest.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MessagePack;
+
+namespace osu.Game.Online.Multiplayer
+{
+    /// <summary>
+    /// User requests to change their slot in the room.
+    /// </summary>
+    [MessagePackObject]
+    public class ChangeSlotRequest : MatchUserRequest
+    {
+        /// <summary>
+        /// The zero-based ID of the desired slot.
+        /// </summary>
+        [Key(0)]
+        public byte SlotID { get; set; }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchRoomState.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Online.Multiplayer
     [Union(0, typeof(TeamVersusRoomState))] // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
     [Union(1, typeof(MatchmakingRoomState))]
     [Union(2, typeof(RankedPlayRoomState))]
+    [Union(3, typeof(StandardMatchRoomState))]
     public abstract class MatchRoomState
     {
     }

--- a/osu.Game/Online/Multiplayer/MatchTypes/TeamVersus/TeamVersusRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/TeamVersus/TeamVersusRoomState.cs
@@ -7,13 +7,10 @@ using MessagePack;
 namespace osu.Game.Online.Multiplayer.MatchTypes.TeamVersus
 {
     [MessagePackObject]
-    public class TeamVersusRoomState : MatchRoomState
+    public class TeamVersusRoomState : StandardMatchRoomState
     {
         [Key(0)]
         public List<MultiplayerTeam> Teams { get; set; } = new List<MultiplayerTeam>();
-
-        [Key(1)]
-        public bool Locked { get; set; }
 
         public static TeamVersusRoomState CreateDefault() =>
             new TeamVersusRoomState

--- a/osu.Game/Online/Multiplayer/MatchTypes/TeamVersus/TeamVersusRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/TeamVersus/TeamVersusRoomState.cs
@@ -12,14 +12,15 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.TeamVersus
         [Key(0)]
         public List<MultiplayerTeam> Teams { get; set; } = new List<MultiplayerTeam>();
 
-        public static TeamVersusRoomState CreateDefault() =>
+        public static TeamVersusRoomState CreateDefault(byte? maxParticipants = null) =>
             new TeamVersusRoomState
             {
                 Teams =
                 {
                     new MultiplayerTeam { ID = 0, Name = "Team Red" },
                     new MultiplayerTeam { ID = 1, Name = "Team Blue" },
-                }
+                },
+                Slots = maxParticipants == null ? null : new int?[maxParticipants.Value]
             };
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchUserRequest.cs
+++ b/osu.Game/Online/Multiplayer/MatchUserRequest.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Online.Multiplayer
     [Union(4, typeof(RankedPlayCardHandReplayRequest))]
     [Union(5, typeof(SetLockStateRequest))]
     [Union(6, typeof(RollRequest))]
+    [Union(7, typeof(ChangeSlotRequest))]
     public abstract class MatchUserRequest
     {
     }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -403,8 +403,9 @@ namespace osu.Game.Online.Multiplayer
         /// <param name="queueMode">The new queue mode, if any.</param>
         /// <param name="autoStartDuration">The new auto-start countdown duration, if any.</param>
         /// <param name="autoSkip">The new auto-skip setting.</param>
+        /// <param name="maxParticipants">The new participant count limit, if any.</param>
         public Task ChangeSettings(Optional<string> name = default, Optional<string> password = default, Optional<MatchType> matchType = default, Optional<QueueMode> queueMode = default,
-                                   Optional<TimeSpan> autoStartDuration = default, Optional<bool> autoSkip = default)
+                                   Optional<TimeSpan> autoStartDuration = default, Optional<bool> autoSkip = default, Optional<byte?> maxParticipants = default)
         {
             if (Room == null)
                 throw new InvalidOperationException("Must be joined to a match to change settings.");
@@ -416,7 +417,8 @@ namespace osu.Game.Online.Multiplayer
                 MatchType = matchType.GetOr(Room.Settings.MatchType),
                 QueueMode = queueMode.GetOr(Room.Settings.QueueMode),
                 AutoStartDuration = autoStartDuration.GetOr(Room.Settings.AutoStartDuration),
-                AutoSkip = autoSkip.GetOr(Room.Settings.AutoSkip)
+                AutoSkip = autoSkip.GetOr(Room.Settings.AutoSkip),
+                MaxParticipants = maxParticipants.GetOr(Room.Settings.MaxParticipants),
             });
         }
 

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Online.Multiplayer
         [Key(6)]
         public bool AutoSkip { get; set; }
 
+        [Key(7)]
+        public byte? MaxParticipants { get; set; }
+
         [IgnoreMember]
         public bool AutoStartEnabled => AutoStartDuration != TimeSpan.Zero;
 
@@ -47,6 +50,7 @@ namespace osu.Game.Online.Multiplayer
             QueueMode = room.QueueMode;
             AutoStartDuration = room.AutoStartDuration;
             AutoSkip = room.AutoSkip;
+            MaxParticipants = room.MaxParticipants;
         }
 
         public bool Equals(MultiplayerRoomSettings? other)
@@ -60,7 +64,8 @@ namespace osu.Game.Online.Multiplayer
                    && MatchType == other.MatchType
                    && QueueMode == other.QueueMode
                    && AutoStartDuration == other.AutoStartDuration
-                   && AutoSkip == other.AutoSkip;
+                   && AutoSkip == other.AutoSkip
+                   && MaxParticipants == other.MaxParticipants;
         }
 
         public override string ToString() => $"Name:{Name}"
@@ -69,6 +74,7 @@ namespace osu.Game.Online.Multiplayer
                                              + $" Item:{PlaylistItemId}"
                                              + $" Queue:{QueueMode}"
                                              + $" Start:{AutoStartDuration}"
-                                             + $" AutoSkip:{AutoSkip}";
+                                             + $" AutoSkip:{AutoSkip}"
+                                             + $" MaxParticipants:{MaxParticipants?.ToString() ?? "no limit"}";
     }
 }

--- a/osu.Game/Online/Multiplayer/SetLockStateRequest.cs
+++ b/osu.Game/Online/Multiplayer/SetLockStateRequest.cs
@@ -10,14 +10,13 @@ namespace osu.Game.Online.Multiplayer
     {
         /// <summary>
         /// <para>
-        /// If <see langword="true"/>, <see cref="MultiplayerRoomUserRole.Player"/>s will not be able to change teams by themselves in the room,
+        /// If <see langword="true"/>, <see cref="MultiplayerRoomUserRole.Player"/>s will not be able to change teams and slots by themselves in the room,
         /// only <see cref="MultiplayerRoomUserRole.Referee"/>s will be able to change teams for the <see cref="MultiplayerRoomUserRole.Player"/>s.
         /// </para>
         /// <para>
-        /// If <see langword="false"/>, any user can change their team in the room.
+        /// If <see langword="false"/>, any user can change their team and slot in the room.
         /// </para>
         /// </summary>
-        // TODO: mention slots as well when slots are reimplemented
         [Key(0)]
         public bool Locked { get; set; }
     }

--- a/osu.Game/Online/Multiplayer/StandardMatchRoomState.cs
+++ b/osu.Game/Online/Multiplayer/StandardMatchRoomState.cs
@@ -29,5 +29,11 @@ namespace osu.Game.Online.Multiplayer
         /// </summary>
         [Key(2)]
         public int?[]? Slots { get; set; }
+
+        public static StandardMatchRoomState Create(byte? maxParticipants = null) =>
+            new StandardMatchRoomState
+            {
+                Slots = maxParticipants == null ? null : new int?[maxParticipants.Value]
+            };
     }
 }

--- a/osu.Game/Online/Multiplayer/StandardMatchRoomState.cs
+++ b/osu.Game/Online/Multiplayer/StandardMatchRoomState.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MessagePack;
+
+namespace osu.Game.Online.Multiplayer
+{
+    [MessagePackObject]
+    public class StandardMatchRoomState : MatchRoomState
+    {
+        /// <summary>
+        /// Whether the room is currently locked.
+        /// When locked, changes to slots (and teams, in team versus) cannot be performed by anyone but room referees.
+        /// </summary>
+        [Key(1)]
+        public bool Locked { get; set; }
+
+        /// <summary>
+        /// The state of slots in the room.
+        /// Linked to <see cref="MultiplayerRoomSettings.MaxParticipants"/>.
+        /// <list type="bullet">
+        /// <item>When <see cref="MultiplayerRoomSettings.MaxParticipants"/> is <see langword="null"/>, this property is also <see langword="null"/>.</item>
+        /// <item>
+        /// When <see cref="MultiplayerRoomSettings.MaxParticipants"/> is not <see langword="null"/>, this property is an array of that length.
+        /// The items of that array represent either an empty slot (represented by <see langword="null"/>),
+        /// or an user occupying that slot (represented by the ID of the relevant user).
+        /// </item>
+        /// </list>
+        /// </summary>
+        [Key(2)]
+        public int?[]? Slots { get; set; }
+    }
+}

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Online.Rooms
         /// <summary>
         /// The maximum number of users allowed in the room.
         /// </summary>
-        public int? MaxParticipants
+        public byte? MaxParticipants
         {
             get => maxParticipants;
             set => SetField(ref maxParticipants, value);
@@ -297,8 +297,8 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("ends_at")]
         private DateTimeOffset? endDate;
 
-        // Not yet serialised (not implemented).
-        private int? maxParticipants;
+        [JsonProperty("max_participants")]
+        private byte? maxParticipants;
 
         [JsonProperty("participant_count")]
         private int participantCount;
@@ -365,6 +365,7 @@ namespace osu.Game.Online.Rooms
             QueueMode = room.Settings.QueueMode;
             AutoStartDuration = room.Settings.AutoStartDuration;
             AutoSkip = room.Settings.AutoSkip;
+            MaxParticipants = room.Settings.MaxParticipants;
             Host = room.Host != null ? new APIUser { Id = room.Host.UserID } : null;
             Playlist = room.Playlist.Select(p => new PlaylistItem(p)).ToArray();
         }

--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Online
         internal static readonly IReadOnlyList<(Type derivedType, Type baseType)> BASE_TYPE_MAPPING = new[]
         {
             // multiplayer
+            (typeof(ChangeSlotRequest), typeof(MatchUserRequest)),
             (typeof(ChangeTeamRequest), typeof(MatchUserRequest)),
             (typeof(StartMatchCountdownRequest), typeof(MatchUserRequest)),
             (typeof(StopCountdownRequest), typeof(MatchUserRequest)),
@@ -32,6 +33,7 @@ namespace osu.Game.Online
             (typeof(CountdownStartedEvent), typeof(MatchServerEvent)),
             (typeof(CountdownStoppedEvent), typeof(MatchServerEvent)),
             (typeof(RollEvent), typeof(MatchServerEvent)),
+            (typeof(StandardMatchRoomState), typeof(MatchRoomState)),
             (typeof(TeamVersusRoomState), typeof(MatchRoomState)),
             (typeof(TeamVersusUserState), typeof(MatchUserState)),
             (typeof(MatchStartCountdown), typeof(MultiplayerCountdown)),

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoomParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoomParticipantsList.cs
@@ -262,6 +262,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     break;
 
                 case nameof(Room.ParticipantCount):
+                case nameof(Room.MaxParticipants):
                     updateRoomParticipantCount();
                     break;
 
@@ -286,7 +287,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         private void updateRoomParticipantCount()
         {
             updateHiddenUsers();
-            totalCount.Text = room.ParticipantCount.ToString();
+            totalCount.Text = room.MaxParticipants == null ? room.ParticipantCount.ToString() : $@"{room.ParticipantCount} / {room.MaxParticipants}";
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -52,8 +52,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
         protected partial class MatchSettings : CompositeDrawable
         {
-            private const float disabled_alpha = 0.2f;
-
             public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
 
             public Action? SettingsApplied;
@@ -223,12 +221,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                             {
                                                                 new Section("Max participants")
                                                                 {
-                                                                    Alpha = disabled_alpha,
                                                                     Child = MaxParticipantsField = new OsuNumberBox
                                                                     {
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,
-                                                                        ReadOnly = true,
+                                                                        PlaceholderText = "No limit"
                                                                     },
                                                                 },
                                                                 new Section("Password (optional)")
@@ -442,6 +439,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 if (!ApplyButton.Enabled.Value)
                     return;
 
+                byte? maxParticipants = !string.IsNullOrWhiteSpace(MaxParticipantsField.Text) && byte.TryParse(MaxParticipantsField.Text, out byte max) ? max : null;
+
                 ErrorText.FadeOut(50);
 
                 Debug.Assert(applyingSettingsOperation == null);
@@ -457,7 +456,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                               matchType: TypePicker.Current.Value,
                               queueMode: QueueModeDropdown.Current.Value,
                               autoStartDuration: TimeSpan.FromSeconds((int)startModeDropdown.Current.Value),
-                              autoSkip: AutoSkipCheckbox.Current.Value)
+                              autoSkip: AutoSkipCheckbox.Current.Value,
+                              maxParticipants: maxParticipants)
                           .ContinueWith(t => Schedule(() =>
                           {
                               if (t.IsCompletedSuccessfully)
@@ -475,6 +475,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     room.AutoStartDuration = TimeSpan.FromSeconds((int)startModeDropdown.Current.Value);
                     room.AutoSkip = AutoSkipCheckbox.Current.Value;
                     room.Playlist = drawablePlaylist.Items.ToArray();
+                    room.MaxParticipants = maxParticipants;
 
                     client.CreateRoom(room).ContinueWith(t => Schedule(() =>
                     {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -57,7 +57,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             public Action? SettingsApplied;
 
             public OsuTextBox NameField = null!;
-            public OsuTextBox MaxParticipantsField = null!;
+            private FormSliderBar<byte> maximumParticipantsSliderBar = null!;
+            private FormCheckBox maximumParticipantsCheckbox = null!;
             public MatchTypePicker TypePicker = null!;
             public OsuEnumDropdown<QueueMode> QueueModeDropdown = null!;
             public OsuTextBox PasswordTextBox = null!;
@@ -219,13 +220,26 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                             Padding = new MarginPadding { Left = FIELD_PADDING / 2 },
                                                             Children = new[]
                                                             {
-                                                                new Section("Max participants")
+                                                                new Section("Player count")
                                                                 {
-                                                                    Child = MaxParticipantsField = new OsuNumberBox
+                                                                    Children = new Drawable[]
                                                                     {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        TabbableContentContainer = this,
-                                                                        PlaceholderText = "No limit"
+                                                                        maximumParticipantsCheckbox = new FormCheckBox
+                                                                        {
+                                                                            Caption = "Limited slots",
+                                                                            HintText = "When enabled, total players allowed in a room will be limited. Unlimited when disabled."
+                                                                        },
+                                                                        maximumParticipantsSliderBar = new FormSliderBar<byte>
+                                                                        {
+                                                                            Caption = "Slot count",
+                                                                            RelativeSizeAxes = Axes.X,
+                                                                            Margin = new MarginPadding { Top = 5 },
+                                                                            Current = new BindableNumber<byte>(16)
+                                                                            {
+                                                                                MinValue = 2,
+                                                                                MaxValue = 16,
+                                                                            }
+                                                                        },
                                                                     },
                                                                 },
                                                                 new Section("Password (optional)")
@@ -362,6 +376,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 updateRoomMaxParticipants();
                 updateRoomAutoStartDuration();
                 updateRoomPlaylist();
+
+                maximumParticipantsCheckbox.Current.BindValueChanged(enabled =>
+                {
+                    maximumParticipantsSliderBar.Alpha = enabled.NewValue ? 1 : 0;
+                }, true);
             }
 
             private void onRoomPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -418,7 +437,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 => AutoSkipCheckbox.Current.Value = room.AutoSkip;
 
             private void updateRoomMaxParticipants()
-                => MaxParticipantsField.Text = room.MaxParticipants?.ToString();
+            {
+                if (room.MaxParticipants.HasValue)
+                {
+                    maximumParticipantsCheckbox.Current.Value = true;
+                    maximumParticipantsSliderBar.Current.Value = room.MaxParticipants.Value;
+                }
+                else
+                    maximumParticipantsCheckbox.Current.Value = false;
+            }
 
             private void updateRoomAutoStartDuration()
                 => startModeDropdown.Current.Value = (StartMode)room.AutoStartDuration.TotalSeconds;
@@ -439,7 +466,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 if (!ApplyButton.Enabled.Value)
                     return;
 
-                byte? maxParticipants = !string.IsNullOrWhiteSpace(MaxParticipantsField.Text) && byte.TryParse(MaxParticipantsField.Text, out byte max) ? max : null;
+                byte? maxParticipants = maximumParticipantsCheckbox.Current.Value ? maximumParticipantsSliderBar.Current.Value : null;
 
                 ErrorText.FadeOut(50);
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -21,6 +21,7 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Database;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
@@ -37,17 +38,17 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 {
-    public partial class ParticipantPanel : PoolableDrawable, IHasContextMenu, IHasCurrentValue<MultiplayerRoomUser>
+    public partial class ParticipantPanel : PoolableDrawable, IHasContextMenu, IHasCurrentValue<Slot>
     {
         public const int HEIGHT = 40;
 
-        public Bindable<MultiplayerRoomUser> Current
+        public Bindable<Slot> Current
         {
             get => current.Current;
             set => current.Current = value;
         }
 
-        private readonly BindableWithCurrent<MultiplayerRoomUser> current = new BindableWithCurrent<MultiplayerRoomUser>(new MultiplayerRoomUser(-1));
+        private readonly BindableWithCurrent<Slot> current = new BindableWithCurrent<Slot>(Slot.FromUser(new MultiplayerRoomUser(-1)));
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -61,6 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private SpriteIcon crown = null!;
 
         private UserCoverBackground userCover = null!;
+        private FillFlowContainer userContent = null!;
         private UpdateableAvatar userAvatar = null!;
         private UpdateableFlag userFlag = null!;
         private OsuSpriteText username = null!;
@@ -69,6 +71,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private StyleDisplayIcon userStyleDisplay = null!;
         private ModDisplay userModsDisplay = null!;
         private StateDisplay userStateDisplay = null!;
+        private ClickableContainer emptySlotMarker = null!;
 
         private IconButton kickButton = null!;
 
@@ -127,7 +130,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                     Width = 0.75f,
                                     Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0), Color4.White.Opacity(0.25f))
                                 },
-                                new FillFlowContainer
+                                userContent = new FillFlowContainer
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Spacing = new Vector2(10),
@@ -195,6 +198,18 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
                                     Margin = new MarginPadding { Right = 10 },
+                                },
+                                emptySlotMarker = new OsuClickableContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Child = new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Font = OsuFont.Style.Caption1,
+                                        Text = "(empty slot)"
+                                    },
+                                    Action = moveToSlot,
                                 }
                             }
                         },
@@ -204,7 +219,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Origin = Anchor.Centre,
                             Alpha = 0,
                             Margin = new MarginPadding(4),
-                            Action = () => client.KickUser(current.Value.UserID).FireAndForget(),
+                            Action = () =>
+                            {
+                                if (!current.Value.IsEmpty)
+                                    client.KickUser(current.Value.User!.UserID).FireAndForget();
+                            },
                         },
                     },
                 }
@@ -216,7 +235,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             base.PrepareForUse();
 
             client.RoomUpdated += onRoomUpdated;
-            updateUser();
+            Current.BindValueChanged(_ => updateUser(), true);
             FinishTransforms(true);
         }
 
@@ -236,18 +255,28 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             current.SetDefault();
         }
 
+        private const double fade_time = 50;
+
         private void updateUser()
         {
-            var user = current.Value.User;
+            userCover.FadeTo(current.Value.IsEmpty ? 0 : 1, fade_time);
+            userContent.FadeTo(current.Value.IsEmpty ? 0 : 1, fade_time);
+            emptySlotMarker.Enabled.Value = current.Value.IsEmpty;
+            emptySlotMarker.FadeTo(current.Value.IsEmpty ? 1 : 0, fade_time);
 
-            userCover.User = user;
-            userAvatar.User = user;
-            userFlag.CountryCode = user?.CountryCode ?? default;
-            teamFlagContainer.Child = new UpdateableTeamFlag(user?.Team)
+            if (!current.Value.IsEmpty)
             {
-                Size = new Vector2(40, 20),
-            };
-            username.Text = user?.Username ?? string.Empty;
+                var user = current.Value.User.User;
+
+                userCover.User = user;
+                userAvatar.User = user;
+                userFlag.CountryCode = user?.CountryCode ?? default;
+                teamFlagContainer.Child = new UpdateableTeamFlag(user?.Team)
+                {
+                    Size = new Vector2(40, 20),
+                };
+                username.Text = user?.Username ?? string.Empty;
+            }
 
             updateState();
         }
@@ -259,17 +288,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             if (client.Room == null || client.LocalUser == null)
                 return;
 
-            const double fade_time = 50;
+            var slot = current.Value;
 
-            var user = current.Value;
-
-            if (client.Room.GetCurrentItem() is MultiplayerPlaylistItem currentItem)
+            if (!slot.IsEmpty && client.Room.GetCurrentItem() is MultiplayerPlaylistItem currentItem)
             {
-                int userBeatmapId = user.BeatmapId ?? currentItem.BeatmapID;
-                int userRulesetId = user.RulesetId ?? currentItem.RulesetID;
+                int userBeatmapId = slot.User.BeatmapId ?? currentItem.BeatmapID;
+                int userRulesetId = slot.User.RulesetId ?? currentItem.RulesetID;
                 Ruleset? userRuleset = rulesets.GetRuleset(userRulesetId)?.CreateInstance();
 
-                int? currentModeRank = userRuleset == null ? null : user.User?.RulesetsStatistics?.GetValueOrDefault(userRuleset.ShortName)?.GlobalRank;
+                int? currentModeRank = userRuleset == null ? null : slot.User.User?.RulesetsStatistics?.GetValueOrDefault(userRuleset.ShortName)?.GlobalRank;
                 userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
                 if (userBeatmapId == currentItem.BeatmapID && userRulesetId == currentItem.RulesetID)
@@ -279,12 +306,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
                 // If the mods are updated at the end of the frame, the flow container will skip a reflow cycle: https://github.com/ppy/osu-framework/issues/4187
                 // This looks particularly jarring here, so re-schedule the update to that start of our frame as a fix.
-                Schedule(() => userModsDisplay.Current.Value = userRuleset == null ? Array.Empty<Mod>() : user.Mods.Select(m => m.ToMod(userRuleset)).ToList());
+                Schedule(() => userModsDisplay.Current.Value = userRuleset == null ? Array.Empty<Mod>() : slot.User.Mods.Select(m => m.ToMod(userRuleset)).ToList());
             }
 
-            userStateDisplay.UpdateStatus(user);
+            userStateDisplay.UpdateStatus(current.Value);
 
-            if (user.BeatmapAvailability.State == DownloadState.LocallyAvailable && user.State != MultiplayerUserState.Spectating)
+            if (!slot.IsEmpty && slot.User.BeatmapAvailability.State == DownloadState.LocallyAvailable && slot.User.State != MultiplayerUserState.Spectating)
             {
                 userModsDisplay.FadeIn(fade_time);
                 userStyleDisplay.FadeIn(fade_time);
@@ -295,8 +322,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 userStyleDisplay.FadeOut(fade_time);
             }
 
-            kickButton.Alpha = (client.IsHost || client.IsReferee) && !user.Equals(client.LocalUser) ? 1 : 0;
-            crown.Alpha = client.Room.Host?.Equals(user) == true ? 1 : 0;
+            kickButton.Alpha = (client.IsHost || client.IsReferee) && !slot.IsEmpty && !slot.User.Equals(client.LocalUser) ? 1 : 0;
+            crown.Alpha = !slot.IsEmpty && client.Room.Host?.Equals(slot.User) == true ? 1 : 0;
         }
 
         public MenuItem[]? ContextMenuItems
@@ -306,7 +333,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 if (client.Room == null)
                     return null;
 
-                var user = current.Value;
+                if (current.Value.IsEmpty)
+                {
+                    return new MenuItem[]
+                    {
+                        new OsuMenuItem("Move to slot", MenuItemType.Highlighted, moveToSlot)
+                    };
+                }
+
+                var user = current.Value.User;
 
                 // If the local user is targetted.
                 if (user.UserID == api.LocalUser.Value.Id)
@@ -337,6 +372,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     })
                 };
             }
+        }
+
+        private void moveToSlot()
+        {
+            if (!current.Value.IsEmpty)
+                return;
+
+            client.SendMatchRequest(new ChangeSlotRequest { SlotID = current.Value.SlotId.Value }).FireAndForget();
         }
 
         public partial class KickButton : IconButton

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -12,11 +14,11 @@ using osu.Game.Online.Multiplayer;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 {
-    public partial class ParticipantsList : VirtualisedListContainer<MultiplayerRoomUser, ParticipantPanel>
+    public partial class ParticipantsList : VirtualisedListContainer<Slot, ParticipantPanel>
     {
-        private BindableList<MultiplayerRoomUser> participants => RowData;
+        private BindableList<Slot> slots => RowData;
 
-        private MultiplayerRoomUser? currentHost;
+        private Slot? currentHost;
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
@@ -44,38 +46,66 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private void updateState()
         {
             if (client.Room == null)
-                participants.Clear();
-            else
             {
-                // Remove panels for users no longer in the room.
-                for (int i = participants.Count - 1; i >= 0; i--)
-                {
-                    var participant = participants[i];
+                slots.Clear();
+                return;
+            }
 
-                    // Note that we *must* use reference equality here, as this call is scheduled and a user may have left and joined since it was last run.
-                    if (client.Room.Users.All(u => !ReferenceEquals(participant, u)))
-                        participants.RemoveAt(i);
+            // pathway for handling rooms with participant count limit and slots
+            if (client.Room.MatchState is StandardMatchRoomState standardMatchRoomState && standardMatchRoomState.Slots is int?[] slotUserIds)
+            {
+                // reset host tracking - in slots mode the host's position is decided solely by their slot
+                // the reset has the side benefit of getting the host pinned to top of list again if slots are turned off (see logic lower down).
+                currentHost = null;
+
+                if (slots.Count > slotUserIds.Length)
+                    slots.RemoveRange(slotUserIds.Length, slots.Count - slotUserIds.Length);
+
+                for (byte i = 0; i < slotUserIds.Length; ++i)
+                {
+                    var participant = slotUserIds[i] == null ? Slot.Empty(i) : Slot.FromUser(client.Room.Users.Single(u => u.UserID == slotUserIds[i]));
+
+                    if (i >= slots.Count)
+                        slots.Add(participant);
+                    if (!participant.Equals(slots[i]))
+                        slots[i] = participant;
                 }
 
-                // Add panels for all users new to the room.
-                foreach (var user in client.Room.Users.Except(participants))
-                    participants.Add(user);
+                return;
+            }
 
-                if (currentHost == null || !currentHost.Equals(client.Room.Host))
+            // Remove panels for empty slots & users no longer in the room.
+            for (int i = slots.Count - 1; i >= 0; i--)
+            {
+                var slot = slots[i];
+
+                // Note that we *must* use reference equality here, as this call is scheduled and a user may have left and joined since it was last run.
+                if (slot.IsEmpty || client.Room.Users.All(u => !ReferenceEquals(slot.User, u)))
+                    slots.RemoveAt(i);
+            }
+
+            // This assertion guarantees that all subsequent accesses to `User` of any `Slot` is safe.
+            // Unfortunately static analysis is not smart enough to pick this up, so there'll be a lot of `.AsNonNull()` lower down.
+            Debug.Assert(slots.All(p => !p.IsEmpty));
+
+            // Add panels for all users new to the room.
+            foreach (var user in client.Room.Users.Except(slots.Select(u => u.User.AsNonNull())))
+                slots.Add(Slot.FromUser(user));
+
+            if (currentHost == null || !currentHost.User.AsNonNull().Equals(client.Room.Host))
+            {
+                currentHost = null;
+
+                // Change position of new host to display above all participants.
+                if (client.Room.Host != null)
                 {
-                    currentHost = null;
+                    currentHost = slots.SingleOrDefault(u => u.User.AsNonNull().Equals(client.Room.Host));
+                    int currentHostIndex = currentHost == null ? -1 : slots.IndexOf(currentHost);
 
-                    // Change position of new host to display above all participants.
-                    if (client.Room.Host != null)
+                    if (currentHostIndex > 0)
                     {
-                        currentHost = participants.SingleOrDefault(u => u.Equals(client.Room.Host));
-                        int currentHostIndex = participants.IndexOf(client.Room.Host);
-
-                        if (currentHostIndex > 0)
-                        {
-                            participants.Move(currentHostIndex, 0);
-                            currentHost = participants[0];
-                        }
+                        slots.Move(currentHostIndex, 0);
+                        currentHost = slots[0];
                     }
                 }
             }
@@ -88,5 +118,27 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             if (client.IsNotNull())
                 client.RoomUpdated -= onRoomUpdated;
         }
+    }
+
+    public record Slot
+    {
+        [MemberNotNullWhen(false, nameof(User))]
+        [MemberNotNullWhen(true, nameof(SlotId))]
+        public bool IsEmpty { get; }
+
+        public MultiplayerRoomUser? User { get; }
+
+        public byte? SlotId { get; }
+
+        private Slot(bool isEmpty, MultiplayerRoomUser? user, byte? slotId)
+        {
+            IsEmpty = isEmpty;
+            User = user;
+            SlotId = slotId;
+        }
+
+        public static Slot FromUser(MultiplayerRoomUser user) => new Slot(false, user, null);
+
+        public static Slot Empty(byte slotId) => new Slot(true, null, slotId);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsListHeader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsListHeader.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             if (room == null)
                 return;
 
-            DetailsText.Value = $"{room.Users.Count}";
+            DetailsText.Value = room.Settings.MaxParticipants == null ? $@"{room.Users.Count}" : $@"{room.Users.Count} / {room.Settings.MaxParticipants}";
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
@@ -85,12 +85,20 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private OsuColour colours = null!;
 
-        public void UpdateStatus(MultiplayerRoomUser user)
+        public void UpdateStatus(Slot slot)
         {
             // the only case where the progress bar is used does its own local fade in.
             // starting by fading out is a sane default.
             progressBar.FadeOut(fade_time);
+
+            if (slot.IsEmpty)
+            {
+                this.FadeOut(fade_time);
+                return;
+            }
+
             this.FadeIn(fade_time);
+            var user = slot.User!;
 
             if (user.Role == MultiplayerRoomUserRole.Referee)
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -22,15 +22,15 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 {
-    internal partial class TeamDisplay : CompositeDrawable, IHasCurrentValue<MultiplayerRoomUser>
+    internal partial class TeamDisplay : CompositeDrawable, IHasCurrentValue<Slot>
     {
-        public Bindable<MultiplayerRoomUser> Current
+        public Bindable<Slot> Current
         {
             get => current.Current;
             set => current.Current = value;
         }
 
-        private readonly BindableWithCurrent<MultiplayerRoomUser> current = new BindableWithCurrent<MultiplayerRoomUser>(new MultiplayerRoomUser(-1));
+        private readonly BindableWithCurrent<Slot> current = new BindableWithCurrent<Slot>(Slot.FromUser(new MultiplayerRoomUser(-1)));
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -116,12 +116,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         {
             // we don't have a way of knowing when an individual user's state has updated, so just handle on RoomUpdated for now.
 
-            var user = current.Value;
-            var userRoomState = client.Room?.Users.FirstOrDefault(u => u.Equals(user))?.MatchState;
+            var slot = current.Value;
+            var userRoomState = slot.IsEmpty ? null : client.Room?.Users.FirstOrDefault(u => u.Equals(slot.User))?.MatchState;
 
             bool roomLocked = (client.Room?.MatchState as TeamVersusRoomState)?.Locked == true;
 
-            if (client.LocalUser?.Equals(user) == true && !roomLocked)
+            if (!slot.IsEmpty && client.LocalUser?.Equals(slot.User) == true && !roomLocked)
             {
                 clickableContent.Action = changeTeam;
                 clickableContent.TooltipText = "Change team";

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
@@ -441,7 +441,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
                 room.Name = NameField.Text;
                 room.Availability = AvailabilityPicker.Current.Value;
-                room.MaxParticipants = int.TryParse(MaxParticipantsField.Text, out int maxParticipants) ? maxParticipants : null;
+                room.MaxParticipants = !string.IsNullOrWhiteSpace(MaxParticipantsField.Text) && byte.TryParse(MaxParticipantsField.Text, out byte maxParticipants) ? maxParticipants : null;
                 room.MaxAttempts = int.TryParse(MaxAttemptsField.Text, out int maxAttempts) ? maxAttempts : null;
                 room.Duration = DurationField.Current.Value;
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -429,6 +429,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                     break;
 
+                case ChangeSlotRequest changeSlot:
+                    if (ServerRoom.MatchState is not StandardMatchRoomState standardMatchRoomState || standardMatchRoomState.Slots is not int?[] slots)
+                        break;
+
+                    byte slotId = changeSlot.SlotID;
+                    if (slotId >= slots.Length || slots[slotId] != null)
+                        break;
+
+                    int previousSlotId = Array.IndexOf(slots, LocalUser.UserID);
+                    if (previousSlotId >= 0)
+                        slots[previousSlotId] = null;
+                    slots[slotId] = LocalUser.UserID;
+                    await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(standardMatchRoomState)).ConfigureAwait(false);
+                    break;
+
                 case StartMatchCountdownRequest startCountdown:
                     await StartCountdown(new MatchStartCountdown { TimeRemaining = startCountdown.Duration }).ConfigureAwait(false);
                     break;
@@ -625,7 +640,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             switch (type)
             {
                 case MatchType.HeadToHead:
-                    ServerRoom.MatchState = null;
+                    ServerRoom.MatchState = StandardMatchRoomState.Create(ServerRoom.Settings.MaxParticipants);
                     await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
 
                     foreach (var user in ServerRoom.Users)
@@ -637,7 +652,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     break;
 
                 case MatchType.TeamVersus:
-                    ServerRoom.MatchState = TeamVersusRoomState.CreateDefault();
+                    ServerRoom.MatchState = TeamVersusRoomState.CreateDefault(ServerRoom.Settings.MaxParticipants);
                     await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
 
                     foreach (var user in ServerRoom.Users)

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -258,7 +258,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     MatchType = ServerAPIRoom.Type,
                     Password = password ?? string.Empty,
                     QueueMode = ServerAPIRoom.QueueMode,
-                    AutoStartDuration = ServerAPIRoom.AutoStartDuration
+                    AutoStartDuration = ServerAPIRoom.AutoStartDuration,
+                    MaxParticipants = ServerAPIRoom.MaxParticipants,
                 },
                 Playlist = ServerAPIRoom.Playlist.Select(item => new MultiplayerPlaylistItem(item)).ToList(),
                 Users = { localUser },
@@ -636,31 +637,40 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private async Task changeMatchType(MatchType type)
         {
             Debug.Assert(ServerRoom != null);
+            int i = 0;
 
             switch (type)
             {
                 case MatchType.HeadToHead:
-                    ServerRoom.MatchState = StandardMatchRoomState.Create(ServerRoom.Settings.MaxParticipants);
-                    await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
+                    var headToHeadRoomState = StandardMatchRoomState.Create(ServerRoom.Settings.MaxParticipants);
 
                     foreach (var user in ServerRoom.Users)
                     {
+                        if (headToHeadRoomState.Slots != null)
+                            headToHeadRoomState.Slots[i++] = user.UserID;
+
                         user.MatchState = null;
                         await ((IMultiplayerClient)this).MatchUserStateChanged(clone(user.UserID), clone(user.MatchState)).ConfigureAwait(false);
                     }
 
+                    ServerRoom.MatchState = headToHeadRoomState;
+                    await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
                     break;
 
                 case MatchType.TeamVersus:
-                    ServerRoom.MatchState = TeamVersusRoomState.CreateDefault(ServerRoom.Settings.MaxParticipants);
-                    await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
+                    var teamVersusRoomState = TeamVersusRoomState.CreateDefault(ServerRoom.Settings.MaxParticipants);
 
                     foreach (var user in ServerRoom.Users)
                     {
+                        if (teamVersusRoomState.Slots != null)
+                            teamVersusRoomState.Slots[i++] = user.UserID;
+
                         user.MatchState = new TeamVersusUserState();
                         await ((IMultiplayerClient)this).MatchUserStateChanged(clone(user.UserID), clone(user.MatchState)).ConfigureAwait(false);
                     }
 
+                    ServerRoom.MatchState = teamVersusRoomState;
+                    await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
                     break;
 
                 case MatchType.Matchmaking:


### PR DESCRIPTION
- Part of https://github.com/ppy/osu-server-spectator/issues/405

<img width="1624" height="900" alt="Screenshot 2026-05-13 at 12 40 07" src="https://github.com/user-attachments/assets/a7f36d54-4cc6-49c9-8e89-ee0d049bb637" />
<img width="1624" height="900" alt="Screenshot 2026-05-13 at 12 31 40" src="https://github.com/user-attachments/assets/0c054dfd-addd-4d00-bbca-119b4c3ec3cb" />

Will not work until relevant server-side support is in.

---

I was in two minds whether to PR this all at once or to PR only https://github.com/ppy/osu/commit/693e4ef4b095042f7a171672224e10f9c4f47c1c to begin with to unblock server-side implementation. In the end I opted for one PR because usage informs the model, so I find everything else relevant as part of review of the model design. If there are concerns about this making it into a release without server-side support and therefore things looking broken I will split the commit out on request.

I put in some effort to add relevant logic in test multiplayer client to simulate the server side but I may well have missed something.