### PR TITLE
Fix client not sending data relevant to replay to spectator server

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Gameplay
                     AccuracyJudgementCount = 1,
                     ComboPortion = 0,
                     BonusPortion = 0
-                }, DateTimeOffset.Now)
+                }, DateTimeOffset.Now, [], 0, [])
             });
 
             Assert.That(scoreProcessor.TotalScore.Value, Is.Zero);
@@ -99,7 +99,7 @@ namespace osu.Game.Tests.Gameplay
                     AccuracyJudgementCount = 0,
                     ComboPortion = 0,
                     BonusPortion = 0
-                }, DateTimeOffset.Now)
+                }, DateTimeOffset.Now, [], 0, [])
             });
 
             Assert.That(scoreProcessor.TotalScore.Value, Is.Zero);

--- a/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
@@ -221,7 +221,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         [HitResult.Miss] = 0,
                         [HitResult.Meh] = 0,
                         [HitResult.Great] = 0
-                    }, new ScoreProcessorStatistics(), DateTimeOffset.Now);
+                    }, new ScoreProcessorStatistics(), DateTimeOffset.Now, [], 0, []);
                 }
 
                 switch (RNG.Next(0, 3))

--- a/osu.Game/Online/Spectator/FrameHeader.cs
+++ b/osu.Game/Online/Spectator/FrameHeader.cs
@@ -62,12 +62,33 @@ namespace osu.Game.Online.Spectator
         /// The set of mods currently active.
         /// </summary>
         /// <remarks>
-        /// Nullable for backwards compatibility with older clients
-        /// (these structures are also used server-side, and <see langword="null"/> will be used as marker that the data isn't there).
-        /// can be made non-nullable 20250407
+        /// This is sent to spectator as mods can change during a play - one relevant circumstance
+        /// is the automatic activation of Touch Device mod when usage of touch devices is detected.
         /// </remarks>
         [Key(7)]
-        public APIMod[]? Mods { get; set; }
+        public APIMod[] Mods { get; set; } = [];
+
+        /// <summary>
+        /// The current total score without mod multipliers active.
+        /// </summary>
+        /// <remarks>
+        /// Nullable for backwards compatibility with older clients that don't send this
+        /// (server-side <see langword="null"/> is used to distinguish the lack of this data).
+        /// can be made non-nullable 20261126
+        /// </remarks>
+        [Key(8)]
+        public long? TotalScoreWithoutMods { get; set; }
+
+        /// <summary>
+        /// The list of time instants in the play at which the player paused the game.
+        /// </summary>
+        /// <remarks>
+        /// Nullable for backwards compatibility with older clients that don't send this
+        /// (server-side <see langword="null"/> is used to distinguish the lack of this data).
+        /// can be made non-nullable 20261126
+        /// </remarks>
+        [Key(9)]
+        public int[]? Pauses { get; set; }
 
         /// <summary>
         /// Construct header summary information from a point-in-time reference to a score which is actively being played.
@@ -83,13 +104,25 @@ namespace osu.Game.Online.Spectator
             // copy for safety
             Statistics = new Dictionary<HitResult, int>(score.Statistics);
             Mods = score.APIMods.ToArray();
+            TotalScoreWithoutMods = score.TotalScoreWithoutMods;
+            Pauses = score.Pauses.ToArray();
 
             ScoreProcessorStatistics = statistics;
         }
 
         [JsonConstructor]
         [SerializationConstructor]
-        public FrameHeader(long totalScore, double accuracy, int combo, int maxCombo, Dictionary<HitResult, int> statistics, ScoreProcessorStatistics scoreProcessorStatistics, DateTimeOffset receivedTime)
+        public FrameHeader(
+            long totalScore,
+            double accuracy,
+            int combo,
+            int maxCombo,
+            Dictionary<HitResult, int> statistics,
+            ScoreProcessorStatistics scoreProcessorStatistics,
+            DateTimeOffset receivedTime,
+            APIMod[] mods,
+            long? totalScoreWithoutMods,
+            int[]? pauses)
         {
             TotalScore = totalScore;
             Accuracy = accuracy;
@@ -98,6 +131,9 @@ namespace osu.Game.Online.Spectator
             Statistics = statistics;
             ScoreProcessorStatistics = scoreProcessorStatistics;
             ReceivedTime = receivedTime;
+            Mods = mods;
+            TotalScoreWithoutMods = totalScoreWithoutMods;
+            Pauses = pauses;
         }
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps.Formats;
 using osu.Game.Extensions;
 using osu.Game.IO.Legacy;
 using osu.Game.IO.Serialization;
+using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Replays;
@@ -20,6 +21,19 @@ using SharpCompress.Compressors.LZMA;
 
 namespace osu.Game.Scoring.Legacy
 {
+    /// <summary>
+    /// Encodes replays.
+    /// </summary>
+    /// <remarks>
+    /// <b>When making <i>ANY</i> changes to the replay format to add new data, consider if:</b>
+    /// <list type="bullet">
+    /// <item><see cref="LATEST_VERSION"/> should be bumped accordingly,</item>
+    /// <item>
+    /// changes need to be made to <see cref="SpectatorClient"/> so that spectator server receives the new data being stored,
+    /// as <b><i>spectator server</i> is responsible for the content of server-stored replays, <i>NOT</i> the client</b>.
+    /// </item>
+    /// </list>
+    /// </remarks>
     public class LegacyScoreEncoder
     {
         /// <summary>


### PR DESCRIPTION
- Related to https://github.com/ppy/osu/issues/37818, but of no material help to it at this point (too late for that)

As noted in https://github.com/ppy/osu/pull/37845#discussion_r3297203361.

Upon comparison of replays recorded by the client and by the server the affected fields are: total score without mods, and the list of user pauses. Additionally, the date of setting the score may differ - server-side it seems to be written with UTC+0 while client-side it's written using the local timezone offset. Not really interested in fixing that last issue at this time.

Also included is an intentionally loud disclaimer in `LegacyScoreEncoder` to tread with caution when treating the class. Not sure it'll help, and it's a bit late for it as pretty much every single versioning primitive has been ravaged to the brink of unusability, but maybe it'll help someone in the future.

This also cleans up an unnecessary nullable on `FrameHeader.Mods` (added in https://github.com/ppy/osu/pull/30137). This change can be only done if users on releases earlier than 2024.1023.0 can no longer connect to spectator server. I leave it to reviewers to determine this as I have no visibility over current spectator server configuration. Inspecting the `osu_builds` table may help confirm this. If it provokes unease, I can back this change out.