### PR TITLE
respect selected ruleset when entering skin editor

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Tests.Visual.Menus
                 InputManager.ReleaseKey(Key.S);
             });
             AddWaitStep("wait for skin editor", 5);
-            AddAssert("ruleset is still taiko", () => Game.Ruleset.Value == taikoRuleset);
+            AddAssert("ruleset is still taiko", () => Game.Ruleset.Value.Equals(taikoRuleset));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -6,12 +6,17 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Configuration;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens.Menu;
+using osu.Game.Tests.Resources;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Menus
@@ -125,6 +130,37 @@ namespace osu.Game.Tests.Visual.Menus
             });
 
             AddUntilStep("wait for dialog", () => Game.ChildrenOfType<DialogOverlay>().SingleOrDefault()?.CurrentDialog != null);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestEnterSkinEditorFromMainMenu(bool allowConverted)
+        {
+            RulesetInfo taikoRuleset = new TaikoRuleset().RulesetInfo;
+            AddStep("import test beatmap set", () => Game.BeatmapManager.Import(TestResources.GetTestBeatmapForImport()));
+            AddStep("set show converted beatmaps", () => Game.LocalConfig.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps).Value = allowConverted);
+            AddStep("select standard ruleset", () => Game.Ruleset.Value = new OsuRuleset().RulesetInfo);
+
+            //makes sure we're initially on an osu! standard beatmap
+            AddStep("enter song select", () =>
+            {
+                InputManager.Key(Key.P);
+                InputManager.Key(Key.P);
+                InputManager.Key(Key.P);
+            });
+            AddStep("exit song select", () => InputManager.Key(Key.Escape));
+            AddStep("Select taiko ruleset", () => Game.Ruleset.Value = taikoRuleset);
+            AddStep("enter skin editor", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.PressKey(Key.S);
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+                InputManager.ReleaseKey(Key.S);
+            });
+            AddWaitStep("wait for skin editor", 5);
+            AddAssert("ruleset is still taiko", () => Game.Ruleset.Value == taikoRuleset);
         }
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -214,7 +214,7 @@ namespace osu.Game.Overlays.SkinEditor
 
                     //first check if the current beatmap set has any other maps that are valid for the current ruleset
                     var activeSet = beatmap.Value.BeatmapSetInfo;
-                    var validBeatmaps = activeSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)).ToArray();
+                    var validBeatmaps = activeSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value));
 
                     if (validBeatmaps.Any())
                         targetMap = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
@@ -230,7 +230,8 @@ namespace osu.Game.Overlays.SkinEditor
                             if (allValidBeatmapSets.Any())
                             {
                                 var randomSet = allValidBeatmapSets.ElementAt(Random.Shared.Next(allValidBeatmapSets.Count()));
-                                targetMap = difficultyRecommender?.GetRecommendedBeatmap(randomSet.Beatmaps) ?? randomSet.Beatmaps.First();
+                                var randomSetValidMaps = randomSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value));
+                                targetMap = difficultyRecommender?.GetRecommendedBeatmap(randomSetValidMaps) ?? randomSetValidMaps.First();
                             }
                         });
                     }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -219,13 +219,13 @@ namespace osu.Game.Overlays.SkinEditor
                     if (validBeatmaps.Any())
                         targetMap = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
                     else
