### PR TITLE
Add Proper Safeguard and Real Time Invalidation to `MatchFoundNotification`

### DIFF
--- a/osu.Game/Localisation/MultiplayerMatchStrings.cs
+++ b/osu.Game/Localisation/MultiplayerMatchStrings.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Your match has been invalidated by the server (Your opponent probably left). Automatically queued again for you."
         /// </summary>
-        public static LocalisableString MatchInvalidatedWithRequeue => new TranslatableString(getKey(@"match_requeued"), @"Your match has been invalidated by the server (Your opponent probably left). Automatically queued again for you.");
+        public static LocalisableString MatchInvalidatedWithRequeue => new TranslatableString(getKey(@"match_invalidated_with_requeue"), @"Your match has been invalidated by the server (Your opponent probably left). Automatically queued again for you.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/MultiplayerMatchStrings.cs
+++ b/osu.Game/Localisation/MultiplayerMatchStrings.cs
@@ -50,9 +50,9 @@ namespace osu.Game.Localisation
         public static LocalisableString MatchIsReady => new TranslatableString(getKey(@"match_is_ready"), @"Your match is ready! Click to join.");
 
         /// <summary>
-        /// "Your match has been invalidated, please queue again. (Most common reason: Match timed out)"
+        /// "Your match has been invalidated by the server. Please queue again. (Most common reason: Match timed out)"
         /// </summary>
-        public static LocalisableString MatchInvalid => new TranslatableString(getKey(@"match_invalid"), @"Your match has been invalidated, please queue again. (Most common reason: Match timed out)");
+        public static LocalisableString MatchInvalid => new TranslatableString(getKey(@"match_invalid"), @"Your match has been invalidated by the server. Please queue again. (Most common reason: Match timed out)");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/MultiplayerMatchStrings.cs
+++ b/osu.Game/Localisation/MultiplayerMatchStrings.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString MatchIsReady => new TranslatableString(getKey(@"match_is_ready"), @"Your match is ready! Click to join.");
 
+        /// <summary>
+        /// "Your match has been invalidated, please queue again. (Most common reason: Match timed out)"
+        /// </summary>
+        public static LocalisableString MatchInvalid => new TranslatableString(getKey(@"match_invalid"), @"Your match has been invalidated, please queue again. (Most common reason: Match timed out)");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/MultiplayerMatchStrings.cs
+++ b/osu.Game/Localisation/MultiplayerMatchStrings.cs
@@ -52,7 +52,12 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Your match has timed out. Click to queue again."
         /// </summary>
-        public static LocalisableString MatchTimedout => new TranslatableString(getKey(@"match_timed_out"), @"Your match has timed out. Click to queue again.");
+        public static LocalisableString MatchInvalidated => new TranslatableString(getKey(@"match_timed_out"), @"Your match has timed out. Click to queue again.");
+
+        /// <summary>
+        /// "Your match has been invalidated by the server (Your opponent probably left). Automatically queued again for you."
+        /// </summary>
+        public static LocalisableString MatchInvalidatedWithRequeue => new TranslatableString(getKey(@"match_requeued"), @"Your match has been invalidated by the server (Your opponent probably left). Automatically queued again for you.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/MultiplayerMatchStrings.cs
+++ b/osu.Game/Localisation/MultiplayerMatchStrings.cs
@@ -50,9 +50,9 @@ namespace osu.Game.Localisation
         public static LocalisableString MatchIsReady => new TranslatableString(getKey(@"match_is_ready"), @"Your match is ready! Click to join.");
 
         /// <summary>
-        /// "Your match has been invalidated by the server. Please queue again. (Most common reason: Match timed out)"
+        /// "Your match has timed out. Click to queue again."
         /// </summary>
-        public static LocalisableString MatchInvalid => new TranslatableString(getKey(@"match_invalid"), @"Your match has been invalidated by the server. Please queue again. (Most common reason: Match timed out)");
+        public static LocalisableString MatchTimedout => new TranslatableString(getKey(@"match_timed_out"), @"Your match has timed out. Click to queue again.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Threading.Tasks;
+using FFmpeg.AutoGen;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -329,39 +330,42 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 [Resolved]
                 private INotificationOverlay? notifications { get; set; }
 
+
+                [Resolved]
+                private MultiplayerClient client { get; set; } = null!;
+
                 private bool isValid = true;
 
                 private readonly QueueController controller;
 
                 public MatchFoundNotification(QueueController controller)
                 {
-                    IsCritical = true;
                     this.controller = controller;
                 }
 
-                protected override void Update()
+                private void onMatchmakingQueueLeft()
                 {
-                    base.Update();
-
-                    if (isValid && controller.CurrentState.Value != ScreenQueue.MatchmakingScreenState.PendingAccept)
+                    Close(false);
+                    notifications?.Post(new SimpleNotification
                     {
-                        Close(false);
-                        notifications?.Post(new SimpleNotification
-                        {
-                            Text = MultiplayerMatchStrings.MatchInvalid,
-                            Icon = FontAwesome.Solid.InfoCircle,
-                            IsCritical = true
-                        });
-                        isValid = false;
-                    }
+                        Text = MultiplayerMatchStrings.MatchInvalid,
+                        Icon = FontAwesome.Solid.InfoCircle,
+                        IsCritical = true
+                    });
                 }
-
 
                 [BackgroundDependencyLoader]
                 private void load(OsuColour colours)
                 {
                     Icon = FontAwesome.Solid.Bolt;
                     IconContent.Colour = ColourInfo.GradientVertical(colours.YellowDark, colours.YellowLight);
+                    client.MatchmakingQueueLeft += onMatchmakingQueueLeft;
+                }
+
+                protected override void Dispose(bool isDisposing)
+                {
+                    base.Dispose(isDisposing);
+                    client.MatchmakingQueueLeft -= onMatchmakingQueueLeft;
                 }
             }
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -333,11 +333,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 [Resolved]
                 private MultiplayerClient client { get; set; } = null!;
 
-                public MatchFoundNotification(QueueController controller)
-                {
-                    this.controller = controller;
-                }
-
                 private void onMatchmakingQueueLeft()
                 {
                     Close(false);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -342,6 +342,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 protected override void Update()
                 {
                     base.Update();
+
                     if (isValid && controller.CurrentState.Value != ScreenQueue.MatchmakingScreenState.PendingAccept)
                     {
                         Close(false);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -330,13 +330,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 [Resolved]
                 private INotificationOverlay? notifications { get; set; }
 
-
                 [Resolved]
                 private MultiplayerClient client { get; set; } = null!;
-
-                private bool isValid = true;
-
-                private readonly QueueController controller;
 
                 public MatchFoundNotification(QueueController controller)
                 {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -247,6 +247,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             [Resolved]
             private MultiplayerClient client { get; set; } = null!;
 
+            [Resolved]
+            private INotificationOverlay? notifications { get; set; }
+
+            private bool isValid = true;
+
             private readonly QueueController controller;
 
             private Notification? foundNotification;
@@ -285,12 +290,29 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 matchFoundSample = audio.Samples.Get(@"Multiplayer/Matchmaking/match-found");
             }
 
+            protected override void Update()
+            {
+                base.Update();
+
+                // This means the user has exited the queue in an abnormal way (Invitation time out etc.)
+                if (isValid && controller.CurrentState.Value == ScreenQueue.MatchmakingScreenState.Idle)
+                {
+                    CloseAll();
+                    notifications?.Post(new SimpleNotification
+                    {
+                        Text = MultiplayerMatchStrings.MatchInvalid,
+                        Icon = FontAwesome.Solid.InfoCircle,
+                    });
+                    isValid = false;
+                }
+            }
+
             public void Complete(MatchmakingRoomInvitationParams invitation)
             {
                 CompletionClickAction = () =>
                 {
                     client.MatchmakingAcceptInvitation().FireAndForget();
-                    controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom;
+                    if (controller.CurrentState.Value == ScreenQueue.MatchmakingScreenState.PendingAccept) controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom;
 
                     performer?.PerformFromScreen(s => s.Push(new ScreenIntro(invitation.Type)));
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -338,40 +338,56 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     this.controller = controller;
                 }
 
-                private void onMatchmakingQueueLeft()
-                {
-                    Close(false);
-                    notifications?.Post(new MatchTimeoutNotification(controller)
-                    {
-                        Text = MultiplayerMatchStrings.MatchTimedout,
-                        Icon = FontAwesome.Solid.InfoCircle,
-                        IsCritical = true
-                    });
-                }
-
                 [BackgroundDependencyLoader]
                 private void load(OsuColour colours)
                 {
                     Icon = FontAwesome.Solid.Bolt;
                     IconContent.Colour = ColourInfo.GradientVertical(colours.YellowDark, colours.YellowLight);
                     client.MatchmakingQueueLeft += onMatchmakingQueueLeft;
+                    client.MatchmakingQueueStatusChanged += onMatchmakingStatusChanged;
+                }
+
+                private void onMatchmakingQueueLeft()
+                {
+                    Close(false);
+                    // 99% of situations like this are caused by Timeouts, better just explain like this to players.
+                    notifications?.Post(new MatchInvalidatedNotification(controller));
+                }
+
+
+                private void onMatchmakingStatusChanged(MatchmakingQueueStatus status)
+                {
+                    Close(false);
+                    if (status is MatchmakingQueueStatus.Searching)
+                    {
+                        notifications?.Post(new SimpleNotification
+                        {
+                            Text = MultiplayerMatchStrings.MatchInvalidatedWithRequeue,
+                            Icon = FontAwesome.Solid.Info,
+                            IsCritical = true
+                        });
+                    }
                 }
 
                 protected override void Dispose(bool isDisposing)
                 {
                     base.Dispose(isDisposing);
                     client.MatchmakingQueueLeft -= onMatchmakingQueueLeft;
+                    client.MatchmakingQueueStatusChanged -= onMatchmakingStatusChanged;
                 }
             }
-            private partial class MatchTimeoutNotification : SimpleNotification
+            private partial class MatchInvalidatedNotification : SimpleNotification
             {
                 [Resolved]
                 private IPerformFromScreenRunner? performer { get; set; }
                 private readonly QueueController controller;
 
-                public MatchTimeoutNotification(QueueController controller)
+                public MatchInvalidatedNotification(QueueController controller)
                 {
                     this.controller = controller;
+                    Text = MultiplayerMatchStrings.MatchInvalidated;
+                    Icon = FontAwesome.Solid.Clock;
+                    IsCritical = true;
                 }
 
                 [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -331,6 +331,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
                 [Resolved]
                 private MultiplayerClient client { get; set; } = null!;
+
                 private readonly QueueController controller;
 
                 public MatchFoundNotification(QueueController controller)
@@ -354,10 +355,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     notifications?.Post(new MatchInvalidatedNotification(controller));
                 }
 
-
                 private void onMatchmakingStatusChanged(MatchmakingQueueStatus status)
                 {
                     Close(false);
+
                     if (status is MatchmakingQueueStatus.Searching)
                     {
                         notifications?.Post(new SimpleNotification
@@ -376,6 +377,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     client.MatchmakingQueueStatusChanged -= onMatchmakingStatusChanged;
                 }
             }
+
             private partial class MatchInvalidatedNotification : SimpleNotification
             {
                 [Resolved]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Threading.Tasks;
-using FFmpeg.AutoGen;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -310,7 +309,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 // this can be moved inside the `MatchFoundNotification` implementation.
                 matchFoundSample?.Play();
 
-                return foundNotification = new MatchFoundNotification(controller)
+                return foundNotification = new MatchFoundNotification
                 {
                     Activated = CompletionClickAction,
                     Text = MultiplayerMatchStrings.MatchIsReady,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -382,6 +382,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 [Resolved]
                 private IPerformFromScreenRunner? performer { get; set; }
+
                 private readonly QueueController controller;
 
                 public MatchInvalidatedNotification(QueueController controller)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -247,11 +247,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             [Resolved]
             private MultiplayerClient client { get; set; } = null!;
 
-            [Resolved]
-            private INotificationOverlay? notifications { get; set; }
-
-            private bool isValid = true;
-
             private readonly QueueController controller;
 
             private Notification? foundNotification;
@@ -290,23 +285,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 matchFoundSample = audio.Samples.Get(@"Multiplayer/Matchmaking/match-found");
             }
 
-            protected override void Update()
-            {
-                base.Update();
-
-                // This means the user has exited the queue in an abnormal way (Invitation time out etc.)
-                if (isValid && controller.CurrentState.Value == ScreenQueue.MatchmakingScreenState.Idle)
-                {
-                    CloseAll();
-                    notifications?.Post(new SimpleNotification
-                    {
-                        Text = MultiplayerMatchStrings.MatchInvalid,
-                        Icon = FontAwesome.Solid.InfoCircle,
-                    });
-                    isValid = false;
-                }
-            }
-
             public void Complete(MatchmakingRoomInvitationParams invitation)
             {
                 CompletionClickAction = () =>
@@ -331,7 +309,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 // this can be moved inside the `MatchFoundNotification` implementation.
                 matchFoundSample?.Play();
 
-                return foundNotification = new MatchFoundNotification
+                return foundNotification = new MatchFoundNotification(controller)
                 {
                     Activated = CompletionClickAction,
                     Text = MultiplayerMatchStrings.MatchIsReady,
@@ -348,10 +326,35 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
 
-                public MatchFoundNotification()
+                [Resolved]
+                private INotificationOverlay? notifications { get; set; }
+
+                private bool isValid = true;
+
+                private readonly QueueController controller;
+
+                public MatchFoundNotification(QueueController controller)
                 {
                     IsCritical = true;
+                    this.controller = controller;
                 }
+
+                protected override void Update()
+                {
+                    base.Update();
+                    if (isValid && controller.CurrentState.Value != ScreenQueue.MatchmakingScreenState.PendingAccept)
+                    {
+                        Close(false);
+                        notifications?.Post(new SimpleNotification
+                        {
+                            Text = MultiplayerMatchStrings.MatchInvalid,
+                            Icon = FontAwesome.Solid.InfoCircle,
+                            IsCritical = true
+                        });
+                        isValid = false;
+                    }
+                }
+
 
                 [BackgroundDependencyLoader]
                 private void load(OsuColour colours)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -309,7 +309,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 // this can be moved inside the `MatchFoundNotification` implementation.
                 matchFoundSample?.Play();
 
-                return foundNotification = new MatchFoundNotification
+                return foundNotification = new MatchFoundNotification(controller)
                 {
                     Activated = CompletionClickAction,
                     Text = MultiplayerMatchStrings.MatchIsReady,
@@ -331,13 +331,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
                 [Resolved]
                 private MultiplayerClient client { get; set; } = null!;
+                private readonly QueueController controller;
+
+                public MatchFoundNotification(QueueController controller)
+                {
+                    this.controller = controller;
+                }
 
                 private void onMatchmakingQueueLeft()
                 {
                     Close(false);
-                    notifications?.Post(new SimpleNotification
+                    notifications?.Post(new MatchTimeoutNotification(controller)
                     {
-                        Text = MultiplayerMatchStrings.MatchInvalid,
+                        Text = MultiplayerMatchStrings.MatchTimedout,
                         Icon = FontAwesome.Solid.InfoCircle,
                         IsCritical = true
                     });
@@ -355,6 +361,29 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 {
                     base.Dispose(isDisposing);
                     client.MatchmakingQueueLeft -= onMatchmakingQueueLeft;
+                }
+            }
+            private partial class MatchTimeoutNotification : SimpleNotification
+            {
+                [Resolved]
+                private IPerformFromScreenRunner? performer { get; set; }
+                private readonly QueueController controller;
+
+                public MatchTimeoutNotification(QueueController controller)
+                {
+                    this.controller = controller;
+                }
+
+                [BackgroundDependencyLoader]
+                private void load()
+                {
+                    Activated = () =>
+                    {
+                        controller.RejoinQueue();
+                        if (controller.CurrentState.Value == ScreenQueue.MatchmakingScreenState.Idle) controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.Queueing;
+                        performer?.PerformFromScreen(s => s.Push(new ScreenIntro(MatchmakingPoolType.RankedPlay)));
+                        return true;
+                    };
                 }
             }
         }


### PR DESCRIPTION
Closes #37214
Closes #37497
Closes #36744

When the match is invalidated (Either via timeout or opponent leaving the queue in any ways), the state of ScreenQueue is updated to Idle and the notification becomes stale and broken when clicked on due to it firing an `AcceptInvite` with outdated information to an non-existant match server-side, leading to a game-paralyzing softlock.

This pr invalidates the notification when the player leaves the queue and send a new notification to notify the player that the need to requeue.