### PR TITLE
Add beatmap difficulty before mods as context for score multiplier calculations

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
+++ b/osu.Game.Benchmarks/BenchmarkScoreMultiplierCalculator.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using NUnit.Framework;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
@@ -42,7 +43,7 @@ namespace osu.Game.Benchmarks
         public override void SetUp()
         {
             base.SetUp();
-            calculator = new OsuRuleset().CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+            calculator = new OsuRuleset().CreateScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
         }
 
         [Benchmark]

--- a/osu.Game.Rulesets.Mania.Tests/ManiaScoreMultiplierTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaScoreMultiplierTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -212,7 +213,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [TestCaseSource(nameof(key_mod_multiplier_test_cases))]
         public void TestKeyModMultiplierCompatibility(DateTimeOffset endDate, string clientVersion, double expectedMultiplier)
         {
-            var calculator = Ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(new ScoreInfo
+            var calculator = Ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty(), new ScoreInfo
             {
                 Date = endDate,
                 ClientVersion = clientVersion

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
                 Mod = doubleTime,
                 PassCondition = () => Player.ScoreProcessor.JudgedHits > 0
                                       && Player.ScoreProcessor.Accuracy.Value == 1
-                                      && Player.ScoreProcessor.TotalScore.Value == (long)(1_000_000 * new ManiaScoreMultiplierCalculator(new ScoreMultiplierContext()).CalculateFor([doubleTime])),
+                                      && Player.ScoreProcessor.TotalScore.Value == (long)(1_000_000 * new ManiaScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty())).CalculateFor([doubleTime])),
                 Autoplay = false,
                 CreateBeatmap = () => new Beatmap
                 {

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreMultiplierCalculatorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreMultiplierCalculatorTest.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
             public TestScoreMultiplierCalculator(ScoreMultiplierContext context)
                 : base(context)
             {
-                Single<OsuModEasy>(hasMultiplier: context.BeatmapDifficultyInfo.ApproachRate == 0 ? 0.1 : 0.15);
+                Single<OsuModEasy>(hasMultiplier: context.BeatmapDifficultyWithoutMods.ApproachRate == 0 ? 0.1 : 0.15);
                 Single<OsuModDaycore>(hasMultiplier: daycore => (1 + daycore.SpeedChange.Value) / 4);
                 Single<OsuModHardRock>(hasMultiplier: _ => context.Score?.ClientVersion == "2024.123.0" ? 1.2 : 1.4);
                 Combination<OsuModEasy, OsuModDaycore>(hasMultiplier: (_, _) => 0.003);

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreMultiplierCalculatorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreMultiplierCalculatorTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -13,7 +14,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [Test]
         public void TestFlatMultiplier()
         {
-            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext());
+            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
 
             double multiplier = calculator.CalculateFor([new OsuModEasy()]);
 
@@ -23,7 +24,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [Test]
         public void TestSettingDependentMultiplier()
         {
-            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext());
+            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
 
             double multiplier = calculator.CalculateFor([new OsuModDaycore { SpeedChange = { Value = 0.6 } }]);
 
@@ -31,7 +32,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         }
 
         [Test]
-        public void TestContextDependentMultiplier()
+        public void TestScoreDependentMultiplier()
         {
             TestScoreMultiplierCalculator calculator;
 
@@ -39,20 +40,39 @@ namespace osu.Game.Tests.Rulesets.Scoring
 
             Assert.Multiple(() =>
             {
-                calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext());
+                calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
                 multiplier = calculator.CalculateFor([new OsuModHardRock()]);
                 Assert.That(multiplier, Is.EqualTo(1.4));
 
-                calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new ScoreInfo { ClientVersion = "2024.123.0" }));
+                calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty(), new ScoreInfo { ClientVersion = "2024.123.0" }));
                 multiplier = calculator.CalculateFor([new OsuModHardRock()]);
                 Assert.That(multiplier, Is.EqualTo(1.2));
             });
         }
 
         [Test]
