### PR TITLE
Add legacy storyboard encoder

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaLegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaLegacyBeatmapEncoderTest.cs
@@ -36,8 +36,8 @@ namespace osu.Game.Rulesets.Mania.Tests
             var decoded = DecodeFromLegacy(beatmaps_resource_store.GetStream($"Resources/Testing/Beatmaps/{name}.osu"), beatmaps_resource_store, name);
             var decodedAfterEncode = DecodeFromLegacy(EncodeToLegacy(decoded), beatmaps_resource_store, name);
 
-            Sort(decoded.beatmap);
-            Sort(decodedAfterEncode.beatmap);
+            Sort(decoded.Beatmap);
+            Sort(decodedAfterEncode.Beatmap);
 
             CompareBeatmaps(decoded, decodedAfterEncode);
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
@@ -792,7 +792,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 AddStep("export beatmap", () =>
                 {
-                    var beatmapEncoder = new LegacyBeatmapEncoder(playableBeatmap, null);
+                    var beatmapEncoder = new LegacyBeatmapEncoder(playableBeatmap, null, null);
 
                     using (var stream = File.Open(Path.Combine(exportLocation, $"{testCaseName}.osu"), FileMode.Create))
                     {

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoPlayerScroller.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoPlayerScroller.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 currentStoryboard = new Storyboard();
 
                 for (int i = 0; i < 10; i++)
-                    currentStoryboard.GetLayer("Foreground").Add(new StoryboardSprite($"test{i}", Anchor.Centre, Vector2.Zero));
+                    currentStoryboard.GetLayer("Foreground").Add(new StoryboardSprite(StoryboardElementSource.Beatmap, $"test{i}", Anchor.Centre, Vector2.Zero));
             });
 
             CreateTest();
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 currentStoryboard = new Storyboard();
 
                 for (int i = 0; i < 10; i++)
-                    currentStoryboard.GetLayer("Overlay").Add(new StoryboardSprite($"test{i}", Anchor.Centre, Vector2.Zero));
+                    currentStoryboard.GetLayer("Overlay").Add(new StoryboardSprite(StoryboardElementSource.Beatmap, $"test{i}", Anchor.Centre, Vector2.Zero));
             });
 
             CreateTest();

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -41,14 +41,14 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
         private static IEnumerable<string> allBeatmaps = beatmaps_resource_store.GetAvailableResources().Where(res => res.EndsWith(".osu", StringComparison.Ordinal));
 
+        public record BeatmapComponents(IBeatmap Beatmap, LegacySkin Skin, Storyboard Storyboard);
+
         [Test]
-        public void TestUnsupportedStoryboardEvents()
+        public void TestStoryboardEvents()
         {
             const string name = "Resources/storyboard_only_video.osu";
 
             var decoded = DecodeFromLegacy(beatmaps_resource_store.GetStream(name), beatmaps_resource_store, name);
-            Assert.That(decoded.beatmap.UnhandledEventLines.Count, Is.EqualTo(1));
-            Assert.That(decoded.beatmap.UnhandledEventLines.Single(), Is.EqualTo("Video,0,\"video.avi\""));
 
             var memoryStream = EncodeToLegacy(decoded);
 
@@ -63,8 +63,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decoded = DecodeFromLegacy(beatmaps_resource_store.GetStream(name), beatmaps_resource_store, name);
             var decodedAfterEncode = DecodeFromLegacy(EncodeToLegacy(decoded), beatmaps_resource_store, name);
 
-            Sort(decoded.beatmap);
-            Sort(decodedAfterEncode.beatmap);
+            Sort(decoded.Beatmap);
+            Sort(decodedAfterEncode.Beatmap);
 
             CompareBeatmaps(decoded, decodedAfterEncode);
         }
@@ -76,10 +76,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decodedAfterEncode = DecodeFromLegacy(EncodeToLegacy(decoded), beatmaps_resource_store, name);
 
             // run an extra convert. this is expected to be stable.
-            decodedAfterEncode.beatmap = convert(decodedAfterEncode.beatmap);
+            decodedAfterEncode = decodedAfterEncode with { Beatmap = convert(decodedAfterEncode.Beatmap) };
 
-            Sort(decoded.beatmap);
-            Sort(decodedAfterEncode.beatmap);
+            Sort(decoded.Beatmap);
+            Sort(decodedAfterEncode.Beatmap);
 
             CompareBeatmaps(decoded, decodedAfterEncode);
         }
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
             // we are testing that the transfer of relevant data to hitobjects (from legacy control points) sticks through encode/decode.
             // before the encode step, the legacy information is removed here.
-            decoded.beatmap.ControlPointInfo = removeLegacyControlPointTypes(decoded.beatmap.ControlPointInfo);
+            decoded.Beatmap.ControlPointInfo = removeLegacyControlPointTypes(decoded.Beatmap.ControlPointInfo);
 
             var decodedAfterEncode = DecodeFromLegacy(EncodeToLegacy(decoded), beatmaps_resource_store, name);
 
@@ -120,17 +120,21 @@ namespace osu.Game.Tests.Beatmaps.Formats
             }
         }
 
-        public static void CompareBeatmaps((IBeatmap beatmap, TestLegacySkin skin) expected, (IBeatmap beatmap, TestLegacySkin skin) actual)
+        public static void CompareBeatmaps(BeatmapComponents expected, BeatmapComponents actual)
         {
             // Check all control points that are still considered to be at a global level.
-            Assert.That(actual.beatmap.ControlPointInfo.TimingPoints.Serialize(), Is.EqualTo(expected.beatmap.ControlPointInfo.TimingPoints.Serialize()));
-            Assert.That(actual.beatmap.ControlPointInfo.EffectPoints.Serialize(), Is.EqualTo(expected.beatmap.ControlPointInfo.EffectPoints.Serialize()));
+            Assert.That(actual.Beatmap.ControlPointInfo.TimingPoints.Serialize(), Is.EqualTo(expected.Beatmap.ControlPointInfo.TimingPoints.Serialize()));
+            Assert.That(actual.Beatmap.ControlPointInfo.EffectPoints.Serialize(), Is.EqualTo(expected.Beatmap.ControlPointInfo.EffectPoints.Serialize()));
 
             // Check all hitobjects.
-            Assert.That(actual.beatmap.HitObjects.Serialize(), Is.EqualTo(expected.beatmap.HitObjects.Serialize()));
+            Assert.That(actual.Beatmap.HitObjects.Serialize(), Is.EqualTo(expected.Beatmap.HitObjects.Serialize()));
 
             // Check skin.
-            ClassicAssert.True(areComboColoursEqual(expected.skin.Configuration, actual.skin.Configuration));
+            ClassicAssert.True(areComboColoursEqual(expected.Skin.Configuration, actual.Skin.Configuration));
+
+            // Do a rough pass on storyboard layers.
+            foreach (string layer in actual.Storyboard.Layers.Concat(expected.Storyboard.Layers).Select(l => l.Name).Distinct())
+                Assert.That(actual.Storyboard.GetLayer(layer).Elements.Count, Is.EqualTo(expected.Storyboard.GetLayer(layer).Elements.Count));
         }
 
         [Test]
@@ -153,9 +157,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 }
             };
 
-            var encoded = EncodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty)));
+            var encoded = EncodeToLegacy(new BeatmapComponents(beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty), new Storyboard()));
             var decodedAfterEncode = DecodeFromLegacy(encoded, beatmaps_resource_store, string.Empty);
-            var decodedSlider = (Slider)decodedAfterEncode.beatmap.HitObjects[0];
+            var decodedSlider = (Slider)decodedAfterEncode.Beatmap.HitObjects[0];
             Assert.That(decodedSlider.Path.ControlPoints.Count, Is.EqualTo(4));
             Assert.That(decodedSlider.Path.ControlPoints[0].Type, Is.EqualTo(PathType.BSpline(3)));
             Assert.That(decodedSlider.Path.ControlPoints[2].Type, Is.EqualTo(PathType.BSpline(3)));
@@ -183,9 +187,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 }
             };
 
-            var encoded = EncodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty)));
+            var encoded = EncodeToLegacy(new BeatmapComponents(beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty), new Storyboard()));
             var decodedAfterEncode = DecodeFromLegacy(encoded, beatmaps_resource_store, string.Empty);
-            var decodedSlider = (Slider)decodedAfterEncode.beatmap.HitObjects[0];
+            var decodedSlider = (Slider)decodedAfterEncode.Beatmap.HitObjects[0];
             Assert.That(decodedSlider.Path.ControlPoints.Count, Is.EqualTo(5));
         }
 
@@ -211,9 +215,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 }
             };
 
-            var encoded = EncodeToLegacy((new Beatmap(), beatmapSkin));
+            var encoded = EncodeToLegacy(new BeatmapComponents(new Beatmap(), beatmapSkin, new Storyboard()));
             var decodedAfterEncode = DecodeFromLegacy(encoded, beatmaps_resource_store, string.Empty);
-            Assert.That(decodedAfterEncode.skin.Configuration.CustomComboColours, Has.Count.EqualTo(8));
+            Assert.That(decodedAfterEncode.Skin.Configuration.CustomComboColours, Has.Count.EqualTo(8));
         }
 
         [Test]
@@ -234,9 +238,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 HitObjects = { originalSlider }
             };
 
-            var encoded = EncodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty)));
+            var encoded = EncodeToLegacy(new BeatmapComponents(beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty), new Storyboard()));
             var decodedAfterEncode = DecodeFromLegacy(encoded, beatmaps_resource_store, string.Empty, version: LegacyBeatmapEncoder.FIRST_LAZER_VERSION);
-            var decodedSlider = (Slider)decodedAfterEncode.beatmap.HitObjects[0];
+            var decodedSlider = (Slider)decodedAfterEncode.Beatmap.HitObjects[0];
             Assert.That(decodedSlider.Path.ControlPoints.Select(p => p.Position),
                 Is.EquivalentTo(originalSlider.Path.ControlPoints.Select(p => p.Position)));
         }
@@ -254,17 +258,17 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 }
             };
 
-            var encoded = EncodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty)));
+            var encoded = EncodeToLegacy(new BeatmapComponents(beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty), new Storyboard()));
             var decodedAfterEncode = DecodeFromLegacy(encoded, beatmaps_resource_store, string.Empty);
 
-            Assert.That(decodedAfterEncode.beatmap.HitObjects[0].Samples[0].Suffix, Is.Null);
-            Assert.That(decodedAfterEncode.beatmap.HitObjects[0].Samples[0].UseBeatmapSamples, Is.False);
+            Assert.That(decodedAfterEncode.Beatmap.HitObjects[0].Samples[0].Suffix, Is.Null);
+            Assert.That(decodedAfterEncode.Beatmap.HitObjects[0].Samples[0].UseBeatmapSamples, Is.False);
 
-            Assert.That(decodedAfterEncode.beatmap.HitObjects[1].Samples[0].Suffix, Is.Null);
-            Assert.That(decodedAfterEncode.beatmap.HitObjects[1].Samples[0].UseBeatmapSamples, Is.True);
+            Assert.That(decodedAfterEncode.Beatmap.HitObjects[1].Samples[0].Suffix, Is.Null);
+            Assert.That(decodedAfterEncode.Beatmap.HitObjects[1].Samples[0].UseBeatmapSamples, Is.True);
 
-            Assert.That(decodedAfterEncode.beatmap.HitObjects[2].Samples[0].Suffix, Is.EqualTo("3"));
-            Assert.That(decodedAfterEncode.beatmap.HitObjects[2].Samples[0].UseBeatmapSamples, Is.True);
+            Assert.That(decodedAfterEncode.Beatmap.HitObjects[2].Samples[0].Suffix, Is.EqualTo("3"));
+            Assert.That(decodedAfterEncode.Beatmap.HitObjects[2].Samples[0].UseBeatmapSamples, Is.True);
         }
 
         private static bool areComboColoursEqual(IHasComboColours a, IHasComboColours b)
@@ -289,7 +293,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             }
         }
 
-        public static (IBeatmap beatmap, TestLegacySkin skin) DecodeFromLegacy(Stream stream, IResourceStore<byte[]> beatmapsResourceStore, string name, int version = LegacyDecoder<Beatmap>.LATEST_VERSION)
+        public static BeatmapComponents DecodeFromLegacy(Stream stream, IResourceStore<byte[]> beatmapsResourceStore, string name, int version = LegacyDecoder<Beatmap>.LATEST_VERSION)
         {
             using (var reader = new LineBufferedReader(stream))
             {
@@ -297,7 +301,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var beatmapSkin = new TestLegacySkin(beatmapsResourceStore, name);
                 stream.Seek(0, SeekOrigin.Begin);
                 beatmapSkin.Configuration = new LegacySkinDecoder().Decode(reader);
-                return (convert(beatmap), beatmapSkin);
+                stream.Seek(0, SeekOrigin.Begin);
+                var storyboard = new LegacyStoryboardDecoder().Decode(reader);
+                return new BeatmapComponents(convert(beatmap), beatmapSkin, storyboard);
             }
         }
 
@@ -309,13 +315,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
             }
         }
 
