### PR TITLE
Make experimental audio the new default

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneMigrateAudioDialog.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneMigrateAudioDialog.cs
@@ -19,11 +19,20 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestBasic()
+        public void TestWasUsing()
         {
             AddStep("create dialog", () =>
             {
-                overlay.Push(new MigrateNewAudioDialog());
+                overlay.Push(new MigrateNewAudioDialog(true));
+            });
+        }
+
+        [Test]
+        public void TestNotUsing()
+        {
+            AddStep("create dialog", () =>
+            {
+                overlay.Push(new MigrateNewAudioDialog(false));
             });
         }
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneMigrateAudioDialog.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneMigrateAudioDialog.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Configuration;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public partial class TestSceneMigrateAudioDialog : OsuManualInputManagerTestScene
+    {
+        private DialogOverlay overlay = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create dialog overlay", () => Child = overlay = new DialogOverlay());
+        }
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("create dialog", () =>
+            {
+                overlay.Push(new MigrateNewAudioDialog());
+            });
+        }
+    }
+}

--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using osu.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
@@ -49,6 +50,11 @@ namespace osu.Game.Beatmaps
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        private Bindable<bool> experimentalAudio = null!;
+
         public bool IsRewinding { get; private set; }
 
         public FramedBeatmapClock(bool applyOffsets, bool requireDecoupling, IClock? source = null)
@@ -66,9 +72,7 @@ namespace osu.Game.Beatmaps
 
             if (applyOffsets)
             {
-                // Audio timings in general with newer BASS versions don't match stable.
-                // This only seems to be required on windows. We need to eventually figure out why, with a bit of luck.
-                platformOffsetClock = new OffsetCorrectionClock(interpolatedTrack) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
+                platformOffsetClock = new OffsetCorrectionClock(interpolatedTrack);
 
                 // User global offset (set in settings) should also be applied.
                 userGlobalOffsetClock = new OffsetCorrectionClock(platformOffsetClock);
@@ -94,6 +98,9 @@ namespace osu.Game.Beatmaps
                 userAudioOffset = config.GetBindable<double>(OsuSetting.AudioOffset);
                 userAudioOffset.BindValueChanged(offset => userGlobalOffsetClock.Offset = offset.NewValue, true);
 
+                experimentalAudio = audioManager.UseExperimentalWasapi.GetBoundCopy();
+                experimentalAudio.BindValueChanged(_ => updatePlatformOffset());
+
                 // TODO: this doesn't update when using ChangeSource() to change beatmap.
                 beatmapOffsetSubscription = realm.SubscribeToPropertyChanged(
                     r => r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID)?.UserSettings,
@@ -102,6 +109,39 @@ namespace osu.Game.Beatmaps
                     {
                         userBeatmapOffsetClock.Offset = val;
                     });
+            }
+        }
+
+        /// <summary>
+        /// Audio timings in general with newer BASS versions don't match stable.
+        /// This only seems to be required on windows. We need to eventually figure out why, with a bit of luck.
+        /// </summary>
+        public const double WINDOWS_BASE_AUDIO_OFFSET = 15;
+
+        /// <summary>
+        /// An additional offset applied to account for experimental mode being much better.
+        /// </summary>
+        public const double WINDOWS_EXPERIMENTAL_AUDIO_OFFSET = -25;
+
+        private void updatePlatformOffset()
+        {
+            if (!applyOffsets)
+                return;
+
+            Debug.Assert(platformOffsetClock != null);
+
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.Windows:
+                    platformOffsetClock.Offset = WINDOWS_BASE_AUDIO_OFFSET;
+
+                    if (audioManager.UseExperimentalWasapi.Value)
+                        platformOffsetClock.Offset += WINDOWS_EXPERIMENTAL_AUDIO_OFFSET;
+                    return;
+
+                default:
+                    platformOffsetClock.Offset = 0;
+                    break;
             }
         }
 

