### PR TITLE
Hide already shown tags in overflow popover

### DIFF
--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -208,6 +208,7 @@ namespace osu.Game.Screens.Select
                 private readonly string[] tags;
                 private readonly Bindable<int> overflowIndex;
                 private readonly Action<string>? performSearch;
+                private readonly LinkFlowContainer textFlow;
 
                 public TagsOverflowPopover(string[] tags, Bindable<int> overflowIndex, Action<string>? performSearchAction)
                 {
@@ -215,20 +216,18 @@ namespace osu.Game.Screens.Select
                     this.overflowIndex = overflowIndex;
                     performSearch = performSearchAction;
 
-                    this.overflowIndex.BindValueChanged(overflowChanged);
-                }
-
-                [BackgroundDependencyLoader]
-                private void load()
-                {
-                    LinkFlowContainer textFlow;
-
                     Child = textFlow = new LinkFlowContainer(t => t.Font = OsuFont.Style.Caption1)
                     {
                         Width = 200,
                         AutoSizeAxes = Axes.Y,
                     };
 
+                    this.overflowIndex.BindValueChanged(overflowChanged);
+                }
+
+                [BackgroundDependencyLoader]
+                private void load()
+                {
                     for (int i = overflowIndex.Value; i < tags.Length; i++)
                     {
                         string tag = tags[i];
@@ -239,6 +238,7 @@ namespace osu.Game.Screens.Select
 
                 private void overflowChanged(ValueChangedEvent<int> e)
                 {
+                    textFlow.Clear();
                     load();
                 }
             }

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -237,12 +237,6 @@ namespace osu.Game.Screens.Select
                 {
                     load();
                 }
-
-                protected override void Dispose(bool isDisposing)
-                {
-                    base.Dispose(isDisposing);
-                    overflowIndex.UnbindEvents();
-                }
             }
         }
     }

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -123,10 +123,11 @@ namespace osu.Game.Screens.Select
                     },
                 });
 
-                Add(overflowButton = new TagsOverflowButton(tags, tagsShownCount)
+                Add(overflowButton = new TagsOverflowButton(tags)
                 {
                     Alpha = 0f,
                     PerformSearch = s => PerformSearch?.Invoke(s),
+                    TagsShownCount = { BindTarget = tagsShownCount },
                 });
 
                 drawSizeLayout.Invalidate();
@@ -146,12 +147,11 @@ namespace osu.Game.Screens.Select
 
                 public Action<string>? PerformSearch { get; init; }
 
-                private readonly Bindable<int> tagsShownCount;
+                public readonly Bindable<int> TagsShownCount = new Bindable<int>();
 
-                public TagsOverflowButton(string[] tags, Bindable<int> tagsShownCount)
+                public TagsOverflowButton(string[] tags)
                 {
                     this.tags = tags;
-                    this.tagsShownCount = tagsShownCount;
                 }
 
                 [BackgroundDependencyLoader]
@@ -200,20 +200,22 @@ namespace osu.Game.Screens.Select
                     return true;
                 }
 