-        public static MemoryStream EncodeToLegacy((IBeatmap beatmap, ISkin skin) fullBeatmap)
+        public static MemoryStream EncodeToLegacy(BeatmapComponents fullBeatmap)
         {
-            var (beatmap, beatmapSkin) = fullBeatmap;
+            var (beatmap, beatmapSkin, storyboard) = fullBeatmap;
             var stream = new MemoryStream();
 
             using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
-                new LegacyBeatmapEncoder(beatmap, beatmapSkin).Encode(writer);
+                new LegacyBeatmapEncoder(beatmap, beatmapSkin, storyboard).Encode(writer);
 
             stream.Position = 0;
 

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardEncoderTest.cs
@@ -1,0 +1,383 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.IO;
+using osu.Game.Storyboards;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Beatmaps.Formats
+{
+    [TestFixture]
+    public class LegacyStoryboardEncoderTest
+    {
+        [Test]
+        public void TestBackground()
+        {
+            var initial = createComponents();
+            initial.Beatmap.BeatmapInfo.Metadata.BackgroundFile = "bg.jpg";
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            Assert.That(decodedAfterEncode.Beatmap.BeatmapInfo.Metadata.BackgroundFile, Is.EqualTo("bg.jpg"));
+        }
+
+        [Test]
+        public void TestVideos()
+        {
+            var initial = createComponents();
+
+            initial.Storyboard.GetLayer("Video").Add(new StoryboardVideo(StoryboardElementSource.Beatmap, "video1.avi", 0));
+            initial.Storyboard.GetLayer("Video").Add(new StoryboardVideo(StoryboardElementSource.SharedStoryboard, "video2.mp4", 1234));
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            Assert.Multiple(() =>
+            {
+                var videoLayer = decodedAfterEncode.Storyboard.GetLayer("Video");
+                Assert.That(videoLayer.Elements, Has.Count.EqualTo(2));
+
+                Assert.That(videoLayer.Elements[0].Source, Is.EqualTo(StoryboardElementSource.Beatmap));
+                Assert.That(videoLayer.Elements[0].Path, Is.EqualTo("video1.avi"));
+                Assert.That(videoLayer.Elements[0].StartTime, Is.EqualTo(0));
+
+                Assert.That(videoLayer.Elements[1].Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(videoLayer.Elements[1].Path, Is.EqualTo("video2.mp4"));
+                Assert.That(videoLayer.Elements[1].StartTime, Is.EqualTo(1234));
+            });
+        }
+
+        [Test]
+        public void TestVideoWithCommands()
+        {
+            var initial = createComponents();
+
+            var video = new StoryboardVideo(StoryboardElementSource.Beatmap, "video1.avi", 0);
+            video.Commands.AddScale(Easing.None, 0, 0, 0.7f, 0.7f);
+            initial.Storyboard.GetLayer("Video").Add(video);
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            Assert.Multiple(() =>
+            {
+                var decodedVideo = (StoryboardVideo)decodedAfterEncode.Storyboard.GetLayer("Video").Elements.Single();
+
+                Assert.That(decodedVideo.Source, Is.EqualTo(StoryboardElementSource.Beatmap));
+                Assert.That(decodedVideo.Path, Is.EqualTo("video1.avi"));
+                Assert.That(decodedVideo.StartTime, Is.EqualTo(0));
+
+                Assert.That(decodedVideo.Commands.Scale, Has.Count.EqualTo(1));
+                var scaleCommand = (decodedVideo.Commands.Scale.Single());
+                Assert.That(scaleCommand.Easing, Is.EqualTo(Easing.None));
+                Assert.That(scaleCommand.StartTime, Is.EqualTo(0));
+                Assert.That(scaleCommand.EndTime, Is.EqualTo(0));
+                Assert.That(scaleCommand.StartValue, Is.EqualTo(0.7f));
+                Assert.That(scaleCommand.EndValue, Is.EqualTo(0.7f));
+            });
+        }
+
+        [Test]
+        public void TestSpritesAndAnimations()
+        {
+            var initial = createComponents();
+
+            initial.Storyboard.GetLayer("Background").Add(new StoryboardSprite(StoryboardElementSource.Beatmap, "1.png", Anchor.TopLeft, new Vector2()));
+            initial.Storyboard.GetLayer("Fail").Add(new StoryboardSprite(StoryboardElementSource.SharedStoryboard, "2.png", Anchor.Centre, new Vector2(-3)));
+            initial.Storyboard.GetLayer("Pass").Add(new StoryboardSprite(StoryboardElementSource.SharedStoryboard, "3.png", Anchor.BottomRight, new Vector2(30, -30)));
+            initial.Storyboard.GetLayer("Foreground").Add(new StoryboardAnimation(StoryboardElementSource.Beatmap, "anim1", Anchor.CentreLeft, new Vector2(30), frameCount: 10, frameDelay: 30, AnimationLoopType.LoopForever));
+            initial.Storyboard.GetLayer("Overlay").Add(new StoryboardAnimation(StoryboardElementSource.SharedStoryboard, "anim2", Anchor.CentreRight, new Vector2(30), frameCount: 4, frameDelay: 100, AnimationLoopType.LoopOnce));
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            var sb = decodedAfterEncode.Storyboard;
+
+            Assert.Multiple(() =>
+            {
+                var backgroundSprite = (StoryboardSprite)sb.GetLayer("Background").Elements.Single();
+                Assert.That(backgroundSprite.Source, Is.EqualTo(StoryboardElementSource.Beatmap));
+                Assert.That(backgroundSprite.Path, Is.EqualTo("1.png"));
+                Assert.That(backgroundSprite.Origin, Is.EqualTo(Anchor.TopLeft));
+                Assert.That(backgroundSprite.InitialPosition, Is.EqualTo(new Vector2()));
+
+                var failSprite = (StoryboardSprite)sb.GetLayer("Fail").Elements.Single();
+                Assert.That(failSprite.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(failSprite.Path, Is.EqualTo("2.png"));
+                Assert.That(failSprite.Origin, Is.EqualTo(Anchor.Centre));
+                Assert.That(failSprite.InitialPosition, Is.EqualTo(new Vector2(-3)));
+
+                var passSprite = (StoryboardSprite)sb.GetLayer("Pass").Elements.Single();
+                Assert.That(passSprite.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(passSprite.Path, Is.EqualTo("3.png"));
+                Assert.That(passSprite.Origin, Is.EqualTo(Anchor.BottomRight));
+                Assert.That(passSprite.InitialPosition, Is.EqualTo(new Vector2(30, -30)));
+
+                var foregroundAnimation = (StoryboardAnimation)sb.GetLayer("Foreground").Elements.Single();
+                Assert.That(foregroundAnimation.Source, Is.EqualTo(StoryboardElementSource.Beatmap));
+                Assert.That(foregroundAnimation.Path, Is.EqualTo("anim1"));
+                Assert.That(foregroundAnimation.Origin, Is.EqualTo(Anchor.CentreLeft));
+                Assert.That(foregroundAnimation.InitialPosition, Is.EqualTo(new Vector2(30)));
+                Assert.That(foregroundAnimation.FrameCount, Is.EqualTo(10));
+                Assert.That(foregroundAnimation.FrameDelay, Is.EqualTo(30));
+                Assert.That(foregroundAnimation.LoopType, Is.EqualTo(AnimationLoopType.LoopForever));
+
+                var overlayAnimation = (StoryboardAnimation)sb.GetLayer("Overlay").Elements.Single();
+                Assert.That(overlayAnimation.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(overlayAnimation.Path, Is.EqualTo("anim2"));
+                Assert.That(overlayAnimation.Origin, Is.EqualTo(Anchor.CentreRight));
+                Assert.That(overlayAnimation.InitialPosition, Is.EqualTo(new Vector2(30)));
+                Assert.That(overlayAnimation.FrameCount, Is.EqualTo(4));
+                Assert.That(overlayAnimation.FrameDelay, Is.EqualTo(100));
+                Assert.That(overlayAnimation.LoopType, Is.EqualTo(AnimationLoopType.LoopOnce));
+            });
+        }
+
+        [Test]
+        public void TestCommands()
+        {
+            var initial = createComponents();
+
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "test.jpg", Anchor.Centre, new Vector2(300));
+            sprite.Commands.AddAlpha(Easing.InBack, 100, 200, 0, 1);
+            sprite.Commands.AddBlendingParameters(Easing.None, 300, 300, BlendingParameters.Additive, BlendingParameters.Additive);
+            sprite.Commands.AddColour(Easing.InCubic, 400, 500, Color4.White, Color4.Aquamarine);
+            sprite.Commands.AddFlipH(Easing.InOutQuad, 600, 600, true, true);
+            sprite.Commands.AddFlipV(Easing.InOutQuad, 800, 900, true, false);
+            sprite.Commands.AddRotation(Easing.OutSine, 1000, 1100, 0, 720);
+            sprite.Commands.AddScale(Easing.OutQuint, 1200, 1300, 1, 4);
+            sprite.Commands.AddVectorScale(Easing.InCirc, 1400, 1500, new Vector2(4), new Vector2(3, 1));
+            sprite.Commands.AddX(Easing.InOutQuad, 1600, 1700, 300, 500);
+            sprite.Commands.AddY(Easing.OutBounce, 1800, 1800, 300, 100);
+            initial.Storyboard.GetLayer("Background").Add(sprite);
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            var decodedSprite = (StoryboardSprite)decodedAfterEncode.Storyboard.GetLayer("Background").Elements.Single();
+
+            Assert.Multiple(() =>
+            {
+                var alphaCommand = decodedSprite.Commands.Alpha.Single();
+                Assert.That(alphaCommand.Easing, Is.EqualTo(Easing.InBack));
+                Assert.That(alphaCommand.StartTime, Is.EqualTo(100));
+                Assert.That(alphaCommand.EndTime, Is.EqualTo(200));
+                Assert.That(alphaCommand.StartValue, Is.EqualTo(0));
+                Assert.That(alphaCommand.EndValue, Is.EqualTo(1));
+
+                var blendingCommand = decodedSprite.Commands.BlendingParameters.Single();
+                Assert.That(blendingCommand.Easing, Is.EqualTo(Easing.None));
+                Assert.That(blendingCommand.StartTime, Is.EqualTo(300));
+                Assert.That(blendingCommand.EndTime, Is.EqualTo(300));
+                Assert.That(blendingCommand.StartValue, Is.EqualTo(BlendingParameters.Additive));
+                Assert.That(blendingCommand.EndValue, Is.EqualTo(BlendingParameters.Additive));
+
+                var colourCommand = decodedSprite.Commands.Colour.Single();
+                Assert.That(colourCommand.Easing, Is.EqualTo(Easing.InCubic));
+                Assert.That(colourCommand.StartTime, Is.EqualTo(400));
+                Assert.That(colourCommand.EndTime, Is.EqualTo(500));
+                Assert.That(colourCommand.StartValue, Is.EqualTo(Color4.White));
+                Assert.That(colourCommand.EndValue, Is.EqualTo(Color4.Aquamarine));
+
+                var flipHCommand = decodedSprite.Commands.FlipH.Single();
+                Assert.That(flipHCommand.Easing, Is.EqualTo(Easing.InOutQuad));
+                Assert.That(flipHCommand.StartTime, Is.EqualTo(600));
+                Assert.That(flipHCommand.EndTime, Is.EqualTo(600));
+                Assert.That(flipHCommand.StartValue, Is.EqualTo(true));
+                Assert.That(flipHCommand.EndValue, Is.EqualTo(true));
+
+                var flipVCommand = decodedSprite.Commands.FlipV.Single();
+                Assert.That(flipVCommand.Easing, Is.EqualTo(Easing.InOutQuad));
+                Assert.That(flipVCommand.StartTime, Is.EqualTo(800));
+                Assert.That(flipVCommand.EndTime, Is.EqualTo(900));
+                Assert.That(flipVCommand.StartValue, Is.EqualTo(true));
+                Assert.That(flipVCommand.EndValue, Is.EqualTo(false));
+
+                var rotationCommand = decodedSprite.Commands.Rotation.Single();
+                Assert.That(rotationCommand.Easing, Is.EqualTo(Easing.OutSine));
+                Assert.That(rotationCommand.StartTime, Is.EqualTo(1000));
+                Assert.That(rotationCommand.EndTime, Is.EqualTo(1100));
+                Assert.That(rotationCommand.StartValue, Is.EqualTo(0));
+                Assert.That(rotationCommand.EndValue, Is.EqualTo(720));
+
+                var scaleCommand = decodedSprite.Commands.Scale.Single();
+                Assert.That(scaleCommand.Easing, Is.EqualTo(Easing.OutQuint));
+                Assert.That(scaleCommand.StartTime, Is.EqualTo(1200));
+                Assert.That(scaleCommand.EndTime, Is.EqualTo(1300));
+                Assert.That(scaleCommand.StartValue, Is.EqualTo(1));
+                Assert.That(scaleCommand.EndValue, Is.EqualTo(4));
+
+                var vectorScaleCommand = decodedSprite.Commands.VectorScale.Single();
+                Assert.That(vectorScaleCommand.Easing, Is.EqualTo(Easing.InCirc));
+                Assert.That(vectorScaleCommand.StartTime, Is.EqualTo(1400));
+                Assert.That(vectorScaleCommand.EndTime, Is.EqualTo(1500));
+                Assert.That(vectorScaleCommand.StartValue, Is.EqualTo(new Vector2(4)));
+                Assert.That(vectorScaleCommand.EndValue, Is.EqualTo(new Vector2(3, 1)));
+
+                var xCommand = decodedSprite.Commands.X.Single();
+                Assert.That(xCommand.Easing, Is.EqualTo(Easing.InOutQuad));
+                Assert.That(xCommand.StartTime, Is.EqualTo(1600));
+                Assert.That(xCommand.EndTime, Is.EqualTo(1700));
+                Assert.That(xCommand.StartValue, Is.EqualTo(300));
+                Assert.That(xCommand.EndValue, Is.EqualTo(500));
+
+                var yCommand = decodedSprite.Commands.Y.Single();
+                Assert.That(yCommand.Easing, Is.EqualTo(Easing.OutBounce));
+                Assert.That(yCommand.StartTime, Is.EqualTo(1800));
+                Assert.That(yCommand.EndTime, Is.EqualTo(1800));
+                Assert.That(yCommand.StartValue, Is.EqualTo(300));
+                Assert.That(yCommand.EndValue, Is.EqualTo(100));
+            });
+        }
+
+        [Test]
+        public void TestLoopingGroup()
+        {
+            var initial = createComponents();
+
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "test.jpg", Anchor.Centre, new Vector2(300));
+            var loopingGroup = sprite.AddLoopingGroup(1000, 44);
+            loopingGroup.AddAlpha(Easing.OutQuint, 1000, 1500, 0, 1);
+            initial.Storyboard.GetLayer("Background").Add(sprite);
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            var decodedSprite = (StoryboardSprite)decodedAfterEncode.Storyboard.GetLayer("Background").Elements.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(decodedSprite.LoopingGroups, Has.Count.EqualTo(1));
+                var decodedLoopingGroup = decodedSprite.LoopingGroups.Single();
+                Assert.That(decodedLoopingGroup.StartTime, Is.EqualTo(1000));
+                Assert.That(decodedLoopingGroup.TotalIterations, Is.EqualTo(45));
+
+                var alphaCommand = decodedLoopingGroup.Alpha.Single();
+                Assert.That(alphaCommand.Easing, Is.EqualTo(Easing.OutQuint));
+                Assert.That(alphaCommand.StartTime, Is.EqualTo(1000));
+                Assert.That(alphaCommand.EndTime, Is.EqualTo(1500));
+                Assert.That(alphaCommand.StartValue, Is.EqualTo(0));
+                Assert.That(alphaCommand.EndValue, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void TestTriggerGroup()
+        {
+            var initial = createComponents();
+
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "test.jpg", Anchor.Centre, new Vector2(300));
+            var triggerGroup = sprite.AddTriggerGroup("Passing", 0, 100000, 33);
+            triggerGroup.AddAlpha(Easing.OutQuint, 0, 500, 0, 1);
+            initial.Storyboard.GetLayer("Background").Add(sprite);
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            var decodedSprite = (StoryboardSprite)decodedAfterEncode.Storyboard.GetLayer("Background").Elements.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(decodedSprite.TriggerGroups, Has.Count.EqualTo(1));
+                var decodedTriggerGroup = decodedSprite.TriggerGroups.Single();
+                Assert.That(decodedTriggerGroup.TriggerName, Is.EqualTo("Passing"));
+                Assert.That(decodedTriggerGroup.TriggerStartTime, Is.EqualTo(0));
+                Assert.That(decodedTriggerGroup.TriggerEndTime, Is.EqualTo(100000));
+                Assert.That(decodedTriggerGroup.GroupNumber, Is.EqualTo(33));
+
+                var alphaCommand = decodedTriggerGroup.Alpha.Single();
+                Assert.That(alphaCommand.Easing, Is.EqualTo(Easing.OutQuint));
+                Assert.That(alphaCommand.StartTime, Is.EqualTo(0));
+                Assert.That(alphaCommand.EndTime, Is.EqualTo(500));
+                Assert.That(alphaCommand.StartValue, Is.EqualTo(0));
+                Assert.That(alphaCommand.EndValue, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void TestStoryboardSamples()
+        {
+            var initial = createComponents();
+
+            initial.Storyboard.GetLayer("Pass").Add(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "pass.wav", 4000, 85));
+            initial.Storyboard.GetLayer("Fail").Add(new StoryboardSampleInfo(StoryboardElementSource.SharedStoryboard, "fail.wav", 4000, 100));
+
+            var encoded = encode(initial);
+            var decodedAfterEncode = decode(encoded);
+
+            Assert.Multiple(() =>
+            {
+                var passingSample = (StoryboardSampleInfo)decodedAfterEncode.Storyboard.GetLayer("Pass").Elements.Single();
+                Assert.That(passingSample.Source, Is.EqualTo(StoryboardElementSource.Beatmap));
+                Assert.That(passingSample.Path, Is.EqualTo("pass.wav"));
+                Assert.That(passingSample.StartTime, Is.EqualTo(4000));
+                Assert.That(passingSample.Volume, Is.EqualTo(85));
+
+                var failingSample = (StoryboardSampleInfo)decodedAfterEncode.Storyboard.GetLayer("Fail").Elements.Single();
+                Assert.That(failingSample.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(failingSample.Path, Is.EqualTo("fail.wav"));
+                Assert.That(failingSample.StartTime, Is.EqualTo(4000));
+                Assert.That(failingSample.Volume, Is.EqualTo(100));
+            });
+        }
+
+        private record DecodedBeatmapComponents(IBeatmap Beatmap, Storyboard Storyboard);
+
+        private record EncodedBeatmapComponents(MemoryStream Beatmap, MemoryStream Storyboard);
+
+        private DecodedBeatmapComponents createComponents()
+        {
+            var beatmapInfo = new BeatmapInfo();
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo = beatmapInfo
+            };
+            var storyboard = new Storyboard
+            {
+                Beatmap = beatmap,
+                BeatmapInfo = beatmapInfo
+            };
+
+            return new DecodedBeatmapComponents(beatmap, storyboard);
+        }
+
+        private EncodedBeatmapComponents encode(DecodedBeatmapComponents decoded)
+        {
+            var beatmapStream = new MemoryStream();
+            using (var beatmapWriter = new StreamWriter(beatmapStream, Encoding.UTF8, 1024, leaveOpen: true))
+                new LegacyBeatmapEncoder(decoded.Beatmap, null, decoded.Storyboard).Encode(beatmapWriter);
+            beatmapStream.Position = 0;
+
+            var storyboardStream = new MemoryStream();
+            using (var storyboardWriter = new StreamWriter(storyboardStream, Encoding.UTF8, 1024, leaveOpen: true))
+                new LegacyStoryboardEncoder(decoded.Storyboard).EncodeStandaloneStoryboard(storyboardWriter);
+            storyboardStream.Position = 0;
+
+            return new EncodedBeatmapComponents(beatmapStream, storyboardStream);
+        }
+
+        private DecodedBeatmapComponents decode(EncodedBeatmapComponents encoded)
+        {
+            using var beatmapReader = new LineBufferedReader(encoded.Beatmap, leaveOpen: true);
+            var beatmap = new LegacyBeatmapDecoder().Decode(beatmapReader);
+
+            encoded.Beatmap.Position = 0;
+            using var storyboardReader = new LineBufferedReader(encoded.Storyboard, leaveOpen: true);
+            var storyboard = new LegacyStoryboardDecoder().Decode(beatmapReader, storyboardReader);
+
+            encoded.Beatmap.Position = 0;
+            encoded.Storyboard.Position = 0;
+
+            return new DecodedBeatmapComponents(beatmap, storyboard);
+        }
+    }
+}

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardEncoderTest.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var initial = createComponents();
 
             initial.Storyboard.GetLayer("Video").Add(new StoryboardVideo(StoryboardElementSource.Beatmap, "video1.avi", 0));
-            initial.Storyboard.GetLayer("Video").Add(new StoryboardVideo(StoryboardElementSource.SharedStoryboard, "video2.mp4", 1234));
+            initial.Storyboard.GetLayer("Video").Add(new StoryboardVideo(StoryboardElementSource.Shared, "video2.mp4", 1234));
 
             var encoded = encode(initial);
             var decodedAfterEncode = decode(encoded);
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(videoLayer.Elements[0].Path, Is.EqualTo("video1.avi"));
                 Assert.That(videoLayer.Elements[0].StartTime, Is.EqualTo(0));
 
-                Assert.That(videoLayer.Elements[1].Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(videoLayer.Elements[1].Source, Is.EqualTo(StoryboardElementSource.Shared));
                 Assert.That(videoLayer.Elements[1].Path, Is.EqualTo("video2.mp4"));
                 Assert.That(videoLayer.Elements[1].StartTime, Is.EqualTo(1234));
             });
@@ -92,10 +92,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var initial = createComponents();
 
             initial.Storyboard.GetLayer("Background").Add(new StoryboardSprite(StoryboardElementSource.Beatmap, "1.png", Anchor.TopLeft, new Vector2()));
-            initial.Storyboard.GetLayer("Fail").Add(new StoryboardSprite(StoryboardElementSource.SharedStoryboard, "2.png", Anchor.Centre, new Vector2(-3)));
-            initial.Storyboard.GetLayer("Pass").Add(new StoryboardSprite(StoryboardElementSource.SharedStoryboard, "3.png", Anchor.BottomRight, new Vector2(30, -30)));
+            initial.Storyboard.GetLayer("Fail").Add(new StoryboardSprite(StoryboardElementSource.Shared, "2.png", Anchor.Centre, new Vector2(-3)));
+            initial.Storyboard.GetLayer("Pass").Add(new StoryboardSprite(StoryboardElementSource.Shared, "3.png", Anchor.BottomRight, new Vector2(30, -30)));
             initial.Storyboard.GetLayer("Foreground").Add(new StoryboardAnimation(StoryboardElementSource.Beatmap, "anim1", Anchor.CentreLeft, new Vector2(30), frameCount: 10, frameDelay: 30, AnimationLoopType.LoopForever));
-            initial.Storyboard.GetLayer("Overlay").Add(new StoryboardAnimation(StoryboardElementSource.SharedStoryboard, "anim2", Anchor.CentreRight, new Vector2(30), frameCount: 4, frameDelay: 100, AnimationLoopType.LoopOnce));
+            initial.Storyboard.GetLayer("Overlay").Add(new StoryboardAnimation(StoryboardElementSource.Shared, "anim2", Anchor.CentreRight, new Vector2(30), frameCount: 4, frameDelay: 100, AnimationLoopType.LoopOnce));
 
             var encoded = encode(initial);
             var decodedAfterEncode = decode(encoded);
@@ -111,13 +111,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(backgroundSprite.InitialPosition, Is.EqualTo(new Vector2()));
 
                 var failSprite = (StoryboardSprite)sb.GetLayer("Fail").Elements.Single();
-                Assert.That(failSprite.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(failSprite.Source, Is.EqualTo(StoryboardElementSource.Shared));
                 Assert.That(failSprite.Path, Is.EqualTo("2.png"));
                 Assert.That(failSprite.Origin, Is.EqualTo(Anchor.Centre));
                 Assert.That(failSprite.InitialPosition, Is.EqualTo(new Vector2(-3)));
 
                 var passSprite = (StoryboardSprite)sb.GetLayer("Pass").Elements.Single();
-                Assert.That(passSprite.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(passSprite.Source, Is.EqualTo(StoryboardElementSource.Shared));
                 Assert.That(passSprite.Path, Is.EqualTo("3.png"));
                 Assert.That(passSprite.Origin, Is.EqualTo(Anchor.BottomRight));
                 Assert.That(passSprite.InitialPosition, Is.EqualTo(new Vector2(30, -30)));
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(foregroundAnimation.LoopType, Is.EqualTo(AnimationLoopType.LoopForever));
 
                 var overlayAnimation = (StoryboardAnimation)sb.GetLayer("Overlay").Elements.Single();
-                Assert.That(overlayAnimation.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(overlayAnimation.Source, Is.EqualTo(StoryboardElementSource.Shared));
                 Assert.That(overlayAnimation.Path, Is.EqualTo("anim2"));
                 Assert.That(overlayAnimation.Origin, Is.EqualTo(Anchor.CentreRight));
                 Assert.That(overlayAnimation.InitialPosition, Is.EqualTo(new Vector2(30)));
@@ -309,7 +309,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var initial = createComponents();
 
             initial.Storyboard.GetLayer("Pass").Add(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "pass.wav", 4000, 85));
-            initial.Storyboard.GetLayer("Fail").Add(new StoryboardSampleInfo(StoryboardElementSource.SharedStoryboard, "fail.wav", 4000, 100));
+            initial.Storyboard.GetLayer("Fail").Add(new StoryboardSampleInfo(StoryboardElementSource.Shared, "fail.wav", 4000, 100));
 
             var encoded = encode(initial);
             var decodedAfterEncode = decode(encoded);
@@ -323,7 +323,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(passingSample.Volume, Is.EqualTo(85));
 
                 var failingSample = (StoryboardSampleInfo)decodedAfterEncode.Storyboard.GetLayer("Fail").Elements.Single();
-                Assert.That(failingSample.Source, Is.EqualTo(StoryboardElementSource.SharedStoryboard));
+                Assert.That(failingSample.Source, Is.EqualTo(StoryboardElementSource.Shared));
                 Assert.That(failingSample.Path, Is.EqualTo("fail.wav"));
                 Assert.That(failingSample.StartTime, Is.EqualTo(4000));
                 Assert.That(failingSample.Volume, Is.EqualTo(100));

--- a/osu.Game.Tests/Editing/Checks/CheckAudioInVideoTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioInVideoTest.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var storyboard = new Storyboard();
             var layer = storyboard.GetLayer("Video");
-            layer.Add(new StoryboardVideo("abc123.mp4", 0));
+            layer.Add(new StoryboardVideo(StoryboardElementSource.Beatmap, "abc123.mp4", 0));
 
             var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);

--- a/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckInconsistentSettingsTest.cs
@@ -260,7 +260,7 @@ namespace osu.Game.Tests.Editing.Checks
             if (hasStoryboard)
             {
                 storyboard = new Storyboard();
-                storyboard.GetLayer("Background").Add(new StoryboardSprite("test.png", Anchor.Centre, Vector2.Zero));
+                storyboard.GetLayer("Background").Add(new StoryboardSprite(StoryboardElementSource.Beatmap, "test.png", Anchor.Centre, Vector2.Zero));
             }
 
             var verifiedCurrentBeatmap = new BeatmapVerifierContext.VerifiedBeatmap(new TestWorkingBeatmap(currentBeatmap, storyboard), currentBeatmap);

--- a/osu.Game.Tests/Editing/Checks/CheckUnusedAudioAtEndTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckUnusedAudioAtEndTest.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var storyboard = new Storyboard();
 
-            var video = new StoryboardVideo("abc123.mp4", 0);
+            var video = new StoryboardVideo(StoryboardElementSource.Beatmap, "abc123.mp4", 0);
 
             storyboard.GetLayer("Video").Add(video);
 
@@ -98,7 +98,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var storyboard = new Storyboard();
 
-            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "unknown", Anchor.TopLeft, Vector2.Zero);
 
             storyboard.GetLayer("Background").Add(sprite);
 

--- a/osu.Game.Tests/Editing/Checks/CheckVideoResolutionTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckVideoResolutionTest.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var storyboard = new Storyboard();
             var layer = storyboard.GetLayer("Video");
-            layer.Add(new StoryboardVideo("abc123.mp4", 0));
+            layer.Add(new StoryboardVideo(StoryboardElementSource.Beatmap, "abc123.mp4", 0));
 
             var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null!, null!);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);

--- a/osu.Game.Tests/Editing/Checks/CheckVideoUsageTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckVideoUsageTest.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Tests.Editing.Checks
             };
 
             var storyboard = new Storyboard();
-            storyboard.GetLayer("Video").Add(new StoryboardVideo(path, startTime));
+            storyboard.GetLayer("Video").Add(new StoryboardVideo(StoryboardElementSource.Beatmap, path, startTime));
 
             var working = new TestWorkingBeatmap(beatmap, storyboard);
             return new BeatmapVerifierContext.VerifiedBeatmap(working, beatmap);

--- a/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
+++ b/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
@@ -362,7 +362,7 @@ namespace osu.Game.Tests.Editing
             using (var encoded = new MemoryStream())
             {
                 using (var sw = new StreamWriter(encoded))
-                    new LegacyBeatmapEncoder(beatmap, null).Encode(sw);
+                    new LegacyBeatmapEncoder(beatmap, null, null).Encode(sw);
 
                 return encoded.ToArray();
             }

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Gameplay
                 {
                     Child = new FrameStabilityContainer
                     {
-                        Child = sample = new DrawableStoryboardSample(new StoryboardSampleInfo(string.Empty, 0, 1))
+                        Child = sample = new DrawableStoryboardSample(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, string.Empty, 0, 1))
                     }
                 });
             });