+        public void TestDifficultyDependentMultiplier()
+        {
+            TestScoreMultiplierCalculator calculator;
+
+            double multiplier;
+
+            Assert.Multiple(() =>
+            {
+                calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
+                multiplier = calculator.CalculateFor([new OsuModEasy()]);
+                Assert.That(multiplier, Is.EqualTo(0.15));
+
+                calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty { ApproachRate = 0 }));
+                multiplier = calculator.CalculateFor([new OsuModEasy()]);
+                Assert.That(multiplier, Is.EqualTo(0.1));
+            });
+        }
+
+        [Test]
         public void TestCombinationMultiplier()
         {
-            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext());
+            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
 
             double multiplier = calculator.CalculateFor([new OsuModEasy(), new OsuModDaycore()]);
 
@@ -62,7 +82,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [Test]
         public void TestCombinationAndFlatMultipliers()
         {
-            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext());
+            var calculator = new TestScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
 
             double multiplier = calculator.CalculateFor([new OsuModDaycore(), new OsuModHardRock(), new OsuModEasy()]);
 
@@ -74,7 +94,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
             public TestScoreMultiplierCalculator(ScoreMultiplierContext context)
                 : base(context)
             {
-                Single<OsuModEasy>(hasMultiplier: 0.15);
+                Single<OsuModEasy>(hasMultiplier: context.BeatmapDifficultyInfo.ApproachRate == 0 ? 0.1 : 0.15);
                 Single<OsuModDaycore>(hasMultiplier: daycore => (1 + daycore.SpeedChange.Value) / 4);
                 Single<OsuModHardRock>(hasMultiplier: _ => context.Score?.ClientVersion == "2024.123.0" ? 1.2 : 1.4);
                 Combination<OsuModEasy, OsuModDaycore>(hasMultiplier: (_, _) => 0.003);

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -481,6 +481,28 @@ namespace osu.Game.Tests.Rulesets.Scoring
             Assert.That(scoreProcessor.HighestCombo.Value, Is.Zero);
         }
 
+        [Test]
+        public void TestScoreMultiplier()
+        {
+            Mod[] mods = new Mod[] { new OsuModHardRock() };
+
+            scoreProcessor = new TestScoreProcessor();
+            scoreProcessor.Mods.Value = mods;
+
+            var workingBeatmap = new TestWorkingBeatmap(beatmap);
+            var playableBeatmap = workingBeatmap.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, mods);
+
+            scoreProcessor.ApplyBeatmap(playableBeatmap);
+
+            var judgementResult = new JudgementResult(beatmap.HitObjects.Single(), new OsuJudgement())
+            {
+                Type = HitResult.Great,
+            };
+            scoreProcessor.ApplyResult(judgementResult);
+
+            Assert.That(scoreProcessor.GetDisplayScore(ScoringMode.Standardised), Is.EqualTo(1_000_000 * 1.1).Within(0.5d));
+        }
+
         private class TestJudgement : Judgement
         {
             public override HitResult MaxResult { get; }
@@ -537,8 +559,19 @@ namespace osu.Game.Tests.Rulesets.Scoring
 
                 public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap) => throw new NotImplementedException();
 
+                public override ScoreMultiplierCalculator CreateScoreMultiplierCalculator(ScoreMultiplierContext context) => new TestScoreMultiplierCalculator(context);
+
                 public override string Description => string.Empty;
                 public override string ShortName => string.Empty;
+            }
+
+            private class TestScoreMultiplierCalculator : ScoreMultiplierCalculator
+            {
+                public TestScoreMultiplierCalculator(ScoreMultiplierContext context)
+                    : base(context)
+                {
+                    Single<OsuModHardRock>(hasMultiplier: context.BeatmapDifficultyWithoutMods.CircleSize == 4 ? 1.1 : 1.0);
+                }
             }
         }
     }

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -500,6 +500,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
             };
             scoreProcessor.ApplyResult(judgementResult);
 