--- a/osu.Game/Configuration/MigrateNewAudioDialog.cs
+++ b/osu.Game/Configuration/MigrateNewAudioDialog.cs
@@ -17,19 +17,45 @@ namespace osu.Game.Configuration
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
-        public MigrateNewAudioDialog()
+        public MigrateNewAudioDialog(bool wasAlreadyUsing)
         {
             Icon = FontAwesome.Regular.Bell;
 
-            HeaderText = @"New audio engine has been enabled";
-            BodyText =
-                $"""
-                 We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now default mode.
+            if (wasAlreadyUsing)
+            {
+                HeaderText = @"New audio engine is now default!";
+                BodyText =
+                    $"""
+                     We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now default mode.
 
-                 If you were already using this engine, your audio offset has been adjusted to account an internal offset change (no intervention required).
+                     As you were already using this engine, your audio offset has been adjusted to account an internal offset change (no intervention required).
 
-                 If you have any issues, you can switch back to the legacy engine below, or at any time in settings via the "{AudioSettingsStrings.LegacyAudioLabel}" checkbox.
-                 """;
+                     If you have any issues, you can switch back to the legacy engine from settings via the "{AudioSettingsStrings.LegacyAudioLabel}" checkbox.
+                     """;
+            }
+            else
+            {
+                HeaderText = @"New audio engine has been enabled";
+                BodyText =
+                    $"""
+                     We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now default mode.
+
+                     If you have any issues, you can switch back to the legacy engine below, or at any time in settings via the "{AudioSettingsStrings.LegacyAudioLabel}" checkbox.
+                     """;
+
+                MainContent.Add(new Container
+                {
+                    Margin = new MarginPadding { Top = 20 },
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 400,
+                    AutoSizeAxes = Axes.Y,
+                    Children = new Drawable[]
+                    {
+                        new LegacyAudioCheckbox(),
+                    }
+                });
+            }
 
             Buttons = new PopupDialogButton[]
             {
@@ -38,19 +64,6 @@ namespace osu.Game.Configuration
                     Text = BeatmapOverlayStrings.UserContentConfirmButtonText,
                 },
             };
-
-            MainContent.Add(new Container
-            {
-                Margin = new MarginPadding { Top = 20 },
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Width = 400,
-                AutoSizeAxes = Axes.Y,
-                Children = new Drawable[]
-                {
-                    new LegacyAudioCheckbox(),
-                }
-            });
         }
     }
 }

