### PR TITLE
Add beat sync to LoadingSpinner

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLoadingSpinner.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLoadingSpinner.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Osu;
 using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -80,6 +84,36 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             Scheduler.AddDelayed(() => loading.ToggleVisibility(), 200, true);
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("set beatmap", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
+                Beatmap.Value.Track.Start();
+            });
+        }
+
+        [Test]
+        public void TestBeatSyncDifferentBPM()
+        {
+            AddStep("set 60 BPM", () =>
+                Beatmap.Value.Beatmap.ControlPointInfo.TimingPoints.ForEach(p => p.BeatLength = 1000));
+            AddWaitStep("wait for beats", 16);
+
+            AddStep("set 100 BPM", () =>
+                Beatmap.Value.Beatmap.ControlPointInfo.TimingPoints.ForEach(p => p.BeatLength = 600));
+            AddWaitStep("wait for beats", 16);
+
+            AddStep("set 150 BPM", () =>
+                Beatmap.Value.Beatmap.ControlPointInfo.TimingPoints.ForEach(p => p.BeatLength = 400));
+            AddWaitStep("wait for beats", 16);
+
+            AddStep("set 200 BPM", () =>
+                Beatmap.Value.Beatmap.ControlPointInfo.TimingPoints.ForEach(p => p.BeatLength = 300));
+            AddWaitStep("wait for beats", 16);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
@@ -1,14 +1,18 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
+using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Backgrounds;
+using osu.Game.Graphics.Containers;
 using osuTK;
 using osuTK.Graphics;
 
@@ -33,10 +37,12 @@ namespace osu.Game.Graphics.UserInterface
 
         private readonly bool withBox;
 
+        private float targetRotation;
+
         private const float spin_duration = 900;
 
         /// <summary>
-        /// Constuct a new loading spinner.
+        /// Construct a new loading spinner.
         /// </summary>
         /// <param name="withBox">Whether the spinner should have a surrounding black box for visibility.</param>
         /// <param name="inverted">Whether colours should be inverted (black spinner instead of white).</param>
@@ -142,7 +148,8 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.LoadComplete();
 
-            rotate();
+            spinner.Spin(spin_duration * 3.5f, RotationDirection.Clockwise);
+            AddInternal(new LoadingSpinnerBeatSyncer(onBeat));
         }
 
         protected override void UpdateAfterChildren()
@@ -168,7 +175,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             if (Alpha < 0.5f)
                 // reset animation if the user can't see us.
-                rotate();
+                targetRotation = MainContents.Rotation;
 
             MainContents.ScaleTo(1, TRANSITION_DURATION, Easing.OutQuint);
 
@@ -185,16 +192,44 @@ namespace osu.Game.Graphics.UserInterface
             this.FadeOut(TRANSITION_DURATION / 2, Easing.OutQuint);
         }
 
