### PR TITLE
Allow rulesets to override `PlacementReplacesExisting` 

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -98,10 +98,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
             if (!base.PlacementReplacesExisting(existing, placement))
                 return false;
 
-            if (placement is IHasColumn placementColumn && existing is IHasColumn existingColumn)
-                return existingColumn.Column == placementColumn.Column;
-
-            return true;
+            return ((IHasColumn)placement).Column == ((IHasColumn)existing).Column;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -93,12 +93,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
             resultPlayfield.ToScreenSpace(new Vector2(DefaultNotePiece.NOTE_HEIGHT)).Y -
             resultPlayfield.ToScreenSpace(Vector2.Zero).Y;
 
-        public override bool PlacementReplacesExisting(HitObject existing, HitObject placement)
-        {
-            if (!base.PlacementReplacesExisting(existing, placement))
-                return false;
-
-            return ((IHasColumn)placement).Column == ((IHasColumn)existing).Column;
-        }
+        public override bool ReplacesExistingObject(HitObject existing)
+            => base.ReplacesExistingObject(existing) && HitObject.Column == ((IHasColumn)existing).Column;
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -9,6 +9,8 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Input;
@@ -90,5 +92,16 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         private float getNoteHeight(Column resultPlayfield) =>
             resultPlayfield.ToScreenSpace(new Vector2(DefaultNotePiece.NOTE_HEIGHT)).Y -
             resultPlayfield.ToScreenSpace(Vector2.Zero).Y;
+
+        public override bool PlacementReplacesExisting(HitObject existing, HitObject placement)
+        {
+            if (!base.PlacementReplacesExisting(existing, placement))
+                return false;
+
+            if (placement is IHasColumn placementColumn && existing is IHasColumn existingColumn)
+                return existingColumn.Column == placementColumn.Column;
+
+            return true;
+        }
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -543,7 +543,10 @@ namespace osu.Game.Rulesets.Edit
             EditorBeatmap.PlacementObject.Value = null;
 
             EditorBeatmap.BeginChange();
-            foreach (var h in EditorBeatmap.HitObjects.Where(ho => HitObjectPlacementBlueprint.PlacementReplacesExisting(ho, hitObject)).ToArray())
+
+            var placementBluprint = (HitObjectPlacementBlueprint)blueprintContainer.CurrentPlacement;
+
+            foreach (var h in EditorBeatmap.HitObjects.Where(ho => placementBluprint.PlacementReplacesExisting(ho, hitObject)).ToArray())
                 EditorBeatmap.Remove(h);
             EditorBeatmap.Add(hitObject);
             EditorBeatmap.EndChange();

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -544,9 +544,7 @@ namespace osu.Game.Rulesets.Edit
 
             EditorBeatmap.BeginChange();
 
-            var placementBluprint = (HitObjectPlacementBlueprint)blueprintContainer.CurrentPlacement;
-
-            foreach (var h in EditorBeatmap.HitObjects.Where(ho => placementBluprint.PlacementReplacesExisting(ho, hitObject)).ToArray())
+            foreach (var h in EditorBeatmap.HitObjects.Where(ho => blueprintContainer.CurrentHitObjectPlacement?.ReplacesExistingObject(ho) == true).ToArray())
                 EditorBeatmap.Remove(h);
             EditorBeatmap.Add(hitObject);
             EditorBeatmap.EndChange();

--- a/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
@@ -69,13 +69,13 @@ namespace osu.Game.Rulesets.Edit
         }
 
         /// <summary>
-        /// Whether <paramref name="existing"/> should be removed because <paramref name="placement"/> is being placed on top of it.
+        /// Whether an existing <see cref="Objects.HitObject"/> should be removed because <see cref="HitObject"/> is being placed on top of it.
         /// </summary>
         /// <remarks>
         /// By default, it matches when start times are within ±<see cref="placement_replace_start_time_leniency_ms"/> ms of each other.
         /// </remarks>
-        public virtual bool PlacementReplacesExisting(HitObject existing, HitObject placement)
-            => Precision.AlmostEquals(existing.StartTime, placement.StartTime, placement_replace_start_time_leniency_ms);
+        public virtual bool ReplacesExistingObject(HitObject existing)
+            => Precision.AlmostEquals(existing.StartTime, HitObject.StartTime, placement_replace_start_time_leniency_ms);
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Edit
         /// Whether <paramref name="existing"/> should be removed because <paramref name="placement"/> is being placed on top of it.
         /// </summary>
         /// <remarks>
-        /// By default, it Matches when start times are within ±<see cref="placement_replace_start_time_leniency_ms"/> ms of each other.
+        /// By default, it matches when start times are within ±<see cref="placement_replace_start_time_leniency_ms"/> ms of each other.
         /// </remarks>
         public virtual bool PlacementReplacesExisting(HitObject existing, HitObject placement)
             => Precision.AlmostEquals(existing.StartTime, placement.StartTime, placement_replace_start_time_leniency_ms);

--- a/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
@@ -72,18 +72,10 @@ namespace osu.Game.Rulesets.Edit
         /// Whether <paramref name="existing"/> should be removed because <paramref name="placement"/> is being placed on top of it.
         /// </summary>
         /// <remarks>
-        /// Matches when start times are within ±<see cref="placement_replace_start_time_leniency_ms"/> ms of each other.
+        /// By default, it Matches when start times are within ±<see cref="placement_replace_start_time_leniency_ms"/> ms of each other.
         /// </remarks>
-        public static bool PlacementReplacesExisting(HitObject existing, HitObject placement)
-        {
-            if (!Precision.AlmostEquals(existing.StartTime, placement.StartTime, placement_replace_start_time_leniency_ms))
-                return false;
-
-            if (placement is IHasColumn placementColumn && existing is IHasColumn existingColumn)
-                return existingColumn.Column == placementColumn.Column;
-
-            return true;
-        }
+        public virtual bool PlacementReplacesExisting(HitObject existing, HitObject placement)
+            => Precision.AlmostEquals(existing.StartTime, placement.StartTime, placement_replace_start_time_leniency_ms);
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
Custom rulesets may have different conditions for replacement, and may not even use the `IHasColumn` interface.