### PR TITLE
Implementing ColumnStart for imported legacy mania skin

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -175,11 +175,24 @@ namespace osu.Game.Rulesets.Mania.UI
         {
             float paddingTop = currentSkin.GetConfig<ManiaSkinConfigurationLookup, float>(new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.StagePaddingTop))?.Value ?? 0;
             float paddingBottom = currentSkin.GetConfig<ManiaSkinConfigurationLookup, float>(new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.StagePaddingBottom))?.Value ?? 0;
+            float? columnStart = currentSkin.GetConfig<ManiaSkinConfigurationLookup, float>(new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.ColumnStart))?.Value;
 
+            if (columnStart is null)
+            {
+                // make the field centered instead
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+            }
+            else
+            {
+                Anchor = Anchor.CentreLeft;
+                Origin = Anchor.CentreLeft;
+            }
             Padding = new MarginPadding
             {
                 Top = paddingTop,
                 Bottom = paddingBottom,
+                Left = columnStart ?? 0
             };
         }
 

--- a/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
@@ -31,6 +31,12 @@ namespace osu.Game.Skinning
 
         public float WidthForNoteHeightScale;
 
+        /// <summary>
+        /// This should originally be 136, as same in stable client. However in lazer the stage is centered by default,
+        /// thus using <see langword="null"/> to represent the centered stage (backward compatibility)
+        /// </summary>
+        public float? ColumnStart = null;
+
         public readonly float[] ColumnLineWidth;
         public readonly float[] ColumnSpacing;
         public readonly float[] ColumnWidth;

--- a/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Skinning
 
     public enum LegacyManiaSkinConfigurationLookups
     {
+        ColumnStart,
         ColumnWidth,
         LightImage,
         HitPosition,

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Skinning
                 switch (pair.Key)
                 {
                     case "ColumnStart":
-                        currentConfig.ColumnStart = float.Parse(pair.Value);
+                        currentConfig.ColumnStart = float.Parse(pair.Value, CultureInfo.InvariantCulture) * LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
                         break;
 
                     case "ColumnLineWidth":

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -74,6 +74,10 @@ namespace osu.Game.Skinning
 
                 switch (pair.Key)
                 {
+                    case "ColumnStart":
+                        currentConfig.ColumnStart = float.Parse(pair.Value);
+                        break;
+
                     case "ColumnLineWidth":
                         parseArrayValue(pair.Value, currentConfig.ColumnLineWidth, false);
                         break;

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -140,6 +140,11 @@ namespace osu.Game.Skinning
 
             switch (maniaLookup.Lookup)
             {
+                case LegacyManiaSkinConfigurationLookups.ColumnStart:
+                    if (existing.ColumnStart == null) return null;
+
+                    return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnStart.Value));
+
                 case LegacyManiaSkinConfigurationLookups.ColumnWidth:
                     Debug.Assert(maniaLookup.ColumnIndex != null);
                     return SkinUtils.As<TValue>(new Bindable<float>(existing.ColumnWidth[maniaLookup.ColumnIndex.Value]));
@@ -396,7 +401,7 @@ namespace osu.Game.Skinning
                                         combo.Origin = Anchor.BottomLeft;
                                         combo.Scale = new Vector2(1.28f);
 
-                                        pos += new Vector2(10, -(combo.DrawHeight * 1.56f + 20) * combo.Scale.X);
+                                        pos += new Vector2(10, -((combo.DrawHeight * 1.56f) + 20) * combo.Scale.X);
                                     }
 
                                     if (spectatorList != null)
@@ -475,7 +480,7 @@ namespace osu.Game.Skinning
                     if (getJudgementAnimation(resultComponent.Component) != null)
                     {
                         // TODO: this should be inside the judgement pieces.
-                        Func<Drawable> createDrawable = () => getJudgementAnimation(resultComponent.Component).AsNonNull();
+                        Drawable createDrawable() => getJudgementAnimation(resultComponent.Component).AsNonNull();
 
                         var particle = getParticleTexture(resultComponent.Component);
 
@@ -583,7 +588,9 @@ namespace osu.Game.Skinning
             IEnumerable<string> lookupNames;
 
             if (sampleInfo is HitSampleInfo hitSample)
+            {
                 lookupNames = getLegacyLookupNames(hitSample);
+            }
             else
             {
                 lookupNames = sampleInfo.LookupNames.SelectMany(getFallbackSampleNames);


### PR DESCRIPTION
Implementing ColumnStart property for imported legacy mania skins.

In this PR, the game will shift the stage from center to the left using `ColumnStart` value if it is emitted in `skin.ini`. I did not touch `LegacyManiaComboCounter` because it is movable by the user in skin layout editor (and I can't seem to figure out how to access or dynamically calculate the width of the stage, to make it centered inside)

Related: #35492, #20252