### PR TITLE
Follow-up fixes for client-side slots implementation

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -1011,6 +1011,7 @@ namespace osu.Game.Online.Multiplayer
             APIRoom.AutoStartDuration = Room.Settings.AutoStartDuration;
             APIRoom.CurrentPlaylistItem = APIRoom.Playlist.Single(item => item.ID == settings.PlaylistItemId);
             APIRoom.AutoSkip = Room.Settings.AutoSkip;
+            APIRoom.MaxParticipants = Room.Settings.MaxParticipants;
 
             SettingsChanged?.Invoke(settings);
             RoomUpdated?.Invoke();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -63,7 +63,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
                 for (byte i = 0; i < slotUserIds.Length; ++i)
                 {
-                    var participant = slotUserIds[i] == null ? Slot.Empty(i) : Slot.FromUser(client.Room.Users.Single(u => u.UserID == slotUserIds[i]));
+                    var user = slotUserIds[i] != null ? client.Room.Users.SingleOrDefault(u => u.UserID == slotUserIds[i]) : null;
+                    var participant = user == null ? Slot.Empty(i) : Slot.FromUser(client.Room.Users.Single(u => u.UserID == slotUserIds[i]));
 
                     if (i >= slots.Count)
                         slots.Add(participant);


### PR DESCRIPTION
Fell out of full-stack testing with https://github.com/ppy/osu-server-spectator/pull/513.

- **Fix missing property copy in multiplayer client**
  Would cause the participant count limit to not update on the multiplayer match screen.
  

- **Fix hard crash when user is kicked from a room with slots active**
  The kicked user is unsubscribed from receiving room state updates before their slot is vacated, which then would lead this code to attempt to look the local, kicked user via the unvacated slot and thus fail because `client.Room.Users` does *not* contain the user anymore.
  
  This is a bit of a dicey change but I think it's less dicey than to try to wiggle ordering server-side.
  