@@ -109,7 +109,7 @@ namespace osu.Game.Tests.Gameplay
                 {
                     Child = new FrameStabilityContainer
                     {
-                        Child = sample = new DrawableStoryboardSample(new StoryboardSampleInfo(string.Empty, 0, 1))
+                        Child = sample = new DrawableStoryboardSample(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, string.Empty, 0, 1))
                     }
                 });
 
@@ -141,7 +141,7 @@ namespace osu.Game.Tests.Gameplay
                     Child = beatmapSkinSourceContainer
                 });
 
-                beatmapSkinSourceContainer.Add(sample = new DrawableStoryboardSample(new StoryboardSampleInfo("test-sample", 1, 1))
+                beatmapSkinSourceContainer.Add(sample = new DrawableStoryboardSample(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "test-sample", 1, 1))
                 {
                     Clock = gameplayContainer
                 });

--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
@@ -355,6 +355,7 @@ namespace osu.Game.Tests.Visual.Background
                 public double StartTime => double.MinValue;
                 public double EndTime => double.MaxValue;
                 public double EndTimeForDisplay => double.MaxValue;
+                public StoryboardElementSource Source => StoryboardElementSource.Beatmap;
 
                 public Drawable CreateDrawable() => new DrawableTestStoryboardElement();
             }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 var layer = storyboard.GetLayer("Background");
 
