### PR TITLE
Update sample bank icons

### DIFF
--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -112,6 +112,14 @@ namespace osu.Game.Graphics
         public static IconUsage EditorSound => get(OsuIconMapping.EditorSound);
         public static IconUsage EditorWhistle => get(OsuIconMapping.EditorWhistle);
         public static IconUsage EditorClap => get(OsuIconMapping.EditorClap);
+        public static IconUsage EditorBankAuto => get(OsuIconMapping.EditorBankAuto);
+        public static IconUsage EditorBankAutoCompact => get(OsuIconMapping.EditorBankAutoCompact);
+        public static IconUsage EditorBankNormal => get(OsuIconMapping.EditorBankNormal);
+        public static IconUsage EditorBankNormalCompact => get(OsuIconMapping.EditorBankNormalCompact);
+        public static IconUsage EditorBankSoft => get(OsuIconMapping.EditorBankSoft);
+        public static IconUsage EditorBankSoftCompact => get(OsuIconMapping.EditorBankSoftCompact);
+        public static IconUsage EditorBankDrum => get(OsuIconMapping.EditorBankDrum);
+        public static IconUsage EditorBankDrumCompact => get(OsuIconMapping.EditorBankDrumCompact);
         public static IconUsage Tortoise => get(OsuIconMapping.Tortoise);
         public static IconUsage Hare => get(OsuIconMapping.Hare);
 
@@ -473,6 +481,30 @@ namespace osu.Game.Graphics
 
             [Description(@"Editor/clap")]
             EditorClap,
+
+            [Description(@"Editor/bank-auto")]
+            EditorBankAuto,
+
+            [Description(@"Editor/bank-auto-compact")]
+            EditorBankAutoCompact,
+
+            [Description(@"Editor/bank-normal")]
+            EditorBankNormal,
+
+            [Description(@"Editor/bank-normal-compact")]
+            EditorBankNormalCompact,
+
+            [Description(@"Editor/bank-soft")]
+            EditorBankSoft,
+
+            [Description(@"Editor/bank-soft-compact")]
+            EditorBankSoftCompact,
+
+            [Description(@"Editor/bank-drum")]
+            EditorBankDrum,
+
+            [Description(@"Editor/bank-drum-compact")]
+            EditorBankDrumCompact,
 
             [Description(@"tortoise")]
             Tortoise,

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 
@@ -17,6 +18,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
     {
         public string BankName { get; }
         public Func<Drawable>? CreateIcon { get; init; }
+
+        public Func<Drawable>? CreateCompactIcon { get; init; }
 
         public readonly BindableWithCurrent<TernaryState> NormalState = new BindableWithCurrent<TernaryState>();
         public readonly BindableWithCurrent<TernaryState> AdditionsState = new BindableWithCurrent<TernaryState>();
@@ -50,6 +53,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                         Current = NormalState,
                         Description = BankName.Titleize(),
                         CreateIcon = CreateIcon,
+                        CreateCompactIcon = CreateCompactIcon,
                     },
                 },
                 new Container
@@ -65,19 +69,70 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                         Current = AdditionsState,
                         Description = BankName.Titleize(),
                         CreateIcon = CreateIcon,
+                        CreateCompactIcon = CreateCompactIcon,
                     },
                 },
             };
         }
 
