### PR TITLE
Move configuration migrations to `OsuGame`

### DIFF
--- a/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
+++ b/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Tests.NonVisual
 
                     Assert.That(storage.GetFullPath("."), Is.EqualTo(defaultStorageLocation));
 
-                    osu.Migrate(customPath);
+                    osu.MigrateUserData(customPath);
 
                     Assert.That(storage.GetFullPath("."), Is.EqualTo(customPath));
 
@@ -183,16 +183,16 @@ namespace osu.Game.Tests.NonVisual
                 {
                     var osu = LoadOsuIntoHost(host);
 
-                    Assert.DoesNotThrow(() => osu.Migrate(customPath));
+                    Assert.DoesNotThrow(() => osu.MigrateUserData(customPath));
                     Assert.That(File.Exists(Path.Combine(customPath, OsuGameBase.CLIENT_DATABASE_FILENAME)));
 
-                    Assert.DoesNotThrow(() => osu.Migrate(customPath2));
+                    Assert.DoesNotThrow(() => osu.MigrateUserData(customPath2));
                     Assert.That(File.Exists(Path.Combine(customPath2, OsuGameBase.CLIENT_DATABASE_FILENAME)));
 
                     // some files may have been left behind for whatever reason, but that's not what we're testing here.
                     cleanupPath(customPath);
 
-                    Assert.DoesNotThrow(() => osu.Migrate(customPath));
+                    Assert.DoesNotThrow(() => osu.MigrateUserData(customPath));
                     Assert.That(File.Exists(Path.Combine(customPath, OsuGameBase.CLIENT_DATABASE_FILENAME)));
                 }
                 finally