-        private void rotate()
+        private void onBeat(double beatLength)
         {
-            spinner.Spin(spin_duration * 3.5f, RotationDirection.Clockwise);
+            targetRotation += 90;
 
-            MainContents.RotateTo(0).Then()
-                        .RotateTo(90, spin_duration, Easing.InOutQuart).Then()
-                        .RotateTo(180, spin_duration, Easing.InOutQuart).Then()
-                        .RotateTo(270, spin_duration, Easing.InOutQuart).Then()
-                        .RotateTo(360, spin_duration, Easing.InOutQuart).Then()
-                        .Loop();
+            MainContents.RotateTo(targetRotation, beatLength, Easing.InOutQuart);
+        }
+
+        private partial class LoadingSpinnerBeatSyncer : BeatSyncedContainer
+        {
+            private readonly Action<double> onBeat;
+
+            public LoadingSpinnerBeatSyncer(Action<double> onBeat)
+            {
+                this.onBeat = onBeat;
+                RelativeSizeAxes = Axes.Both;
+                AllowMistimedEventFiring = false;
+            }
+
+            protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+            {
+                base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
+
+                double beatLength = timingPoint.BeatLength;
+                int beatsPerStep = 1;
+
+                // Ensure rotation duration is long enough to be visually smooth at 100+ BPM.
+                while (beatLength < 600)
+                {
+                    beatLength *= 2;
+                    beatsPerStep *= 2;
+                }
+
+                // Skip beats that don't align with the current step.
+                if (beatIndex % beatsPerStep != 0)
+                    return;
+
+                onBeat(beatLength);
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
@@ -174,8 +174,11 @@ namespace osu.Game.Graphics.UserInterface
         protected override void PopIn()
         {
             if (Alpha < 0.5f)
+            {
                 // reset animation if the user can't see us.
-                targetRotation = MainContents.Rotation;
+                targetRotation = 0;
+                MainContents.RotateTo(0);
+            }
 
             MainContents.ScaleTo(1, TRANSITION_DURATION, Easing.OutQuint);
 

--- a/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
@@ -198,7 +198,6 @@ namespace osu.Game.Graphics.UserInterface
         private void onBeat(double beatLength)
         {
             targetRotation += 90;
-
             MainContents.RotateTo(targetRotation, beatLength, Easing.InOutQuart);
         }
 
@@ -208,10 +207,9 @@ namespace osu.Game.Graphics.UserInterface
 
             public LoadingSpinnerBeatSyncer(Action<double> onBeat)
             {
-                this.onBeat = onBeat;
-                RelativeSizeAxes = Axes.Both;
                 AllowMistimedEventFiring = false;
-                EarlyActivationMilliseconds = 60;
+
+                this.onBeat = onBeat;
             }
 
             protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
@@ -227,6 +225,8 @@ namespace osu.Game.Graphics.UserInterface
                     beatLength *= 2;
                     beatsPerStep *= 2;
                 }
+
+                EarlyActivationMilliseconds = beatLength / 3;
 
                 // Skip beats that don't align with the current step.
                 if (beatIndex % beatsPerStep != 0)

--- a/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private float targetRotation;
 
-        private const float spin_duration = 900;
+        private const float spin_duration = 3150;
 
         /// <summary>
         /// Construct a new loading spinner.
@@ -148,7 +148,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.LoadComplete();
 
-            spinner.Spin(spin_duration * 3.5f, RotationDirection.Clockwise);
+            spinner.Spin(spin_duration, RotationDirection.Clockwise);
             AddInternal(new LoadingSpinnerBeatSyncer(onBeat));
         }
 
@@ -208,6 +208,7 @@ namespace osu.Game.Graphics.UserInterface
                 this.onBeat = onBeat;
                 RelativeSizeAxes = Axes.Both;
                 AllowMistimedEventFiring = false;
+                EarlyActivationMilliseconds = 60;
             }
 
             protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)

--- a/osu.Game/Screens/Select/BeatmapLeaderboardWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardWedge.cs
@@ -421,20 +421,18 @@ namespace osu.Game.Screens.Select
             if (state == displayedState)
                 return;
 
+            loading.Hide();
+
             if (state == LeaderboardState.Retrieving)
             {
                 // Slight delay so this doesn't display for a few silly frames for local score retrievals.
-                loadingShowDelegate ??= Scheduler.AddDelayed(() => loading.Show(), 200);
+                loadingShowDelegate ??= Scheduler.AddDelayed(() => loading.Show(), 250);
             }
             else
             {
                 loadingShowDelegate?.Cancel();
                 loadingShowDelegate = null;
-
-                loading.Hide();
             }
-
-            loading.Hide();
 
             displayedState = state;
 


### PR DESCRIPTION
From https://github.com/ppy/osu/discussions/37729 discussion

This PR Introduces `LoadingSpinner` sync rotation with selected beatmap BPM.  
Uses `BeatSyncedContainer` for that.

If BPM > 100 *(< 600ms beatLength)*: beatLength will be doubled, so window will be [600ms, 1200ms], not too fast, but not too slow too (before changes it was 900ms)

\* Also this PR fix typo in `LoadingSpinner` class documentation (constuct -> construct)

### Showcase

https://github.com/user-attachments/assets/24252468-ff2e-4607-b013-72eac7f94fe4


