### PR TITLE
Obsolete `Mod.ScoreMultiplier` and remove all other references to it

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -13,8 +13,6 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public partial class CatchModFlashlight : ModFlashlight<CatchHitObject>
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
-
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override string Name => "Floating Fruits";
         public override string Acronym => "FF";
         public override LocalisableString Description => "The fruits are... floating?";
-        public override double ScoreMultiplier => 1;
         public override IconUsage? Icon => OsuIcon.ModFloatingFruits;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
@@ -10,8 +10,6 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModHardRock : ModHardRock, IApplicableToBeatmapProcessor
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
-
         public void ApplyToBeatmapProcessor(IBeatmapProcessor beatmapProcessor)
         {
             var catchProcessor = (CatchBeatmapProcessor)beatmapProcessor;

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Catch.Mods
     public class CatchModHidden : ModHidden, IApplicableToDrawableRuleset<CatchHitObject>
     {
         public override LocalisableString Description => @"Play with fading fruits.";
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
 
         private const double fade_out_offset_multiplier = 0.6;
         private const double fade_out_duration_multiplier = 0.44;

--- a/osu.Game.Rulesets.Catch/Mods/CatchModMovingFast.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModMovingFast.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override string Acronym => "MF";
         public override LocalisableString Description => "Dashing by default, slow down!";
         public override ModType Type => ModType.Fun;
-        public override double ScoreMultiplier => 1;
         public override IconUsage? Icon => OsuIcon.ModMovingFast;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax) };
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => Name;
         public abstract int KeyCount { get; }
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 0.9;
         public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override string Acronym => "CS";
 
-        public override double ScoreMultiplier => 0.9;
-
         public override LocalisableString Description => "No more tricky speed changes!";
 
         public override IconUsage? Icon => OsuIcon.ModConstantSpeed;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
@@ -20,8 +20,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => @"Decrease the playfield's viewing area.";
 
-        public override double ScoreMultiplier => 1;
-
         protected override CoverExpandDirection ExpandDirection => Direction.Value;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
@@ -7,9 +7,5 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModDoubleTime : ModDoubleTime, IManiaRateAdjustmentMod
     {
-        // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
-        // make the map harder and is more of a personal preference.
-        // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.
-        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDualStages.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDualStages.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override LocalisableString Description => @"Double the stages, double the fun!";
         public override IconUsage? Icon => OsuIcon.ModDualStages;
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 1;
 
         private bool isForCurrentRuleset;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => "FI";
         public override IconUsage? Icon => OsuIcon.ModFadeIn;
         public override LocalisableString Description => @"Keys appear out of nowhere!";
-        public override double ScoreMultiplier => 1;
         public override bool ValidForFreestyleAsRequiredMod => false;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public partial class ManiaModFlashlight : ModFlashlight<ManiaHitObject>
     {
-        public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => new[] { typeof(ModHidden) };
 
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
@@ -10,7 +10,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModHardRock : ModHardRock, IApplicableToHitObject
     {
-        public override double ScoreMultiplier => 1;
         public override bool Ranked => false;
 
         public const double HIT_WINDOW_DIFFICULTY_MULTIPLIER = 1.4;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         private const float coverage_increase_per_combo = 0.5f;
 
         public override LocalisableString Description => @"Keys fade out before you hit them!";
-        public override double ScoreMultiplier => 1;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHoldOff.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHoldOff.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override string Acronym => "HO";
 
-        public override double ScoreMultiplier => 0.9;
-
         public override LocalisableString Description => @"Replaces all hold notes with normal notes.";
 
         public override IconUsage? Icon => OsuIcon.ModHoldOff;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Invert";
 
         public override string Acronym => "IN";
-        public override double ScoreMultiplier => 1;
 
         public override LocalisableString Description => "Hold the keys. To the beat.";
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
@@ -8,9 +8,5 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModNightcore : ModNightcore<ManiaHitObject>, IManiaRateAdjustmentMod
     {
-        // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
-        // make the map any harder and is more of a personal preference.
-        // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.
-        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -26,8 +26,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => "No more timing the end of hold notes.";
 
-        public override double ScoreMultiplier => 0.9;
-
         public override IconUsage? Icon => OsuIcon.ModNoRelease;
 
         public override ModType Type => ModType.DifficultyReduction;

--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public abstract partial class InputBlockingMod : Mod, IApplicableToDrawableRuleset<OsuHitObject>, IUpdatableByPlayfield
     {
-        public override double ScoreMultiplier => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(OsuModCinema) };
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Name => "Approach Different";
         public override string Acronym => "AD";
         public override LocalisableString Description => "Never trust the approach circles...";
-        public override double ScoreMultiplier => 1;
         public override IconUsage? Icon => OsuIcon.ModApproachDifferent;
 
         public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles), typeof(OsuModFreezeFrame) };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModAutopilot;
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => @"Automatic cursor movement - just follow the rhythm.";
-        public override double ScoreMultiplier => 0.1;
 
         public override Type[] IncompatibleMods => new[]
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModBlinds;
         public override ModType Type => ModType.DifficultyIncrease;
 
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight) };
         public override bool Ranked => true;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
