### PR TITLE
Add configurable scroll volume step

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -101,6 +101,7 @@ namespace osu.Game.Configuration
 
             // Audio
             SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.ScrollVolumeAdjustmentStep, 0.01, 0.01, 1, 0.01);
 
             SetDefault(OsuSetting.MenuVoice, true);
             SetDefault(OsuSetting.MenuMusic, true);
@@ -360,6 +361,7 @@ namespace osu.Game.Configuration
         AudioOffset,
 
         VolumeInactive,
+        ScrollVolumeAdjustmentStep,
         MenuMusic,
         MenuVoice,
         MenuTips,

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -45,6 +45,16 @@ namespace osu.Game.Localisation
         public static LocalisableString MasterVolumeInactive => new TranslatableString(getKey(@"master_volume_inactive"), @"Master (window inactive)");
 
         /// <summary>
+        /// "Scroll volume step"
+        /// </summary>
+        public static LocalisableString ScrollVolumeAdjustmentStep => new TranslatableString(getKey(@"scroll_volume_adjustment_step"), @"Scroll volume step");
+
+        /// <summary>
+        /// "How much volume changes per wheel notch when adjusting volume with the scroll wheel."
+        /// </summary>
+        public static LocalisableString ScrollVolumeAdjustmentStepTooltip => new TranslatableString(getKey(@"scroll_volume_adjustment_step_tooltip"), @"How much volume changes per wheel notch when adjusting volume with the scroll wheel.");
+
+        /// <summary>
         /// "Effect"
         /// </summary>
         public static LocalisableString EffectVolume => new TranslatableString(getKey(@"effect_volume"), @"Effect");

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
@@ -35,6 +36,17 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
                 }),
+                new SettingsItemV2(new FormSliderBar<double>
+                {
+                    Caption = AudioSettingsStrings.ScrollVolumeAdjustmentStep,
+                    HintText = AudioSettingsStrings.ScrollVolumeAdjustmentStepTooltip,
+                    Current = config.GetBindable<double>(OsuSetting.ScrollVolumeAdjustmentStep),
+                    KeyboardStep = 0.01f,
+                    DisplayAsPercentage = true,
+                })
+                {
+                    ApplyClassicDefault = c => ((IHasCurrentValue<double>)c).Current.Value = 0.05,
+                },
                 new SettingsItemV2(new FormSliderBar<double>
                 {
                     Caption = AudioSettingsStrings.EffectVolume,

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Overlays.Toolbar
         protected override bool OnScroll(ScrollEvent e)
         {
             focusForAdjustment();
-            volume?.Adjust(GlobalAction.IncreaseVolume, e.ScrollDelta.Y, e.IsPrecise);
+            volume?.AdjustFromScroll(e.ScrollDelta.Y, e.IsPrecise);
             return true;
         }
 

--- a/osu.Game/Overlays/Volume/GlobalScrollAdjustsVolume.cs
+++ b/osu.Game/Overlays/Volume/GlobalScrollAdjustsVolume.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Overlays.Volume
                 return false;
 
             // forward any unhandled mouse scroll events to the volume control.
-            return volumeOverlay?.Adjust(GlobalAction.IncreaseVolume, e.ScrollDelta.Y, e.IsPrecise) ?? false;
+            return volumeOverlay?.AdjustFromScroll(e.ScrollDelta.Y, e.IsPrecise) ?? false;
         }
     }
 }

--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -22,6 +22,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -53,6 +54,7 @@ namespace osu.Game.Overlays.Volume
         private Sample hoverSample;
         private Sample notchSample;
         private double sampleLastPlaybackTime;
+        private OsuConfigManager config = null!;
 
         [CanBeNull]
         public event Action<SelectionState> StateChanged;
@@ -86,11 +88,12 @@ namespace osu.Game.Overlays.Volume
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, AudioManager audio)
+        private void load(OsuColour colours, AudioManager audio, OsuConfigManager config)
         {
             hoverSample = audio.Samples.Get($@"UI/{HoverSampleSet.Button.GetDescription()}-hover");
             notchSample = audio.Samples.Get(@"UI/notch-tick");
             sampleLastPlaybackTime = Time.Current;
+            this.config = config;
 
             Color4 backgroundColour = colours.Gray1;
 
@@ -310,8 +313,15 @@ namespace osu.Game.Overlays.Volume
 
         private const double adjust_step = 0.01;
 
-        public void Increase(double amount = 1, bool isPrecise = false) => adjust(amount, isPrecise);
-        public void Decrease(double amount = 1, bool isPrecise = false) => adjust(-amount, isPrecise);
+        public void Increase(double amount = 1) => Increase(amount, false);
+        public void Decrease(double amount = 1) => Decrease(amount, false);
+        public void Increase(double amount, bool isPrecise) => adjust(amount, isPrecise, adjust_step, allowAcceleration: true);
+        public void Decrease(double amount, bool isPrecise) => adjust(-amount, isPrecise, adjust_step, allowAcceleration: true);
+        public void AdjustFromScroll(double amount, bool isPrecise)
+        {
+            double step = config.Get<double>(OsuSetting.ScrollVolumeAdjustmentStep);
+            adjust(amount, isPrecise, step, allowAcceleration: Precision.AlmostEquals(step, adjust_step));
+        }
 
         // because volume precision is set to 0.01, this local is required to keep track of more precise adjustments and only apply when possible.
         private double scrollAccumulation;
@@ -354,24 +364,32 @@ namespace osu.Game.Overlays.Volume
             dragDelta = 0;
         }
 
