### PR TITLE
Add slider velocity control to toolbox

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
@@ -7,6 +7,9 @@ using osu.Framework.Input;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit;
@@ -129,6 +132,63 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddAssert("slider has correct velocity", () => slider!.Velocity, () => Is.EqualTo(velocityBefore));
             AddAssert("slider has correct duration", () => slider!.Duration, () => Is.EqualTo(durationBefore));
+        }
+
+        [Test]
+        public void TestVelocityToolbox()
+        {
+            ExpandableSlider<double> velocitySlider = null!;
+            ExpandableButton useLastSliderButton = null!;
+
+            AddStep("enter editor", () => Game.ScreenStack.Push(new EditorLoader()));
+            AddUntilStep("wait for editor load", () => editor?.ReadyForUse == true);
+            AddStep("retrieve controls", () =>
+            {
+                var toolbox = this.ChildrenOfType<OsuSliderVelocityToolboxGroup>().Single();
+                velocitySlider = toolbox.ChildrenOfType<ExpandableSlider<double>>().Single();
+                useLastSliderButton = toolbox.ChildrenOfType<ExpandableButton>().Single();
+            });
+
+            AddAssert("velocity slider at 1x", () => velocitySlider.Current.Value, () => Is.EqualTo(1));
+            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+
+            AddStep("seek to 5000", () => editorClock.Seek(5000));
+            AddStep("set 2x velocity", () => velocitySlider.Current.Value = 2);
+            placeSlider();
+            AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(2));
+            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+
+            AddStep("seek to 6000", () => editorClock.Seek(6000));
+            placeSlider();
+            AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(2));
+            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+
+            AddStep("seek to 9000", () => editorClock.Seek(9000));
+            AddStep("set 3x velocity", () => velocitySlider.Current.Value = 3);
+            placeSlider();
+            AddAssert("placed slider has 3x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(3));
+            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+
+            AddStep("seek to 10000", () => editorClock.Seek(10000));
+            AddStep("set 1x velocity", () => velocitySlider.Current.Value = 1);
+            AddStep("use last slider velocity instead", () => useLastSliderButton.TriggerClick());
+            placeSlider();
+            AddAssert("placed slider has 3x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(3));
+            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+
+            AddStep("seek back to 7000", () => editorClock.Seek(7000));
+            placeSlider();
+            AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().ElementAt(2).SliderVelocityMultiplier, () => Is.EqualTo(2));
+            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+
+            void placeSlider()
+            {
+                AddStep("enter slider placement mode", () => InputManager.Key(Key.Number3));
+                AddStep("move mouse to top left", () => InputManager.MoveMouseTo(editor.ChildrenOfType<Playfield>().First().ScreenSpaceDrawQuad.TopLeft + new Vector2(50)));
+                AddStep("start placement", () => InputManager.Click(MouseButton.Left));
+                AddStep("move mouse to bottom right", () => InputManager.MoveMouseTo(editor.ChildrenOfType<Playfield>().First().ScreenSpaceDrawQuad.BottomRight - new Vector2(50)));
+                AddStep("end placement", () => InputManager.Click(MouseButton.Right));
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
@@ -150,23 +150,31 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             });
 
             AddAssert("velocity slider at 1x", () => velocitySlider.Current.Value, () => Is.EqualTo(1));
+            AddStep("expand right toolbox", () => InputManager.MoveMouseTo(this.ChildrenOfType<ExpandingToolboxContainer>().Last()));
+            AddUntilStep("wait for expand", () => useLastSliderButton.Expanded.Value, () => Is.True);
             AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
 
             AddStep("seek to 5000", () => editorClock.Seek(5000));
             AddStep("set 2x velocity", () => velocitySlider.Current.Value = 2);
             placeSlider();
             AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(2));
+            AddStep("expand right toolbox", () => InputManager.MoveMouseTo(this.ChildrenOfType<ExpandingToolboxContainer>().Last()));
+            AddUntilStep("wait for expand", () => useLastSliderButton.Expanded.Value, () => Is.True);
             AddAssert("use last slider button enabled", () => useLastSliderButton.Enabled.Value, () => Is.True);
 
             AddStep("seek to 6000", () => editorClock.Seek(6000));
             placeSlider();
             AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(2));
