### PR TITLE
RankedPlayCardBackSide: flip opponent's osu logo 180 degrees

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCardBackSide.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCardBackSide.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                     Size = new Vector2(32),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Rotation = 180
                 },
             };
         }


### PR DESCRIPTION
teeniest tiny-est little change possible. I love ranked play, but I found it odd that your opponent's cards aren't oriented the way most would expect for a top-down video game with cards. this *literal* one line change does that- rotates the osu logo on the card back 180º to make it appear like the whole card is flipped.

thanks! <3

<details>
<summary>prior art showcasing 180º flip</summary>
<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/35a0b0fe-2294-4444-af8c-e03d084042d3" />
<img width="640" alt="image" src="https://github.com/user-attachments/assets/ea373199-0dab-41c3-8afa-1d081a87c513" />

</details>