### PR TITLE
Add score multiplier calculator API

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
+++ b/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Benchmarks
+{
+    public class BenchmarkScoreMultiplierCalculator : BenchmarkTest
+    {
+        private ScoreMultiplierCalculator calculator = null!;
+
+        [Params(1, 10, 100)]
+        public int Times { get; set; }
+
+        public record ModTestCase(string Description, IEnumerable<Mod> Mods)
+        {
+            public override string ToString() => Description;
+        }
+
+        public static IEnumerable<ModTestCase> ValuesForMods =>
+        [
+            new ModTestCase("no mods", []),
+            new ModTestCase("single mod", [new OsuModHardRock()]),
+            new ModTestCase("multiple mods", [new OsuModHidden(), new OsuModHardRock(), new OsuModDoubleTime()]),
+            new ModTestCase("mods with adjusted settings", [
+                new OsuModDoubleTime { SpeedChange = { Value = 2 } },
+                new OsuModHidden { OnlyFadeApproachCircles = { Value = true } },
+                new OsuModHardRock()
+            ]),
+        ];
+
+        [ParamsSource(nameof(ValuesForMods))]
+        public ModTestCase Mods { get; set; } = null!;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            calculator = new OsuRuleset().CreateScoreMultiplierCalculator();
+        }
+
+        [Benchmark]
+        public double ViaModScoreMultiplier()
+        {
+            double scoreMultiplier = 1;
+
+            for (int i = 0; i < Times; ++i)
+            {
+                scoreMultiplier = 1;
+
+                foreach (var mod in Mods.Mods)
+                    scoreMultiplier *= mod.ScoreMultiplier;
+            }
+
+            return scoreMultiplier;
+        }
+
+        [Benchmark]
+        public double ViaCalculator()
+        {
+            double scoreMultiplier = 1;
+
+            for (int i = 0; i < Times; ++i)
+                scoreMultiplier = calculator.CalculateFor(Mods.Mods);
+
+            return scoreMultiplier;
+        }
+    }
+}

--- a/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
+++ b/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Benchmarks
         [
             new ModTestCase("no mods", []),
             new ModTestCase("single mod", [new OsuModHardRock()]),
+            new ModTestCase("single mod 2", [new OsuModEasy()]),
             new ModTestCase("multiple mods", [new OsuModHidden(), new OsuModHardRock(), new OsuModDoubleTime()]),
             new ModTestCase("mods with adjusted settings", [
                 new OsuModDoubleTime { SpeedChange = { Value = 2 } },

--- a/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
+++ b/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
@@ -44,15 +45,21 @@ namespace osu.Game.Benchmarks
         }
 
         [Benchmark]
-        public double ViaModScoreMultiplier()
+        public double ViaModScoreMultiplier() => viaModScoreMultiplier(Times, Mods);
+
+        [Test]
+        public void ViaModScoreMultiplier([Values(100)] int times, [ValueSource(nameof(ValuesForMods))] ModTestCase mods)
+            => viaModScoreMultiplier(times, mods);
+
+        private double viaModScoreMultiplier(int times, ModTestCase mods)
         {
             double scoreMultiplier = 1;
 
-            for (int i = 0; i < Times; ++i)
+            for (int i = 0; i < times; ++i)
             {
                 scoreMultiplier = 1;
 
-                foreach (var mod in Mods.Mods)
+                foreach (var mod in mods.Mods)
                     scoreMultiplier *= mod.ScoreMultiplier;
             }
 
@@ -61,11 +68,18 @@ namespace osu.Game.Benchmarks
 
         [Benchmark]
         public double ViaCalculator()
+            => viaCalculator(Times, Mods);
+
+        [Test]
+        public void ViaCalculator([Values(100)] int times, [ValueSource(nameof(ValuesForMods))] ModTestCase mods)
+            => viaCalculator(times, mods);
+
+        private double viaCalculator(int times, ModTestCase mods)
         {
             double scoreMultiplier = 1;
 
-            for (int i = 0; i < Times; ++i)
-                scoreMultiplier = calculator.CalculateFor(Mods.Mods);
+            for (int i = 0; i < times; ++i)
+                scoreMultiplier = calculator.CalculateFor(mods.Mods);
 
             return scoreMultiplier;
         }

--- a/osu.Game.Rulesets.Catch.Tests/CatchScoreMultiplierTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchScoreMultiplierTest.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Catch.Mods;
+using osu.Game.Tests.Rulesets;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public class CatchScoreMultiplierTest : RulesetScoreMultiplierTest
+    {
+        public CatchScoreMultiplierTest()
+            : base(new CatchRuleset())
+        {
+        }
+
+        [Test]
+        public void TestFlashlightOnNonDefaultSettings()
+            => TestModCombination([new CatchModFlashlight { ComboBasedSize = { Value = false } }]);
+
+        [Test]
+        public void TestHalfTimeSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new CatchModHalfTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDaycoreSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new CatchModDaycore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDoubleTimeSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new CatchModDoubleTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestNightcoreSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new CatchModNightcore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestMultiplicativeCombination()
+            => TestModCombination([new CatchModHidden(), new CatchModHardRock()]);
+    }
+}

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -169,6 +169,8 @@ namespace osu.Game.Rulesets.Catch
             }
         }
 