-        private partial class InlineDrawableTernaryButton : DrawableTernaryButton
+        private partial class InlineDrawableTernaryButton : DrawableTernaryButton, IExpandable
         {
+            public new Func<Drawable>? CreateIcon { get; init; }
+
+            public Func<Drawable>? CreateCompactIcon { get; init; }
+
+            private Drawable icon = null!;
+            private Drawable iconCompact = null!;
+
+            public BindableBool Expanded { get; } = new BindableBool();
+
+            [Resolved(canBeNull: true)]
+            private IExpandingContainer? expandingContainer { get; set; }
+
+            public InlineDrawableTernaryButton()
+            {
+                base.CreateIcon = createBaseIcon;
+            }
+
+            private Drawable createBaseIcon()
+            {
+                var container = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                };
+
+                if (CreateIcon != null)
+                    container.Add(icon = CreateIcon.Invoke());
+
+                if (CreateCompactIcon != null)
+                    container.Add(iconCompact = CreateCompactIcon.Invoke());
+
+                return container;
+            }
+
             [BackgroundDependencyLoader]
             private void load()
             {
                 Content.Masking = false;
                 Content.CornerRadius = 0;
                 Icon.X = 4.5f;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                expandingContainer?.Expanded.BindValueChanged(containerExpanded =>
+                {
+                    Expanded.Value = containerExpanded.NewValue;
+                }, true);
+
+                Expanded.BindValueChanged(expanded =>
+                {
+                    icon.FadeTo(expanded.NewValue ? 1 : 0, 150, Easing.OutQuint);
+                    iconCompact.FadeTo(expanded.NewValue ? 0 : 1, 150, Easing.OutQuint);
+                }, true);
             }
 
             protected override SpriteText CreateText() => new ExpandableSpriteText

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
@@ -17,9 +17,9 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
     public partial class SampleBankTernaryButton : CompositeDrawable
     {
         public string BankName { get; }
-        public Func<Drawable>? CreateIcon { get; init; }
+        public required Func<Drawable> CreateIcon { get; init; }
 
-        public Func<Drawable>? CreateCompactIcon { get; init; }
+        public required Func<Drawable> CreateCompactIcon { get; init; }
 
         public readonly BindableWithCurrent<TernaryState> NormalState = new BindableWithCurrent<TernaryState>();
         public readonly BindableWithCurrent<TernaryState> AdditionsState = new BindableWithCurrent<TernaryState>();
@@ -77,9 +77,9 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 
         private partial class InlineDrawableTernaryButton : DrawableTernaryButton, IExpandable
         {
-            public new Func<Drawable>? CreateIcon { get; init; }
+            public new required Func<Drawable> CreateIcon { get; init; }
 
-            public Func<Drawable>? CreateCompactIcon { get; init; }
+            public required Func<Drawable> CreateCompactIcon { get; init; }
 
             private Drawable icon = null!;
             private Drawable iconCompact = null!;
@@ -94,22 +94,16 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 base.CreateIcon = createBaseIcon;
             }
 
-            private Drawable createBaseIcon()
+            private Drawable createBaseIcon() => new Container
             {
-                var container = new Container
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Children = new[]
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                };
-
-                if (CreateIcon != null)
-                    container.Add(icon = CreateIcon.Invoke());
-
-                if (CreateCompactIcon != null)
-                    container.Add(iconCompact = CreateCompactIcon.Invoke());
-
-                return container;
-            }
+                    icon = CreateIcon(),
+                    iconCompact = CreateCompactIcon(),
+                }
+            };
 
             [BackgroundDependencyLoader]
             private void load()

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -17,7 +17,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
@@ -208,20 +207,41 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 {
                     NormalState = { Current = SelectionHandler.SelectionBankStates[bankName], },
                     AdditionsState = { Current = SelectionHandler.SelectionAdditionBankStates[bankName], },
-                    CreateIcon = () => getIconForBank(bankName)
+                    CreateIcon = () => getIconForBank(bankName),
+                    CreateCompactIcon = () => getCompactIconForBank(bankName),
                 };
             }
         }
 
         private Drawable getIconForBank(string sampleName)
         {
-            return new OsuSpriteText
+            return new SpriteIcon
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Y = -1,
-                Font = OsuFont.Default.With(weight: FontWeight.Bold, size: 20),
-                Text = $"{char.ToUpperInvariant(sampleName.First())}"
+                Size = new Vector2(20, 20),
+                Icon = sampleName switch
+                {
+                    EditorSelectionHandler.HIT_BANK_AUTO => OsuIcon.EditorBankAuto,
+                    HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormal,
+                    HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoft,
+                    HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrum,
+                    _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null)
+                },
+            };
+        }
+
+        private Drawable getCompactIconForBank(string sampleName)
+        {
+            return new SpriteIcon
+            {
+                Size = new Vector2(10, 20),
+                Icon = sampleName switch
+                {
+                    EditorSelectionHandler.HIT_BANK_AUTO => OsuIcon.EditorBankAutoCompact,
+                    HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormalCompact,
+                    HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoftCompact,
+                    HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrumCompact,
+                    _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null)
+                },
             };
         }
 


### PR DESCRIPTION
Depends on https://github.com/ppy/osu-resources/pull/425.

This PR updates the sample bank icons in the editor toolbox with new designs by [Adarin](https://osu.ppy.sh/users/118360).

Because the icons would be too illegible when scaled down to fit the buttons in the collapsed toolbox, they revert to simple letters when in said state.

| expanded | collapsed |
|--------|--------|
| <img width="299" height="319" alt="image" src="https://github.com/user-attachments/assets/2b7c53e9-d203-4652-8c7b-86c693b65f4d" /> | <img width="75" height="295" alt="image" src="https://github.com/user-attachments/assets/e8479442-52ac-4d56-b8b8-c5e419812046" /> | 

Transition between expanded/collapsed:

[Screencast_20260519_153046.webm](https://github.com/user-attachments/assets/1f018c68-8db5-4e4e-aacb-72f606b54b3e)