@@ -26,7 +26,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModBloom;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "The cursor blooms into.. a larger cursor!";
-        public override double ScoreMultiplier => 1;
         protected const float MIN_SIZE = 1;
         protected const float TRANSITION_DURATION = 100;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight), typeof(OsuModNoScope), typeof(ModTouchDevice) };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override LocalisableString Description => "Don't let their popping distract you!";
 
-        public override double ScoreMultiplier => 1;
-
         public override IconUsage? Icon => OsuIcon.ModBubbles;
 
         public override ModType Type => ModType.Fun;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModDepth;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "3D. Almost.";
-        public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModFreezeFrame), typeof(ModWithVisibilityAdjustment) }).ToArray();
 
         private static readonly Vector3 camera_position = new Vector3(OsuPlayfield.BASE_SIZE.X * 0.5f, OsuPlayfield.BASE_SIZE.Y * 0.5f, -200);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public partial class OsuModFlashlight : ModFlashlight<OsuHitObject>, IApplicableToDrawableHitObject
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModBloom), typeof(OsuModBlinds) }).ToArray();
 
         private const double default_follow_delay = 120;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -23,8 +23,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override IconUsage? Icon => OsuIcon.ModFreezeFrame;
 
-        public override double ScoreMultiplier => 1;
-
         public override LocalisableString Description => "Burn the notes into your memory.";
 
         /// <remarks>

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -13,8 +13,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModHardRock : ModHardRock, IApplicableToHitObject
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
-
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModMirror)).ToArray();
 
         public void ApplyToHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -24,7 +24,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public Bindable<bool> OnlyFadeApproachCircles { get; } = new BindableBool();
 
         public override LocalisableString Description => @"Play with no approach circles and fading circles/sliders.";
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
 
         public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn), typeof(OsuModDepth), typeof(OsuModFreezeFrame) };
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModMagnetised;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "No need to chase the circles – your cursor is a magnet!";
-        public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModRelax), typeof(OsuModRepel), typeof(OsuModBubbles), typeof(OsuModDepth) };
 
         [SettingSource("Attraction strength", "How strong the pull is.", 0)]

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -19,8 +19,6 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override ModType Type => ModType.Fun;
 
-        public override double ScoreMultiplier => 1;
-
         [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
         public abstract BindableNumber<float> StartScale { get; }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModRepel;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Hit objects run away!";
-        public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModMagnetised), typeof(OsuModBubbles), typeof(OsuModDepth) };
 
         [SettingSource("Repulsion strength", "How strong the repulsion is.", 0)]

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModSpinIn;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Circles spin in. No approach circles.";
-        public override double ScoreMultiplier => 1;
 
         // todo: this mod needs to be incompatible with "hidden" due to forcing the circle to remain opaque,
         // further implementation will be required for supporting that.

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModSpunOut;
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => @"Spinners will be automatically completed.";
-        public override double ScoreMultiplier => 0.9;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(OsuModAutopilot), typeof(OsuModTargetPractice) };
         public override bool Ranked => UsesDefaultConfiguration;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
