### PR TITLE
Add a per-ruleset star filter

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFiltering.cs
@@ -157,6 +157,20 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestPerRulesetStarFilter()
+        {
+            LoadSongSelect();
+
+            ImportBeatmapForRuleset(0);
+
+            AddStep("enable per-ruleset star filter", () => Config.SetValue(OsuSetting.UsePerRulesetStarFilter, true));
+
+            ChangeRuleset(0);
+            AddUntilStep("wait for filter", () => !Carousel.IsFiltering);
+            AddUntilStep("3 beatmaps shown", () => Carousel.MatchedBeatmapsCount, () => Is.EqualTo(3));
+        }
+
+        [Test]
         public void TestCutInFilterTextBox()
         {
             LoadSongSelect();

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ShowConvertedBeatmaps, true);
             SetDefault(OsuSetting.DisplayStarsMinimum, 0.0, 0, 10, 0.1);
             SetDefault(OsuSetting.DisplayStarsMaximum, 10.1, 0, 10.1, 0.1);
+            SetDefault(OsuSetting.UsePerRulesetStarFilter, false);
 
             SetDefault(OsuSetting.SongSelectGroupMode, GroupMode.None);
             SetDefault(OsuSetting.SongSelectSortingMode, SortMode.Title);
@@ -419,6 +420,7 @@ namespace osu.Game.Configuration
         SaveUsername,
         DisplayStarsMinimum,
         DisplayStarsMaximum,
+        UsePerRulesetStarFilter,
         SongSelectGroupMode,
         SongSelectSortingMode,
         RandomSelectAlgorithm,

--- a/osu.Game/Localisation/UserInterfaceStrings.cs
+++ b/osu.Game/Localisation/UserInterfaceStrings.cs
@@ -110,6 +110,11 @@ namespace osu.Game.Localisation
         public static LocalisableString StarsMaximum => new TranslatableString(getKey(@"stars_maximum"), @"up to");
 
         /// <summary>