+            AddStep("expand right toolbox", () => InputManager.MoveMouseTo(this.ChildrenOfType<ExpandingToolboxContainer>().Last()));
+            AddUntilStep("wait for expand", () => useLastSliderButton.Expanded.Value, () => Is.True);
             AddAssert("use last slider button enabled", () => useLastSliderButton.Enabled.Value, () => Is.True);
 
             AddStep("seek to 9000", () => editorClock.Seek(9000));
             AddStep("set 3x velocity", () => velocitySlider.Current.Value = 3);
             placeSlider();
             AddAssert("placed slider has 3x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(3));
+            AddStep("expand right toolbox", () => InputManager.MoveMouseTo(this.ChildrenOfType<ExpandingToolboxContainer>().Last()));
+            AddUntilStep("wait for expand", () => useLastSliderButton.Expanded.Value, () => Is.True);
             AddAssert("use last slider button enabled", () => useLastSliderButton.Enabled.Value, () => Is.True);
 
             AddStep("seek to 10000", () => editorClock.Seek(10000));
@@ -174,11 +182,15 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("use last slider velocity instead", () => useLastSliderButton.TriggerClick());
             placeSlider();
             AddAssert("placed slider has 3x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(3));
+            AddStep("expand right toolbox", () => InputManager.MoveMouseTo(this.ChildrenOfType<ExpandingToolboxContainer>().Last()));
+            AddUntilStep("wait for expand", () => useLastSliderButton.Expanded.Value, () => Is.True);
             AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
 
             AddStep("seek back to 7000", () => editorClock.Seek(7000));
             placeSlider();
             AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().ElementAt(2).SliderVelocityMultiplier, () => Is.EqualTo(2));
+            AddStep("expand right toolbox", () => InputManager.MoveMouseTo(this.ChildrenOfType<ExpandingToolboxContainer>().Last()));
+            AddUntilStep("wait for expand", () => useLastSliderButton.Expanded.Value, () => Is.True);
             AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
 
             void placeSlider()

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
@@ -156,18 +156,18 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("set 2x velocity", () => velocitySlider.Current.Value = 2);
             placeSlider();
             AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(2));
-            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+            AddAssert("use last slider button enabled", () => useLastSliderButton.Enabled.Value, () => Is.True);
 
             AddStep("seek to 6000", () => editorClock.Seek(6000));
             placeSlider();
             AddAssert("placed slider has 2x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(2));
-            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+            AddAssert("use last slider button enabled", () => useLastSliderButton.Enabled.Value, () => Is.True);
 
             AddStep("seek to 9000", () => editorClock.Seek(9000));
             AddStep("set 3x velocity", () => velocitySlider.Current.Value = 3);
             placeSlider();
             AddAssert("placed slider has 3x velocity", () => editorBeatmap.HitObjects.OfType<Slider>().Last().SliderVelocityMultiplier, () => Is.EqualTo(3));
-            AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+            AddAssert("use last slider button enabled", () => useLastSliderButton.Enabled.Value, () => Is.True);
 
             AddStep("seek to 10000", () => editorClock.Seek(10000));
             AddStep("set 1x velocity", () => velocitySlider.Current.Value = 1);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -54,6 +54,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         [Resolved]
         private EditorClock? editorClock { get; set; }
 
+        [Resolved]
+        private OsuSliderVelocityToolboxGroup? sliderVelocityToolbox { get; set; }
+
         private Bindable<bool> limitedDistanceSnap { get; set; } = null!;
 
         private readonly IncrementalBSplineBuilder bSplineBuilder = new IncrementalBSplineBuilder { Degree = 4 };
@@ -111,9 +114,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             }
         }
 