--- a/osu.Game/Configuration/MigrateNewAudioDialog.cs
+++ b/osu.Game/Configuration/MigrateNewAudioDialog.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Dialog;
+using osu.Game.Overlays.Settings.Sections.Audio;
+
+namespace osu.Game.Configuration
+{
+    public partial class MigrateNewAudioDialog : PopupDialog
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        public MigrateNewAudioDialog()
+        {
+            Icon = FontAwesome.Regular.Bell;
+
+            HeaderText = @"New audio engine has been enabled";
+            BodyText =
+                $"""
+                 We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now default mode.
+
+                 If you were already using this engine, your audio offset has been adjusted to account an internal offset change (no intervention required).
+
+                 If you have any issues, you can switch back to the legacy engine below, or at any time in settings via the "{AudioSettingsStrings.LegacyAudioLabel}" checkbox.
+                 """;
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogOkButton
+                {
+                    Text = BeatmapOverlayStrings.UserContentConfirmButtonText,
+                },
+            };
+
+            MainContent.Add(new Container
+            {
+                Margin = new MarginPadding { Top = 20 },
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 400,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
+                {
+                    new LegacyAudioCheckbox(),
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Configuration/MigrateNewAudioDialog.cs
+++ b/osu.Game/Configuration/MigrateNewAudioDialog.cs
@@ -26,9 +26,9 @@ namespace osu.Game.Configuration
                 HeaderText = @"New audio engine is now default!";
                 BodyText =
                     $"""
-                     We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now default mode.
+                     We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now the default mode.
 
-                     As you were already using this engine, your audio offset has been adjusted to account an internal offset change (no intervention required).
+                     As you were already using this engine, your audio offset has been adjusted to account for an internal offset change (no intervention required).
 
                      If you have any issues, you can switch back to the legacy engine from settings via the "{AudioSettingsStrings.LegacyAudioLabel}" checkbox.
                      """;
@@ -38,7 +38,7 @@ namespace osu.Game.Configuration
                 HeaderText = @"New audio engine has been enabled";
                 BodyText =
                     $"""
-                     We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now default mode.
+                     We recently added a new "Experimental Audio" backend for Windows users to reduce hitsound latency. Due to overwhelmingly positive feedback, this is now the default mode.
 
                      If you have any issues, you can switch back to the legacy engine below, or at any time in settings via the "{AudioSettingsStrings.LegacyAudioLabel}" checkbox.
                      """;

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -100,19 +100,14 @@ namespace osu.Game.Localisation
         public static LocalisableString AdjustBeatmapOffsetAutomaticallyTooltip => new TranslatableString(getKey(@"adjust_beatmap_offset_automatically_tooltip"), @"If enabled, the offset suggested from last play on a beatmap is automatically applied.");
 
         /// <summary>
-        /// "Use experimental audio mode"
+        /// "Use legacy audio mode"
         /// </summary>
-        public static LocalisableString WasapiLabel => new TranslatableString(getKey(@"wasapi_label"), @"Use experimental audio mode");
+        public static LocalisableString LegacyAudioLabel => new TranslatableString(getKey(@"legacy_audio_label"), @"Use legacy audio mode");
 
         /// <summary>
-        /// "This will attempt to initialise the audio engine in a lower latency mode."
+        /// "Use this if you are experiencing audio issues. Note that audio latency will be higher when this is toggled on."
         /// </summary>
-        public static LocalisableString WasapiTooltip => new TranslatableString(getKey(@"wasapi_tooltip"), @"This will attempt to initialise the audio engine in a lower latency mode.");
-
-        /// <summary>
-        /// "Due to reduced latency, your audio offset will need to be adjusted when enabling this setting. Generally expect to subtract 20 - 60 ms from your known value."
-        /// </summary>
-        public static LocalisableString WasapiNotice => new TranslatableString(getKey(@"wasapi_notice"), @"Due to reduced latency, your audio offset will need to be adjusted when enabling this setting. Generally expect to subtract 20 - 60 ms from your known value.");
+        public static LocalisableString LegacyAudioTooltip => new TranslatableString(getKey(@"legacy_audio_tooltip"), @"Use this if you are experiencing audio issues. Note that audio latency will be higher when this is toggled on.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1345,6 +1345,15 @@ namespace osu.Game
                 if (penHandler != null && mouseHandler != null && penHandler.Sensitivity.IsDefault)
                     penHandler.Sensitivity.Value = mouseHandler.Sensitivity.Value;
             }
+
+            if (combined < 20260521 && RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
+            {
+                // account for users that already had this set on and had adjusted their offset.
+                if (Audio.UseExperimentalWasapi.Value)
+                    LocalConfig.SetValue(OsuSetting.AudioOffset, LocalConfig.Get<double>(OsuSetting.AudioOffset) - FramedBeatmapClock.WINDOWS_EXPERIMENTAL_AUDIO_OFFSET);
+
+                Audio.UseExperimentalWasapi.Value = true;
+            }
         }
 
         private void handleBackButton()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -161,6 +161,8 @@ namespace osu.Game
 
         private OnScreenDisplay onScreenDisplay;
 
+        private DialogOverlay dialogOverlay;
+
         [Resolved]
         private FrameworkConfigManager frameworkConfig { get; set; }
 
@@ -1237,7 +1239,7 @@ namespace osu.Game
             }, rightFloatingOverlayContent.Add, true);
 
             loadComponentSingleFile(new AccountCreationOverlay(), topMostOverlayContent.Add, true);
-            loadComponentSingleFile<IDialogOverlay>(new DialogOverlay(), topMostOverlayContent.Add, true);
+            loadComponentSingleFile<IDialogOverlay>(dialogOverlay = new DialogOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add);
@@ -1353,6 +1355,8 @@ namespace osu.Game
                     LocalConfig.SetValue(OsuSetting.AudioOffset, LocalConfig.Get<double>(OsuSetting.AudioOffset) - FramedBeatmapClock.WINDOWS_EXPERIMENTAL_AUDIO_OFFSET);
 
                 Audio.UseExperimentalWasapi.Value = true;
+
+                dialogOverlay.Push(new MigrateNewAudioDialog());
             }
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1352,7 +1352,9 @@ namespace osu.Game
             {
                 bool wasAlreadyUsing = Audio.UseExperimentalWasapi.Value;
 
-                // account for users that already had this set on and had adjusted their offset.
+                // see application of FramedBeatmapClock.WINDOWS_EXPERIMENTAL_AUDIO_OFFSET in FramedBeatmapClock.
+                // this basically undoes this new offset assuming that users which have been using this setting for a while
+                // already have had things tuned.
                 if (wasAlreadyUsing)
                     LocalConfig.SetValue(OsuSetting.AudioOffset, LocalConfig.Get<double>(OsuSetting.AudioOffset) - FramedBeatmapClock.WINDOWS_EXPERIMENTAL_AUDIO_OFFSET);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1047,6 +1047,7 @@ namespace osu.Game
                 { FrameworkSetting.VolumeUniversal, 0.6 },
                 { FrameworkSetting.VolumeMusic, 0.6 },
                 { FrameworkSetting.VolumeEffect, 0.6 },
+                { FrameworkSetting.AudioUseExperimentalWasapi, true },
             };
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1350,13 +1350,15 @@ namespace osu.Game
 
             if (combined < 20260521 && RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
             {
+                bool wasAlreadyUsing = Audio.UseExperimentalWasapi.Value;
+
                 // account for users that already had this set on and had adjusted their offset.
-                if (Audio.UseExperimentalWasapi.Value)
+                if (wasAlreadyUsing)
                     LocalConfig.SetValue(OsuSetting.AudioOffset, LocalConfig.Get<double>(OsuSetting.AudioOffset) - FramedBeatmapClock.WINDOWS_EXPERIMENTAL_AUDIO_OFFSET);
 
                 Audio.UseExperimentalWasapi.Value = true;
 
-                dialogOverlay.Push(new MigrateNewAudioDialog());
+                dialogOverlay.Push(new MigrateNewAudioDialog(wasAlreadyUsing));
             }
         }
 

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -40,6 +40,8 @@ namespace osu.Game.Overlays.Dialog
         private readonly TextFlowContainer header;
         private readonly TextFlowContainer body;
 
+        public Container MainContent { get; private set; }
+
         private bool actionInvoked;
 
         public IconUsage Icon
@@ -220,6 +222,13 @@ namespace osu.Game.Overlays.Dialog
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                     Padding = new MarginPadding { Horizontal = 15 },
+                                },
+                                MainContent = new Container
+                                {
+                                    Origin = Anchor.TopCentre,
+                                    Anchor = Anchor.TopCentre,
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
                                 },
                                 buttonsContainer = new FillFlowContainer<PopupDialogButton>
                                 {

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -26,8 +26,6 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 
         private FormCheckBox? legacyAudio;
 
-        private Bindable<bool>? configExperimentalAudio;
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -44,28 +42,12 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
             {
-                configExperimentalAudio = audio.UseExperimentalWasapi.GetBoundCopy();
-
-                Add(new SettingsItemV2(legacyAudio = new FormCheckBox
-                {
-                    Caption = AudioSettingsStrings.LegacyAudioLabel,
-                    HintText = AudioSettingsStrings.LegacyAudioTooltip,
-                })
+                Add(new SettingsItemV2(legacyAudio = new LegacyAudioCheckbox())
                 {
                     Keywords = new[] { "wasapi", "latency", "exclusive", "legacy", "experimental" },
                 });
 
-                // Manual two-way binding because we're inversing what the framework exposes.
-                legacyAudio.Current.ValueChanged += legacy =>
-                {
-                    configExperimentalAudio.Value = !legacy.NewValue;
-                    onDeviceChanged(string.Empty);
-                };
-
-                configExperimentalAudio.BindValueChanged(experimental =>
-                {
-                    legacyAudio.Current.Value = !experimental.NewValue;
-                }, true);
+                legacyAudio.Current.ValueChanged += _ => onDeviceChanged(string.Empty);
             }
 
             audio.OnNewDevice += onDeviceChanged;
@@ -75,7 +57,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
             onDeviceChanged(string.Empty);
         }
 
-        private void onDeviceChanged(string _) => updateItems();
+        private void onDeviceChanged(string _) => Scheduler.AddOnce(updateItems);
 
         private void updateItems()
         {
@@ -114,6 +96,39 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
         {
             protected override LocalisableString GenerateItemText(string item)
                 => string.IsNullOrEmpty(item) ? CommonStrings.Default : base.GenerateItemText(item);
+        }
+    }
+
+    public partial class LegacyAudioCheckbox : FormCheckBox
+    {
+        private Bindable<bool> configExperimentalAudio = null!;
+
+        public LegacyAudioCheckbox()
+        {
+            Caption = AudioSettingsStrings.LegacyAudioLabel;
+            HintText = AudioSettingsStrings.LegacyAudioTooltip;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            configExperimentalAudio = audio.UseExperimentalWasapi.GetBoundCopy();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // Manual two-way binding because we're inversing what the framework exposes.
+            Current.ValueChanged += legacy =>
+            {
+                configExperimentalAudio.Value = !legacy.NewValue;
+            };
+
+            configExperimentalAudio.BindValueChanged(experimental =>
+            {
+                Current.Value = !experimental.NewValue;
+            }, true);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
         {
             base.LoadComplete();
 
-            // Manual two-way binding because we're inversing what the framework exposes.
+            // Manual two-way binding because we're inverting what the framework exposes.
             Current.ValueChanged += legacy =>
             {
                 configExperimentalAudio.Value = !legacy.NewValue;

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -24,9 +24,9 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 
         private AudioDeviceDropdown dropdown = null!;
 
-        private FormCheckBox? wasapiExperimental;
+        private FormCheckBox? legacyAudio;
 
-        private readonly Bindable<SettingsNote.Data?> wasapiExperimentalNote = new Bindable<SettingsNote.Data?>();
+        private Bindable<bool>? configExperimentalAudio;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -44,18 +44,28 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
             {
-                Add(new SettingsItemV2(wasapiExperimental = new FormCheckBox
+                configExperimentalAudio = audio.UseExperimentalWasapi.GetBoundCopy();
+
+                Add(new SettingsItemV2(legacyAudio = new FormCheckBox
                 {
-                    Caption = AudioSettingsStrings.WasapiLabel,
-                    HintText = AudioSettingsStrings.WasapiTooltip,
-                    Current = audio.UseExperimentalWasapi,
+                    Caption = AudioSettingsStrings.LegacyAudioLabel,
+                    HintText = AudioSettingsStrings.LegacyAudioTooltip,
                 })
                 {
-                    Keywords = new[] { "wasapi", "latency", "exclusive" },
-                    Note = { BindTarget = wasapiExperimentalNote },
+                    Keywords = new[] { "wasapi", "latency", "exclusive", "legacy", "experimental" },
                 });
 
-                wasapiExperimental.Current.ValueChanged += _ => onDeviceChanged(string.Empty);
+                // Manual two-way binding because we're inversing what the framework exposes.
+                legacyAudio.Current.ValueChanged += legacy =>
+                {
+                    configExperimentalAudio.Value = !legacy.NewValue;
+                    onDeviceChanged(string.Empty);
+                };
+
+                configExperimentalAudio.BindValueChanged(experimental =>
+                {
+                    legacyAudio.Current.Value = !experimental.NewValue;
+                }, true);
             }
 
             audio.OnNewDevice += onDeviceChanged;
@@ -65,18 +75,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
             onDeviceChanged(string.Empty);
         }
 
-        private void onDeviceChanged(string _)
-        {
-            updateItems();
-
-            if (wasapiExperimental != null)
-            {
-                if (wasapiExperimental.Current.Value)
-                    wasapiExperimentalNote.Value = new SettingsNote.Data(AudioSettingsStrings.WasapiNotice, SettingsNote.Type.Warning);
-                else
-                    wasapiExperimentalNote.Value = null;
-            }
-        }
+        private void onDeviceChanged(string _) => updateItems();
 
         private void updateItems()
         {


### PR DESCRIPTION
Internal offset adjust is based on [survey results](https://docs.google.com/forms/d/1bWdwN9LPB4dJsqh2NO4z0HBiMiod1k8-tJN5oca-1Iw/edit) results (mean: 17.95, median: 24.5) with slight skewing based on cherry-picking results and personal experiences.

For users which have had the setting disabled:

<img width="1380" height="774" alt="osu! 2026-05-21 at 09 19 06" src="https://github.com/user-attachments/assets/0526517a-fa0b-485b-ac1b-b61b2fccd2af" />

For users which are already using it:

<img width="1380" height="774" alt="osu! 2026-05-21 at 09 20 24" src="https://github.com/user-attachments/assets/1bd77b39-5d75-43e8-8fe1-b324064b25fa" />

Note the button is intentionally hidden to avoid any confusion (it's inverse now, so some users may mistakenly click it). Assume if a user is already on the new engine, they are happy with it.

Test migration dialog in startup game flow using:

```diff
diff --git a/osu.Game/OsuGame.cs b/osu.Game/OsuGame.cs
index 4bd5ab83a3..091af6d428 100644
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1315,6 +1315,8 @@ protected override void LoadComplete()
         /// </remarks>
         private void applyConfigMigrations()
         {
+            dialogOverlay.Push(new MigrateNewAudioDialog(true));
+
             // arrives as 2020.123.0-lazer
             string rawVersion = LocalConfig.Get<string>(OsuSetting.Version);
 

```
