### PR TITLE
Fix flashes on some form controls going beyond the borders

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormButton.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             if (Enabled.Value)
             {
-                background.Flash();
+                background.FlashOnCommit();
                 button.TriggerClick();
             }
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             current.BindValueChanged(_ =>
             {
                 updateState();
-                background.Flash();
+                background.FlashOnCommit();
 
                 ValueChanged?.Invoke();
             });

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -59,8 +59,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 },
                 flashOverlayLayer = new Box
                 {
-                    RelativeSizeAxes = Axes.Both,
                     Colour = Colour4.Transparent,
+                    RelativeSizeAxes = Axes.Both,
                 },
                 sounds = new HoverSounds(),
             };

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
         private readonly Box box;
+        private readonly Box flashOverlayLayer;
 
         private readonly HoverSounds sounds;
 
@@ -56,6 +57,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     Colour = Color4.White,
                     RelativeSizeAxes = Axes.Both,
                 },
+                flashOverlayLayer = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Colour4.Transparent,
+                },
                 sounds = new HoverSounds(),
             };
         }
@@ -71,6 +77,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public void Flash()
         {
             box.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
+        }
+
+        public void FlashOverlay(ColourInfo flashColour, double duration)
+        {
+            flashOverlayLayer.Colour = flashColour;
+            flashOverlayLayer.FadeOutFromOne(duration, Easing.OutQuint);
         }
 
         private void updateStyle()

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
         private readonly Box box;
-        private readonly Box flashOverlayLayer;
+        private readonly Box flashLayer;
 
         private readonly HoverSounds sounds;
 
@@ -57,7 +57,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     Colour = Color4.White,
                     RelativeSizeAxes = Axes.Both,
                 },
-                flashOverlayLayer = new Box
+                flashLayer = new Box
                 {
                     Colour = Colour4.Transparent,
                     RelativeSizeAxes = Axes.Both,
@@ -74,16 +74,21 @@ namespace osu.Game.Graphics.UserInterfaceV2
             FinishTransforms(true);
         }
 
-        public void Flash()
+        private void flash(Colour4 flashColour, double duration)
         {
-            box.FlashColour(ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Dark2), 800, Easing.OutQuint);
+            flashLayer.Colour = ColourInfo.GradientVertical(flashColour.Opacity(0), flashColour);
+            flashLayer.FadeOutFromOne(duration, Easing.OutQuint);
         }
 
-        public void FlashOverlay(ColourInfo flashColour, double duration)
-        {
-            flashOverlayLayer.Colour = flashColour;
-            flashOverlayLayer.FadeOutFromOne(duration, Easing.OutQuint);
-        }
+        /// <summary>
+        /// Use when indicating that a change in value or a definitive action has occurred.
+        /// </summary>
+        public void FlashOnCommit() => flash(colourProvider.Dark2, 800);
+
+        /// <summary>
+        /// Use when rejecting the user's input as incorrect.
+        /// </summary>
+        public void FlashOnInputError() => flash(Colour4.Red, 200);
 
         private void updateStyle()
         {

--- a/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormControlBackground.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             Masking = true;
             CornerRadius = 5;
+            CornerExponent = 2.5f;
 
             CornerExponent = CORNER_EXPONENT;
             BorderThickness = BORDER_THICKNESS;

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -151,9 +151,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
             [BackgroundDependencyLoader]
             private void load()
             {
-                Masking = true;
-                CornerRadius = 5;
-
                 // We use our own background for more control.
                 Background.Alpha = 0;
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             initialChooserPath = Current.Value?.DirectoryName;
             placeholderText.Alpha = Current.Value == null ? 1 : 0;
             filenameText.Text = Current.Value?.Name ?? string.Empty;
-            background.Flash();
+            background.FlashOnCommit();
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -123,7 +123,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public Func<T, LocalisableString> TooltipFormat { get; init; }
 
         private FormControlBackground background = null!;
-        private Box flashLayer = null!;
         private FormTextBox.InnerTextBox textBox = null!;
         private OsuSpriteText valueLabel = null!;
         private FormFieldCaption captionText = null!;
@@ -198,18 +197,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Masking = true;
-            CornerRadius = 5;
-            CornerExponent = 2.5f;
-
             InternalChildren = new Drawable[]
             {
                 background = new FormControlBackground(),
-                flashLayer = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Colour4.Transparent,
-                },
                 new Container
                 {
                     RelativeSizeAxes = Axes.X,
@@ -255,11 +245,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                             AlwaysPresent = true,
                                             CommitOnFocusLost = true,
                                             SelectAllOnFocus = true,
-                                            OnInputError = () =>
-                                            {
-                                                flashLayer.Colour = ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3);
-                                                flashLayer.FadeOutFromOne(200, Easing.OutQuint);
-                                            },
+                                            OnInputError = () => background.FlashOverlay(ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3), 200),
                                             TabbableContentContainer = tabbableContentContainer,
                                         },
                                         valueLabel = new TruncatingSpriteText

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -10,7 +10,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
@@ -245,7 +244,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                             AlwaysPresent = true,
                                             CommitOnFocusLost = true,
                                             SelectAllOnFocus = true,