-        [Resolved]
-        private EditorBeatmap editorBeatmap { get; set; } = null!;
-
         public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double fallbackTime)
         {
             var result = composer?.TrySnapToNearbyObjects(screenSpacePosition, fallbackTime);
@@ -129,11 +129,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 case SliderPlacementState.Initial:
                     BeginPlacement();
 
-                    double? nearestSliderVelocity = (editorBeatmap
-                                                     .HitObjects
-                                                     .LastOrDefault(h => h is Slider && h.GetEndTime() < HitObject.StartTime) as Slider)?.SliderVelocityMultiplier;
-
-                    HitObject.SliderVelocityMultiplier = nearestSliderVelocity ?? 1;
+                    HitObject.SliderVelocityMultiplier = sliderVelocityToolbox?.SliderVelocity.Value ?? 1;
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
 
                     // Replacing the DifficultyControlPoint above doesn't trigger any kind of invalidation.

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Edit
     public partial class FreehandSliderToolboxGroup : EditorToolboxGroup
     {
         public FreehandSliderToolboxGroup()
-            : base("slider")
+            : base("freehand")
         {
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -76,6 +76,9 @@ namespace osu.Game.Rulesets.Osu.Edit
         public readonly OsuDistanceSnapProvider DistanceSnapProvider = new OsuDistanceSnapProvider();
 
         [Cached]
+        private readonly OsuSliderVelocityToolboxGroup sliderVelocityToolboxGroup = new OsuSliderVelocityToolboxGroup();
+
+        [Cached]
         protected readonly OsuGridToolboxGroup OsuGridToolboxGroup = new OsuGridToolboxGroup();
 
         [Cached]
@@ -111,6 +114,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             RightToolbox.AddRange(new Drawable[]
                 {
+                    sliderVelocityToolboxGroup,
                     OsuGridToolboxGroup,
                     new TransformToolboxGroup
                     {
@@ -484,6 +488,14 @@ namespace osu.Game.Rulesets.Osu.Edit
                 return null;
 
             return new OsuDistanceSnapGrid((OsuHitObject)sourceObject, (OsuHitObject)targetObject, sliderVelocitySource);
+        }
+
+        public override void CommitPlacement(HitObject hitObject)
+        {
+            base.CommitPlacement(hitObject);
+
+            if (hitObject is IHasSliderVelocity)
+                sliderVelocityToolboxGroup.UseLastSliderVelocity = true;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -489,13 +489,5 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             return new OsuDistanceSnapGrid((OsuHitObject)sourceObject, (OsuHitObject)targetObject, sliderVelocitySource);
         }
-
-        public override void CommitPlacement(HitObject hitObject)
-        {
-            base.CommitPlacement(hitObject);
-
-            if (hitObject is IHasSliderVelocity)
-                sliderVelocityToolboxGroup.UseLastSliderVelocity = true;
-        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
@@ -1,0 +1,197 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Caching;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Osu.Edit
+{
+    public partial class OsuSliderVelocityToolboxGroup : EditorToolboxGroup
+    {
+        /// <summary>
+        /// Whether the last slider's velocity should be used (if available).
+        /// </summary>
+        public bool UseLastSliderVelocity;
+
+        /// <summary>
+        /// The slider velocity to be used for new object placements.
+        /// </summary>
+        public IBindable<double> SliderVelocity => sliderVelocity;
+
+        private readonly BindableDouble sliderVelocity = new BindableDouble(1)
+        {
+            Precision = 0.01,
+            MinValue = 0.1,
+            MaxValue = 10,
+        };
+
+        private ExpandableSlider<double> slider = null!;
+        private ExpandableButton useLastSliderButton = null!;
+
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
+
+        [Resolved]
+        private EditorClock editorClock { get; set; } = null!;
+
+        private bool syncingBindables;
+        private double lastClockPosition = double.NegativeInfinity;
+        private readonly Cached<Slider?> sliderVelocitySourceObject = new Cached<Slider?>();
+
+        public OsuSliderVelocityToolboxGroup()
+            : base("velocity")
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new Drawable[]
+            {
+                slider = new ExpandableSlider<double>
+                {
+                    ExpandedLabelText = "Slider velocity",
+                    Current = new BindableDouble(1)
+                    {
+                        Precision = 0.01,
+                        MinValue = 0.1,
+                        MaxValue = 10,
+                    },
+                    KeyboardStep = 0.1f,
+                },
+                useLastSliderButton = new ExpandableButton
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Action = () => UseLastSliderVelocity = true,
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // set unconditionally to true initially.
+            // if there is no object available to get the slider velocity from, the code in `Update()` will handle that.
+            UseLastSliderVelocity = true;
+
+            sliderVelocity.BindValueChanged(_ => updateSliderFromVelocity(), true);
+            slider.Current.BindValueChanged(_ =>
+            {
+                updateVelocityFromSlider();
+                updateContractedText();
+            });
+            updateContractedText();
+
+            editorBeatmap.HitObjectAdded += invalidateSliderVelocitySourceObject;
+            editorBeatmap.HitObjectUpdated += invalidateSliderVelocitySourceObject;
+            editorBeatmap.HitObjectRemoved += invalidateSliderVelocitySourceObject;
+        }
+
+        private void updateContractedText()
+        {
+            slider.ContractedLabelText = LocalisableString.Interpolate($@"SV: {slider.Current.Value.ToLocalisableString("N2")}x");
+        }
+
+        /// <summary>
+        /// Updates the displayed value of this toolbox's slider from a change to <see cref="SliderVelocity"/>
+        /// (which is the source-of-truth used for new object placements).
+        /// This is only relevant when <see cref="UseLastSliderVelocity"/> is true,
+        /// in which case this code is responsible for propagating the velocity from <see cref="sliderVelocitySourceObject"/> to the slider.
+        /// </summary>
+        private void updateSliderFromVelocity()
+        {
+            if (syncingBindables)
+                return;
+
+            if (!UseLastSliderVelocity)
+                return;
+
+            syncingBindables = true;
+            slider.Current.Value = sliderVelocity.Value;
+            syncingBindables = false;
+        }
+
+        /// <summary>
+        /// Updates the value of <see cref="SliderVelocity"/> from a change to the slider's state.
+        /// This change is assumed to be user-provoked, and therefore <see cref="UseLastSliderVelocity"/> is switched unconditionally off
+        /// as the presumed intent is to override the velocity from <see cref="sliderVelocitySourceObject"/>.
+        /// </summary>
+        private void updateVelocityFromSlider()
+        {
+            if (syncingBindables)
+                return;
+
+            syncingBindables = true;
+            UseLastSliderVelocity = false;
+            sliderVelocity.Value = slider.Current.Value;
+            syncingBindables = false;
+        }
+
+        private void invalidateSliderVelocitySourceObject(HitObject _) => sliderVelocitySourceObject.Invalidate();
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (editorClock.CurrentTime != lastClockPosition)
+            {
+                sliderVelocitySourceObject.Invalidate();
+                lastClockPosition = editorClock.CurrentTime;
+            }
+
+            // Two possible causes of invalidation:
+            // - The user seeked the clock, which means we may want a different velocity source object
+            // - Some change to the beatmap was made, which means the previously-used velocity source object may no longer be the most relevant one
+            if (!sliderVelocitySourceObject.IsValid)
+                sliderVelocitySourceObject.Value = getLastSlider();
+
+            // This functions as a null check and allows simplified access later (instead of needing to type `sliderVelocitySourceObject.Value` multiple times)
+            if (sliderVelocitySourceObject.Value is not Slider lastSlider)
+            {
+                useLastSliderButton.Enabled.Value = false;
+                useLastSliderButton.ExpandedLabelText = "No sliders to get velocity from";
+            }
+            else
+            {
+                useLastSliderButton.Enabled.Value = !UseLastSliderVelocity;
+                useLastSliderButton.ExpandedLabelText = UseLastSliderVelocity
+                    ? "Using last slider's velocity"
+                    : LocalisableString.Interpolate($@"Use last slider's velocity ({lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x)");
+                if (UseLastSliderVelocity)
+                    sliderVelocity.Value = lastSlider.SliderVelocityMultiplier;
+            }
+        }
+
+        private Slider? getLastSlider()
+        {
+            return editorBeatmap
+                   .HitObjects
+                   .OfType<Slider>()
+                   .LastOrDefault(h => h.StartTime <= editorClock.CurrentTime);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (editorBeatmap.IsNotNull())
+            {
+                editorBeatmap.HitObjectAdded -= invalidateSliderVelocitySourceObject;
+                editorBeatmap.HitObjectUpdated -= invalidateSliderVelocitySourceObject;
+                editorBeatmap.HitObjectRemoved -= invalidateSliderVelocitySourceObject;
+            }
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// <summary>
         /// Whether the last slider's velocity should be used (if available).
         /// </summary>
-        public bool UseLastSliderVelocity;
+        private bool useLastSliderVelocity;
 
         /// <summary>
         /// The slider velocity to be used for new object placements.
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 useLastSliderButton = new ExpandableButton
                 {
                     RelativeSizeAxes = Axes.X,
-                    Action = () => UseLastSliderVelocity = true,
+                    Action = () => useLastSliderVelocity = true,
                 }
             };
         }
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             // set unconditionally to true initially.
             // if there is no object available to get the slider velocity from, the code in `Update()` will handle that.
-            UseLastSliderVelocity = true;
+            useLastSliderVelocity = true;
 
             sliderVelocity.BindValueChanged(_ => updateSliderFromVelocity(), true);
             slider.Current.BindValueChanged(_ =>
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// <summary>
         /// Updates the displayed value of this toolbox's slider from a change to <see cref="SliderVelocity"/>
         /// (which is the source-of-truth used for new object placements).
-        /// This is only relevant when <see cref="UseLastSliderVelocity"/> is true,
+        /// This is only relevant when <see cref="useLastSliderVelocity"/> is true,
         /// in which case this code is responsible for propagating the velocity from <see cref="sliderVelocitySourceObject"/> to the slider.
         /// </summary>
         private void updateSliderFromVelocity()
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             if (syncingBindables)
                 return;
 
-            if (!UseLastSliderVelocity)
+            if (!useLastSliderVelocity)
                 return;
 
             syncingBindables = true;
@@ -125,7 +125,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         /// <summary>
         /// Updates the value of <see cref="SliderVelocity"/> from a change to the slider's state.
-        /// This change is assumed to be user-provoked, and therefore <see cref="UseLastSliderVelocity"/> is switched unconditionally off
+        /// This change is assumed to be user-provoked, and therefore <see cref="useLastSliderVelocity"/> is switched unconditionally off
         /// as the presumed intent is to override the velocity from <see cref="sliderVelocitySourceObject"/>.
         /// </summary>
         private void updateVelocityFromSlider()
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 return;
 
             syncingBindables = true;
-            UseLastSliderVelocity = false;
+            useLastSliderVelocity = false;
             sliderVelocity.Value = slider.Current.Value;
             syncingBindables = false;
         }
@@ -165,11 +165,11 @@ namespace osu.Game.Rulesets.Osu.Edit
             }
             else
             {
-                useLastSliderButton.Enabled.Value = !UseLastSliderVelocity;
-                useLastSliderButton.ExpandedLabelText = UseLastSliderVelocity
+                useLastSliderButton.Enabled.Value = !useLastSliderVelocity;
+                useLastSliderButton.ExpandedLabelText = useLastSliderVelocity
                     ? "Using last slider's velocity"
                     : LocalisableString.Interpolate($@"Use last slider's velocity ({lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x)");
-                if (UseLastSliderVelocity)
+                if (useLastSliderVelocity)
                     sliderVelocity.Value = lastSlider.SliderVelocityMultiplier;
             }
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -57,6 +58,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         [BackgroundDependencyLoader]
         private void load()
         {
+            Spacing = new Vector2(5);
             Children = new Drawable[]
             {
                 slider = new ExpandableSlider<double>
@@ -73,7 +75,11 @@ namespace osu.Game.Rulesets.Osu.Edit
                 useLastSliderButton = new ExpandableButton
                 {
                     RelativeSizeAxes = Axes.X,
-                    Action = () => useLastSliderVelocity = true,
+                    Action = () =>
+                    {
+                        useLastSliderVelocity = true;
+                        sliderVelocitySourceObject.Invalidate();
+                    },
                 }
             };
         }
@@ -93,6 +99,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 updateContractedText();
             });
             updateContractedText();
+            useLastSliderButton.Expanded.BindValueChanged(_ => sliderVelocitySourceObject.Invalidate());
 
             editorBeatmap.HitObjectAdded += invalidateSliderVelocitySourceObject;
             editorBeatmap.HitObjectUpdated += invalidateSliderVelocitySourceObject;
@@ -137,6 +144,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             useLastSliderVelocity = false;
             sliderVelocity.Value = slider.Current.Value;
             syncingBindables = false;
+            sliderVelocitySourceObject.Invalidate();
         }
 
         private void invalidateSliderVelocitySourceObject(HitObject _) => sliderVelocitySourceObject.Invalidate();
@@ -151,26 +159,34 @@ namespace osu.Game.Rulesets.Osu.Edit
                 lastClockPosition = editorClock.CurrentTime;
             }
 
-            // Two possible causes of invalidation:
-            // - The user seeked the clock, which means we may want a different velocity source object
-            // - Some change to the beatmap was made, which means the previously-used velocity source object may no longer be the most relevant one
+            // Three possible causes of invalidation:
+            // - The user seeked the clock, which means a different velocity source object needs to be used.
+            // - Some change to the beatmap was made, which means the previously-used velocity source object may no longer be the most relevant one.
+            // - The user is interacting with the toolbox in a way that requires a visual state update
+            //   (hovered to expand it, clicked the button to use last slider's velocity, or dragged the manual velocity slider).
+            //   This is a procedural one, because `sliderVelocitySourceObject` will have been pointing at the correct object already,
+            //   but to decrease unnecessary work being done every frame, the invalidation is explicitly re-triggered to update the toolbox state.
             if (!sliderVelocitySourceObject.IsValid)
-                sliderVelocitySourceObject.Value = getLastSlider();
+            {
+                var lastSlider = getLastSlider();
+                sliderVelocitySourceObject.Value = lastSlider;
 
-            // This functions as a null check and allows simplified access later (instead of needing to type `sliderVelocitySourceObject.Value` multiple times)
-            if (sliderVelocitySourceObject.Value is not Slider lastSlider)
-            {
-                useLastSliderButton.Enabled.Value = false;
-                useLastSliderButton.ExpandedLabelText = "No sliders to get velocity from";
-            }
-            else
-            {
-                useLastSliderButton.Enabled.Value = !useLastSliderVelocity;
-                useLastSliderButton.ExpandedLabelText = useLastSliderVelocity
-                    ? "Using last slider's velocity"
-                    : LocalisableString.Interpolate($@"Use last slider's velocity ({lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x)");
-                if (useLastSliderVelocity)
-                    sliderVelocity.Value = lastSlider.SliderVelocityMultiplier;
+                if (lastSlider == null)
+                {
+                    useLastSliderButton.Enabled.Value = false;
+                    useLastSliderButton.ExpandedLabelText = "No sliders to get velocity from";
+                    useLastSliderButton.ContractedLabelText = default;
+                }
+                else
+                {
+                    useLastSliderButton.Enabled.Value = useLastSliderButton.Expanded.Value && !useLastSliderVelocity;
+                    useLastSliderButton.ExpandedLabelText = useLastSliderVelocity
+                        ? "Using last slider's velocity"
+                        : LocalisableString.Interpolate($@"Use last slider's velocity ({lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x)");
+                    useLastSliderButton.ContractedLabelText = $@"current {lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x";
+                    if (useLastSliderVelocity)
+                        sliderVelocity.Value = lastSlider.SliderVelocityMultiplier;
+                }
             }
         }
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -538,7 +538,7 @@ namespace osu.Game.Rulesets.Edit
             EditorBeatmap.PlacementObject.Value = null;
         }
 
