### PR TITLE
Add small indicator for last stand

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
@@ -80,5 +80,15 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddStep("set to importing", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Importing()));
             AddStep("set to available", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable()));
         }
+
+        [Test]
+        public void TestLastStand()
+        {
+            AddStep("active last stand", () =>
+            {
+                health.Value = 1_000_000;
+                health.Value = 1;
+            });
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -41,8 +41,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private readonly RankedPlayColourScheme colourScheme;
 
         private BufferedContainer grayScaleContainer = null!;
-
         private OsuSpriteText beatmapState = null!;
+        private OsuSpriteText lastStandText = null!;
 
         private BeatmapAvailability availability = BeatmapAvailability.Unknown();
 
@@ -104,6 +104,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                     Direction = FillDirection.Vertical,
                     Children =
                     [
+                        lastStandText = new OsuSpriteText
+                        {
+                            Anchor = contentAnchor,
+                            Origin = contentAnchor,
+                            Text = "Last Stand!",
+                            Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
+                            Alpha = 0,
+                            AlwaysPresent = true
+                        },
                         HealthDisplay = new HealthBar(colourScheme, (contentAnchor & Anchor.x0) != 0, shear)
                         {
                             Health = { BindTarget = Health },
@@ -155,6 +164,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             {
                 grayScaleContainer.GrayscaleTo(e.NewValue <= 0 ? 1 : 0, 300);
                 cornerPiece?.OnHealthChanged(e.NewValue);
+
+                if (e.NewValue == 1)
+                    lastStandText.FadeIn(100).Delay(3000).FadeOut(400);
             });
 
             client.RoomUpdated += onRoomUpdated;


### PR DESCRIPTION
This is _very_ uninspired. Although there are proposals for how this could be displayed, I'm purposefully taking the easy path here to not lock into a particular behaviour for this mechanic.

https://github.com/user-attachments/assets/e37a62ea-118a-4cbe-bcc1-2ba93f17972c