@@ -29,7 +29,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModStrictTracking;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => @"Once you start a slider, follow precisely or get a miss.";
-        public override double ScoreMultiplier => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModClassic), typeof(OsuModTargetPractice) };
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
@@ -39,7 +39,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Conversion;
         public override IconUsage? Icon => OsuIcon.ModTargetPractice;
         public override LocalisableString Description => @"Practice keeping up with the beat of the song.";
-        public override double ScoreMultiplier => 0.1;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModTraceable;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Put your faith in the approach circles...";
-        public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
 
         public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles), typeof(OsuModDepth) };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
@@ -22,7 +22,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModTransform;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Everything rotates. EVERYTHING.";
-        public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModFreezeFrame), typeof(OsuModDepth) }).ToArray();
 
         private float theta;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModWiggle;
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "They just won't stay still...";
-        public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModTransform), typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModDepth) };
 
         private const int wiggle_duration = 100; // (ms) Higher = fewer wiggles

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModConstantSpeed.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModConstantSpeed.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override string Name => "Constant Speed";
         public override string Acronym => "CS";
-        public override double ScoreMultiplier => 0.9;
         public override LocalisableString Description => "No more tricky speed changes!";
         public override IconUsage? Icon => OsuIcon.ModConstantSpeed;
         public override ModType Type => ModType.Conversion;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -14,8 +14,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public partial class TaikoModFlashlight : ModFlashlight<TaikoHitObject>
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
-
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
@@ -9,8 +9,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModHardRock : ModHardRock
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
-
         /// <summary>
         /// Multiplier factor added to the scrolling speed.
         /// </summary>

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
     public class TaikoModHidden : ModHidden, IApplicableToDrawableRuleset<TaikoHitObject>
     {
         public override LocalisableString Description => @"Beats fade out before you hit them!";
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
 
         /// <summary>
         /// How far away from the hit target should hitobjects start to fade out.

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSimplifiedRhythm.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override string Name => "Simplified Rhythm";
         public override string Acronym => "SR";
-        public override double ScoreMultiplier => 0.6;
         public override LocalisableString Description => "Simplify tricky rhythms!";
         public override IconUsage? Icon => OsuIcon.ModSimplifiedRhythm;
         public override ModType Type => ModType.DifficultyReduction;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override LocalisableString Description => @"One key for dons, one key for kats.";
 
         public override bool Ranked => true;
-        public override double ScoreMultiplier => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema) };
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override LocalisableString Description => @"Dons become kats, kats become dons";
         public override IconUsage? Icon => OsuIcon.ModSwap;
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModRandom)).ToArray();
         public override bool Ranked => true;
 

--- a/osu.Game.Tests/Mods/ModSettingsTest.cs
+++ b/osu.Game.Tests/Mods/ModSettingsTest.cs
@@ -91,7 +91,6 @@ namespace osu.Game.Tests.Mods
         {
             public override string Name => "Non-matching setting type mod";
             public override LocalisableString Description => "Description";
-            public override double ScoreMultiplier => 1;
             public override ModType Type => ModType.Conversion;
 
             [SettingSource("Test setting")]

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -421,7 +421,6 @@ namespace osu.Game.Tests.Mods
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
             public override string Acronym => string.Empty;
-            public override double ScoreMultiplier => 1;
             public override bool HasImplementation => true;
             public override bool ValidForMultiplayer => false;
             public override bool ValidForMultiplayerAsFreeMod => false;
@@ -432,7 +431,6 @@ namespace osu.Game.Tests.Mods
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
             public override string Acronym => string.Empty;
-            public override double ScoreMultiplier => 1;
             public override bool HasImplementation => true;
             public override bool ValidForMultiplayerAsFreeMod => false;
         }