-        public void CommitPlacement(HitObject hitObject)
+        public virtual void CommitPlacement(HitObject hitObject)
         {
             EditorBeatmap.PlacementObject.Value = null;
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -538,7 +538,7 @@ namespace osu.Game.Rulesets.Edit
             EditorBeatmap.PlacementObject.Value = null;
         }
 
-        public virtual void CommitPlacement(HitObject hitObject)
+        public void CommitPlacement(HitObject hitObject)
         {
             EditorBeatmap.PlacementObject.Value = null;
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/2a511e0d-51f8-4abf-a3ab-de0992618b6b

This implements a rather opinionated UX that's designed to be a middle ground between the previous lazer behaviour of unconditionally inheriting the last slider's velocity and just a textbox that you'd need to manually fiddle with every time.

As to what that means, precisely:

- By default, the control follows the last slider's velocity (updates on seeks as well as changes to existing objects).
- When the slider control in the toolbox is manually adjusted, the control decouples from the last slider's velocity and instead uses the last manually-specified value.
- There is a button that allows the user to couple back to the last slider's velocity if they consider to have made a mistake in adjusting it.
- Upon successful placement of a slider, the control reverts to following the last slider's velocity.

Of note, this control *only interacts with and affects the next placed slider*. It is in no way coupled to any selected objects. This may be confusing to users but was an intentional choice to limit complexity (what if there are multiple selected objects with multiple velocities?)

For adjusting existing objects you can use the green pieces on the timeline, which notably do support changing multiple selected objects at once.

---

- Closes https://github.com/ppy/osu/issues/36844
- Supersedes / closes https://github.com/ppy/osu/pull/33707