### PR TITLE
Allow specifying `LengthLimit` on form text boxes

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
@@ -68,6 +68,13 @@ namespace osu.Game.Tests.Visual.UserInterface
                                         },
                                         new FormTextBox
                                         {
+                                            Caption = "Length limited text",
+                                            PlaceholderText = "I can only hold 10 characters!",
+                                            LengthLimit = 10,
+                                            TabbableContentContainer = this,
+                                        },
+                                        new FormTextBox
+                                        {
                                             Caption = "Artist",
                                             HintText = "Poot artist here!",
                                             PlaceholderText = "Here is an artist",

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -77,6 +77,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public LocalisableString PlaceholderText { get; init; }
 
+        /// <summary>
+        /// Maximum allowed length of text.
+        /// </summary>
+        public int? LengthLimit { get; init; }
+
         private FormControlBackground background = null!;
         private Box flashLayer = null!;
         private InnerTextBox textBox = null!;
@@ -120,6 +125,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             t.RelativeSizeAxes = Axes.X;
                             t.Width = 1;
                             t.PlaceholderText = PlaceholderText;
+                            t.LengthLimit = LengthLimit;
                             t.Current = Current;
                             t.CommitOnFocusLost = true;
                             t.OnCommit += (textBox, newText) =>


### PR DESCRIPTION
Will come in handy for stuff like the multiplayer match creation screen.

[Screencast_20260527_162854.webm](https://github.com/user-attachments/assets/03d36104-da6c-4cdf-a1ad-439ddfd2036a)