@@ -441,7 +439,6 @@ namespace osu.Game.Tests.Mods
         {
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
             public override string Acronym => string.Empty;
             public override bool HasImplementation => true;
             public override bool ValidForFreestyleAsRequiredMod => false;

--- a/osu.Game.Tests/Mods/TestCustomisableModRuleset.cs
+++ b/osu.Game.Tests/Mods/TestCustomisableModRuleset.cs
@@ -59,8 +59,6 @@ namespace osu.Game.Tests.Mods
 
         public abstract class TestModCustomisable : Mod, IApplicableMod
         {
-            public override double ScoreMultiplier => 1.0;
-
             public override LocalisableString Description => "This is a customisable test mod.";
 
             public override ModType Type => ModType.Conversion;

--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -161,7 +161,6 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => nameof(ModA);
             public override string Acronym => nameof(ModA);
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModIncompatibleWithA), typeof(ModIncompatibleWithAAndB) };
         }
@@ -171,7 +170,6 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => nameof(ModB);
             public override LocalisableString Description => string.Empty;
             public override string Acronym => nameof(ModB);
-            public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModIncompatibleWithAAndB) };
         }
@@ -181,7 +179,6 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => nameof(ModC);
             public override string Acronym => nameof(ModC);
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
         }
 
         private class ModIncompatibleWithA : Mod
@@ -189,7 +186,6 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => $"Incompatible With {nameof(ModA)}";
             public override string Acronym => $"Incompatible With {nameof(ModA)}";
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModA) };
         }
@@ -208,7 +204,6 @@ namespace osu.Game.Tests.NonVisual
             public override string Name => $"Incompatible With {nameof(ModA)} and {nameof(ModB)}";
             public override string Acronym => $"Incompatible With {nameof(ModA)} and {nameof(ModB)}";
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModA), typeof(ModB) };
         }

--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -185,7 +185,6 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
 
             [SettingSource("Test")]
             public BindableNumber<double> TestSetting { get; } = new BindableDouble
@@ -202,7 +201,6 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TMTR";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]
             public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1.5)

--- a/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
@@ -104,7 +104,6 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
 
             [SettingSource("Test")]
             public BindableNumber<double> TestSetting { get; } = new BindableDouble
@@ -121,7 +120,6 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TMTR";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]
             public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1.5)
@@ -148,7 +146,6 @@ namespace osu.Game.Tests.Online
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
             public override LocalisableString Description => "This is a test mod.";
-            public override double ScoreMultiplier => 1;
 
             [SettingSource("Test")]
             public Bindable<TestEnum> TestSetting { get; } = new Bindable<TestEnum>();

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -222,12 +222,10 @@ namespace osu.Game.Tests.Resources
 
         private class TestModHardRock : ModHardRock
         {
-            public override double ScoreMultiplier => 1;
         }
 
         private class TestModDoubleTime : ModDoubleTime
         {
-            public override double ScoreMultiplier => 1;
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
@@ -244,7 +244,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             public override string Name => string.Empty;
             public override LocalisableString Description => string.Empty;
-            public override double ScoreMultiplier => 1.0;
             public override string Acronym => "Test";
         }
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -1146,7 +1146,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             public override string Name => "Unimplemented mod";
             public override string Acronym => "UM";
             public override LocalisableString Description => "A mod that is not implemented.";
-            public override double ScoreMultiplier => 1;
             public override ModType Type => ModType.Conversion;
         }
 

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -84,7 +84,8 @@ namespace osu.Game.Rulesets.Mods
         /// The score multiplier of this mod.
         /// </summary>
         [JsonIgnore]
