### PR TITLE
Cancel any download of the same map in the global `BeatmapModelDownloader` instance when Downloading in `RankedPlayBeatmapAvailabilityTracker`

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
@@ -92,6 +92,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                     if (beatmapSet == null)
                         return;
+
                     beatmapDownloaderResolved.GetExistingDownload(beatmapSet)?.Cancel();
                     beatmapDownloader.Download(beatmapSet, config.Get<bool>(OsuSetting.PreferNoVideo));
                 }));

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
@@ -9,7 +9,6 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
-using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -30,17 +29,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
 
+        [Resolved]
         private BeatmapModelDownloader beatmapDownloader { get; set; } = null!;
 
         private CancellationTokenSource? downloadCheckCancellation;
         private int? lastDownloadCheckedBeatmapId;
-
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-        {
-            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-            dependencies.CacheAs(beatmapDownloader = new BeatmapModelDownloader(parent.Get<BeatmapManager>(), parent.Get<IAPIProvider>()));
-            return dependencies;
-        }
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBeatmapAvailabilityTracker.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -30,7 +31,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private OsuConfigManager config { get; set; } = null!;
 
         [Resolved]
+        private BeatmapModelDownloader beatmapDownloaderResolved { get; set; } = null!;
+
         private BeatmapModelDownloader beatmapDownloader { get; set; } = null!;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            dependencies.CacheAs(beatmapDownloader = new BeatmapModelDownloader(parent.Get<BeatmapManager>(), parent.Get<IAPIProvider>()));
+            return dependencies;
+        }
 
         private CancellationTokenSource? downloadCheckCancellation;
         private int? lastDownloadCheckedBeatmapId;
@@ -82,7 +92,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                     if (beatmapSet == null)
                         return;
-
+                    beatmapDownloaderResolved.GetExistingDownload(beatmapSet)?.Cancel();
                     beatmapDownloader.Download(beatmapSet, config.Get<bool>(OsuSetting.PreferNoVideo));
                 }));
         }


### PR DESCRIPTION
Closes #37530 