+        /// "Star filter per gamemode"
+        /// </summary>
+        public static LocalisableString PerRulesetStarFilter => new TranslatableString(getKey(@"star_filter"), @"Star filter per gamemode");
+
+        /// <summary>
         /// "Random selection algorithm"
         /// </summary>
         public static LocalisableString RandomSelectionAlgorithm => new TranslatableString(getKey(@"random_selection_algorithm"), @"Random selection algorithm");

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -29,6 +29,11 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                 {
                     Keywords = new[] { "converts", "converted" }
                 },
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = UserInterfaceStrings.PerRulesetStarFilter,
+                    Current = config.GetBindable<bool>(OsuSetting.UsePerRulesetStarFilter),
+                }),
                 new SettingsItemV2(new FormEnumDropdown<RandomSelectAlgorithm>
                 {
                     Caption = UserInterfaceStrings.RandomSelectionAlgorithm,

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -81,6 +81,49 @@ namespace osu.Game.Screens.Select
 
         private FilterCriteria currentCriteria = null!;
 
+        private readonly Bindable<bool> usePerRulesetStarFilter = new BindableBool();
+        private BindableDouble configDisplayStarsMinimum = null!;
+        private BindableDouble configDisplayStarsMaximum = null!;
+
+        private static readonly Dictionary<string, StarFilter> per_ruleset_star_filters = new Dictionary<string, StarFilter>();
+
+        private struct StarFilter
+        {
+            public double Min;
+            public double Max;
+        }
+
+        private StarFilter getStarFilter(RulesetInfo ruleset)
+        {
+            if (usePerRulesetStarFilter.Value && per_ruleset_star_filters.TryGetValue(ruleset.ShortName, out var filter))
+                return filter;
+
+            return new StarFilter
+            {
+                Min = configDisplayStarsMinimum.Value,
+                Max = configDisplayStarsMaximum.Value
+            };
+        }
+
+        private void setStarFilter(RulesetInfo ruleset, StarFilter value)
+        {
+            if (usePerRulesetStarFilter.Value)
+            {
+                per_ruleset_star_filters[ruleset.ShortName] = value;
+            }
+            else
+            {
+                configDisplayStarsMinimum.Value = value.Min;
+                configDisplayStarsMaximum.Value = value.Max;
+            }
+        }
+
+        public void ClearStarsFilter()
+        {
+            difficultyRangeSlider.LowerBound.SetDefault();
+            difficultyRangeSlider.UpperBound.SetDefault();
+        }
+
         private IDisposable? collectionsSubscription;
 
         [BackgroundDependencyLoader]
@@ -221,12 +264,33 @@ namespace osu.Game.Screens.Select
         {
             base.LoadComplete();
 
-            difficultyRangeSlider.LowerBound = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum);
-            difficultyRangeSlider.UpperBound = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
+            config.BindWith(OsuSetting.UsePerRulesetStarFilter, usePerRulesetStarFilter);
+            configDisplayStarsMinimum = (BindableDouble)config.GetBindable<double>(OsuSetting.DisplayStarsMinimum);
+            configDisplayStarsMaximum = (BindableDouble)config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
+
+            difficultyRangeSlider.LowerBound = new BindableDouble { MinValue = configDisplayStarsMinimum.MinValue, MaxValue = configDisplayStarsMinimum.MaxValue, Default = configDisplayStarsMinimum.Default };
+            difficultyRangeSlider.UpperBound = new BindableDouble { MinValue = configDisplayStarsMaximum.MinValue, MaxValue = configDisplayStarsMaximum.MaxValue, Default = configDisplayStarsMaximum.Default };
+
+            void applyFilterToSlider()
+            {
+                var filter = getStarFilter(ruleset.Value);
+                difficultyRangeSlider.LowerBound.Value = filter.Min;
+                difficultyRangeSlider.UpperBound.Value = filter.Max;
+            }
+
+            configDisplayStarsMinimum.BindValueChanged(_ => { if (!usePerRulesetStarFilter.Value) applyFilterToSlider(); });
+            configDisplayStarsMaximum.BindValueChanged(_ => { if (!usePerRulesetStarFilter.Value) applyFilterToSlider(); });
+
             config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmapsButton.Active);
             config.BindWith(OsuSetting.SongSelectSortingMode, sortDropdown.Current);
 
-            ruleset.BindValueChanged(_ => updateCriteria());
+            usePerRulesetStarFilter.BindValueChanged(_ => applyFilterToSlider(), true);
+
+            ruleset.BindValueChanged(_ =>
+            {
+                applyFilterToSlider();
+                updateCriteria();
+            });
             mods.BindValueChanged(m =>
             {
                 // The following is a note carried from old song select and may not be a valid reason anymore:
@@ -255,8 +319,16 @@ namespace osu.Game.Screens.Select
                 sliderDebounce = Scheduler.AddDelayed(() => updateCriteria(), 50);
             }
 
-            difficultyRangeSlider.LowerBound.BindValueChanged(_ => debouncedUpdateCriteria());
-            difficultyRangeSlider.UpperBound.BindValueChanged(_ => debouncedUpdateCriteria());
+            difficultyRangeSlider.LowerBound.BindValueChanged(v =>
+            {
+                setStarFilter(ruleset.Value, new StarFilter { Min = v.NewValue, Max = difficultyRangeSlider.UpperBound.Value });
+                debouncedUpdateCriteria();
+            });
+            difficultyRangeSlider.UpperBound.BindValueChanged(v =>
+            {
+                setStarFilter(ruleset.Value, new StarFilter { Min = difficultyRangeSlider.LowerBound.Value, Max = v.NewValue });
+                debouncedUpdateCriteria();
+            });
 
             showConvertedBeatmapsButton.Active.BindValueChanged(_ => updateCriteria());
             sortDropdown.Current.BindValueChanged(_ => updateCriteria());

--- a/osu.Game/Screens/Select/NoResultsPlaceholder.cs
+++ b/osu.Game/Screens/Select/NoResultsPlaceholder.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Select
     public partial class NoResultsPlaceholder : VisibilityContainer
     {
         public Action? RequestClearFilterText { get; init; }
-
+        public Action? RequestClearStarsFilter { get; set; }
         private FilterCriteria? filter;
 
         private LinkFlowContainer textFlow = null!;
@@ -168,8 +168,13 @@ namespace osu.Game.Screens.Select
                     textFlow.AddText("Try ");
                     textFlow.AddLink("removing", () =>
                     {
-                        config.SetValue(OsuSetting.DisplayStarsMinimum, 0.0);
-                        config.SetValue(OsuSetting.DisplayStarsMaximum, 10.1);
+                        if (RequestClearStarsFilter != null)
+                            RequestClearStarsFilter.Invoke();
+                        else
+                        {
+                            config.SetValue(OsuSetting.DisplayStarsMinimum, 0.0);
+                            config.SetValue(OsuSetting.DisplayStarsMaximum, 10.1);
+                        }
                     });
 
                     string lowerStar = $"{filter.UserStarDifficulty.Min ?? 0:N1}";

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -283,7 +283,8 @@ namespace osu.Game.Screens.Select
                                                             },
                                                             noResultsPlaceholder = new NoResultsPlaceholder
                                                             {
-                                                                RequestClearFilterText = () => FilterControl.Search(string.Empty)
+                                                                RequestClearFilterText = () => FilterControl.Search(string.Empty),
+                                                                RequestClearStarsFilter = () => FilterControl.ClearStarsFilter()
                                                             }
                                                         }
                                                     },


### PR DESCRIPTION
Hello,
Since i play of lot of maps in different game mode, i found myself fighting the star filter quite a lot. For example, i play a map in standard, and then i want to play a bit of mania, but i need to change the star filter to different values each time. So i tried implementing a per ruleset (i believe that's how it's called even outside of the code) star filter. I know some people won't like my system, so that why i added a toggle to the menu (i tried to copy what's the menu `LocalisableString` but not sure of how i works tho...). I know that there is a low change of this getting merged, but if someone out there kind enough to make this clean, i would appreciate this. Have a good day :)