-        private void adjust(double delta, bool isPrecise)
+        private void adjust(double delta, bool isPrecise, double step, bool allowAcceleration)
         {
             if (delta == 0)
                 return;
 
-            // every adjust increment increases the rate at which adjustments happen up to a cutoff.
-            // this debounce will reset on inactivity.
-            accelerationDebounce?.Cancel();
-            accelerationDebounce = Scheduler.AddDelayed(resetAcceleration, 150);
+            if (allowAcceleration)
+            {
+                // every adjust increment increases the rate at which adjustments happen up to a cutoff.
+                // this debounce will reset on inactivity.
+                accelerationDebounce?.Cancel();
+                accelerationDebounce = Scheduler.AddDelayed(resetAcceleration, 150);
 
-            delta *= accelerationModifier;
-            accelerationModifier = Math.Min(max_acceleration, accelerationModifier * acceleration_multiplier);
+                delta *= accelerationModifier;
+                accelerationModifier = Math.Min(max_acceleration, accelerationModifier * acceleration_multiplier);
+            }
+            else
+            {
+                accelerationDebounce?.Cancel();
+                resetAcceleration();
+            }
 
             double precision = Bindable.Precision;
 
             if (isPrecise)
             {
-                scrollAccumulation += delta * adjust_step;
+                scrollAccumulation += delta * step;
 
                 while (Precision.AlmostBigger(Math.Abs(scrollAccumulation), precision))
                 {
@@ -381,13 +399,13 @@ namespace osu.Game.Overlays.Volume
             }
             else
             {
-                Volume += Math.Sign(delta) * Math.Max(precision, Math.Abs(delta * adjust_step));
+                Volume += Math.Sign(delta) * Math.Max(precision, Math.Abs(delta * step));
             }
         }
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            adjust(e.ScrollDelta.Y, e.IsPrecise);
+            AdjustFromScroll(e.ScrollDelta.Y, e.IsPrecise);
             return true;
         }
 

--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Overlays
                 volumeMeter.Bindable.ValueChanged += _ => Show();
         }
 
-        public bool Adjust(GlobalAction action, float amount = 1, bool isPrecise = false)
+        public bool Adjust(GlobalAction action)
         {
             if (!IsLoaded) return false;
 
@@ -101,14 +101,14 @@ namespace osu.Game.Overlays
                     if (State.Value == Visibility.Hidden)
                         Show();
                     else
-                        volumeMeters.Selected?.Decrease(amount, isPrecise);
+                        volumeMeters.Selected?.Decrease();
                     return true;
 
                 case GlobalAction.IncreaseVolume:
                     if (State.Value == Visibility.Hidden)
                         Show();
                     else
-                        volumeMeters.Selected?.Increase(amount, isPrecise);
+                        volumeMeters.Selected?.Increase();
                     return true;
 
                 case GlobalAction.NextVolumeMeter:
@@ -134,6 +134,33 @@ namespace osu.Game.Overlays
             }
 
             return false;
+        }
+
+        public bool Adjust(GlobalAction action, float amount = 1, bool isPrecise = false)
+        {
+            switch (action)
+            {
+                case GlobalAction.DecreaseVolume:
+                case GlobalAction.IncreaseVolume:
+                    return AdjustFromScroll(action == GlobalAction.IncreaseVolume ? amount : -amount, isPrecise);
+            }
+
+            return Adjust(action);
+        }
+
+        public bool AdjustFromScroll(float amount, bool isPrecise)
+        {
+            if (!IsLoaded || amount == 0)
+                return false;
+
+            if (State.Value == Visibility.Hidden)
+            {
+                Show();
+                return true;
+            }
+
+            volumeMeters.Selected?.AdjustFromScroll(amount, isPrecise);
+            return true;
         }
 
         public void FocusMasterVolume()


### PR DESCRIPTION
## What's changed
- add a configurable scroll volume step setting under Audio > Volume
- default the lazer setting to 1% while providing a classic default of 5%
- wire the setting into first-run behaviour presets via the existing classic default flow
- keep scroll acceleration only for 1% adjustments to avoid extra 1% jumps when using larger step sizes

## Testing
- `dotnet build osu.Desktop.slnf --no-restore`
- manually verified behaviour on macOS
- manually verified behaviour on Windows