### PR TITLE
Fix popup dialogs not appearing if pushed when `OverlayActivationMode` is wrong

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDialogOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDialogOverlay.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
@@ -16,9 +17,11 @@ using osu.Game.Overlays.Dialog;
 namespace osu.Game.Tests.Visual.UserInterface
 {
     [TestFixture]
-    public partial class TestSceneDialogOverlay : OsuTestScene
+    public partial class TestSceneDialogOverlay : OsuTestScene, IOverlayManager
     {
         private DialogOverlay overlay;
+
+        private readonly Bindable<OverlayActivation> overlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -99,7 +102,8 @@ namespace osu.Game.Tests.Visual.UserInterface
             {
                 Icon = FontAwesome.Regular.TrashAlt,
                 HeaderText = @"Confirm deletion ofConfirm deletion ofConfirm deletion ofConfirm deletion ofConfirm deletion ofConfirm deletion of",
-                BodyText = @"Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver. ",
+                BodyText =
+                    @"Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver.Ayase Rie - Yuima-ru*World TVver. ",
                 Buttons = new PopupDialogButton[]
                 {
                     new PopupDialogOkButton
@@ -114,6 +118,36 @@ namespace osu.Game.Tests.Visual.UserInterface
                     },
                 },
             }));
+        }
+
+        [Test]
+        public void TestPushWhileOverlayActivationDisabled()
+        {
+            PopupDialog dialog = null;
+
+            AddStep("set activation mode disabled", () => overlayActivationMode.Value = OverlayActivation.Disabled);
+
+            AddStep("push dialog", () =>
+            {
+                overlay.Push(dialog = new TestPopupDialog
+                {
+                    Buttons = new PopupDialogButton[]
+                    {
+                        new PopupDialogOkButton { Text = @"OK" },
+                    },
+                });
+            });
+
+            AddUntilStep("overlay not visible", () => overlay.State.Value, () => Is.EqualTo(Visibility.Hidden));
+
+            AddStep("set activation mode enabled", () => overlayActivationMode.Value = OverlayActivation.All);
+
+            AddUntilStep("overlay visible", () => overlay.State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddUntilStep("dialog displayed", () => dialog.State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddStep("set activation mode disabled", () => overlayActivationMode.Value = OverlayActivation.Disabled);
+
+            AddUntilStep("dialog hidden", () => dialog.State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("dialog dismissed", () => overlay.CurrentDialog, () => Is.Null);
         }
 
         [Test]
@@ -192,6 +226,18 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         private partial class TestPopupDialog : PopupDialog
+        {
+        }
+
+        public IBindable<OverlayActivation> OverlayActivationMode => overlayActivationMode;
+
+        public IDisposable RegisterBlockingOverlay(OverlayContainer overlayContainer) => throw new NotImplementedException();
+
+        public void ShowBlockingOverlay(OverlayContainer overlay)
+        {
+        }
+
+        public void HideBlockingOverlay(OverlayContainer overlay)
         {
         }
     }

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -14,7 +14,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osuTK;
@@ -243,7 +242,7 @@ namespace osu.Game.Overlays.Dialog
         }
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio, OsuColour colours)
+        private void load(AudioManager audio)
         {
             flashSample = audio.Samples.Get(@"UI/default-select-disabled");
         }

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Input.Events;
+using osu.Framework.Logging;
 
 namespace osu.Game.Overlays
 {
@@ -28,8 +29,9 @@ namespace osu.Game.Overlays
 
         public PopupDialog CurrentDialog { get; private set; }
 
-        public override bool IsPresent => Scheduler.HasPendingTasks
-                                          || dialogContainer.Children.Count > 0;
+        public override bool IsPresent => (Scheduler.HasPendingTasks
+                                           || dialogContainer.Children.Count > 0)
+                                          && OverlayActivationMode.Value == OverlayActivation.All;
 
         [CanBeNull]
         private IDisposable duckOperation;
@@ -77,6 +79,7 @@ namespace osu.Game.Overlays
                     return;
                 }
 
+                Logger.Log($"{nameof(DialogOverlay)}: Showing dialog {dialog}");
                 dialogContainer.Add(dialog);
                 Show();
 
@@ -98,6 +101,7 @@ namespace osu.Game.Overlays
                 // Handle the case where the dialog is the currently displayed dialog.
                 // In this scenario, the overlay itself should also be hidden.
                 Hide();
+                Logger.Log($"{nameof(DialogOverlay)}: Dismissing dialog {dialog}");
                 CurrentDialog = null;
             }
         }

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -29,8 +29,13 @@ namespace osu.Game.Overlays
 
         public PopupDialog CurrentDialog { get; private set; }
 
-        public override bool IsPresent => (Scheduler.HasPendingTasks
-                                           || dialogContainer.Children.Count > 0)
+        public override bool IsPresent => (Scheduler.HasPendingTasks || dialogContainer.Children.Count > 0)
+                                          // The following line ensures that dialogs are not presented while the dialog overlay
+                                          // cannot be displayed. This is due to the `Schedule` usage inside `Push()`.
+                                          //
+                                          // Without this, a dialog pushed during disabled overlay activation mode would be presented,
+                                          // but immediately dismissed without ever being seen by the user (see
+                                          // https://github.com/ppy/osu/blob/ce5e54c9d27b17d460d99e774de502f9480fb710/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs#L131-L136).
                                           && OverlayActivationMode.Value == OverlayActivation.All;
 
         [CanBeNull]


### PR DESCRIPTION
This change is a prerequisite for making a migration dialog which runs on startup to let users know that something hs changed.

A few cases this could happen:

- During start (intro still playing)
- During gameplay

Basically making dialogs get poofed without the user ever seeing them.

Arguably, we should also change the way dialogs are still poofed when activation mode becomes not-`All` (deferring for later response rather than dismissing?).