### PR TITLE
Fix edge cases around matchmaking queue notifications

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -292,10 +292,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 CompletionClickAction = () =>
                 {
-                    client.MatchmakingAcceptInvitation().FireAndForget();
-                    controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom;
+                    performer?.PerformFromScreen(s =>
+                    {
+                        client.MatchmakingAcceptInvitation().FireAndForget();
+                        controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom;
 
-                    performer?.PerformFromScreen(s => s.Push(new ScreenIntro(invitation.Type)));
+                        if (s is ScreenIntro || s is ScreenQueue)
+                            return;
+
+                        s.Push(new ScreenIntro(invitation.Type));
+                    }, [typeof(ScreenIntro), typeof(ScreenQueue)]);
 
                     Close(false);
                     return true;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -163,8 +163,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private void onMatchmakingQueueLeft() => Scheduler.Add(() =>
         {
-            if (CurrentState.Value != ScreenQueue.MatchmakingScreenState.InRoom)
-                CurrentState.Value = ScreenQueue.MatchmakingScreenState.Idle;
+            CurrentState.Value = ScreenQueue.MatchmakingScreenState.Idle;
 
             closeNotification();
         });
@@ -175,6 +174,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             postNotification();
             backgroundNotification?.Complete(invitation);
+        });
+
+        private void onMatchmakingRoomReady(long roomId, string password) => Scheduler.Add(() =>
+        {
+            CurrentState.Value = ScreenQueue.MatchmakingScreenState.InRoom;
+
+            client.JoinRoom(new Room { RoomID = roomId }, password).FireAndForget();
         });
 
         private void onMatchmakingDuelIssued(MatchmakingDuelIssuedParams duel)
@@ -191,15 +197,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 Scheduler.Add(() => notifications?.Post(new DuelNotification(this, user, duel)));
             }
         }
-
-        private void onMatchmakingRoomReady(long roomId, string password) => Scheduler.Add(() =>
-        {
-            client.JoinRoom(new Room { RoomID = roomId }, password)
-                  .FireAndForget(() => Scheduler.Add(() =>
-                  {
-                      CurrentState.Value = ScreenQueue.MatchmakingScreenState.InRoom;
-                  }));
-        });
 
         private void postNotification()
         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -133,9 +133,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 return;
 
             isBackgrounded = true;
-
-            if (CurrentState.Value == ScreenQueue.MatchmakingScreenState.Queueing)
-                postNotification();
+            postNotification();
         }
 
         /// <summary>
@@ -147,7 +145,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 return;
 
             isBackgrounded = false;
-            closeNotifications();
+            closeNotification();
         }
 
         private void onRoomUpdated() => Scheduler.Add(() =>
@@ -160,11 +158,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         {
             CurrentState.Value = ScreenQueue.MatchmakingScreenState.Queueing;
 
-            if (isBackgrounded)
-            {
-                closeNotifications();
-                postNotification();
-            }
+            postNotification();
         });
 
         private void onMatchmakingQueueLeft() => Scheduler.Add(() =>
@@ -172,18 +166,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             if (CurrentState.Value != ScreenQueue.MatchmakingScreenState.InRoom)
                 CurrentState.Value = ScreenQueue.MatchmakingScreenState.Idle;
 
-            closeNotifications();
+            closeNotification();
         });
 
         private void onMatchmakingRoomInvited(MatchmakingRoomInvitationParams invitation) => Scheduler.Add(() =>
         {
-            if (isBackgrounded)
-                postNotification();
-
             CurrentState.Value = ScreenQueue.MatchmakingScreenState.PendingAccept;
 
+            postNotification();
             backgroundNotification?.Complete(invitation);
-            backgroundNotification = null;
         });
 
         private void onMatchmakingDuelIssued(MatchmakingDuelIssuedParams duel)
