### PR TITLE
Stop applying UI scale to ranked play

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/InverseScalingDrawSizePreservingFillContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/InverseScalingDrawSizePreservingFillContainer.cs
@@ -15,8 +15,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         protected override void Update()
         {
-            // TODO: Consider whether we still want to be applying OsuGame.ScalingContainerTargetDrawSize here
-            // to allow mobile to not become unusable.
+            // We may want this container to apply scale still, just at a multiplier
+            // of the original scale. Basically in a system like ranked play, we decide
+            // what the max UI scale to be supported is, then adjust the inverse
+            // container's ctor to stay within the appropriate range.
+            //
+            // Will become more important when we have mobile releases live and it is more
+            // of an immediate concern.
 
             Size = new Vector2(CurrentScale);
             Scale = new Vector2(1 / CurrentScale);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/InverseScalingDrawSizePreservingFillContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/InverseScalingDrawSizePreservingFillContainer.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         protected override void Update()
         {
+            // TODO: Consider whether we still want to be applying OsuGame.ScalingContainerTargetDrawSize here
+            // to allow mobile to not become unusable.
+
             Size = new Vector2(CurrentScale);
             Scale = new Vector2(1 / CurrentScale);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -150,17 +150,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                     },
-                                    chat = new RankedPlayChatDisplay(room)
-                                    {
-                                        Anchor = Anchor.BottomRight,
-                                        Origin = Anchor.BottomRight,
-                                        Margin = new MarginPadding
-                                        {
-                                            Bottom = 10,
-                                            Right = 10
-                                        },
-                                        State = { Value = Visibility.Hidden }
-                                    },
                                     new HamburgerMenu
                                     {
                                         Size = new Vector2(56),
@@ -175,6 +164,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                         overlayContainer = new CardDetailsOverlayContainer(),
                         particleContainer = new SongPreviewParticleContainer(),
                     },
+                },
+                chat = new RankedPlayChatDisplay(room)
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Margin = new MarginPadding
+                    {
+                        Bottom = 10,
+                        Right = 10
+                    },
+                    State = { Value = Visibility.Hidden }
                 },
             };
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -40,7 +40,7 @@ using osuTK;
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     [Cached]
-    public partial class RankedPlayScreen : OsuScreen, IPreviewTrackOwner, IHandlePresentBeatmap
+    public sealed partial class RankedPlayScreen : OsuScreen, IPreviewTrackOwner, IHandlePresentBeatmap
     {
         protected override bool InitialBackButtonVisibility => false;
 
@@ -103,6 +103,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private readonly Bindable<Visibility> cornerPieceVisibility = new Bindable<Visibility>();
         private readonly Bindable<bool> showBeatmapBackground = new Bindable<bool>();
 
+        private readonly Container content;
+
         [Cached]
         private readonly RankedPlayChatDisplay chat;
 
@@ -127,45 +129,53 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             InternalChildren = new Drawable[]
             {
                 matchInfo = new RankedPlayMatchInfo(),
+                backgroundMusic = new BackgroundMusicManager(),
                 new RankedPlayBeatmapAvailabilityTracker(),
                 new GlobalScrollAdjustsVolume(),
-                new PopoverContainer
+                content = new InverseScalingDrawSizePreservingFillContainer
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = new OsuContextMenuContainer
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Children = new Drawable[]
+                        new PopoverContainer
                         {
-                            screenContainer = new Container<RankedPlaySubScreen>
+                            RelativeSizeAxes = Axes.Both,
+                            Child = new OsuContextMenuContainer
                             {
                                 RelativeSizeAxes = Axes.Both,
-                            },
-                            chat = new RankedPlayChatDisplay(room)
-                            {
-                                Anchor = Anchor.BottomRight,
-                                Origin = Anchor.BottomRight,
-                                Margin = new MarginPadding
+                                Children = new Drawable[]
                                 {
-                                    Bottom = 10,
-                                    Right = 10
-                                },
-                                State = { Value = Visibility.Hidden }
-                            },
-                            new HamburgerMenu
-                            {
-                                Size = new Vector2(56),
+                                    screenContainer = new Container<RankedPlaySubScreen>
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                    },
+                                    chat = new RankedPlayChatDisplay(room)
+                                    {
+                                        Anchor = Anchor.BottomRight,
+                                        Origin = Anchor.BottomRight,
+                                        Margin = new MarginPadding
+                                        {
+                                            Bottom = 10,
+                                            Right = 10
+                                        },
+                                        State = { Value = Visibility.Hidden }
+                                    },
+                                    new HamburgerMenu
+                                    {
+                                        Size = new Vector2(56),
+                                    }
+                                }
                             }
-                        }
-                    }
+                        },
+                        stageOverlayContainer = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        overlayContainer = new CardDetailsOverlayContainer(),
+                        particleContainer = new SongPreviewParticleContainer(),
+                    },
                 },