-                                            OnInputError = () => background.FlashOverlay(ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3), 200),
+                                            OnInputError = background.FlashOnInputError,
                                             TabbableContentContainer = tabbableContentContainer,
                                         },
                                         valueLabel = new TruncatingSpriteText
@@ -313,7 +312,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             currentNumberInstantaneous.TriggerChange();
             current.Value = currentNumberInstantaneous.Value;
 
-            background.Flash();
+            background.FlashOnCommit();
         }
 
         private void tryUpdateSliderFromTextBox()

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -92,6 +92,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
+            Masking = true;
+            CornerRadius = 5;
+            CornerExponent = 2.5f;
+
             InternalChildren = new Drawable[]
             {
                 background = new FormControlBackground(),

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
@@ -78,7 +77,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public LocalisableString PlaceholderText { get; init; }
 
         private FormControlBackground background = null!;
-        private Box flashLayer = null!;
         private InnerTextBox textBox = null!;
         private FormFieldCaption caption = null!;
         private IFocusManager focusManager = null!;
@@ -92,18 +90,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Masking = true;
-            CornerRadius = 5;
-            CornerExponent = 2.5f;
-
             InternalChildren = new Drawable[]
             {
                 background = new FormControlBackground(),
-                flashLayer = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Colour4.Transparent,
-                },
                 new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
@@ -131,16 +120,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                 OnCommit?.Invoke(textBox, newText);
 
                                 if (!current.Disabled && !ReadOnly)
-                                {
-                                    flashLayer.Colour = ColourInfo.GradientVertical(colourProvider.Dark2.Opacity(0), colourProvider.Dark2);
-                                    flashLayer.FadeOutFromOne(800, Easing.OutQuint);
-                                }
+                                    background.FlashOverlay(ColourInfo.GradientVertical(colourProvider.Dark2.Opacity(0), colourProvider.Dark2), 800);
                             };
-                            t.OnInputError = () =>
-                            {
-                                flashLayer.Colour = ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3);
-                                flashLayer.FadeOutFromOne(200, Easing.OutQuint);
-                            };
+                            t.OnInputError = () => background.FlashOverlay(ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3), 200);
                             t.TabbableContentContainer = tabbableContentContainer;
                         }),
                     },

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -120,9 +118,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                 OnCommit?.Invoke(textBox, newText);
 
                                 if (!current.Disabled && !ReadOnly)
-                                    background.FlashOverlay(ColourInfo.GradientVertical(colourProvider.Dark2.Opacity(0), colourProvider.Dark2), 800);
+                                    background.FlashOnCommit();
                             };
-                            t.OnInputError = () => background.FlashOverlay(ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3), 200);
+                            t.OnInputError = () => background.FlashOnInputError();
                             t.TabbableContentContainer = tabbableContentContainer;
                         }),
                     },


### PR DESCRIPTION
changes can be reviewed commit by commit, explanations are attached

| master | 58c677007efd436ff6cabc87e88d26dc21d7d352 | 2f21914ee2ef63ba3370580ab45e30ac1373a1b6 |
|-|-|-|
| <img width="517" height="86" alt="Снимок экрана 2026-05-23 235003" src="https://github.com/user-attachments/assets/6c11bdac-118e-4f63-883a-ec6a802b94a9" /> | <img width="514" height="86" alt="Снимок экрана 2026-05-23 235109" src="https://github.com/user-attachments/assets/d46aac3e-08d1-4462-b4f6-083c1e321c09" /> | <img width="516" height="82" alt="Снимок экрана 2026-05-24 142215" src="https://github.com/user-attachments/assets/063317f2-7643-4fe6-bae8-e8e8c4145641" /> |
| <img width="521" height="90" alt="Снимок экрана 2026-05-24 142702" src="https://github.com/user-attachments/assets/5530fd71-a2d8-4700-827d-485ca41bc1a6" /> | <img width="518" height="90" alt="Снимок экрана 2026-05-24 142552" src="https://github.com/user-attachments/assets/35865f21-9120-4384-ab32-7dd135dd907e" /> | <img width="526" height="89" alt="Снимок экрана 2026-05-24 142412" src="https://github.com/user-attachments/assets/27ea3af6-9b1d-400b-9f02-eee453e23b64" /> |

master

https://github.com/user-attachments/assets/0d37c1b1-ab1d-4f07-ac3a-024fa4af5fc3

58c677007efd436ff6cabc87e88d26dc21d7d352

https://github.com/user-attachments/assets/a315a5da-330a-4dec-b323-ac11f081939a

2f21914ee2ef63ba3370580ab45e30ac1373a1b6

https://github.com/user-attachments/assets/b8197983-2be7-478b-b5b1-c554b72d56e2