### PR TITLE
Fix Memory Leak on Ranked Play's ScreenQueue.cs

### DIFF
--- a/osu.Game/Database/UserLookupCache.cs
+++ b/osu.Game/Database/UserLookupCache.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Database
         public Task<APIUser?[]> GetUsersAsync(int[] userIds, CancellationToken token = default) => LookupAsync(userIds, token);
 
         /// <summary>
-        /// Invalidate previously looked up users with <see cref="GetuserAsync"/> or <see cref="GetUsersAsync"/>. Used to clear only a part of the cache, instead of the entire package.
+        /// Invalidate previously looked up users with <see cref="GetUserAsync"/> or <see cref="GetUsersAsync"/>. Used to clear only a part of the cache, instead of the entire package.
         /// </summary>
         /// <param name="userIds"></param>
         public void InvalidateUsers(IEnumerable<int> userIds)

--- a/osu.Game/Database/UserLookupCache.cs
+++ b/osu.Game/Database/UserLookupCache.cs
@@ -28,6 +28,16 @@ namespace osu.Game.Database
         /// <returns>The populated users. May include null results for failed retrievals.</returns>
         public Task<APIUser?[]> GetUsersAsync(int[] userIds, CancellationToken token = default) => LookupAsync(userIds, token);
 
+        /// <summary>
+        /// Invalidate previously looked up users with <see cref="GetuserAsync"/> or <see cref="GetUsersAsync"/>. Used to clear only a part of the cache, instead of the entire package.
+        /// </summary>
+        /// <param name="userIds"></param>
+        public void InvalidateUsers(IEnumerable<int> userIds)
+        {
+            var idSet = userIds.ToHashSet();
+            Invalidate(id => idSet.Contains(id));
+        }
+
         protected override LookupUsersRequest CreateRequest(IEnumerable<int> ids) => new LookupUsersRequest(ids.ToArray());
 
         protected override IEnumerable<APIUser>? RetrieveResults(LookupUsersRequest request) => request.Response?.Users;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayMatchPanel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
@@ -36,6 +37,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         [Resolved]
         private UserLookupCache userLookupCache { get; set; } = null!;
+
+        public IEnumerable<int> UserIds => state.Users.Keys;
 
         private readonly RankedPlayRoomState state;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -101,6 +101,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private int? userRating;
 
+        private int resultPanelInsertDepth;
+        private const int max_match_panels = 50;
+
+        private bool initialMatchesLoaded;
+
         private GridContainer mainGrid = null!;
 
         private IBindable<bool> isConnected = null!;
@@ -438,7 +443,20 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             ratingGraph.SetData(status.RatingDistribution, userRating);
 
-            loadRecentMatches(status.RecentMatches.OfType<RankedPlayRoomState>().ToArray()).FireAndForget();
+            if (status.RecentMatches.Length <= 0)
+                return;
+
+            var newMatches = status.RecentMatches.OfType<RankedPlayRoomState>().ToArray();
+
+            if (!initialMatchesLoaded)
+            {
+                loadRecentMatches(newMatches.TakeLast(max_match_panels).ToArray()).FireAndForget();
+                initialMatchesLoaded = true;
+            }
+            else
+            {
+                loadRecentMatches(newMatches).FireAndForget();
+            }
         });
 
         private async Task loadRecentMatches(RankedPlayRoomState[] matches)
@@ -449,11 +467,24 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 foreach (var match in matches)
                 {
-                    resultPanelContainer.Insert(-resultPanelContainer.Count, new RankedPlayMatchPanel(match)
+                    resultPanelContainer.Insert(--resultPanelInsertDepth, new RankedPlayMatchPanel(match)
                     {
                         RelativeSizeAxes = Axes.X,
                         Width = 0.48f
                     });
+                }
+
+                if (resultPanelContainer.Count > max_match_panels)
+                {
+                    var excess = resultPanelContainer.Children.SkipLast(max_match_panels).ToArray();
+
+                    foreach (var panel in excess)
+                    {
+                        var matchPanel = (RankedPlayMatchPanel)panel;
+                        userLookupCache.InvalidateUsers(matchPanel.UserIds);
+                        resultPanelContainer.Remove(panel, disposeImmediately: false);
+                        panel.FadeOut(300, Easing.OutQuint).Expire();
+                    }
                 }
 
                 if (resultPanelContainer.Any(c => c.Position != Vector2.Zero))
@@ -488,6 +519,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             ratingGraph.SetData([], null);
 
             cloud.Users = Array.Empty<APIUser>();
+            resultPanelInsertDepth = 0;
+            initialMatchesLoaded = false;
+            userLookupCache.Clear();
         }
 
         public override void OnEntering(ScreenTransitionEvent e)
@@ -726,11 +760,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-
             stopWaitingLoopPlayback();
-
+            userLookupCancellation.Cancel();
             if (client.IsNotNull())
                 client.MatchmakingLobbyStatusChanged -= onMatchmakingLobbyStatusChanged;
+            userLookupCache.Clear();
         }
 
         public enum MatchmakingScreenState


### PR DESCRIPTION
Got approached by SgtPepega after they left their game open on the queue screen for ranked play. After leaving the game open for a couple hours, the RAM usage from Lazer was extremely high and it did not go down untl closing the game. Did some investigating and found out that users are never removed from the cache or even limited when adding new matches to the MatchPanel section.

Was able to replicate this issue by literally just leaving the game open on said screen, monitored with powershell.
[memory_log.csv](https://github.com/user-attachments/files/27981875/memory_log.csv)

Had to do some tinkering since I don't have access to server side, good to know that `onMatchmakingLobbyStatusChanged` is literally called every 10 seconds, put a check in place so `loadRecentMatches` isn't being triggered because of this if the new matches are set to 0, otherwise it was going through this code for no reason.

Changes made:
- Limit the number of displayed recent match panels and add targeted user-cache invalidation.
- Inside `UserLookupCache.cs` we add `InvalidateUsers` to remove specific users from the lookup cache.
- Inside `RankedPlayMatchPanel.cs` we now exposes `UserIds` so removed panels can clear their associated user entries.
- Inside `ScreenQueue.cs` we add `resultPanelInsertDepth`, `max_match_panels` (set to 50) and `initialMatchesLoaded`. Initial load takes the last matches from `RankedPlayRoomState[] matches`. Subsequent updates append normally. 
- Excess panels are removed (with fade/expire) and their users invalidated to avoid unbounded UI growth and stale cache entries.
- Also reset insert depth/flags on clear, cancel user lookup on dispose/server disconnect, and clear the full user lookup cache.