+            Assert.That(scoreProcessor.MaximumTotalScore, Is.EqualTo(1_000_000 * 1.1).Within(0.5d));
             Assert.That(scoreProcessor.GetDisplayScore(ScoringMode.Standardised), Is.EqualTo(1_000_000 * 1.1).Within(0.5d));
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFooterButtonMods.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFooterButtonMods.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
@@ -120,7 +121,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void assertModsMultiplier(Ruleset ruleset, IEnumerable<Mod> mods)
         {
-            var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+            var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
             double multiplier = scoreMultiplierCalculator.CalculateFor(mods);
             string expectedValue = ModUtils.FormatScoreMultiplier(multiplier).ToString();
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -15,6 +15,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -124,7 +125,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("two panels active", () => modSelectOverlay.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
             AddAssert("mod multiplier correct", () =>
             {
-                double multiplier = new OsuScoreMultiplierCalculator(new ScoreMultiplierContext()).CalculateFor(SelectedMods.Value);
+                double multiplier = new OsuScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty())).CalculateFor(SelectedMods.Value);
                 return Precision.AlmostEquals(multiplier, this.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
@@ -139,7 +140,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("two panels active", () => modSelectOverlay.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
             AddAssert("mod multiplier correct", () =>
             {
-                double multiplier = new OsuScoreMultiplierCalculator(new ScoreMultiplierContext()).CalculateFor(SelectedMods.Value);
+                double multiplier = new OsuScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty())).CalculateFor(SelectedMods.Value);
                 return Precision.AlmostEquals(multiplier, this.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -188,7 +188,10 @@ namespace osu.Game.Database
             }
 
             var ruleset = score.Ruleset.CreateInstance();
-            var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(score));
+
+            Debug.Assert(score.BeatmapInfo != null);
+
+            var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(score.BeatmapInfo.Difficulty, score));
             double modMultiplier = scoreMultiplierCalculator.CalculateFor(score.Mods);
 
             return (long)Math.Round((1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore) * modMultiplier);
@@ -351,7 +354,7 @@ namespace osu.Game.Database
             long maximumLegacyBaseScore = maximumLegacyAccuracyScore + maximumLegacyComboScore;
             double bonusProportion = Math.Max(0, ((long)score.LegacyTotalScore - maximumLegacyBaseScore) * maximumLegacyBonusRatio);
 
-            var modMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+            var modMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(difficulty));
             double modMultiplier = modMultiplierCalculator.CalculateFor(score.Mods);
 
             long convertedTotalScoreWithoutMods;

--- a/osu.Game/Overlays/Mods/ModSelectFooterContent.cs
+++ b/osu.Game/Overlays/Mods/ModSelectFooterContent.cs
@@ -102,6 +102,8 @@ namespace osu.Game.Overlays.Mods
             {
                 if (beatmapAttributesDisplay != null)
                     beatmapAttributesDisplay.BeatmapInfo.Value = b.NewValue?.BeatmapInfo;
+
+                updateInformation();
             }, true);
 
             Ruleset.BindValueChanged(_ => updateInformation());
