### PR TITLE
Move ternary button setup to `HitObjectComposer`

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
@@ -3,16 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -26,29 +21,6 @@ namespace osu.Game.Rulesets.Catch.Edit
             : base(composer)
         {
         }
-
-        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        Icon = OsuIcon.EditorFruit,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new CatchSelectionHandler();
 

--- a/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
@@ -3,16 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -26,29 +21,6 @@ namespace osu.Game.Rulesets.Mania.Edit
             : base(composer)
         {
         }
-
-        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        Icon = OsuIcon.EditorNote,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
 
         public override HitObjectSelectionBlueprint? CreateHitObjectBlueprintFor(HitObject hitObject)
         {

--- a/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
@@ -18,7 +18,6 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
@@ -55,8 +54,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         [BackgroundDependencyLoader]
         private void load()
         {
-            var selectionHandler = (EditorSelectionHandler)composer.BlueprintContainer.SelectionHandler;
-            newComboState = selectionHandler.SelectionNewComboState.GetBoundCopy();
+            newComboState = composer.BlueprintContainer.SelectionHandler.SelectionNewComboState.GetBoundCopy();
 
             AllowableAnchors = new[] { Anchor.CentreLeft, Anchor.CentreRight };
 

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
@@ -3,15 +3,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -25,29 +20,6 @@ namespace osu.Game.Rulesets.Taiko.Edit
             : base(composer)
         {
         }
-
-        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        Icon = OsuIcon.EditorHit,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new TaikoSelectionHandler();
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -6,21 +6,27 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
+using Humanizer;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Testing;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Edit.Tools;
@@ -87,7 +93,7 @@ namespace osu.Game.Rulesets.Edit
 
         private EditorRadioButtonCollection toolboxCollection;
         private FillFlowContainer togglesCollection;
-        private FillFlowContainer sampleBankTogglesCollection;
+        private FillFlowContainer<SampleBankTernaryButton> sampleBankTogglesCollection;
 
         private IBindable<bool> hasTiming;
         private Bindable<bool> autoSeekOnPlacement;
@@ -224,7 +230,7 @@ namespace osu.Game.Rulesets.Edit
                                                     },
                                                 }
                                             },
-                                            sampleBankTogglesCollection = new FillFlowContainer
+                                            sampleBankTogglesCollection = new FillFlowContainer<SampleBankTernaryButton>
                                             {
                                                 RelativeSizeAxes = Axes.X,
                                                 AutoSizeAxes = Axes.Y,
@@ -268,7 +274,7 @@ namespace osu.Game.Rulesets.Edit
 
             togglesCollection.AddRange(CreateTernaryButtons().ToArray());
 
-            sampleBankTogglesCollection.AddRange(BlueprintContainer.SampleBankTernaryStates);
+            sampleBankTogglesCollection.AddRange(createSampleBankTernaryButtons().ToArray());
 
             SetSelectTool();
 
@@ -320,6 +326,11 @@ namespace osu.Game.Rulesets.Edit
                     rightToolboxBackground.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
                 }
             }, true);
+
+            newCombo.BindTo(BlueprintContainer.SelectionHandler.SelectionNewComboState);
+
+            autoSelectionBankEnabled.BindTo(BlueprintContainer.SelectionHandler.AutoSelectionBankEnabled);
+            autoSelectionBankEnabled.BindValueChanged(_ => updateAutoBankTernaryButtonTooltip());
         }
 
         protected override void Update()
@@ -364,10 +375,81 @@ namespace osu.Game.Rulesets.Edit
         /// </remarks>
         protected abstract IReadOnlyList<CompositionTool> CompositionTools { get; }
 
+        private readonly BindableBool autoSelectionBankEnabled = new BindableBool();
+        private readonly Bindable<TernaryState> newCombo = new Bindable<TernaryState> { Description = "New Combo" };
+
         /// <summary>
         /// Create all ternary states required to be displayed to the user.
         /// </summary>
