### PR TITLE
Replace new combo button icons with ruleset-specifc ones

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
@@ -3,11 +3,16 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -21,6 +26,29 @@ namespace osu.Game.Rulesets.Catch.Edit
             : base(composer)
         {
         }
+
+        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
+        {
+            Current = NewCombo,
+            CreateIcon = () => new Container
+            {
+                Children = new Drawable[]
+                {
+                    new SpriteIcon
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Icon = OsuIcon.EditorFruit,
+                        Size = new Vector2(15),
+                    },
+                    new SpriteIcon
+                    {
+                        Icon = OsuIcon.EditorNewComboSparkles,
+                        Size = new Vector2(20),
+                    }
+                },
+            },
+        };
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new CatchSelectionHandler();
 

--- a/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
@@ -3,11 +3,16 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -21,6 +26,29 @@ namespace osu.Game.Rulesets.Mania.Edit
             : base(composer)
         {
         }
+
+        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
+        {
+            Current = NewCombo,
+            CreateIcon = () => new Container
+            {
+                Children = new Drawable[]
+                {
+                    new SpriteIcon
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Icon = OsuIcon.EditorNote,
+                        Size = new Vector2(15),
+                    },
+                    new SpriteIcon
+                    {
+                        Icon = OsuIcon.EditorNewComboSparkles,
+                        Size = new Vector2(20),
+                    }
+                },
+            },
+        };
 
         public override HitObjectSelectionBlueprint? CreateHitObjectBlueprintFor(HitObject hitObject)
         {

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
@@ -3,10 +3,15 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -20,6 +25,29 @@ namespace osu.Game.Rulesets.Taiko.Edit
             : base(composer)
         {
         }
+
+        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
+        {
+            Current = NewCombo,
+            CreateIcon = () => new Container
+            {
+                Children = new Drawable[]
+                {
+                    new SpriteIcon
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Icon = OsuIcon.EditorHit,
+                        Size = new Vector2(15),
+                    },
+                    new SpriteIcon
+                    {
+                        Icon = OsuIcon.EditorNewComboSparkles,
+                        Size = new Vector2(20),
+                    }
+                },
+            },
+        };
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new TaikoSelectionHandler();
 

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Graphics
         public static IconUsage EditorDistanceSnap => get(OsuIconMapping.EditorDistanceSnap);
         public static IconUsage EditorFinish => get(OsuIconMapping.EditorFinish);
         public static IconUsage EditorGridSnap => get(OsuIconMapping.EditorGridSnap);
-        public static IconUsage EditorNewCombo => get(OsuIconMapping.EditorNewCombo);
+        public static IconUsage EditorNewComboSparkles => get(OsuIconMapping.EditorNewComboSparkles);
         public static IconUsage EditorSelect => get(OsuIconMapping.EditorSelect);
         public static IconUsage EditorSound => get(OsuIconMapping.EditorSound);
         public static IconUsage EditorWhistle => get(OsuIconMapping.EditorWhistle);
@@ -459,8 +459,8 @@ namespace osu.Game.Graphics
             [Description(@"Editor/grid-snap")]
             EditorGridSnap,
 
-            [Description(@"Editor/new-combo")]
-            EditorNewCombo,
+            [Description(@"Editor/new-combo-sparkles")]
+            EditorNewComboSparkles,
 
             [Description(@"Editor/select")]
             EditorSelect,

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 {
     public partial class NewComboTernaryButton : CompositeDrawable, IHasCurrentValue<TernaryState>
     {
+        public Func<Drawable>? CreateIcon { get; init; }
+
         public Bindable<TernaryState> Current
         {
             get => current.Current;
@@ -61,7 +63,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                     {
                         Current = Current,
                         Description = "New combo",
-                        CreateIcon = () => new SpriteIcon { Icon = OsuIcon.EditorNewCombo },
+                        CreateIcon = CreateIcon,
                     },
                 },
                 pickerButton = new ColourPickerButton

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -182,12 +182,49 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public SampleBankTernaryButton[] SampleBankTernaryStates { get; private set; }
 
         /// <summary>
+        /// Create the new combo ternary button. Mainly used to customize the displayed icon
+        /// depending on the ruleset. Can be overriden to return null if a ruleset does not
+        /// provide combo-supporting HitObjects.
+        /// </summary>
+        /// <returns></returns>
+        [CanBeNull]
+        protected virtual Drawable CreateNewComboButton() => new NewComboTernaryButton
+        {
+            Current = NewCombo,
+            CreateIcon = () => new Container
+            {
+                Children = new Drawable[]
+                {
+                    new SpriteIcon
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        // This is currently using the osu! hitcircle icon as a default in order
+                        // not to break any custom rulesets that depend on there being a defined
+                        // new combo button.
+                        // Could consider removing it and let rulesets specify their own buttons/icons.
+                        Icon = OsuIcon.EditorHitCircle,
+                        Size = new Vector2(15),
+                    },
+                    new SpriteIcon
+                    {
+                        Icon = OsuIcon.EditorNewComboSparkles,
+                        Size = new Vector2(20),
+                    }
+                },
+            },
+        };
+
+        /// <summary>
         /// Create all ternary states required to be displayed to the user.
         /// </summary>
         protected virtual IEnumerable<Drawable> CreateTernaryButtons()
         {
             //TODO: this should only be enabled (visible?) for rulesets that provide combo-supporting HitObjects.
-            yield return new NewComboTernaryButton { Current = NewCombo };
+            var newComboButton = CreateNewComboButton();
+
+            if (newComboButton != null)
+                yield return newComboButton;
 
             foreach (var kvp in SelectionHandler.SelectionSampleStates)
             {


### PR DESCRIPTION
- Depends on https://github.com/ppy/osu-resources/pull/425.
- Closes https://github.com/ppy/osu/issues/37874

This makes the new combo button use the new icons added in https://github.com/ppy/osu/pull/37804. Instead of having four separate icons per ruleset, the "sparkle" texture is overlaid on top of the appropriate icon.

I'm not sure if I've overdone it with how every ruleset copypastes the same code for the icon (in `<ruleset>BlueprintContainer`), so that can be scaled down if necessary.

| osu | taiko | catch | mania |
|--------|--------|--------|--------|
| <img width="200" height="67" alt="image" src="https://github.com/user-attachments/assets/88a31611-f200-4da8-8490-39e6803a452c" /> | <img width="194" height="69" alt="image" src="https://github.com/user-attachments/assets/fbe5c7c0-2a53-4f3f-9c80-67c8769dfb52" /> | <img width="194" height="69" alt="image" src="https://github.com/user-attachments/assets/dbfbd183-0469-4b57-9059-40351604aa64" /> | <img width="190" height="68" alt="image" src="https://github.com/user-attachments/assets/708fc2e0-34fb-4983-b696-8c23431f8af4" /> | 