-                stageOverlayContainer = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
-                overlayContainer = new CardDetailsOverlayContainer(),
-                particleContainer = new SongPreviewParticleContainer(),
-                backgroundMusic = new BackgroundMusicManager()
             };
         }
 
@@ -198,7 +208,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             localUser = users.GetUserAsync(localUserId).GetResultSafely() ?? api.LocalUser.Value;
             opponentUser = users.GetUserAsync(opponentUserId).GetResultSafely() ?? APIUser.UnknownUser(opponentUserId);
 
-            AddRangeInternal([
+            content.AddRange([
                 new RankedPlayCornerPiece(RankedPlayColourScheme.BLUE, Anchor.BottomLeft)
                 {
                     State = { BindTarget = cornerPieceVisibility },

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -10,7 +10,9 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Logging;
 using osu.Framework.Testing;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Screens;
 using osu.Game.Screens.Footer;
@@ -40,38 +42,51 @@ namespace osu.Game.Tests.Visual
             ScreenStackFooter screenStackFooter;
             ScreenFooter.BackReceptor backReceptor;
 
-            base.Content.AddRange(new Drawable[]
+            base.Content.Add(new ScalingContainer(ScalingMode.Everything)
             {
-                backReceptor = new ScreenFooter.BackReceptor(),
-                new PopoverContainer
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    backReceptor = new ScreenFooter.BackReceptor(),
+                    new PopoverContainer
                     {
-                        Stack = new OsuScreenStack
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
                         {
-                            Name = nameof(ScreenTestScene),
-                            RelativeSizeAxes = Axes.Both
-                        },
-                        // TODO: is this ever used? it probably shouldn't be.
-                        content = new Container { RelativeSizeAxes = Axes.Both },
-                        overlayContent = new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Child = DialogOverlay = new DialogOverlay()
-                        },
-                        screenStackFooter = new ScreenStackFooter(Stack, backReceptor)
-                        {
-                            BackButtonPressed = BackButtonPressed,
+                            Stack = new OsuScreenStack
+                            {
+                                Name = nameof(ScreenTestScene),
+                                RelativeSizeAxes = Axes.Both
+                            },
+                            // TODO: is this ever used? it probably shouldn't be.
+                            content = new Container { RelativeSizeAxes = Axes.Both },
+                            overlayContent = new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Child = DialogOverlay = new DialogOverlay()
+                            },
+                            screenStackFooter = new ScreenStackFooter(Stack, backReceptor)
+                            {
+                                BackButtonPressed = BackButtonPressed,
+                            }
                         }
                     }
-                },
+                }
             });
 
             ScreenFooter = screenStackFooter.Footer;
-
             Stack.ScreenPushed += (_, newScreen) => Logger.Log($"{nameof(ScreenTestScene)} screen changed → {newScreen}");
             Stack.ScreenExited += (_, newScreen) => Logger.Log($"{nameof(ScreenTestScene)} screen changed ← {newScreen}");
+        }
+
+        [Resolved]
+
+        private OsuConfigManager config { get; set; } = null!;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AddSliderStep("ui scale", 0.8f, 1.6f, 1f, scale => config.SetValue(OsuSetting.UIScale, scale));
         }
 
         protected virtual void BackButtonPressed() => Stack.Exit();

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -79,7 +79,6 @@ namespace osu.Game.Tests.Visual
         }
 
         [Resolved]
-
         private OsuConfigManager config { get; set; } = null!;
 
         protected override void LoadComplete()


### PR DESCRIPTION
We already [did this for quick play](https://github.com/ppy/osu/pull/36025) but it was never carried across. Some of the new UI *could* work with UI scale with more consideration, but for now, let's disable it globally to fix cases like the results screen which people completely unusable at higher scales.

---

@ppy/team-client would hope to get this into today's build, if priority review could be given to it.

Closes https://github.com/ppy/osu/issues/37407.

- Note that this adds a UI scale slider to all `ScreenTestScenes`. In some testing, this seems to work just fine.
- May be worth reading 6c8dd589f7384d46377620340d300e53aec7eed5 commit message for one future concern i have.