@@ -212,8 +212,8 @@ namespace osu.Game.Tests.NonVisual
                 {
                     var osu = LoadOsuIntoHost(host);
 
-                    Assert.DoesNotThrow(() => osu.Migrate(customPath));
-                    Assert.Throws<ArgumentException>(() => osu.Migrate(customPath));
+                    Assert.DoesNotThrow(() => osu.MigrateUserData(customPath));
+                    Assert.Throws<ArgumentException>(() => osu.MigrateUserData(customPath));
                 }
                 finally
                 {
@@ -238,14 +238,14 @@ namespace osu.Game.Tests.NonVisual
 
                     string originalDirectory = storage.GetFullPath(".");
 
-                    Assert.DoesNotThrow(() => osu.Migrate(customPath));
+                    Assert.DoesNotThrow(() => osu.MigrateUserData(customPath));
                     Assert.That(File.Exists(Path.Combine(customPath, OsuGameBase.CLIENT_DATABASE_FILENAME)));
 
                     Directory.CreateDirectory(customPath2);
                     File.WriteAllText(Path.Combine(customPath2, OsuGameBase.CLIENT_DATABASE_FILENAME), "I am a text");
 
                     // Fails because file already exists.
-                    Assert.Throws<ArgumentException>(() => osu.Migrate(customPath2));
+                    Assert.Throws<ArgumentException>(() => osu.MigrateUserData(customPath2));
 
                     osuStorage?.ChangeDataPath(customPath2);
 
@@ -269,7 +269,7 @@ namespace osu.Game.Tests.NonVisual
                 {
                     var osu = LoadOsuIntoHost(host);
 
-                    Assert.DoesNotThrow(() => osu.Migrate(customPath));
+                    Assert.DoesNotThrow(() => osu.MigrateUserData(customPath));
 
                     string subFolder = Path.Combine(customPath, "sub");
 
@@ -278,7 +278,7 @@ namespace osu.Game.Tests.NonVisual
 
                     Directory.CreateDirectory(subFolder);
 
-                    Assert.Throws<ArgumentException>(() => osu.Migrate(subFolder));
+                    Assert.Throws<ArgumentException>(() => osu.MigrateUserData(subFolder));
                 }
                 finally
                 {
@@ -297,7 +297,7 @@ namespace osu.Game.Tests.NonVisual
                 {
                     var osu = LoadOsuIntoHost(host);
 
-                    Assert.DoesNotThrow(() => osu.Migrate(customPath));
+                    Assert.DoesNotThrow(() => osu.MigrateUserData(customPath));
 
                     string seeminglySubFolder = customPath + "sub";
 
@@ -306,7 +306,7 @@ namespace osu.Game.Tests.NonVisual
 
                     Directory.CreateDirectory(seeminglySubFolder);
 
-                    osu.Migrate(seeminglySubFolder);
+                    osu.MigrateUserData(seeminglySubFolder);
                 }
                 finally
                 {

--- a/osu.Game/Configuration/DevelopmentOsuConfigManager.cs
+++ b/osu.Game/Configuration/DevelopmentOsuConfigManager.cs
@@ -9,8 +9,8 @@ namespace osu.Game.Configuration
     {
         protected override string Filename => base.Filename.Replace(".ini", ".dev.ini");
 
-        public DevelopmentOsuConfigManager(Storage storage, GameHost? host = null)
-            : base(storage, host)
+        public DevelopmentOsuConfigManager(Storage storage)
+            : base(storage)
         {
         }
     }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -2,15 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
-using osu.Framework.Input.Handlers.Mouse;
-using osu.Framework.Input.Handlers.Pen;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps.Drawables.Cards;
@@ -33,14 +30,9 @@ namespace osu.Game.Configuration
 {
     public class OsuConfigManager : IniConfigManager<OsuSetting>, IGameplaySettings
     {
-        private readonly GameHost? host;
-
-        public OsuConfigManager(Storage storage, GameHost? host = null)
+        public OsuConfigManager(Storage storage)
             : base(storage)
         {
-            this.host = host;
-
-            Migrate();
         }
 
         protected override void InitialiseDefaults()
@@ -256,42 +248,6 @@ namespace osu.Game.Configuration
             }
 
             return false;
-        }
-
-        public void Migrate()
-        {
-            // arrives as 2020.123.0-lazer
-            string rawVersion = Get<string>(OsuSetting.Version);
-
-            if (rawVersion.Length < 6)
-                return;
-
-            string[] pieces = rawVersion.Split('.');
-
-            // on a fresh install or when coming from a non-release build, execution will end here.
-            // we don't want to run migrations in such cases.
-            if (!int.TryParse(pieces[0], out int year)) return;
-            if (!int.TryParse(pieces[1], out int monthDay)) return;
-
-            int combined = year * 10000 + monthDay;
-
-            if (combined < 20250214)
-            {
-                // UI scaling on mobile platforms has been internally adjusted such that 1x UI scale looks correctly zoomed in than before.
-                if (RuntimeInfo.IsMobile)
-                    GetBindable<float>(OsuSetting.UIScale).SetDefault();
-            }
-
-            if (combined < 20250428)
-            {
-                // Pen tablet sensitivity is now separated from cursor sensitivity.
-                // Most users will want the default to be what they already had set on cursor sensitivity so let's transfer it.
-                var mouseHandler = host?.AvailableInputHandlers.OfType<MouseHandler>().SingleOrDefault();
-                var penHandler = host?.AvailableInputHandlers.OfType<PenHandler>().SingleOrDefault();
-
-                if (penHandler != null && mouseHandler != null && penHandler.Sensitivity.IsDefault)
-                    penHandler.Sensitivity.Value = mouseHandler.Sensitivity.Value;
-            }
         }
 
         public override TrackedSettings CreateTrackedSettings()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -26,6 +26,8 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Input.Handlers.Pen;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
@@ -1293,6 +1295,51 @@ namespace osu.Game
 
             // Importantly, this should be run after binding PostNotification to the import handlers so they can present the import after game startup.
             handleStartupImport();
+
+            applyMigrations();
+        }
+
+        /// <summary>
+        /// Apply any migrations to configuration.
+        /// </summary>
+        /// <remarks>
+        /// For database migrations, see <see cref="RealmAccess.applyMigrationsForVersion"/>.
+        /// </remarks>
+        /// <exception cref="NotImplementedException"></exception>
+        private void applyMigrations()
+        {
+            // arrives as 2020.123.0-lazer
+            string rawVersion = LocalConfig.Get<string>(OsuSetting.Version);
+
+            if (rawVersion.Length < 6)
+                return;
+
+            string[] pieces = rawVersion.Split('.');
+
+            // on a fresh install or when coming from a non-release build, execution will end here.
+            // we don't want to run migrations in such cases.
+            if (!int.TryParse(pieces[0], out int year)) return;
+            if (!int.TryParse(pieces[1], out int monthDay)) return;
+
+            int combined = year * 10000 + monthDay;
+
+            if (combined < 20250214)
+            {
+                // UI scaling on mobile platforms has been internally adjusted such that 1x UI scale looks correctly zoomed in than before.
+                if (RuntimeInfo.IsMobile)
+                    LocalConfig.GetBindable<float>(OsuSetting.UIScale).SetDefault();
+            }
+
+            if (combined < 20250428)
+            {
+                // Pen tablet sensitivity is now separated from cursor sensitivity.
+                // Most users will want the default to be what they already had set on cursor sensitivity so let's transfer it.
+                var mouseHandler = Host?.AvailableInputHandlers.OfType<MouseHandler>().SingleOrDefault();
+                var penHandler = Host?.AvailableInputHandlers.OfType<PenHandler>().SingleOrDefault();
+
+                if (penHandler != null && mouseHandler != null && penHandler.Sensitivity.IsDefault)
+                    penHandler.Sensitivity.Value = mouseHandler.Sensitivity.Value;
+            }
         }
 
         private void handleBackButton()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1296,7 +1296,7 @@ namespace osu.Game
             // Importantly, this should be run after binding PostNotification to the import handlers so they can present the import after game startup.
             handleStartupImport();
 
-            applyMigrations();
+            applyConfigMigrations();
         }
 
         /// <summary>
@@ -1306,7 +1306,7 @@ namespace osu.Game
         /// For database migrations, see <see cref="RealmAccess.applyMigrationsForVersion"/>.
         /// </remarks>
         /// <exception cref="NotImplementedException"></exception>
-        private void applyMigrations()
+        private void applyConfigMigrations()
         {
             // arrives as 2020.123.0-lazer
             string rawVersion = LocalConfig.Get<string>(OsuSetting.Version);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1297,6 +1297,11 @@ namespace osu.Game
             handleStartupImport();
 
             applyConfigMigrations();
+
+            // finally, update the version stored to the configuration.
+            // this MUST happen after `applyConfigMigrations()` call, as it relies on comparing the previous version.
+            // debug / local compilations will reset to a non-release string.
+            LocalConfig.SetValue(OsuSetting.Version, Version);
         }
 
         /// <summary>
@@ -1340,10 +1345,6 @@ namespace osu.Game
                 if (penHandler != null && mouseHandler != null && penHandler.Sensitivity.IsDefault)
                     penHandler.Sensitivity.Value = mouseHandler.Sensitivity.Value;
             }