-                    {//otherwise get a random beatmap set in the current ruleset
-
+                    {
+                        //otherwise get a random beatmap set in the current ruleset
                         realm.Run(r =>
                         {
                             var allValidBeatmapSets = r.All<BeatmapSetInfo>().Where(s => !s.DeletePending)
-                                .AsEnumerable()
-                                .Where(s => s.Beatmaps.Any(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)));
+                           .AsEnumerable()
+                           .Where(s => s.Beatmaps.Any(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)));
 
                             if (allValidBeatmapSets.Any())
                             {

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -210,33 +210,7 @@ namespace osu.Game.Overlays.SkinEditor
                 // if we're anywhere else, the state is unknown and may not make sense, so forcibly set something that does.
                 if (screen is not SoloSongSelect && !beatmap.Value.BeatmapInfo.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value))
                 {
-                    BeatmapInfo? targetMap = null;
-
-                    //first check if the current beatmap set has any other maps that are valid for the current ruleset
-                    var activeSet = beatmap.Value.BeatmapSetInfo;
-                    var validBeatmaps = activeSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value));
-
-                    if (validBeatmaps.Any())
-                        targetMap = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
-                    else
-                    {
-                        //otherwise get a random beatmap set in the current ruleset
-                        realm.Run(r =>
-                        {
-                            var allValidBeatmapSets = r.All<BeatmapSetInfo>().Where(s => !s.DeletePending)
-                           .AsEnumerable()
-                           .Where(s => s.Beatmaps.Any(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)));
-
-                            if (allValidBeatmapSets.Any())
-                            {
-                                var randomSet = allValidBeatmapSets.ElementAt(Random.Shared.Next(allValidBeatmapSets.Count()));
-                                var randomSetValidMaps = randomSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value));
-                                targetMap = difficultyRecommender?.GetRecommendedBeatmap(randomSetValidMaps) ?? randomSetValidMaps.First();
-                            }
-                        });
-                    }
-
-                    if (targetMap != null)
+                    if (getBeatmapForCurrentRuleset() is BeatmapInfo targetMap)
                         beatmap.Value = beatmapManager.GetWorkingBeatmap(targetMap);
                     else
                         ruleset.Value = beatmap.Value.BeatmapInfo.Ruleset;
@@ -256,6 +230,29 @@ namespace osu.Game.Overlays.SkinEditor
             }, new[] { typeof(Player), typeof(SoloSongSelect) });
         }
 
+        private BeatmapInfo? getBeatmapForCurrentRuleset()
+        {
+            //first check if the current beatmap set has any other maps that are valid for the current ruleset
+            var activeSet = beatmap.Value.BeatmapSetInfo;
+            var validBeatmaps = activeSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value));
+
+            if (validBeatmaps.Any())
+                return difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
+
+            //otherwise get a random beatmap set in the current ruleset
+            var allValidBeatmapSets = realm.Realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending)
+                .AsEnumerable()
+                .Where(s => s.Beatmaps.Any(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)));
+
+            if (allValidBeatmapSets.Any())
+            {
+                var randomSet = allValidBeatmapSets.ElementAt(Random.Shared.Next(allValidBeatmapSets.Count()));
+                var randomSetValidMaps = randomSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value));
+                return difficultyRecommender?.GetRecommendedBeatmap(randomSetValidMaps) ?? randomSetValidMaps.First();
+            }
+
+            return null;
+        }
         protected override void Update()
         {
             base.Update();

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -232,7 +232,6 @@ namespace osu.Game.Overlays.SkinEditor
                                 targetMap = difficultyRecommender?.GetRecommendedBeatmap(randomSet.Beatmaps) ?? randomSet.Beatmaps.First();
                             }
                         });
- 
                     }
 
                     if (targetMap != null)

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -31,6 +31,7 @@ using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osu.Game.Users;
 using osu.Game.Utils;