-                public Popover GetPopover() => new TagsOverflowPopover(tags, tagsShownCount, PerformSearch);
+                public Popover GetPopover() => new TagsOverflowPopover(tags, PerformSearch)
+                {
+                    TagsShownCount = { BindTarget = TagsShownCount },
+                };
             }
 
             public partial class TagsOverflowPopover : OsuPopover
             {
                 private readonly string[] tags;
-                private readonly Bindable<int> tagsShownCount;
+                public readonly Bindable<int> TagsShownCount = new Bindable<int>();
                 private readonly Action<string>? performSearch;
                 private readonly LinkFlowContainer textFlow;
 
-                public TagsOverflowPopover(string[] tags, Bindable<int> tagsShownCount, Action<string>? performSearchAction)
+                public TagsOverflowPopover(string[] tags, Action<string>? performSearchAction)
                 {
                     this.tags = tags;
-                    this.tagsShownCount = tagsShownCount;
                     performSearch = performSearchAction;
 
                     Child = textFlow = new LinkFlowContainer(t => t.Font = OsuFont.Style.Caption1)
@@ -221,19 +223,24 @@ namespace osu.Game.Screens.Select
                         Width = 200,
                         AutoSizeAxes = Axes.Y,
                     };
-
-                    this.tagsShownCount.BindValueChanged(overflowChanged);
                 }
 
                 [BackgroundDependencyLoader]
                 private void load()
                 {
-                    for (int i = tagsShownCount.Value; i < tags.Length; i++)
+                    for (int i = TagsShownCount.Value; i < tags.Length; i++)
                     {
                         string tag = tags[i];
                         textFlow.AddLink(tag, () => performSearch?.Invoke(tag));
                         textFlow.AddText(" ");
                     }
+                }
+
+                protected override void LoadComplete()
+                {
+                    base.LoadComplete();
+
+                    TagsShownCount.BindValueChanged(overflowChanged);
                 }
 
                 private void overflowChanged(ValueChangedEvent<int> e)

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -146,12 +146,12 @@ namespace osu.Game.Screens.Select
 
                 public Action<string>? PerformSearch { get; init; }
 
-                private readonly Bindable<int> overflowIndex;
+                private readonly Bindable<int> tagsShownCount;
 
-                public TagsOverflowButton(string[] tags, Bindable<int> overflowIndex)
+                public TagsOverflowButton(string[] tags, Bindable<int> tagsShownCount)
                 {
                     this.tags = tags;
-                    this.overflowIndex = overflowIndex;
+                    this.tagsShownCount = tagsShownCount;
                 }
 
                 [BackgroundDependencyLoader]
@@ -200,20 +200,20 @@ namespace osu.Game.Screens.Select
                     return true;
                 }
 
-                public Popover GetPopover() => new TagsOverflowPopover(tags, overflowIndex, PerformSearch);
+                public Popover GetPopover() => new TagsOverflowPopover(tags, tagsShownCount, PerformSearch);
             }
 
             public partial class TagsOverflowPopover : OsuPopover
             {
                 private readonly string[] tags;
-                private readonly Bindable<int> overflowIndex;
+                private readonly Bindable<int> tagsShownCount;
                 private readonly Action<string>? performSearch;
                 private readonly LinkFlowContainer textFlow;
 
-                public TagsOverflowPopover(string[] tags, Bindable<int> overflowIndex, Action<string>? performSearchAction)
+                public TagsOverflowPopover(string[] tags, Bindable<int> tagsShownCount, Action<string>? performSearchAction)
                 {
                     this.tags = tags;
-                    this.overflowIndex = overflowIndex;
+                    this.tagsShownCount = tagsShownCount;
                     performSearch = performSearchAction;
 
                     Child = textFlow = new LinkFlowContainer(t => t.Font = OsuFont.Style.Caption1)
@@ -222,13 +222,13 @@ namespace osu.Game.Screens.Select
                         AutoSizeAxes = Axes.Y,
                     };
 
-                    this.overflowIndex.BindValueChanged(overflowChanged);
+                    this.tagsShownCount.BindValueChanged(overflowChanged);
                 }
 
                 [BackgroundDependencyLoader]
                 private void load()
                 {
-                    for (int i = overflowIndex.Value; i < tags.Length; i++)
+                    for (int i = tagsShownCount.Value; i < tags.Length; i++)
                     {
                         string tag = tags[i];
                         textFlow.AddLink(tag, () => performSearch?.Invoke(tag));

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -82,20 +82,20 @@ namespace osu.Game.Screens.Select
                 float limit = DrawWidth - overflowButton.DrawWidth - 5;
                 int totalTagsShown = 0;
 
-                foreach (var text in Children)
+                foreach (var child in Children)
                 {
-                    if (text is not OsuHoverContainer) continue;
+                    if (child is TagsOverflowButton) continue;
 
-                    if (text.X + text.DrawWidth < limit)
+                    if (child.X + child.DrawWidth < limit)
                     {
-                        text.AlwaysPresent = true;
-                        text.Show();
+                        child.AlwaysPresent = true;
+                        child.Show();
                         totalTagsShown += 1;
                     }
                     else
                     {
-                        text.AlwaysPresent = false;
-                        text.Hide();
+                        child.AlwaysPresent = false;
+                        child.Hide();
                     }
                 }
 

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Select
             private string[] tags = Array.Empty<string>();
 
             private TagsOverflowButton? overflowButton;
-            private readonly Bindable<int> shownText = new Bindable<int>();
+            private readonly Bindable<int> tagsShownCount = new Bindable<int>();
 
             public string[] Tags
             {
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.Select
 
                 if (showOverflow)
                 {
-                    shownText.Value = Children.Count(text => text.IsPresent && text is OsuHoverContainer);
+                    tagsShownCount.Value = Children.Count(text => text.IsPresent && text is OsuHoverContainer);
                     overflowButton.Show();
                 }
                 else
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.Select
                     },
                 });
 