-        public abstract double ScoreMultiplier { get; }
+        [Obsolete("This property is no longer used to calculate the score multiplier. Use `Ruleset.CreateScoreMultiplierCalculator()` instead.")]
+        public virtual double ScoreMultiplier => 1;
 
         /// <summary>
         /// Returns true if this mod is implemented (and playable).

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -30,8 +30,6 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.DifficultyIncrease;
 
-        public override double ScoreMultiplier => 1.0;
-
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModEasyWithExtraLives), typeof(ModPerfect) }).ToArray();
 
         public override bool RequiresConfiguration => false;

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -33,8 +33,6 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.Fun;
 
-        public override double ScoreMultiplier => 0.5;
-
         public sealed override bool ValidForMultiplayer => false;
         public sealed override bool ValidForMultiplayerAsFreeMod => false;
 

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -18,7 +18,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModAutoplay;
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => "Watch a perfect automated play through the song.";
-        public override double ScoreMultiplier => 1;
 
         public sealed override bool UserPlayable => false;
         public sealed override bool ValidForMultiplayer => false;

--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -40,7 +40,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "BR";
         public override IconUsage? Icon => OsuIcon.ModBarrelRoll;
         public override LocalisableString Description => "The whole playfield is on a wheel!";
-        public override double ScoreMultiplier => 1;
 
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
         {

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -13,8 +13,6 @@ namespace osu.Game.Rulesets.Mods
 
         public override string Acronym => "CL";
 
-        public override double ScoreMultiplier => 0.96;
-
         public override IconUsage? Icon => OsuIcon.ModClassic;
 
         public override LocalisableString Description => "Feeling nostalgic?";

--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -30,13 +30,10 @@ namespace osu.Game.Rulesets.Mods
 
         private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
         private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
-        private readonly RateAdjustModHelper rateAdjustHelper;
 
         protected ModDaycore()
         {
-            rateAdjustHelper = new RateAdjustModHelper(SpeedChange);
-
-            // intentionally not deferring the speed change handling to `RateAdjustModHelper`
+            // intentionally not using `RateAdjustModHelper`
             // as the expected result of operation is not the same (daycore should preserve constant pitch).
             SpeedChange.BindValueChanged(val =>
             {
@@ -50,7 +47,5 @@ namespace osu.Game.Rulesets.Mods
             track.AddAdjustment(AdjustableProperty.Frequency, freqAdjust);
             track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjust);
         }
-
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Rulesets.Mods
 
         public override IconUsage? Icon => OsuIcon.ModDifficultyAdjust;
 
-        public override double ScoreMultiplier => 0.5;
-
         public override bool RequiresConfiguration => true;
 
         public override bool ValidForFreestyleAsRequiredMod => true;

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -56,7 +56,5 @@ namespace osu.Game.Rulesets.Mods
         {
             rateAdjustHelper.ApplyToTrack(track);
         }
-
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "EZ";
         public override IconUsage? Icon => OsuIcon.ModEasy;
         public override ModType Type => ModType.DifficultyReduction;
-        public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock), typeof(ModDifficultyAdjust) };
         public override bool Ranked => UsesDefaultConfiguration;
         public override bool ValidForFreestyleAsRequiredMod => true;

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -56,7 +56,5 @@ namespace osu.Game.Rulesets.Mods
         {
             rateAdjustHelper.ApplyToTrack(track);
         }
-
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -12,6 +12,5 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "MR";
         public override IconUsage? Icon => OsuIcon.ModMirror;
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModMuted;
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
-        public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
         public override bool ValidForFreestyleAsRequiredMod => true;
     }

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -61,8 +61,6 @@ namespace osu.Game.Rulesets.Mods
             track.AddAdjustment(AdjustableProperty.Frequency, freqAdjust);
             track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjust);
         }
-
-        public override double ScoreMultiplier => rateAdjustHelper.ScoreMultiplier;
     }
 
     public abstract partial class ModNightcore<TObject> : ModNightcore, IApplicableToDrawableRuleset<TObject>

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -41,13 +41,9 @@ namespace osu.Game.Rulesets.Mods
         private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
         private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
 
