### PR TITLE
Fix "Click to see what's new!" notification no longer appearing

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1301,10 +1301,17 @@ namespace osu.Game
 
             applyConfigMigrations();
 
+            string lastVersion = LocalConfig.Get<string>(OsuSetting.Version);
+            string version = Version;
+
+            // only show a notification if we've previously saved a version to the config file (ie. not the first run).
+            if (IsDeployedBuild && !string.IsNullOrEmpty(lastVersion) && version != lastVersion)
+                Notifications.Post(new UpdateCompleteNotification(version));
+
             // finally, update the version stored to the configuration.
             // this MUST happen after `applyConfigMigrations()` call, as it relies on comparing the previous version.
             // debug / local compilations will reset to a non-release string.
-            LocalConfig.SetValue(OsuSetting.Version, Version);
+            LocalConfig.SetValue(OsuSetting.Version, version);
         }
 
         /// <summary>

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -56,15 +56,8 @@ namespace osu.Game.Updater
         {
             base.LoadComplete();
 
-            string version = game.Version;
-            string lastVersion = config.Get<string>(OsuSetting.Version);
-
             if (game.IsDeployedBuild)
             {
-                // only show a notification if we've previously saved a version to the config file (ie. not the first run).
-                if (!string.IsNullOrEmpty(lastVersion) && version != lastVersion)
-                    Notifications.Post(new UpdateCompleteNotification(version));
-
                 // make sure the release stream setting matches the build which was just run.
                 if (FixedReleaseStream != null)
                     config.SetValue(OsuSetting.ReleaseStream, FixedReleaseStream.Value);
@@ -135,31 +128,6 @@ namespace osu.Game.Updater
 
             updateCancellationSource.Cancel();
             updateCancellationSource.Dispose();
-        }
-
-        private partial class UpdateCompleteNotification : SimpleNotification
-        {
-            private readonly string version;
-
-            public UpdateCompleteNotification(string version)
-            {
-                this.version = version;
-                Text = NotificationsStrings.GameVersionAfterUpdate(version);
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours, ChangelogOverlay changelog, INotificationOverlay notificationOverlay)
-            {
-                Icon = FontAwesome.Solid.CheckSquare;
-                IconContent.Colour = colours.BlueDark;
-
-                Activated = delegate
-                {
-                    notificationOverlay.Hide();
-                    changelog.ShowBuild(version);
-                    return true;
-                };
-            }
         }
 
         public partial class UpdateDownloadProgressNotification : ProgressNotification
@@ -257,6 +225,31 @@ namespace osu.Game.Updater
                 if (cancellationToken.IsCancellationRequested)
                     Close(false);
             }
+        }
+    }
+
+    public partial class UpdateCompleteNotification : SimpleNotification
+    {
+        private readonly string version;
+
+        public UpdateCompleteNotification(string version)
+        {
+            this.version = version;
+            Text = NotificationsStrings.GameVersionAfterUpdate(version);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, ChangelogOverlay changelog, INotificationOverlay notificationOverlay)
+        {
+            Icon = FontAwesome.Solid.CheckSquare;
+            IconContent.Colour = colours.BlueDark;
+
+            Activated = delegate
+            {
+                notificationOverlay.Hide();
+                changelog.ShowBuild(version);
+                return true;
+            };
         }
     }
 }


### PR DESCRIPTION
- Regressed with https://github.com/ppy/osu/pull/37839.
- Closes https://github.com/ppy/osu/issues/37870

I feel like `UpdateManager` should remain a background component, so moving this notification into a new stable execution path is best to me.