-        protected virtual IEnumerable<Drawable> CreateTernaryButtons() => BlueprintContainer.MainTernaryStates;
+        protected virtual IEnumerable<Drawable> CreateTernaryButtons()
+        {
+            var firstToolIcon = CompositionTools.First().CreateIcon();
+            Debug.Assert(firstToolIcon != null);
+
+            //TODO: this should only be enabled (visible?) for rulesets that provide combo-supporting HitObjects.
+            yield return new NewComboTernaryButton
+            {
+                Current = newCombo,
+                CreateIcon = () => new Container
+                {
+                    firstToolIcon.With(i =>
+                    {
+                        i.Anchor = Anchor.BottomLeft;
+                        i.Origin = Anchor.BottomLeft;
+                        i.Size = new Vector2(15);
+                    }),
+                    new SpriteIcon
+                    {
+                        Icon = OsuIcon.EditorNewComboSparkles,
+                        Size = new Vector2(20),
+                    },
+                },
+            };
+
+            foreach (var kvp in BlueprintContainer.SelectionHandler.SelectionSampleStates)
+            {
+                yield return new DrawableTernaryButton
+                {
+                    Current = kvp.Value,
+                    Description = kvp.Key.Replace(@"hit", string.Empty).Titleize(),
+                    CreateIcon = () => GetIconForSample(kvp.Key),
+                };
+            }
+        }
+
+        private IEnumerable<SampleBankTernaryButton> createSampleBankTernaryButtons()
+        {
+            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(EditorSelectionHandler.HIT_BANK_AUTO))
+            {
+                yield return new SampleBankTernaryButton(bankName)
+                {
+                    NormalState = { Current = BlueprintContainer.SelectionHandler.SelectionBankStates[bankName], },
+                    AdditionsState = { Current = BlueprintContainer.SelectionHandler.SelectionAdditionBankStates[bankName], },
+                    CreateIcon = () => getIconForBank(bankName)
+                };
+            }
+        }
+
+        private Drawable getIconForBank(string sampleName)
+        {
+            return new OsuSpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Y = -1,
+                Font = OsuFont.Default.With(weight: FontWeight.Bold, size: 20),
+                Text = $"{char.ToUpperInvariant(sampleName.First())}"
+            };
+        }
+
+        private void updateAutoBankTernaryButtonTooltip()
+        {
+            bool enabled = autoSelectionBankEnabled.Value;
+
+            var autoBankButton = sampleBankTogglesCollection.Single(t => t.BankName == EditorSelectionHandler.HIT_BANK_AUTO);
+            autoBankButton.NormalButton.Enabled.Value = enabled;
+            autoBankButton.NormalButton.TooltipText = !enabled ? "Auto normal bank can only be used during hit object placement" : string.Empty;
+        }
 
         /// <summary>
         /// Construct a relevant blueprint container. This will manage hitobject selection/placement input handling and display logic.
@@ -619,5 +701,23 @@ namespace osu.Game.Rulesets.Edit
         /// <param name="timestamp">The time instant to seek to, in milliseconds.</param>
         /// <param name="objectDescription">The ruleset-specific description of objects to select at the given timestamp.</param>
         public virtual void SelectFromTimestamp(double timestamp, string objectDescription) { }