-                Add(overflowButton = new TagsOverflowButton(tags, shownText)
+                Add(overflowButton = new TagsOverflowButton(tags, tagsShownCount)
                 {
                     Alpha = 0f,
                     PerformSearch = s => PerformSearch?.Invoke(s),

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -88,6 +88,7 @@ namespace osu.Game.Screens.Select
 
                     if (text.X + text.DrawWidth < limit)
                     {
+                        text.AlwaysPresent = true;
                         text.Show();
                         totalTagsShown += 1;
                     }

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -80,25 +80,28 @@ namespace osu.Game.Screens.Select
                 Debug.Assert(overflowButton != null);
 
                 float limit = DrawWidth - overflowButton.DrawWidth - 5;
-                bool showOverflow = false;
+                int totalTagsShown = 0;
 
                 foreach (var text in Children)
                 {
+                    if (text is not OsuHoverContainer) continue;
+
                     if (text.X + text.DrawWidth < limit)
+                    {
                         text.Show();
+                        totalTagsShown += 1;
+                    }
                     else
                     {
-                        showOverflow = true;
                         text.AlwaysPresent = false;
                         text.Hide();
                     }
                 }
 
-                if (showOverflow)
-                {
-                    tagsShownCount.Value = Children.Count(text => text.IsPresent && text is OsuHoverContainer);
+                tagsShownCount.Value = totalTagsShown;
+
+                if (totalTagsShown < tags.Length)
                     overflowButton.Show();
-                }
                 else
                     overflowButton.Hide();
             }

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -208,26 +208,35 @@ namespace osu.Game.Screens.Select
 
             public partial class TagsOverflowPopover : OsuPopover
             {
-                private readonly string[] tags;
                 public readonly Bindable<int> TagsShownCount = new Bindable<int>();
+
+                private readonly string[] tags;
                 private readonly Action<string>? performSearch;
-                private readonly LinkFlowContainer textFlow;
+
+                private LinkFlowContainer textFlow = null!;
 
                 public TagsOverflowPopover(string[] tags, Action<string>? performSearchAction)
                 {
                     this.tags = tags;
                     performSearch = performSearchAction;
-
-                    Child = textFlow = new LinkFlowContainer(t => t.Font = OsuFont.Style.Caption1)
-                    {
-                        Width = 200,
-                        AutoSizeAxes = Axes.Y,
-                    };
                 }
 
                 [BackgroundDependencyLoader]
                 private void load()
                 {
+                    Child = textFlow = new LinkFlowContainer(t => t.Font = OsuFont.Style.Caption1)
+                    {
+                        Width = 200,
+                        AutoSizeAxes = Axes.Y,
+                    };
+
+                    updateTags();
+                }
+
+                private void updateTags()
+                {
+                    textFlow.Clear();
+
                     for (int i = TagsShownCount.Value; i < tags.Length; i++)
                     {
                         string tag = tags[i];
@@ -240,13 +249,7 @@ namespace osu.Game.Screens.Select
                 {
                     base.LoadComplete();
 
-                    TagsShownCount.BindValueChanged(overflowChanged);
-                }
-
-                private void overflowChanged(ValueChangedEvent<int> e)
-                {
-                    textFlow.Clear();
-                    load();
+                    TagsShownCount.BindValueChanged(_ => updateTags());
                 }
             }
         }

--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.TagsLine.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -33,6 +34,7 @@ namespace osu.Game.Screens.Select
             private string[] tags = Array.Empty<string>();
 
             private TagsOverflowButton? overflowButton;
+            private readonly Bindable<int> shownText = new Bindable<int>();
 
             public string[] Tags
             {
@@ -93,7 +95,10 @@ namespace osu.Game.Screens.Select
                 }
 
                 if (showOverflow)
+                {
+                    shownText.Value = Children.Count(text => text.IsPresent && text is OsuHoverContainer);
                     overflowButton.Show();
+                }
                 else
                     overflowButton.Hide();
             }
@@ -114,7 +119,7 @@ namespace osu.Game.Screens.Select
                     },
                 });
 