@@ -212,20 +203,30 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private void postNotification()
         {
-            if (backgroundNotification != null)
+            // Check if we can re-use an existing notification.
+            if (backgroundNotification?.State == ProgressNotificationState.Active || backgroundNotification?.State == ProgressNotificationState.Queued)
+                return;
+
+            // Existing notification could be in a post-completion state.
+            closeNotification();
+
+            if (!isBackgrounded)
+                return;
+
+            if (CurrentState.Value != ScreenQueue.MatchmakingScreenState.Queueing)
                 return;
 
             notifications?.Post(backgroundNotification = new BackgroundQueueNotification(this));
         }
 
-        private void closeNotifications()
+        private void closeNotification()
         {
-            if (backgroundNotification != null)
-            {
-                backgroundNotification.State = ProgressNotificationState.Cancelled;
-                backgroundNotification.CloseAll();
-                backgroundNotification = null;
-            }
+            if (backgroundNotification == null)
+                return;
+
+            backgroundNotification.State = ProgressNotificationState.Cancelled;
+            backgroundNotification.CloseAll();
+            backgroundNotification = null;
         }
 
         protected override void Dispose(bool isDisposing)
@@ -290,6 +291,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             public void Complete(MatchmakingRoomInvitationParams invitation)
             {
+                if (State != ProgressNotificationState.Active && State != ProgressNotificationState.Queued)
+                    return;
+
                 CompletionClickAction = () =>
                 {
                     performer?.PerformFromScreen(s =>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -60,8 +60,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             client.MatchmakingQueueJoined += onMatchmakingQueueJoined;
             client.MatchmakingQueueLeft += onMatchmakingQueueLeft;
             client.MatchmakingRoomInvited += onMatchmakingRoomInvited;
-            client.MatchmakingDuelIssued += onMatchmakingDuelIssued;
             client.MatchmakingRoomReady += onMatchmakingRoomReady;
+            client.MatchmakingDuelIssued += onMatchmakingDuelIssued;
         }
 
         /// <summary>
@@ -235,6 +235,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 client.MatchmakingQueueLeft -= onMatchmakingQueueLeft;
                 client.MatchmakingRoomInvited -= onMatchmakingRoomInvited;
                 client.MatchmakingRoomReady -= onMatchmakingRoomReady;
+                client.MatchmakingDuelIssued -= onMatchmakingDuelIssued;
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -185,9 +185,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
         private void onMatchmakingDuelIssued(MatchmakingDuelIssuedParams duel)
         {
-            handleDuelRequestAsync().FireAndForget();
-
-            async Task handleDuelRequestAsync()
+            Task.Run(async () =>
             {
                 APIUser? user = await users.GetUserAsync(duel.UserId).ConfigureAwait(false);
 
@@ -195,7 +193,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     return;
 
                 Scheduler.Add(() => notifications?.Post(new DuelNotification(this, user, duel)));
-            }
+            }).FireAndForget();
         }
 
         private void postNotification()


### PR DESCRIPTION
Supersedes / closes https://github.com/ppy/osu/pull/37881
Fixes https://github.com/ppy/osu/issues/37497
Fixes https://github.com/ppy/osu/issues/37214
Fixes https://github.com/ppy/osu/issues/36744

## Some ranked play matches getting stuck in the database

This is an issue I've been investigating for a while now, and I have suspicions that it's related to the following sentry event: https://sentry.ppy.sh/organizations/ppy/issues/15519/events/7a0d5a390a2d4894ae382a1fdcfd54cc/

```
Unobserved exception occurred via FireAndForget call: Cannot join a multiplayer room while already in one.
```

While I haven't repro'd the exact failure case where `ends_at` is `NULL`, it does put the game into a weird state:

https://github.com/user-attachments/assets/1d97cfbf-ae97-4f78-89bb-6b3f186c7c4e

Should be fixed by 787ef7fe2d456f0f11b0363e36abed45a9ad7b02

## Game sometimes deadlocking when accepting queue invitations

I've personally experienced this when waiting for the invitation notification to time out.

https://github.com/user-attachments/assets/cc191cbd-d72a-4a2e-a300-81f22b3fc993

Should be fixed by b238bf8aeab1597fc10e6a41d4aeb1bd116165d7