-        private readonly RateAdjustModHelper rateAdjustHelper;
-
         protected ModNightcore()
         {
-            rateAdjustHelper = new RateAdjustModHelper(SpeedChange);
-
-            // intentionally not deferring the speed change handling to `RateAdjustModHelper`
+            // intentionally not using `RateAdjustModHelper`
             // as the expected result of operation is not the same (nightcore should preserve constant pitch).
             SpeedChange.BindValueChanged(val =>
             {

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -18,7 +18,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModNoFail;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "You can't fail, no matter what.";
-        public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModFailCondition), typeof(ModCinema) };
         public override bool Ranked => UsesDefaultConfiguration;
         public override bool ValidForFreestyleAsRequiredMod => true;

--- a/osu.Game/Rulesets/Mods/ModNoMod.cs
+++ b/osu.Game/Rulesets/Mods/ModNoMod.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "No Mod";
         public override string Acronym => "NM";
         public override LocalisableString Description => "No mods applied.";
-        public override double ScoreMultiplier => 1;
         public override IconUsage? Icon => OsuIcon.ModNoMod;
         public override ModType Type => ModType.System;
     }

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -22,7 +22,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "NS";
         public override ModType Type => ModType.Fun;
         public override IconUsage? Icon => OsuIcon.ModNoScope;
-        public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
 
         /// <summary>

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "PF";
         public override IconUsage? Icon => OsuIcon.ModPerfect;
         public override ModType Type => ModType.DifficultyIncrease;
-        public override double ScoreMultiplier => 1;
         public override LocalisableString Description => "SS or quit.";
         public override bool Ranked => true;
         public override bool ValidForFreestyleAsRequiredMod => true;

--- a/osu.Game/Rulesets/Mods/ModRandom.cs
+++ b/osu.Game/Rulesets/Mods/ModRandom.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "RD";
         public override ModType Type => ModType.Conversion;
         public override IconUsage? Icon => OsuIcon.ModRandom;
-        public override double ScoreMultiplier => 1;
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> Seed { get; } = new Bindable<int?>();

--- a/osu.Game/Rulesets/Mods/ModRelax.cs
+++ b/osu.Game/Rulesets/Mods/ModRelax.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "RX";
         public override IconUsage? Icon => OsuIcon.ModRelax;
         public override ModType Type => ModType.Automation;
-        public override double ScoreMultiplier => 0.1;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay) };
     }
 }

--- a/osu.Game/Rulesets/Mods/ModScoreV2.cs
+++ b/osu.Game/Rulesets/Mods/ModScoreV2.cs
@@ -18,7 +18,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModScoreV2;
         public override ModType Type => ModType.System;
         public override LocalisableString Description => "Score set on earlier osu! versions with the V2 scoring algorithm active.";
-        public override double ScoreMultiplier => 1;
         public override bool UserPlayable => false;
         public override bool ValidForMultiplayer => false;
         public override bool ValidForMultiplayerAsFreeMod => false;

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -18,7 +18,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModSuddenDeath;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Miss and fail.";
-        public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
         public override bool ValidForFreestyleAsRequiredMod => true;
 

--- a/osu.Game/Rulesets/Mods/ModSynesthesia.cs
+++ b/osu.Game/Rulesets/Mods/ModSynesthesia.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Synesthesia";
         public override string Acronym => "SY";
         public override LocalisableString Description => "Colours hit objects based on the rhythm.";
-        public override double ScoreMultiplier => 0.8;
         public override IconUsage? Icon => OsuIcon.ModSynesthesia;
         public override ModType Type => ModType.Fun;
     }

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         public const double FINAL_RATE_PROGRESS = 0.75f;
 
-        public override double ScoreMultiplier => 0.5;
-
         [SettingSource("Initial rate", "The starting speed of the track", SettingControlType = typeof(MultiplierSettingsSlider))]
         public abstract BindableNumber<double> InitialRate { get; }
 

