### PR TITLE
Implement legacy footer buttons UI

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneLegacyFooterButtons.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneLegacyFooterButtons.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Skinning;
+using osu.Game.Skinning.Select;
+
+namespace osu.Game.Tests.Visual.SongSelect
+{
+    public partial class TestSceneLegacyFooterButtons : OsuTestScene
+    {
+        [Resolved]
+        private SkinManager skins { get; set; } = null!;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            const float ruleset_width = 57.6f * 1.6f;
+            const float button_width = 48f * 1.6f;
+
+            Child = new SkinProvidingContainer(skins.DefaultClassicSkin)
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.None,
+                AutoSizeAxes = Axes.Both,
+                Child = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Children = new[]
+                    {
+                        new LegacyRulesetFooterButton(),
+                        new LegacyFooterButton("mods") { X = ruleset_width },
+                        new LegacyFooterButton("random") { X = ruleset_width + button_width },
+                        new LegacyFooterButton("options") { X = ruleset_width + button_width * 2 },
+                    }
+                },
+            };
+        });
+    }
+}

--- a/osu.Game/Skinning/Select/LegacyFooterButton.cs
+++ b/osu.Game/Skinning/Select/LegacyFooterButton.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Skinning.Select
             {
                 new Sprite
                 {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
                     Texture = skin.GetTexture($"selection-{kind}"),
                     // to match stable, the button input area should not be taken from this sprite. it should be taken from the hover sprite below.
                     // see: https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameModes/Select/SongSelection.cs#L340-L349
@@ -41,6 +43,8 @@ namespace osu.Game.Skinning.Select
                 },
                 hoverSprite = new Sprite
                 {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
                     Texture = skin.GetTexture($"selection-{kind}-over"),
                     Alpha = 0f,
                     AlwaysPresent = true,
@@ -54,7 +58,7 @@ namespace osu.Game.Skinning.Select
         {
             hoverSprite.FadeIn(100);
             hoverSound.Play();
-            return base.OnHover(e);
+            return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)

--- a/osu.Game/Skinning/Select/LegacyFooterButton.cs
+++ b/osu.Game/Skinning/Select/LegacyFooterButton.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Audio;
+
+namespace osu.Game.Skinning.Select
+{
+    public partial class LegacyFooterButton : ClickableContainer
+    {
+        private readonly string kind;
+
+        private Sprite hoverSprite = null!;
+        private SkinnableSound hoverSound = null!;
+        private SkinnableSound clickSound = null!;
+
+        public LegacyFooterButton(string kind)
+        {
+            this.kind = kind;
+
+            Enabled.Value = true;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skin)
+        {
+            AutoSizeAxes = Axes.Both;
+
+            Children = new Drawable[]
+            {
+                new Sprite
+                {
+                    Texture = skin.GetTexture($"selection-{kind}"),
+                    // to match stable, the button input area should not be taken from this sprite. it should be taken from the hover sprite below.
+                    // see: https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameModes/Select/SongSelection.cs#L340-L349
+                    BypassAutoSizeAxes = Axes.Both,
+                },
+                hoverSprite = new Sprite
+                {
+                    Texture = skin.GetTexture($"selection-{kind}-over"),
+                    Alpha = 0f,
+                    AlwaysPresent = true,
+                },
+                hoverSound = new SkinnableSound(new SampleInfo("click-short")),
+                clickSound = new SkinnableSound(new SampleInfo("click-short-confirm")),
+            };
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            hoverSprite.FadeIn(100);
+            hoverSound.Play();
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            hoverSprite.FadeOut(100);
+            base.OnHoverLost(e);
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            clickSound.Play();
+            return base.OnClick(e);
+        }
+    }
+}

--- a/osu.Game/Skinning/Select/LegacyRulesetFooterButton.cs
+++ b/osu.Game/Skinning/Select/LegacyRulesetFooterButton.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Skinning.Select
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.Centre,
+                BypassAutoSizeAxes = Axes.Both,
                 X = 57.6f / 2 * 1.6f,
                 Y = -35 * 1.6f,
             });

--- a/osu.Game/Skinning/Select/LegacyRulesetFooterButton.cs
+++ b/osu.Game/Skinning/Select/LegacyRulesetFooterButton.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Skinning.Select
+{
+    public partial class LegacyRulesetFooterButton : LegacyFooterButton
+    {
+        private Sprite modeIcon = null!;
+
+        [Resolved]
+        private ISkinSource skin { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        public LegacyRulesetFooterButton()
+            : base("mode")
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(modeIcon = new Sprite
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.Centre,
+                X = 57.6f / 2 * 1.6f,
+                Y = -35 * 1.6f,
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ruleset.BindValueChanged(r =>
+            {
+                modeIcon.Texture = skin.GetTexture($@"mode-{r.NewValue.ShortName}-small");
+            }, true);
+        }
+    }
+}


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-resources/pull/426

<img width="617" height="248" alt="CleanShot 2026-05-21 at 05 27 57" src="https://github.com/user-attachments/assets/0f335383-07f7-4d31-bc54-4c59db97f06c" />

Notes:
 - The ruleset button temporarily plays `click-short-confirm` on click rather than `select-expand` like in stable. Can be changed when the menu displayed from the button is implemented (if implemented).