+using osu.Game.Database;
 
 namespace osu.Game.Overlays.SkinEditor
 {
@@ -71,7 +72,18 @@ namespace osu.Game.Overlays.SkinEditor
         private Bindable<RulesetInfo> ruleset { get; set; } = null!;
 
         [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+        private Bindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+        [Resolved]
+        private DifficultyRecommender? difficultyRecommender { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        private readonly Bindable<bool> showConvertedBeatmaps = new Bindable<bool>();
 
         private OsuScreen? lastTargetScreen;
         private InvokeOnDisposal? nestedInputManagerDisable;
@@ -92,6 +104,7 @@ namespace osu.Game.Overlays.SkinEditor
         {
             config.BindWith(OsuSetting.BeatmapSkins, beatmapSkins);
             config.BindWith(OsuSetting.HUDVisibilityMode, configVisibilityMode);
+            config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmaps);
         }
 
         protected override void LoadComplete()
@@ -195,8 +208,38 @@ namespace osu.Game.Overlays.SkinEditor
 
                 // the validity of the current game-wide beatmap + ruleset combination is enforced by song select.
                 // if we're anywhere else, the state is unknown and may not make sense, so forcibly set something that does.
-                if (screen is not SoloSongSelect)
-                    ruleset.Value = beatmap.Value.BeatmapInfo.Ruleset;
+                if (screen is not SoloSongSelect && !beatmap.Value.BeatmapInfo.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value))
+                {
+                    BeatmapInfo? targetMap = null;
+
+                    //first check if the current beatmap set has any other maps that are valid for the current ruleset
+                    var activeSet = beatmap.Value.BeatmapSetInfo;
+                    var validBeatmaps = activeSet.Beatmaps.Where((m) => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)).ToArray();
+
+                    if (validBeatmaps.Any())
+                        targetMap = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
+                    else
+                    {//otherwise get a random beatmap set in the current ruleset
+                        realm.Run(r =>
+                        {
+                            var allValidBeatmapSets = r.All<BeatmapSetInfo>().Where(s => !s.DeletePending)
+                           .AsEnumerable()
+                           .Where(s => s.Beatmaps.Any(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)));
+
+                            if (allValidBeatmapSets.Any())
+                            {
+                                var randomSet = allValidBeatmapSets.ElementAt(Random.Shared.Next(allValidBeatmapSets.Count()));
+                                targetMap = difficultyRecommender?.GetRecommendedBeatmap(randomSet.Beatmaps) ?? randomSet.Beatmaps.First();
+                            }
+                        });
+ 
+                    }
+
+                    if (targetMap != null)
+                        beatmap.Value = beatmapManager.GetWorkingBeatmap(targetMap);
+                    else
+                        ruleset.Value = beatmap.Value.BeatmapInfo.Ruleset;
+                }
                 var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
 
                 IReadOnlyList<Mod> usableMods = mods.Value;

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -214,17 +214,18 @@ namespace osu.Game.Overlays.SkinEditor
 
                     //first check if the current beatmap set has any other maps that are valid for the current ruleset
                     var activeSet = beatmap.Value.BeatmapSetInfo;
-                    var validBeatmaps = activeSet.Beatmaps.Where((m) => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)).ToArray();
+                    var validBeatmaps = activeSet.Beatmaps.Where(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)).ToArray();
 
                     if (validBeatmaps.Any())
                         targetMap = difficultyRecommender?.GetRecommendedBeatmap(validBeatmaps) ?? validBeatmaps.First();
                     else
                     {//otherwise get a random beatmap set in the current ruleset
+
                         realm.Run(r =>
                         {
                             var allValidBeatmapSets = r.All<BeatmapSetInfo>().Where(s => !s.DeletePending)
-                           .AsEnumerable()
-                           .Where(s => s.Beatmaps.Any(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)));
+                                .AsEnumerable()
+                                .Where(s => s.Beatmaps.Any(m => m.AllowGameplayWithRuleset(ruleset.Value, showConvertedBeatmaps.Value)));
 
                             if (allValidBeatmapSets.Any())
                             {


### PR DESCRIPTION
fixes #37806

if the current ruleset doesn't match the current beatmap then it'll attempt to resolve in this order:
 - use a beatmap in the same set that's playable in current ruleset
 - find a random beatmap matching the ruleset
 - switch the ruleset same to the current beatmap's (old behavior)

I've also made it take into account the show converted beatmaps setting.

I've recorded tests both using the automated test flow and myself manually running tests. With the automated flows I couldn't figure out how to add more beatmaps that actually had data in them other than Renatus, so that's why I have two videos.

https://github.com/user-attachments/assets/e43a639e-7af6-4823-9458-42ca7d6342f5

https://github.com/user-attachments/assets/cfdb0186-bce0-450e-a7d6-a67d73f6e8d0