+        public override ScoreMultiplierCalculator CreateScoreMultiplierCalculator() => new CatchScoreMultiplierCalculator();
+
         public override string Description => "osu!catch";
 
         public override string ShortName => SHORT_NAME;

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreMultiplierCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreMultiplierCalculator.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Mods;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Catch.Scoring
+{
+    public class CatchScoreMultiplierCalculator : ScoreMultiplierCalculator
+    {
+        static CatchScoreMultiplierCalculator()
+        {
+            #region Difficulty Reduction
+
+            Single<CatchModEasy>(hasMultiplier: 0.5);
+            Single<CatchModNoFail>(hasMultiplier: 0.5);
+            Single<CatchModHalfTime>(hasMultiplier: halfTime => rateAdjustMultiplier(halfTime.SpeedChange.Value));
+            Single<CatchModDaycore>(hasMultiplier: daycore => rateAdjustMultiplier(daycore.SpeedChange.Value));
+
+            #endregion
+
+            #region Difficulty Increase
+
+            Single<CatchModHardRock>(hasMultiplier: hardRock => hardRock.UsesDefaultConfiguration ? 1.12 : 1);
+            // Sudden Death
+            // Perfect
+            Single<CatchModDoubleTime>(hasMultiplier: doubleTime => rateAdjustMultiplier(doubleTime.SpeedChange.Value));
+            Single<CatchModNightcore>(hasMultiplier: nightcore => rateAdjustMultiplier(nightcore.SpeedChange.Value));
+            Single<CatchModHidden>(hasMultiplier: hidden => hidden.UsesDefaultConfiguration ? 1.06 : 1);
+            Single<CatchModFlashlight>(hasMultiplier: flashlight => flashlight.UsesDefaultConfiguration ? 1.12 : 1);
+            // Accuracy Challenge
+
+            #endregion
+
+            #region Conversion
+
+            Single<CatchModDifficultyAdjust>(hasMultiplier: 0.5);
+            Single<CatchModClassic>(hasMultiplier: 0.96);
+            // Mirror
+
+            #endregion
+
+            #region Automation
+
+            // Autoplay
+            // Cinema
+            Single<CatchModRelax>(hasMultiplier: 0.1);
+
+            #endregion
+
+            #region Fun
+
+            Single<ModWindUp>(hasMultiplier: 0.5);
+            Single<ModWindDown>(hasMultiplier: 0.5);
+            // Floating Fruits
+            // Muted
+            // No Scope
+            // Moving Fast
+            Single<CatchModSynesthesia>(hasMultiplier: 0.8);
+
+            #endregion
+
+            #region System
+
+            // Score V2
+
+            #endregion
+        }
+
+        private static double rateAdjustMultiplier(double speedChange)
+        {
+            // Round to the nearest multiple of 0.1.
+            double value = (int)(speedChange * 10) / 10.0;
+
+            // Offset back to 0.
+            value -= 1;
+
+            if (speedChange >= 1)
+                return 1 + value / 5;
+            else
+                return 0.6 + value;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/ManiaScoreMultiplierTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaScoreMultiplierTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Tests.Rulesets;
+
+namespace osu.Game.Rulesets.Mania.Tests
+{
+    public class ManiaScoreMultiplierTest : RulesetScoreMultiplierTest
+    {
+        public ManiaScoreMultiplierTest()
+            : base(new ManiaRuleset())
+        {
+        }
+
+        [Test]
+        public void TestHalfTimeSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new ManiaModHalfTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDaycoreSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new ManiaModDaycore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDoubleTimeSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new ManiaModDoubleTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestNightcoreSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new ManiaModNightcore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestMultiplicativeCombination()
+            => TestModCombination([new ManiaModEasy(), new ManiaModKey4()]);
+    }
+}

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -307,6 +307,8 @@ namespace osu.Game.Rulesets.Mania
             }
         }
 
+        public override ScoreMultiplierCalculator CreateScoreMultiplierCalculator() => new ManiaScoreMultiplierCalculator();
+
         public override string Description => "osu!mania";
 
         public override string ShortName => SHORT_NAME;

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreMultiplierCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreMultiplierCalculator.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Scoring
+{
+    public class ManiaScoreMultiplierCalculator : ScoreMultiplierCalculator
+    {
+        static ManiaScoreMultiplierCalculator()
+        {
+            #region Difficulty Reduction
+
+            Single<ManiaModEasy>(hasMultiplier: 0.5);
+            Single<ManiaModNoFail>(hasMultiplier: 0.5);
+            Single<ManiaModHalfTime>(hasMultiplier: halfTime => rateAdjustMultiplier(halfTime.SpeedChange.Value));
+            Single<ManiaModDaycore>(hasMultiplier: daycore => rateAdjustMultiplier(daycore.SpeedChange.Value));
+            Single<ManiaModNoRelease>(hasMultiplier: 0.9);
+
+            #endregion
+
+            #region Difficulty Increase
+
+            // Hard Rock
+            // Sudden Death
+            // Perfect
+            // Double Time
+            // Nightcore
+            // Fade In
+            // Hidden
+            // Cover
+            // Flashlight
+            // Accuracy Challenge
+
+            #endregion
+
+            #region Conversion
+
+            // Random
+            // Dual Stages
+            // Mirror
+            Single<ManiaModDifficultyAdjust>(hasMultiplier: 0.5);
+            Single<ManiaModClassic>(hasMultiplier: 0.96);
+            // Invert
+            Single<ManiaModConstantSpeed>(hasMultiplier: 0.9);
+            Single<ManiaModHoldOff>(hasMultiplier: 0.9);
+            Single<ManiaModKey1>(hasMultiplier: 0.9);
+            Single<ManiaModKey2>(hasMultiplier: 0.9);
+            Single<ManiaModKey3>(hasMultiplier: 0.9);
+            Single<ManiaModKey4>(hasMultiplier: 0.9);
+            Single<ManiaModKey5>(hasMultiplier: 0.9);
+            Single<ManiaModKey6>(hasMultiplier: 0.9);
+            Single<ManiaModKey7>(hasMultiplier: 0.9);
+            Single<ManiaModKey8>(hasMultiplier: 0.9);
+            Single<ManiaModKey9>(hasMultiplier: 0.9);
+            Single<ManiaModKey10>(hasMultiplier: 0.9);
+
+            #endregion
+
+            #region Automation
+
+            // Autoplay
+            // Cinema
+
+            #endregion
+
+            #region Fun
+
+            Single<ModWindUp>(hasMultiplier: 0.5);
+            Single<ModWindDown>(hasMultiplier: 0.5);
+            // Muted
+            Single<ModAdaptiveSpeed>(hasMultiplier: 0.5);
+
+            #endregion
+
+            #region System
+
+            // Score V2
+
+            #endregion
+        }
+
+        private static double rateAdjustMultiplier(double speedChange)
+        {
+            // Round to the nearest multiple of 0.1.
+            double value = (int)(speedChange * 10) / 10.0;
+
+            // Offset back to 0.
+            value -= 1;
+
+            if (speedChange >= 1)
+                return 1 + value / 5;
+            else
+                return 0.6 + value;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/OsuScoreMultiplierTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuScoreMultiplierTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Tests.Rulesets;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public class OsuScoreMultiplierTest : RulesetScoreMultiplierTest
+    {
+        public OsuScoreMultiplierTest()
+            : base(new OsuRuleset())
+        {
+        }
+
+        [Test]
+        public void TestFlashlightOnNonDefaultSettings()
+            => TestModCombination([new OsuModFlashlight { ComboBasedSize = { Value = false } }]);
+
+        [Test]
+        public void TestHiddenOnNonDefaultSettings()
+            => TestModCombination([new OsuModHidden { OnlyFadeApproachCircles = { Value = true } }]);
+
+        [Test]
+        public void TestHalfTimeSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new OsuModHalfTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDaycoreSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new OsuModDaycore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDoubleTimeSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new OsuModDoubleTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestNightcoreSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new OsuModNightcore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestMultiplicativeCombination()
+            => TestModCombination([new OsuModHidden(), new OsuModHardRock()]);
+    }
+}

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -234,6 +234,8 @@ namespace osu.Game.Rulesets.Osu
             }
         }
 
+        public override ScoreMultiplierCalculator CreateScoreMultiplierCalculator() => new OsuScoreMultiplierCalculator();
+
         public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.RulesetOsu };
 
         public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap) => new OsuDifficultyCalculator(RulesetInfo, beatmap);

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreMultiplierCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreMultiplierCalculator.cs
@@ -1,0 +1,100 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Scoring
+{
+    public class OsuScoreMultiplierCalculator : ScoreMultiplierCalculator
+    {
+        static OsuScoreMultiplierCalculator()
+        {
+            #region Difficulty Reduction
+
+            Single<OsuModEasy>(hasMultiplier: 0.5);
+            Single<OsuModNoFail>(hasMultiplier: 0.5);
+            Single<OsuModHalfTime>(hasMultiplier: halfTime => rateAdjustMultiplier(halfTime.SpeedChange.Value));
+            Single<OsuModDaycore>(hasMultiplier: daycore => rateAdjustMultiplier(daycore.SpeedChange.Value));
+
+            #endregion
+
+            #region Difficulty Increase
+
+            Single<OsuModHardRock>(hasMultiplier: hardRock => hardRock.UsesDefaultConfiguration ? 1.06 : 1);
+            // Sudden Death
+            // Perfect
+            Single<OsuModDoubleTime>(hasMultiplier: doubleTime => rateAdjustMultiplier(doubleTime.SpeedChange.Value));
+            Single<OsuModNightcore>(hasMultiplier: nightcore => rateAdjustMultiplier(nightcore.SpeedChange.Value));
+            Single<OsuModHidden>(hasMultiplier: hidden => hidden.UsesDefaultConfiguration ? 1.06 : 1);
+            // Traceable
+            Single<OsuModFlashlight>(hasMultiplier: flashlight => flashlight.UsesDefaultConfiguration ? 1.12 : 1);
+            Single<OsuModBlinds>(hasMultiplier: blinds => blinds.UsesDefaultConfiguration ? 1.12 : 1);
+            // Strict Tracking
+            // Accuracy Challenge
+
+            #endregion
+
+            #region Conversion
+
+            Single<OsuModTargetPractice>(hasMultiplier: 0.1);
+            Single<OsuModDifficultyAdjust>(hasMultiplier: 0.5);
+            Single<OsuModClassic>(hasMultiplier: 0.96);
+            // Random
+            // Mirror
+            // Alternate
+            // Single Tap
+
+            #endregion
+
+            #region Automation
+
+            // Autoplay
+            // Cinema
+            Single<OsuModRelax>(hasMultiplier: 0.1);
+            Single<OsuModAutopilot>(hasMultiplier: 0.1);
+            Single<OsuModSpunOut>(hasMultiplier: 0.9);
+
+            #endregion
+
+            #region Fun
+
+            // Transform
+            // Wiggle
+            // Spin In
+            // Grow
+            // Deflate
+            Single<ModWindUp>(hasMultiplier: 0.5);
+            Single<ModWindDown>(hasMultiplier: 0.5);
+            // Barrel Roll
+            // Approach Different
+            // Muted
+            // No Scope
+            Single<OsuModMagnetised>(hasMultiplier: 0.5);
+            // Repel
+            Single<ModAdaptiveSpeed>(hasMultiplier: 0.5);
+            // Freeze Frame
+            // Bubbles
+            Single<OsuModSynesthesia>(hasMultiplier: 0.8);
+            // Depth
+            // Bloom
+
+            #endregion
+        }
+
+        private static double rateAdjustMultiplier(double speedChange)
+        {
+            // Round to the nearest multiple of 0.1.
+            double value = (int)(speedChange * 10) / 10.0;
+
+            // Offset back to 0.
+            value -= 1;
+
+            if (speedChange >= 1)
+                return 1 + value / 5;
+            else
+                return 0.6 + value;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoScoreMultiplierTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoScoreMultiplierTest.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Taiko.Mods;
+using osu.Game.Tests.Rulesets;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TaikoScoreMultiplierTest : RulesetScoreMultiplierTest
+    {
+        public TaikoScoreMultiplierTest()
+            : base(new TaikoRuleset())
+        {
+        }
+
+        [Test]
+        public void TestFlashlightOnNonDefaultSettings()
+            => TestModCombination([new TaikoModFlashlight { ComboBasedSize = { Value = false } }]);
+
+        [Test]
+        public void TestHalfTimeSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new TaikoModHalfTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDaycoreSpeeds([Values(0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99)] double speedChange)
+            => TestModCombination([new TaikoModDaycore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestDoubleTimeSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new TaikoModDoubleTime { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestNightcoreSpeeds([Values(1.01, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45, 1.5, 1.55, 1.6, 1.65, 1.7, 1.75, 1.8, 1.85, 1.9, 1.95, 2)] double speedChange)
+            => TestModCombination([new TaikoModNightcore { SpeedChange = { Value = speedChange } }]);
+
+        [Test]
+        public void TestMultiplicativeCombination()
+            => TestModCombination([new TaikoModHidden(), new TaikoModHardRock()]);
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreMultiplierCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreMultiplierCalculator.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Mods;
+
+namespace osu.Game.Rulesets.Taiko.Scoring
+{
+    public class TaikoScoreMultiplierCalculator : ScoreMultiplierCalculator
+    {
+        static TaikoScoreMultiplierCalculator()
+        {
+            #region Difficulty Reduction
+
+            Single<TaikoModEasy>(hasMultiplier: 0.5);
+            Single<TaikoModNoFail>(hasMultiplier: 0.5);
+            Single<TaikoModHalfTime>(hasMultiplier: halfTime => rateAdjustMultiplier(halfTime.SpeedChange.Value));
+            Single<TaikoModDaycore>(hasMultiplier: daycore => rateAdjustMultiplier(daycore.SpeedChange.Value));
+            Single<TaikoModSimplifiedRhythm>(hasMultiplier: 0.6);
+
+            #endregion
+
+            #region Difficulty Increase
+
+            Single<TaikoModHardRock>(hasMultiplier: hardRock => hardRock.UsesDefaultConfiguration ? 1.06 : 1);
+            // Sudden Death
+            // Perfect
+            Single<TaikoModDoubleTime>(hasMultiplier: doubleTime => rateAdjustMultiplier(doubleTime.SpeedChange.Value));
+            Single<TaikoModNightcore>(hasMultiplier: nightcore => rateAdjustMultiplier(nightcore.SpeedChange.Value));
+            Single<TaikoModHidden>(hasMultiplier: hidden => hidden.UsesDefaultConfiguration ? 1.06 : 1);
+            Single<TaikoModFlashlight>(hasMultiplier: flashlight => flashlight.UsesDefaultConfiguration ? 1.12 : 1);
+            // Accuracy Challenge
+
+            #endregion
+
+            #region Conversion
+
+            // Random
+            Single<TaikoModDifficultyAdjust>(hasMultiplier: 0.5);
+            Single<TaikoModClassic>(hasMultiplier: 0.96);
+            // Swap
+            // Single Tap
+            Single<TaikoModConstantSpeed>(hasMultiplier: 0.9);
+
+            #endregion
+
+            #region Automation
+
+            // Autoplay
+            // Cinema
+            Single<TaikoModRelax>(hasMultiplier: 0.1);
+
+            #endregion
+
+            #region Fun
+
+            Single<ModWindUp>(hasMultiplier: 0.5);
+            Single<ModWindDown>(hasMultiplier: 0.5);
+            // Muted
+            Single<ModAdaptiveSpeed>(hasMultiplier: 0.5);
+
+            #endregion
+
+            #region System
+
+            // Score V2
+
+            #endregion
+        }
+
+        private static double rateAdjustMultiplier(double speedChange)
+        {
+            // Round to the nearest multiple of 0.1.
+            double value = (int)(speedChange * 10) / 10.0;
+
+            // Offset back to 0.
+            value -= 1;
+
+            if (speedChange >= 1)
+                return 1 + value / 5;
+            else
+                return 0.6 + value;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -188,6 +188,8 @@ namespace osu.Game.Rulesets.Taiko
             }
         }
 
+        public override ScoreMultiplierCalculator CreateScoreMultiplierCalculator() => new TaikoScoreMultiplierCalculator();
+
         public override string Description => "osu!taiko";
 
         public override string ShortName => SHORT_NAME;

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreMultiplierCalculatorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreMultiplierCalculatorTest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Tests.Rulesets.Scoring
+{
+    public class ScoreMultiplierCalculatorTest
+    {
+        [Test]
+        public void TestFlatMultiplier()
+        {
+            var calculator = new TestScoreMultiplierCalculator();
+
+            double multiplier = calculator.CalculateFor([new OsuModEasy()]);
+
+            Assert.That(multiplier, Is.EqualTo(0.15));
+        }
+
+        [Test]
+        public void TestSettingDependentMultiplier()
+        {
+            var calculator = new TestScoreMultiplierCalculator();
+
+            double multiplier = calculator.CalculateFor([new OsuModDaycore { SpeedChange = { Value = 0.6 } }]);
+
+            Assert.That(multiplier, Is.EqualTo(0.4));
+        }
+
+        [Test]
+        public void TestContextDependentMultiplier()
+        {
+            var calculator = new TestScoreMultiplierCalculator();
+
+            double multiplier;
+
+            Assert.Multiple(() =>
+            {
+                calculator.HardRockPenalty = false;
+                multiplier = calculator.CalculateFor([new OsuModHardRock()]);
+                Assert.That(multiplier, Is.EqualTo(1.4));
+
+                calculator.HardRockPenalty = true;
+                multiplier = calculator.CalculateFor([new OsuModHardRock()]);
+                Assert.That(multiplier, Is.EqualTo(1.2));
+            });
+        }
+
+        [Test]
+        public void TestCombinationMultiplier()
+        {
+            var calculator = new TestScoreMultiplierCalculator();
+
+            double multiplier = calculator.CalculateFor([new OsuModEasy(), new OsuModDaycore()]);
+
+            Assert.That(multiplier, Is.EqualTo(0.003));
+        }
+
+        [Test]
+        public void TestCombinationAndFlatMultipliers()
+        {
+            var calculator = new TestScoreMultiplierCalculator();
+
+            double multiplier = calculator.CalculateFor([new OsuModDaycore(), new OsuModHardRock(), new OsuModEasy()]);
+
+            Assert.That(multiplier, Is.EqualTo(0.003 * 1.4));
+        }
+
+        private class TestScoreMultiplierCalculator : ScoreMultiplierCalculator
+        {
+            static TestScoreMultiplierCalculator()
+            {
+                Single<OsuModEasy>(hasMultiplier: 0.15);
+                Single<OsuModDaycore>(hasMultiplier: daycore => (1 + daycore.SpeedChange.Value) / 4);
+                Single<OsuModHardRock, TestScoreMultiplierCalculator>(hasMultiplier: (_, ctx) => ctx.HardRockPenalty ? 1.2 : 1.4);
+                Combination<OsuModEasy, OsuModDaycore>(hasMultiplier: (_, _) => 0.003);
+            }
+
+            public bool HardRockPenalty { get; set; }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -211,6 +211,11 @@ namespace osu.Game.Rulesets
         public ModTouchDevice? GetTouchDeviceMod() => CreateMod<ModTouchDevice>();
 
         /// <summary>
+        /// Creates a <see cref="ScoreMultiplierCalculator"/> relevant to this ruleset.
+        /// </summary>
+        public ScoreMultiplierCalculator CreateScoreMultiplierCalculator() => new ScoreMultiplierCalculator();
+
+        /// <summary>
         /// Create a transformer which adds lookups specific to a ruleset to skin sources.
         /// </summary>
         /// <param name="skin">The source skin.</param>

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -213,7 +213,7 @@ namespace osu.Game.Rulesets
         /// <summary>
         /// Creates a <see cref="ScoreMultiplierCalculator"/> relevant to this ruleset.
         /// </summary>
-        public ScoreMultiplierCalculator CreateScoreMultiplierCalculator() => new ScoreMultiplierCalculator();
+        public virtual ScoreMultiplierCalculator CreateScoreMultiplierCalculator() => new ScoreMultiplierCalculator();
 
         /// <summary>
         /// Create a transformer which adds lookups specific to a ruleset to skin sources.

--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -85,10 +85,10 @@ namespace osu.Game.Rulesets.Scoring
 
             foreach (var modType in remainingModTypes)
             {
-                if (single_multipliers_with_context.TryGetValue(modType, out var multiplierWithContext))
-                    result *= multiplierWithContext(allModsByType[modType], this);
-                else if (single_multipliers.TryGetValue(modType, out var multiplier))
+                if (single_multipliers.TryGetValue(modType, out var multiplier))
                     result *= multiplier(allModsByType[modType]);
+                else if (single_multipliers_with_context.TryGetValue(modType, out var multiplierWithContext))
+                    result *= multiplierWithContext(allModsByType[modType], this);
             }
 
             return result;

--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Scoring
+{
+    /// <summary>
+    /// Calculates the multiplier to be applied to score with a given combination of mods.
+    /// </summary>
+    public class ScoreMultiplierCalculator
+    {
+        /// <summary>
+        /// Calculates the multiplier to be applied to score with the given <paramref name="mods"/>.
+        /// </summary>
+        public double CalculateFor(IEnumerable<Mod> mods) => 1;
+    }
+}

--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -62,17 +62,24 @@ namespace osu.Game.Rulesets.Scoring
         public double CalculateFor(IEnumerable<Mod> mods)
         {
             var allModsByType = mods.ToDictionary(m => m.GetType());
+
+            if (allModsByType.Count == 0)
+                return 1;
+
             var remainingModTypes = allModsByType.Keys.ToHashSet();
 
             double result = 1;
 
-            foreach (var (combination, multiplier) in combination_multipliers)
+            if (allModsByType.Count > 1)
             {
-                if (remainingModTypes.IsSupersetOf(combination))
+                foreach (var (combination, multiplier) in combination_multipliers)
                 {
-                    var instances = combination.Select(t => allModsByType[t]).ToArray();
-                    result *= multiplier(instances);
-                    remainingModTypes.ExceptWith(combination);
+                    if (remainingModTypes.IsSupersetOf(combination))
+                    {
+                        var instances = combination.Select(t => allModsByType[t]).ToArray();
+                        result *= multiplier(instances);
+                        remainingModTypes.ExceptWith(combination);
+                    }
                 }
             }
 

--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Scoring
@@ -11,9 +13,78 @@ namespace osu.Game.Rulesets.Scoring
     /// </summary>
     public class ScoreMultiplierCalculator
     {
+        private static readonly List<(Type[] mods, Func<Mod[], double> multiplier)> combination_multipliers = [];
+        private static readonly Dictionary<Type, Func<Mod, ScoreMultiplierCalculator, double>> single_multipliers_with_context = [];
+        private static readonly Dictionary<Type, Func<Mod, double>> single_multipliers = [];
+
+        /// <summary>
+        /// Defines a flat, setting-independent score multiplier for the given <typeparamref name="TMod"/>.
+        /// </summary>
+        public static void Single<TMod>(double hasMultiplier)
+            where TMod : Mod
+        {
+            single_multipliers[typeof(TMod)] = _ => hasMultiplier;
+        }
+
+        /// <summary>
+        /// Defines a setting-dependent score multiplier for the given <typeparamref name="TMod"/>.
+        /// </summary>
+        public static void Single<TMod>(Func<TMod, double> hasMultiplier)
+            where TMod : Mod
+        {
+            single_multipliers[typeof(TMod)] = mod => hasMultiplier.Invoke((TMod)mod);
+        }
+
+        /// <summary>
+        /// Defines a setting-dependent score multiplier for the given <typeparamref name="TMod"/>.
+        /// The multiplier calculation is given additional context to calculate the multiplier via the <typeparamref name="TContext"/> type instance.
+        /// </summary>
+        public static void Single<TMod, TContext>(Func<TMod, TContext, double> hasMultiplier)
+            where TMod : Mod
+            where TContext : ScoreMultiplierCalculator
+        {
+            single_multipliers_with_context[typeof(TMod)] = (mod, context) => hasMultiplier.Invoke((TMod)mod, (TContext)context);
+        }
+
+        /// <summary>
+        /// Defines a score multiplier specific to when both <typeparamref name="T1"/> and <typeparamref name="T2"/> mods are present.
+        /// </summary>
+        public static void Combination<T1, T2>(Func<T1, T2, double> hasMultiplier)
+            where T1 : Mod
+            where T2 : Mod
+        {
+            combination_multipliers.Add(([typeof(T1), typeof(T2)], mods => hasMultiplier((T1)mods[0], (T2)mods[1])));
+        }
+
         /// <summary>
         /// Calculates the multiplier to be applied to score with the given <paramref name="mods"/>.
         /// </summary>
-        public double CalculateFor(IEnumerable<Mod> mods) => 1;
+        public double CalculateFor(IEnumerable<Mod> mods)
+        {
+            var allModsByType = mods.ToDictionary(m => m.GetType());
+            var remainingModTypes = allModsByType.Keys.ToHashSet();
+
+            double result = 1;
+
+            foreach (var (combination, multiplier) in combination_multipliers)
+            {
+                if (remainingModTypes.IsSupersetOf(combination))
+                {
+                    var instances = combination.Select(t => allModsByType[t]).ToArray();
+                    result *= multiplier(instances);
+                    remainingModTypes.ExceptWith(combination);
+                }
+            }
+
+            foreach (var modType in remainingModTypes)
+            {
+                if (single_multipliers_with_context.TryGetValue(modType, out var multiplierWithContext))
+                    result *= multiplierWithContext(allModsByType[modType], this);
+                else if (single_multipliers.TryGetValue(modType, out var multiplier))
+                    result *= multiplier(allModsByType[modType]);
+            }
+
+            return result;
+        }
     }
 }

--- a/osu.Game/Tests/Rulesets/RulesetScoreMultiplierTest.cs
+++ b/osu.Game/Tests/Rulesets/RulesetScoreMultiplierTest.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Tests.Rulesets
+{
+    [TestFixture]
+    public abstract class RulesetScoreMultiplierTest
+    {
+        public Ruleset Ruleset { get; }
+
+        protected RulesetScoreMultiplierTest(Ruleset ruleset)
+        {
+            Ruleset = ruleset;
+        }
+
+        [Test]
+        public void TestDefaultMultiplierIsOne()
+        {
+            var calculator = Ruleset.CreateScoreMultiplierCalculator();
+            Assert.That(calculator.CalculateFor([]), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestMultipliersMatchForIndividualMods()
+        {
+            var mods = Ruleset.CreateAllMods();
+            var calculator = Ruleset.CreateScoreMultiplierCalculator();
+
+            Assert.Multiple(() =>
+            {
+                foreach (var mod in mods)
+                    Assert.That(calculator.CalculateFor(mod.Yield()), Is.EqualTo(mod.ScoreMultiplier), message: $"Score multiplier not matching for mod {mod.Name}");
+            });
+        }
+
+        protected void TestModCombination(IEnumerable<Mod> mods)
+        {
+            var calculator = Ruleset.CreateScoreMultiplierCalculator();
+
+            double expected = 1;
+            foreach (var mod in mods)
+                expected *= mod.ScoreMultiplier;
+
+            Assert.That(calculator.CalculateFor(mods), Is.EqualTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
- Part of https://github.com/ppy/osu/issues/37818
- Continued from https://github.com/ppy/osu/pull/37355#issuecomment-4449248107

## Overview

This PR introduces an alternative API, `ScoreMultiplierCalculator`, to be used going forward for calculating mod multipliers.

The reason for introducing this new API is that it has been requested that:
- For any two given mods, it should be possible to have the combined mod multipliers of them in combination be *different* than the product of the individual mods' multipliers in isolation, i.e. $mult( \\{ A, B \\} ) \neq mult( \\{ A \\} ) \cdot mult( \\{ B \\} )$.
- For an individual mod, it should be possible to have the mod multipliers depend on a quantity that is *not* the presence of another mod or the direct value of a setting on the mod.

This capability is being demonstrated in this PR via the `osu.Game.Tests.Rulesets.Scoring.ScoreMultiplierCalculatorTest` test fixture.

## Parity with `Mod.ScoreMultiplier`

This PR contains a `ScoreMultiplierCalculator` implementation for each of the built-in four rulesets.

The abstract `osu.Game.Tests.Rulesets.RulesetScoreMultiplierTest` and its four derived ruleset-specific test fixtures were written to ensure that the new implementations do not diverge from the current state of affairs.

`Mod.ScoreMultiplier` is not removed in this diff to keep size low. It will be removed as a follow-up.

## Performance

This PR contains a benchmark comparing the current implementation via `Mod.ScoreMultiplier` and the new `ScoreMultiplierCalculator` API. Results below.

<details>

| Method                | Times | Mods                 | Mean          | Error       | StdDev      | Gen0    | Allocated |
|---------------------- |------ |--------------------- |--------------:|------------:|------------:|--------:|----------:|
| ViaModScoreMultiplier | 1     | mods (...)tings [27] |    121.171 ns |   1.5284 ns |   1.4297 ns |  0.0782 |     656 B |
| ViaCalculator         | 1     | mods (...)tings [27] |    248.509 ns |   1.9313 ns |   1.6127 ns |  0.1364 |    1144 B |
| ViaModScoreMultiplier | 1     | multiple mods        |    128.357 ns |   0.4282 ns |   0.4006 ns |  0.0782 |     656 B |
| ViaCalculator         | 1     | multiple mods        |    252.953 ns |   1.2860 ns |   1.2029 ns |  0.1364 |    1144 B |
| ViaModScoreMultiplier | 1     | no mods              |      3.007 ns |   0.0345 ns |   0.0288 ns |       - |         - |
| ViaCalculator         | 1     | no mods              |     14.802 ns |   0.0616 ns |   0.0576 ns |  0.0134 |     112 B |
| ViaModScoreMultiplier | 1     | single mod           |     40.271 ns |   0.1238 ns |   0.1098 ns |  0.0258 |     216 B |
| ViaCalculator         | 1     | single mod           |    113.033 ns |   0.3140 ns |   0.2937 ns |  0.0842 |     704 B |
| ViaModScoreMultiplier | 1     | single mod 2         |      3.653 ns |   0.0384 ns |   0.0359 ns |  0.0038 |      32 B |
| ViaCalculator         | 1     | single mod 2         |     78.172 ns |   0.0680 ns |   0.0603 ns |  0.0621 |     520 B |
| ViaModScoreMultiplier | 10    | mods (...)tings [27] |  1,169.609 ns |   4.3058 ns |   4.0276 ns |  0.7839 |    6560 B |
| ViaCalculator         | 10    | mods (...)tings [27] |  2,575.264 ns |  21.2705 ns |  19.8964 ns |  1.3657 |   11440 B |
| ViaModScoreMultiplier | 10    | multiple mods        |  1,171.775 ns |   6.2332 ns |   5.2050 ns |  0.7839 |    6560 B |
| ViaCalculator         | 10    | multiple mods        |  2,579.593 ns |  22.1010 ns |  20.6733 ns |  1.3657 |   11440 B |
| ViaModScoreMultiplier | 10    | no mods              |     35.943 ns |   0.1665 ns |   0.1476 ns |       - |         - |
| ViaCalculator         | 10    | no mods              |    154.980 ns |   0.2381 ns |   0.1988 ns |  0.1338 |    1120 B |
| ViaModScoreMultiplier | 10    | single mod           |    404.185 ns |   1.3190 ns |   1.2338 ns |  0.2580 |    2160 B |
| ViaCalculator         | 10    | single mod           |  1,167.279 ns |   6.1641 ns |   5.7659 ns |  0.8411 |    7040 B |
| ViaModScoreMultiplier | 10    | single mod 2         |     42.128 ns |   0.2878 ns |   0.2692 ns |  0.0382 |     320 B |
| ViaCalculator         | 10    | single mod 2         |    775.435 ns |   2.3318 ns |   2.1811 ns |  0.6208 |    5200 B |
| ViaModScoreMultiplier | 100   | mods (...)tings [27] | 11,623.346 ns |  51.7174 ns |  43.1863 ns |  7.8430 |   65600 B |
| ViaCalculator         | 100   | mods (...)tings [27] | 25,252.987 ns |  44.4352 ns |  39.3906 ns | 13.6719 |  114400 B |
| ViaModScoreMultiplier | 100   | multiple mods        | 11,928.536 ns |  35.2079 ns |  32.9334 ns |  7.8430 |   65600 B |
| ViaCalculator         | 100   | multiple mods        | 25,399.378 ns | 152.4597 ns | 127.3108 ns | 13.6719 |  114400 B |
| ViaModScoreMultiplier | 100   | no mods              |    328.158 ns |   0.5827 ns |   0.5165 ns |       - |         - |
| ViaCalculator         | 100   | no mods              |  1,517.485 ns |  10.2304 ns |   9.5695 ns |  1.3390 |   11200 B |
| ViaModScoreMultiplier | 100   | single mod           |  3,986.251 ns |  24.2523 ns |  21.4991 ns |  2.5787 |   21600 B |
| ViaCalculator         | 100   | single mod           | 11,479.514 ns |  23.3738 ns |  20.7203 ns |  8.4076 |   70400 B |
| ViaModScoreMultiplier | 100   | single mod 2         |    385.679 ns |   3.5190 ns |   3.2917 ns |  0.3824 |    3200 B |
| ViaCalculator         | 100   | single mod 2         |  7,658.646 ns |  21.8274 ns |  19.3494 ns |  6.2103 |   52000 B |

</details>

While the calculator is obviously slower, in my view it is not egregiously so. The main overheads both time- and memory-wise are collection allocations for the dictionary and the set which I consider to be directly caused by the requested additional complexity and as such I don't really consider them eliminable.

I have tried and applied some micro-optimisations (e2469ce338f026c9a4ad750e4857d41c6a8f55ff, cb33abec17243d5fdd3288acdcf9d661c739592f), albeit with negligible effect. I have also tried to key the mods by `Acronym` instead of by `Type` and the difference was basically nil.

<details>
<summary>patch for keying by acronym</summary>

```diff
diff --git a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
index 772f9d178b..7f5907cbda 100644
--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -13,26 +13,26 @@ namespace osu.Game.Rulesets.Scoring
     /// </summary>
     public class ScoreMultiplierCalculator
     {
-        private static readonly List<(Type[] mods, Func<Mod[], double> multiplier)> combination_multipliers = [];
-        private static readonly Dictionary<Type, Func<Mod, ScoreMultiplierCalculator, double>> single_multipliers_with_context = [];
-        private static readonly Dictionary<Type, Func<Mod, double>> single_multipliers = [];
+        private static readonly List<(string[] modAcronyms, Func<Mod[], double> multiplier)> combination_multipliers = [];
+        private static readonly Dictionary<string, Func<Mod, ScoreMultiplierCalculator, double>> single_multipliers_with_context = [];
+        private static readonly Dictionary<string, Func<Mod, double>> single_multipliers = [];
 
         /// <summary>
         /// Defines a flat, setting-independent score multiplier for the given <typeparamref name="TMod"/>.
         /// </summary>
         public static void Single<TMod>(double hasMultiplier)
-            where TMod : Mod
+            where TMod : Mod, new()
         {
-            single_multipliers[typeof(TMod)] = _ => hasMultiplier;
+            single_multipliers[new TMod().Acronym] = _ => hasMultiplier;
         }
 
         /// <summary>
         /// Defines a setting-dependent score multiplier for the given <typeparamref name="TMod"/>.
         /// </summary>
         public static void Single<TMod>(Func<TMod, double> hasMultiplier)
-            where TMod : Mod
+            where TMod : Mod, new()
         {
-            single_multipliers[typeof(TMod)] = mod => hasMultiplier.Invoke((TMod)mod);
+            single_multipliers[new TMod().Acronym] = mod => hasMultiplier.Invoke((TMod)mod);
         }
 
         /// <summary>
@@ -40,20 +40,20 @@ public static void Single<TMod>(Func<TMod, double> hasMultiplier)
         /// The multiplier calculation is given additional context to calculate the multiplier via the <typeparamref name="TContext"/> type instance.
         /// </summary>
         public static void Single<TMod, TContext>(Func<TMod, TContext, double> hasMultiplier)
-            where TMod : Mod
+            where TMod : Mod, new()
             where TContext : ScoreMultiplierCalculator
         {
-            single_multipliers_with_context[typeof(TMod)] = (mod, context) => hasMultiplier.Invoke((TMod)mod, (TContext)context);
+            single_multipliers_with_context[new TMod().Acronym] = (mod, context) => hasMultiplier.Invoke((TMod)mod, (TContext)context);
         }
 
         /// <summary>
         /// Defines a score multiplier specific to when both <typeparamref name="T1"/> and <typeparamref name="T2"/> mods are present.
         /// </summary>
         public static void Combination<T1, T2>(Func<T1, T2, double> hasMultiplier)
-            where T1 : Mod
-            where T2 : Mod
+            where T1 : Mod, new()
+            where T2 : Mod, new()
         {
-            combination_multipliers.Add(([typeof(T1), typeof(T2)], mods => hasMultiplier((T1)mods[0], (T2)mods[1])));
+            combination_multipliers.Add(([new T1().Acronym, new T2().Acronym], mods => hasMultiplier((T1)mods[0], (T2)mods[1])));
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ public static void Combination<T1, T2>(Func<T1, T2, double> hasMultiplier)
         /// </summary>
         public double CalculateFor(IEnumerable<Mod> mods)
         {
-            var allModsByType = mods.ToDictionary(m => m.GetType());
+            var allModsByType = mods.ToDictionary(m => m.Acronym);
 
             if (allModsByType.Count == 0)
                 return 1;
@@ -83,7 +83,7 @@ public double CalculateFor(IEnumerable<Mod> mods)
                 }
             }
 
-            foreach (var modType in remainingModTypes)
+            foreach (string modType in remainingModTypes)
             {
                 if (single_multipliers.TryGetValue(modType, out var multiplier))
                     result *= multiplier(allModsByType[modType]);

```

</details>

One particular parallel thread that may warrant follow-up is that `Mod.UsesDefaultConfiguration` is disproportionately expensive due to calling into regexes via Humanizer internals.

<img width="1517" height="517" alt="Screenshot_2026-05-19_at_10 58 30" src="https://github.com/user-attachments/assets/68309a8c-74e7-4f96-8ef9-62868eeca337" />