-                var sprite = new StoryboardSprite(lookup_name, Anchor.TopLeft, new Vector2(256, 192));
+                var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, lookup_name, Anchor.TopLeft, new Vector2(256, 192));
                 sprite.Commands.AddAlpha(Easing.None, 0, 2000, 0, 2);
 
                 layer.Elements.Clear();
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 var layer = storyboard.GetLayer("Video");
 
-                var sprite = new StoryboardVideo("Videos/test-video.mp4", Time.Current);
+                var sprite = new StoryboardVideo(StoryboardElementSource.Beatmap, "Videos/test-video.mp4", Time.Current);
 
                 if (scaleTransformProvided)
                 {
@@ -250,7 +250,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var layer = storyboard.GetLayer("Background");
 
-            var sprite = new StoryboardSprite(lookupName, origin, initialPosition);
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, lookupName, origin, initialPosition);
             var loop = sprite.AddLoopingGroup(Time.Current, 100);
             loop.AddAlpha(Easing.None, 0, 10000, 1, 1);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var storyboard = new Storyboard();
 
-            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "unknown", Anchor.TopLeft, Vector2.Zero);
 
             sprite.Commands.AddAlpha(Easing.None, firstStoryboardEvent, firstStoryboardEvent + 500, 0, 1);
 
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             var storyboard = new Storyboard();
 
-            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "unknown", Anchor.TopLeft, Vector2.Zero);
 
             // these should be ignored as we have an alpha visibility blocker proceeding this command.
             sprite.Commands.AddScale(Easing.None, loop_start_time, -18000, 0, 1);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardCommands.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardCommands.cs
@@ -201,7 +201,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var layer = storyboard.GetLayer("Background");
 
-            var sprite = new StoryboardSprite(lookup_name, Anchor.Centre, new Vector2(320, 240));
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, lookup_name, Anchor.Centre, new Vector2(320, 240));
             sprite.Commands.AddScale(Easing.None, 0, clock_limit, 0.5f, 0.5f);
             sprite.Commands.AddAlpha(Easing.None, 0, clock_limit, 1, 1);
             addCommands?.Invoke(sprite);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
@@ -38,10 +38,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             storyboard = new Storyboard();
             var backgroundLayer = storyboard.GetLayer("Background");
-            backgroundLayer.Add(new StoryboardSampleInfo("Intro/welcome.mp3", time: -7000, volume: 20));
-            backgroundLayer.Add(new StoryboardSampleInfo("Intro/welcome.mp3", time: -5000, volume: 20));
-            backgroundLayer.Add(new StoryboardSampleInfo("Intro/welcome.mp3", time: 0, volume: 20));
-            backgroundLayer.Add(new StoryboardSampleInfo("Intro/welcome.mp3", time: 2000, volume: 20));
+            backgroundLayer.Add(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "Intro/welcome.mp3", time: -7000, volume: 20));
+            backgroundLayer.Add(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "Intro/welcome.mp3", time: -5000, volume: 20));
+            backgroundLayer.Add(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "Intro/welcome.mp3", time: 0, volume: 20));
+            backgroundLayer.Add(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "Intro/welcome.mp3", time: 2000, volume: 20));
         }
 
         [SetUp]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithIntro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithIntro.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private Storyboard createStoryboard(double startTime)
         {
             var storyboard = new Storyboard();
-            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "unknown", Anchor.TopLeft, Vector2.Zero);
             sprite.Commands.AddAlpha(Easing.None, startTime, 0, 0, 1);
             storyboard.GetLayer("Background").Add(sprite);
             return storyboard;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -215,7 +215,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private Storyboard createStoryboard(double duration)
         {
             var storyboard = new Storyboard();
-            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "unknown", Anchor.TopLeft, Vector2.Zero);
             sprite.Commands.AddAlpha(Easing.None, 0, duration, 1, 0);
             storyboard.GetLayer("Background").Add(sprite);
             return storyboard;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -493,7 +493,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestIntroStoryboardElement() => testLeadIn(b =>
         {
-            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, "unknown", Anchor.TopLeft, Vector2.Zero);
             sprite.Commands.AddAlpha(Easing.None, -2000, 0, 0, 1);
             b.Storyboard.GetLayer("Background").Add(sprite);
         });

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -65,8 +65,6 @@ namespace osu.Game.Beatmaps
 
         public SortedList<BreakPeriod> Breaks { get; set; } = new SortedList<BreakPeriod>(Comparer<BreakPeriod>.Default);
 
-        public List<string> UnhandledEventLines { get; set; } = new List<string>();
-
         [JsonIgnore]
         public double TotalBreakTime => Breaks.Sum(b => b.Duration);
 

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -72,7 +72,6 @@ namespace osu.Game.Beatmaps
             beatmap.ControlPointInfo = original.ControlPointInfo;
             beatmap.HitObjects = convertHitObjects(original.HitObjects, original, cancellationToken).OrderBy(s => s.StartTime).ToList();
             beatmap.Breaks = original.Breaks;
-            beatmap.UnhandledEventLines = original.UnhandledEventLines;
             beatmap.AudioLeadIn = original.AudioLeadIn;
             beatmap.StackLeniency = original.StackLeniency;
             beatmap.SpecialStyle = original.SpecialStyle;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -27,6 +27,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Skinning;
+using osu.Game.Storyboards;
 using osu.Game.Utils;
 using Realms;
 
@@ -216,7 +217,7 @@ namespace osu.Game.Beatmaps
             targetBeatmapSet.Beatmaps.Add(newBeatmap.BeatmapInfo);
             newBeatmap.BeatmapInfo.BeatmapSet = targetBeatmapSet;
 
-            save(newBeatmap.BeatmapInfo, newBeatmap, beatmapSkin, transferCollections: false);
+            save(newBeatmap.BeatmapInfo, newBeatmap, beatmapSkin, new Storyboard(), transferCollections: false);
 
             workingBeatmapCache.Invalidate(targetBeatmapSet);
             return GetWorkingBeatmap(newBeatmap.BeatmapInfo);
@@ -359,8 +360,9 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> to save the content against. The file referenced by <see cref="BeatmapInfo.Path"/> will be replaced.</param>
         /// <param name="beatmapContent">The <see cref="IBeatmap"/> content to write.</param>
         /// <param name="beatmapSkin">The beatmap <see cref="ISkin"/> content to write, null if to be omitted.</param>
-        public virtual void Save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin? beatmapSkin = null) =>
-            save(beatmapInfo, beatmapContent, beatmapSkin, transferCollections: true);
+        /// <param name="storyboard">The storyboard content to write, null if to be omitted.</param>
+        public virtual void Save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin? beatmapSkin = null, Storyboard? storyboard = null) =>
+            save(beatmapInfo, beatmapContent, beatmapSkin, storyboard, transferCollections: true);
 
         public void DeleteAllVideos()
         {
@@ -502,7 +504,7 @@ namespace osu.Game.Beatmaps
             setInfo.Status = BeatmapOnlineStatus.LocallyModified;
         }
 