-                Add(overflowButton = new TagsOverflowButton(tags)
+                Add(overflowButton = new TagsOverflowButton(tags, shownText)
                 {
                     Alpha = 0f,
                     PerformSearch = s => PerformSearch?.Invoke(s),
@@ -137,9 +142,12 @@ namespace osu.Game.Screens.Select
 
                 public Action<string>? PerformSearch { get; init; }
 
-                public TagsOverflowButton(string[] tags)
+                private readonly Bindable<int> overflowIndex;
+
+                public TagsOverflowButton(string[] tags, Bindable<int> overflowIndex)
                 {
                     this.tags = tags;
+                    this.overflowIndex = overflowIndex;
                 }
 
                 [BackgroundDependencyLoader]
@@ -188,18 +196,22 @@ namespace osu.Game.Screens.Select
                     return true;
                 }
 
-                public Popover GetPopover() => new TagsOverflowPopover(tags, PerformSearch);
+                public Popover GetPopover() => new TagsOverflowPopover(tags, overflowIndex, PerformSearch);
             }
 
             public partial class TagsOverflowPopover : OsuPopover
             {
                 private readonly string[] tags;
+                private readonly Bindable<int> overflowIndex;
                 private readonly Action<string>? performSearch;
 
-                public TagsOverflowPopover(string[] tags, Action<string>? performSearchAction)
+                public TagsOverflowPopover(string[] tags, Bindable<int> overflowIndex, Action<string>? performSearchAction)
                 {
                     this.tags = tags;
+                    this.overflowIndex = overflowIndex;
                     performSearch = performSearchAction;
+
+                    this.overflowIndex.BindValueChanged(overflowChanged);
                 }
 
                 [BackgroundDependencyLoader]
@@ -213,11 +225,23 @@ namespace osu.Game.Screens.Select
                         AutoSizeAxes = Axes.Y,
                     };
 
-                    foreach (string tag in tags)
+                    for (int i = overflowIndex.Value; i < tags.Length; i++)
                     {
+                        string tag = tags[i];
                         textFlow.AddLink(tag, () => performSearch?.Invoke(tag));
                         textFlow.AddText(" ");
                     }
+                }
+
+                private void overflowChanged(ValueChangedEvent<int> e)
+                {
+                    load();
+                }
+
+                protected override void Dispose(bool isDisposing)
+                {
+                    base.Dispose(isDisposing);
+                    overflowIndex.UnbindEvents();
                 }
             }
         }


### PR DESCRIPTION
I found that the overflow in mapper tags was showing the tags that were already shown, so I removed them in the popup. I've also let the popup react to layout updates.


https://github.com/user-attachments/assets/f952c23b-990c-4bce-8c44-58ecf7db33f6