### PR TITLE
Fix Background doesn't exist in the beatmap archive

### DIFF
--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -432,7 +432,9 @@ namespace osu.Game.Beatmaps
                         Tags = decoded.Metadata.Tags,
                         PreviewTime = decoded.Metadata.PreviewTime,
                         AudioFile = decoded.Metadata.AudioFile,
-                        BackgroundFile = decoded.Metadata.BackgroundFile,
+                        BackgroundFile = !string.IsNullOrEmpty(decoded.Metadata.BackgroundFile) && beatmapSet.Files.Any(f => f.Filename.Equals(decoded.Metadata.BackgroundFile, StringComparison.OrdinalIgnoreCase))
+                            ? decoded.Metadata.BackgroundFile
+                            : string.Empty,
                     };
 
                     var beatmap = new BeatmapInfo(ruleset, difficulty, metadata)


### PR DESCRIPTION
Fix BackgroundFile being set to a filename that doesn't exist in the beatmap archive.

When externally editing a beatmap and replacing the background image without
updating the .osu file's [Events] section, the importer would store the old
(now missing) filename in metadata. Added a validation check to clear
BackgroundFile if the referenced file doesn't exist in the archive.

Fixes #37884