-        private void save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin? beatmapSkin, bool transferCollections)
+        private void save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin? beatmapSkin, Storyboard? storyboard, bool transferCollections)
         {
             var setInfo = beatmapInfo.BeatmapSet;
             Debug.Assert(setInfo != null);
@@ -526,7 +528,7 @@ namespace osu.Game.Beatmaps
             {
                 using var stream = new MemoryStream();
                 using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
-                    new LegacyBeatmapEncoder(beatmapContent, beatmapSkin).Encode(sw);
+                    new LegacyBeatmapEncoder(beatmapContent, beatmapSkin, storyboard).Encode(sw);
 
                 stream.Seek(0, SeekOrigin.Begin);
 

--- a/osu.Game/Beatmaps/Formats/Decoder.cs
+++ b/osu.Game/Beatmaps/Formats/Decoder.cs
@@ -19,11 +19,11 @@ namespace osu.Game.Beatmaps.Formats
         {
             var output = CreateTemplateObject();
             foreach (LineBufferedReader stream in otherStreams.Prepend(primaryStream))
-                ParseStreamInto(stream, output);
+                ParseStreamInto(stream, stream == primaryStream, output);
             return output;
         }
 
-        protected abstract void ParseStreamInto(LineBufferedReader stream, TOutput output);
+        protected abstract void ParseStreamInto(LineBufferedReader stream, bool isPrimaryStream, TOutput output);
     }
 
     public abstract class Decoder

--- a/osu.Game/Beatmaps/Formats/JsonBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/JsonBeatmapDecoder.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Beatmaps.Formats
             AddDecoder<Beatmap>("{", _ => new JsonBeatmapDecoder());
         }
 
-        protected override void ParseStreamInto(LineBufferedReader stream, Beatmap output)
+        protected override void ParseStreamInto(LineBufferedReader stream, bool isPrimaryStream, Beatmap output)
         {
             stream.ReadToEnd().DeserializeInto(output);
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Beatmaps.Formats
             return templateBeatmap;
         }
 
-        protected override void ParseStreamInto(LineBufferedReader stream, Beatmap beatmap)
+        protected override void ParseStreamInto(LineBufferedReader stream, bool isPrimaryStream, Beatmap beatmap)
         {
             this.beatmap = beatmap;
             this.beatmap.BeatmapVersion = FormatVersion;
@@ -89,7 +89,7 @@ namespace osu.Game.Beatmaps.Formats
 
             ApplyLegacyDefaults(this.beatmap);
 
-            base.ParseStreamInto(stream, beatmap);
+            base.ParseStreamInto(stream, isPrimaryStream, beatmap);
 
             applyDifficultyRestrictions(beatmap.Difficulty, beatmap);
 
@@ -204,7 +204,7 @@ namespace osu.Game.Beatmaps.Formats
             beatmap.BeatmapInfo.Ruleset = RulesetStore?.GetRuleset(0) ?? beatmap.BeatmapInfo.Ruleset;
         }
 
-        protected override void ParseLine(Beatmap beatmap, Section section, string line)
+        protected override void ParseLine(Beatmap beatmap, Section section, string line, bool isPrimaryStream)
         {
             switch (section)
             {
@@ -237,7 +237,7 @@ namespace osu.Game.Beatmaps.Formats
                     return;
             }
 
-            base.ParseLine(beatmap, section, line);
+            base.ParseLine(beatmap, section, line, isPrimaryStream);
         }
 
         private void handleGeneral(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -430,10 +430,6 @@ namespace osu.Game.Beatmaps.Formats
         {
             string[] split = line.Split(',');
 
-            // Until we have full storyboard encoder coverage, let's track any lines which aren't handled
-            // and store them to a temporary location such that they aren't lost on editor save / export.
-            bool lineSupportedByEncoder = false;
-
             if (Enum.TryParse(split[0], out LegacyEventType type))
             {
                 switch (type)
@@ -445,7 +441,6 @@ namespace osu.Game.Beatmaps.Formats
                         if (string.IsNullOrEmpty(beatmap.BeatmapInfo.Metadata.BackgroundFile))
                         {
                             beatmap.BeatmapInfo.Metadata.BackgroundFile = CleanFilename(split[3]);
-                            lineSupportedByEncoder = true;
                         }
 
                         break;
@@ -459,14 +454,12 @@ namespace osu.Game.Beatmaps.Formats
                         if (!SupportedExtensions.VIDEO_EXTENSIONS.Contains(Path.GetExtension(filename).ToLowerInvariant()))
                         {
                             beatmap.BeatmapInfo.Metadata.BackgroundFile = filename;
-                            lineSupportedByEncoder = true;
                         }
 
                         break;
 
                     case LegacyEventType.Background:
                         beatmap.BeatmapInfo.Metadata.BackgroundFile = CleanFilename(split[2]);
-                        lineSupportedByEncoder = true;
                         break;
 
                     case LegacyEventType.Break:
@@ -474,13 +467,9 @@ namespace osu.Game.Beatmaps.Formats
                         double end = Math.Max(start, getOffsetTime(Parsing.ParseDouble(split[2])));
 
                         beatmap.Breaks.Add(new BreakPeriod(start, end));
-                        lineSupportedByEncoder = true;
                         break;
                 }
             }
-
-            if (!lineSupportedByEncoder)
-                beatmap.UnhandledEventLines.Add(line);
         }
 
         private void handleTimingPoint(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Skinning;
+using osu.Game.Storyboards;
 using osuTK;
 using osuTK.Graphics;
 
@@ -24,8 +25,8 @@ namespace osu.Game.Beatmaps.Formats
         public const int FIRST_LAZER_VERSION = 128;
 
         private readonly IBeatmap beatmap;
-
         private readonly ISkin? skin;
+        private readonly LegacyStoryboardEncoder? storyboardEncoder;
 
         private readonly int onlineRulesetID;
 
@@ -34,10 +35,17 @@ namespace osu.Game.Beatmaps.Formats
         /// </summary>
         /// <param name="beatmap">The beatmap to encode.</param>
         /// <param name="skin">The beatmap's skin, used for encoding combo colours.</param>
-        public LegacyBeatmapEncoder(IBeatmap beatmap, ISkin? skin)
+        /// <param name="storyboard">
+        /// The combined storyboard, loaded from both the <c>.osu</c> and the <c>.osz</c>.
+        /// Only elements from the <c>.osu</c> (marked via <see cref="StoryboardElementSource.Beatmap"/>) will be encoded to the beatmap.
+        /// </param>
+        public LegacyBeatmapEncoder(IBeatmap beatmap, ISkin? skin, Storyboard? storyboard)
         {
             this.beatmap = beatmap;
             this.skin = skin;
+
+            if (storyboard != null)
+                storyboardEncoder = new LegacyStoryboardEncoder(storyboard);
 
             onlineRulesetID = beatmap.BeatmapInfo.Ruleset.OnlineID;
 
@@ -101,7 +109,12 @@ namespace osu.Game.Beatmaps.Formats
                 writer.WriteLine(FormattableString.Invariant($@"CountdownOffset: {beatmap.CountdownOffset}"));
             if (onlineRulesetID == 3)
                 writer.WriteLine(FormattableString.Invariant($"SpecialStyle: {(beatmap.SpecialStyle ? '1' : '0')}"));
-            writer.WriteLine(FormattableString.Invariant($"WidescreenStoryboard: {(beatmap.WidescreenStoryboard ? '1' : '0')}"));
+
+            if (storyboardEncoder != null)
+                storyboardEncoder.EncodeGeneralToBeatmap(writer);
+            else
+                writer.WriteLine(FormattableString.Invariant($"WidescreenStoryboard: {(beatmap.WidescreenStoryboard ? '1' : '0')}"));
+
             if (beatmap.SamplesMatchPlaybackRate)
                 writer.WriteLine(@"SamplesMatchPlaybackRate: 1");
         }
@@ -151,8 +164,15 @@ namespace osu.Game.Beatmaps.Formats
         {
             writer.WriteLine("[Events]");
 
-            if (!string.IsNullOrEmpty(beatmap.BeatmapInfo.Metadata.BackgroundFile))
-                writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Background},0,\"{beatmap.BeatmapInfo.Metadata.BackgroundFile}\",0,0"));
+            if (storyboardEncoder != null)
+            {
+                storyboardEncoder.EncodeEventsToBeatmap(writer);
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(beatmap.BeatmapInfo.Metadata.BackgroundFile))
+                    writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Background},0,\"{beatmap.BeatmapInfo.Metadata.BackgroundFile}\",0,0"));
+            }
 
             writer.WriteLine("// Break Periods");
             foreach (var b in beatmap.Breaks)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -177,9 +177,6 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine("// Break Periods");
             foreach (var b in beatmap.Breaks)
                 writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Break},{b.StartTime},{b.EndTime}"));
-
-            foreach (string l in beatmap.UnhandledEventLines)
-                writer.WriteLine(l);
         }
 
         private void handleControlPoints(TextWriter writer)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -154,6 +154,7 @@ namespace osu.Game.Beatmaps.Formats
             if (!string.IsNullOrEmpty(beatmap.BeatmapInfo.Metadata.BackgroundFile))
                 writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Background},0,\"{beatmap.BeatmapInfo.Metadata.BackgroundFile}\",0,0"));
 
+            writer.WriteLine("// Break Periods");
             foreach (var b in beatmap.Breaks)
                 writer.WriteLine(FormattableString.Invariant($"{(int)LegacyEventType.Break},{b.StartTime},{b.EndTime}"));
 

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Beatmaps.Formats
             FormatVersion = version;
         }
 
-        protected override void ParseStreamInto(LineBufferedReader stream, T output)
+        protected override void ParseStreamInto(LineBufferedReader stream, bool isPrimaryStream, T output)
         {
             Section section = Section.General;
 
@@ -65,7 +65,7 @@ namespace osu.Game.Beatmaps.Formats
 
                 try
                 {
-                    ParseLine(output, section, line);
+                    ParseLine(output, section, line, isPrimaryStream);
                 }
                 catch (Exception e)
                 {
@@ -84,7 +84,7 @@ namespace osu.Game.Beatmaps.Formats
         {
         }
 
-        protected virtual void ParseLine(T output, Section section, string line)
+        protected virtual void ParseLine(T output, Section section, string line, bool isPrimaryStream)
         {
             switch (section)
             {

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -194,7 +194,8 @@ namespace osu.Game.Beatmaps.Formats
                         string triggerName = split[1];
                         double startTime = split.Length > 2 ? Parsing.ParseDouble(split[2]) : double.MinValue;
                         double endTime = split.Length > 3 ? Parsing.ParseDouble(split[3]) : double.MaxValue;
-                        int groupNumber = split.Length > 4 ? Parsing.ParseInt(split[4]) : 0;
+                        // negation as per https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L736
+                        int groupNumber = split.Length > 4 ? -Parsing.ParseInt(split[4]) : 0;
                         currentCommandsGroup = storyboardSprite?.AddTriggerGroup(triggerName, startTime, endTime, groupNumber);
                         break;
                     }

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Beatmaps.Formats
                 if (!Enum.TryParse(split[0], out LegacyEventType type))
                     throw new InvalidDataException($@"Unknown event type: {split[0]}");
 
-                var source = isPrimaryStream ? StoryboardElementSource.Beatmap : StoryboardElementSource.SharedStoryboard;
+                var source = isPrimaryStream ? StoryboardElementSource.Beatmap : StoryboardElementSource.Shared;
 
                 switch (type)
                 {

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -49,13 +49,13 @@ namespace osu.Game.Beatmaps.Formats
             return sb;
         }
 
-        protected override void ParseStreamInto(LineBufferedReader stream, Storyboard storyboard)
+        protected override void ParseStreamInto(LineBufferedReader stream, bool isPrimaryStream, Storyboard storyboard)
         {
             this.storyboard = storyboard;
-            base.ParseStreamInto(stream, storyboard);
+            base.ParseStreamInto(stream, isPrimaryStream, storyboard);
         }
 
-        protected override void ParseLine(Storyboard storyboard, Section section, string line)
+        protected override void ParseLine(Storyboard storyboard, Section section, string line, bool isPrimaryStream)
         {
             switch (section)
             {
@@ -64,7 +64,7 @@ namespace osu.Game.Beatmaps.Formats
                     return;
 
                 case Section.Events:
-                    handleEvents(line);
+                    handleEvents(line, isPrimaryStream);
                     return;
 
                 case Section.Variables:
@@ -72,7 +72,7 @@ namespace osu.Game.Beatmaps.Formats
                     return;
             }
 
-            base.ParseLine(storyboard, section, line);
+            base.ParseLine(storyboard, section, line, isPrimaryStream);
         }
 
         private void handleGeneral(Storyboard storyboard, string line)
@@ -91,7 +91,7 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private void handleEvents(string line)
+        private void handleEvents(string line, bool isPrimaryStream)
         {
             decodeVariables(ref line);
 
@@ -116,6 +116,8 @@ namespace osu.Game.Beatmaps.Formats
                 if (!Enum.TryParse(split[0], out LegacyEventType type))
                     throw new InvalidDataException($@"Unknown event type: {split[0]}");
 
+                var source = isPrimaryStream ? StoryboardElementSource.Beatmap : StoryboardElementSource.SharedStoryboard;
+
                 switch (type)
                 {
                     case LegacyEventType.Video:
@@ -131,7 +133,7 @@ namespace osu.Game.Beatmaps.Formats
                         if (!SupportedExtensions.VIDEO_EXTENSIONS.Contains(Path.GetExtension(path).ToLowerInvariant()))
                             break;
 
-                        storyboard.GetLayer("Video").Add(storyboardSprite = new StoryboardVideo(path, offset));
+                        storyboard.GetLayer("Video").Add(storyboardSprite = new StoryboardVideo(source, path, offset));
                         break;
                     }
 
@@ -142,7 +144,7 @@ namespace osu.Game.Beatmaps.Formats
                         string path = CleanFilename(split[3]);
                         float x = Parsing.ParseFloat(split[4], Parsing.MAX_COORDINATE_VALUE);
                         float y = Parsing.ParseFloat(split[5], Parsing.MAX_COORDINATE_VALUE);
-                        storyboardSprite = new StoryboardSprite(path, origin, new Vector2(x, y));
+                        storyboardSprite = new StoryboardSprite(source, path, origin, new Vector2(x, y));
                         storyboard.GetLayer(layer).Add(storyboardSprite);
                         break;
                     }
@@ -162,7 +164,7 @@ namespace osu.Game.Beatmaps.Formats
                             frameDelay = Math.Round(0.015 * frameDelay) * 1.186 * (1000 / 60f);
 
                         var loopType = split.Length > 8 ? parseAnimationLoopType(split[8]) : AnimationLoopType.LoopForever;
-                        storyboardSprite = new StoryboardAnimation(path, origin, new Vector2(x, y), frameCount, frameDelay, loopType);
+                        storyboardSprite = new StoryboardAnimation(source, path, origin, new Vector2(x, y), frameCount, frameDelay, loopType);
                         storyboard.GetLayer(layer).Add(storyboardSprite);
                         break;
                     }
@@ -173,7 +175,7 @@ namespace osu.Game.Beatmaps.Formats
                         string layer = parseLayer(split[2]);
                         string path = CleanFilename(split[3]);
                         float volume = split.Length > 4 ? Parsing.ParseFloat(split[4]) : 100;
-                        storyboard.GetLayer(layer).Add(new StoryboardSampleInfo(path, time, (int)volume));
+                        storyboard.GetLayer(layer).Add(new StoryboardSampleInfo(source, path, time, (int)volume));
                         break;
                     }
                 }

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Beatmaps.Formats
         public void EncodeStandaloneStoryboard(TextWriter writer)
         {
             writer.WriteLine(@"[Events]");
-            encodeEvents(writer, StoryboardElementSource.SharedStoryboard);
+            encodeEvents(writer, StoryboardElementSource.Shared);
         }
 
         #endregion

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
@@ -22,27 +22,46 @@ namespace osu.Game.Beatmaps.Formats
             this.storyboard = storyboard;
         }
 
