### PR TITLE
Add `Moving Always` and `First Person` mod into the osu!catch ruleset

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -156,6 +156,8 @@ namespace osu.Game.Rulesets.Catch
                         new CatchModNoScope(),
                         new CatchModMovingFast(),
                         new CatchModSynesthesia(),
+                        new CatchModMovingAlways(),
+                        new CatchModFirstPerson(),
                     };
 
                 case ModType.System:

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFirstPerson.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFirstPerson.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
+using osu.Game.Storyboards.Drawables;
+
+namespace osu.Game.Rulesets.Catch.Mods
+{
+    public class CatchModFirstPerson : Mod, IApplicableToPlayer, IUpdatableByPlayfield
+    {
+        public override string Name => "First Person";
+        public override string Acronym => "FP";
+        public override LocalisableString Description => "Catch, from the catcher's perspective!";
+        public override ModType Type => ModType.Fun;
+        public override double ScoreMultiplier => 1;
+        public override IconUsage? Icon => OsuIcon.ModMovingFast;
+        public override Type[] IncompatibleMods => new[] { typeof(ModCinema), typeof(ModNoScope) };
+
+        [SettingSource("Centred background", "Have the background follow.")] // From the perspective of the player
+        public BindableBool CentredBackground { get; } = new BindableBool();
+
+        [SettingSource("Centred storyboard / video", "Have the storyboard / video follow.")] // From the perspective of the player
+        public BindableBool CentredStoryboard { get; } = new BindableBool();
+
+        private DimmableStoryboard dimmableStoryboard = null!;
+        private Action<float> setBackgroundX = null!;
+
+        private const float shift_x_factor = 1.6f; // Bruteforced, is magical, todo: may need more intricate calculation
+
+        public void ApplyToPlayer(Player player)
+        {
+            dimmableStoryboard = player.DimmableStoryboard;
+            setBackgroundX = x => player.ApplyToBackground(b => b.X = x);
+        }
+
+        public void Update(Playfield playfield)
+        {
+            var catchPlayfield = (CatchPlayfield)playfield;
+
+            catchPlayfield.X = CatchPlayfield.CENTER_X - catchPlayfield.Catcher.X;
+            float miscellaneousXOffset = shift_x_factor * catchPlayfield.X;
+
+            if (!CentredBackground.Value)
+                setBackgroundX(miscellaneousXOffset); // TODO: Fix crashing when exiting replay (from Auto) and the leaving background at the same X when exiting until there is a background refresh
+            if (!CentredStoryboard.Value)
+                dimmableStoryboard.Children.Where(c => c is DrawableStoryboard).ForEach(ds => ds.X = miscellaneousXOffset);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Mods/CatchModMovingAlways.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModMovingAlways.cs
@@ -1,0 +1,118 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Framework.Input.States;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Mods
+{
+    public partial class CatchModMovingAlways : Mod, IApplicableToDrawableRuleset<CatchHitObject>, IApplicableToPlayer
+    {
+        public override string Name => "Moving Always";
+        public override string Acronym => "MA";
+        public override LocalisableString Description => "Absolutely restless... no sense in stopping!";
+        public override ModType Type => ModType.Fun;
+        public override double ScoreMultiplier => 1;
+        public override IconUsage? Icon => OsuIcon.ModMovingFast;
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax) };
+
+        private DrawableCatchRuleset drawableRuleset = null!;
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)
+        {
+            this.drawableRuleset = (DrawableCatchRuleset)drawableRuleset;
+        }
+
+        public void ApplyToPlayer(Player player)
+        {
+            if (!drawableRuleset.HasReplayLoaded.Value)
+            {
+                var catchPlayfield = (CatchPlayfield)drawableRuleset.Playfield;
+                catchPlayfield.CatcherArea.Add(new NonstopMoveInputHelper(catchPlayfield.CatcherArea));
+            }
+        }
+
+        private partial class NonstopMoveInputHelper : Drawable, IKeyBindingHandler<CatchAction>
+        {
+            private readonly CatcherArea catcherArea;
+
+            // To work with CatcherArea's OnPressed and OnReleased helping set its currentDirection accordingly always to -1 (left) or 1 (right)
+            private int currentDirection;
+
+            private const int left = -1;
+            private const int right = 1;
+
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+
+            public NonstopMoveInputHelper(CatcherArea catcherArea)
+            {
+                this.catcherArea = catcherArea;
+
+                RelativeSizeAxes = Axes.Both;
+
+                // Just like Catcher's default VisualDirection except already moving in that direction
+                this.catcherArea.OnPressed(new KeyBindingPressEvent<CatchAction>(new InputState(), CatchAction.MoveRight));
+                currentDirection = right;
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<CatchAction> e)
+            {
+                switch (e.Action)
+                {
+                    case CatchAction.MoveLeft:
+                        if (currentDirection == right) // act out an extra left key press to transition to moving left instead of a stop
+                            catcherArea.OnPressed((new KeyBindingPressEvent<CatchAction>(new InputState(), CatchAction.MoveLeft)));
+                        else // act out a neutralizing left key release to stay moving left instead of moving faster left
+                            catcherArea.OnReleased((new KeyBindingReleaseEvent<CatchAction>(new InputState(), CatchAction.MoveLeft)));
+
+                        currentDirection = left;
+                        break;
+
+                    case CatchAction.MoveRight:
+                        if (currentDirection == left) // act out an extra right key press to transition to moving right instead of a stop
+                            catcherArea.OnPressed((new KeyBindingPressEvent<CatchAction>(new InputState(), CatchAction.MoveRight)));
+                        else // act out a neutralizing right key release to stay moving right instead of moving faster right
+                            catcherArea.OnReleased((new KeyBindingReleaseEvent<CatchAction>(new InputState(), CatchAction.MoveRight)));
+
+                        currentDirection = right;
+                        break;
+
+                    case CatchAction.Dash:
+                        break;
+                }
+
+                return false;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<CatchAction> e)
+            {
+                // Moving Always means releasing a movement key does nothing in trying to stop moving, so neutralize by acting out its key press
+                switch (e.Action)
+                {
+                    case CatchAction.MoveLeft:
+                        catcherArea.OnPressed(new KeyBindingPressEvent<CatchAction>(new InputState(), CatchAction.MoveLeft));
+                        break;
+
+                    case CatchAction.MoveRight:
+                        catcherArea.OnPressed(new KeyBindingPressEvent<CatchAction>(new InputState(), CatchAction.MoveRight));
+                        break;
+
+                    case CatchAction.Dash:
+                        break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hey, so, I got the obsessive interest of wanting to try to contribute to osu!lazer by implementing some new Fun mods into Catch and gave it a go, though it needs a bit more polishing. Out of the ideas I came up with, these seemed to be the two best ones for me to try to implement, Moving Always and First Person.

Also, when I mention storyboard, this does include the video if there is one because that is how it is in osu!lazer. And also, I used my own skin when playing Catch in these videos which does have playfield boundaries. Heh, sorry about that!

### What are these mods?

Showcase

https://github.com/user-attachments/assets/09387234-16b0-4edf-8b42-1b16a54e14f7

Storyboard Following Accurately **(WARNING: skip to 0:44 if you are sensitive to fruits moving too quickly across the screen and with some flashing lights)**

https://github.com/user-attachments/assets/8594d427-575d-4d28-8680-3d83481dfe6f



Moving Always (MA): The catcher is always moving no matter what. The direction they are facing is where they will be moving and if both left and right are being held down at the same time, the most recent direction pressed is the direction the Catcher will move towards. This was easier overall to implement and was inspired from the Moving Fast mod (https://github.com/ppy/osu/pull/33688). If that mod is a cookie, then this mod is the milk. Both involve the catcher being energetic and restless.

First Person (FP): I got inspired by the Centered Cursor pull request (https://github.com/ppy/osu/pull/37487) and when I thought about it, this seemed ideal for Catch given that there is one less dimension and how the catcher is bounded by the playfield. The catcher is fully centered on the screen which gives the appearance of moving with the catcher. The player gets to sense how the catcher feels doing all those rapid movements at such high speeds. Very fun mod, though I hope not that many could be sensitive to all the movements. The configurations I added of the background and storyboard being centered are that storyboard-heavy-for-gameplay maps such as Galaxy Collapse (https://osu.ppy.sh/beatmapsets/521900#fruits/1108507) with the red vertical lines following the Catcher in the storyboard and Dodge the Beat Space Invaders (https://osu.ppy.sh/beatmapsets/1237212#fruits/2571609) lasers and bullets match the same positions visually if needed so those same maps can be watched and enjoyed in FIRST PERSON.


### Are these mods ready?

Almost, _probably._

- **_Both mods require the mod icon. For now, they are just the Moving Fast mod icon._**

Moving Always is fully functional, but unfortunately,
- **_Catch replays record the Catcher's position for movement, not the left and right key presses._**

Even when playing No Mod, when bumping into a wall with the catcher, the input stops flashing in the replay. For Moving Always, the replay will just look like the play that occurred but as if the player was playing No Mod which is honestly not that bad. (Incidentally,
- **_for the Moving Fast mod that was already implemented, the catcher shines instead when they are walking in the replay._**)

Besides that, I am happy with how this mod came out and decided to implement the more challenging looking rollercoaster-level-exhilarating one, First Person.

First Person is a bit more brutal. The mod could be a bit neater in the code once some of the bugs are fixed. For one, this float of 1.6f which perfectly adjusts the background and storyboard with respect to the centered catcher from the catch playfield getting a new range from x=0f to x=[-256f, 256f], I have seen it referenced as the osu-stable "magic ratio" (https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Osu/UI/OsuPlayfieldAdjustmentContainer.cs#L57-L58).
- **_Regardless, this 1.6f I effectively guessed through bruteforce and should instead be calculated however it is supposed to be calculated. When osu!lazer's window falls below the aspect ratio of approximately 4:3, even No Mod, storyboards seem to misalign and go off screen, so that is not a fault of this mod. If the aspect ratio is approximately greater than or equal to 4:3, then this magical 1.6f seems to work since that fundamental bug does not occur._**
- **_Background x coordinate is not reset upon leaving a map._**
- **_Leaving a map in certain situations with the background NOT being centered can cause the game to crash._**


### Why was it chosen to only have the background and the whole storyboard be able to be uncentered?

Convenience in programming and also because there are too many visual elements to account for if going deeper which would cause _setting-itis_. For example, it is rare that the HUD elements should have to be uncentered unless some crazy Catch Aspire map goes that far out that I am not aware of. Storyboard including everything inside of itself including the video ensures full compatibility with Catch maps with gameplay elements that depend on its storyboard.

### Conclusion
I hope for the best. I did the pull request not just to present the idea, but because I would like some more help so these mods can be the best they can be and so I don't somehow lose the code I did. Thank you Rudicito for osu! infrastructure guidance, thank you bdach/spaceman (computers graphics seems crazy hard, the Planet mod may have to take the furthest backseat there is, hoping to somehow do Wrap mod eventually), thank you Tenexxt for going for implementing the DtB mod and carrying the same interests, and the few others that have jumped in the osu! dev server to help! osu! has lots of layers in development, I see.