+
+        public static Drawable GetIconForSample(string sampleName)
+        {
+            switch (sampleName)
+            {
+                case HitSampleInfo.HIT_CLAP:
+                    return new SpriteIcon { Icon = OsuIcon.EditorClap };
+
+                case HitSampleInfo.HIT_WHISTLE:
+                    return new SpriteIcon { Icon = OsuIcon.EditorWhistle };
+
+                case HitSampleInfo.HIT_FINISH:
+                    return new SpriteIcon { Icon = OsuIcon.EditorFinish };
+
+                default:
+                    return Empty();
+            }
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -6,18 +6,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Humanizer;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
@@ -25,7 +21,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components
@@ -37,7 +32,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
     {
         private readonly Container<PlacementBlueprint> placementBlueprintContainer;
 
-        protected new EditorSelectionHandler SelectionHandler => (EditorSelectionHandler)base.SelectionHandler;
+        public new EditorSelectionHandler SelectionHandler => (EditorSelectionHandler)base.SelectionHandler;
 
         public PlacementBlueprint CurrentPlacement { get; private set; }
 
@@ -68,9 +63,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            MainTernaryStates = CreateTernaryButtons().ToArray();
-            SampleBankTernaryStates = createSampleBankTernaryButtons().ToArray();
-
             AddInternal(new DrawableRulesetDependenciesProvidingContainer(Composer.Ruleset)
             {
                 Child = placementBlueprintContainer
@@ -98,8 +90,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             foreach (var kvp in SelectionHandler.SelectionAdditionBankStates)
                 kvp.Value.BindValueChanged(_ => updatePlacementSamples());
-
-            SelectionHandler.AutoSelectionBankEnabled.BindValueChanged(_ => updateAutoBankTernaryButtonTooltip(), true);
         }
 
         protected override void TransferBlueprintFor(HitObject hitObject, DrawableHitObject drawableObject)
@@ -173,120 +163,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         public readonly Bindable<TernaryState> NewCombo = new Bindable<TernaryState> { Description = "New Combo" };
-
-        /// <summary>
-        /// A collection of states which will be displayed to the user in the toolbox.
-        /// </summary>
-        public Drawable[] MainTernaryStates { get; private set; }
-
-        public SampleBankTernaryButton[] SampleBankTernaryStates { get; private set; }
-
-        /// <summary>
-        /// Create the new combo ternary button. Mainly used to customize the displayed icon
-        /// depending on the ruleset. Can be overriden to return null if a ruleset does not
-        /// provide combo-supporting HitObjects.
-        /// </summary>
-        /// <returns></returns>
-        [CanBeNull]
-        protected virtual Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        // This is currently using the osu! hitcircle icon as a default in order
-                        // not to break any custom rulesets that depend on there being a defined
-                        // new combo button.
-                        // Could consider removing it and let rulesets specify their own buttons/icons.
-                        Icon = OsuIcon.EditorHitCircle,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
-
-        /// <summary>
-        /// Create all ternary states required to be displayed to the user.
-        /// </summary>
-        protected virtual IEnumerable<Drawable> CreateTernaryButtons()
-        {
-            //TODO: this should only be enabled (visible?) for rulesets that provide combo-supporting HitObjects.
-            var newComboButton = CreateNewComboButton();
-
-            if (newComboButton != null)
-                yield return newComboButton;
-
-            foreach (var kvp in SelectionHandler.SelectionSampleStates)
-            {
-                yield return new DrawableTernaryButton
-                {
-                    Current = kvp.Value,
-                    Description = kvp.Key.Replace(@"hit", string.Empty).Titleize(),
-                    CreateIcon = () => GetIconForSample(kvp.Key),
-                };
-            }
-        }
-
-        private IEnumerable<SampleBankTernaryButton> createSampleBankTernaryButtons()
-        {
-            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(EditorSelectionHandler.HIT_BANK_AUTO))
-            {
-                yield return new SampleBankTernaryButton(bankName)
-                {
-                    NormalState = { Current = SelectionHandler.SelectionBankStates[bankName], },
-                    AdditionsState = { Current = SelectionHandler.SelectionAdditionBankStates[bankName], },
-                    CreateIcon = () => getIconForBank(bankName)
-                };
-            }
-        }
-
-        private Drawable getIconForBank(string sampleName)
-        {
-            return new OsuSpriteText
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Y = -1,
-                Font = OsuFont.Default.With(weight: FontWeight.Bold, size: 20),
-                Text = $"{char.ToUpperInvariant(sampleName.First())}"
-            };
-        }
-
-        public static Drawable GetIconForSample(string sampleName)
-        {
-            switch (sampleName)
-            {
-                case HitSampleInfo.HIT_CLAP:
-                    return new SpriteIcon { Icon = OsuIcon.EditorClap };
-
-                case HitSampleInfo.HIT_WHISTLE:
-                    return new SpriteIcon { Icon = OsuIcon.EditorWhistle };
-
-                case HitSampleInfo.HIT_FINISH:
-                    return new SpriteIcon { Icon = OsuIcon.EditorFinish };
-            }
-
-            return null;
-        }
-
-        private void updateAutoBankTernaryButtonTooltip()
-        {
-            bool enabled = SelectionHandler.AutoSelectionBankEnabled.Value;
-
-            var autoBankButton = SampleBankTernaryStates.Single(t => t.BankName == EditorSelectionHandler.HIT_BANK_AUTO);
-            autoBankButton.NormalButton.Enabled.Value = enabled;
-            autoBankButton.NormalButton.TooltipText = !enabled ? "Auto normal bank can only be used during hit object placement" : string.Empty;
-        }
 
         #region Placement
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -19,6 +19,7 @@ using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
@@ -582,7 +583,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     {
                         Current = bindable,
                         Description = string.Empty,
-                        CreateIcon = () => ComposeBlueprintContainer.GetIconForSample(sampleName),
+                        CreateIcon = () => HitObjectComposer.GetIconForSample(sampleName),
                         RelativeSizeAxes = Axes.None,
                         Size = new Vector2(40, 40),
                     };


### PR DESCRIPTION
As per https://github.com/ppy/osu/pull/37848#discussion_r3287018539, this PR migrates the code responsible for creating the ternary buttons used for the editor toggles and sample bank from `ComposeBlueprintContainer` to `HitObjectComposer`, mainly because it has nothing to do with blueprints.

Also it makes the new combo icon added in https://github.com/ppy/osu/pull/37848 automatically generated based on the first tool in the toolbox.