-        public void EncodeGeneral(TextWriter writer)
+        #region Storyboards embedded in beatmaps
+
+        public void EncodeGeneralToBeatmap(TextWriter writer)
         {
             writer.WriteLine(FormattableString.Invariant($@"UseSkinSprites: {(storyboard.UseSkinSprites ? '1' : '0')}"));
             writer.WriteLine(FormattableString.Invariant($@"WidescreenStoryboard: {(storyboard.Beatmap.WidescreenStoryboard ? '1' : '0')}"));
         }
 
-        public void EncodeEvents(TextWriter writer)
+        public void EncodeEventsToBeatmap(TextWriter writer)
+            => encodeEvents(writer, StoryboardElementSource.Beatmap);
+
+        #endregion
+
+        #region Standalone storyboards
+
+        public void EncodeStandaloneStoryboard(TextWriter writer)
         {
-            // TODO: these are never written to .osb
+            writer.WriteLine(@"[Events]");
+            encodeEvents(writer, StoryboardElementSource.SharedStoryboard);
+        }
+
+        #endregion
+
+        private void encodeEvents(TextWriter writer, StoryboardElementSource target)
+        {
             // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameModes/Edit/Modes/EditorModeDesign.cs#L189
             // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/Events/EventManager.cs#L368
             writer.WriteLine(@"// Background and Video events");
 
-            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1499
-            // TODO: handle nonzero background offset (https://github.com/ppy/osu/issues/14238)
-            writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
-                @"{0},{1},""{2}"",{3},{4}",
-                (int)LegacyEventType.Background, 0, storyboard.BeatmapInfo.Metadata.BackgroundFile, 0, 0));
+            if (target == StoryboardElementSource.Beatmap)
+            {
+                // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1499
+                // TODO: handle nonzero background offset (https://github.com/ppy/osu/issues/14238)
+                writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                    @"{0},{1},""{2}"",{3},{4}",
+                    (int)LegacyEventType.Background, 0, storyboard.BeatmapInfo.Metadata.BackgroundFile, 0, 0));
+            }
 
             // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1496
-            foreach (var video in storyboard.GetLayer(@"Video").Elements.OfType<StoryboardVideo>())
+            foreach (var video in storyboard.GetLayer(@"Video").Elements.OfType<StoryboardVideo>().Where(v => v.Source == target))
             {
                 writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
                     @"{0},{1},""{2}""",
@@ -58,7 +77,7 @@ namespace osu.Game.Beatmaps.Formats
                     legacyLayer));
                 string layerName = legacyLayer.ToString();
                 var layer = storyboard.GetLayer(layerName);
-                encodeSpritesFromLayer(writer, layer);
+                encodeSpritesFromLayer(writer, layer, target);
             }
 
             // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1478-L1481
@@ -69,7 +88,7 @@ namespace osu.Game.Beatmaps.Formats
                 string layerName = legacyLayer.ToString();
                 var layer = storyboard.GetLayer(layerName);
 
-                foreach (var sample in layer.Elements.OfType<StoryboardSampleInfo>())
+                foreach (var sample in layer.Elements.OfType<StoryboardSampleInfo>().Where(s => s.Source == target))
                 {
                     writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
                         @"{0},{1},{2},""{3}"",{4}",
@@ -82,9 +101,9 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private void encodeSpritesFromLayer(TextWriter writer, StoryboardLayer layer)
+        private void encodeSpritesFromLayer(TextWriter writer, StoryboardLayer layer, StoryboardElementSource target)
         {
-            foreach (var element in layer.Elements)
+            foreach (var element in layer.Elements.Where(elem => elem.Source == target))
             {
                 LegacyOrigins origin;
 

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
@@ -307,7 +307,7 @@ namespace osu.Game.Beatmaps.Formats
                 typeAcronym,
                 (int)command.Easing,
                 command.StartTime - relativeToTime,
-                command.StartTime == command.EndTime ? (double?)null : command.EndTime - relativeToTime,
+                command.StartTime == command.EndTime ? null : command.EndTime - relativeToTime,
                 details));
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardEncoder.cs
@@ -1,0 +1,331 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps.Legacy;
+using osu.Game.Storyboards;
+using osu.Game.Storyboards.Commands;
+
+namespace osu.Game.Beatmaps.Formats
+{
+    public class LegacyStoryboardEncoder
+    {
+        private readonly Storyboard storyboard;
+
+        public LegacyStoryboardEncoder(Storyboard storyboard)
+        {
+            this.storyboard = storyboard;
+        }
+
+        public void EncodeGeneral(TextWriter writer)
+        {
+            writer.WriteLine(FormattableString.Invariant($@"UseSkinSprites: {(storyboard.UseSkinSprites ? '1' : '0')}"));
+            writer.WriteLine(FormattableString.Invariant($@"WidescreenStoryboard: {(storyboard.Beatmap.WidescreenStoryboard ? '1' : '0')}"));
+        }
+
+        public void EncodeEvents(TextWriter writer)
+        {
+            // TODO: these are never written to .osb
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameModes/Edit/Modes/EditorModeDesign.cs#L189
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/Events/EventManager.cs#L368
+            writer.WriteLine(@"// Background and Video events");
+
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1499
+            // TODO: handle nonzero background offset (https://github.com/ppy/osu/issues/14238)
+            writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                @"{0},{1},""{2}"",{3},{4}",
+                (int)LegacyEventType.Background, 0, storyboard.BeatmapInfo.Metadata.BackgroundFile, 0, 0));
+
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1496
+            foreach (var video in storyboard.GetLayer(@"Video").Elements.OfType<StoryboardVideo>())
+            {
+                writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                    @"{0},{1},""{2}""",
+                    nameof(LegacyEventType.Video), video.StartTime, video.Path));
+                encodeCommands(writer, video);
+            }
+
+            foreach (var legacyLayer in Enum.GetValues<LegacyStoryLayer>().Except(LegacyStoryLayer.Video.Yield()))
+            {
+                writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                    @"// Storyboard Layer {0} ({1})",
+                    (int)legacyLayer,
+                    legacyLayer));
+                string layerName = legacyLayer.ToString();
+                var layer = storyboard.GetLayer(layerName);
+                encodeSpritesFromLayer(writer, layer);
+            }
+
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1478-L1481
+            writer.WriteLine(@"// Storyboard Sound Samples");
+
+            foreach (var legacyLayer in Enum.GetValues<LegacyStoryLayer>().Except(LegacyStoryLayer.Video.Yield()))
+            {
+                string layerName = legacyLayer.ToString();
+                var layer = storyboard.GetLayer(layerName);
+
+                foreach (var sample in layer.Elements.OfType<StoryboardSampleInfo>())
+                {
+                    writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                        @"{0},{1},{2},""{3}"",{4}",
+                        nameof(LegacyEventType.Sample),
+                        sample.StartTime,
+                        (int)legacyLayer,
+                        sample.Path,
+                        sample.Volume));
+                }
+            }
+        }
+
+        private void encodeSpritesFromLayer(TextWriter writer, StoryboardLayer layer)
+        {
+            foreach (var element in layer.Elements)
+            {
+                LegacyOrigins origin;
+
+                switch (element)
+                {
+                    case StoryboardAnimation animation:
+                    {
+                        origin = convertOrigin(animation.Origin);
+                        // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1505-L1507
+                        writer.WriteLine(string.Format(
+                            CultureInfo.InvariantCulture,
+                            @"{0},{1},{2},""{3}"",{4},{5},{6},{7},{8}",
+                            nameof(LegacyEventType.Animation),
+                            layer.Name,
+                            origin,
+                            animation.Path,
+                            animation.InitialPosition.X,
+                            animation.InitialPosition.Y,
+                            animation.FrameCount,
+                            animation.FrameDelay,
+                            animation.LoopType));
+
+                        encodeCommands(writer, animation);
+                        break;
+                    }
+
+                    case StoryboardSprite sprite:
+                    {
+                        origin = convertOrigin(sprite.Origin);
+                        // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1502
+                        writer.WriteLine(string.Format(
+                            CultureInfo.InvariantCulture,
+                            @"{0},{1},{2},""{3}"",{4},{5}",
+                            nameof(LegacyEventType.Sprite),
+                            layer.Name,
+                            origin,
+                            sprite.Path,
+                            sprite.InitialPosition.X,
+                            sprite.InitialPosition.Y));
+
+                        encodeCommands(writer, sprite);
+                        break;
+                    }
+                }
+            }
+        }
+
+        private void encodeCommands(TextWriter writer, StoryboardSprite sprite)
+        {
+            foreach (var loopingGroup in sprite.LoopingGroups)
+            {
+                writer.WriteLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    @" L,{0},{1}",
+                    loopingGroup.StartTime, loopingGroup.TotalIterations));
+                foreach (var command in loopingGroup.AllCommands)
+                    // see `StoryboardLoopingCommand` ctor for why `relativeToTime` is passed
+                    encodeCommand(writer, command, 2, relativeToTime: loopingGroup.StartTime);
+            }
+
+            foreach (var command in sprite.Commands.AllCommands)
+                encodeCommand(writer, command, 1);
+
+            foreach (var triggerGroup in sprite.TriggerGroups)
+            {
+                // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1564-L1572
+                writer.Write(string.Format(
+                    CultureInfo.InvariantCulture,
+                    @" T,{0}",
+                    triggerGroup.TriggerName));
+
+                if (triggerGroup.TriggerEndTime != 0)
+                {
+                    writer.Write(string.Format(
+                        CultureInfo.InvariantCulture,
+                        @",{0},{1}",
+                        triggerGroup.TriggerStartTime, triggerGroup.TriggerEndTime));
+                }
+
+                if (triggerGroup.GroupNumber != 0)
+                {
+                    writer.Write(string.Format(CultureInfo.InvariantCulture, @",{0}", -triggerGroup.GroupNumber));
+                }
+
+                writer.WriteLine();
+
+                foreach (var command in triggerGroup.AllCommands)
+                    encodeCommand(writer, command, 2);
+            }
+        }
+
+        private void encodeCommand(TextWriter writer, IStoryboardCommand command, int depth, double relativeToTime = 0)
+        {
+            for (int i = 0; i < depth; ++i)
+                writer.Write(' ');
+
+            string typeAcronym;
+            string details;
+
+            if (command is IStoryboardLoopingCommand loopingCommand)
+                command = loopingCommand.OriginalCommand;
+
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1546-L1550
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1690-L1730
+            switch (command)
+            {
+                case StoryboardVectorScaleCommand vectorScale:
+                    typeAcronym = @"V";
+                    details = vectorScale.StartValue == vectorScale.EndValue
+                        ? string.Format(CultureInfo.InvariantCulture, @"{0},{1}", vectorScale.StartValue.X, vectorScale.StartValue.Y)
+                        : string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1},{2},{3}",
+                            vectorScale.StartValue.X, vectorScale.StartValue.Y, vectorScale.EndValue.X, vectorScale.EndValue.Y);
+                    break;
+
+                case StoryboardAlphaCommand fade:
+                    typeAcronym = @"F";
+                    details = fade.StartValue == fade.EndValue
+                        ? fade.StartValue.ToString(CultureInfo.InvariantCulture)
+                        : string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1}",
+                            fade.StartValue,
+                            fade.EndValue);
+                    break;
+
+                case StoryboardRotationCommand rotation:
+                    typeAcronym = @"R";
+                    details = rotation.StartValue == rotation.EndValue
+                        ? rotation.StartValue.ToString(CultureInfo.InvariantCulture)
+                        : string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1}",
+                            float.DegreesToRadians(rotation.StartValue),
+                            float.DegreesToRadians(rotation.EndValue));
+                    break;
+
+                case StoryboardScaleCommand scale:
+                    typeAcronym = @"S";
+                    details = scale.StartValue == scale.EndValue
+                        ? scale.StartValue.ToString(CultureInfo.InvariantCulture)
+                        : string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1}",
+                            scale.StartValue,
+                            scale.EndValue);
+                    break;
+
+                // stable has M commands that combine X and Y movement, but we decompose those into X/Y with no way to undo
+
+                case StoryboardXCommand movementX:
+                    typeAcronym = @"MX";
+                    details = movementX.StartValue == movementX.EndValue
+                        ? movementX.StartValue.ToString(CultureInfo.InvariantCulture)
+                        : string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1}",
+                            movementX.StartValue,
+                            movementX.EndValue);
+                    break;
+
+                case StoryboardYCommand movementY:
+                    typeAcronym = @"MY";
+                    details = movementY.StartValue == movementY.EndValue
+                        ? movementY.StartValue.ToString(CultureInfo.InvariantCulture)
+                        : string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1}",
+                            movementY.StartValue,
+                            movementY.EndValue);
+                    break;
+
+                case StoryboardColourCommand colour:
+                    typeAcronym = @"C";
+                    details = colour.StartValue == colour.EndValue
+                        ? string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1},{2}",
+                            (int)(colour.StartValue.R * 255), (int)(colour.StartValue.G * 255), (int)(colour.StartValue.B * 255))
+                        : string.Format(CultureInfo.InvariantCulture,
+                            @"{0},{1},{2},{3},{4},{5}",
+                            (int)(colour.StartValue.R * 255), (int)(colour.StartValue.G * 255), (int)(colour.StartValue.B * 255),
+                            (int)(colour.EndValue.R * 255), (int)(colour.EndValue.G * 255), (int)(colour.EndValue.B * 255));
+                    break;
+
+                case StoryboardFlipHCommand:
+                    typeAcronym = @"P";
+                    details = @"H";
+                    break;
+
+                case StoryboardFlipVCommand:
+                    typeAcronym = @"P";
+                    details = @"V";
+                    break;
+
+                case StoryboardBlendingParametersCommand:
+                    typeAcronym = @"P";
+                    details = @"A";
+                    break;
+
+                default:
+                    return;
+            }
+
+            writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                @"{0},{1},{2},{3},{4}",
+                typeAcronym,
+                (int)command.Easing,
+                command.StartTime - relativeToTime,
+                command.StartTime == command.EndTime ? (double?)null : command.EndTime - relativeToTime,
+                details));
+        }
+
+        private LegacyOrigins convertOrigin(Anchor anchor)
+        {
+            switch (anchor)
+            {
+                case Anchor.TopLeft:
+                    return LegacyOrigins.TopLeft;
+
+                case Anchor.TopCentre:
+                    return LegacyOrigins.TopCentre;
+
+                case Anchor.TopRight:
+                    return LegacyOrigins.TopRight;
+
+                case Anchor.CentreLeft:
+                    return LegacyOrigins.CentreLeft;
+
+                case Anchor.Centre:
+                    return LegacyOrigins.Centre;
+
+                case Anchor.CentreRight:
+                    return LegacyOrigins.CentreRight;
+
+                case Anchor.BottomLeft:
+                    return LegacyOrigins.BottomLeft;
+
+                case Anchor.BottomCentre:
+                    return LegacyOrigins.BottomCentre;
+
+                case Anchor.BottomRight:
+                    return LegacyOrigins.BottomRight;
+
+                default:
+                    return LegacyOrigins.TopLeft;
+            }
+        }
+    }
+}

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -45,12 +45,6 @@ namespace osu.Game.Beatmaps
         SortedList<BreakPeriod> Breaks { get; set; }
 
         /// <summary>