@@ -122,9 +124,11 @@ namespace osu.Game.Overlays.Mods
 
         private void updateInformation()
         {
-            if (rankingInformationDisplay != null)
+            WorkingBeatmap? workingBeatmap = Beatmap.Value;
+
+            if (rankingInformationDisplay != null && workingBeatmap != null)
             {
-                var scoreMultiplierCalculator = Ruleset.Value?.CreateInstance().CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+                var scoreMultiplierCalculator = Ruleset.Value?.CreateInstance().CreateScoreMultiplierCalculator(new ScoreMultiplierContext(workingBeatmap.BeatmapInfo.Difficulty));
                 double multiplier = scoreMultiplierCalculator?.CalculateFor(ActiveMods.Value) ?? 1;
 
                 rankingInformationDisplay.ModMultiplier.Value = multiplier;

--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -98,8 +98,9 @@ namespace osu.Game.Rulesets.Scoring
     {
         /// <summary>
         /// The difficulty info for the beatmap that the multipliers are calculated for.
+        /// This must be the difficulty info for the beatmap BEFORE any mod application.
         /// </summary>
-        public IBeatmapDifficultyInfo BeatmapDifficultyInfo { get; }
+        public IBeatmapDifficultyInfo BeatmapDifficultyWithoutMods { get; }
 
         /// <summary>
         /// The score that the multipliers are calculated for.
@@ -111,17 +112,18 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
-        /// <param name="beatmapDifficultyInfo">
+        /// <param name="beatmapDifficultyWithoutMods">
         /// The difficulty info for the beatmap that the multipliers are calculated for.
+        /// This must be the difficulty info for the beatmap BEFORE any mod application.
         /// </param>
         /// <param name="score">
         /// The score that the multipliers are calculated for.
         /// Mostly relevant and present in backwards compatibility scenarios.
         /// In usages where the current valid score multipliers are required, pass <see langword="null"/> or omit this parameter entirely.
         /// </param>
-        public ScoreMultiplierContext(IBeatmapDifficultyInfo beatmapDifficultyInfo, ScoreInfo? score = null)
+        public ScoreMultiplierContext(IBeatmapDifficultyInfo beatmapDifficultyWithoutMods, ScoreInfo? score = null)
         {
-            BeatmapDifficultyInfo = beatmapDifficultyInfo;
+            BeatmapDifficultyWithoutMods = beatmapDifficultyWithoutMods;
             Score = score;
         }
     }

--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 
@@ -96,6 +97,11 @@ namespace osu.Game.Rulesets.Scoring
     public class ScoreMultiplierContext
     {
         /// <summary>
+        /// The difficulty info for the beatmap that the multipliers are calculated for.
+        /// </summary>
+        public IBeatmapDifficultyInfo BeatmapDifficultyInfo { get; }
+
+        /// <summary>
         /// The score that the multipliers are calculated for.
         /// Mostly relevant and present in backwards compatibility scenarios.
         /// In usages where the current valid score multipliers are required, pass <see langword="null"/> or use a constructor that does not require this.
@@ -104,24 +110,19 @@ namespace osu.Game.Rulesets.Scoring
 
         /// <summary>
         /// Constructs a new instance.
-        /// Use this in situations wherein the current valid score multipliers are needed.
-        /// </summary>
-        public ScoreMultiplierContext()
-            : this(null)
-        {
-        }
-
-        /// <summary>
-        /// Constructs a new instance.
         /// Use this in backwards compatibility scenarios when dealing with a specific <paramref name="score"/>.
         /// </summary>
+        /// <param name="beatmapDifficultyInfo">
+        /// The difficulty info for the beatmap that the multipliers are calculated for.
+        /// </param>
         /// <param name="score">
         /// The score that the multipliers are calculated for.
         /// Mostly relevant and present in backwards compatibility scenarios.
         /// In usages where the current valid score multipliers are required, pass <see langword="null"/> or use a constructor that does not require this.
         /// </param>
-        public ScoreMultiplierContext(ScoreInfo? score)
+        public ScoreMultiplierContext(IBeatmapDifficultyInfo beatmapDifficultyInfo, ScoreInfo? score = null)
         {
+            BeatmapDifficultyInfo = beatmapDifficultyInfo;
             Score = score;
         }
     }

--- a/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreMultiplierCalculator.cs
@@ -110,7 +110,6 @@ namespace osu.Game.Rulesets.Scoring
 
         /// <summary>
         /// Constructs a new instance.
-        /// Use this in backwards compatibility scenarios when dealing with a specific <paramref name="score"/>.
         /// </summary>
         /// <param name="beatmapDifficultyInfo">
         /// The difficulty info for the beatmap that the multipliers are calculated for.
@@ -118,7 +117,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="score">
         /// The score that the multipliers are calculated for.
         /// Mostly relevant and present in backwards compatibility scenarios.
-        /// In usages where the current valid score multipliers are required, pass <see langword="null"/> or use a constructor that does not require this.
+        /// In usages where the current valid score multipliers are required, pass <see langword="null"/> or omit this parameter entirely.
         /// </param>
         public ScoreMultiplierContext(IBeatmapDifficultyInfo beatmapDifficultyInfo, ScoreInfo? score = null)
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -92,6 +92,11 @@ namespace osu.Game.Rulesets.Scoring
         public readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         /// <summary>
+        /// The current beatmap.
+        /// </summary>
+        public readonly Bindable<IBeatmap?> Beatmap = new Bindable<IBeatmap?>();
+
+        /// <summary>
         /// The current rank.
         /// </summary>
         public IBindable<ScoreRank> Rank => rank;
@@ -206,8 +211,20 @@ namespace osu.Game.Rulesets.Scoring
 
             Mods.ValueChanged += mods =>
             {
-                var calculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
-                scoreMultiplier = calculator.CalculateFor(mods.NewValue);
+                if (Beatmap.Value != null)
+                {
+                    var calculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(Beatmap.Value.BeatmapInfo.Difficulty));
+                    scoreMultiplier = calculator.CalculateFor(mods.NewValue);
+                }
+
+                updateScore();
+                updateRank();
+            };
+
+            Beatmap.ValueChanged += beatmap =>
+            {
+                var calculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(beatmap.NewValue!.BeatmapInfo.Difficulty));
+                scoreMultiplier = calculator.CalculateFor(Mods.Value);
 
                 updateScore();
                 updateRank();
@@ -218,6 +235,7 @@ namespace osu.Game.Rulesets.Scoring
         {
             base.ApplyBeatmap(beatmap);
             beatmapApplied = true;
+            Beatmap.Value = beatmap;
         }
 
         protected sealed override void ApplyResultInternal(JudgementResult result)

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -211,20 +211,14 @@ namespace osu.Game.Rulesets.Scoring
 
             Mods.ValueChanged += mods =>
             {
-                if (Beatmap.Value != null)
-                {
-                    var calculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(Beatmap.Value.BeatmapInfo.Difficulty));
-                    scoreMultiplier = calculator.CalculateFor(mods.NewValue);
-                }
-
+                updateScoreMultiplier();
                 updateScore();
                 updateRank();
             };
 
             Beatmap.ValueChanged += beatmap =>
             {
-                var calculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(beatmap.NewValue!.BeatmapInfo.Difficulty));
-                scoreMultiplier = calculator.CalculateFor(Mods.Value);
+                updateScoreMultiplier();
             };
         }
 