--- a/osu.Game/Rulesets/Mods/ModTouchDevice.cs
+++ b/osu.Game/Rulesets/Mods/ModTouchDevice.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Rulesets.Mods
         public sealed override string Acronym => "TD";
         public sealed override IconUsage? Icon => OsuIcon.ModTouchDevice;
         public sealed override LocalisableString Description => "Automatically applied to plays on devices with a touchscreen.";
-        public sealed override double ScoreMultiplier => 1;
         public sealed override ModType Type => ModType.System;
         public sealed override bool ValidForMultiplayer => false;
         public sealed override bool ValidForMultiplayerAsFreeMod => false;

--- a/osu.Game/Rulesets/Mods/MultiMod.cs
+++ b/osu.Game/Rulesets/Mods/MultiMod.cs
@@ -12,7 +12,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => string.Empty;
         public override string Acronym => string.Empty;
         public override LocalisableString Description => string.Empty;
-        public override double ScoreMultiplier => 0;
 
         public Mod[] Mods { get; }
 

--- a/osu.Game/Rulesets/Mods/RateAdjustModHelper.cs
+++ b/osu.Game/Rulesets/Mods/RateAdjustModHelper.cs
@@ -19,26 +19,6 @@ namespace osu.Game.Rulesets.Mods
         private BindableBool? adjustPitch;
 
         /// <summary>
-        /// The score multiplier for the current <see cref="SpeedChange"/>.
-        /// </summary>
-        public double ScoreMultiplier
-        {
-            get
-            {
-                // Round to the nearest multiple of 0.1.
-                double value = (int)(SpeedChange.Value * 10) / 10.0;
-
-                // Offset back to 0.
-                value -= 1;
-
-                if (SpeedChange.Value >= 1)
-                    return 1 + value / 5;
-                else
-                    return 0.6 + value;
-            }
-        }
-
-        /// <summary>
         /// Construct a new <see cref="RateAdjustModHelper"/>.
         /// </summary>
         /// <param name="speedChange">The main speed adjust parameter which is exposed to the user.</param>

--- a/osu.Game/Rulesets/Mods/UnknownMod.cs
+++ b/osu.Game/Rulesets/Mods/UnknownMod.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => $"Unknown mod ({OriginalAcronym})";
         public override string Acronym => $"{OriginalAcronym}??";
         public override LocalisableString Description => "This mod could not be resolved by the game.";
-        public override double ScoreMultiplier => 0;
 
         public override bool UserPlayable => false;
         public override bool ValidForMultiplayer => false;

--- a/osu.Game/Tests/Rulesets/RulesetScoreMultiplierTest.cs
+++ b/osu.Game/Tests/Rulesets/RulesetScoreMultiplierTest.cs
@@ -26,16 +26,8 @@ namespace osu.Game.Tests.Rulesets
 
         protected void TestModCombination(IEnumerable<Mod> mods, double expectedMultiplier)
         {
-            Assert.Multiple(() =>
-            {
-                double multiplierViaOldAPI = 1;
-                foreach (var mod in mods)
-                    multiplierViaOldAPI *= mod.ScoreMultiplier;
-                Assert.That(multiplierViaOldAPI, Is.EqualTo(expectedMultiplier).Within(Precision.DOUBLE_EPSILON));
-
-                var calculator = Ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
-                Assert.That(calculator.CalculateFor(mods), Is.EqualTo(expectedMultiplier).Within(Precision.DOUBLE_EPSILON));
-            });
+            var calculator = Ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+            Assert.That(calculator.CalculateFor(mods), Is.EqualTo(expectedMultiplier).Within(Precision.DOUBLE_EPSILON));
         }
     }
 }


### PR DESCRIPTION
- Part of https://github.com/ppy/osu/issues/37818
- [x] Depends on https://github.com/ppy/osu/pull/37845

Purely mechanical, split away for ease of review / due to size.