-        /// All lines from the [Events] section which aren't handled in the encoding process yet.
-        /// These lines should be written out to the beatmap file on save or export.
-        /// </summary>
-        List<string> UnhandledEventLines { get; }
-
-        /// <summary>
         /// Total amount of break time in the beatmap.
         /// </summary>
         double TotalBreakTime { get; }

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -67,6 +67,14 @@ namespace osu.Game.Database
                 Configuration = new LegacySkinDecoder().Decode(skinStreamReader)
             };
 
+            using var storyboardStream = base.GetFileContents(model, file);
+
+            if (storyboardStream == null)
+                return null;
+
+            using var storyboardStreamReader = new LineBufferedReader(storyboardStream);
+            var beatmapStoryboard = new LegacyStoryboardDecoder().Decode(storyboardStreamReader);
+
             MutateBeatmap(model, playableBeatmap);
 
             // Encode to legacy format
@@ -78,7 +86,7 @@ namespace osu.Game.Database
                 // If we don't do that, uploads to BSS may show changes where there are none.
                 sw.NewLine = "\r\n";
 
-                new LegacyBeatmapEncoder(playableBeatmap, beatmapSkin).Encode(sw);
+                new LegacyBeatmapEncoder(playableBeatmap, beatmapSkin, beatmapStoryboard).Encode(sw);
             }
 
             stream.Seek(0, SeekOrigin.Begin);

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -342,8 +342,6 @@ namespace osu.Game.Rulesets.Difficulty
                 set => baseBeatmap.Breaks = value;
             }
 
-            public List<string> UnhandledEventLines => baseBeatmap.UnhandledEventLines;
-
             public double TotalBreakTime => baseBeatmap.TotalBreakTime;
             public IEnumerable<BeatmapStatistic> GetStatistics() => baseBeatmap.GetStatistics();
             public double GetMostCommonBeatLength() => baseBeatmap.GetMostCommonBeatLength();

--- a/osu.Game/Screens/Edit/BeatmapEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/BeatmapEditorChangeHandler.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Edit
         protected override void WriteCurrentStateToStream(MemoryStream stream)
         {
             using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
-                new LegacyBeatmapEncoder(editorBeatmap, editorBeatmap.BeatmapSkin).Encode(sw);
+                new LegacyBeatmapEncoder(editorBeatmap, editorBeatmap.BeatmapSkin, editorBeatmap.Storyboard).Encode(sw);
         }
 
         protected override void ApplyStateChange(byte[] previousState, byte[] newState) =>

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -296,7 +296,7 @@ namespace osu.Game.Screens.Edit
             // todo: remove caching of this and consume via editorBeatmap?
             dependencies.Cache(beatDivisor);
 
-            AddInternal(editorBeatmap = new EditorBeatmap(playableBeatmap, loadableBeatmap.GetSkin(), loadableBeatmap.BeatmapInfo));
+            AddInternal(editorBeatmap = new EditorBeatmap(playableBeatmap, loadableBeatmap.GetSkin(), loadableBeatmap.Storyboard, loadableBeatmap.BeatmapInfo));
             dependencies.CacheAs(editorBeatmap);
 
             editorBeatmap.UpdateInProgress.BindValueChanged(_ => updateSampleDisabledState());
@@ -589,7 +589,7 @@ namespace osu.Game.Screens.Edit
             try
             {
                 // save the loaded beatmap's data stream.
-                beatmapManager.Save(editorBeatmap.BeatmapInfo, editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin);
+                beatmapManager.Save(editorBeatmap.BeatmapInfo, editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin, editorBeatmap.Storyboard);
             }
             catch (Exception ex)
             {

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -19,6 +19,7 @@ using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Skinning;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Screens.Edit
 {
@@ -82,6 +83,8 @@ namespace osu.Game.Screens.Edit
         [CanBeNull]
         public readonly EditorBeatmapSkin BeatmapSkin;
 
+        public readonly Storyboard Storyboard;
+
         [Resolved]
         private BindableBeatDivisor beatDivisor { get; set; }
 
@@ -94,7 +97,7 @@ namespace osu.Game.Screens.Edit
 
         private readonly Dictionary<HitObject, Bindable<double>> startTimeBindables = new Dictionary<HitObject, Bindable<double>>();
 
-        public EditorBeatmap(IBeatmap playableBeatmap, ISkin beatmapSkin = null, BeatmapInfo beatmapInfo = null)
+        public EditorBeatmap(IBeatmap playableBeatmap, ISkin beatmapSkin = null, Storyboard storyboard = null, BeatmapInfo beatmapInfo = null)
         {
             PlayableBeatmap = playableBeatmap;
             PlayableBeatmap.ControlPointInfo = ConvertControlPoints(PlayableBeatmap.ControlPointInfo);
@@ -103,6 +106,10 @@ namespace osu.Game.Screens.Edit
 
             if (beatmapSkin is LegacyBeatmapSkin skin)
                 BeatmapSkin = new EditorBeatmapSkin(this, skin);
+
+            Storyboard = storyboard ?? new Storyboard();
+            Storyboard.Beatmap = this;
+            Storyboard.BeatmapInfo = this.beatmapInfo;
 
             beatmapProcessor = new EditorBeatmapProcessor(this, playableBeatmap.BeatmapInfo.Ruleset.CreateInstance());
 

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -203,8 +203,6 @@ namespace osu.Game.Screens.Edit
             set => PlayableBeatmap.Breaks = value;
         }
 
-        public List<string> UnhandledEventLines => PlayableBeatmap.UnhandledEventLines;
-
         public double TotalBreakTime => PlayableBeatmap.TotalBreakTime;
 
         public IReadOnlyList<HitObject> HitObjects => PlayableBeatmap.HitObjects;

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.Edit.Setup
                 try
                 {
                     var targetWorking = beatmaps.GetWorkingBeatmap(b);
-                    beatmaps.Save(b, targetWorking.GetPlayableBeatmap(b.Ruleset), targetWorking.GetSkin());
+                    beatmaps.Save(b, targetWorking.GetPlayableBeatmap(b.Ruleset), targetWorking.GetSkin(), targetWorking.Storyboard);
                 }
                 catch (Exception e)
                 {

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -217,7 +217,7 @@ namespace osu.Game.Screens.Edit.Setup
                     // note that this triggers a full save flow, including triggering a difficulty calculation.
                     // this is not a cheap operation and should be reconsidered in the future.
                     var beatmapWorking = beatmaps.GetWorkingBeatmap(b);
-                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset), beatmapWorking.GetSkin());
+                    beatmaps.Save(b, beatmapWorking.GetPlayableBeatmap(b.Ruleset), beatmapWorking.GetSkin(), beatmapWorking.Storyboard);
                 }
             }
 

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Skinning
             currentConfig = null;
         }
 
-        protected override void ParseLine(List<LegacyManiaSkinConfiguration> output, Section section, string line)
+        protected override void ParseLine(List<LegacyManiaSkinConfiguration> output, Section section, string line, bool isPrimaryStream)
         {
             switch (section)
             {

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Skinning
         {
         }
 
-        protected override void ParseLine(SkinConfiguration skin, Section section, string line)
+        protected override void ParseLine(SkinConfiguration skin, Section section, string line, bool isPrimaryStream)
         {
             if (section != Section.Colours)
             {
@@ -54,7 +54,7 @@ namespace osu.Game.Skinning
                     skin.ConfigDictionary[pair.Key] = pair.Value;
             }
 
-            base.ParseLine(skin, section, line);
+            base.ParseLine(skin, section, line, isPrimaryStream);
         }
 
         protected override SkinConfiguration CreateTemplateObject()

--- a/osu.Game/Storyboards/Commands/IStoryboardCommand.cs
+++ b/osu.Game/Storyboards/Commands/IStoryboardCommand.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Storyboards.Commands
         /// </summary>
         double EndTime { get; }
 
+        Easing Easing { get; }
+
         /// <summary>
         /// The name of the <see cref="Drawable"/> property affected by this storyboard command.
         /// Used to apply initial property values based on the list of commands given in <see cref="StoryboardSprite"/>.
@@ -42,5 +44,10 @@ namespace osu.Game.Storyboards.Commands
         /// <returns>The sequence of transforms applied to the target drawable.</returns>
         TransformSequence<TDrawable> ApplyTransforms<TDrawable>(TDrawable d)
             where TDrawable : Drawable, IFlippable, IVectorScalable;
+    }
+
+    public interface IStoryboardLoopingCommand : IStoryboardCommand
+    {
+        IStoryboardCommand OriginalCommand { get; }
     }
 }