@@ -413,6 +407,15 @@ namespace osu.Game.Rulesets.Scoring
                 newRank = mod.AdjustRank(newRank, Accuracy.Value);
 
             rank.Value = newRank;
+        }
+
+        private void updateScoreMultiplier()
+        {
+            if (Beatmap.Value == null)
+                return;
+
+            var calculator = Ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(Beatmap.Value.BeatmapInfo.Difficulty));
+            scoreMultiplier = calculator.CalculateFor(Mods.Value);
         }
 
         protected virtual double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -225,9 +225,6 @@ namespace osu.Game.Rulesets.Scoring
             {
                 var calculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(beatmap.NewValue!.BeatmapInfo.Difficulty));
                 scoreMultiplier = calculator.CalculateFor(Mods.Value);
-
-                updateScore();
-                updateRank();
             };
         }
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -230,9 +230,10 @@ namespace osu.Game.Rulesets.Scoring
 
         public override void ApplyBeatmap(IBeatmap beatmap)
         {
+            Beatmap.Value = beatmap;
+
             base.ApplyBeatmap(beatmap);
             beatmapApplied = true;
-            Beatmap.Value = beatmap;
         }
 
         protected sealed override void ApplyResultInternal(JudgementResult result)

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -224,6 +224,12 @@ namespace osu.Game.Rulesets.Scoring
 
         public override void ApplyBeatmap(IBeatmap beatmap)
         {
+            // NOTE: The ordering of operations here is significant.
+            // `Beatmap.Value` must be set before `base.ApplyBeatmap()` because changes to `Beatmap.Value`
+            // trigger recalculation of `scoreMultiplier`,
+            // and `base.ApplyBeatmap()` calls `SimulateAutoplay()` then `Reset(storeResults: true)`.
+            // failing to calculate the correct score multiplier *before* autoplay simulation would result in
+            // storing the incorrect value of `MaximumTotalScore`.
             Beatmap.Value = beatmap;
 
             base.ApplyBeatmap(beatmap);

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -258,8 +258,10 @@ namespace osu.Game.Scoring.Legacy
 
         public static void PopulateTotalScoreWithoutMods(ScoreInfo score)
         {
+            Debug.Assert(score.BeatmapInfo != null);
+
             var ruleset = score.Ruleset.CreateInstance();
-            var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(score));
+            var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(score.BeatmapInfo.Difficulty, score));
             double modMultiplier = scoreMultiplierCalculator.CalculateFor(score.Mods);
 
             score.TotalScoreWithoutMods = (long)Math.Round(score.TotalScore / modMultiplier);

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.Tooltip.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.Tooltip.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.Select
                             new StatisticRow(s.DisplayName.ToUpper(), s.Count.ToLocalisableString("N0"), colours.ForHitResult(s.Result)));
 
                         var ruleset = value.Ruleset.CreateInstance();
