### PR TITLE
Fix legacy beatmap export dropping background specification

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
@@ -123,6 +123,29 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
+        public void TestBackgroundSpecificationPreserved()
+        {
+            IWorkingBeatmap beatmap = null!;
+            MemoryStream outStream = null!;
+
+            // Ensure importer encoding is correct
+            AddStep("import beatmap", () => beatmap = importBeatmapFromArchives(@"241526 Soleily - Renatus.osz"));
+            AddAssert("beatmap background is correct", () => beatmap.BeatmapInfo.Metadata.BackgroundFile, () => Is.EqualTo("machinetop_background.jpg"));
+
+            // Ensure exporter legacy conversion is correct
+            AddStep("export", () =>
+            {
+                outStream = new MemoryStream();
+
+                new LegacyBeatmapExporter(LocalStorage)
+                    .ExportToStream((BeatmapSetInfo)beatmap.BeatmapInfo.BeatmapSet!, outStream, null);
+            });
+
+            AddStep("import beatmap again", () => beatmap = importBeatmapFromStream(outStream));
+            AddAssert("beatmap background is still correct", () => beatmap.BeatmapInfo.Metadata.BackgroundFile, () => Is.EqualTo("machinetop_background.jpg"));
+        }
+
+        [Test]
         public void TestExportStability()
         {
             IWorkingBeatmap beatmap = null!;

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -74,6 +74,8 @@ namespace osu.Game.Database
 
             using var storyboardStreamReader = new LineBufferedReader(storyboardStream);
             var beatmapStoryboard = new LegacyStoryboardDecoder().Decode(storyboardStreamReader);
+            beatmapStoryboard.Beatmap = beatmapContent;
+            beatmapStoryboard.BeatmapInfo = beatmapInfo;
 
             MutateBeatmap(model, playableBeatmap);
 

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Storyboards
         private readonly Dictionary<string, StoryboardLayer> layers = new Dictionary<string, StoryboardLayer>();
         public IEnumerable<StoryboardLayer> Layers => layers.Values;
 
-        public BeatmapInfo BeatmapInfo = new BeatmapInfo();
+        public BeatmapInfo BeatmapInfo { get; set; } = new BeatmapInfo();
         public IBeatmap Beatmap { get; set; } = new Beatmap();
 
         /// <summary>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/37884
- Closes https://github.com/ppy/osu/pull/37890

Due to lack of population of `Storyboard.Beatmap` and `Storyboard.BeatmapInfo` post-decoding, `LegacyBeatmapExporter` would completely drop background specifications on exported beatmap packages. This affects both direct legacy export to file (`.osz`) as well as beatmap submission.

I will not pretend that the API here is optimal but I do not see very easy opportunities to curtail misuse. Storyboards can be treated as either parts of a beatmap or standalone entities, and if a requirement is added to forcibly provide a beatmap and its info when encoding out a storyboard, I also foresee a requirement to bypass this later when design mode is implemented, which would be a return to square one.

There is likely room for cleanup around `Storyboard` to maybe make this nicer (remove passing of both `Beatmap` and `BeatmapInfo` and just pass `Beatmap` instead, maybe shuffle some properties from `Beatmap` to `Storyboard` to remove the requirement of having to bolt the beatmap on to begin with). I leave voicing opinions on that, and how soon that should be done, to reviewers. My primary intent at this time is to hotfix a major issue in a released build.

The external editing feature is not involved in this bug and any attempts to claim so are misdirections.