### PR TITLE
Add custom editor toolbox icons for taiko, mania, and catch

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
@@ -5,7 +5,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
-using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 
@@ -14,7 +13,7 @@ namespace osu.Game.Rulesets.Catch.Edit
     public class BananaShowerCompositionTool : CompositionTool
     {
         public BananaShowerCompositionTool()
-            : base(nameof(BananaShower))
+            : base("Banana shower")
         {
         }
 

--- a/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorBananaShower };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new BananaShowerPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Catch/Edit/FruitCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/FruitCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorFruit };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new FruitPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Catch/Edit/JuiceStreamCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/JuiceStreamCompositionTool.cs
@@ -5,7 +5,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
-using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 
@@ -14,7 +13,7 @@ namespace osu.Game.Rulesets.Catch.Edit
     public class JuiceStreamCompositionTool : CompositionTool
     {
         public JuiceStreamCompositionTool()
-            : base(nameof(JuiceStream))
+            : base("Juice stream")
         {
         }
 

--- a/osu.Game.Rulesets.Catch/Edit/JuiceStreamCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/JuiceStreamCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorJuiceStream };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new JuiceStreamPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Mania/Edit/HoldNoteCompositionTool.cs
+++ b/osu.Game.Rulesets.Mania/Edit/HoldNoteCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Mania.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorHoldNote };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new HoldNotePlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Mania/Edit/NoteCompositionTool.cs
+++ b/osu.Game.Rulesets.Mania/Edit/NoteCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Mania.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorNote };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new NotePlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Osu/Edit/HitCircleCompositionTool.cs
+++ b/osu.Game.Rulesets.Osu/Edit/HitCircleCompositionTool.cs
@@ -7,14 +7,13 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
-using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
     public class HitCircleCompositionTool : CompositionTool
     {
         public HitCircleCompositionTool()
-            : base(nameof(HitCircle))
+            : base("Hit circle")
         {
         }
 

--- a/osu.Game.Rulesets.Taiko/Edit/DrumRollCompositionTool.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/DrumRollCompositionTool.cs
@@ -7,14 +7,13 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
-using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Edit
 {
     public class DrumRollCompositionTool : CompositionTool
     {
         public DrumRollCompositionTool()
-            : base(nameof(DrumRoll))
+            : base("Drum roll")
         {
         }
 

--- a/osu.Game.Rulesets.Taiko/Edit/DrumRollCompositionTool.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/DrumRollCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorDrumRoll };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new DrumRollPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Taiko/Edit/HitCompositionTool.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/HitCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorHit };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new HitPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Taiko/Edit/SwellCompositionTool.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/SwellCompositionTool.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
         {
         }
 
-        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners);
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.EditorSwell };
 
         public override HitObjectPlacementBlueprint CreatePlacementBlueprint() => new SwellPlacementBlueprint();
     }

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -93,6 +93,14 @@ namespace osu.Game.Graphics
         public static IconUsage EditorHitCircle => get(OsuIconMapping.EditorHitCircle);
         public static IconUsage EditorSlider => get(OsuIconMapping.EditorSlider);
         public static IconUsage EditorSpinner => get(OsuIconMapping.EditorSpinner);
+        public static IconUsage EditorHit => get(OsuIconMapping.EditorHit);
+        public static IconUsage EditorDrumRoll => get(OsuIconMapping.EditorDrumRoll);
+        public static IconUsage EditorSwell => get(OsuIconMapping.EditorSwell);
+        public static IconUsage EditorFruit => get(OsuIconMapping.EditorFruit);
+        public static IconUsage EditorJuiceStream => get(OsuIconMapping.EditorJuiceStream);
+        public static IconUsage EditorNote => get(OsuIconMapping.EditorNote);
+        public static IconUsage EditorHoldNote => get(OsuIconMapping.EditorHoldNote);
+        public static IconUsage EditorBananaShower => get(OsuIconMapping.EditorBananaShower);
         public static IconUsage EditorGrid => get(OsuIconMapping.EditorGrid);
         public static IconUsage EditorAddControlPoint => get(OsuIconMapping.EditorAddControlPoint);
         public static IconUsage EditorConvertToStream => get(OsuIconMapping.EditorConvertToStream);
@@ -408,6 +416,30 @@ namespace osu.Game.Graphics
 
             [Description(@"Editor/spinner")]
             EditorSpinner,
+
+            [Description(@"Editor/hit")]
+            EditorHit,
+
+            [Description(@"Editor/drum-roll")]
+            EditorDrumRoll,
+
+            [Description(@"Editor/swell")]
+            EditorSwell,
+
+            [Description(@"Editor/fruit")]
+            EditorFruit,
+
+            [Description(@"Editor/juice-stream")]
+            EditorJuiceStream,
+
+            [Description(@"Editor/banana-shower")]
+            EditorBananaShower,
+
+            [Description(@"Editor/note")]
+            EditorNote,
+
+            [Description(@"Editor/hold-note")]
+            EditorHoldNote,
 
             [Description(@"Editor/grid")]
             EditorGrid,

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="20.1.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2026.513.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.516.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.519.0" />
     <PackageReference Include="Sentry" Version="6.2.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.48.0" />


### PR DESCRIPTION
Requires https://github.com/ppy/osu-resources/pull/424.

Replaces the editor toolbox icons for taiko, mania, and catch rulesets with new designs, courtesy of [Adarin](https://osu.ppy.sh/users/118360).

| taiko | catch | mania |
|--------|--------|--------|
| <img width="369" height="401" alt="image" src="https://github.com/user-attachments/assets/25dc6259-02b4-4a23-9a80-529a366c270e" /> | <img width="369" height="401" alt="image" src="https://github.com/user-attachments/assets/4bf67bf9-8a45-4075-8d33-f0501cdb08cb" /> | <img width="369" height="317" alt="image" src="https://github.com/user-attachments/assets/d130a97e-c082-4b01-a88a-d3209c05e33b" /> | 