-
-            // debug / local compilations will reset to a non-release string.
-            // can be useful to check when an install has transitioned between release and otherwise (see OsuConfigManager's migrations).
-            LocalConfig.SetValue(OsuSetting.Version, Version);
         }
 
         private void handleBackButton()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1335,7 +1335,7 @@ namespace osu.Game
                     LocalConfig.GetBindable<float>(OsuSetting.UIScale).SetDefault();
             }
 
-            if (combined < 20250428)
+            if (combined < 20260520)
             {
                 // Pen tablet sensitivity is now separated from cursor sensitivity.
                 // Most users will want the default to be what they already had set on cursor sensitivity so let's transfer it.

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1310,7 +1310,6 @@ namespace osu.Game
         /// <remarks>
         /// For database migrations, see <see cref="RealmAccess.applyMigrationsForVersion"/>.
         /// </remarks>
-        /// <exception cref="NotImplementedException"></exception>
         private void applyConfigMigrations()
         {
             // arrives as 2020.123.0-lazer

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1340,6 +1340,10 @@ namespace osu.Game
                 if (penHandler != null && mouseHandler != null && penHandler.Sensitivity.IsDefault)
                     penHandler.Sensitivity.Value = mouseHandler.Sensitivity.Value;
             }
+
+            // debug / local compilations will reset to a non-release string.
+            // can be useful to check when an install has transitioned between release and otherwise (see OsuConfigManager's migrations).
+            LocalConfig.SetValue(OsuSetting.Version, Version);
         }
 
         private void handleBackButton()

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -541,8 +541,8 @@ namespace osu.Game
             Storage ??= host.Storage;
 
             LocalConfig ??= UseDevelopmentServer
-                ? new DevelopmentOsuConfigManager(Storage, host)
-                : new OsuConfigManager(Storage, host);
+                ? new DevelopmentOsuConfigManager(Storage)
+                : new OsuConfigManager(Storage);
 
             host.ExceptionThrown += onExceptionThrown;
         }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -590,7 +590,7 @@ namespace osu.Game
         /// <param name="path">The path to migrate to.</param>
         /// <returns>Whether migration succeeded to completion. If <c>false</c>, some files were left behind.</returns>
         /// <exception cref="TimeoutException"></exception>
-        public bool Migrate(string path)
+        public bool MigrateUserData(string path)
         {
             Logger.Log($@"Migrating osu! data from ""{Storage.GetFullPath(string.Empty)}"" to ""{path}""...");
 

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                                 });
         }
 
-        protected virtual bool PerformMigration() => game?.Migrate(destination.FullName) != false;
+        protected virtual bool PerformMigration() => game?.MigrateUserData(destination.FullName) != false;
 
         public override void OnEntering(ScreenTransitionEvent e)
         {

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -80,10 +80,6 @@ namespace osu.Game.Updater
                 Logger.Log(NotificationsStrings.NotOfficialBuild.ToString());
             }
 
-            // debug / local compilations will reset to a non-release string.
-            // can be useful to check when an install has transitioned between release and otherwise (see OsuConfigManager's migrations).
-            config.SetValue(OsuSetting.Version, version);
-
             config.BindWith(OsuSetting.ReleaseStream, releaseStream);
             releaseStream.BindValueChanged(_ => CheckForUpdate());
 


### PR DESCRIPTION
As we go forward, migrations are going to likely become more complex, requiring access to more components and also at a point in time where they are ready.

In the upcoming case, `DialogOverlay` and `Audio` are important. Access to `Audio` is a killer as migrations were run before the `GameHost` has a chance to initialise it.