--- a/osu.Game/Storyboards/Commands/StoryboardLoopingGroup.cs
+++ b/osu.Game/Storyboards/Commands/StoryboardLoopingGroup.cs
@@ -34,8 +34,10 @@ namespace osu.Game.Storyboards.Commands
 
         public override string ToString() => $"{loopStartTime} x{TotalIterations}";
 
-        private class StoryboardLoopingCommand<T> : StoryboardCommand<T>
+        private class StoryboardLoopingCommand<T> : StoryboardCommand<T>, IStoryboardLoopingCommand
         {
+            IStoryboardCommand IStoryboardLoopingCommand.OriginalCommand => command;
+
             private readonly StoryboardCommand<T> command;
             private readonly StoryboardLoopingGroup loopingGroup;
 

--- a/osu.Game/Storyboards/IStoryboardElement.cs
+++ b/osu.Game/Storyboards/IStoryboardElement.cs
@@ -7,12 +7,31 @@ namespace osu.Game.Storyboards
 {
     public interface IStoryboardElement
     {
+        /// <summary>
+        /// Whether this element was declared in the individual beatmap's <c>.osu</c> file,
+        /// or in a beatmapset-shared <c>.osb</c> file.
+        /// </summary>
+        StoryboardElementSource Source { get; }
+
         string Path { get; }
         bool IsDrawable { get; }
 
         double StartTime { get; }
 
         Drawable CreateDrawable();
+    }
+
+    public enum StoryboardElementSource
+    {
+        /// <summary>
+        /// This element was declared in the individual beatmap's <c>.osu</c> file.
+        /// </summary>
+        Beatmap,
+
+        /// <summary>
+        /// This element was declared in a beatmapset-shared <c>.osb</c> file.
+        /// </summary>
+        SharedStoryboard
     }
 
     public static class StoryboardElementExtensions

--- a/osu.Game/Storyboards/IStoryboardElement.cs
+++ b/osu.Game/Storyboards/IStoryboardElement.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Storyboards
         /// <summary>
         /// This element was declared in a beatmapset-shared <c>.osb</c> file.
         /// </summary>
-        SharedStoryboard
+        Shared
     }
 
     public static class StoryboardElementExtensions

--- a/osu.Game/Storyboards/StoryboardAnimation.cs
+++ b/osu.Game/Storyboards/StoryboardAnimation.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Storyboards
         public double FrameDelay;
         public AnimationLoopType LoopType;
 
-        public StoryboardAnimation(string path, Anchor origin, Vector2 initialPosition, int frameCount, double frameDelay, AnimationLoopType loopType)
-            : base(path, origin, initialPosition)
+        public StoryboardAnimation(StoryboardElementSource source, string path, Anchor origin, Vector2 initialPosition, int frameCount, double frameDelay, AnimationLoopType loopType)
+            : base(source, path, origin, initialPosition)
         {
             FrameCount = frameCount;
             FrameDelay = frameDelay;

--- a/osu.Game/Storyboards/StoryboardSample.cs
+++ b/osu.Game/Storyboards/StoryboardSample.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Storyboards
 {
     public class StoryboardSampleInfo : IStoryboardElement, ISampleInfo
     {
+        public StoryboardElementSource Source { get; }
         public string Path { get; }
         public bool IsDrawable => true;
 
@@ -24,8 +25,9 @@ namespace osu.Game.Storyboards
             System.IO.Path.ChangeExtension(Path, null),
         };
 
-        public StoryboardSampleInfo(string path, double time, int volume)
+        public StoryboardSampleInfo(StoryboardElementSource source, string path, double time, int volume)
         {
+            Source = source;
             Path = path;
             StartTime = time;
             Volume = volume;

--- a/osu.Game/Storyboards/StoryboardSprite.cs
+++ b/osu.Game/Storyboards/StoryboardSprite.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Storyboards
         public readonly List<StoryboardLoopingGroup> LoopingGroups = new List<StoryboardLoopingGroup>();
         public readonly List<StoryboardTriggerGroup> TriggerGroups = new List<StoryboardTriggerGroup>();
 
+        public StoryboardElementSource Source { get; }
         public string Path { get; }
         public virtual bool IsDrawable => HasCommands;
 
@@ -110,8 +111,9 @@ namespace osu.Game.Storyboards
 
         public bool HasCommands => Commands.HasCommands || LoopingGroups.Any(l => l.HasCommands);
 
-        public StoryboardSprite(string path, Anchor origin, Vector2 initialPosition)
+        public StoryboardSprite(StoryboardElementSource source, string path, Anchor origin, Vector2 initialPosition)
         {
+            Source = source;
             Path = path;
             Origin = origin;
             InitialPosition = initialPosition;

--- a/osu.Game/Storyboards/StoryboardSprite.cs
+++ b/osu.Game/Storyboards/StoryboardSprite.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Storyboards
 {
     public class StoryboardSprite : IStoryboardElementWithDuration
     {
-        private readonly List<StoryboardLoopingGroup> loopingGroups = new List<StoryboardLoopingGroup>();
-        private readonly List<StoryboardTriggerGroup> triggerGroups = new List<StoryboardTriggerGroup>();
+        public readonly List<StoryboardLoopingGroup> LoopingGroups = new List<StoryboardLoopingGroup>();
+        public readonly List<StoryboardTriggerGroup> TriggerGroups = new List<StoryboardTriggerGroup>();
 
         public string Path { get; }
         public virtual bool IsDrawable => HasCommands;
@@ -41,7 +41,7 @@ namespace osu.Game.Storyboards
                         break;
                 }
 
-                foreach (var loop in loopingGroups)
+                foreach (var loop in LoopingGroups)
                 {
                     foreach (var command in loop.Alpha)
                     {
@@ -76,7 +76,7 @@ namespace osu.Game.Storyboards
                 // If we got to this point, either no alpha commands were present, or the earliest had a non-zero start value.
                 // The sprite's StartTime will be determined by the earliest command, regardless of type.
                 double earliestStartTime = Commands.StartTime;
-                foreach (var l in loopingGroups)
+                foreach (var l in LoopingGroups)
                     earliestStartTime = Math.Min(earliestStartTime, l.StartTime);
                 return earliestStartTime;
             }
@@ -88,7 +88,7 @@ namespace osu.Game.Storyboards
             {
                 double latestEndTime = Commands.EndTime;
 
-                foreach (var l in loopingGroups)
+                foreach (var l in LoopingGroups)
                     latestEndTime = Math.Max(latestEndTime, l.EndTime);
 
                 return latestEndTime;
@@ -101,14 +101,14 @@ namespace osu.Game.Storyboards
             {
                 double latestEndTime = Commands.EndTime;
 
-                foreach (var l in loopingGroups)
+                foreach (var l in LoopingGroups)
                     latestEndTime = Math.Max(latestEndTime, l.StartTime + l.Duration * l.TotalIterations);
 
                 return latestEndTime;
             }
         }
 
-        public bool HasCommands => Commands.HasCommands || loopingGroups.Any(l => l.HasCommands);
+        public bool HasCommands => Commands.HasCommands || LoopingGroups.Any(l => l.HasCommands);
 
         public StoryboardSprite(string path, Anchor origin, Vector2 initialPosition)
         {
@@ -122,14 +122,14 @@ namespace osu.Game.Storyboards
         public StoryboardLoopingGroup AddLoopingGroup(double loopStartTime, int repeatCount)
         {
             var loop = new StoryboardLoopingGroup(loopStartTime, repeatCount);
-            loopingGroups.Add(loop);
+            LoopingGroups.Add(loop);
             return loop;
         }
 
         public StoryboardTriggerGroup AddTriggerGroup(string triggerName, double startTime, double endTime, int groupNumber)
         {
             var trigger = new StoryboardTriggerGroup(triggerName, startTime, endTime, groupNumber);
-            triggerGroups.Add(trigger);
+            TriggerGroups.Add(trigger);
             return trigger;
         }
 
@@ -141,7 +141,7 @@ namespace osu.Game.Storyboards
             // For performance reasons, we need to apply the commands in chronological order.
             // Not doing so will cause many functions to be interleaved, resulting in O(n^2) complexity.
             IEnumerable<IStoryboardCommand> commands = Commands.AllCommands;
-            commands = commands.Concat(loopingGroups.SelectMany(l => l.AllCommands));
+            commands = commands.Concat(LoopingGroups.SelectMany(l => l.AllCommands));
 
             foreach (var command in commands.OrderBy(c => c.StartTime))
             {

--- a/osu.Game/Storyboards/StoryboardVideo.cs
+++ b/osu.Game/Storyboards/StoryboardVideo.cs
@@ -9,8 +9,8 @@ namespace osu.Game.Storyboards
 {
     public class StoryboardVideo : StoryboardSprite
     {
-        public StoryboardVideo(string path, double offset)
-            : base(path, Anchor.Centre, Vector2.Zero)
+        public StoryboardVideo(StoryboardElementSource source, string path, double offset)
+            : base(source, path, Anchor.Centre, Vector2.Zero)
         {
             // This is just required to get a valid StartTime based on the incoming offset.
             // Actual fades are handled inside DrawableStoryboardVideo for now.

--- a/osu.Game/Tests/Beatmaps/TestBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestBeatmap.cs
@@ -26,7 +26,6 @@ namespace osu.Game.Tests.Beatmaps
 
             BeatmapInfo = baseBeatmap.BeatmapInfo;
             ControlPointInfo = baseBeatmap.ControlPointInfo;
-            UnhandledEventLines = baseBeatmap.UnhandledEventLines;
             AudioLeadIn = baseBeatmap.AudioLeadIn;
             StackLeniency = baseBeatmap.StackLeniency;
             SpecialStyle = baseBeatmap.SpecialStyle;

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -20,6 +20,7 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Menu;
 using osu.Game.Skinning;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Tests.Visual
 {
@@ -178,7 +179,7 @@ namespace osu.Game.Tests.Visual
                     => testBeatmapManager.TestBeatmap;
             }
 
-            public override void Save(BeatmapInfo info, IBeatmap beatmapContent, ISkin beatmapSkin = null)
+            public override void Save(BeatmapInfo info, IBeatmap beatmapContent, ISkin beatmapSkin = null, Storyboard storyboard = null)
             {
                 // don't actually care about saving for this context.
             }

--- a/osu.Game/Tests/Visual/LegacyReplayPlaybackTestScene.cs
+++ b/osu.Game/Tests/Visual/LegacyReplayPlaybackTestScene.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual
                 Ruleset.Value = CreateRuleset()!.RulesetInfo;
                 playableBeatmap = Beatmap.Value.GetPlayableBeatmap(Ruleset.Value);
 
-                var beatmapEncoder = new LegacyBeatmapEncoder(beatmap, null);
+                var beatmapEncoder = new LegacyBeatmapEncoder(beatmap, null, null);
 
                 using (var writer = new StreamWriter(beatmapStream, Encoding.UTF8, leaveOpen: true))
                     beatmapEncoder.Encode(writer);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/37757

Commit-by-commit reading is recommended. Commits will be split to PRs on request but I consider this to be the minimal viable functional increment.

## Done

- This adds a first version of a full storyboard encoder (a66dc406f498e35d4e0c8f2a462e946a9a1aeccc). I expect there to be hiccups due to weird corners of the `.osb` format; this is only intended to be somewhat correct as a start to build upon. Storyboarders are asked to file issues as necessary.
- Due to the fact that storyboard definitions can reside both in the `.osu` and the `.osb`, b60698a95c4de1bfeb36fbb159fd5a6028920832 adds the required storage to be able to tell which storyboard element lives where, so that it can be decoded properly later.
- In c9d3e04a4135886b5b0943c85f3cc6f4fe99c84c, the storyboard decoder is weaved into the beatmap decoder to handle the `.osu` part of the storyboard, via the `LegacyStoryboardEncoder.Encode{General,Events}ToBeatmap()` methods. For `.osb`s, `LegacyStoryboardEncoder.EncodeStandaloneStoryboard()` is intended, but for now is not used outside tests.
- Because of the above, dd1c4e43dc51154cd67860f096712f8b4f229661 removes `Beatmap.UnhandledEventLines` as no longer required.
- 26ac417ed98a8937c42e5f52c4e15ef065a48902 adds tests. They are mostly handwritten to ensure basic encode-decode roundtripping. Using existing storyboards is difficult, see "Known issues" section as to why.
- 5cc542366db7caac38eb0729260d884905a2c0d5 fixes a bug in the storyboard decoder where the trigger group number was not properly negated on decode (see inline comment reference to relevant stable code).

## Known issues

- Any and all variables in the `[Variables]` section are inlined into their usages by `LegacyStoryboardDecoder`, and as such `LegacyStoryboardEncoder` will end up inlining them and discarding the `[Variables]` section. As far as I can tell stable will also do this.
- `LegacyStoryboardDecoder` splits all `M` (move) commands into `MX`/`MY` commands. Therefore, `LegacyStoryboardEncoder` will write out things in the same split way. I did not put in effort to attempt to reconcile this, for reasons of part laziness, part not wanting to bloat this already-large diff.
- Ordering of storyboard samples on decode may not match the order on decode. I'm crossing fingers this doesn't matter.