### PR TITLE
Increase minimum size of video/storyboard icons globally

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
@@ -244,10 +244,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             });
 
             if (BeatmapSet.HasVideo)
-                leftIconArea.Add(new VideoIconPill { IconSize = new Vector2(16) });
+                leftIconArea.Add(new VideoIconPill());
 
             if (BeatmapSet.HasStoryboard)
-                leftIconArea.Add(new StoryboardIconPill { IconSize = new Vector2(16) });
+                leftIconArea.Add(new StoryboardIconPill());
 
             if (BeatmapSet.FeaturedInSpotlight)
             {

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -226,10 +226,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             });
 
             if (BeatmapSet.HasVideo)
-                leftIconArea.Add(new VideoIconPill { IconSize = new Vector2(16) });
+                leftIconArea.Add(new VideoIconPill());
 
             if (BeatmapSet.HasStoryboard)
-                leftIconArea.Add(new StoryboardIconPill { IconSize = new Vector2(16) });
+                leftIconArea.Add(new StoryboardIconPill());
 
             if (BeatmapSet.FeaturedInSpotlight)
             {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Match/BeatmapSelect/MatchmakingSelectPanel.CardContentBeatmap.cs
@@ -307,10 +307,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Match.BeatmapSelect
                 };
 
                 if (beatmapSet.HasVideo)
-                    leftIconArea.Add(new VideoIconPill { IconSize = new Vector2(16) });
+                    leftIconArea.Add(new VideoIconPill());
 
                 if (beatmapSet.HasStoryboard)
-                    leftIconArea.Add(new StoryboardIconPill { IconSize = new Vector2(16) });
+                    leftIconArea.Add(new StoryboardIconPill());
 
                 if (beatmapSet.HasExplicitContent)
                 {


### PR DESCRIPTION
They were shockingly small.

| Before | After |
| :---: | :---: |
| <img width="1358" height="601" alt="osu! 2026-05-22 at 08 19 27" src="https://github.com/user-attachments/assets/4e3ea756-2970-4b7a-b59d-0e684d5bfe49" /> | <img width="1358" height="601" alt="osu! 2026-05-22 at 08 17 23" src="https://github.com/user-attachments/assets/f0ce6385-6da8-4cb3-837c-0199f0034529" /> |
| <img width="1358" height="601" alt="osu! 2026-05-22 at 08 19 34" src="https://github.com/user-attachments/assets/97bb06ed-4563-4fbc-a897-490abb593151" /> | <img width="1358" height="601" alt="osu! 2026-05-22 at 08 17 16" src="https://github.com/user-attachments/assets/294a14f9-09b5-480a-a383-15d82bde1aa0" /> |