-                        var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+                        var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(score.BeatmapInfo!.Difficulty));
                         double multiplier = scoreMultiplierCalculator.CalculateFor(value.Mods);
 
                         var generalStatistics = new[]

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -77,6 +78,9 @@ namespace osu.Game.Screens.Select
 
         [Resolved]
         private OsuGameBase game { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
         private IBindable<Language> currentLanguage = null!;
 
@@ -175,6 +179,7 @@ namespace osu.Game.Screens.Select
             currentLanguage.BindValueChanged(_ => ScheduleAfterChildren(updateDisplay));
 
             Ruleset.BindValueChanged(_ => updateDisplay());
+            beatmap.BindValueChanged(_ => updateDisplay());
             Mods.BindValueChanged(m =>
             {
                 modSettingChangeTracker?.Dispose();
@@ -244,7 +249,7 @@ namespace osu.Game.Screens.Select
                 modDisplay.FadeIn(duration, easing);
             }
 
-            var scoreMultiplierCalculator = Ruleset.Value?.CreateInstance().CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+            var scoreMultiplierCalculator = Ruleset.Value?.CreateInstance().CreateScoreMultiplierCalculator(new ScoreMultiplierContext(beatmap.Value.BeatmapInfo.Difficulty));
             double multiplier = scoreMultiplierCalculator?.CalculateFor(Mods.Value) ?? 1;
             multiplierText.Text = ModUtils.FormatScoreMultiplier(multiplier);
 

--- a/osu.Game/Tests/Rulesets/RulesetScoreMultiplierTest.cs
+++ b/osu.Game/Tests/Rulesets/RulesetScoreMultiplierTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -33,7 +34,7 @@ namespace osu.Game.Tests.Rulesets
                     multiplierViaOldAPI *= mod.ScoreMultiplier;
                 Assert.That(multiplierViaOldAPI, Is.EqualTo(expectedMultiplier).Within(Precision.DOUBLE_EPSILON));
 
-                var calculator = Ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext());
+                var calculator = Ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
                 Assert.That(calculator.CalculateFor(mods), Is.EqualTo(expectedMultiplier).Within(Precision.DOUBLE_EPSILON));
             });
         }


### PR DESCRIPTION
- Part of https://github.com/ppy/osu/issues/37818

Access to difficulty info is required for the upcoming multiplier proposals. All places providing difficulty info intentionally use `IBeatmapInfo` as the difficulty info exposed to the calculator should _always_ be pre-mods for our usecase.

There's a couple of quirks:

- The usage in `ScoreProcessor` is a bit troubling to me but I can't see a way to make it better without refactoring it. Essentially, we don't have a beatmap until `ApplyBeatmap` is called, but most usages of `ScoreProcessor` are setting `Mods` prior to `ApplyBeatmap` so there is a `null` check in the logic for when mods change. Additionally, this means a new bindable of the beatmap via `ApplyBeatmap` which also feels a bit dirty. Open to suggestions.
- ~~`BeatmapLeaderboardScore.Tooltip` is using a null-forgiving on the `BeatmapInfo`, but there's basically no context available on if this is an issue - the only code path which sets the score is `SetContent` which has no callers, so it's essentially dead code. Makes sense given it's Select V1.~~